### PR TITLE
Reduce use of protected functions in Source/WebCore/dom

### DIFF
--- a/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp
@@ -109,7 +109,7 @@ void ClipboardItemBindingsDataSource::getType(const String& type, Ref<DeferredPr
         String string;
         result.getString(globalObject, string);
         if (!string.isNull()) {
-            promise->resolve<IDLInterface<Blob>>(ClipboardItem::blobFromString(promise->protectedScriptExecutionContext().get(), string, type));
+            promise->resolve<IDLInterface<Blob>>(ClipboardItem::blobFromString(protect(promise->scriptExecutionContext()).get(), string, type));
             return;
         }
 

--- a/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
+++ b/Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp
@@ -45,7 +45,7 @@ Ref<DOMAudioSession> NavigatorAudioSession::audioSession(Navigator& navigator)
 {
     auto* navigatorAudioSession = NavigatorAudioSession::from(navigator);
     if (!navigatorAudioSession->m_audioSession)
-        lazyInitialize(navigatorAudioSession->m_audioSession, DOMAudioSession::create(navigator.protectedScriptExecutionContext().get()));
+        lazyInitialize(navigatorAudioSession->m_audioSession, DOMAudioSession::create(protect(navigator.scriptExecutionContext()).get()));
     return *navigatorAudioSession->m_audioSession;
 }
 

--- a/Source/WebCore/Modules/cache/DOMCache.cpp
+++ b/Source/WebCore/Modules/cache/DOMCache.cpp
@@ -240,7 +240,7 @@ ExceptionOr<Ref<FetchRequest>> DOMCache::requestFromInfo(RequestInfo&& info, boo
             return Exception { ExceptionCode::TypeError, "Request method is not GET"_s };
         }
     } else {
-        auto result = FetchRequest::create(*protectedScriptExecutionContext(), WTF::move(info), { });
+        auto result = FetchRequest::create(*protect(scriptExecutionContext()), WTF::move(info), { });
         if (result.hasException())
             return result.releaseException();
         request = result.releaseReturnValue();
@@ -401,7 +401,7 @@ void DOMCache::put(RequestInfo&& info, Ref<FetchResponse>&& response, DOMPromise
 
     // FIXME: for efficiency, we should load blobs/form data directly instead of going through the readableStream path.
     if (response->isBlobBody() || response->isBlobFormData()) {
-        auto streamOrException = response->readableStream(*protectedScriptExecutionContext()->globalObject());
+        auto streamOrException = response->readableStream(*protect(scriptExecutionContext())->globalObject());
         if (streamOrException.hasException()) [[unlikely]] {
             promise.reject(streamOrException.releaseException());
             return;

--- a/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
+++ b/Source/WebCore/Modules/cache/DOMCacheStorage.cpp
@@ -294,9 +294,9 @@ void DOMCacheStorage::doRemove(const String& name, DOMPromiseDeferred<IDLBoolean
         return;
     }
 
-    protectedScriptExecutionContext()->enqueueTaskWhenSettled(m_connection->remove(m_caches[position]->identifier()), TaskSource::DOMManipulation, [this, promise = WTF::move(promise), pendingActivity = makePendingActivity(*this)](const auto& result) mutable {
+    protect(scriptExecutionContext())->enqueueTaskWhenSettled(m_connection->remove(m_caches[position]->identifier()), TaskSource::DOMManipulation, [this, promise = WTF::move(promise), pendingActivity = makePendingActivity(*this)](const auto& result) mutable {
         if (!result)
-            promise.reject(DOMCacheEngine::convertToExceptionAndLog(protectedScriptExecutionContext().get(), result.error()));
+            promise.reject(DOMCacheEngine::convertToExceptionAndLog(protect(scriptExecutionContext()).get(), result.error()));
         else
             promise.resolve(result.value());
     });

--- a/Source/WebCore/Modules/fetch/FetchBody.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBody.cpp
@@ -203,7 +203,7 @@ void FetchBody::consumeAsStream(FetchBodyOwner& owner, FetchBodySource& source)
     } else if (isBlob())
         owner.loadBlob(protect(blobBody()).get(), nullptr);
     else if (isFormData())
-        checkedConsumer()->consumeFormDataAsStream(protect(formDataBody()).get(), source, owner.protectedScriptExecutionContext().get());
+        checkedConsumer()->consumeFormDataAsStream(protect(formDataBody()).get(), source, protect(owner.scriptExecutionContext()).get());
     else if (CheckedRef consumer = this->consumer(); consumer->hasData())
         closeStream = source.enqueue(consumer->asArrayBuffer());
     else
@@ -243,7 +243,7 @@ void FetchBody::consumeBlob(FetchBodyOwner& owner, Ref<DeferredPromise>&& promis
 
 void FetchBody::consumeFormData(FetchBodyOwner& owner, Ref<DeferredPromise>&& promise)
 {
-    checkedConsumer()->resolveWithFormData(WTF::move(promise), owner.contentType(), protect(formDataBody()).get(), owner.protectedScriptExecutionContext().get());
+    checkedConsumer()->resolveWithFormData(WTF::move(promise), owner.contentType(), protect(formDataBody()).get(), protect(owner.scriptExecutionContext()).get());
     m_data = nullptr;
 }
 

--- a/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp
@@ -399,7 +399,7 @@ void FetchBodyConsumer::resolve(Ref<DeferredPromise>&& promise, const String& co
         return;
     case FetchBodyConsumer::Type::FormData: {
         auto buffer = takeData();
-        if (auto formData = packageFormData(promise->protectedScriptExecutionContext().get(), contentType, buffer ? buffer->makeContiguous()->span() : std::span<const uint8_t> { }))
+        if (auto formData = packageFormData(protect(promise->scriptExecutionContext()).get(), contentType, buffer ? buffer->makeContiguous()->span() : std::span<const uint8_t> { }))
             promise->resolve<IDLInterface<DOMFormData>>(*formData);
         else
             promise->reject(ExceptionCode::TypeError);

--- a/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
+++ b/Source/WebCore/Modules/fetch/FetchBodyOwner.cpp
@@ -214,7 +214,7 @@ void FetchBodyOwner::formData(Ref<DeferredPromise>&& promise)
     if (isBodyNullOrOpaque()) {
         if (isBodyNull()) {
             // If the content-type is 'application/x-www-form-urlencoded', a body is not required and we should package an empty byte sequence as per the specification.
-            if (auto formData = FetchBodyConsumer::packageFormData(promise->protectedScriptExecutionContext().get(), contentType(), { })) {
+            if (auto formData = FetchBodyConsumer::packageFormData(protect(promise->scriptExecutionContext()).get(), contentType(), { })) {
                 promise->resolve<IDLInterface<DOMFormData>>(*formData);
                 return;
             }
@@ -282,7 +282,7 @@ void FetchBodyOwner::loadBlob(const Blob& blob, FetchBodyConsumer* consumer)
     Ref loader = FetchLoader::create(blobLoader.get(), consumer);
     blobLoader->loader = loader.copyRef();
 
-    loader->start(*protectedScriptExecutionContext(), blob);
+    loader->start(*protect(scriptExecutionContext()), blob);
     if (!loader->isStarted()) {
         m_body->loadingFailed(Exception { ExceptionCode::TypeError, "Blob loading failed"_s });
         m_blobLoader = nullptr;

--- a/Source/WebCore/Modules/fetch/FetchRequest.cpp
+++ b/Source/WebCore/Modules/fetch/FetchRequest.cpp
@@ -164,7 +164,7 @@ ExceptionOr<void> FetchRequest::initializeOptions(const Init& init)
 {
     ASSERT(scriptExecutionContext());
 
-    auto exception = buildOptions(m_options, m_request, m_referrer, m_priority, *protectedScriptExecutionContext(), init);
+    auto exception = buildOptions(m_options, m_request, m_referrer, m_priority, *protect(scriptExecutionContext()), init);
     if (exception)
         return WTF::move(exception.value());
 

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -345,7 +345,7 @@ int Geolocation::watchPosition(Ref<PositionCallback>&& successCallback, RefPtr<P
     int watchID;
     // Keep asking for the next id until we're given one that we don't already have.
     do {
-        watchID = protectedScriptExecutionContext()->circularSequentialID();
+        watchID = protect(scriptExecutionContext())->circularSequentialID();
     } while (!m_watchers.add(watchID, notifier.copyRef()));
     return watchID;
 }

--- a/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
+++ b/Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp
@@ -147,7 +147,7 @@ void CredentialRequestCoordinator::prepareCredentialRequest(const Document& docu
 
     setState(PickerState::Presenting);
     setCurrentPromise(WTF::move(promise));
-    observeContext(document.protectedScriptExecutionContext().get());
+    observeContext(protect(document.scriptExecutionContext()).get());
 
     auto validatedCredentialRequests = validatedRequestsOrException.releaseReturnValue();
     DigitalCredentialsRequestData requestData {

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -524,7 +524,7 @@ ExceptionOr<Ref<IDBIndex>> IDBObjectStore::index(const String& indexName)
     if (!info)
         return Exception { ExceptionCode::NotFoundError, "Failed to execute 'index' on 'IDBObjectStore': The specified index was not found."_s };
 
-    auto index = IDBIndex::create(*protectedScriptExecutionContext(), *info, *this);
+    auto index = IDBIndex::create(*protect(scriptExecutionContext()), *info, *this);
 
     Ref referencedIndex { index.get() };
 

--- a/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp
@@ -148,7 +148,7 @@ void IDBOpenDBRequest::onSuccess(const IDBResultData& resultData)
 
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    setResult(IDBDatabase::create(*protectedScriptExecutionContext(), connectionProxy(), resultData));
+    setResult(IDBDatabase::create(*protect(scriptExecutionContext()), connectionProxy(), resultData));
     setReadyState(ReadyState::Done);
 
     enqueueEvent(IDBRequestCompletionEvent::create(eventNames().successEvent, Event::CanBubble::No, Event::IsCancelable::No, *this));
@@ -158,7 +158,7 @@ void IDBOpenDBRequest::onUpgradeNeeded(const IDBResultData& resultData)
 {
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
-    Ref database = IDBDatabase::create(*protectedScriptExecutionContext(), connectionProxy(), resultData);
+    Ref database = IDBDatabase::create(*protect(scriptExecutionContext()), connectionProxy(), resultData);
     Ref transaction = database->startVersionChangeTransaction(resultData.transactionInfo(), *this);
 
     ASSERT(transaction->info().mode() == IDBTransactionMode::Versionchange);

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.h
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.h
@@ -108,7 +108,6 @@ public:
     IndexedDB::IndexRecordType requestedIndexRecordType() const;
 
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using IDBActiveDOMObject::protectedScriptExecutionContext;
 
     // ActiveDOMObject.
     void ref() const final { ThreadSafeRefCounted::ref(); }

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -182,7 +182,7 @@ ExceptionOr<Ref<IDBObjectStore>> IDBTransaction::objectStore(const String& objec
     if (!info || (!found && !isVersionChange()))
         return Exception { ExceptionCode::NotFoundError, "Failed to execute 'objectStore' on 'IDBTransaction': The specified object store was not found."_s };
 
-    auto objectStore = IDBObjectStore::create(*protectedScriptExecutionContext(), *info, *this);
+    auto objectStore = IDBObjectStore::create(*protect(scriptExecutionContext()), *info, *this);
     Ref objectStoreRef { objectStore.get() };
     m_referencedObjectStores.set(objectStoreName, objectStore.moveToUniquePtr());
 
@@ -664,7 +664,7 @@ Ref<IDBObjectStore> IDBTransaction::createObjectStore(const IDBObjectStoreInfo& 
 
     Locker locker { m_referencedObjectStoreLock };
 
-    auto objectStore = IDBObjectStore::create(*protectedScriptExecutionContext(), info, *this);
+    auto objectStore = IDBObjectStore::create(*protect(scriptExecutionContext()), info, *this);
     Ref objectStoreRef { objectStore.get() };
     m_referencedObjectStores.set(info.name(), objectStore.moveToUniquePtr());
 
@@ -752,7 +752,7 @@ std::unique_ptr<IDBIndex> IDBTransaction::createIndex(IDBObjectStore& objectStor
         protectedThis->createIndexOnServer(operation, info);
     }), IsWriteOperation::Yes);
 
-    return IDBIndex::create(*protectedScriptExecutionContext(), info, objectStore).moveToUniquePtr();
+    return IDBIndex::create(*protect(scriptExecutionContext()), info, objectStore).moveToUniquePtr();
 }
 
 void IDBTransaction::createIndexOnServer(IDBClient::TransactionOperation& operation, const IDBIndexInfo& info)
@@ -851,7 +851,7 @@ Ref<IDBRequest> IDBTransaction::doRequestOpenCursor(Ref<IDBCursor>&& cursor)
     ASSERT(isActive());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
-    auto request = IDBRequest::create(*protectedScriptExecutionContext(), cursor.get(), *this);
+    auto request = IDBRequest::create(*protect(scriptExecutionContext()), cursor.get(), *this);
     addRequest(request.get());
     addCursorRequest(request.get());
 
@@ -938,7 +938,7 @@ Ref<IDBRequest> IDBTransaction::requestGetAllObjectStoreRecords(IDBObjectStore& 
     ASSERT(isActive());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
-    auto request = IDBRequest::create(*protectedScriptExecutionContext(), objectStore, *this);
+    auto request = IDBRequest::create(*protect(scriptExecutionContext()), objectStore, *this);
     addRequest(request.get());
 
     IDBGetAllRecordsData getAllRecordsData { keyRangeData, getAllType, count, objectStore.info().identifier() };
@@ -960,7 +960,7 @@ Ref<IDBRequest> IDBTransaction::requestGetAllIndexRecords(IDBIndex& index, const
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
 
-    auto request = IDBRequest::create(*protectedScriptExecutionContext(), index, *this);
+    auto request = IDBRequest::create(*protect(scriptExecutionContext()), index, *this);
     addRequest(request.get());
 
     IDBGetAllRecordsData getAllRecordsData { keyRangeData, getAllType, count, index.objectStore().info().identifier(), index.info().identifier() };
@@ -1017,7 +1017,7 @@ Ref<IDBRequest> IDBTransaction::requestGetRecord(IDBObjectStore& objectStore, co
 
     IndexedDB::ObjectStoreRecordType type = getRecordData.type == IDBGetRecordDataType::KeyAndValue ? IndexedDB::ObjectStoreRecordType::ValueOnly : IndexedDB::ObjectStoreRecordType::KeyOnly;
 
-    auto request = IDBRequest::createObjectStoreGet(*protectedScriptExecutionContext(), objectStore, type, *this);
+    auto request = IDBRequest::createObjectStoreGet(*protect(scriptExecutionContext()), objectStore, type, *this);
     addRequest(request.get());
 
     LOG(IndexedDBOperations, "IDB get record operation: %s %s", objectStore.info().condensedLoggingString().utf8().data(), getRecordData.loggingString().utf8().data());
@@ -1053,7 +1053,7 @@ Ref<IDBRequest> IDBTransaction::requestIndexRecord(IDBIndex& index, IndexedDB::I
     ASSERT(!range.isNull());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
-    auto request = IDBRequest::createIndexGet(*protectedScriptExecutionContext(), index, type, *this);
+    auto request = IDBRequest::createIndexGet(*protect(scriptExecutionContext()), index, type, *this);
     addRequest(request.get());
 
     IDBGetRecordData getRecordData = { range, IDBGetRecordDataType::KeyAndValue };
@@ -1116,7 +1116,7 @@ Ref<IDBRequest> IDBTransaction::requestCount(IDBObjectStore& objectStore, const 
     ASSERT(!range.isNull());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
-    auto request = IDBRequest::create(*protectedScriptExecutionContext(), objectStore, *this);
+    auto request = IDBRequest::create(*protect(scriptExecutionContext()), objectStore, *this);
     addRequest(request.get());
 
     LOG(IndexedDBOperations, "IDB object store count operation: %s, range %s", objectStore.info().condensedLoggingString().utf8().data(), range.loggingString().utf8().data());
@@ -1136,7 +1136,7 @@ Ref<IDBRequest> IDBTransaction::requestCount(IDBIndex& index, const IDBKeyRangeD
     ASSERT(!range.isNull());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
-    auto request = IDBRequest::create(*protectedScriptExecutionContext(), index, *this);
+    auto request = IDBRequest::create(*protect(scriptExecutionContext()), index, *this);
     addRequest(request.get());
 
     LOG(IndexedDBOperations, "IDB index count operation: %s, range %s", index.info().condensedLoggingString().utf8().data(), range.loggingString().utf8().data());
@@ -1173,7 +1173,7 @@ Ref<IDBRequest> IDBTransaction::requestDeleteRecord(IDBObjectStore& objectStore,
     ASSERT(!range.isNull());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
-    auto request = IDBRequest::create(*protectedScriptExecutionContext(), objectStore, *this);
+    auto request = IDBRequest::create(*protect(scriptExecutionContext()), objectStore, *this);
     addRequest(request.get());
 
     LOG(IndexedDBOperations, "IDB delete record operation: %s, range %s", objectStore.info().condensedLoggingString().utf8().data(), range.loggingString().utf8().data());
@@ -1208,7 +1208,7 @@ Ref<IDBRequest> IDBTransaction::requestClearObjectStore(IDBObjectStore& objectSt
     ASSERT(isActive());
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
-    auto request = IDBRequest::create(*protectedScriptExecutionContext(), objectStore, *this);
+    auto request = IDBRequest::create(*protect(scriptExecutionContext()), objectStore, *this);
     addRequest(request.get());
 
     auto objectStoreIdentifier = objectStore.info().identifier();
@@ -1248,7 +1248,7 @@ Ref<IDBRequest> IDBTransaction::requestPutOrAdd(IDBObjectStore& objectStore, Ref
     ASSERT(objectStore.info().autoIncrement() || key);
     ASSERT(canCurrentThreadAccessThreadLocalData(m_database->originThread()));
 
-    auto request = IDBRequest::create(*protectedScriptExecutionContext(), objectStore, *this);
+    auto request = IDBRequest::create(*protect(scriptExecutionContext()), objectStore, *this);
     addRequest(request.get());
 
     LOG(IndexedDBOperations, "IDB putOrAdd operation: %s key: %s", objectStore.info().condensedLoggingString().utf8().data(), key ? key->loggingString().utf8().data() : "<null key>");

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.h
@@ -91,7 +91,6 @@ public:
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::IDBTransaction; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void refEventTarget() final { ThreadSafeRefCounted::ref(); }
     void derefEventTarget() final { ThreadSafeRefCounted::deref(); }
     using EventTarget::dispatchEvent;

--- a/Source/WebCore/Modules/mediasession/MediaSession.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaSession.cpp
@@ -163,7 +163,7 @@ MediaSession::MediaSession(Navigator& navigator)
     , m_navigator(navigator)
     , m_platformSession { PlatformMediaSession::create(*this) }
 #if ENABLE(MEDIA_SESSION_COORDINATOR)
-    , m_coordinator(MediaSessionCoordinator::create(navigator.protectedScriptExecutionContext().get()))
+    , m_coordinator(MediaSessionCoordinator::create(protect(navigator.scriptExecutionContext()).get()))
 #endif
 {
     m_logger = Document::sharedLogger();

--- a/Source/WebCore/Modules/mediasource/MediaSource.h
+++ b/Source/WebCore/Modules/mediasource/MediaSource.h
@@ -137,7 +137,6 @@ public:
     bool detachable() const { return m_detachable; }
 
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     static const MediaTime& currentTimeFudgeFactor();
     static bool contentTypeShouldGenerateTimestamps(const ContentType&);

--- a/Source/WebCore/Modules/mediasource/SourceBuffer.h
+++ b/Source/WebCore/Modules/mediasource/SourceBuffer.h
@@ -119,7 +119,6 @@ public:
 
     // EventTarget
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     enum class AppendMode { Segments, Sequence };
     AppendMode mode() const { return m_mode; }

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp
@@ -234,7 +234,7 @@ RefPtr<MediaStreamTrack> MediaStreamTrack::clone()
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
-    auto clone = MediaStreamTrack::create(*protectedScriptExecutionContext(), m_private->clone(), RegisterCaptureTrackToOwner::No);
+    auto clone = MediaStreamTrack::create(*protect(scriptExecutionContext()), m_private->clone(), RegisterCaptureTrackToOwner::No);
 
     clone->m_readyState = m_readyState;
     if (clone->ended() && clone->m_readyState == State::Live)
@@ -501,7 +501,7 @@ void MediaStreamTrack::trackEnded(MediaStreamTrackPrivate&)
     ALWAYS_LOG(LOGIDENTIFIER);
 
     if (m_isCaptureTrack && m_private->captureDidFail() && m_readyState != State::Ended)
-        protectedScriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "A MediaStreamTrack ended due to a capture failure"_s);
+        protect(scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "A MediaStreamTrack ended due to a capture failure"_s);
 
     // http://w3c.github.io/mediacapture-main/#life-cycle
     // When a MediaStreamTrack track ends for any reason other than the stop() method being invoked, the User Agent must

--- a/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
+++ b/Source/WebCore/Modules/mediastream/MediaStreamTrack.h
@@ -204,7 +204,6 @@ public:
 protected:
     MediaStreamTrack(ScriptExecutionContext&, Ref<MediaStreamTrackPrivate>&&);
 
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
 private:
     explicit MediaStreamTrack(MediaStreamTrack&);

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp
@@ -109,7 +109,7 @@ ExceptionOr<void> RTCDTMFSender::insertDTMF(const String& tones, size_t duration
         return { };
 
     m_isPendingPlayoutTask = true;
-    protectedScriptExecutionContext()->postTask([protectedThis = Ref { *this }](auto&) {
+    protect(scriptExecutionContext())->postTask([protectedThis = Ref { *this }](auto&) {
         protectedThis->playNextTone();
     });
     return { };

--- a/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
+++ b/Source/WebCore/Modules/mediastream/RTCDTMFSender.h
@@ -64,7 +64,6 @@ private:
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCDTMFSender; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     bool virtualHasPendingActivity() const final { return m_isPendingPlayoutTask; }
 
     void refEventTarget() final { ref(); }

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.cpp
@@ -73,10 +73,10 @@ Ref<NetworkSendQueue> RTCDataChannel::createMessageQueue(ScriptExecutionContext&
 {
     return NetworkSendQueue::create(context, [&channel](auto& utf8) {
         if (!channel.m_handler->sendStringData(utf8))
-            channel.protectedScriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Error sending string through RTCDataChannel."_s);
+            protect(channel.scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Error sending string through RTCDataChannel."_s);
     }, [&channel](auto span) {
         if (!channel.m_handler->sendRawData(span))
-            channel.protectedScriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Error sending binary data through RTCDataChannel."_s);
+            protect(channel.scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Error sending binary data through RTCDataChannel."_s);
     }, [&channel](ExceptionCode errorCode) {
         if (RefPtr context = channel.scriptExecutionContext()) {
             auto code = static_cast<int>(errorCode);
@@ -217,7 +217,7 @@ void RTCDataChannel::didReceiveRawData(std::span<const uint8_t> data)
 {
     switch (m_binaryType) {
     case BinaryType::Blob:
-        scheduleDispatchEvent(MessageEvent::create(Blob::create(protectedScriptExecutionContext().get(), Vector(data), emptyString()), { }));
+        scheduleDispatchEvent(MessageEvent::create(Blob::create(protect(scriptExecutionContext()).get(), Vector(data), emptyString()), { }));
         return;
     case BinaryType::Arraybuffer:
         scheduleDispatchEvent(MessageEvent::create(ArrayBuffer::create(data)));

--- a/Source/WebCore/Modules/mediastream/RTCDataChannel.h
+++ b/Source/WebCore/Modules/mediastream/RTCDataChannel.h
@@ -106,7 +106,6 @@ private:
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCDataChannel; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -1143,7 +1143,7 @@ Ref<RTCIceTransport> RTCPeerConnection::getOrCreateIceTransport(UniqueRef<RTCIce
     auto index = m_iceTransports.findIf([&backend](auto& transport) { return backend.get() == transport->backend(); });
     if (index == notFound) {
         index = m_iceTransports.size();
-        m_iceTransports.append(RTCIceTransport::create(*protectedScriptExecutionContext(), WTF::move(backend), *this));
+        m_iceTransports.append(RTCIceTransport::create(*protect(scriptExecutionContext()), WTF::move(backend), *this));
     }
 
     return m_iceTransports[index].copyRef();

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.h
@@ -171,7 +171,6 @@ public:
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCPeerConnection; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     // API used by PeerConnectionBackend and relatives
     void updateIceGatheringState(RTCIceGatheringState);

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp
@@ -219,7 +219,7 @@ void transformFrame(Frame& frame, JSDOMGlobalObject& globalObject, RTCRtpSFrameT
 
 ExceptionOr<void> RTCRtpSFrameTransform::createStreams()
 {
-    auto* globalObject = scriptExecutionContext() ? JSC::jsCast<JSDOMGlobalObject*>(protectedScriptExecutionContext()->globalObject()) : nullptr;
+    auto* globalObject = scriptExecutionContext() ? JSC::jsCast<JSDOMGlobalObject*>(protect(scriptExecutionContext())->globalObject()) : nullptr;
     if (!globalObject)
         return Exception { ExceptionCode::InvalidStateError };
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -90,7 +90,6 @@ private:
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::RTCRtpSFrameTransform; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSender.cpp
@@ -204,7 +204,7 @@ std::optional<RTCRtpCapabilities> RTCRtpSender::getCapabilities(ScriptExecutionC
 RTCDTMFSender* RTCRtpSender::dtmf()
 {
     if (!m_dtmfSender && m_connection && m_connection->scriptExecutionContext() && m_backend && m_trackKind == "audio"_s)
-        m_dtmfSender = RTCDTMFSender::create(*m_connection->protectedScriptExecutionContext(), *this, m_backend->createDTMFBackend());
+        m_dtmfSender = RTCDTMFSender::create(*protect(m_connection->scriptExecutionContext()), *this, m_backend->createDTMFBackend());
 
     return m_dtmfSender.get();
 }

--- a/Source/WebCore/Modules/notifications/Notification.h
+++ b/Source/WebCore/Modules/notifications/Notification.h
@@ -107,7 +107,6 @@ public:
     static void requestPermission(Document&, RefPtr<NotificationPermissionCallback>&&, Ref<DeferredPromise>&&);
 
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     WEBCORE_EXPORT NotificationData data() const;
     RefPtr<NotificationResources> resources() const { return m_resources; }

--- a/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
+++ b/Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp
@@ -81,7 +81,7 @@ void NotificationResourcesLoader::start(CompletionHandler<void(RefPtr<Notificati
         Ref notification = m_notification.get();
         const URL& iconURL = notification->icon();
         if (!iconURL.isEmpty()) {
-            Ref loader = ResourceLoader::create(*notification->protectedScriptExecutionContext(), iconURL, [this](ResourceLoader* loader, RefPtr<BitmapImage>&& image) {
+            Ref loader = ResourceLoader::create(*protect(notification->scriptExecutionContext()), iconURL, [this](ResourceLoader* loader, RefPtr<BitmapImage>&& image) {
                 if (m_stopped)
                     return;
 

--- a/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.cpp
@@ -84,7 +84,7 @@ ExceptionOr<void> MerchantValidationEvent::complete(Ref<DOMPromise>&& merchantSe
     if (m_isCompleted)
         return Exception { ExceptionCode::InvalidStateError };
 
-    auto exception = downcast<PaymentRequest>(protectedTarget())->completeMerchantValidation(*this, WTF::move(merchantSessionPromise));
+    auto exception = downcast<PaymentRequest>(protect(target()))->completeMerchantValidation(*this, WTF::move(merchantSessionPromise));
     if (exception.hasException())
         return exception.releaseException();
 

--- a/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.cpp
+++ b/Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.cpp
@@ -73,7 +73,7 @@ ExceptionOr<void> PaymentRequestUpdateEvent::updateWith(Ref<DOMPromise>&& detail
         return Exception { ExceptionCode::TypeError };
     }
 
-    auto exception = downcast<PaymentRequest>(protectedTarget())->updateWith(reason, WTF::move(detailsPromise));
+    auto exception = downcast<PaymentRequest>(protect(target()))->updateWith(reason, WTF::move(detailsPromise));
     if (exception.hasException())
         return exception.releaseException();
 

--- a/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp
@@ -62,7 +62,7 @@ WakeLock& NavigatorScreenWakeLock::wakeLock(Navigator& navigator)
 WakeLock& NavigatorScreenWakeLock::wakeLock()
 {
     if (!m_wakeLock)
-        lazyInitialize(m_wakeLock, WakeLock::create(downcast<Document>(m_navigator->protectedScriptExecutionContext().get())));
+        lazyInitialize(m_wakeLock, WakeLock::create(downcast<Document>(protect(m_navigator->scriptExecutionContext()).get())));
     return *m_wakeLock;
 }
 

--- a/Source/WebCore/Modules/streams/ReadableStream.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStream.cpp
@@ -140,12 +140,12 @@ ExceptionOr<Ref<ReadableStream>> ReadableStream::createFromJSValues(JSC::JSGloba
     if (result.hasException())
         return result.releaseException();
 
-    return adoptRef(*new ReadableStream(jsDOMGlobalObject.protectedScriptExecutionContext().get(), result.releaseReturnValue()));
+    return adoptRef(*new ReadableStream(protect(jsDOMGlobalObject.scriptExecutionContext()).get(), result.releaseReturnValue()));
 }
 
 ExceptionOr<Ref<ReadableStream>> ReadableStream::createFromByteUnderlyingSource(JSDOMGlobalObject& globalObject, JSC::JSValue underlyingSource, UnderlyingSource&& underlyingSourceDict, double highWaterMark)
 {
-    Ref readableStream = adoptRef(*new ReadableStream(globalObject.protectedScriptExecutionContext().get()));
+    Ref readableStream = adoptRef(*new ReadableStream(protect(globalObject.scriptExecutionContext()).get()));
 
     auto exception = readableStream->setupReadableByteStreamControllerFromUnderlyingSource(globalObject, underlyingSource, WTF::move(underlyingSourceDict), highWaterMark);
     if (exception.hasException())
@@ -167,7 +167,7 @@ ExceptionOr<Ref<ReadableStream>> ReadableStream::create(JSDOMGlobalObject& globa
 Ref<ReadableStream> ReadableStream::create(Ref<InternalReadableStream>&& internalReadableStream)
 {
     auto* globalObject = internalReadableStream->globalObject();
-    return adoptRef(*new ReadableStream(globalObject->protectedScriptExecutionContext().get(), WTF::move(internalReadableStream)));
+    return adoptRef(*new ReadableStream(protect(globalObject->scriptExecutionContext()).get(), WTF::move(internalReadableStream)));
 }
 
 class AsyncIteratorSource : public ReadableStreamSource, public RefCountedAndCanMakeWeakPtr<AsyncIteratorSource> {
@@ -383,7 +383,7 @@ ReadableStreamDefaultReader* ReadableStream::defaultReader()
 // https://streams.spec.whatwg.org/#abstract-opdef-createreadablebytestream
 Ref<ReadableStream> ReadableStream::createReadableByteStream(JSDOMGlobalObject& globalObject, ReadableByteStreamController::PullAlgorithm&& pullAlgorithm, ReadableByteStreamController::CancelAlgorithm&& cancelAlgorithm, ByteStreamOptions&& options)
 {
-    Ref readableStream = adoptRef(*new ReadableStream(globalObject.protectedScriptExecutionContext().get(), { }, WTF::move(options.dependencyToVisit), options.isSourceReachableFromOpaqueRoot));
+    Ref readableStream = adoptRef(*new ReadableStream(protect(globalObject.scriptExecutionContext()).get(), { }, WTF::move(options.dependencyToVisit), options.isSourceReachableFromOpaqueRoot));
     readableStream->setupReadableByteStreamController(globalObject, WTF::move(pullAlgorithm), WTF::move(cancelAlgorithm), options.highwaterMark, options.startSynchronously);
     return readableStream;
 }

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -46,7 +46,7 @@ class StreamPipeToState : public RefCounted<StreamPipeToState>, public ContextDe
 public:
     static Ref<StreamPipeToState> create(JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& source, Ref<WritableStream>&& destination, Ref<ReadableStreamDefaultReader>&& reader, Ref<InternalWritableStreamWriter>&& writer, StreamPipeOptions&& options, RefPtr<DeferredPromise>&& promise)
     {
-        Ref state = adoptRef(*new StreamPipeToState(globalObject.protectedScriptExecutionContext().get(), WTF::move(source), WTF::move(destination), WTF::move(reader), WTF::move(writer), WTF::move(options), WTF::move(promise)));
+        Ref state = adoptRef(*new StreamPipeToState(protect(globalObject.scriptExecutionContext()).get(), WTF::move(source), WTF::move(destination), WTF::move(reader), WTF::move(writer), WTF::move(options), WTF::move(promise)));
 
         state->handleSignal();
 

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -48,7 +48,7 @@ public:
     static Ref<StreamTeeState> create(JSDOMGlobalObject& globalObject, Ref<ReadableStream>&& stream, Ref<Reader>&& reader)
     {
         auto [cancelPromise, cancelDeferred] = createPromiseAndWrapper(globalObject);
-        return adoptRef(*new StreamTeeState(globalObject.protectedScriptExecutionContext().get(), WTF::move(stream), WTF::move(reader), WTF::move(cancelDeferred), WTF::move(cancelPromise)));
+        return adoptRef(*new StreamTeeState(protect(globalObject.scriptExecutionContext()).get(), WTF::move(stream), WTF::move(reader), WTF::move(cancelDeferred), WTF::move(cancelPromise)));
     }
 
     ~StreamTeeState();

--- a/Source/WebCore/Modules/web-locks/WebLockManager.cpp
+++ b/Source/WebCore/Modules/web-locks/WebLockManager.cpp
@@ -164,7 +164,7 @@ Ref<WebLockManager> WebLockManager::create(NavigatorBase& navigator)
 
 WebLockManager::WebLockManager(NavigatorBase& navigator)
     : ActiveDOMObject(navigator.scriptExecutionContext())
-    , m_mainThreadBridge(MainThreadBridge::create(navigator.protectedScriptExecutionContext().get()))
+    , m_mainThreadBridge(MainThreadBridge::create(protect(navigator.scriptExecutionContext()).get()))
 {
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -90,7 +90,7 @@ ExceptionOr<Ref<AudioWorkletNode>> AudioWorkletNode::create(JSC::JSGlobalObject&
     if (!context.scriptExecutionContext())
         return Exception { ExceptionCode::InvalidStateError, "Audio context's frame is detached"_s };
 
-    auto messageChannel = MessageChannel::create(*context.protectedScriptExecutionContext());
+    auto messageChannel = MessageChannel::create(*protect(context.scriptExecutionContext()));
     auto& nodeMessagePort = messageChannel->port1();
     auto& processorMessagePort = messageChannel->port2();
 

--- a/Source/WebCore/Modules/webaudio/BaseAudioContext.h
+++ b/Source/WebCore/Modules/webaudio/BaseAudioContext.h
@@ -215,7 +215,6 @@ public:
 
     // EventTarget
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     virtual void sourceNodeWillBeginPlayback(AudioNode&);
     // When a source node has no more processing to do (has finished playing), then it tells the context to dereference it.

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp
@@ -152,7 +152,7 @@ ExceptionOr<void> WebCodecsAudioDecoder::configure(ScriptExecutionContext&, WebC
             });
         });
 
-        protectedScriptExecutionContext()->enqueueTaskWhenSettled(WTF::move(createDecoderPromise), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }] (AudioDecoder::CreateResult&& result) mutable {
+        protect(scriptExecutionContext())->enqueueTaskWhenSettled(WTF::move(createDecoderPromise), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }] (AudioDecoder::CreateResult&& result) mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
@@ -183,7 +183,7 @@ ExceptionOr<void> WebCodecsAudioDecoder::decode(Ref<WebCodecsEncodedAudioChunk>&
 
     queueCodecControlMessageAndProcess({ *this, [this, chunk = WTF::move(chunk)]() mutable {
         incrementCodecOperationCount();
-        protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalDecoder }->decode({ chunk->span(), chunk->type() == WebCodecsEncodedAudioChunkType::Key, chunk->timestamp(), chunk->duration() }), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
+        protect(scriptExecutionContext())->enqueueTaskWhenSettled(Ref { *m_internalDecoder }->decode({ chunk->span(), chunk->type() == WebCodecsEncodedAudioChunkType::Key, chunk->timestamp(), chunk->duration() }), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
@@ -208,7 +208,7 @@ ExceptionOr<void> WebCodecsAudioDecoder::flush(Ref<DeferredPromise>&& promise)
     m_isKeyChunkRequired = true;
     m_pendingFlushPromises.append(promise);
     queueControlMessageAndProcess({ *this, [this, promise = WTF::move(promise)]() mutable {
-        protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalDecoder }->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this), promise = WTF::move(promise)] (auto&&) {
+        protect(scriptExecutionContext())->enqueueTaskWhenSettled(Ref { *m_internalDecoder }->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this), promise = WTF::move(promise)] (auto&&) {
             promise->resolve();
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->m_pendingFlushPromises.removeFirstMatching([&](auto& flushPromise) { return promise.ptr() == flushPromise.ptr(); });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp
@@ -181,7 +181,7 @@ ExceptionOr<void> WebCodecsAudioEncoder::configure(ScriptExecutionContext&, WebC
         queueControlMessageAndProcess({ *this, [this, config]() mutable {
             blockControlMessageQueue();
 
-            protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalEncoder }->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, config = WTF::move(config)] (auto&&) mutable {
+            protect(scriptExecutionContext())->enqueueTaskWhenSettled(Ref { *m_internalEncoder }->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, config = WTF::move(config)] (auto&&) mutable {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis)
                     return;
@@ -309,7 +309,7 @@ ExceptionOr<void> WebCodecsAudioEncoder::encode(Ref<WebCodecsAudioData>&& frame)
         }
 
         incrementCodecOperationCount();
-        protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalEncoder }->encode({ WTF::move(audioData), timestamp, duration }), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
+        protect(scriptExecutionContext())->enqueueTaskWhenSettled(Ref { *m_internalEncoder }->encode({ WTF::move(audioData), timestamp, duration }), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
@@ -336,7 +336,7 @@ void WebCodecsAudioEncoder::flush(Ref<DeferredPromise>&& promise)
 
     m_pendingFlushPromises.append(promise);
     queueControlMessageAndProcess({ *this, [this, promise = WTF::move(promise)]() mutable {
-        protectedScriptExecutionContext()->enqueueTaskWhenSettled(Ref { *m_internalEncoder }->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this), promise = WTF::move(promise)] (auto&&) {
+        protect(scriptExecutionContext())->enqueueTaskWhenSettled(Ref { *m_internalEncoder }->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this), promise = WTF::move(promise)] (auto&&) {
             promise->resolve();
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->m_pendingFlushPromises.removeFirstMatching([&](auto& flushPromise) { return promise.ptr() == flushPromise.ptr(); });

--- a/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsBase.h
@@ -61,7 +61,6 @@ public:
 protected:
     WebCodecsBase(ScriptExecutionContext&);
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     void setState(WebCodecsCodecState state) { m_state = state; }
 

--- a/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
+++ b/Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp
@@ -217,7 +217,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::decode(Ref<WebCodecsEncodedVideoChunk>&
     queueCodecControlMessageAndProcess({ *this, [this, chunk = WTF::move(chunk)]() mutable {
         incrementCodecOperationCount();
         Ref internalDecoder = *m_internalDecoder;
-        protectedScriptExecutionContext()->enqueueTaskWhenSettled(internalDecoder->decode({ chunk->span(), chunk->type() == WebCodecsEncodedVideoChunkType::Key, chunk->timestamp(), chunk->duration() }), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { * this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
+        protect(scriptExecutionContext())->enqueueTaskWhenSettled(internalDecoder->decode({ chunk->span(), chunk->type() == WebCodecsEncodedVideoChunkType::Key, chunk->timestamp(), chunk->duration() }), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { * this }, pendingActivity = makePendingActivity(*this)] (auto&& result) {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)
                 return;
@@ -242,7 +242,7 @@ ExceptionOr<void> WebCodecsVideoDecoder::flush(Ref<DeferredPromise>&& promise)
     m_pendingFlushPromises.append(promise);
     queueControlMessageAndProcess({ *this, [this, promise = WTF::move(promise)]() mutable {
         Ref internalDecoder = *m_internalDecoder;
-        protectedScriptExecutionContext()->enqueueTaskWhenSettled(internalDecoder->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this), promise = WTF::move(promise)] (auto&&) {
+        protect(scriptExecutionContext())->enqueueTaskWhenSettled(internalDecoder->flush(), TaskSource::MediaElement, [weakThis = ThreadSafeWeakPtr { *this }, pendingActivity = makePendingActivity(*this), promise = WTF::move(promise)] (auto&&) {
             promise->resolve();
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->m_pendingFlushPromises.removeFirstMatching([&](auto& flushPromise) { return promise.ptr() == flushPromise.ptr(); });

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
@@ -213,7 +213,7 @@ const SecurityOriginData& DatabaseContext::securityOrigin() const
 
 bool DatabaseContext::isContextThread() const
 {
-    return protectedScriptExecutionContext()->isContextThread();
+    return protect(scriptExecutionContext())->isContextThread();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -427,7 +427,7 @@ ExceptionOr<void> WebSocket::close(std::optional<unsigned short> optionalCode, c
             return Exception { ExceptionCode::InvalidAccessError };
         CString utf8 = reason.utf8(StrictConversionReplacingUnpairedSurrogatesWithFFFD);
         if (utf8.length() > maxReasonSizeInBytes) {
-            protectedScriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "WebSocket close message is too long."_s);
+            protect(scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "WebSocket close message is too long."_s);
             return Exception { ExceptionCode::SyntaxError };
         }
     }
@@ -581,7 +581,7 @@ void WebSocket::didReceiveBinaryData(Vector<uint8_t>&& binaryData)
         switch (socket.m_binaryType) {
         case BinaryType::Blob:
             // FIXME: We just received the data from NetworkProcess, and are sending it back. This is inefficient.
-            socket.dispatchEvent(MessageEvent::create(Blob::create(socket.protectedScriptExecutionContext().get(), WTF::move(binaryData), emptyString()), socket.m_origin.copyRef()));
+            socket.dispatchEvent(MessageEvent::create(Blob::create(protect(socket.scriptExecutionContext()).get(), WTF::move(binaryData), emptyString()), socket.m_origin.copyRef()));
             break;
         case BinaryType::Arraybuffer:
             socket.dispatchEvent(MessageEvent::create(ArrayBuffer::create(binaryData), socket.m_origin.copyRef()));

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -103,7 +103,6 @@ public:
     void setBinaryType(BinaryType);
 
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
 private:
     explicit WebSocket(ScriptExecutionContext&);

--- a/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp
+++ b/Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp
@@ -42,7 +42,7 @@ ExceptionOr<Ref<WebTransportReceiveStream>> WebTransportReceiveStream::create(We
     if (result.hasException())
         return result.releaseException();
 
-    return adoptRef(*new WebTransportReceiveStream(globalObject.protectedScriptExecutionContext().get(), identifier, session, result.releaseReturnValue()));
+    return adoptRef(*new WebTransportReceiveStream(protect(globalObject.scriptExecutionContext()).get(), identifier, session, result.releaseReturnValue()));
 }
 
 WebTransportReceiveStream::WebTransportReceiveStream(ScriptExecutionContext* context, WebTransportStreamIdentifier identifier, WebTransportSession& session, Ref<InternalReadableStream>&& stream)

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -229,7 +229,7 @@ void AnimationTimelinesController::updateAnimationsAndSendEvents(ReducedResoluti
 
         // 7. Dispatch each of the events in events to dispatch at their corresponding target using the order established in the previous step.
         for (auto& event : events)
-            event->protectedTarget()->dispatchEvent(event);
+            protect(event->target())->dispatchEvent(event);
     }
 
     // This will cancel any scheduled invalidation if we end up removing all animations.

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -190,7 +190,6 @@ public:
 
     // ContextDestructionObserver.
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void contextDestroyed() final;
 
 protected:

--- a/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
+++ b/Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp
@@ -133,7 +133,7 @@ void reportException(JSGlobalObject* lexicalGlobalObject, JSC::Exception* except
     }
 
     auto errorMessage = retrieveErrorMessage(*lexicalGlobalObject, vm, exception->value(), scope);
-    globalObject->protectedScriptExecutionContext()->reportException(errorMessage, lineNumber, columnNumber, exceptionSourceURL, exception, callStack->size() ? callStack.ptr() : nullptr, cachedScript, fromModule);
+    protect(globalObject->scriptExecutionContext())->reportException(errorMessage, lineNumber, columnNumber, exceptionSourceURL, exception, callStack->size() ? callStack.ptr() : nullptr, cachedScript, fromModule);
 
     if (exceptionDetails) {
         exceptionDetails->message = errorMessage;

--- a/Source/WebCore/bindings/js/JSDOMIterator.h
+++ b/Source/WebCore/bindings/js/JSDOMIterator.h
@@ -147,7 +147,7 @@ template<typename JSIterator, typename... ArgTypes> JSC::JSValue iteratorCreate(
     ASSERT(thisObject.globalObject());
     JSDOMGlobalObject& globalObject = *thisObject.globalObject();
 
-    auto result = thisObject.wrapped().createIterator(globalObject.protectedScriptExecutionContext().get(), std::forward<ArgTypes>(args)...);
+    auto result = thisObject.wrapped().createIterator(protect(globalObject.scriptExecutionContext()).get(), std::forward<ArgTypes>(args)...);
 
     if constexpr (IsExceptionOr<decltype(result)>) {
         if (result.hasException()) [[unlikely]] {
@@ -223,7 +223,7 @@ template<typename JSIterator> JSC::JSValue iteratorForEach(JSC::JSGlobalObject& 
     if (callData.type == JSC::CallData::Type::None)
         return throwTypeError(&lexicalGlobalObject, scope, "Cannot call callback"_s);
 
-    auto iterator = thisObject.wrapped().createIterator(JSC::jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->protectedScriptExecutionContext().get());
+    auto iterator = thisObject.wrapped().createIterator(protect(JSC::jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->scriptExecutionContext()).get());
     while (auto value = iterator.next()) {
         JSC::MarkedArgumentBuffer arguments;
         appendForEachArguments<JSIterator>(lexicalGlobalObject, *thisObject.globalObject(), arguments, value);

--- a/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
+++ b/Source/WebCore/bindings/js/JSDOMPromiseDeferred.h
@@ -136,7 +136,7 @@ public:
         auto& vm = lexicalGlobalObject->vm();
         JSC::JSLockHolder locker(vm);
         auto scope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        auto jsValue = toJSNewlyCreated<IDLType>(*lexicalGlobalObject, *globalObject(), createValue(*globalObject()->protectedScriptExecutionContext()));
+        auto jsValue = toJSNewlyCreated<IDLType>(*lexicalGlobalObject, *globalObject(), createValue(*protect(globalObject()->scriptExecutionContext())));
         DEFERRED_PROMISE_HANDLE_AND_RETURN_IF_EXCEPTION(scope, lexicalGlobalObject);
         resolve(*lexicalGlobalObject, jsValue);
     }

--- a/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -206,13 +206,13 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
         if (scope.exception()) [[unlikely]] {
             auto* exception = scope.exception();
             scope.clearException();
-            event.protectedTarget()->uncaughtExceptionInEventHandler();
+            protect(event.target())->uncaughtExceptionInEventHandler();
             reportException(jsFunctionGlobalObject, exception);
             return;
         }
         callData = JSC::getCallData(handleEventFunction);
         if (callData.type == CallData::Type::None) {
-            event.protectedTarget()->uncaughtExceptionInEventHandler();
+            protect(event.target())->uncaughtExceptionInEventHandler();
             reportException(jsFunctionGlobalObject, createTypeError(lexicalGlobalObject, "'handleEvent' property of event listener should be callable"_s));
             return;
         }
@@ -248,7 +248,7 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
         }
 
         if (exception) {
-            event.protectedTarget()->uncaughtExceptionInEventHandler();
+            protect(event.target())->uncaughtExceptionInEventHandler();
             reportException(jsFunctionGlobalObject, exception);
             return true;
         }

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -244,7 +244,7 @@ JSC::JSValue ScriptController::linkAndEvaluateModuleScriptInWorld(LoadableModule
     Ref protectedFrame { m_frame.get() };
 
     NakedPtr<JSC::Exception> evaluationException;
-    auto returnValue = JSExecState::linkAndEvaluateModule(lexicalGlobalObject, Identifier::fromUid(vm, moduleScript.protectedModuleKey().get()), jsUndefined(), evaluationException);
+    auto returnValue = JSExecState::linkAndEvaluateModule(lexicalGlobalObject, Identifier::fromUid(vm, protect(moduleScript.moduleKey()).get()), jsUndefined(), evaluationException);
     if (evaluationException) {
         // FIXME: Give a chance to dump the stack trace if the "crossorigin" attribute allows.
         // https://bugs.webkit.org/show_bug.cgi?id=164539
@@ -957,12 +957,12 @@ public:
 
     void reportWarning(const String& message) const final
     {
-        m_globalObject->protectedScriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, message);
+        protect(m_globalObject->scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, message);
     }
 
     void reportError(const String& message) const final
     {
-        m_globalObject->protectedScriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Error, message);
+        protect(m_globalObject->scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Error, message);
     }
 
 private:

--- a/Source/WebCore/crypto/SubtleCrypto.cpp
+++ b/Source/WebCore/crypto/SubtleCrypto.cpp
@@ -638,7 +638,7 @@ void SubtleCrypto::encrypt(JSC::JSGlobalObject& state, AlgorithmIdentifier&& alg
             rejectWithException(promise.releaseNonNull(), ec);
     };
 
-    algorithm->encrypt(*params, key, WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protectedScriptExecutionContext(), m_workQueue);
+    algorithm->encrypt(*params, key, WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protect(scriptExecutionContext()), m_workQueue);
 }
 
 void SubtleCrypto::decrypt(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& key, BufferSource&& dataBufferSource, Ref<DeferredPromise>&& promise)
@@ -678,7 +678,7 @@ void SubtleCrypto::decrypt(JSC::JSGlobalObject& state, AlgorithmIdentifier&& alg
             rejectWithException(promise.releaseNonNull(), ec);
     };
 
-    algorithm->decrypt(*params, key, WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protectedScriptExecutionContext(), m_workQueue);
+    algorithm->decrypt(*params, key, WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protect(scriptExecutionContext()), m_workQueue);
 }
 
 void SubtleCrypto::sign(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& key, BufferSource&& dataBufferSource, Ref<DeferredPromise>&& promise)
@@ -716,7 +716,7 @@ void SubtleCrypto::sign(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algori
             rejectWithException(promise.releaseNonNull(), ec);
     };
 
-    algorithm->sign(*params, key, WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protectedScriptExecutionContext(), m_workQueue);
+    algorithm->sign(*params, key, WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protect(scriptExecutionContext()), m_workQueue);
 }
 
 void SubtleCrypto::doVerify(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& key, BufferSource&& signatureBufferSource, BufferSource&& dataBufferSource, Ref<DeferredPromise>&& promise)
@@ -755,7 +755,7 @@ void SubtleCrypto::doVerify(JSC::JSGlobalObject& state, AlgorithmIdentifier&& al
             rejectWithException(promise.releaseNonNull(), ec);
     };
 
-    algorithm->doVerify(*params, key, WTF::move(signature), WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protectedScriptExecutionContext(), m_workQueue);
+    algorithm->doVerify(*params, key, WTF::move(signature), WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protect(scriptExecutionContext()), m_workQueue);
 }
 
 void SubtleCrypto::digest(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, BufferSource&& dataBufferSource, Ref<DeferredPromise>&& promise)
@@ -783,7 +783,7 @@ void SubtleCrypto::digest(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algo
             rejectWithException(promise.releaseNonNull(), ec);
     };
 
-    algorithm->digest(WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protectedScriptExecutionContext(), m_workQueue);
+    algorithm->digest(WTF::move(data), WTF::move(callback), WTF::move(exceptionCallback), *protect(scriptExecutionContext()), m_workQueue);
 }
 
 void SubtleCrypto::generateKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&& promise)
@@ -830,7 +830,7 @@ void SubtleCrypto::generateKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&&
     // The 26 January 2017 version of the specification suggests we should perform the following task asynchronously
     // regardless what kind of keys it produces: https://www.w3.org/TR/WebCryptoAPI/#SubtleCrypto-method-generateKey
     // That's simply not efficient for AES, HMAC and EC keys. Therefore, we perform it as an async task only for RSA keys.
-    algorithm->generateKey(*params, extractable, keyUsagesBitmap, WTF::move(callback), WTF::move(exceptionCallback), *protectedScriptExecutionContext());
+    algorithm->generateKey(*params, extractable, keyUsagesBitmap, WTF::move(callback), WTF::move(exceptionCallback), *protect(scriptExecutionContext()));
 }
 
 void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, AlgorithmIdentifier&& derivedKeyType, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&& promise)
@@ -907,7 +907,7 @@ void SubtleCrypto::deriveKey(JSC::JSGlobalObject& state, AlgorithmIdentifier&& a
             rejectWithException(promise.releaseNonNull(), ec);
     };
 
-    algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *protectedScriptExecutionContext(), m_workQueue);
+    algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *protect(scriptExecutionContext()), m_workQueue);
 }
 
 void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& algorithmIdentifier, CryptoKey& baseKey, std::optional<unsigned> length, Ref<DeferredPromise>&& promise)
@@ -943,7 +943,7 @@ void SubtleCrypto::deriveBits(JSC::JSGlobalObject& state, AlgorithmIdentifier&& 
             rejectWithException(promise.releaseNonNull(), ec);
     };
 
-    algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *protectedScriptExecutionContext(), m_workQueue);
+    algorithm->deriveBits(*params, baseKey, length, WTF::move(callback), WTF::move(exceptionCallback), *protect(scriptExecutionContext()), m_workQueue);
 }
 
 void SubtleCrypto::importKey(JSC::JSGlobalObject& state, KeyFormat format, KeyDataVariant&& keyDataVariant, AlgorithmIdentifier&& algorithmIdentifier, bool extractable, Vector<CryptoKeyUsage>&& keyUsages, Ref<DeferredPromise>&& promise)
@@ -1254,7 +1254,7 @@ void SubtleCrypto::unwrapKey(JSC::JSGlobalObject& state, KeyFormat format, Buffe
         return;
     }
 
-    unwrapAlgorithm->decrypt(*unwrapParams, unwrappingKey, WTF::move(wrappedKey), WTF::move(callback), WTF::move(exceptionCallback), *protectedScriptExecutionContext(), m_workQueue);
+    unwrapAlgorithm->decrypt(*unwrapParams, unwrappingKey, WTF::move(wrappedKey), WTF::move(callback), WTF::move(exceptionCallback), *protect(scriptExecutionContext()), m_workQueue);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -119,7 +119,7 @@ void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const AtomString& f
     Ref owningFontSelector = *m_owningFontSelector;
     if (!owningFontSelector->scriptExecutionContext())
         return;
-    auto allowUserInstalledFonts = owningFontSelector->protectedScriptExecutionContext()->settingsValues().shouldAllowUserInstalledFonts ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No;
+    auto allowUserInstalledFonts = protect(owningFontSelector->scriptExecutionContext())->settingsValues().shouldAllowUserInstalledFonts ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No;
     auto capabilities = FontCache::forCurrentThread()->getFontSelectionCapabilitiesInFamily(familyName, allowUserInstalledFonts);
     if (capabilities.isEmpty())
         return;
@@ -128,7 +128,7 @@ void CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered(const AtomString& f
     for (auto item : capabilities) {
         auto face = CSSFontFace::create(owningFontSelector, nullptr, nullptr, true);
 
-        auto& pool = owningFontSelector->protectedScriptExecutionContext()->cssValuePool();
+        auto& pool = protect(owningFontSelector->scriptExecutionContext())->cssValuePool();
         face->setFamily(pool.createFontFamilyValue(familyName));
         face->setFontSelectionCapabilities(item);
         face->adoptSource(makeUniqueWithoutRefCountedCheck<CSSFontFaceSource>(face.get(), familyName));

--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -114,7 +114,7 @@ FontFaceSet& CSSFontSelector::fontFaceSet()
 {
     if (!m_fontFaceSet) {
         ASSERT(m_context);
-        m_fontFaceSet = FontFaceSet::create(protectedScriptExecutionContext(), m_cssFontFaceSet.get());
+        m_fontFaceSet = FontFaceSet::create(protect(*scriptExecutionContext()), m_cssFontFaceSet.get());
     }
 
     return *m_fontFaceSet;
@@ -214,7 +214,7 @@ void CSSFontSelector::addFontFaceRule(StyleRuleFontFace& fontFaceRule, bool isIn
     if (sizeAdjust)
         fontFace->setSizeAdjust(*sizeAdjust);
 
-    CSSFontFace::appendSources(fontFace, *srcList, protectedScriptExecutionContext().ptr(), isInitiatingElementInUserAgentShadowTree);
+    CSSFontFace::appendSources(fontFace, *srcList, protect(scriptExecutionContext()), isInitiatingElementInUserAgentShadowTree);
 
     if (RefPtr<CSSFontFace> existingFace = m_cssFontFaceSet->lookUpByCSSConnection(fontFaceRule)) {
         // This adoption is fairly subtle. Script can trigger a purge of m_cssFontFaceSet at any time,
@@ -340,7 +340,7 @@ std::optional<AtomString> CSSFontSelector::resolveGenericFamily(const FontDescri
     if (!m_context)
         return std::nullopt;
 
-    const auto& settings = protectedScriptExecutionContext()->settingsValues();
+    const auto& settings = protect(scriptExecutionContext())->settingsValues();
 
     UScriptCode script = fontDescription.script();
     auto familyNameIndex = m_fontFamilyNames.find(familyName);
@@ -452,7 +452,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     // Handle the generic math font family a bit differently.
     if (familyName == m_fontFamilyNames.at(FamilyNamesIndex::MathFamily)) {
         // First check if the user has defined a preference.
-        const auto& settings = protectedScriptExecutionContext()->settingsValues();
+        const auto& settings = protect(scriptExecutionContext())->settingsValues();
         const String& preferredMathFamily = settings.fontGenericFamilies.mathFontFamily(fontDescription.script());
         if (!preferredMathFamily.isEmpty() && familyName != preferredMathFamily) {
             auto ranges = fontRangesForFamily(fontDescription, AtomString(preferredMathFamily));
@@ -498,7 +498,7 @@ size_t CSSFontSelector::fallbackFontCount()
     if (m_isStopped)
         return 0;
 
-    return protectedScriptExecutionContext()->settingsValues().fontFallbackPrefersPictographs ? 1 : 0;
+    return protect(scriptExecutionContext())->settingsValues().fontFallbackPrefersPictographs ? 1 : 0;
 }
 
 RefPtr<Font> CSSFontSelector::fallbackFontAt(const FontDescription& fontDescription, size_t index)

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -97,7 +97,7 @@ RefPtr<FontFace> FontFaceSet::Iterator::next()
 {
     if (m_index >= m_target->size())
         return nullptr;
-    return m_target->backing()[m_index++].wrapper(m_target->protectedScriptExecutionContext().get());
+    return m_target->backing()[m_index++].wrapper(protect(m_target->scriptExecutionContext()).get());
 }
 
 FontFaceSet::PendingPromise::PendingPromise(LoadPromise&& promise)
@@ -204,7 +204,7 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
     bool waiting = false;
 
     for (auto& face : matchingFaces) {
-        pendingPromise->faces.append(face.get().wrapper(protectedScriptExecutionContext().get()));
+        pendingPromise->faces.append(face.get().wrapper(protect(scriptExecutionContext()).get()));
         if (face.get().status() == CSSFontFace::Status::Success)
             continue;
         waiting = true;

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -109,7 +109,6 @@ private:
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::FontFaceSet; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/dom/AbortSignal.cpp
+++ b/Source/WebCore/dom/AbortSignal.cpp
@@ -134,7 +134,7 @@ void AbortSignal::signalAbort(JSC::JSValue reason)
     // 2. ... if the reason is not given, set it to a new "AbortError" DOMException.
     ASSERT(reason);
     if (reason.isUndefined()) {
-        auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(protectedScriptExecutionContext()->globalObject());
+        auto* globalObject = JSC::jsCast<JSDOMGlobalObject*>(protect(scriptExecutionContext())->globalObject());
         if (!globalObject)
             return;
         reason = toJS(globalObject, globalObject, DOMException::create(ExceptionCode::AbortError));

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -98,7 +98,6 @@ private:
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::AbortSignal; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ContextDestructionObserver::protectedScriptExecutionContext;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/dom/BoundaryPoint.h
+++ b/Source/WebCore/dom/BoundaryPoint.h
@@ -36,7 +36,6 @@ struct BoundaryPoint {
     BoundaryPoint(Ref<Node>&&, unsigned);
 
     inline Document& document() const; // Defined in BoundaryPointInlines.h
-    inline Ref<Document> protectedDocument() const; // Defined in BoundaryPointInlines.h
 
     String debugDescription() const;
 };

--- a/Source/WebCore/dom/BoundaryPointInlines.h
+++ b/Source/WebCore/dom/BoundaryPointInlines.h
@@ -36,11 +36,6 @@ inline Document& BoundaryPoint::document() const
     return container->document();
 }
 
-inline Ref<Document> BoundaryPoint::protectedDocument() const
-{
-    return document();
-}
-
 BoundaryPoint makeBoundaryPointAfterNodeContents(Node& node)
 {
     return { node, node.length() };

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -96,7 +96,7 @@ private:
 BroadcastChannel::MainThreadBridge::MainThreadBridge(BroadcastChannel& channel, const String& name)
     : m_broadcastChannel(channel)
     , m_name(name.isolatedCopy())
-    , m_origin(partitionedSecurityOriginFromContext(*channel.protectedScriptExecutionContext()).isolatedCopy())
+    , m_origin(partitionedSecurityOriginFromContext(*protect(channel.scriptExecutionContext())).isolatedCopy())
 {
 }
 

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -77,7 +77,6 @@ private:
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::BroadcastChannel; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void refEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::ref(); }
     void derefEventTarget() final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/dom/ContextDestructionObserver.h
+++ b/Source/WebCore/dom/ContextDestructionObserver.h
@@ -39,7 +39,6 @@ public:
     WEBCORE_EXPORT virtual void contextDestroyed();
 
     inline ScriptExecutionContext* scriptExecutionContext() const; // Defined in ContextDestructionObserverInlines.h.
-    inline RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const; // Defined in ContextDestructionObserverInlines.h.
 
 protected:
     WEBCORE_EXPORT explicit ContextDestructionObserver(ScriptExecutionContext*);

--- a/Source/WebCore/dom/ContextDestructionObserverInlines.h
+++ b/Source/WebCore/dom/ContextDestructionObserverInlines.h
@@ -35,9 +35,4 @@ inline ScriptExecutionContext* ContextDestructionObserver::scriptExecutionContex
     return m_scriptExecutionContext.get();
 }
 
-inline RefPtr<ScriptExecutionContext> ContextDestructionObserver::protectedScriptExecutionContext() const
-{
-    return m_scriptExecutionContext.get();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/DataTransferItemList.cpp
+++ b/Source/WebCore/dom/DataTransferItemList.cpp
@@ -124,7 +124,7 @@ ExceptionOr<void> DataTransferItemList::remove(unsigned index)
     removedItem->clearListAndPutIntoDisabledMode();
     items.removeAt(index);
     if (removedItem->isFile())
-        dataTransfer->updateFileList(protectedScriptExecutionContext().get());
+        dataTransfer->updateFileList(protect(scriptExecutionContext()).get());
 
     return { };
 }
@@ -143,7 +143,7 @@ void DataTransferItemList::clear()
     }
 
     if (removedItemContainingFile)
-        dataTransfer->updateFileList(protectedScriptExecutionContext().get());
+        dataTransfer->updateFileList(protect(scriptExecutionContext()).get());
 }
 
 Vector<Ref<DataTransferItem>>& DataTransferItemList::ensureItems() const

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -199,17 +199,12 @@ ExceptionOr<void> DatasetDOMStringMap::setNamedItem(const String& name, const At
 {
     if (!isValidPropertyName(name))
         return Exception { ExceptionCode::SyntaxError };
-    return protectedElement()->setAttribute(convertPropertyNameToAttributeName(name), value);
+    return protect(element())->setAttribute(convertPropertyNameToAttributeName(name), value);
 }
 
 bool DatasetDOMStringMap::deleteNamedProperty(const String& name)
 {
-    return protectedElement()->removeAttribute(convertPropertyNameToAttributeName(name));
-}
-
-Ref<Element> DatasetDOMStringMap::protectedElement() const
-{
-    return m_element.get();
+    return protect(element())->removeAttribute(convertPropertyNameToAttributeName(name));
 }
 
 DatasetDOMStringMap::~DatasetDOMStringMap() = default;

--- a/Source/WebCore/dom/DatasetDOMStringMap.h
+++ b/Source/WebCore/dom/DatasetDOMStringMap.h
@@ -55,7 +55,6 @@ public:
     bool deleteNamedProperty(const String& name);
 
     Element& element() { return m_element; }
-    Ref<Element> protectedElement() const;
 
 private:
     const AtomString* item(const String& name) const;

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -53,7 +53,7 @@ public:
     static void exitFullscreen(Document&, Ref<DeferredPromise>&&);
     static bool fullscreenEnabled(Document&);
     static bool webkitFullscreenEnabled(Document& document) { return protect(document.fullscreen())->enabledByPermissionsPolicy(); }
-    static Element* webkitFullscreenElement(Document& document) { return document.ancestorElementInThisScope(protect(document.fullscreen())->protectedFullscreenElement().get()); };
+    static Element* webkitFullscreenElement(Document& document) { return document.ancestorElementInThisScope(protect(protect(document.fullscreen())->fullscreenElement()).get()); };
     WEBCORE_EXPORT static void webkitExitFullscreen(Document&);
     static bool webkitIsFullScreen(Document& document) { return protect(document.fullscreen())->isFullscreen(); };
     static bool webkitFullScreenKeyboardInputAllowed(Document& document) { return protect(document.fullscreen())->isFullscreenKeyboardInputAllowed(); };
@@ -62,7 +62,6 @@ public:
     // Helpers.
     Document& document() { return m_document; }
     const Document& document() const { return m_document; }
-    Ref<Document> protectedDocument() const { return m_document; }
     LocalFrame* frame() const;
     Element* documentElement() const { return document().documentElement(); }
     bool isSimpleFullscreenDocument() const;
@@ -70,7 +69,6 @@ public:
 
     // WHATWG Fullscreen API.
     WEBCORE_EXPORT Element* fullscreenElement() const;
-    RefPtr<Element> protectedFullscreenElement() const { return fullscreenElement(); }
     WEBCORE_EXPORT bool enabledByPermissionsPolicy() const;
     WEBCORE_EXPORT void exitFullscreen(CompletionHandler<void(ExceptionOr<void>)>&&);
     WEBCORE_EXPORT void fullyExitFullscreen();
@@ -115,14 +113,14 @@ private:
     using CompletionHandlerScope = Document::CompletionHandlerScope;
 
 #if !RELEASE_LOG_DISABLED
-    const Logger& logger() const { return protectedDocument()->logger(); }
+    const Logger& logger() const { return protect(document())->logger(); }
     uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "DocumentFullscreen"_s; }
     WTFLogChannel& logChannel() const;
 #endif
 
     Page* page() const;
-    Document* mainFrameDocument() { return protectedDocument()->mainFrameDocument(); }
+    Document* mainFrameDocument() { return protect(document())->mainFrameDocument(); }
 
     RefPtr<Element> fullscreenOrPendingElement() const { return m_fullscreenElement ? m_fullscreenElement : m_pendingFullscreenElement; }
 

--- a/Source/WebCore/dom/DocumentImmersive.cpp
+++ b/Source/WebCore/dom/DocumentImmersive.cpp
@@ -56,7 +56,7 @@ Element* DocumentImmersive::immersiveElement(Document& document)
     RefPtr documentImmersive = document.immersiveIfExists();
     if (!documentImmersive)
         return nullptr;
-    return document.ancestorElementInThisScope(documentImmersive->protectedImmersiveElement().get());
+    return document.ancestorElementInThisScope(protect(documentImmersive->immersiveElement()).get());
 }
 
 HTMLModelElement* DocumentImmersive::immersiveElement() const

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -56,7 +56,6 @@ public:
     const Document& document() const { return m_document; }
 
     HTMLModelElement* immersiveElement() const;
-    RefPtr<HTMLModelElement> protectedImmersiveElement() const { return immersiveElement(); }
 
     void requestImmersive(HTMLModelElement*, CompletionHandler<void(ExceptionOr<void>)>&&);
     void exitImmersive(CompletionHandler<void(ExceptionOr<void>)>&&);

--- a/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp
@@ -43,7 +43,7 @@ Element* DocumentOrShadowRootFullscreen::fullscreenElement(TreeScope& treeScope)
     RefPtr documentFullscreen = document->fullscreenIfExists();
     if (!documentFullscreen)
         return nullptr;
-    return treeScope.ancestorElementInThisScope(documentFullscreen->protectedFullscreenElement().get());
+    return treeScope.ancestorElementInThisScope(protect(documentFullscreen->fullscreenElement()).get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentParser.cpp
+++ b/Source/WebCore/dom/DocumentParser.cpp
@@ -77,9 +77,4 @@ void DocumentParser::resumeScheduledTasks()
 {
 }
 
-RefPtr<Document> DocumentParser::protectedDocument() const
-{
-    return document();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/DocumentParser.h
+++ b/Source/WebCore/dom/DocumentParser.h
@@ -67,7 +67,6 @@ public:
 
     // document() will return 0 after detach() is called.
     Document* document() const { ASSERT(m_document); return m_document.get(); }
-    RefPtr<Document> protectedDocument() const;
 
     bool isParsing() const { return m_state == ParserState::Parsing; }
     bool isStopping() const { return m_state == ParserState::Stopping; }

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -140,16 +140,6 @@ void Event::setTarget(RefPtr<EventTarget>&& target)
         receivedTarget();
 }
 
-RefPtr<EventTarget> Event::protectedTarget() const
-{
-    return m_target;
-}
-
-RefPtr<EventTarget> Event::protectedCurrentTarget() const
-{
-    return m_currentTarget;
-}
-
 void Event::setCurrentTarget(RefPtr<EventTarget>&& currentTarget, std::optional<bool> isInShadowTree)
 {
     m_currentTarget = WTF::move(currentTarget);
@@ -172,7 +162,7 @@ Vector<Ref<EventTarget>> Event::composedPath(JSC::JSGlobalObject& lexicalGlobalO
         return Vector<Ref<EventTarget>>();
     if (JSC::jsCast<JSDOMGlobalObject*>(&lexicalGlobalObject)->world().shadowRootIsAlwaysOpen())
         return m_eventPath->computePathTreatingAllShadowRootsAsOpen();
-    return m_eventPath->computePathUnclosedToTarget(*protectedCurrentTarget());
+    return m_eventPath->computePathUnclosedToTarget(*protect(currentTarget()));
 }
 
 void Event::setUnderlyingEvent(Event* underlyingEvent)

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -79,11 +79,9 @@ public:
     enum EventInterfaceType interfaceType() const { return static_cast<enum EventInterfaceType>(m_eventInterface); }
 
     EventTarget* target() const { return m_target.get(); }
-    RefPtr<EventTarget> protectedTarget() const;
     void setTarget(RefPtr<EventTarget>&&);
 
     EventTarget* currentTarget() const { return m_currentTarget.get(); }
-    RefPtr<EventTarget> protectedCurrentTarget() const;
     void setCurrentTarget(RefPtr<EventTarget>&&, std::optional<bool> isInShadowTree = std::nullopt);
     bool currentTargetIsInShadowTree() const { return m_currentTargetIsInShadowTree; }
 

--- a/Source/WebCore/dom/EventContext.cpp
+++ b/Source/WebCore/dom/EventContext.cpp
@@ -75,12 +75,12 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
 #endif
 
     if (!m_node) {
-        protectedCurrentTarget()->fireEventListeners(event, phase);
+        protect(currentTarget())->fireEventListeners(event, phase);
         return;
     }
 
     if (m_type == Type::Window) [[unlikely]] {
-        protectedCurrentTarget()->fireEventListeners(event, phase);
+        protect(currentTarget())->fireEventListeners(event, phase);
         return;
     }
 
@@ -97,7 +97,7 @@ void EventContext::handleLocalEvents(Event& event, EventInvokePhase phase) const
     if (!m_node->hasEventTargetData())
         return;
 
-    protectedNode()->fireEventListeners(event, phase);
+    protect(node())->fireEventListeners(event, phase);
 }
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/dom/EventContext.h
+++ b/Source/WebCore/dom/EventContext.h
@@ -49,12 +49,9 @@ public:
     EventContext(Type, Node&, Node* currentTarget, EventTarget* origin, int closedShadowDepth);
 
     Node* node() const { return m_node.get(); }
-    RefPtr<Node> protectedNode() const { return m_node; }
     EventTarget* currentTarget() const { return m_currentTarget.get(); }
-    RefPtr<EventTarget> protectedCurrentTarget() const { return m_currentTarget; }
     bool isCurrentTargetInShadowTree() const { return m_currentTargetIsInShadowTree; }
     EventTarget* target() const { return m_target.get(); }
-    RefPtr<EventTarget> protectedTarget() const { return m_target; }
     int closedShadowDepth() const { return m_closedShadowDepth; }
 
     void handleLocalEvents(Event&, EventInvokePhase) const;
@@ -65,7 +62,6 @@ public:
     bool isWindowContext() const { return m_type == Type::Window; }
 
     Node* relatedTarget() const { return m_relatedTarget.get(); }
-    RefPtr<Node> protectedRelatedTarget() const { return m_relatedTarget; }
     void setRelatedTarget(RefPtr<Node>&&);
 
 #if ENABLE(TOUCH_EVENTS)

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -210,7 +210,7 @@ void EventDispatcher::dispatchEvent(Node& node, Event& event)
         // FIXME: We should also set shouldClearTargetsAfterDispatch to true if an EventTarget object in eventContext's touch target list
         // is a node and its root is a shadow root.
         if (eventContext.target()) {
-            shouldClearTargetsAfterDispatch = isInShadowTree(eventContext.protectedTarget().get()) || isInShadowTree(eventContext.protectedRelatedTarget().get());
+            shouldClearTargetsAfterDispatch = isInShadowTree(protect(eventContext.target()).get()) || isInShadowTree(protect(eventContext.relatedTarget()).get());
             break;
         }
     }

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -78,11 +78,6 @@ EventTarget::~EventTarget()
         eventTargetData->clear();
 }
 
-RefPtr<ScriptExecutionContext> EventTarget::protectedScriptExecutionContext() const
-{
-    return scriptExecutionContext();
-}
-
 bool EventTarget::isPaymentRequest() const
 {
     return false;

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -95,7 +95,6 @@ public:
 
     virtual enum EventTargetInterfaceType eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;
-    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
     virtual bool isPaymentRequest() const;
 

--- a/Source/WebCore/dom/InternalObserverEvery.cpp
+++ b/Source/WebCore/dom/InternalObserverEvery.cpp
@@ -53,7 +53,7 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        auto* globalObject = protect(scriptExecutionContext())->globalObject();
         ASSERT(globalObject);
 
         Ref vm = globalObject->vm();

--- a/Source/WebCore/dom/InternalObserverFind.cpp
+++ b/Source/WebCore/dom/InternalObserverFind.cpp
@@ -54,7 +54,7 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        auto* globalObject = protect(scriptExecutionContext())->globalObject();
         ASSERT(globalObject);
 
         Ref vm = globalObject->vm();

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -52,7 +52,7 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        auto* globalObject = protect(scriptExecutionContext())->globalObject();
         ASSERT(globalObject);
 
         Ref vm = globalObject->vm();

--- a/Source/WebCore/dom/InternalObserverInspect.cpp
+++ b/Source/WebCore/dom/InternalObserverInspect.cpp
@@ -65,7 +65,7 @@ public:
             }
 
             if (RefPtr subscribe = m_inspector.subscribe) {
-                auto* globalObject = protectedScriptExecutionContext()->globalObject();
+                auto* globalObject = protect(scriptExecutionContext())->globalObject();
                 ASSERT(globalObject);
 
                 Ref vm = globalObject->vm();
@@ -200,7 +200,7 @@ private:
 
     JSC::VM& vm() const
     {
-        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        auto* globalObject = protect(scriptExecutionContext())->globalObject();
         ASSERT(globalObject);
         return globalObject->vm();
     }

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -61,7 +61,7 @@ private:
             return;
         }
 
-        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        auto* globalObject = protect(scriptExecutionContext())->globalObject();
         ASSERT(globalObject);
 
         Ref vm = globalObject->vm();

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -53,7 +53,7 @@ public:
 private:
     void next(JSC::JSValue value) final
     {
-        auto* globalObject = protectedScriptExecutionContext()->globalObject();
+        auto* globalObject = protect(scriptExecutionContext())->globalObject();
         ASSERT(globalObject);
 
         Ref vm = globalObject->vm();

--- a/Source/WebCore/dom/LiveNodeList.h
+++ b/Source/WebCore/dom/LiveNodeList.h
@@ -68,7 +68,6 @@ protected:
     LiveNodeList(ContainerNode& ownerNode, LiveNodeListType, NodeListInvalidationType);
 
     inline Document& document() const;
-    inline Ref<Document> protectedDocument() const;
 
 private:
     bool isLiveNodeList() const final { return true; }

--- a/Source/WebCore/dom/LiveNodeListInlines.h
+++ b/Source/WebCore/dom/LiveNodeListInlines.h
@@ -72,11 +72,6 @@ inline Document& LiveNodeList::document() const
     return m_ownerNode->document();
 }
 
-inline Ref<Document> LiveNodeList::protectedDocument() const
-{
-    return document();
-}
-
 inline ContainerNode& LiveNodeList::rootNode() const
 {
     if (isRootedAtTreeScope() && m_ownerNode->isInTreeScope())

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -56,7 +56,6 @@ public:
     void notifyLoadWasCanceled();
 
     UniquedStringImpl* moduleKey() const { return m_moduleKey.get(); }
-    RefPtr<UniquedStringImpl> protectedModuleKey() const { return m_moduleKey; }
 
     ModuleFetchParameters& parameters() { return m_parameters.get(); }
 

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -145,7 +145,7 @@ MessagePort::~MessagePort()
 
 void MessagePort::entangle()
 {
-    MessagePortChannelProvider::protectedFromContext(*protectedScriptExecutionContext())->entangleLocalPortInThisProcessToRemote(m_identifier, m_remoteIdentifier);
+    MessagePortChannelProvider::protectedFromContext(*protect(scriptExecutionContext()))->entangleLocalPortInThisProcessToRemote(m_identifier, m_remoteIdentifier);
 }
 
 ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& globalObject, JSC::JSValue messageValue, StructuredSerializeOptions&& options)
@@ -179,7 +179,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& globalObject, JS
 
     LOG(MessagePorts, "Actually posting message to port %s (to be received by port %s)", m_identifier.logString().utf8().data(), m_remoteIdentifier.logString().utf8().data());
 
-    MessagePortChannelProvider::protectedFromContext(*protectedScriptExecutionContext())->postMessageToRemote(WTF::move(message), m_remoteIdentifier);
+    MessagePortChannelProvider::protectedFromContext(*protect(scriptExecutionContext()))->postMessageToRemote(WTF::move(message), m_remoteIdentifier);
     return { };
 }
 
@@ -230,7 +230,7 @@ void MessagePort::start()
         return;
 
     m_started = true;
-    protectedScriptExecutionContext()->processMessageWithMessagePortsSoon([pendingActivity = makePendingActivity(*this)] { });
+    protect(scriptExecutionContext())->processMessageWithMessagePortsSoon([pendingActivity = makePendingActivity(*this)] { });
 }
 
 void MessagePort::close()

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -98,7 +98,6 @@ public:
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MessagePort; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/dom/NamedNodeMap.cpp
+++ b/Source/WebCore/dom/NamedNodeMap.cpp
@@ -49,17 +49,17 @@ void NamedNodeMap::deref()
 
 RefPtr<Attr> NamedNodeMap::getNamedItem(const AtomString& name) const
 {
-    return protectedElement()->getAttributeNode(name);
+    return protect(element())->getAttributeNode(name);
 }
 
 bool NamedNodeMap::isSupportedPropertyName(const AtomString& name) const
 {
-    return protectedElement()->hasAttribute(name);
+    return protect(element())->hasAttribute(name);
 }
 
 RefPtr<Attr> NamedNodeMap::getNamedItemNS(const AtomString& namespaceURI, const AtomString& localName) const
 {
-    return protectedElement()->getAttributeNodeNS(namespaceURI, localName);
+    return protect(element())->getAttributeNodeNS(namespaceURI, localName);
 }
 
 ExceptionOr<Ref<Attr>> NamedNodeMap::removeNamedItem(const AtomString& name)
@@ -73,12 +73,7 @@ ExceptionOr<Ref<Attr>> NamedNodeMap::removeNamedItem(const AtomString& name)
     return element->detachAttribute(index);
 }
 
-Element& NamedNodeMap::element()
-{
-    return m_element.get();
-}
-
-Ref<Element> NamedNodeMap::protectedElement() const
+Element& NamedNodeMap::element() const
 {
     return m_element.get();
 }
@@ -111,7 +106,7 @@ ExceptionOr<Ref<Attr>> NamedNodeMap::removeNamedItemNS(const AtomString& namespa
 
 ExceptionOr<RefPtr<Attr>> NamedNodeMap::setNamedItem(Attr& attr)
 {
-    return protectedElement()->setAttributeNode(attr);
+    return protect(element())->setAttributeNode(attr);
 }
 
 RefPtr<Attr> NamedNodeMap::item(unsigned index) const

--- a/Source/WebCore/dom/NamedNodeMap.h
+++ b/Source/WebCore/dom/NamedNodeMap.h
@@ -56,8 +56,7 @@ public:
 
     Vector<String> supportedPropertyNames() const;
 
-    Element& element();
-    Ref<Element> protectedElement() const;
+    Element& element() const;
 
 private:
     WeakRef<Element, WeakPtrImplWithEventTargetData> m_element;

--- a/Source/WebCore/fileapi/Blob.cpp
+++ b/Source/WebCore/fileapi/Blob.cpp
@@ -291,7 +291,7 @@ void Blob::loadBlob(FileReaderLoader::ReadType readType, Function<void(BlobLoade
         pendingActivity->object().m_blobLoaders.take(&blobLoader);
     });
 
-    blobLoader->start(*this, protectedScriptExecutionContext().get(), readType);
+    blobLoader->start(*this, protect(scriptExecutionContext()).get(), readType);
 
     if (blobLoader->isLoading())
         m_blobLoaders.add(WTF::move(blobLoader));

--- a/Source/WebCore/fileapi/FileReader.cpp
+++ b/Source/WebCore/fileapi/FileReader.cpp
@@ -135,7 +135,7 @@ ExceptionOr<void> FileReader::readInternal(Blob& blob, FileReaderLoader::ReadTyp
     m_loader = loader.copyRef();
     loader->setEncoding(m_encoding);
     loader->setDataType(m_blob->type());
-    loader->start(protectedScriptExecutionContext().get(), blob);
+    loader->start(protect(scriptExecutionContext()).get(), blob);
 
     return { };
 }

--- a/Source/WebCore/fileapi/FileReader.h
+++ b/Source/WebCore/fileapi/FileReader.h
@@ -90,7 +90,6 @@ private:
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::FileReader; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/html/DOMFormData.cpp
+++ b/Source/WebCore/html/DOMFormData.cpp
@@ -97,10 +97,10 @@ static auto createFileEntry(const String& name, Blob& blob, const String& filena
 
     if (RefPtr file = dynamicDowncast<File>(blob)) {
         if (!filename.isNull())
-            return { usvName, File::create(blob.protectedScriptExecutionContext().get(), *file, filename) };
+            return { usvName, File::create(protect(blob.scriptExecutionContext()).get(), *file, filename) };
         return { usvName, WTF::move(file) };
     }
-    return { usvName, File::create(blob.protectedScriptExecutionContext().get(), blob, filename.isNull() ? "blob"_s : filename) };
+    return { usvName, File::create(protect(blob.scriptExecutionContext()).get(), blob, filename.isNull() ? "blob"_s : filename) };
 }
 
 void DOMFormData::append(const String& name, const String& value)

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -294,7 +294,7 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
             return;
         }
 
-        handlePopoverTargetAction(event.protectedTarget().get());
+        handlePopoverTargetAction(protect(event.target()).get());
     }
 
     if (RefPtr keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -73,7 +73,6 @@ public:
     static Ref<HTMLCanvasElement> create(const QualifiedName&, Document&);
     virtual ~HTMLCanvasElement();
 
-    using HTMLElement::protectedScriptExecutionContext;
 
     WEBCORE_EXPORT ExceptionOr<void> setWidth(unsigned);
     WEBCORE_EXPORT ExceptionOr<void> setHeight(unsigned);

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3879,7 +3879,7 @@ void HTMLMediaElement::setAudioOutputDevice(String&& deviceId, DOMPromiseDeferre
     if (RefPtr player = m_player)
         player->audioOutputDeviceChanged();
 
-    protectedScriptExecutionContext()->checkedEventLoop()->queueTask(TaskSource::MediaElement, [this, protectedThis = Ref { *this }, deviceId = WTF::move(deviceId), promise = WTF::move(promise)]() mutable {
+    protect(scriptExecutionContext())->checkedEventLoop()->queueTask(TaskSource::MediaElement, [this, protectedThis = Ref { *this }, deviceId = WTF::move(deviceId), promise = WTF::move(promise)]() mutable {
         m_audioOutputHashedDeviceId = WTF::move(deviceId);
         promise.resolve();
     });
@@ -5086,7 +5086,7 @@ void HTMLMediaElement::mediaPlayerDidAddAudioTrack(AudioTrackPrivate& track)
         setAutoplayEventPlaybackState(AutoplayEventPlaybackState::PreventedAutoplay);
     }
 
-    addAudioTrack(AudioTrack::create(protectedScriptExecutionContext().get(), track));
+    addAudioTrack(AudioTrack::create(protect(scriptExecutionContext()).get(), track));
 }
 
 void HTMLMediaElement::mediaPlayerDidAddTextTrack(InbandTextTrackPrivate& track)
@@ -5123,7 +5123,7 @@ void HTMLMediaElement::mediaPlayerDidAddTextTrack(InbandTextTrackPrivate& track)
 
 void HTMLMediaElement::mediaPlayerDidAddVideoTrack(VideoTrackPrivate& track)
 {
-    addVideoTrack(VideoTrack::create(protectedScriptExecutionContext().get(), track));
+    addVideoTrack(VideoTrack::create(protect(scriptExecutionContext()).get(), track));
 }
 
 void HTMLMediaElement::mediaPlayerDidRemoveAudioTrack(AudioTrackPrivate& track)
@@ -5309,7 +5309,7 @@ ExceptionOr<Ref<TextTrack>> HTMLMediaElement::addTextTrack(const AtomString& kin
 AudioTrackList& HTMLMediaElement::ensureAudioTracks()
 {
     if (!m_audioTracks) {
-        lazyInitialize(m_audioTracks, AudioTrackList::create(ActiveDOMObject::protectedScriptExecutionContext().get()));
+        lazyInitialize(m_audioTracks, AudioTrackList::create(protect(ActiveDOMObject::scriptExecutionContext()).get()));
         m_audioTracks->setOpaqueRootObserver(m_opaqueRootProvider);
     }
 
@@ -5319,7 +5319,7 @@ AudioTrackList& HTMLMediaElement::ensureAudioTracks()
 TextTrackList& HTMLMediaElement::ensureTextTracks()
 {
     if (!m_textTracks) {
-        lazyInitialize(m_textTracks, TextTrackList::create(ActiveDOMObject::protectedScriptExecutionContext().get()));
+        lazyInitialize(m_textTracks, TextTrackList::create(protect(ActiveDOMObject::scriptExecutionContext()).get()));
         m_textTracks->setOpaqueRootObserver(m_opaqueRootProvider);
         m_textTracks->setDuration(durationMediaTime());
     }
@@ -5330,7 +5330,7 @@ TextTrackList& HTMLMediaElement::ensureTextTracks()
 VideoTrackList& HTMLMediaElement::ensureVideoTracks()
 {
     if (!m_videoTracks) {
-        lazyInitialize(m_videoTracks, VideoTrackList::create(ActiveDOMObject::protectedScriptExecutionContext().get()));
+        lazyInitialize(m_videoTracks, VideoTrackList::create(protect(ActiveDOMObject::scriptExecutionContext()).get()));
         m_videoTracks->setOpaqueRootObserver(m_opaqueRootProvider);
     }
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -193,7 +193,6 @@ public:
     // ActiveDOMObject, AudioSessionConfigurationChangeObserver.
     void ref() const final { HTMLElement::ref(); }
     void deref() const final { HTMLElement::deref(); }
-    using HTMLElement::protectedScriptExecutionContext;
 
     MediaPlayer* player() const { return m_player.get(); }
     RefPtr<MediaPlayer> protectedPlayer() const { return m_player; }

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -151,12 +151,12 @@ void HTMLScriptElement::unblockRendering()
 // https://html.spec.whatwg.org/multipage/scripting.html#dom-script-text
 ExceptionOr<void> HTMLScriptElement::setText(Variant<RefPtr<TrustedScript>, String>&& value)
 {
-    return setTextContent(trustedTypeCompliantString(*protectedScriptExecutionContext(), WTF::move(value), "HTMLScriptElement text"_s));
+    return setTextContent(trustedTypeCompliantString(*protect(scriptExecutionContext()), WTF::move(value), "HTMLScriptElement text"_s));
 }
 
 ExceptionOr<void> HTMLScriptElement::setTextContent(std::optional<Variant<RefPtr<TrustedScript>, String>>&& value)
 {
-    return setTextContent(trustedTypeCompliantString(*protectedScriptExecutionContext(), value ? WTF::move(*value) : emptyString(), "HTMLScriptElement textContent"_s));
+    return setTextContent(trustedTypeCompliantString(*protect(scriptExecutionContext()), value ? WTF::move(*value) : emptyString(), "HTMLScriptElement textContent"_s));
 }
 
 ExceptionOr<void> HTMLScriptElement::setTextContent(ExceptionOr<String> value)
@@ -173,7 +173,7 @@ ExceptionOr<void> HTMLScriptElement::setTextContent(ExceptionOr<String> value)
 
 ExceptionOr<void> HTMLScriptElement::setInnerText(Variant<RefPtr<TrustedScript>, String>&& value)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*protectedScriptExecutionContext(), WTF::move(value), "HTMLScriptElement innerText"_s);
+    auto stringValueHolder = trustedTypeCompliantString(*protect(scriptExecutionContext()), WTF::move(value), "HTMLScriptElement innerText"_s);
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
 
@@ -207,7 +207,7 @@ String HTMLScriptElement::src() const
 
 ExceptionOr<void> HTMLScriptElement::setSrc(Variant<RefPtr<TrustedScriptURL>, String>&& value)
 {
-    auto stringValueHolder = trustedTypeCompliantString(*protectedScriptExecutionContext(), WTF::move(value), "HTMLScriptElement src"_s);
+    auto stringValueHolder = trustedTypeCompliantString(*protect(scriptExecutionContext()), WTF::move(value), "HTMLScriptElement src"_s);
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
 

--- a/Source/WebCore/html/HTMLSummaryElement.cpp
+++ b/Source/WebCore/html/HTMLSummaryElement.cpp
@@ -95,7 +95,7 @@ void HTMLSummaryElement::defaultEventHandler(Event& event)
 {
     if (isActiveSummary()) {
         auto& eventNames = WebCore::eventNames();
-        if (event.type() == eventNames.DOMActivateEvent && !isInSummaryInteractiveContent(event.protectedTarget().get())) {
+        if (event.type() == eventNames.DOMActivateEvent && !isInSummaryInteractiveContent(protect(event.target()).get())) {
             if (RefPtr<HTMLDetailsElement> details = detailsElement())
                 details->toggleOpen();
             event.setDefaultHandled();

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -811,7 +811,7 @@ private:
     void createImageBitmapAndCallCompletionHandlerSoon(RefPtr<ArrayBuffer>&& arrayBuffer)
     {
         m_arrayBufferToProcess = WTF::move(arrayBuffer);
-        protectedScriptExecutionContext()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakThis = WeakPtr { *this }] {
+        protect(scriptExecutionContext())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakThis = WeakPtr { *this }] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->createImageBitmapAndCallCompletionHandler();
         });

--- a/Source/WebCore/html/PublicURLManager.cpp
+++ b/Source/WebCore/html/PublicURLManager.cpp
@@ -55,7 +55,7 @@ void PublicURLManager::registerURL(const URL& url, URLRegistrable& registrable)
     if (m_isStopped || !scriptExecutionContext())
         return;
 
-    registrable.registry().registerURL(*protectedScriptExecutionContext(), url, registrable);
+    registrable.registry().registerURL(*protect(scriptExecutionContext()), url, registrable);
 }
 
 void PublicURLManager::revoke(const URL& url)

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -77,7 +77,7 @@ void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum ta
     context->graphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    context->protectedScriptExecutionContext()->checkedEventLoop()->queueMicrotask([&] {
+    protect(context->scriptExecutionContext())->checkedEventLoop()->queueMicrotask([&] {
         query.makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -72,7 +72,7 @@ void PlaceholderRenderingContextSource::setPlaceholderBuffer(ImageBuffer& imageB
         RefPtr placeholder = weakPlaceholder.get();
         if (!placeholder)
             return;
-        RefPtr imageBuffer = SerializedImageBuffer::sinkIntoImageBuffer(WTF::move(buffer), placeholder->protectedCanvas()->protectedScriptExecutionContext()->graphicsClient());
+        RefPtr imageBuffer = SerializedImageBuffer::sinkIntoImageBuffer(WTF::move(buffer), protect(placeholder->protectedCanvas()->scriptExecutionContext())->graphicsClient());
         if (!imageBuffer)
             return;
         Ref source = placeholder->source();

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1809,7 +1809,7 @@ void WebGL2RenderingContext::endQuery(GCGLenum target)
     graphicsContextGL()->endQuery(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    protectedScriptExecutionContext()->checkedEventLoop()->queueMicrotask([query = WTF::move(m_activeQueries[*activeQueryKey])] {
+    protect(scriptExecutionContext())->checkedEventLoop()->queueMicrotask([query = WTF::move(m_activeQueries[*activeQueryKey])] {
         query->makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -491,7 +491,7 @@ WebGLRenderingContextBase::WebGLRenderingContextBase(CanvasBase& canvas, CanvasR
     , m_generatedImageCache(4)
     , m_attributes(WTF::move(attributes))
     , m_creationAttributes(m_attributes)
-    , m_numGLErrorsToConsoleAllowed(protectedScriptExecutionContext()->settingsValues().webGLErrorsToConsoleEnabled ? maxGLErrorsAllowedToConsole : 0)
+    , m_numGLErrorsToConsoleAllowed(protect(scriptExecutionContext())->settingsValues().webGLErrorsToConsoleEnabled ? maxGLErrorsAllowedToConsole : 0)
 {
     ASSERT(isWebGL());
 }

--- a/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandWebVTTTextTrack.cpp
@@ -60,7 +60,7 @@ WebVTTParser& InbandWebVTTTextTrack::parser()
 {
     ASSERT(is<Document>(scriptExecutionContext()));
     if (!m_webVTTParser)
-        m_webVTTParser = makeUnique<WebVTTParser>(static_cast<WebVTTParserClient&>(*this), downcast<Document>(*protectedScriptExecutionContext()));
+        m_webVTTParser = makeUnique<WebVTTParser>(static_cast<WebVTTParserClient&>(*this), downcast<Document>(*protect(scriptExecutionContext())));
     return *m_webVTTParser;
 }
 

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -407,7 +407,7 @@ void VTTRegion::scrollTimerFired()
 
 RefPtr<Document> VTTRegion::protectedDocument() const
 {
-    return downcast<Document>(protectedScriptExecutionContext());
+    return downcast<Document>(protect(scriptExecutionContext()));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/InspectorCanvasCallTracer.cpp
+++ b/Source/WebCore/inspector/InspectorCanvasCallTracer.cpp
@@ -39,7 +39,7 @@ static InspectorCanvasAgent* enabledCanvasAgent(CanvasRenderingContext& canvasRe
 {
     ASSERT(InspectorInstrumentationPublic::hasFrontends());
 
-    RefPtr agents = InspectorInstrumentation::instrumentingAgents(canvasRenderingContext.canvasBase().protectedScriptExecutionContext().get());
+    RefPtr agents = InspectorInstrumentation::instrumentingAgents(protect(canvasRenderingContext.canvasBase().scriptExecutionContext()).get());
     ASSERT(agents);
     if (!agents)
         return nullptr;

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1140,7 +1140,7 @@ void InspectorInstrumentation::didEnableExtensionImpl(InstrumentingAgents& instr
 void InspectorInstrumentation::willDestroyWebGLProgram(WebGLProgram& program)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    if (RefPtr agents = instrumentingAgents(program.protectedScriptExecutionContext().get()))
+    if (RefPtr agents = instrumentingAgents(protect(program.scriptExecutionContext()).get()))
         willDestroyWebGLProgramImpl(*agents, program);
 }
 

--- a/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
+++ b/Source/WebCore/inspector/agents/WebDebuggerAgent.cpp
@@ -82,7 +82,7 @@ void WebDebuggerAgent::didAddEventListener(EventTarget& target, const AtomString
     if (m_registeredEventListeners.contains(registeredListener.ptr()))
         return;
 
-    auto* globalObject = target.protectedScriptExecutionContext()->globalObject();
+    auto* globalObject = protect(target.scriptExecutionContext())->globalObject();
     if (!globalObject)
         return;
 

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -425,7 +425,7 @@ Seconds DOMTimer::intervalClampedToMinimum() const
         return interval;
 
     // Apply two throttles - the global (per Page) minimum, and also a per-timer throttle.
-    interval = std::max(interval, protectedScriptExecutionContext()->minimumDOMTimerInterval());
+    interval = std::max(interval, protect(scriptExecutionContext())->minimumDOMTimerInterval());
     if (m_throttleState == ShouldThrottle)
         interval = std::max(interval, minIntervalForNonUserObservableChangeTimers);
     return interval;

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -80,7 +80,6 @@ private:
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::EventSource; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -788,7 +788,7 @@ BarProp& LocalDOMWindow::toolbar()
 Navigator& LocalDOMWindow::navigator()
 {
     if (!m_navigator)
-        m_navigator = Navigator::create(protectedScriptExecutionContext().get(), *this);
+        m_navigator = Navigator::create(protect(scriptExecutionContext()).get(), *this);
     ASSERT(m_navigator->scriptExecutionContext() == document());
 
     return *m_navigator;

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -390,7 +390,6 @@ private:
     explicit LocalDOMWindow(Document&);
 
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ContextDestructionObserver::protectedScriptExecutionContext;
 
     void closePage() final;
     void eventListenersDidChange() final;

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -49,7 +49,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(NavigationHistoryEntry);
 
 NavigationHistoryEntry::NavigationHistoryEntry(Navigation& navigation, const DocumentState& originalDocumentState, Ref<HistoryItem>&& historyItem, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state, WTF::UUID id)
-    : ActiveDOMObject(navigation.protectedScriptExecutionContext().get())
+    : ActiveDOMObject(protect(navigation.scriptExecutionContext()).get())
     , m_navigation(navigation)
     , m_urlString(urlString)
     , m_key(key)
@@ -62,7 +62,7 @@ NavigationHistoryEntry::NavigationHistoryEntry(Navigation& navigation, const Doc
 
 Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(Navigation& navigation, Ref<HistoryItem>&& historyItem)
 {
-    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(navigation.protectedScriptExecutionContext().get()), WTF::move(historyItem), historyItem->urlString(), historyItem->uuidIdentifier()));
+    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(protect(navigation.scriptExecutionContext()).get()), WTF::move(historyItem), historyItem->urlString(), historyItem->uuidIdentifier()));
     entry->suspendIfNeeded();
     return entry;
 }
@@ -73,7 +73,7 @@ Ref<NavigationHistoryEntry> NavigationHistoryEntry::create(Navigation& navigatio
     RefPtr state = historyItem->navigationAPIStateObject();
     if (!state)
         state = other.m_state;
-    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(other.protectedScriptExecutionContext().get()), WTF::move(historyItem), other.m_urlString, other.m_key, WTF::move(state), other.m_id));
+    Ref entry = adoptRef(*new NavigationHistoryEntry(navigation, DocumentState::fromContext(protect(other.scriptExecutionContext()).get()), WTF::move(historyItem), other.m_urlString, other.m_key, WTF::move(state), other.m_id));
     entry->suspendIfNeeded();
     return entry;
 }

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -87,7 +87,6 @@ private:
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/page/NavigatorBase.cpp
+++ b/Source/WebCore/page/NavigatorBase.cpp
@@ -171,7 +171,7 @@ ServiceWorkerContainer& NavigatorBase::serviceWorker()
 {
     ASSERT(!scriptExecutionContext() || scriptExecutionContext()->settingsValues().serviceWorkersEnabled);
     if (!m_serviceWorkerContainer)
-        m_serviceWorkerContainer = ServiceWorkerContainer::create(protectedScriptExecutionContext().get(), *this).moveToUniquePtr();
+        m_serviceWorkerContainer = ServiceWorkerContainer::create(protect(scriptExecutionContext()).get(), *this).moveToUniquePtr();
     return *m_serviceWorkerContainer;
 }
 

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -269,7 +269,7 @@ void Worker::dispatchEvent(Event& event)
 
     AbstractWorker::dispatchEvent(event);
     if (auto* errorEvent = dynamicDowncast<ErrorEvent>(event); errorEvent && !event.defaultPrevented() && event.isTrusted() && scriptExecutionContext())
-        protectedScriptExecutionContext()->reportException(errorEvent->message(), errorEvent->lineno(), errorEvent->colno(), errorEvent->filename(), nullptr, nullptr);
+        protect(scriptExecutionContext())->reportException(errorEvent->message(), errorEvent->lineno(), errorEvent->colno(), errorEvent->filename(), nullptr, nullptr);
 }
 
 void Worker::reportError(const String& errorMessage)

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -79,7 +79,6 @@ public:
     const String& name() const { return m_options.name; }
 
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     void dispatchEvent(Event&) final;
     void reportError(const String&);

--- a/Source/WebCore/workers/WorkerEventLoop.cpp
+++ b/Source/WebCore/workers/WorkerEventLoop.cpp
@@ -60,7 +60,7 @@ void WorkerEventLoop::scheduleToRun()
 
 bool WorkerEventLoop::isContextThread() const
 {
-    return protectedScriptExecutionContext()->isContextThread();
+    return protect(scriptExecutionContext())->isContextThread();
 }
 
 MicrotaskQueue& WorkerEventLoop::microtaskQueue()

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -114,7 +114,7 @@ static ScriptExecutionContextIdentifier loaderContextIdentifierFromContext(const
 WorkerMessagingProxy::WorkerMessagingProxy(Worker& workerObject)
     : m_scriptExecutionContext(workerObject.scriptExecutionContext())
     , m_scriptExecutionContextIdentifier(m_scriptExecutionContext ? std::optional { m_scriptExecutionContext->identifier() } : std::nullopt)
-    , m_loaderContextIdentifier(loaderContextIdentifierFromContext(*workerObject.protectedScriptExecutionContext()))
+    , m_loaderContextIdentifier(loaderContextIdentifierFromContext(*protect(workerObject.scriptExecutionContext())))
     , m_inspectorProxy(WorkerInspectorProxy::create(workerObject.identifier()))
     , m_workerObject(&workerObject)
 {

--- a/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletScriptController.cpp
@@ -451,7 +451,7 @@ void WorkerOrWorkletScriptController::linkAndEvaluateModule(WorkerScriptFetcher&
     JSLockHolder lock { vm };
 
     NakedPtr<JSC::Exception> returnedException;
-    JSExecState::linkAndEvaluateModule(globalObject, Identifier::fromUid(vm, scriptFetcher.protectedModuleKey().get()), jsUndefined(), returnedException);
+    JSExecState::linkAndEvaluateModule(globalObject, Identifier::fromUid(vm, protect(scriptFetcher.moduleKey()).get()), jsUndefined(), returnedException);
     if ((returnedException && vm.isTerminationException(returnedException)) || isTerminatingExecution()) {
         forbidExecution();
         return;

--- a/Source/WebCore/workers/service/ServiceWorker.cpp
+++ b/Source/WebCore/workers/service/ServiceWorker.cpp
@@ -152,7 +152,7 @@ void ServiceWorker::stop()
 {
     m_isStopped = true;
     removeAllEventListeners();
-    protectedScriptExecutionContext()->unregisterServiceWorker(*this);
+    protect(scriptExecutionContext())->unregisterServiceWorker(*this);
     updatePendingActivityForEventDispatch();
 }
 

--- a/Source/WebCore/workers/service/ServiceWorker.h
+++ b/Source/WebCore/workers/service/ServiceWorker.h
@@ -81,7 +81,6 @@ private:
 
     enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.h
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.h
@@ -147,7 +147,6 @@ private:
     Ref<SWClientConnection> ensureProtectedSWClientConnection();
 
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ServiceWorkerContainer; }
     void refEventTarget() final;
     void derefEventTarget() final;

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -377,7 +377,7 @@ void ServiceWorkerRegistration::addCookieChangeSubscriptions(Vector<CookieStoreG
         if (subscription.url.isNull())
             url = scope();
         else {
-            url = protectedScriptExecutionContext()->completeURL(subscription.url).string();
+            url = protect(scriptExecutionContext())->completeURL(subscription.url).string();
             if (!url.startsWith(scope())) {
                 promise->reject(Exception { ExceptionCode::TypeError, "The service worker cannot subcribe to cookie changes for URLs outside of its scope"_s });
                 return;
@@ -405,7 +405,7 @@ void ServiceWorkerRegistration::removeCookieChangeSubscriptions(Vector<CookieSto
         if (subscription.url.isNull())
             url = scope();
         else {
-            url = protectedScriptExecutionContext()->completeURL(subscription.url).string();
+            url = protect(scriptExecutionContext())->completeURL(subscription.url).string();
             if (!url.startsWith(scope())) {
                 promise->reject(Exception { ExceptionCode::TypeError, "The service worker cannot unsubcribe from cookie changes for URLs outside of its scope"_s });
                 return;

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -122,7 +122,6 @@ private:
 
     enum EventTargetInterfaceType eventTargetInterface() const final;
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 

--- a/Source/WebCore/workers/shared/SharedWorker.h
+++ b/Source/WebCore/workers/shared/SharedWorker.h
@@ -63,7 +63,6 @@ public:
 
     // EventTarget.
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     void reportNetworkUsage(size_t bytesTransferredOverNetworkDelta);
 

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
@@ -59,7 +59,7 @@ void SharedWorkerScriptLoader::load(CompletionHandler<void(WorkerFetchResult&&, 
     m_completionHandler = WTF::move(completionHandler);
 
     auto source = m_options.type == WorkerType::Module ? WorkerScriptLoader::Source::ModuleScript : WorkerScriptLoader::Source::ClassicWorkerScript;
-    m_loader->loadAsynchronously(*m_worker->protectedScriptExecutionContext(), ResourceRequest(URL { m_url }), source, m_worker->workerFetchOptions(m_options, FetchOptions::Destination::Sharedworker), ContentSecurityPolicyEnforcement::EnforceWorkerSrcDirective, ServiceWorkersMode::All, *this, WorkerRunLoop::defaultMode(), ScriptExecutionContextIdentifier::generate());
+    m_loader->loadAsynchronously(*protect(m_worker->scriptExecutionContext()), ResourceRequest(URL { m_url }), source, m_worker->workerFetchOptions(m_options, FetchOptions::Destination::Sharedworker), ContentSecurityPolicyEnforcement::EnforceWorkerSrcDirective, ServiceWorkersMode::All, *this, WorkerRunLoop::defaultMode(), ScriptExecutionContextIdentifier::generate());
 }
 
 void SharedWorkerScriptLoader::didReceiveResponse(ScriptExecutionContextIdentifier mainContextIdentifier, std::optional<ResourceLoaderIdentifier> identifier, const ResourceResponse&)

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -215,7 +215,7 @@ Ref<Blob> XMLHttpRequest::createResponseBlob()
     Vector<uint8_t> data;
     if (m_binaryResponseBuilder)
         data = m_binaryResponseBuilder.takeBuffer()->extractData();
-    return Blob::create(protectedScriptExecutionContext().get(), WTF::move(data), responseMIMEType(FinalMIMEType::Yes)); // responseMIMEType defaults to text/xml which may be incorrect.
+    return Blob::create(protect(scriptExecutionContext()).get(), WTF::move(data), responseMIMEType(FinalMIMEType::Yes)); // responseMIMEType defaults to text/xml which may be incorrect.
 }
 
 RefPtr<ArrayBuffer> XMLHttpRequest::createResponseArrayBuffer()
@@ -336,7 +336,7 @@ ExceptionOr<void> XMLHttpRequest::setWithCredentials(bool value)
 ExceptionOr<void> XMLHttpRequest::open(const String& method, const String& url)
 {
     // If the async argument is omitted, set async to true.
-    return open(method, protectedScriptExecutionContext()->completeURL(url), true);
+    return open(method, protect(scriptExecutionContext())->completeURL(url), true);
 }
 
 ExceptionOr<void> XMLHttpRequest::open(const String& method, const URL& url, bool async)
@@ -400,7 +400,7 @@ ExceptionOr<void> XMLHttpRequest::open(const String& method, const URL& url, boo
 
 ExceptionOr<void> XMLHttpRequest::open(const String& method, const String& url, bool async, const String& user, const String& password)
 {
-    auto urlWithCredentials = protectedScriptExecutionContext()->completeURL(url);
+    auto urlWithCredentials = protect(scriptExecutionContext())->completeURL(url);
     if (!user.isNull())
         urlWithCredentials.setUser(user);
     if (!password.isNull())
@@ -445,7 +445,7 @@ std::optional<ExceptionOr<void>> XMLHttpRequest::prepareToSend()
 
 ExceptionOr<void> XMLHttpRequest::send(std::optional<SendTypes>&& sendType)
 {
-    InspectorInstrumentation::willSendXMLHttpRequest(protectedScriptExecutionContext().get(), url().string());
+    InspectorInstrumentation::willSendXMLHttpRequest(protect(scriptExecutionContext()).get(), url().string());
     m_userGestureToken = UserGestureIndicator::currentUserGesture();
 
     ExceptionOr<void> result;
@@ -528,7 +528,7 @@ ExceptionOr<void> XMLHttpRequest::send(Blob& body)
             // but because of the architecture of blob-handling that will require a fair amount of work.
 
             ASCIILiteral consoleMessage { "POST of a Blob to non-HTTP protocols in XMLHttpRequest.send() is currently unsupported."_s };
-            protectedScriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, consoleMessage);
+            protect(scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, consoleMessage);
 
             return createRequest();
         }
@@ -570,7 +570,7 @@ ExceptionOr<void> XMLHttpRequest::send(DOMFormData& body)
 ExceptionOr<void> XMLHttpRequest::send(ArrayBuffer& body)
 {
     ASCIILiteral consoleMessage { "ArrayBuffer is deprecated in XMLHttpRequest.send(). Use ArrayBufferView instead."_s };
-    protectedScriptExecutionContext()->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, consoleMessage);
+    protect(scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, consoleMessage);
     return sendBytesData(body.span());
 }
 
@@ -807,7 +807,7 @@ ExceptionOr<void> XMLHttpRequest::setRequestHeader(const String& name, const Str
         return Exception { ExceptionCode::SyntaxError };
 
     if (isForbiddenHeader(name, normalizedValue)) {
-        logConsoleError(protectedScriptExecutionContext().get(), makeString("Refused to set unsafe header \""_s, name, '"'));
+        logConsoleError(protect(scriptExecutionContext()).get(), makeString("Refused to set unsafe header \""_s, name, '"'));
         return { };
     }
 

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -80,7 +80,6 @@ public:
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::XMLHttpRequest; }
     ScriptExecutionContext* scriptExecutionContext() const final;
-    using ActiveDOMObject::protectedScriptExecutionContext;
 
     using SendTypes = Variant<RefPtr<Document>, RefPtr<Blob>, RefPtr<JSC::ArrayBufferView>, RefPtr<JSC::ArrayBuffer>, RefPtr<DOMFormData>, String, RefPtr<URLSearchParams>>;
 

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -67,7 +67,7 @@ void XMLHttpRequestProgressEventThrottle::updateProgress(bool isAsync, bool leng
         ASSERT(!m_hasPendingThrottledProgressEvent);
 
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(eventNames().progressEvent, lengthComputable, loaded, total));
-        m_dispatchThrottledProgressEventTimer = target->protectedScriptExecutionContext()->checkedEventLoop()->scheduleRepeatingTask(
+        m_dispatchThrottledProgressEventTimer = protect(target->scriptExecutionContext())->checkedEventLoop()->scheduleRepeatingTask(
             minimumProgressEventDispatchingInterval, minimumProgressEventDispatchingInterval, TaskSource::Networking, [weakTarget = WeakPtr { m_target.get() }] {
             if (RefPtr protectedTarget = weakTarget.get())
                 protectedTarget->dispatchThrottledProgressEventIfNeeded();


### PR DESCRIPTION
#### f60cfd987f2da2464b2b82388d9f111e9d1c3c01
<pre>
Reduce use of protected functions in Source/WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=307111">https://bugs.webkit.org/show_bug.cgi?id=307111</a>

Reviewed by Ryosuke Niwa and Darin Adler.

Reduce use of protected functions in Source/WebCore/dom and call
`protect()` at call sites instead.

* Source/WebCore/Modules/async-clipboard/ClipboardItemBindingsDataSource.cpp:
(WebCore::ClipboardItemBindingsDataSource::getType):
* Source/WebCore/Modules/audiosession/NavigatorAudioSession.cpp:
(WebCore::NavigatorAudioSession::audioSession):
* Source/WebCore/Modules/cache/DOMCache.cpp:
(WebCore::DOMCache::requestFromInfo):
(WebCore::DOMCache::put):
* Source/WebCore/Modules/cache/DOMCacheStorage.cpp:
(WebCore::DOMCacheStorage::doRemove):
* Source/WebCore/Modules/fetch/FetchBody.cpp:
(WebCore::FetchBody::consumeAsStream):
(WebCore::FetchBody::consumeFormData):
* Source/WebCore/Modules/fetch/FetchBodyConsumer.cpp:
(WebCore::FetchBodyConsumer::resolve):
* Source/WebCore/Modules/fetch/FetchBodyOwner.cpp:
(WebCore::FetchBodyOwner::formData):
(WebCore::FetchBodyOwner::loadBlob):
* Source/WebCore/Modules/fetch/FetchRequest.cpp:
(WebCore::FetchRequest::initializeOptions):
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::watchPosition):
* Source/WebCore/Modules/identity/CredentialRequestCoordinator.cpp:
(WebCore::CredentialRequestCoordinator::prepareCredentialRequest):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::index):
* Source/WebCore/Modules/indexeddb/IDBOpenDBRequest.cpp:
(WebCore::IDBOpenDBRequest::onSuccess):
(WebCore::IDBOpenDBRequest::onUpgradeNeeded):
* Source/WebCore/Modules/indexeddb/IDBRequest.h:
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::objectStore):
(WebCore::IDBTransaction::createObjectStore):
(WebCore::IDBTransaction::createIndex):
(WebCore::IDBTransaction::doRequestOpenCursor):
(WebCore::IDBTransaction::requestGetAllObjectStoreRecords):
(WebCore::IDBTransaction::requestGetAllIndexRecords):
(WebCore::IDBTransaction::requestGetRecord):
(WebCore::IDBTransaction::requestIndexRecord):
(WebCore::IDBTransaction::requestCount):
(WebCore::IDBTransaction::requestDeleteRecord):
(WebCore::IDBTransaction::requestClearObjectStore):
(WebCore::IDBTransaction::requestPutOrAdd):
* Source/WebCore/Modules/indexeddb/IDBTransaction.h:
* Source/WebCore/Modules/mediasession/MediaSession.cpp:
(WebCore::m_coordinator):
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::MediaSource):
(WebCore::MediaSource::completeSeek):
(WebCore::MediaSource::createSourceBufferPrivate):
(WebCore::MediaSource::addAudioTrackMirrorToElement):
(WebCore::MediaSource::addTextTrackMirrorToElement):
(WebCore::MediaSource::addVideoTrackMirrorToElement):
* Source/WebCore/Modules/mediasource/MediaSource.h:
* Source/WebCore/Modules/mediasource/SourceBuffer.cpp:
(WebCore::SourceBuffer::rangeRemoval):
(WebCore::SourceBuffer::appendBufferInternal):
(WebCore::SourceBuffer::maximumBufferSize const):
(WebCore::SourceBuffer::videoTracks):
(WebCore::SourceBuffer::audioTracks):
(WebCore::SourceBuffer::textTracks):
(WebCore::SourceBuffer::sourceBufferPrivateDidReceiveInitializationSegment):
(WebCore::SourceBuffer::reportExtraMemoryAllocated):
* Source/WebCore/Modules/mediasource/SourceBuffer.h:
* Source/WebCore/Modules/mediastream/MediaStreamTrack.cpp:
(WebCore::MediaStreamTrack::clone):
(WebCore::MediaStreamTrack::trackEnded):
* Source/WebCore/Modules/mediastream/MediaStreamTrack.h:
* Source/WebCore/Modules/mediastream/RTCDTMFSender.cpp:
(WebCore::RTCDTMFSender::insertDTMF):
* Source/WebCore/Modules/mediastream/RTCDTMFSender.h:
* Source/WebCore/Modules/mediastream/RTCDataChannel.cpp:
(WebCore::RTCDataChannel::createMessageQueue):
(WebCore::RTCDataChannel::didReceiveRawData):
* Source/WebCore/Modules/mediastream/RTCDataChannel.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::getOrCreateIceTransport):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.h:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.cpp:
(WebCore::RTCRtpSFrameTransform::createStreams):
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpSender.cpp:
(WebCore::RTCRtpSender::dtmf):
* Source/WebCore/Modules/notifications/Notification.h:
* Source/WebCore/Modules/notifications/NotificationResourcesLoader.cpp:
(WebCore::NotificationResourcesLoader::start):
* Source/WebCore/Modules/paymentrequest/MerchantValidationEvent.cpp:
(WebCore::MerchantValidationEvent::complete):
* Source/WebCore/Modules/paymentrequest/PaymentRequestUpdateEvent.cpp:
(WebCore::PaymentRequestUpdateEvent::updateWith):
* Source/WebCore/Modules/screen-wake-lock/NavigatorScreenWakeLock.cpp:
(WebCore::NavigatorScreenWakeLock::wakeLock):
* Source/WebCore/Modules/streams/ReadableStream.cpp:
(WebCore::ReadableStream::createFromJSValues):
(WebCore::ReadableStream::createFromByteUnderlyingSource):
(WebCore::ReadableStream::create):
(WebCore::ReadableStream::createReadableByteStream):
* Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
(WebCore::StreamPipeToState::create):
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
* Source/WebCore/Modules/web-locks/WebLockManager.cpp:
(WebCore::WebLockManager::WebLockManager):
* Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp:
(WebCore::AudioWorkletNode::create):
* Source/WebCore/Modules/webaudio/BaseAudioContext.h:
* Source/WebCore/Modules/webcodecs/WebCodecsAudioDecoder.cpp:
(WebCore::WebCodecsAudioDecoder::configure):
(WebCore::WebCodecsAudioDecoder::decode):
(WebCore::WebCodecsAudioDecoder::flush):
* Source/WebCore/Modules/webcodecs/WebCodecsAudioEncoder.cpp:
(WebCore::WebCodecsAudioEncoder::configure):
(WebCore::WebCodecsAudioEncoder::encode):
(WebCore::WebCodecsAudioEncoder::flush):
* Source/WebCore/Modules/webcodecs/WebCodecsBase.h:
* Source/WebCore/Modules/webcodecs/WebCodecsVideoDecoder.cpp:
(WebCore::WebCodecsVideoDecoder::decode):
(WebCore::WebCodecsVideoDecoder::flush):
* Source/WebCore/Modules/webcodecs/WebCodecsVideoEncoder.cpp:
(WebCore::WebCodecsVideoEncoder::updateRates):
(WebCore::WebCodecsVideoEncoder::configure):
(WebCore::WebCodecsVideoEncoder::encode):
(WebCore::WebCodecsVideoEncoder::flush):
* Source/WebCore/Modules/webdatabase/DatabaseContext.cpp:
(WebCore::DatabaseContext::isContextThread const):
* Source/WebCore/Modules/websockets/WebSocket.cpp:
(WebCore::WebSocket::close):
(WebCore::WebSocket::didReceiveBinaryData):
* Source/WebCore/Modules/websockets/WebSocket.h:
* Source/WebCore/Modules/webtransport/WebTransportReceiveStream.cpp:
(WebCore::WebTransportReceiveStream::create):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::updateAnimationsAndSendEvents):
* Source/WebCore/animation/WebAnimation.h:
* Source/WebCore/bindings/js/JSDOMExceptionHandling.cpp:
(WebCore::reportException):
* Source/WebCore/bindings/js/JSDOMIterator.h:
(WebCore::iteratorCreate):
(WebCore::iteratorForEach):
* Source/WebCore/bindings/js/JSDOMPromiseDeferred.h:
(WebCore::DeferredPromise::resolveCallbackValueWithNewlyCreated):
* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::handleEvent):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::linkAndEvaluateModuleScriptInWorld):
* Source/WebCore/crypto/SubtleCrypto.cpp:
(WebCore::SubtleCrypto::encrypt):
(WebCore::SubtleCrypto::decrypt):
(WebCore::SubtleCrypto::sign):
(WebCore::SubtleCrypto::doVerify):
(WebCore::SubtleCrypto::digest):
(WebCore::SubtleCrypto::generateKey):
(WebCore::SubtleCrypto::deriveKey):
(WebCore::SubtleCrypto::deriveBits):
(WebCore::SubtleCrypto::unwrapKey):
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered):
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::fontFaceSet):
(WebCore::CSSFontSelector::addFontFaceRule):
(WebCore::CSSFontSelector::resolveGenericFamily):
(WebCore::CSSFontSelector::fontRangesForFamily):
(WebCore::CSSFontSelector::fallbackFontCount):
* Source/WebCore/css/FontFaceSet.cpp:
(WebCore::FontFaceSet::Iterator::next):
(WebCore::FontFaceSet::load):
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/dom/AbortSignal.cpp:
(WebCore::AbortSignal::signalAbort):
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/BoundaryPoint.h:
* Source/WebCore/dom/BoundaryPointInlines.h:
(WebCore::BoundaryPoint::protectedDocument const): Deleted.
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::MainThreadBridge::MainThreadBridge):
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/ContextDestructionObserver.h:
* Source/WebCore/dom/ContextDestructionObserverInlines.h:
(WebCore::ContextDestructionObserver::protectedScriptExecutionContext const): Deleted.
* Source/WebCore/dom/DataTransferItemList.cpp:
(WebCore::DataTransferItemList::remove):
(WebCore::DataTransferItemList::clear):
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::DatasetDOMStringMap::setNamedItem):
(WebCore::DatasetDOMStringMap::deleteNamedProperty):
(WebCore::DatasetDOMStringMap::protectedElement const): Deleted.
* Source/WebCore/dom/DatasetDOMStringMap.h:
* Source/WebCore/dom/DocumentFullscreen.h:
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::immersiveElement):
* Source/WebCore/dom/DocumentImmersive.h:
* Source/WebCore/dom/DocumentOrShadowRootFullscreen.cpp:
(WebCore::DocumentOrShadowRootFullscreen::fullscreenElement):
* Source/WebCore/dom/DocumentParser.cpp:
(WebCore::DocumentParser::protectedDocument const): Deleted.
* Source/WebCore/dom/DocumentParser.h:
(WebCore::DocumentParser::document const):
* Source/WebCore/dom/Event.cpp:
(WebCore::Event::composedPath const):
(WebCore::Event::protectedTarget const): Deleted.
(WebCore::Event::protectedCurrentTarget const): Deleted.
* Source/WebCore/dom/Event.h:
(WebCore::Event::target const):
(WebCore::Event::currentTarget const):
* Source/WebCore/dom/EventContext.cpp:
(WebCore::EventContext::handleLocalEvents const):
* Source/WebCore/dom/EventContext.h:
(WebCore::EventContext::node const):
(WebCore::EventContext::currentTarget const):
(WebCore::EventContext::target const):
(WebCore::EventContext::relatedTarget const):
(WebCore::EventContext::protectedNode const): Deleted.
(WebCore::EventContext::protectedCurrentTarget const): Deleted.
(WebCore::EventContext::protectedTarget const): Deleted.
(WebCore::EventContext::protectedRelatedTarget const): Deleted.
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::EventDispatcher::dispatchEvent):
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::protectedScriptExecutionContext const): Deleted.
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/InternalObserverEvery.cpp:
* Source/WebCore/dom/InternalObserverFind.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverInspect.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/LiveNodeList.h:
* Source/WebCore/dom/LiveNodeListInlines.h:
(WebCore::LiveNodeList::protectedDocument const): Deleted.
* Source/WebCore/dom/LoadableModuleScript.h:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::MessagePort::entangle):
(WebCore::MessagePort::postMessage):
(WebCore::MessagePort::start):
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/NamedNodeMap.cpp:
(WebCore::NamedNodeMap::getNamedItem const):
(WebCore::NamedNodeMap::isSupportedPropertyName const):
(WebCore::NamedNodeMap::getNamedItemNS const):
(WebCore::NamedNodeMap::element const):
(WebCore::NamedNodeMap::setNamedItem):
(WebCore::NamedNodeMap::element): Deleted.
(WebCore::NamedNodeMap::protectedElement const): Deleted.
* Source/WebCore/dom/NamedNodeMap.h:
* Source/WebCore/fileapi/Blob.cpp:
(WebCore::Blob::loadBlob):
* Source/WebCore/fileapi/FileReader.cpp:
(WebCore::FileReader::readInternal):
* Source/WebCore/fileapi/FileReader.h:
* Source/WebCore/html/DOMFormData.cpp:
(WebCore::createFileEntry):
* Source/WebCore/html/HTMLButtonElement.cpp:
(WebCore::HTMLButtonElement::defaultEventHandler):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::setAudioOutputDevice):
(WebCore::HTMLMediaElement::mediaPlayerDidAddAudioTrack):
(WebCore::HTMLMediaElement::mediaPlayerDidAddVideoTrack):
(WebCore::HTMLMediaElement::ensureAudioTracks):
(WebCore::HTMLMediaElement::ensureTextTracks):
(WebCore::HTMLMediaElement::ensureVideoTracks):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLScriptElement.cpp:
(WebCore::HTMLScriptElement::setText):
(WebCore::HTMLScriptElement::setTextContent):
(WebCore::HTMLScriptElement::setInnerText):
(WebCore::HTMLScriptElement::setSrc):
* Source/WebCore/html/HTMLSummaryElement.cpp:
(WebCore::HTMLSummaryElement::defaultEventHandler):
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/PublicURLManager.cpp:
(WebCore::PublicURLManager::registerURL):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp:
(WebCore::EXTDisjointTimerQueryWebGL2::queryCounterEXT):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContextSource::setPlaceholderBuffer):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::endQuery):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::WebGLRenderingContextBase):
* Source/WebCore/html/track/InbandWebVTTTextTrack.cpp:
(WebCore::InbandWebVTTTextTrack::parser):
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::VTTRegion::protectedDocument const):
* Source/WebCore/inspector/InspectorCanvasCallTracer.cpp:
(WebCore::enabledCanvasAgent):
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::willDestroyWebGLProgram):
* Source/WebCore/inspector/agents/WebDebuggerAgent.cpp:
(WebCore::WebDebuggerAgent::didAddEventListener):
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::intervalClampedToMinimum const):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::scheduleInitialConnect):
(WebCore::EventSource::scheduleReconnect):
(WebCore::EventSource::responseIsValid const):
(WebCore::EventSource::resume):
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::navigator):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/NavigationHistoryEntry.cpp:
(WebCore::NavigationHistoryEntry::NavigationHistoryEntry):
(WebCore::NavigationHistoryEntry::create):
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/NavigatorBase.cpp:
(WebCore::NavigatorBase::serviceWorker):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::dispatchEvent):
* Source/WebCore/workers/Worker.h:
* Source/WebCore/workers/WorkerEventLoop.cpp:
(WebCore::WorkerEventLoop::isContextThread const):
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
* Source/WebCore/workers/WorkerOrWorkletScriptController.cpp:
(WebCore::WorkerOrWorkletScriptController::linkAndEvaluateModule):
* Source/WebCore/workers/service/ServiceWorker.cpp:
(WebCore::ServiceWorker::stop):
* Source/WebCore/workers/service/ServiceWorker.h:
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::addRegistration):
(WebCore::ServiceWorkerContainer::getRegistration):
(WebCore::ServiceWorkerContainer::updateRegistrationState):
(WebCore::ServiceWorkerContainer::getRegistrations):
(WebCore::ServiceWorkerContainer::jobResolvedWithRegistration):
* Source/WebCore/workers/service/ServiceWorkerContainer.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.cpp:
(WebCore::ServiceWorkerRegistration::addCookieChangeSubscriptions):
(WebCore::ServiceWorkerRegistration::removeCookieChangeSubscriptions):
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/workers/shared/SharedWorker.h:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:
(WebCore::SharedWorkerScriptLoader::load):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createResponseBlob):
(WebCore::XMLHttpRequest::open):
(WebCore::XMLHttpRequest::send):
(WebCore::XMLHttpRequest::setRequestHeader):
* Source/WebCore/xml/XMLHttpRequest.h:
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::updateProgress):

Canonical link: <a href="https://commits.webkit.org/306917@main">https://commits.webkit.org/306917@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/596d393cbe281ee652bb484039ddd6cee9d9267f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142744 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5664 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151418 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95933 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96dfff22-88af-43d2-9635-c0ebfe313a9c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15297 "Built successfully") | [⏳ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/WPE-WK2-Tests-EWS "Waiting to run tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95933 "An unexpected error occured. Recent messages:Printed configuration") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bf6616f-df35-4bd0-b59b-d8229feb8114) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145693 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12243 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127711 "Passed tests") | [⏳ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/API-Tests-WPE-EWS "Waiting to run tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec95b9a2-7503-4cc1-b65b-df7aaf547a48) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11747 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9419 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1417 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121122 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153731 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14842 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117792 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118124 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30137 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14121 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124997 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70539 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14885 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3953 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14620 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78594 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14828 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14682 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->