### PR TITLE
[iOS] Visibility is not propagated to iframe processes

### DIFF
--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -40,6 +40,7 @@
 #import "PrintInfo.h"
 #import "RemoteLayerTreeCommitBundle.h"
 #import "RemoteLayerTreeDrawingAreaProxyIOS.h"
+#import "RemotePageProxy.h"
 #import "SmartMagnificationController.h"
 #import "UIKitSPI.h"
 #import "UIKitUtilities.h"
@@ -358,8 +359,14 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
         return;
 
 #if USE(EXTENSIONKIT)
+    auto& mainFrameProcess = _page->siteIsolatedProcess();
     for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
-        [visibilityPropagationView propagateVisibilityToProcess:_page->legacyMainFrameProcess()];
+        [visibilityPropagationView propagateVisibilityToProcess:mainFrameProcess];
+    auto remotePages = mainFrameProcess.remotePages();
+    for (auto& remotePage : remotePages) {
+        for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
+            [visibilityPropagationView propagateVisibilityToProcess:remotePage->process()];
+    }
 #else
 
     auto processID = _page->legacyMainFrameProcess().processID();
@@ -436,8 +443,14 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 {
 #if USE(EXTENSIONKIT)
     if (RefPtr page = _page.get()) {
+        auto& mainFrameProcess = _page->siteIsolatedProcess();
         for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
-            [visibilityPropagationView stopPropagatingVisibilityToProcess:page->legacyMainFrameProcess()];
+            [visibilityPropagationView stopPropagatingVisibilityToProcess:mainFrameProcess];
+        auto remotePages = mainFrameProcess.remotePages();
+        for (auto& remotePage : remotePages) {
+            for (WKVisibilityPropagationView *visibilityPropagationView in _visibilityPropagationViews.get())
+                [visibilityPropagationView stopPropagatingVisibilityToProcess:remotePage->process()];
+        }
     }
 #endif
 


### PR DESCRIPTION
#### 2d935edf3a14febe570c84416e2d5b4ef10eb56d
<pre>
[iOS] Visibility is not propagated to iframe processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307112">https://bugs.webkit.org/show_bug.cgi?id=307112</a>
<a href="https://rdar.apple.com/169747327">rdar://169747327</a>

Reviewed by Basuke Suzuki.

When ExtensionKit is enabled (iOS), make sure visibility is propagated to all WebContent processes.
The other platforms will be addressed in a follow-up patch.

* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _setupVisibilityPropagationForWebProcess]):
(-[WKContentView _removeVisibilityPropagationViewForWebProcess]):

Canonical link: <a href="https://commits.webkit.org/307072@main">https://commits.webkit.org/307072@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4af94af8f8673c96fbc9e122ff0f632c63c29416

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142743 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15215 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151417 "Built successfully") | [💥 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95932 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/175c21f8-18c0-46e6-b3ba-d2576110ce21) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15871 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15296 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109772 "Passed tests") | [💥 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/95932 "An unexpected error occured. Recent messages:Printed configuration") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5ac0822-edc4-46e3-9a2e-1fbc9f77c0eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127712 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90680 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7af8a439-ce07-4779-8834-4dd5e9b06ce9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11740 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9416 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1416 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121114 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153730 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14841 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4825 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117788 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12890 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118119 "Found 1 new API test failure: WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14118 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/124998 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70538 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22089 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14884 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3954 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14619 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78593 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14827 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14681 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->