### PR TITLE
[visionOS] Panorama photos fullscreened with QuickLook should launch with `launchInImmersiveMode` parameter

### DIFF
--- a/Source/WebCore/platform/graphics/BitmapImage.h
+++ b/Source/WebCore/platform/graphics/BitmapImage.h
@@ -123,6 +123,7 @@ private:
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     bool shouldUseQuickLookForFullscreen() const final { return m_source->shouldUseQuickLookForFullscreen(); }
+    bool isPanorama() const final { return m_source->isPanorama(); }
 #endif
 
 #if ENABLE(SPATIAL_IMAGE_DETECTION)

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
@@ -281,6 +281,13 @@ bool BitmapImageDescriptor::shouldUseQuickLookForFullscreen() const
         return decoder->shouldUseQuickLookForFullscreen();
     return false;
 }
+
+bool BitmapImageDescriptor::isPanorama() const
+{
+    if (auto decoder = m_source->decoderIfExists())
+        return decoder->isPanorama();
+    return false;
+}
 #endif
 
 #if ENABLE(SPATIAL_IMAGE_DETECTION)

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.h
@@ -70,6 +70,7 @@ public:
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     bool shouldUseQuickLookForFullscreen() const;
+    bool isPanorama() const;
 #endif
 
 #if ENABLE(SPATIAL_IMAGE_DETECTION)

--- a/Source/WebCore/platform/graphics/BitmapImageSource.h
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.h
@@ -176,6 +176,7 @@ private:
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     bool shouldUseQuickLookForFullscreen() const final { return m_descriptor.shouldUseQuickLookForFullscreen(); }
+    bool isPanorama() const final { return m_descriptor.isPanorama(); }
 #endif
 
 #if ENABLE(SPATIAL_IMAGE_DETECTION)

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -167,6 +167,7 @@ public:
 #endif
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     virtual bool shouldUseQuickLookForFullscreen() const { return false; }
+    virtual bool isPanorama() const { return false; }
 #endif
 
 #if ENABLE(SPATIAL_IMAGE_DETECTION)

--- a/Source/WebCore/platform/graphics/ImageDecoder.h
+++ b/Source/WebCore/platform/graphics/ImageDecoder.h
@@ -94,6 +94,7 @@ public:
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     virtual bool shouldUseQuickLookForFullscreen() const { return false; }
+    virtual bool isPanorama() const { return false; }
 #endif
 
 #if ENABLE(SPATIAL_IMAGE_DETECTION)

--- a/Source/WebCore/platform/graphics/ImageSource.h
+++ b/Source/WebCore/platform/graphics/ImageSource.h
@@ -97,6 +97,7 @@ public:
 
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     virtual bool shouldUseQuickLookForFullscreen() const { return false; }
+    virtual bool isPanorama() const { return false; }
 #endif
 
 #if ENABLE(SPATIAL_IMAGE_DETECTION)

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp
@@ -69,6 +69,10 @@ const CFStringRef kCGImageSourceEnableRestrictedDecoding = CFSTR("kCGImageSource
 const CFStringRef kCGImageSourceCreateUnpremultipliedPNG = CFSTR("kCGImageSourceCreateUnpremultipliedPNG");
 #endif
 
+#if ENABLE(QUICKLOOK_FULLSCREEN)
+constexpr float panoramicImageAspectRatioThreshold = 2.0;
+#endif
+
 static RetainPtr<CFMutableDictionaryRef> createImageSourceOptions()
 {
     RetainPtr<CFMutableDictionaryRef> options = adoptCF(CFDictionaryCreateMutable(nullptr, 0, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks));
@@ -768,8 +772,20 @@ bool ImageDecoderCG::isMaybePanoramic() const
     auto imageSize = FloatSize(frameSizeAtIndex(0));
     auto aspectRatio = imageSize.aspectRatio();
 
-    constexpr float panoramicImageAspectRatioThreshold = 2.0;
     return aspectRatio > panoramicImageAspectRatioThreshold;
+}
+
+bool ImageDecoderCG::isPanorama() const
+{
+    auto imageSize = FloatSize(frameSizeAtIndex(0));
+    auto aspectRatio = imageSize.aspectRatio();
+
+    if (aspectRatio <= panoramicImageAspectRatioThreshold)
+        return false;
+
+    constexpr float panoramicImageMinDimension = 800;
+    constexpr float panoramicImageMaxDimension = 30000;
+    return imageSize.minDimension() > panoramicImageMinDimension && imageSize.maxDimension() < panoramicImageMaxDimension;
 }
 
 bool ImageDecoderCG::isSpatial() const

--- a/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
+++ b/Source/WebCore/platform/graphics/cg/ImageDecoderCG.h
@@ -86,6 +86,7 @@ private:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     bool isSpatial() const;
     bool isMaybePanoramic() const;
+    bool isPanorama() const;
     bool shouldUseQuickLookForFullscreen() const;
 #endif
 

--- a/Source/WebKit/Platform/spi/visionos/QuickLook_SPI_Temp.swiftinterface
+++ b/Source/WebKit/Platform/spi/visionos/QuickLook_SPI_Temp.swiftinterface
@@ -15,10 +15,12 @@ final public class PreviewApplication {
     public static let showCloseButtonKey: Swift.String
     public static let matchScenePlacementIDKey: Swift.String
     public static let isContentManaged: Swift.String
+    public static let launchInImmersiveModeKey: Swift.String
     public var hideDocumentMenu: Swift.Bool
     public var showCloseButton: Swift.Bool
     public var matchScenePlacementID: Swift.String?
     public var isContentManaged: Swift.Bool
+    public var launchInImmersiveMode: Swift.Bool
     public init()
   }
   @objc deinit

--- a/Source/WebKit/Shared/FullScreenMediaDetails.h
+++ b/Source/WebKit/Shared/FullScreenMediaDetails.h
@@ -38,6 +38,7 @@ struct FullScreenMediaDetails {
 
     String mimeType { };
     std::optional<WebCore::SharedMemory::Handle> imageHandle { std::nullopt };
+    bool launchInImmersive { false };
 };
 
 }

--- a/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
+++ b/Source/WebKit/Shared/FullScreenMediaDetails.serialization.in
@@ -33,4 +33,5 @@
     WebCore::FloatSize mediaDimensions;
     String mimeType;
     std::optional<WebCore::SharedMemory::Handle> imageHandle;
+    bool launchInImmersive;
 };

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp
@@ -208,6 +208,7 @@ Awaitable<bool> WebFullScreenManagerProxy::enterFullScreen(IPC::Connection& conn
             m_imageBuffer = sharedMemoryBuffer->createSharedBuffer(sharedMemoryBuffer->size());
     }
     m_imageMIMEType = mediaDetails.mimeType;
+    m_launchInImmersive = mediaDetails.launchInImmersive;
 #endif // ENABLE(QUICKLOOK_FULLSCREEN)
 #endif // PLATFORM(IOS_FAMILY)
 

--- a/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
+++ b/Source/WebKit/UIProcess/WebFullScreenManagerProxy.h
@@ -98,6 +98,7 @@ public:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     bool isImageElement() const { return m_imageBuffer; }
     void prepareQuickLookImageURL(CompletionHandler<void(URL&&)>&&) const;
+    bool launchInImmersive() const { return m_launchInImmersive; }
 #endif // QUICKLOOK_FULLSCREEN
     void close();
     void detachFromClient();
@@ -155,6 +156,7 @@ private:
 #if ENABLE(QUICKLOOK_FULLSCREEN)
     String m_imageMIMEType;
     RefPtr<WebCore::SharedBuffer> m_imageBuffer;
+    bool m_launchInImmersive { false };
 #endif // QUICKLOOK_FULLSCREEN
     Vector<CompletionHandler<void()>> m_closeCompletionHandlers;
     WeakPtr<WebProcessProxy> m_fullScreenProcess;

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1062,9 +1062,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
         OBJC_ALWAYS_LOG(OBJC_LOGIDENTIFIER, "(QL) presentation updated");
 
-        manager->prepareQuickLookImageURL([strongSelf = retainPtr(self), self, window = retainPtr([webView window]), completionHandler = WTF::move(completionHandler), logIdentifier = OBJC_LOGIDENTIFIER] (URL&& url) mutable {
+        bool launchInImmersive = manager->launchInImmersive();
+        manager->prepareQuickLookImageURL([strongSelf = retainPtr(self), self, window = retainPtr([webView window]), launchInImmersive, completionHandler = WTF::move(completionHandler), logIdentifier = OBJC_LOGIDENTIFIER] (URL&& url) mutable {
             UIWindowScene *scene = [window windowScene];
-            _previewWindowController = adoptNS([WebKit::allocWKPreviewWindowControllerInstance() initWithURL:url.createNSURL().get() sceneID:scene._sceneIdentifier]);
+            _previewWindowController = adoptNS([WebKit::allocWKPreviewWindowControllerInstance() initWithURL:url.createNSURL().get() sceneID:scene._sceneIdentifier launchInImmersive:launchInImmersive]);
             [_previewWindowController setDelegate:self];
             [_previewWindowController presentWindowWithCompletionHandler:^{ }];
             _fullScreenState = WebKit::InFullScreen;

--- a/Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.h
+++ b/Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.h
@@ -40,7 +40,8 @@ NS_SWIFT_UI_ACTOR
 @interface WKPreviewWindowController : NSObject
 @property (nonatomic, weak, nullable) id <WKPreviewWindowControllerDelegate> delegate;
 
-- (instancetype)initWithURL:(NSURL *)url sceneID:(NSString *)sceneID NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithURL:(NSURL *)url sceneID:(NSString *)sceneID launchInImmersive:(BOOL)launchInImmersive NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithURL:(NSURL *)url sceneID:(NSString *)sceneID;
 - (void)presentWindowWithCompletionHandler:(NS_SWIFT_UI_ACTOR void(^)(void))completionHandler;
 - (void)updateImage:(NSURL *)url completionHandler:(NS_SWIFT_UI_ACTOR void(^)(void))completionHandler;
 - (void)dismissWindowWithCompletionHandler:(NS_SWIFT_UI_ACTOR void(^)(void))completionHandler;

--- a/Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.swift
+++ b/Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.swift
@@ -91,18 +91,26 @@ extension WKPreviewWindowController {
 
     weak var delegate: WKPreviewWindowControllerDelegate?
 
-    @objc(initWithURL:sceneID:)
-    init(url: URL, sceneID: String) {
+    @objc(initWithURL:sceneID:launchInImmersive:)
+    init(url: URL, sceneID: String, launchInImmersive: Bool) {
         let item = PreviewItem(url: url, displayName: nil, editingMode: .disabled)
 
         var configuration = PreviewApplication.PreviewConfiguration()
         configuration.hideDocumentMenu = true
         configuration.showCloseButton = true
         configuration.matchScenePlacementID = sceneID
+        #if canImport(QuickLook, _version: 1023)
+        configuration.launchInImmersiveMode = launchInImmersive
+        #endif
 
         self.base = Base(item: item, configuration: configuration)
 
         super.init()
+    }
+
+    @objc(initWithURL:sceneID:)
+    convenience init(url: URL, sceneID: String) {
+        self.init(url: url, sceneID: sceneID, launchInImmersive: false)
     }
 
     func presentWindow() async {


### PR DESCRIPTION
#### df2046a70dcacbb569831c9fb6d0972942cde482
<pre>
[visionOS] Panorama photos fullscreened with QuickLook should launch with `launchInImmersiveMode` parameter
<a href="https://bugs.webkit.org/show_bug.cgi?id=307116">https://bugs.webkit.org/show_bug.cgi?id=307116</a>
<a href="https://rdar.apple.com/163077545">rdar://163077545</a>

Reviewed by Etienne Segonzac.

When fullscreening panoramic images on visionOS, we now wait for responsive images
to load before deciding whether to defer to QuickLook for fullscreen. This ensures
that images which appear potentially panoramic due to their aspect ratio but are too
small to qualify as panoramic can properly pass along the launchInImmersiveMode
parameter to QuickLook after the larger responsive image loads.

The implementation triggers larger responsive image source changes, then waits up to
1 second for the larger image to load. If the new image qualifies as a true panorama,
we defer to QuickLook with launchInImmersiveMode set. If it times out or doesn&apos;t
qualify, we fall back to regular fullscreen or QuickLook without the immersive
parameter accordingly.

* Source/WebCore/platform/graphics/BitmapImage.h:
* Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp:
(WebCore::BitmapImageDescriptor::isPanorama const):
* Source/WebCore/platform/graphics/BitmapImageDescriptor.h:
* Source/WebCore/platform/graphics/BitmapImageSource.h:
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::isPanorama const):
* Source/WebCore/platform/graphics/ImageDecoder.h:
(WebCore::ImageDecoder::isPanorama const):
* Source/WebCore/platform/graphics/ImageSource.h:
(WebCore::ImageSource::isPanorama const):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.cpp:
(WebCore::ImageDecoderCG::isMaybePanoramic const):
(WebCore::ImageDecoderCG::isPanorama const):
* Source/WebCore/platform/graphics/cg/ImageDecoderCG.h:
Added isPanorama() to determine if an image qualifies as panoramic.

* Source/WebKit/Platform/spi/visionos/QuickLook_SPI_Temp.swiftinterface:
Added launchInImmersiveModeKey and launchInImmersiveMode to PreviewConfiguration.

* Source/WebKit/Shared/FullScreenMediaDetails.h:
* Source/WebKit/Shared/FullScreenMediaDetails.serialization.in:
Added launchInImmersive boolean field.

* Source/WebKit/UIProcess/WebFullScreenManagerProxy.cpp:
(WebKit::WebFullScreenManagerProxy::enterFullScreen):
* Source/WebKit/UIProcess/WebFullScreenManagerProxy.h:
Store and forward launchInImmersive flag from FullScreenMediaDetails.

(WebKit::WebFullScreenManagerProxy::launchInImmersive const):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
* Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.h:
* Source/WebKit/WebKitSwift/Preview/WKPreviewWindowController.swift:
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::WebFullScreenManager):
(WebKit::WebFullScreenManager::invalidate):
(WebKit::WebFullScreenManager::enterFullScreenForElement):
(WebKit::WebFullScreenManager::performEnterFullScreen):
(WebKit::WebFullScreenManager::updateImageSource):
(WebKit::WebFullScreenManager::waitForLargerImageLoadTimerFired):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.h:
Added responsive image loading logic. When fullscreening an image that appears
potentially panoramic but is too small to qualify, wait up to 1 second for a larger
responsive image to load. Added m_waitingForLargerImageLoad and
m_waitForLargerImageLoadTimer to track async image loading. Added m_pendingWillEnterCallback,
m_pendingDidEnterCallback, m_pendingMode, and m_pendingImageMediaDetails to store state
for the async callback path. Added performEnterFullScreen() as the common entry point
for fullscreen after async work completes.

Canonical link: <a href="https://commits.webkit.org/307317@main">https://commits.webkit.org/307317@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d28e42cdd94518576943551efef8871a18d7b804

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16164 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7860 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96920 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16252 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110506 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79505 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12946 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129146 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91424 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10145 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5730 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154663 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16211 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118511 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16247 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13660 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118867 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30531 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14810 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126939 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71625 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15832 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5468 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79604 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15779 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15631 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->