### PR TITLE
[WPE][cross-toolchain-helper] Issues cross-building WebKit inside the SDK due to LD_LIBRARY_PATH

### DIFF
--- a/Tools/Scripts/cross-toolchain-helper
+++ b/Tools/Scripts/cross-toolchain-helper
@@ -220,6 +220,22 @@ class YoctoCrossBuilder():
                         os.remove(candidate_cmake_cache_file)
 
     def _initialize_environment_for_target(self, no_export_environment):
+        # If running inside the SDK then clear all the jhbuild related vars which may cause issues with the cross-target environment
+        if os.environ.get('WEBKIT_CONTAINER_SDK') == '1':
+            for env_var, env_val in list(os.environ.items()):
+                if '/jhbuild/install/' in env_val:
+                    if env_var == 'PATH':
+                        os.environ['PATH'] = ':'.join(p for p in os.environ['PATH'].split(':') if '/jhbuild/install/' not in p)
+                        _log.debug(f'cross-target environment: reset variable "PATH={os.environ["PATH"]}"')
+                    else:
+                        os.environ.pop(env_var)
+                        _log.debug(f'cross-target environment: unset variable "{env_var}={env_val}"')
+        # Otherwise clear the usual suspects but in this case also warn the user
+        for env_var in ['C_INCLUDE_PATH', 'CPLUS_INCLUDE_PATH', 'GI_TYPELIB_PATH', 'LDFLAGS', 'LD_LIBRARY_PATH', 'PKG_CONFIG_PATH']:
+            if env_var in os.environ:
+                _log.warning(f'Detected environment variable "{env_var}={os.environ[env_var]}". This is problematic. Unsetting it for the cross-target environment.')
+                os.environ.pop(env_var)
+        # Now set the env vars for the target
         environment_for_target = self._targets_config.get_environment(self._target)
         if environment_for_target:
             if no_export_environment:

--- a/Tools/yocto/README.md
+++ b/Tools/yocto/README.md
@@ -143,9 +143,6 @@ This is an example on how to build and run WPE for development on the RPi:
 
 1. Build the image that will be flashed on the board:
 
-# NOTE: If you are using the **WebKit Container SDK** remember to unset the *LD_LIBRARY_PATH*
-# before building, if you don't it can cause problems with the yocto setup.
-
 ```
 user@workstation $ Tools/Scripts/cross-toolchain-helper --cross-target=rpi3-32bits-mesa --build-image
 ```


### PR DESCRIPTION
#### c518b4423ada4c5bb7510fe4b1a22e64d88d25b0
<pre>
[WPE][cross-toolchain-helper] Issues cross-building WebKit inside the SDK due to LD_LIBRARY_PATH
<a href="https://bugs.webkit.org/show_bug.cgi?id=307119">https://bugs.webkit.org/show_bug.cgi?id=307119</a>

Reviewed by Nikolas Zimmermann.

Inside the SDK by default LD_LIBRARY_PATH is defined to the /jhbuild path. This seems to cause
problems with the cross-builds via cross-toolchain-helper, because it ends producing artifacts
for the native architecture instead for the cross-target one.

There are also a bunch of other env vars defined on the SDK by default (related to jhbuild)
that are potentially problematic for a cross-build environment.

This patch ensures that this the environment variables for the cross-target build are cleaned
automatically before starting the build.

* Tools/Scripts/cross-toolchain-helper:
(YoctoCrossBuilder._initialize_environment_for_target):
* Tools/yocto/README.md:

Canonical link: <a href="https://commits.webkit.org/307070@main">https://commits.webkit.org/307070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10ce188b3ce6d88c882b718374ca84cc93f25b25

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15792 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7198 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151993 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145184 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110225 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96538 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146266 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/12670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/128675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91134 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12158 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9868 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1991 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/5138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154304 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15836 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/6133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118242 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13356 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118583 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14518 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126336 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71231 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22088 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15461 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/4994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15195 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15406 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->