### PR TITLE
[GFC] Implement intrinsic width computation for grid containers

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -127,6 +127,13 @@ public:
 
     void layout(GridLayoutConstraints);
 
+    struct IntrinsicWidths {
+        LayoutUnit minimum;
+        LayoutUnit maximum;
+    };
+
+    IntrinsicWidths computeIntrinsicWidths();
+
     PlacedGridItems constructPlacedGridItems(const GridAreas&) const;
 
     const ElementBox& root() const { return m_gridBox; }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -486,7 +486,7 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& pla
 }
 
 // Helper to compute margins from axis sizes
-static UsedMargins computeMarginsForAxis(const auto& axisSizes, const Style::ZoomFactor& zoomFactor)
+static UsedMargins computeMarginsForAxis(const ComputedSizes& axisSizes, const Style::ZoomFactor& zoomFactor)
 {
     auto marginStart = [&] -> LayoutUnit {
         if (auto fixedMarginStart = axisSizes.marginStart.tryFixed())

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -378,6 +378,27 @@ static void stretchAutoTracks(std::optional<LayoutUnit> freeSpace, UnsizedTracks
         unsizedTracks[trackIndex].baseSize += spacePerTrack;
 }
 
+// https://drafts.csswg.org/css-grid-1/#algo-grow-tracks
+static void maximizeTracks(UnsizedTracks& unsizedTracks, const FreeSpaceScenario& freeSpaceScenario)
+{
+    switch (freeSpaceScenario) {
+    case FreeSpaceScenario::MaxContent:
+        // If sizing the grid container under a max-content constraint, the free space is infinite.
+        // Set each track's base size to its growth limit.
+        for (auto& track : unsizedTracks)
+            track.baseSize = track.growthLimit;
+        break;
+    case FreeSpaceScenario::MinContent:
+        // if sizing under a min-content constraint, the free space is zero, and the track sizes are not increased beyond their base sizes.
+        return;
+    case FreeSpaceScenario::Definite:
+        // If the free space is positive, distribute it equally to the base sizes of all tracks,
+        // freezing tracks as they reach their growth limits (and continuing to grow the unfrozen tracks as needed).
+        notImplemented();
+        return;
+    }
+}
+
 // https://drafts.csswg.org/css-grid-1/#algo-track-sizing
 TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const ComputedSizesList& gridItemComputedSizesList,
     const UsedBorderAndPaddingList& borderAndPaddingList, const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions,
@@ -393,10 +414,7 @@ TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, co
     resolveIntrinsicTrackSizes(unsizedTracks, gridItems, gridItemComputedSizesList, borderAndPaddingList, gridItemSpanList, oppositeAxisConstraints, gridItemSizingFunctions);
 
     // 3. Maximize Tracks
-    auto maximizeTracks = [] {
-        notImplemented();
-    };
-    UNUSED_VARIABLE(maximizeTracks);
+    maximizeTracks(unsizedTracks, freeSpaceScenario);
 
     // 4. Expand Flexible Tracks
     // https://drafts.csswg.org/css-grid-1/#algo-flex-tracks

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -105,8 +105,6 @@ enum class GridAvoidanceReason : uint8_t {
 
 static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnStart, const Style::GridPosition columnEnd, size_t linesFromGridTemplateColumnsCount)
 {
-    UNUSED_PARAM(explicitColumnStart);
-
     return WTF::switchOn(columnEnd,
         [](const CSS::Keyword::Auto&) {
             return false;
@@ -114,6 +112,16 @@ static bool hasValidColumnEnd(const Style::GridPositionExplicit& explicitColumnS
         [&](const Style::GridPositionExplicit&) {
             if (!columnEnd.namedGridLine().isEmpty() || columnEnd.explicitPosition() < 0 || columnEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateColumnsCount))
                 return false;
+
+            // FIXME: Multi-span items are not yet supported in intrinsic sizing
+            // (see TrackSizingAlgorithm::sizeTracksForIntrinsicSizing).
+            // Only accept items that span a single column.
+            auto startPosition = explicitColumnStart.position.value;
+            auto endPosition = columnEnd.explicitPosition();
+            auto gridLineDistance = endPosition - startPosition;
+            if (gridLineDistance != 1)
+                return false;
+
             return true;
         },
         [&](const Style::GridPositionSpan&) {
@@ -145,7 +153,7 @@ static bool hasValidColumnEnd(const CSS::Keyword::Auto& autoColumnStart, const S
     );
 }
 
-static bool hasValidRowEnd(const Style::GridPositionExplicit&, const Style::GridPosition rowEnd, size_t linesFromGridTemplateRowsCount)
+static bool hasValidRowEnd(const Style::GridPositionExplicit& explicitRowStart, const Style::GridPosition rowEnd, size_t linesFromGridTemplateRowsCount)
 {
     return WTF::switchOn(rowEnd,
         [&](const CSS::Keyword::Auto&) {
@@ -154,6 +162,16 @@ static bool hasValidRowEnd(const Style::GridPositionExplicit&, const Style::Grid
         [&](const Style::GridPositionExplicit&) {
             if (!rowEnd.namedGridLine().isEmpty() || rowEnd.explicitPosition() < 0 || rowEnd.explicitPosition() > static_cast<int>(linesFromGridTemplateRowsCount))
                 return false;
+
+            // FIXME: Multi-span items are not yet supported in intrinsic sizing
+            // (see TrackSizingAlgorithm::sizeTracksForIntrinsicSizing).
+            // Only accept items that span a single row.
+            auto startPosition = explicitRowStart.position.value;
+            auto endPosition = rowEnd.explicitPosition();
+            auto gridLineDistance = endPosition - startPosition;
+            if (gridLineDistance != 1)
+                return false;
+
             return true;
         },
         [&](const Style::GridPositionSpan&) {

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -149,6 +149,13 @@ void GridLayout::updateFormattingContextRootRenderer()
         orderIteratorPopulator.collectChild(CheckedRef { downcast<RenderBox>(*layoutBox->rendererForIntegration()) });
 }
 
+std::pair<LayoutUnit, LayoutUnit> GridLayout::computeIntrinsicWidths()
+{
+    auto gridFormattingContext = Layout::GridFormattingContext { gridBox(), layoutState() };
+    auto intrinsicWidths = gridFormattingContext.computeIntrinsicWidths();
+    return { intrinsicWidths.minimum, intrinsicWidths.maximum };
+}
+
 void GridLayout::layout()
 {
     Layout::GridFormattingContext { gridBox(), layoutState() }.layout(constraintsForGridContent(gridBox()));

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -50,6 +50,8 @@ public:
 
     void layout();
 
+    std::pair<LayoutUnit, LayoutUnit> computeIntrinsicWidths();
+
     friend WTF::TextStream& operator<<(WTF::TextStream&, const GridLayout&);
 
 private:

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -810,6 +810,20 @@ LayoutUnit RenderGrid::guttersSize(Style::GridTrackSizingDirection direction, un
 
 void RenderGrid::computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const
 {
+    if (LayoutIntegration::canUseForGridLayout(*this)) {
+        // const_cast is safe here: computeIntrinsicWidths() only reads grid properties
+        // and does not mutate RenderGrid state, matching the legacy path pattern below.
+        auto gridLayout = LayoutIntegration::GridLayout { const_cast<RenderGrid&>(*this) };
+        gridLayout.updateFormattingContextGeometries();
+        std::tie(minLogicalWidth, maxLogicalWidth) = gridLayout.computeIntrinsicWidths();
+
+        // Add scrollbar width
+        LayoutUnit scrollbarWidth = intrinsicScrollbarLogicalWidthIncludingGutter();
+        minLogicalWidth += scrollbarWidth;
+        maxLogicalWidth += scrollbarWidth;
+        return;
+    }
+
     RenderGridLayoutState gridLayoutState;
 
     LayoutUnit gridItemMinWidth;


### PR DESCRIPTION
#### 7fbc5d7ef25617a6f0b4ca7e5c3d2fe4007cecc5
<pre>
[GFC] Implement intrinsic width computation for grid containers
<a href="https://bugs.webkit.org/show_bug.cgi?id=306916">https://bugs.webkit.org/show_bug.cgi?id=306916</a>
&lt;<a href="https://rdar.apple.com/169576858">rdar://169576858</a>&gt;

Reviewed by Sammy Gill.

Add computeIntrinsicWidths() to GridFormattingContext to compute min-content
and max-content sizes per CSS Grid Level 1 Section 5.2. This enables
RenderGrid::computeIntrinsicLogicalWidths to use the modern grid layout path
for grids that pass coverage requirements.

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::layout):
(WebCore::Layout::GridFormattingContext::computeIntrinsicWidths):
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::computeMarginsForAxis):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::maximizeTracks):
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::hasValidColumnEnd):
(WebCore::LayoutIntegration::hasValidRowEnd):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
(WebCore::LayoutIntegration::GridLayout::computeIntrinsicWidths):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeIntrinsicLogicalWidths const):

Canonical link: <a href="https://commits.webkit.org/307225@main">https://commits.webkit.org/307225@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/986aee88cf4126bc551732ab276493197d37b370

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152380 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145587 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16870 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16281 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110522 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43760d50-cb38-4d47-955e-da114b38a028) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146675 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129159 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91440 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9db87e30-cc40-409c-bcd6-7d08f63e61fe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12439 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10163 "Passed tests") | [  ~~🛠 wpe-libwebrtc~~](https://ews-build.webkit.org/#/builders/172/builds/2382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121892 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5745 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154692 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6788 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118545 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118883 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14823 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126954 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71654 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22175 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15862 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5480 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15596 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15808 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15660 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->