### PR TITLE
AX: Add client-side accessibility testing support for site isolation tests

### DIFF
--- a/LayoutTests/accessibility/mac/client/README.md
+++ b/LayoutTests/accessibility/mac/client/README.md
@@ -1,0 +1,8 @@
+Client-side accessibility layout tests
+
+These tests use the client-side accessibility API - the same one used by VoiceOver, etc.
+as opposed to the normal accessibility layout tests that call into WebCore for the
+current web content process directly.
+
+This layer was added so that we have a way to test site isolation - it enables us to
+walk the entire cross-process accessibility tree from one test.

--- a/LayoutTests/accessibility/mac/client/button-expected.txt
+++ b/LayoutTests/accessibility/mac/client/button-expected.txt
@@ -1,0 +1,10 @@
+Test properties of a button via the client accessibility APIs.
+Root: AXRole: AXScrollArea
+Web area: AXRole: AXWebArea
+Button role: AXRole: AXButton
+Button title: This is a button
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/client/button.html
+++ b/LayoutTests/accessibility/mac/client/button.html
@@ -1,0 +1,49 @@
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="button">This is a button</button>
+
+<script>
+var output = "Test properties of a button via the client accessibility APIs.\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setClientAccessibilityMode(true);
+
+    setTimeout(async function() {
+        rootElement = null;
+        webArea = null;
+        button = null;
+
+        // Keep polling until all of the elements in the tree are present.
+	// Some accessibility elements aren't initialized until queried.
+	// TODO: replace with waitFor() or make a new general-purpose helper.
+        while (true) {
+            rootElement = accessibilityController.rootElement;
+            if (rootElement)
+                webArea = rootElement.childAtIndex(0);
+            if (webArea)
+                button = webArea.childAtIndex(0);
+            if (button)
+                break;
+            await new Promise(resolve => setTimeout(resolve, 10));
+        }
+
+        output += `Root: ${rootElement.role}\n`;
+        output += `Web area: ${webArea.role}\n`;
+        output += `Button role: ${button.role}\n`;
+        output += `Button title: ${button.title}\n`;
+
+        debug(output);
+        document.getElementById("button").hidden = true;
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -120,6 +120,10 @@ fast/dom/Window/slow-unload-handler-only-frame-is-stopped.html
 
 webkit.org/b/306558 accessibility/mac/style-range.html [ Failure ]
 
+# Skip accessibility tests that use the accessibility client API on most builders;
+# requires an extra permission for WKTR
+accessibility/mac/client [ Skip ]
+
 # Skip glib-only combobox accessibility tests.
 accessibility/combobox/gtk [ Skip ]
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -6703,6 +6703,11 @@ static Vector<Ref<API::TargetedElementInfo>> elementsFromWKElements(NSArray<_WKT
     return _impl->hasRemoteAccessibilityChild();
 }
 
+- (NSData *)_remoteAccessibilityChildToken
+{
+    return _impl->remoteAccessibilityChildToken();
+}
+
 - (RetainPtr<NSPopUpButtonCell>)_activePopupButtonCell
 {
     RefPtr popupMenu = dynamicDowncast<WebKit::WebPopupMenuProxyMac>(_page->activePopupMenu());

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -649,6 +649,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 - (NSUInteger)accessibilityUIProcessLocalTokenHash;
 - (NSArray<NSNumber *> *)registeredRemoteAccessibilityPids;
 - (bool)hasRemoteAccessibilityChild;
+- (NSData *)_remoteAccessibilityChildToken;
 #endif
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -533,6 +533,7 @@ public:
     NSUInteger accessibilityRemoteChildTokenHash();
     NSUInteger accessibilityUIProcessLocalTokenHash();
     NSArray<NSNumber *> *registeredRemoteAccessibilityPids();
+    NSData *remoteAccessibilityChildToken();
     bool hasRemoteAccessibilityChild();
 
     void updatePrimaryTrackingAreaOptions(NSTrackingAreaOptions);

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -3865,6 +3865,11 @@ NSUInteger WebViewImpl::accessibilityUIProcessLocalTokenHash()
     return [m_remoteAccessibilityTokenGeneratedByUIProcess hash];
 }
 
+NSData *WebViewImpl::remoteAccessibilityChildToken()
+{
+    return m_remoteAccessibilityChildToken.get();
+}
+
 NSArray<NSNumber *> *WebViewImpl::registeredRemoteAccessibilityPids()
 {
     NSMutableArray<NSNumber *> *result = [NSMutableArray new];

--- a/Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements
+++ b/Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements
@@ -14,6 +14,14 @@
 	<true/>
 	<key>com.apple.networkd.persistent_interface</key>
 	<true/>
+	<key>com.apple.private.accessibility.accessProtectedContent</key>
+	<true/>
+	<key>com.apple.private.accessibility.inspection</key>
+	<true/>
+	<key>com.apple.private.tcc.allow</key>
+	<array>
+		<string>kTCCServiceAccessibility</string>
+	</array>
 	<key>com.apple.security.temporary-exception.sbpl</key>
 	<array>
 		<string>(allow mach-issue-extension (require-all (extension-class &quot;com.apple.webkit.extension.mach&quot;)))</string>

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp
@@ -39,6 +39,10 @@
 #include "AccessibilityNotificationHandler.h"
 #endif
 
+#if PLATFORM(MAC)
+#include "mac/AccessibilityUIElementClientMac.h"
+#endif
+
 namespace WTR {
 
 Ref<AccessibilityController> AccessibilityController::create()
@@ -78,6 +82,16 @@ void AccessibilityController::setForceInitialFrameCaching(bool shouldForce)
     WKAccessibilitySetForceInitialFrameCaching(shouldForce);
 }
 
+void AccessibilityController::setClientAccessibilityMode(bool flag)
+{
+    m_enableClientAccessibilityMode = flag;
+
+    if (flag) {
+        setIsolatedTreeMode(true);
+        platformInitializeClientAccessibility();
+    }
+}
+
 void AccessibilityController::makeWindowObject(JSContextRef context)
 {
     setGlobalObjectProperty(context, "accessibilityController", this);
@@ -102,6 +116,11 @@ bool AccessibilityController::enhancedAccessibilityEnabled()
 
 Ref<AccessibilityUIElement> AccessibilityController::rootElement(JSContextRef context)
 {
+#if PLATFORM(MAC)
+    if (m_enableClientAccessibilityMode)
+        return AccessibilityUIElementClientMac::createForUIProcess();
+#endif
+
     PlatformUIElement root;
     executeOnAXThreadAndWait([&] () {
         root = static_cast<PlatformUIElement>(_WKAccessibilityRootObjectForTesting(WKBundleFrameForJavaScriptContext(context)));
@@ -179,6 +198,11 @@ void AccessibilityController::announce(JSStringRef message)
 #if !PLATFORM(MAC)
 void AccessibilityController::platformInitialize()
 {
+}
+
+void AccessibilityController::platformInitializeClientAccessibility()
+{
+    // Client accessibility mode is only supported on macOS
 }
 #endif
 

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h
@@ -63,6 +63,10 @@ public:
     void setForceDeferredSpellChecking(bool);
     void setForceInitialFrameCaching(bool);
 
+    // Client accessibility mode - uses AXUIElement APIs instead of internal accessibility objects
+    void setClientAccessibilityMode(bool);
+    bool clientAccessibilityModeEnabled() const { return m_enableClientAccessibilityMode; }
+
     JSRetainPtr<JSStringRef> platformName();
 
     // Controller Methods - platform-independent implementations.
@@ -100,6 +104,7 @@ public:
 private:
     AccessibilityController();
     void platformInitialize();
+    void platformInitializeClientAccessibility();
 
 #if PLATFORM(COCOA)
     RetainPtr<id> m_globalNotificationHandler;
@@ -118,6 +123,8 @@ private:
 
     bool m_accessibilityIsolatedTreeMode { false };
 #endif
+
+    bool m_enableClientAccessibilityMode { false };
 };
 
 #if PLATFORM(COCOA)

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -29,6 +29,7 @@
 #include "JSAccessibilityUIElement.h"
 
 #if PLATFORM(MAC)
+#include "mac/AccessibilityUIElementClientMac.h"
 #include "mac/AccessibilityUIElementMac.h"
 #elif PLATFORM(IOS_FAMILY)
 #include "ios/AccessibilityUIElementIOS.h"

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityController.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityController.idl
@@ -32,6 +32,10 @@ interface AccessibilityController {
     AccessibilityUIElement retainedElement();
     undefined setForceInitialFrameCaching(boolean shouldForce);
 
+    // Client accessibility mode
+    undefined setClientAccessibilityMode(boolean enable);
+    readonly attribute boolean clientAccessibilityModeEnabled;
+
     readonly attribute DOMString platformName;
     readonly attribute AccessibilityUIElement rootElement;
     readonly attribute AccessibilityUIElement focusedElement;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if PLATFORM(MAC)
+
+#include "AccessibilityUIElement.h"
+#include <stdint.h>
+
+namespace WTR {
+
+// Client Mac implementation using AXUIElement APIs
+class AccessibilityUIElementClientMac final : public AccessibilityUIElement {
+public:
+    static Ref<AccessibilityUIElementClientMac> create(uint64_t elementToken);
+    static Ref<AccessibilityUIElementClientMac> create(const AccessibilityUIElementClientMac&);
+
+    // Create a root element for the UI process (parent process of the current web content process)
+    static Ref<AccessibilityUIElementClientMac> createForUIProcess();
+
+    virtual ~AccessibilityUIElementClientMac();
+
+    PlatformUIElement platformUIElement() override;
+
+    // Attribute getters.
+    bool isValid() const override;
+    JSRetainPtr<JSStringRef> role() override;
+    JSRetainPtr<JSStringRef> title() override;
+    JSRetainPtr<JSStringRef> description() override;
+    JSRetainPtr<JSStringRef> stringValue() override;
+    unsigned childrenCount() override;
+    RefPtr<AccessibilityUIElement> childAtIndex(unsigned) override;
+
+    // Helpers.
+    JSRetainPtr<JSStringRef> getStringAttribute(const char* attributeName) const;
+    Vector<RefPtr<AccessibilityUIElement>> getChildren() const;
+    Vector<RefPtr<AccessibilityUIElement>> getChildrenInRange(unsigned location, unsigned length) const;
+
+private:
+    AccessibilityUIElementClientMac(uint64_t elementToken);
+    AccessibilityUIElementClientMac(const AccessibilityUIElementClientMac&);
+
+    uint64_t m_elementToken { 0 };
+};
+
+} // namespace WTR
+
+#endif // PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AccessibilityUIElementClientMac.h"
+
+#if PLATFORM(MAC)
+
+#import "DictionaryFunctions.h"
+#import "InjectedBundle.h"
+#import <JavaScriptCore/JSRetainPtr.h>
+#import <JavaScriptCore/JSStringRef.h>
+#import <JavaScriptCore/OpaqueJSString.h>
+#import <WebKit/WKBundle.h>
+#import <WebKit/WKBundlePrivate.h>
+#import <wtf/RetainPtr.h>
+
+namespace WTR {
+
+// IPC helper functions for client accessibility
+static uint64_t axGetRoot()
+{
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    WKTypeRef returnData = nullptr;
+    WKBundlePostSynchronousMessage(InjectedBundle::singleton().bundle(), toWK("AXGetRoot").get(), nullptr, &returnData);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    if (!returnData || WKGetTypeID(returnData) != WKUInt64GetTypeID())
+        return 0;
+
+    uint64_t token = WKUInt64GetValue(static_cast<WKUInt64Ref>(returnData));
+    WKRelease(returnData);
+    return token;
+}
+
+static WKRetainPtr<WKStringRef> axCopyAttributeValueAsString(uint64_t elementToken, const char* attributeName)
+{
+    WKRetainPtr dictionary = adoptWK(WKMutableDictionaryCreate());
+    setValue(dictionary, "elementToken", elementToken);
+    setValue(dictionary, "attributeName", attributeName);
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    WKTypeRef returnData = nullptr;
+    WKBundlePostSynchronousMessage(InjectedBundle::singleton().bundle(), toWK("AXCopyAttributeValueAsString").get(), dictionary.get(), &returnData);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    if (!returnData || WKGetTypeID(returnData) != WKStringGetTypeID())
+        return nullptr;
+
+    return adoptWK(static_cast<WKStringRef>(returnData));
+}
+
+static WKRetainPtr<WKArrayRef> axCopyAttributeValueAsElementArray(uint64_t elementToken, const char* attributeName)
+{
+    WKRetainPtr dictionary = adoptWK(WKMutableDictionaryCreate());
+    setValue(dictionary, "elementToken", elementToken);
+    setValue(dictionary, "attributeName", attributeName);
+
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
+    WKTypeRef returnData = nullptr;
+    WKBundlePostSynchronousMessage(InjectedBundle::singleton().bundle(), toWK("AXCopyAttributeValueAsElementArray").get(), dictionary.get(), &returnData);
+    ALLOW_DEPRECATED_DECLARATIONS_END
+
+    if (!returnData || WKGetTypeID(returnData) != WKArrayGetTypeID())
+        return nullptr;
+
+    return adoptWK(static_cast<WKArrayRef>(returnData));
+}
+
+Ref<AccessibilityUIElementClientMac> AccessibilityUIElementClientMac::create(uint64_t elementToken)
+{
+    return adoptRef(*new AccessibilityUIElementClientMac(elementToken));
+}
+
+Ref<AccessibilityUIElementClientMac> AccessibilityUIElementClientMac::create(const AccessibilityUIElementClientMac& other)
+{
+    return adoptRef(*new AccessibilityUIElementClientMac(other));
+}
+
+Ref<AccessibilityUIElementClientMac> AccessibilityUIElementClientMac::createForUIProcess()
+{
+    return create(axGetRoot());
+}
+
+AccessibilityUIElementClientMac::AccessibilityUIElementClientMac(uint64_t elementToken)
+    : AccessibilityUIElement(nullptr)
+    , m_elementToken(elementToken)
+{
+}
+
+AccessibilityUIElementClientMac::AccessibilityUIElementClientMac(const AccessibilityUIElementClientMac& other)
+    : AccessibilityUIElement(other)
+    , m_elementToken(other.m_elementToken)
+{
+}
+
+AccessibilityUIElementClientMac::~AccessibilityUIElementClientMac()
+{
+}
+
+PlatformUIElement AccessibilityUIElementClientMac::platformUIElement()
+{
+    // Client elements don't have a local platform element
+    return nullptr;
+}
+
+bool AccessibilityUIElementClientMac::isValid() const
+{
+    return m_elementToken;
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::getStringAttribute(const char* attributeName) const
+{
+    if (!isValid())
+        return nullptr;
+
+    WKRetainPtr value = axCopyAttributeValueAsString(m_elementToken, attributeName);
+    if (!value)
+        return nullptr;
+
+    return JSRetainPtr<JSStringRef>(Adopt, OpaqueJSString::tryCreate(toWTFString(value.get())).leakRef());
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::role()
+{
+    if (!isValid())
+        return nullptr;
+
+    WKRetainPtr value = axCopyAttributeValueAsString(m_elementToken, "AXRole");
+    if (!value)
+        return nullptr;
+
+    String roleString = toWTFString(value.get());
+    String result = makeString("AXRole: "_s, roleString);
+    return JSRetainPtr<JSStringRef>(Adopt, OpaqueJSString::tryCreate(result).leakRef());
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::title()
+{
+    return getStringAttribute("AXTitle");
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::description()
+{
+    return getStringAttribute("AXDescription");
+}
+
+JSRetainPtr<JSStringRef> AccessibilityUIElementClientMac::stringValue()
+{
+    return getStringAttribute("AXValue");
+}
+
+Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElementClientMac::getChildren() const
+{
+    Vector<RefPtr<AccessibilityUIElement>> children;
+    if (!isValid())
+        return children;
+
+    WKRetainPtr value = axCopyAttributeValueAsElementArray(m_elementToken, "AXChildren");
+    if (!value)
+        return children;
+
+    size_t count = WKArrayGetSize(value.get());
+    for (size_t i = 0; i < count; i++) {
+        WKTypeRef item = WKArrayGetItemAtIndex(value.get(), i);
+        if (WKGetTypeID(item) == WKUInt64GetTypeID()) {
+            uint64_t childToken = WKUInt64GetValue(static_cast<WKUInt64Ref>(item));
+            children.append(AccessibilityUIElementClientMac::create(childToken));
+        }
+    }
+
+    return children;
+}
+
+Vector<RefPtr<AccessibilityUIElement>> AccessibilityUIElementClientMac::getChildrenInRange(unsigned location, unsigned length) const
+{
+    Vector allChildren = getChildren();
+
+    if (location >= allChildren.size())
+        return { };
+
+    unsigned end = std::min(location + length, static_cast<unsigned>(allChildren.size()));
+    Vector<RefPtr<AccessibilityUIElement>> result;
+    result.reserveInitialCapacity(end - location);
+
+    for (unsigned i = location; i < end; i++)
+        result.append(allChildren[i]);
+
+    return result;
+}
+
+unsigned AccessibilityUIElementClientMac::childrenCount()
+{
+    return getChildren().size();
+}
+
+RefPtr<AccessibilityUIElement> AccessibilityUIElementClientMac::childAtIndex(unsigned index)
+{
+    Vector children = getChildrenInRange(index, 1);
+    return children.size() == 1 ? children[0] : nullptr;
+}
+
+} // namespace WTR
+
+#endif // PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -478,6 +478,11 @@ public:
 
     void uiScriptDidComplete(const String& result, unsigned scriptCallbackID);
 
+#if PLATFORM(MAC)
+    // Client accessibility testing support
+    void initializeWebProcessAccessibility();
+#endif
+
 private:
     WKRetainPtr<WKPageConfigurationRef> generatePageConfiguration(const TestOptions&);
     WKRetainPtr<WKContextConfigurationRef> generateContextConfiguration(const TestOptions&) const;
@@ -566,6 +571,20 @@ private:
     void didReceiveKeyDownMessageFromInjectedBundle(WKDictionaryRef messageBodyDictionary, bool synchronous);
     void didReceiveRawKeyDownMessageFromInjectedBundle(WKDictionaryRef messageBodyDictionary, bool synchronous);
     void didReceiveRawKeyUpMessageFromInjectedBundle(WKDictionaryRef messageBodyDictionary, bool synchronous);
+
+#if PLATFORM(MAC)
+    // Client accessibility testing support
+    uint64_t storeAXElement(CFTypeRef);
+    CFTypeRef getAXElement(uint64_t token);
+    CFDataRef getRemoteAccessibilityToken();
+    WKRetainPtr<WKTypeRef> handleAXGetRoot();
+    RetainPtr<CFTypeRef> axCopyAttributeValue(WKDictionaryRef);
+    WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsString(WKDictionaryRef);
+    WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsElement(WKDictionaryRef);
+    WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsElementArray(WKDictionaryRef);
+    WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsNumber(WKDictionaryRef);
+    WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsBoolean(WKDictionaryRef);
+#endif
 
     // WKContextClient
     static void networkProcessDidCrashWithDetails(WKContextRef, WKProcessID, WKProcessTerminationReason, const void*);
@@ -858,6 +877,12 @@ private:
     bool m_waitBeforeFinishingFullscreenExit { false };
     bool m_scrollDuringEnterFullscreen { false };
     bool m_useWorkQueue { false };
+
+#if PLATFORM(MAC)
+    // Client accessibility testing support
+    std::atomic<uint64_t> m_nextAXElementToken { 1 };
+    HashMap<uint64_t, RetainPtr<CFTypeRef>> m_axElementTokens;
+#endif
 
 #if ENABLE(WPE_PLATFORM)
     bool m_useWPELegacyAPI { false };

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -614,6 +614,14 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
         return nullptr;
     }
 
+#if PLATFORM(MAC)
+    if (WKStringIsEqualToUTF8CString(messageName, "InitializeWebProcessAccessibility")) {
+        // Initialize accessibility in the web content process by sending the IPC message
+        TestController::singleton().initializeWebProcessAccessibility();
+        return nullptr;
+    }
+#endif
+
     if (WKStringIsEqualToUTF8CString(messageName, "SetPrinting")) {
         setPrinting();
         return nullptr;

--- a/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
+++ b/Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj
@@ -77,6 +77,7 @@
 		29210EB5144CACD500835BB5 /* AccessibilityTextMarkerMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29210EB3144CACD400835BB5 /* AccessibilityTextMarkerMac.mm */; };
 		29210EDA144CC3EA00835BB5 /* AccessibilityUIElementMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29210EAB144CACB200835BB5 /* AccessibilityUIElementMac.mm */; };
 		29210EDA144CC3EA00835BB6 /* AccessibilityCommonCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29210EAB144CACB200835BB6 /* AccessibilityCommonCocoa.mm */; };
+		29210EDA144CC3EA00835BB7 /* AccessibilityUIElementClientMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 29210EAB144CACB200835BB7 /* AccessibilityUIElementClientMac.mm */; };
 		29210EDB144CD47900835BB5 /* JSAccessibilityController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 583913D014335E95008307E5 /* JSAccessibilityController.cpp */; };
 		29210EE1144CDB2600835BB5 /* JSAccessibilityUIElement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29210EDB146727E711835BB5 /* JSAccessibilityUIElement.cpp */; };
 		29A8FCCB145EF02E009045A6 /* JSAccessibilityTextMarker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 29210EE1144CDE6789815EE5 /* JSAccessibilityTextMarker.cpp */; };
@@ -335,6 +336,7 @@
 		29210EAA144CACB200835BB5 /* AccessibilityUIElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilityUIElement.h; sourceTree = "<group>"; };
 		29210EAB144CACB200835BB5 /* AccessibilityUIElementMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AccessibilityUIElementMac.mm; sourceTree = "<group>"; };
 		29210EAB144CACB200835BB6 /* AccessibilityCommonCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AccessibilityCommonCocoa.mm; sourceTree = "<group>"; };
+		29210EAB144CACB200835BB7 /* AccessibilityUIElementClientMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AccessibilityUIElementClientMac.mm; sourceTree = "<group>"; };
 		29210EB1144CACD400835BB5 /* AccessibilityTextMarker.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AccessibilityTextMarker.cpp; sourceTree = "<group>"; };
 		29210EB2144CACD400835BB5 /* AccessibilityTextMarker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccessibilityTextMarker.h; sourceTree = "<group>"; };
 		29210EB3144CACD400835BB5 /* AccessibilityTextMarkerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AccessibilityTextMarkerMac.mm; path = mac/AccessibilityTextMarkerMac.mm; sourceTree = "<group>"; };
@@ -432,6 +434,8 @@
 		8034C6611487636400AC32E9 /* AccessibilityControllerMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = AccessibilityControllerMac.mm; sourceTree = "<group>"; };
 		8097338814874A5A008156D9 /* AccessibilityNotificationHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AccessibilityNotificationHandler.h; path = mac/AccessibilityNotificationHandler.h; sourceTree = "<group>"; };
 		8097338914874A5A008156D9 /* AccessibilityNotificationHandler.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AccessibilityNotificationHandler.mm; path = mac/AccessibilityNotificationHandler.mm; sourceTree = "<group>"; };
+		80A359B02F2945980018924A /* AccessibilityUIElementClientMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessibilityUIElementClientMac.h; sourceTree = "<group>"; };
+		80A359B12F2945A20018924A /* AccessibilityUIElementMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AccessibilityUIElementMac.h; sourceTree = "<group>"; };
 		841CC00D181185BF0042E9B6 /* Options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Options.cpp; sourceTree = "<group>"; };
 		841CC00E181185BF0042E9B6 /* Options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Options.h; sourceTree = "<group>"; };
 		8DD76FA10486AA7600D96B5E /* WebKitTestRunner */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = WebKitTestRunner; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -864,6 +868,9 @@
 			isa = PBXGroup;
 			children = (
 				8034C6611487636400AC32E9 /* AccessibilityControllerMac.mm */,
+				80A359B02F2945980018924A /* AccessibilityUIElementClientMac.h */,
+				29210EAB144CACB200835BB7 /* AccessibilityUIElementClientMac.mm */,
+				80A359B12F2945A20018924A /* AccessibilityUIElementMac.h */,
 				29210EAB144CACB200835BB5 /* AccessibilityUIElementMac.mm */,
 				BC8DAD771316D7B900EC96FC /* InjectedBundleMac.mm */,
 			);
@@ -1468,6 +1475,7 @@
 				29A8FCE2145F037B009045A6 /* AccessibilityTextMarkerRange.cpp in Sources */,
 				29A8FCE5145F0464009045A6 /* AccessibilityTextMarkerRangeCocoa.mm in Sources */,
 				29210EAE144CACB700835BB5 /* AccessibilityUIElement.cpp in Sources */,
+				29210EDA144CC3EA00835BB7 /* AccessibilityUIElementClientMac.mm in Sources */,
 				2E63EDA11891B291002A7AFC /* AccessibilityUIElementIOS.mm in Sources */,
 				29210EDA144CC3EA00835BB5 /* AccessibilityUIElementMac.mm in Sources */,
 				65EB85A011EC67CC0034D300 /* ActivateFontsCocoa.mm in Sources */,

--- a/Tools/WebKitTestRunner/mac/TestControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/TestControllerMac.mm
@@ -490,4 +490,29 @@ const char* TestController::platformLibraryPathForTesting()
     return [platformLibraryPath.get() UTF8String];
 }
 
+CFDataRef TestController::getRemoteAccessibilityToken()
+{
+    if (!m_mainWebView)
+        return nullptr;
+
+    auto* platformView = m_mainWebView->platformView();
+    if (!platformView)
+        return nullptr;
+
+    return (__bridge CFDataRef)[platformView _remoteAccessibilityChildToken];
+}
+
+void TestController::initializeWebProcessAccessibility()
+{
+    auto* platformView = m_mainWebView->platformView();
+    if (!platformView)
+        return;
+
+    // Trigger accessibility initialization by accessing an accessibility attribute.
+    // This will call WebViewImpl::enableAccessibilityIfNecessary() which then calls
+    // WebProcessPool::initializeAccessibilityIfNecessary() to send the InitializeAccessibility
+    // IPC message to the web content process.
+    [platformView accessibilityAttributeValue:NSAccessibilityRoleAttribute];
+}
+
 } // namespace WTR


### PR DESCRIPTION
#### 08520761a0f9675f05de8ddbf42d89dcb44a6960
<pre>
AX: Add client-side accessibility testing support for site isolation tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=306382">https://bugs.webkit.org/show_bug.cgi?id=306382</a>
<a href="https://rdar.apple.com/169048334">rdar://169048334</a>

Reviewed by Tyler Wilcock.

Enables using Mac client-side accessibility APIs
(e.g. AXUIElementCopyAttributeValue, used by clients like VoiceOver),
in accessibility layout tests, which will allow us to test that
accessibility APIs work correctly across site isolation boundaries.

This adds a new subclass of AccessibilityUIElement, used to represent
each element in an accessibility layout test. When this class is
chosen, the client-side accessibility API is used to explore the
accessibility tree, rather than calling accessibility APIs in WebCore
directly.

This can&apos;t be done from the web content process due to sandboxing,
so instead we send an IPC to the main WebKitTestRunner process and
have it call the APIs there. Each AXUIElement is stored in a map and
represented by an opaque token.

Because the JavaScript API is blocked on an IPC to the main process,
and the main process&apos;s accessibility call blocks on an IPC to the
web content process, this only works if isolated tree mode is enabled,
because that uses a secondary accessibility thread.

This initial patch just starts with a very simple layout test to
demonstrate usage, and we will follow up with site isolation tests.

Note: originally merged as 306715@main, reverted in 306802@main because
internal bots failed. The issue was with changes to WebCoreTestSupport,
so I modified it to remove the need for changes there.

Test: accessibility/mac/client/button.html

* LayoutTests/accessibility/mac/client/README.md: Added.
* LayoutTests/accessibility/mac/client/button-expected.txt: Added.
* LayoutTests/accessibility/mac/client/button.html: Added.
* LayoutTests/platform/mac/TestExpectations:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _remoteAccessibilityChildToken]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::remoteAccessibilityChildToken):
* Tools/WebKitTestRunner/Configurations/WebKitTestRunner-internal.entitlements:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.cpp:
(WTR::AccessibilityController::setClientAccessibilityMode):
(WTR::AccessibilityController::rootElement):
(WTR::AccessibilityController::platformInitializeClientAccessibility):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityController.h:
(WTR::AccessibilityController::clientAccessibilityModeEnabled const):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityController.idl:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::platformInitializeClientAccessibility):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h: Added.
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm: Added.
(WTR::axGetRoot):
(WTR::axCopyAttributeValueAsString):
(WTR::axCopyAttributeValueAsElementArray):
(WTR::AccessibilityUIElementClientMac::create):
(WTR::AccessibilityUIElementClientMac::createForUIProcess):
(WTR::AccessibilityUIElementClientMac::AccessibilityUIElementClientMac):
(WTR::AccessibilityUIElementClientMac::~AccessibilityUIElementClientMac):
(WTR::AccessibilityUIElementClientMac::platformUIElement):
(WTR::AccessibilityUIElementClientMac::isValid const):
(WTR::AccessibilityUIElementClientMac::getStringAttribute const):
(WTR::AccessibilityUIElementClientMac::role):
(WTR::AccessibilityUIElementClientMac::title):
(WTR::AccessibilityUIElementClientMac::description):
(WTR::AccessibilityUIElementClientMac::stringValue):
(WTR::AccessibilityUIElementClientMac::getChildren const):
(WTR::AccessibilityUIElementClientMac::getChildrenInRange const):
(WTR::AccessibilityUIElementClientMac::childrenCount):
(WTR::AccessibilityUIElementClientMac::childAtIndex):
* Tools/WebKitTestRunner/TestController.cpp:
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
* Tools/WebKitTestRunner/WebKitTestRunner.xcodeproj/project.pbxproj:
* Tools/WebKitTestRunner/mac/TestControllerMac.mm:
(WTR::TestController::getRemoteAccessibilityToken):
(WTR::TestController::initializeWebProcessAccessibility):

Canonical link: <a href="https://commits.webkit.org/306961@main">https://commits.webkit.org/306961@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f93baa26fb25ccc27b9c881ffb789be68a4f8678

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142892 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15364 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/5919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151566 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144759 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109891 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12348 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11846 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9531 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1565 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121230 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/4383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153879 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14990 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/5028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15027 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13015 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118244 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30228 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14227 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/125209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15033 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/4119 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78744 "Built successfully") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14830 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->