### PR TITLE
[GFC] Implement Step 3 of grid auto-placement for single-cell items.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -137,14 +137,14 @@ auto GridLayout::placeGridItems(UnplacedGridItems& unplacedGridItems, const Vect
         implicitGrid.insertUnplacedGridItem(nonAutoPositionedItem);
 
     // 2. Process the items locked to a given row.
-    // Phase 1: Only single-cell items within explicit grid bounds
-    HashMap<size_t, size_t, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>> rowCursors;
     for (auto& definiteRowPositionedItem : unplacedGridItems.definiteRowPositionedItems)
-        implicitGrid.insertDefiniteRowItem(definiteRowPositionedItem, autoFlowOptions, &rowCursors);
+        implicitGrid.insertDefiniteRowItem(definiteRowPositionedItem, autoFlowOptions);
 
-    // 3. FIXME: Process auto-positioned items (not implemented yet)
-    ASSERT(unplacedGridItems.autoPositionedItems.isEmpty());
-
+    // 3. Process auto-positioned items
+    // FIXME: Spec Step 4 requires special handling for items with a definite column
+    // position but auto row position; we currently treat them as fully auto-positioned.
+    if (!unplacedGridItems.autoPositionedItems.isEmpty())
+        implicitGrid.insertAutoPositionedItems(unplacedGridItems.autoPositionedItems, autoFlowOptions);
 
     return Result { implicitGrid.gridAreas(), implicitGrid.columnsCount(), implicitGrid.rowsCount() };
 }

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -53,12 +53,14 @@ void ImplicitGrid::insertUnplacedGridItem(const UnplacedGridItem& unplacedGridIt
     auto [columnStart, columnEnd] = unplacedGridItem.normalizedColumnStartEnd();
     auto [rowStart, rowEnd] = unplacedGridItem.normalizedRowStartEnd();
 
+    // FIXME: Support explicit items spanning multiple columns.
     // Multi-cell items (spanning multiple columns) are not yet supported.
     if (columnEnd - columnStart > 1) {
         ASSERT_NOT_IMPLEMENTED_YET();
         return;
     }
 
+    // FIXME: Support explicit items spanning multiple rows.
     // Multi-cell items (spanning multiple rows) are not yet supported.
     if (rowEnd - rowStart > 1) {
         ASSERT_NOT_IMPLEMENTED_YET();
@@ -71,7 +73,6 @@ void ImplicitGrid::insertUnplacedGridItem(const UnplacedGridItem& unplacedGridIt
         for (auto columnIndex = columnsRange.begin(); columnIndex < columnsRange.end(); ++columnIndex)
             m_gridMatrix[rowIndex][columnIndex].append(unplacedGridItem);
     }
-
 }
 
 GridAreas ImplicitGrid::gridAreas() const
@@ -93,7 +94,27 @@ GridAreas ImplicitGrid::gridAreas() const
     return gridAreas;
 }
 
-void ImplicitGrid::insertDefiniteRowItem(const UnplacedGridItem& unplacedGridItem, GridAutoFlowOptions autoFlowOptions, HashMap<size_t, size_t, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>* rowCursors)
+void ImplicitGrid::growGridColumnsToFit(size_t columnSpan, size_t normalizedRowStart, size_t normalizedRowEnd)
+{
+    auto currentColumnsCount = columnsCount();
+
+    // Find the last occupied column in the spanned rows
+    size_t lastOccupiedColumn = 0;
+    for (size_t row = normalizedRowStart; row < normalizedRowEnd; ++row) {
+        for (size_t column = currentColumnsCount; column > 0; --column) {
+            if (!m_gridMatrix[row][column - 1].isEmpty()) {
+                lastOccupiedColumn = std::max(lastOccupiedColumn, column - 1);
+                break;
+            }
+        }
+    }
+
+    size_t minimumColumnsNeeded = lastOccupiedColumn + 1 + columnSpan;
+    for (auto& row : m_gridMatrix)
+        row.resize(minimumColumnsNeeded);
+}
+
+void ImplicitGrid::insertDefiniteRowItem(const UnplacedGridItem& unplacedGridItem, GridAutoFlowOptions autoFlowOptions)
 {
     // Step 2 of CSS Grid auto-placement algorithm:
     // Process items locked to a given row (definite row position, auto column position)
@@ -105,63 +126,19 @@ void ImplicitGrid::insertDefiniteRowItem(const UnplacedGridItem& unplacedGridIte
 
     ASSERT(unplacedGridItem.hasDefiniteRowPosition() && !unplacedGridItem.hasDefiniteColumnPosition());
     auto [normalizedRowStart, normalizedRowEnd] = unplacedGridItem.normalizedRowStartEnd();
-    // FIXME: Support multi-row spans
+    // FIXME: Support multi-row spans.
     ASSERT(normalizedRowEnd - normalizedRowStart == 1);
 
-    auto findColumnPosition = [&]() -> std::optional<size_t> {
-        if (autoFlowOptions.strategy == PackingStrategy::Dense) {
-            // Dense packing: always start searching from column 0
-            return findFirstAvailableColumnPosition(normalizedRowStart, normalizedRowEnd, columnSpan, 0);
-        }
-        // Sparse packing: use per-row cursors to maintain placement order
-        // For multi-row items, use the maximum cursor position across all spanned rows
-        ASSERT(autoFlowOptions.strategy == PackingStrategy::Sparse);
-        size_t startSearchColumn = 0;
-        for (size_t row = normalizedRowStart; row < normalizedRowEnd; ++row)
-            startSearchColumn = std::max(startSearchColumn, rowCursors->get(row));
-        return findFirstAvailableColumnPosition(normalizedRowStart, normalizedRowEnd, columnSpan, startSearchColumn);
-    };
-
-    auto growGridToFit = [&](size_t columnSpan, size_t normalizedRowStart, size_t normalizedRowEnd, size_t currentColumnsCount) {
-        // Find the last occupied column in the spanned rows
-        size_t lastOccupiedColumn = 0;
-        for (size_t row = normalizedRowStart; row < normalizedRowEnd; ++row) {
-            for (size_t column = currentColumnsCount; column > 0; --column) {
-                if (!m_gridMatrix[row][column - 1].isEmpty()) {
-                    lastOccupiedColumn = std::max(lastOccupiedColumn, column - 1);
-                    break;
-                }
-            }
-        }
-
-        size_t minimumColumnsNeeded = lastOccupiedColumn + 1 + columnSpan;
-        for (auto& row : m_gridMatrix)
-            row.resize(minimumColumnsNeeded);
-    };
-
-    auto columnPosition = findColumnPosition();
+    auto columnPosition = findColumnPositionForDefiniteRowItem(normalizedRowStart, normalizedRowEnd, columnSpan, autoFlowOptions.strategy);
 
     if (!columnPosition) {
-        growGridToFit(columnSpan, normalizedRowStart, normalizedRowEnd, columnsCount());
+        growGridColumnsToFit(columnSpan, normalizedRowStart, normalizedRowEnd);
 
         // Retry finding position in the grown grid
-        columnPosition = findColumnPosition();
+        columnPosition = findColumnPositionForDefiniteRowItem(normalizedRowStart, normalizedRowEnd, columnSpan, autoFlowOptions.strategy);
 #ifndef NDEBUG
-        ASSERT(columnPosition); // Must succeed after growing
-
-        // Verify the found position doesn't overlap with existing items
-        ASSERT(isCellRangeEmpty(*columnPosition, *columnPosition + columnSpan, normalizedRowStart, normalizedRowEnd),
-            "After grid growth, placed item overlaps with occupied cells.");
-
-        auto verifyHasEmptyLastColumn = [&]() {
-            for (size_t row = 0; row < m_gridMatrix.size(); ++row) {
-                if (!m_gridMatrix[row].last().isEmpty())
-                    return false;
-            }
-            ASSERT_NOT_REACHED();
-            return true;
-        };
-        verifyHasEmptyLastColumn();
+        ASSERT(columnPosition);
+        ASSERT(isCellRangeEmpty(*columnPosition, *columnPosition + columnSpan, normalizedRowStart, normalizedRowEnd));
 #endif
     }
 
@@ -169,7 +146,7 @@ void ImplicitGrid::insertDefiniteRowItem(const UnplacedGridItem& unplacedGridIte
 
     if (autoFlowOptions.strategy != PackingStrategy::Dense) {
         for (size_t row = normalizedRowStart; row < normalizedRowEnd; ++row)
-            rowCursors->set(row, *columnPosition + columnSpan);
+            m_rowCursors.set(row, *columnPosition + columnSpan);
     }
 }
 
@@ -201,11 +178,136 @@ bool ImplicitGrid::isCellRangeEmpty(size_t columnStart, size_t columnEnd, size_t
     return true;
 }
 
+std::optional<size_t> ImplicitGrid::findColumnPositionForDefiniteRowItem(size_t rowStart, size_t rowEnd, size_t columnSpan, PackingStrategy strategy) const
+{
+    size_t startSearchColumn = 0;
+
+    if (strategy == PackingStrategy::Sparse) {
+        // Use per-row cursors to maintain placement order
+        for (size_t row = rowStart; row < rowEnd; ++row)
+            startSearchColumn = std::max(startSearchColumn, m_rowCursors.get(row));
+    }
+
+    return findFirstAvailableColumnPosition(rowStart, rowEnd, columnSpan, startSearchColumn);
+}
+
 void ImplicitGrid::insertItemInArea(const UnplacedGridItem& unplacedGridItem, size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd)
 {
     for (size_t row = rowStart; row < rowEnd; ++row) {
         for (size_t column = columnStart; column < columnEnd; ++column)
             m_gridMatrix[row][column].append(unplacedGridItem);
+    }
+}
+
+std::optional<GridPosition> ImplicitGrid::findFirstAvailablePosition(size_t rowSpan, size_t columnSpan, size_t startRow, size_t startColumn) const
+{
+    // Search for the first available position starting from (startRow, startColumn)
+    // following row-major order (left-to-right, top-to-bottom).
+    // This implements the auto-placement cursor search for grid-auto-flow: row.
+
+    auto currentColumnsCount = columnsCount();
+    auto currentRowsCount = rowsCount();
+
+    // Search through existing grid rows
+    for (size_t row = startRow; row < currentRowsCount; ++row) {
+        // For the starting row, begin search from startColumn
+        // For subsequent rows, start from column 0
+        size_t searchStartColumn = (row == startRow) ? startColumn : 0;
+
+        // Try each column position in this row
+        for (size_t column = searchStartColumn; column < currentColumnsCount; ++column) {
+            // Check if item fits within current grid bounds
+            if (column + columnSpan <= currentColumnsCount && row + rowSpan <= currentRowsCount) {
+                if (isCellRangeEmpty(column, column + columnSpan, row, row + rowSpan))
+                    return GridPosition { row, column };
+            }
+        }
+    }
+
+    // No position found in existing grid
+    return std::nullopt;
+}
+
+void ImplicitGrid::growGridToSize(size_t newColumnsCount, size_t newRowsCount)
+{
+    auto targetColumnsCount = std::max(columnsCount(), newColumnsCount);
+
+    // Grow columns in existing rows if needed
+    if (targetColumnsCount > columnsCount()) {
+        for (auto& row : m_gridMatrix)
+            row.resize(targetColumnsCount);
+    }
+
+    // Grow rows if needed (with correct column count)
+    while (m_gridMatrix.size() < newRowsCount)
+        m_gridMatrix.append(Vector<GridCell>(targetColumnsCount));
+}
+
+GridPosition ImplicitGrid::placeAutoPositionedItem(const UnplacedGridItem& item)
+{
+    auto rowSpan = item.rowSpanSize();
+    auto columnSpan = item.columnSpanSize();
+
+    // FIXME: Support multi-span items
+    // Multi-span items should be blocked by coverage check in LayoutIntegrationGridCoverage.cpp
+    if (rowSpan != 1 || columnSpan != 1) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+
+    // Try to find an available position starting from the cursor
+    auto position = findFirstAvailablePosition(rowSpan, columnSpan, m_autoPlacementCursor.row, m_autoPlacementCursor.column);
+
+    if (!position) {
+        // No position found in existing grid - need to grow the grid
+        // Add a new implicit row and place item at the start of that row
+        auto newRowIndex = rowsCount();
+        auto newColumnsCount = std::max(columnsCount(), columnSpan);
+        growGridToSize(newColumnsCount, newRowIndex + rowSpan);
+
+        // Per CSS Grid spec, when no position is found in existing rows,
+        // add a new implicit row at the end and place the item there.
+        // https://drafts.csswg.org/css-grid-1/#auto-placement-algo step 4.1.2.3
+        position = GridPosition { newRowIndex, 0 };
+
+        // Verify the position is empty after grid growth
+        ASSERT(isCellRangeEmpty(0, columnSpan, newRowIndex, newRowIndex + rowSpan));
+    }
+
+    insertItemInArea(item, position->column, position->column + columnSpan, position->row, position->row + rowSpan);
+
+    return *position;
+}
+
+void ImplicitGrid::insertAutoPositionedItems(const Vector<UnplacedGridItem>& autoPositionedItems, GridAutoFlowOptions autoFlowOptions)
+{
+    // CSS Grid Spec Section 8.5 Step 3: Position the remaining grid items
+    // https://drafts.csswg.org/css-grid-1/#auto-placement-algo
+    // FIXME: Step 4.1.2.1/4.1.2.2 (items with definite column position, auto row)
+    // are not handled; we only support fully auto-positioned items here.
+
+    if (autoFlowOptions.direction != GridAutoFlowDirection::Row) {
+        // FIXME: Support grid-auto-flow: column.
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    m_autoPlacementCursor.reset();
+
+    for (const auto& item : autoPositionedItems) {
+        if (item.rowSpanSize() != 1 || item.columnSpanSize() != 1) {
+            // FIXME: Support auto-placement for spanning items.
+            ASSERT_NOT_IMPLEMENTED_YET();
+            continue;
+        }
+
+        auto position = placeAutoPositionedItem(item);
+
+        // Update cursor based on packing strategy
+        if (autoFlowOptions.strategy == PackingStrategy::Dense)
+            m_autoPlacementCursor.reset();
+        else
+            m_autoPlacementCursor.advancePast(position.row, position.column + item.columnSpanSize(), columnsCount());
     }
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/GridTypeAliases.h>
+#include "GridTypeAliases.h"
 #include <wtf/Forward.h>
 #include <wtf/Vector.h>
 
@@ -36,6 +36,27 @@ namespace Layout {
 enum class GridLayoutAlgorithm : uint8_t;
 struct GridAutoFlowOptions;
 
+struct GridPosition {
+    size_t row { 0 };
+    size_t column { 0 };
+};
+
+struct AutoPlacementCursor {
+    size_t row { 0 };
+    size_t column { 0 };
+
+    void reset() { row = 0; column = 0; }
+    void advancePast(size_t placedRow, size_t placedColumnEnd, size_t gridColumnsCount)
+    {
+        row = placedRow;
+        column = placedColumnEnd;
+        if (column >= gridColumnsCount) {
+            row++;
+            column = 0;
+        }
+    }
+};
+
 // https://drafts.csswg.org/css-grid-1/#implicit-grids
 class ImplicitGrid {
 public:
@@ -45,16 +66,31 @@ public:
     size_t columnsCount() const { return rowsCount() ? m_gridMatrix[0].size() : 0; }
 
     void insertUnplacedGridItem(const UnplacedGridItem&);
-    void insertDefiniteRowItem(const UnplacedGridItem&, GridAutoFlowOptions, HashMap<size_t, size_t, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>*);
+    void insertDefiniteRowItem(const UnplacedGridItem&, GridAutoFlowOptions);
+    void insertAutoPositionedItems(const Vector<UnplacedGridItem>&, GridAutoFlowOptions);
 
     GridAreas gridAreas() const;
 
 private:
+    using RowCursors = HashMap<size_t, size_t, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>;
+
     std::optional<size_t> findFirstAvailableColumnPosition(size_t rowStart, size_t rowEnd, size_t columnSpan, size_t startSearchColumn) const;
+    std::optional<GridPosition> findFirstAvailablePosition(size_t rowSpan, size_t columnSpan, size_t startRow, size_t startColumn) const;
+    std::optional<size_t> findColumnPositionForDefiniteRowItem(size_t rowStart, size_t rowEnd, size_t columnSpan, PackingStrategy) const;
     bool isCellRangeEmpty(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd) const;
     void insertItemInArea(const UnplacedGridItem&, size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd);
+    void growGridToSize(size_t newColumnsCount, size_t newRowsCount);
+    void growGridColumnsToFit(size_t columnSpan, size_t normalizedRowStart, size_t normalizedRowEnd);
+    GridPosition placeAutoPositionedItem(const UnplacedGridItem&);
 
     GridMatrix m_gridMatrix;
+
+    // Per-row cursors for Step 2 sparse packing (definite row items)
+    RowCursors m_rowCursors;
+
+    // Auto-placement cursor for Step 3 of the grid placement algorithm
+    // https://drafts.csswg.org/css-grid-1/#auto-placement-cursor
+    AutoPlacementCursor m_autoPlacementCursor;
 };
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -132,24 +132,36 @@ bool UnplacedGridItem::hasAutoColumnPosition() const
 
 size_t UnplacedGridItem::columnSpanSize() const
 {
-    auto firstPosition = m_columnPosition.first;
-    auto secondPosition = m_columnPosition.second;
+    auto& firstPosition = m_columnPosition.first;
+    auto& secondPosition = m_columnPosition.second;
 
-    // Case 1: Both positions are explicit - calculate span size
-    if (firstPosition.isExplicit() && secondPosition.isExplicit()) {
-        auto spanSize = explicitColumnEnd() - explicitColumnStart();
-        return spanSize;
-    }
+    if (firstPosition.isExplicit() && secondPosition.isExplicit())
+        return explicitColumnEnd() - explicitColumnStart();
 
-    // Case 2: One position is a span - extract its span size.
     ASSERT(!(firstPosition.isSpan() && secondPosition.isSpan()));
     if (firstPosition.isSpan())
         return firstPosition.spanPosition();
     if (secondPosition.isSpan())
         return secondPosition.spanPosition();
 
-    // Default to span 1
     ASSERT(hasAutoColumnPosition());
+    return 1;
+}
+
+size_t UnplacedGridItem::rowSpanSize() const
+{
+    auto& firstPosition = m_rowPosition.first;
+    auto& secondPosition = m_rowPosition.second;
+
+    if (firstPosition.isExplicit() && secondPosition.isExplicit())
+        return explicitRowEnd() - explicitRowStart();
+
+    ASSERT(!(firstPosition.isSpan() && secondPosition.isSpan()));
+    if (firstPosition.isSpan())
+        return firstPosition.spanPosition();
+    if (secondPosition.isSpan())
+        return secondPosition.spanPosition();
+
     return 1;
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <WebCore/StyleGridPosition.h>
+#include "StyleGridPosition.h"
 
 namespace WebCore {
 namespace Layout {
@@ -53,6 +53,7 @@ public:
     bool hasDefiniteColumnPosition() const;
     bool hasAutoColumnPosition() const;
     size_t columnSpanSize() const;
+    size_t rowSpanSize() const;
 
     std::pair<size_t, size_t> normalizedRowStartEnd() const;
     std::pair<size_t, size_t> normalizedColumnStartEnd() const;
@@ -97,7 +98,7 @@ private:
 
 // https://drafts.csswg.org/css-grid-1/#auto-placement-algo
 struct UnplacedGridItems {
-    // 1. Position anything that’s not auto-positioned.
+    // 1. Position anything that's not auto-positioned.
     Vector<UnplacedGridItem> nonAutoPositionedItems;
     // 2. Process the items locked to a given row.
     Vector<UnplacedGridItem> definiteRowPositionedItems;
@@ -105,8 +106,8 @@ struct UnplacedGridItems {
     Vector<UnplacedGridItem> autoPositionedItems;
 };
 
-}
-}
+} // namespace Layout
+} // namespace WebCore
 
 namespace WTF {
 

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -447,6 +447,12 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         auto& rowStart = gridItemStyle->gridItemRowStart();
         auto rowPositioningAvoidanceReason = WTF::switchOn(rowStart,
             [&](const CSS::Keyword::Auto&) -> std::optional<GridAvoidanceReason> {
+                // Allow auto row start if row end is also auto (fully auto-positioned item)
+                auto& rowEnd = gridItemStyle->gridItemRowEnd();
+                if (rowEnd.isAuto())
+                    return std::nullopt;
+
+                // Auto row start with definite row end not yet supported
                 return GridAvoidanceReason::GridItemHasUnsupportedRowPlacement;
             },
             [&](const Style::GridPositionExplicit& explicitPosition) -> std::optional<GridAvoidanceReason> {


### PR DESCRIPTION
#### d5f67242af01b8ba68591c502beabcf94e554879
<pre>
[GFC] Implement Steps 3 and 4 of grid auto-placement for single-cell items.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306960">https://bugs.webkit.org/show_bug.cgi?id=306960</a>
&lt;<a href="https://rdar.apple.com/169629496">rdar://169629496</a>&gt;

Reviewed by NOBODY (OOPS!).

This PR implements Steps 3 and 4 of the CSS Grid auto-placement algorithm
for Grid Formatting Context. Step 3 sets the column count for the implicit grid
by checking the column positions and spans of the unplaced items.

Step 4 positions the remaining auto-positioned items using the auto placement
cursor tracking the current insertion point.

This PR supports both sparse and dense packing.

Definite column positioned items are positioned by searching down their
specificed column, while fully automatically positioned items are positioned
by searching left-&gt;right and top-&gt;down. We dynamically add implicit rows as
needed during placement.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::placeGridItems):
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp:
(WebCore::Layout::ImplicitGrid::insertDefiniteRowItem):
(WebCore::Layout::ImplicitGrid::determineImplicitGridColumns):
(WebCore::Layout::ImplicitGrid::insertAutoPositionedItems):
(WebCore::Layout::ImplicitGrid::growColumnsToFit):
(WebCore::Layout::ImplicitGrid::growRowsToFit):
(WebCore::Layout::ImplicitGrid::placeAutoPositionedItemWithDefiniteColumn):
(WebCore::Layout::ImplicitGrid::placeAutoPositionedItemWithAutoColumnAndRow):
(WebCore::Layout::ImplicitGrid::verifyHasEmptyLastColumn const): Deleted.
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h:
</pre>