### PR TITLE
Use `protect()` in more places in RenderMedia & RenderVideo

### DIFF
--- a/Source/WebCore/rendering/RenderMedia.cpp
+++ b/Source/WebCore/rendering/RenderMedia.cpp
@@ -57,17 +57,17 @@ void RenderMedia::layout()
     LayoutSize oldSize = size();
     RenderImage::layout();
     if (oldSize != size())
-        protectedMediaElement()->layoutSizeChanged();
+        protect(mediaElement())->layoutSizeChanged();
 }
 
 void RenderMedia::styleDidChange(Style::Difference difference, const RenderStyle* oldStyle)
 {
     RenderImage::styleDidChange(difference, oldStyle);
     if (!oldStyle || style().usedVisibility() != oldStyle->usedVisibility())
-        protectedMediaElement()->visibilityDidChange();
+        protect(mediaElement())->visibilityDidChange();
 
     if (!oldStyle || style().dynamicRangeLimit() != oldStyle->dynamicRangeLimit())
-        protectedMediaElement()->dynamicRangeLimitDidChange(style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
+        protect(mediaElement())->dynamicRangeLimitDidChange(style().dynamicRangeLimit().toPlatformDynamicRangeLimit());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderMedia.h
+++ b/Source/WebCore/rendering/RenderMedia.h
@@ -39,7 +39,6 @@ public:
     virtual ~RenderMedia();
 
     inline HTMLMediaElement& mediaElement() const; // Defined in RenderMediaInlines.h
-    inline Ref<HTMLMediaElement> protectedMediaElement() const; // Defined in RenderMediaInlines.h
 
     bool shouldDisplayBrokenImageIcon() const final { return false; }
 

--- a/Source/WebCore/rendering/RenderMediaInlines.h
+++ b/Source/WebCore/rendering/RenderMediaInlines.h
@@ -45,9 +45,4 @@ inline HTMLMediaElement& RenderMedia::mediaElement() const
     return downcast<HTMLMediaElement>(nodeForNonAnonymous());
 }
 
-inline Ref<HTMLMediaElement> RenderMedia::protectedMediaElement() const
-{
-    return mediaElement();
-}
-
 }

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -70,7 +70,7 @@ void RenderVideo::willBeDestroyed()
 {
     visibleInViewportStateChanged();
 
-    if (RefPtr player = protectedVideoElement()->player())
+    if (RefPtr player = protect(videoElement())->player())
         player->renderVideoWillBeDestroyed();
 
     RenderMedia::willBeDestroyed();
@@ -78,7 +78,7 @@ void RenderVideo::willBeDestroyed()
 
 void RenderVideo::visibleInViewportStateChanged()
 {
-    protectedVideoElement()->isVisibleInViewportChanged();
+    protect(videoElement())->isVisibleInViewportChanged();
 }
 
 IntSize RenderVideo::defaultSize()
@@ -92,7 +92,7 @@ IntSize RenderVideo::defaultSize()
 
 void RenderVideo::intrinsicSizeChanged()
 {
-    if (protectedVideoElement()->shouldDisplayPosterImage())
+    if (protect(videoElement())->shouldDisplayPosterImage())
         RenderMedia::intrinsicSizeChanged();
     if (updateIntrinsicSize())
         invalidateLineLayout();
@@ -106,7 +106,7 @@ bool RenderVideo::updateIntrinsicSize()
         return false;
 
     // Treat the media player's natural size as visually non-empty.
-    if (protectedVideoElement()->readyState() >= HTMLMediaElementEnums::HAVE_METADATA)
+    if (protect(videoElement())->readyState() >= HTMLMediaElementEnums::HAVE_METADATA)
         incrementVisuallyNonEmptyPixelCountIfNeeded(roundedIntSize(size));
 
     if (size == intrinsicSize())
@@ -187,7 +187,7 @@ void RenderVideo::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
     // Cache the image intrinsic size so we can continue to use it to draw the image correctly
     // even if we know the video intrinsic size but aren't able to draw video frames yet
     // (we don't want to scale the poster to the video size without keeping aspect ratio).
-    if (protectedVideoElement()->shouldDisplayPosterImage())
+    if (protect(videoElement())->shouldDisplayPosterImage())
         m_cachedImageSize = intrinsicSize();
 
     // The intrinsic size is now that of the image, but in case we already had the
@@ -224,7 +224,7 @@ IntRect RenderVideo::videoBoxInRootView() const
 
 bool RenderVideo::shouldDisplayVideo() const
 {
-    return !protectedVideoElement()->shouldDisplayPosterImage();
+    return !protect(videoElement())->shouldDisplayPosterImage();
 }
 
 bool RenderVideo::failedToLoadPosterImage() const
@@ -322,11 +322,6 @@ HTMLVideoElement& RenderVideo::videoElement() const
     return downcast<HTMLVideoElement>(RenderMedia::mediaElement());
 }
 
-Ref<HTMLVideoElement> RenderVideo::protectedVideoElement() const
-{
-    return videoElement();
-}
-
 void RenderVideo::updateFromElement()
 {
     RenderMedia::updateFromElement();
@@ -366,17 +361,17 @@ LayoutUnit RenderVideo::minimumReplacedHeight() const
 
 bool RenderVideo::supportsAcceleratedRendering() const
 {
-    return protectedVideoElement()->supportsAcceleratedRendering();
+    return protect(videoElement())->supportsAcceleratedRendering();
 }
 
 void RenderVideo::acceleratedRenderingStateChanged()
 {
-    protectedVideoElement()->acceleratedRenderingStateChanged();
+    protect(videoElement())->acceleratedRenderingStateChanged();
 }
 
 bool RenderVideo::requiresImmediateCompositing() const
 {
-    RefPtr player = protectedVideoElement()->player();
+    RefPtr player = protect(videoElement())->player();
     return player && player->requiresImmediateCompositing();
 }
 
@@ -397,7 +392,7 @@ bool RenderVideo::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect,
 
 bool RenderVideo::hasVideoMetadata() const
 {
-    if (RefPtr player = protectedVideoElement()->player())
+    if (RefPtr player = protect(videoElement())->player())
         return player->readyState() >= MediaPlayerEnums::ReadyState::HaveMetadata;
     return false;
 }
@@ -409,7 +404,7 @@ bool RenderVideo::hasPosterFrameSize() const
     // so that contain: inline-size could affect the intrinsic size, which should be 0 x block-size.
     if (shouldApplyInlineSizeContainment())
         isEmpty = isHorizontalWritingMode() ? !m_cachedImageSize.height() : !m_cachedImageSize.width();
-    return protectedVideoElement()->shouldDisplayPosterImage() && !isEmpty && !checkedImageResource()->errorOccurred();
+    return protect(videoElement())->shouldDisplayPosterImage() && !isEmpty && !checkedImageResource()->errorOccurred();
 }
 
 bool RenderVideo::hasDefaultObjectSize() const

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -41,7 +41,6 @@ public:
     virtual ~RenderVideo();
 
     WEBCORE_EXPORT HTMLVideoElement& videoElement() const;
-    WEBCORE_EXPORT Ref<HTMLVideoElement> protectedVideoElement() const;
 
     IntRect videoBox() const;
     WEBCORE_EXPORT IntRect videoBoxInRootView() const;

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -78,7 +78,7 @@ RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateSh
 
 #if ENABLE(VIDEO)
     if (auto* renderVideo = dynamicDowncast<RenderVideo>(renderImage))
-        return renderVideo->protectedVideoElement()->bitmapImageForCurrentTimeSync();
+        return protect(renderVideo->videoElement())->bitmapImageForCurrentTimeSync();
 #endif // ENABLE(VIDEO)
 
     auto* cachedImage = renderImage.cachedImage();
@@ -114,7 +114,7 @@ RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateSh
 Ref<NativePromise<Ref<WebCore::ShareableBitmap>, void>> createShareableBitmapAsync(WebCore::RenderImage& renderImage, CreateShareableBitmapFromImageOptions&& options)
 {
     if (auto* renderVideo = dynamicDowncast<RenderVideo>(renderImage))
-        return renderVideo->protectedVideoElement()->bitmapImageForCurrentTime();
+        return protect(renderVideo->videoElement())->bitmapImageForCurrentTime();
     if (RefPtr shareableBitmap = createShareableBitmap(renderImage, WTF::move(options)))
         return NativePromise<Ref<WebCore::ShareableBitmap>, void>::createAndResolve(shareableBitmap.releaseNonNull());
     return NativePromise<Ref<WebCore::ShareableBitmap>, void>::createAndReject();


### PR DESCRIPTION
#### 0ddbe2d53caed76fdb3826b929a0ec5718963381
<pre>
Use `protect()` in more places in RenderMedia &amp; RenderVideo
<a href="https://bugs.webkit.org/show_bug.cgi?id=307122">https://bugs.webkit.org/show_bug.cgi?id=307122</a>
<a href="https://rdar.apple.com/169755465">rdar://169755465</a>

Reviewed by Chris Dumez.

Use `protect()` in more places in RenderMedia &amp; RenderVideo.

No new tests, as this should not have any impact on functionality.

* Source/WebCore/rendering/RenderMedia.cpp:
(WebCore::RenderMedia::layout):
(WebCore::RenderMedia::styleDidChange):
* Source/WebCore/rendering/RenderMedia.h:
* Source/WebCore/rendering/RenderMediaInlines.h:
(WebCore::RenderMedia::protectedMediaElement const): Deleted.
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::willBeDestroyed):
(WebCore::RenderVideo::visibleInViewportStateChanged):
(WebCore::RenderVideo::intrinsicSizeChanged):
(WebCore::RenderVideo::updateIntrinsicSize):
(WebCore::RenderVideo::imageChanged):
(WebCore::RenderVideo::shouldDisplayVideo const):
(WebCore::RenderVideo::supportsAcceleratedRendering const):
(WebCore::RenderVideo::acceleratedRenderingStateChanged):
(WebCore::RenderVideo::requiresImmediateCompositing const):
(WebCore::RenderVideo::hasVideoMetadata const):
(WebCore::RenderVideo::hasPosterFrameSize const):
(WebCore::RenderVideo::protectedVideoElement const): Deleted.
* Source/WebCore/rendering/RenderVideo.h:
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
(WebKit::createShareableBitmap):
(WebKit::createShareableBitmapAsync):

Canonical link: <a href="https://commits.webkit.org/306928@main">https://commits.webkit.org/306928@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28598be7989ba2b15cdfa3318cb0ca71067573df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142774 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95963 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6cec9fd-a8f2-49ed-a5e4-5def0584208c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15902 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109798 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79130 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7fce1712-73ab-44e5-a9e4-ccce35893d9b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90707 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ffe4c8b-fd6b-480f-a3e4-7ed717444011) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11760 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9438 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1447 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121136 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153761 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14872 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4839 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117813 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14909 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12915 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118146 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30202 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14137 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125012 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70569 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14915 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3973 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14650 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78624 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14858 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14712 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->