### PR TITLE
Video slider thumb display is wrong

### DIFF
--- a/LayoutTests/media/modern-media-controls/slider/slider-knob-none-expected.txt
+++ b/LayoutTests/media/modern-media-controls/slider/slider-knob-none-expected.txt
@@ -1,0 +1,13 @@
+Testing that Slider with KnobStyle.None has no visible gap.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS knobStyle.display is "none"
+PASS primaryStyle.flexGrow is "50"
+PASS trackStyle.flexGrow is "50"
+PASS primaryRight is trackLeft
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/media/modern-media-controls/slider/slider-knob-none.html
+++ b/LayoutTests/media/modern-media-controls/slider/slider-knob-none.html
@@ -1,0 +1,62 @@
+<script src="../../../resources/js-test-pre.js"></script>
+<script src="../resources/media-controls-utils.js" type="text/javascript"></script>
+<script src="../resources/media-controls-loader.js" type="text/javascript"></script>
+<body>
+<script type="text/javascript">
+
+description("Testing that <code>Slider</code> with <code>KnobStyle.None</code> has no visible gap.");
+
+window.jsTestIsAsync = true;
+
+const layoutDelegate = null;
+
+const slider = new Slider(layoutDelegate, "", Slider.KnobStyle.None);
+slider.width = 200;
+slider.height = 25;
+slider.value = 0.5;
+
+var knobStyle, primaryStyle, trackStyle;
+var primaryRight, trackLeft;
+
+scheduler.frameDidFire = function()
+{
+    document.body.appendChild(slider.element);
+
+    slider.layout();
+
+    const appearance = slider.element.querySelector('.appearance');
+    const fill = appearance.querySelector('.fill');
+    const knobElement = fill.querySelector('.knob.none');
+    const primaryElement = fill.querySelector('.primary');
+    const trackElement = fill.querySelector('.track');
+
+    if (knobElement) {
+        knobStyle = window.getComputedStyle(knobElement);
+        shouldBeEqualToString("knobStyle.display", "none");
+    } else {
+        testFailed("Could not find knob element");
+    }
+
+    if (primaryElement && trackElement) {
+        primaryStyle = window.getComputedStyle(primaryElement);
+        trackStyle = window.getComputedStyle(trackElement);
+
+        shouldBeEqualToString("primaryStyle.flexGrow", "50");
+        shouldBeEqualToString("trackStyle.flexGrow", "50");
+
+        const primaryRect = primaryElement.getBoundingClientRect();
+        const trackRect = trackElement.getBoundingClientRect();
+        
+        primaryRight = Math.round(primaryRect.right);
+        trackLeft = Math.round(trackRect.left);
+        shouldBe("primaryRight", "trackLeft");
+    } else {
+        testFailed("Could not find primary or track elements");
+    }
+
+    finishMediaControlsTest();
+}
+
+</script>
+<script src="../../../resources/js-test-post.js"></script>
+</body>

--- a/Source/WebCore/Modules/modern-media-controls/controls/slider.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/slider.css
@@ -121,10 +121,7 @@
 }
 
 .slider.default > .appearance > .fill > .knob.none {
-    width: 9px;
-    height: 9px;
-    border-radius: 50%;
-    background-color: transparent;
+    display: none;
 }
 
 /* When disabled, we only want to show the track and turn off interaction. */


### PR DESCRIPTION
#### 40f71fbd2f18e78cc1e2afe76763ef546970b0cc
<pre>
Video slider thumb display is wrong
<a href="https://rdar.apple.com/168797980">rdar://168797980</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307114">https://bugs.webkit.org/show_bug.cgi?id=307114</a>

Reviewed by Andy Estes.

The .knob.none element was transparent but still occupied 9px width,
leaving a visible gap in the timeline slider. Use display: none to
completely remove it from the flexbox layout.

Test: media/modern-media-controls/slider/slider-knob-none.html

* LayoutTests/media/modern-media-controls/slider/slider-knob-none-expected.txt: Added.
* LayoutTests/media/modern-media-controls/slider/slider-knob-none.html: Added.
* Source/WebCore/Modules/modern-media-controls/controls/slider.css:
(.slider.default &gt; .appearance &gt; .fill &gt; .knob.none):

Canonical link: <a href="https://commits.webkit.org/306959@main">https://commits.webkit.org/306959@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1054bace1463bb7706187b173b6ad3e940ceac99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151449 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95964 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5985bbb9-f48c-4057-a7fa-8787e15ffc46) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15903 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15328 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109797 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79129 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eda0c03a-e359-41b7-aa5f-9227978b3ee3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145724 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12254 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127739 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90706 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37213ec9-3074-4870-9384-8fee41fa963c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11758 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9439 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1448 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121134 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4203 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153762 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14873 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117814 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118147 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30229 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14136 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125026 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70570 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14916 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3987 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14651 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78625 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14859 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14713 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->