### PR TITLE
[GFC] Initial implementation of Stretch auto Tracks

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -190,7 +190,10 @@ void GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
 
     GridDefinition gridDefinition { gridTemplateColumns, gridTemplateRows, autoFlowOptions };
 
-    GridLayoutState layoutState { layoutConstraints, gridDefinition };
+    auto usedJustifyContent = gridStyle->justifyContent().resolve();
+    auto usedAlignContent = gridStyle->alignContent().resolve();
+
+    GridLayoutState layoutState { layoutConstraints, gridDefinition, usedJustifyContent, usedAlignContent };
 
     auto [ usedTrackSizes, gridItemRects ] = GridLayout { *this }.layout(unplacedGridItems, layoutState);
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -69,7 +69,8 @@ private:
 
     static TrackSizingFunctionsList trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes);
 
-    UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&, const GridLayoutConstraints&) const;
+    UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&, const GridLayoutConstraints&,
+        const StyleContentAlignmentData& usedJustifyContent, const StyleContentAlignmentData& usedAlignContent) const;
 
     std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const GridAreaSizes&) const;
 

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutState.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutState.h
@@ -33,6 +33,8 @@ struct GridLayoutConstraints;
 struct GridLayoutState {
     const GridLayoutConstraints gridLayoutConstraints;
     const GridDefinition gridDefinition;
+    const StyleContentAlignmentData usedJustifyContent;
+    const StyleContentAlignmentData usedAlignContent;
 };
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -52,8 +52,9 @@ struct GridItemSizingFunctions {
 class TrackSizingAlgorithm {
 public:
     static TrackSizes sizeTracks(const PlacedGridItems&, const ComputedSizesList&, const UsedBorderAndPaddingList&,
-    const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableGridSpace,
-    const GridItemSizingFunctions&, const IntegrationUtils&, const FreeSpaceScenario&, const LayoutUnit& gapSize);
+        const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableGridSpace,
+        const GridItemSizingFunctions&, const IntegrationUtils&, const FreeSpaceScenario&, const LayoutUnit& gapSize,
+        const StyleContentAlignmentData& usedContentAlignment);
 
 private:
 


### PR DESCRIPTION
#### f3b648df34298128c912017a95df0e5c9dd68e57
<pre>
[GFC] Initial implementation of Stretch auto Tracks
<a href="https://bugs.webkit.org/show_bug.cgi?id=307124">https://bugs.webkit.org/show_bug.cgi?id=307124</a>
<a href="https://rdar.apple.com/169760592">rdar://169760592</a>

Reviewed by Alan Baradlay.

In the final step of the track sizing algorithm, if there is any
definite free space left and there are tracks with an auto max track
sizing function, we should distribute it equally amongst those tracks.
This can only be down, however, if the content alignment property for
that dimension is either normal or stretch. This patch provides the
initial implementation for this step. The only missing portion is the
scenario in which the free space may be definite but the minimum
preferred size in that dimension is definite.
<a href="https://drafts.csswg.org/css-grid-1/#algo-stretch">https://drafts.csswg.org/css-grid-1/#algo-stretch</a>

* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::layout):
Adds the content alignment values to GridLayoutState so that GridLayout,
and ultimately TrackSizingAlgorithm, will have access to it.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::tracksWithAutoMaxTrackSizingFunction):
Helper function to help determine the tracks associated with the
&quot;expands tracks that have an auto max track sizing function,&quot; of this
step.

(WebCore::Layout::totalGuttersSize):
Helper to compute the total space the gutters take up based on the
number of tracks. We previously had this logic in findSizeOfFr so we can
just share it between the two using this function.

(WebCore::Layout::computeFreeSpace):
Determines the free space available following the definition of &quot;free
space,&quot; in the spec.

(WebCore::Layout::stretchAutoTracks):
Actual logic that will stretch the tracks with an auto max track sizing
function. There are a few cases in which we can bail early because
either the content alignment property does not allow it or it wouldn&apos;t
really make sense to continue (e.g. free space is indefinite or zero).

Canonical link: <a href="https://commits.webkit.org/307143@main">https://commits.webkit.org/307143@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80a3640d9358d997d393d8a8b3c6c9e266bd3515

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143531 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16012 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7621 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152196 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9305bfd0-01bf-4ea5-8801-63b3fb1edc3a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110368 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9458228f-08a5-4a5b-98a1-5bf4f409ec12) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146494 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/12820 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91287 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17b6059e-7606-45f8-8d62-ba69fe68c008) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2198 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5500 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154508 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16059 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6538 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118378 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13525 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118731 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30424 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14671 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126705 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15680 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15415 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->