### PR TITLE
Reduce use of protected functions in Source/WebCore/css

### DIFF
--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -88,7 +88,6 @@ public:
     bool isCSSFontSelector() const final { return true; }
 
     ScriptExecutionContext* scriptExecutionContext() const { return m_context.get(); }
-    Ref<ScriptExecutionContext> protectedScriptExecutionContext() const { return *m_context; }
 
     FontFaceSet* fontFaceSetIfExists();
     FontFaceSet& fontFaceSet();

--- a/Source/WebCore/css/CSSGridLineValue.cpp
+++ b/Source/WebCore/css/CSSGridLineValue.cpp
@@ -69,11 +69,11 @@ bool CSSGridLineValue::equals(const CSSGridLineValue& other) const
         return (!value && !otherValue) || value->equals(*otherValue);
     };
 
-    if (!equals(protectedSpanValue().get(), other.protectedSpanValue().get()))
+    if (!equals(protect(spanValue()).get(), protect(other.spanValue()).get()))
         return false;
-    if (!equals(protectedNumericValue().get(), other.protectedNumericValue().get()))
+    if (!equals(protect(numericValue()).get(), protect(other.numericValue()).get()))
         return false;
-    if (!equals(protectedGridLineName().get(), other.protectedGridLineName().get()))
+    if (!equals(protect(gridLineName()).get(), protect(other.gridLineName()).get()))
         return false;
 
     return true;

--- a/Source/WebCore/css/CSSGridLineValue.h
+++ b/Source/WebCore/css/CSSGridLineValue.h
@@ -38,11 +38,8 @@ public:
     bool equals(const CSSGridLineValue& other) const;
 
     CSSPrimitiveValue* spanValue() const { return m_spanValue.get(); }
-    RefPtr<CSSPrimitiveValue> protectedSpanValue() const { return m_spanValue.get(); }
     CSSPrimitiveValue* numericValue() const { return m_numericValue.get(); }
-    RefPtr<CSSPrimitiveValue> protectedNumericValue() const { return m_numericValue.get(); }
     CSSPrimitiveValue* gridLineName() const { return m_gridLineName.get(); }
-    RefPtr<CSSPrimitiveValue> protectedGridLineName() const { return m_gridLineName.get(); }
 
 private:
     explicit CSSGridLineValue(RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&, RefPtr<CSSPrimitiveValue>&&);

--- a/Source/WebCore/css/CSSGroupingRule.cpp
+++ b/Source/WebCore/css/CSSGroupingRule.cpp
@@ -56,16 +56,6 @@ CSSGroupingRule::~CSSGroupingRule()
     }
 }
 
-Ref<const StyleRuleGroup> CSSGroupingRule::protectedGroupRule() const
-{
-    return m_groupRule;
-}
-
-Ref<StyleRuleGroup> CSSGroupingRule::protectedGroupRule()
-{
-    return m_groupRule;
-}
-
 ExceptionOr<unsigned> CSSGroupingRule::insertRule(const String& ruleString, unsigned index)
 {
     ASSERT(m_childRuleCSSOMWrappers.size() == m_groupRule->childRules().size());

--- a/Source/WebCore/css/CSSGroupingRule.h
+++ b/Source/WebCore/css/CSSGroupingRule.h
@@ -46,8 +46,6 @@ protected:
     CSSGroupingRule(StyleRuleGroup&, CSSStyleSheet* parent);
     const StyleRuleGroup& groupRule() const { return m_groupRule; }
     StyleRuleGroup& groupRule() { return m_groupRule; }
-    Ref<const StyleRuleGroup> protectedGroupRule() const;
-    Ref<StyleRuleGroup> protectedGroupRule();
     void reattach(StyleRuleBase&) override;
     void appendCSSTextForItems(StringBuilder&) const;
     void appendCSSTextWithReplacementURLsForItems(StringBuilder&, const CSS::SerializationContext&) const;

--- a/Source/WebCore/css/CSSImageSetOptionValue.h
+++ b/Source/WebCore/css/CSSImageSetOptionValue.h
@@ -44,7 +44,6 @@ public:
     CSSValue& image() const { return m_image; }
 
     CSSPrimitiveValue& resolution() const { return m_resolution; }
-    Ref<CSSPrimitiveValue> protectedResolution() const { return m_resolution; }
     void setResolution(Ref<CSSPrimitiveValue>&&);
 
     String type() const { return m_mimeType; }

--- a/Source/WebCore/css/CSSImageSetValue.cpp
+++ b/Source/WebCore/css/CSSImageSetValue.cpp
@@ -66,7 +66,7 @@ RefPtr<StyleImage> CSSImageSetValue::createStyleImage(const Style::BuilderState&
 
     Vector<ImageWithScale> images(length, [&](size_t i) {
         RefPtr<const CSSImageSetOptionValue> option = downcast<CSSImageSetOptionValue>(item(i));
-        return ImageWithScale { state.createStyleImage(option->image()), option->protectedResolution()->resolveAsResolution<float>(state.cssToLengthConversionData()), option->type() };
+        return ImageWithScale { state.createStyleImage(option->image()), protect(option->resolution())->resolveAsResolution<float>(state.cssToLengthConversionData()), option->type() };
     });
 
     // Sort the images so that they are stored in order from lowest resolution to highest.

--- a/Source/WebCore/css/CSSImportRule.cpp
+++ b/Source/WebCore/css/CSSImportRule.cpp
@@ -132,11 +132,6 @@ CSSStyleSheet* CSSImportRule::styleSheet() const
     return m_styleSheetCSSOMWrapper.get(); 
 }
 
-RefPtr<CSSStyleSheet> CSSImportRule::protectedStyleSheet() const
-{
-    return styleSheet();
-}
-
 void CSSImportRule::reattach(StyleRuleBase&)
 {
     // FIXME: Implement when enabling caching for stylesheets with import rules.

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -42,7 +42,6 @@ public:
     WEBCORE_EXPORT String href() const;
     WEBCORE_EXPORT MediaList& media() const;
     WEBCORE_EXPORT CSSStyleSheet* styleSheet() const;
-    RefPtr<CSSStyleSheet> protectedStyleSheet() const;
     String layerName() const;
     String supportsText() const;
 

--- a/Source/WebCore/css/CSSMediaRule.cpp
+++ b/Source/WebCore/css/CSSMediaRule.cpp
@@ -49,7 +49,7 @@ const MQ::MediaQueryList& CSSMediaRule::mediaQueries() const
 
 void CSSMediaRule::setMediaQueries(MQ::MediaQueryList&& queries)
 {
-    downcast<StyleRuleMedia>(protectedGroupRule())->setMediaQueries(WTF::move(queries));
+    downcast<StyleRuleMedia>(protect(groupRule()))->setMediaQueries(WTF::move(queries));
 }
 
 String CSSMediaRule::cssText() const

--- a/Source/WebCore/css/CSSPositionTryRule.cpp
+++ b/Source/WebCore/css/CSSPositionTryRule.cpp
@@ -46,7 +46,7 @@ StyleRulePositionTry::StyleRulePositionTry(AtomString&& name, Ref<StylePropertie
 StyleRulePositionTry::StyleRulePositionTry(const StyleRulePositionTry& o)
     : StyleRuleBase(o)
     , m_name(o.m_name)
-    , m_properties(o.protectedProperties()->mutableCopy())
+    , m_properties(protect(o.properties())->mutableCopy())
 {
 }
 
@@ -95,7 +95,7 @@ void CSSPositionTryRule::reattach(StyleRuleBase& rule)
 {
     m_positionTryRule = downcast<StyleRulePositionTry>(rule);
     if (RefPtr propertiesCSSOMWrapper = m_propertiesCSSOMWrapper)
-        propertiesCSSOMWrapper->reattach(protectedPositionTryRule()->protectedMutableProperties());
+        propertiesCSSOMWrapper->reattach(protect(protectedPositionTryRule()->mutableProperties()));
 }
 
 AtomString CSSPositionTryRule::name() const

--- a/Source/WebCore/css/CSSPositionTryRule.h
+++ b/Source/WebCore/css/CSSPositionTryRule.h
@@ -44,9 +44,7 @@ public:
     AtomString name() const { return m_name; }
 
     StyleProperties& properties() const { return m_properties; }
-    Ref<StyleProperties> protectedProperties() const { return m_properties; }
     MutableStyleProperties& mutableProperties();
-    Ref<MutableStyleProperties> protectedMutableProperties() { return mutableProperties(); }
 
 private:
     explicit StyleRulePositionTry(AtomString&& name, Ref<StyleProperties>&&);

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -833,7 +833,7 @@ String CSSPrimitiveValue::stringValue() const
     case CSSUnitType::CSS_PROPERTY_ID:
         return nameString(m_value.propertyID);
     case CSSUnitType::CSS_ATTR:
-        return protectedCssAttrValue()->cssText(CSS::defaultSerializationContext());
+        return protect(cssAttrValue())->cssText(CSS::defaultSerializationContext());
     default:
         return String();
     }
@@ -1009,9 +1009,9 @@ ALWAYS_INLINE String CSSPrimitiveValue::serializeInternal(const CSS::Serializati
     case CSSUnitType::CSS_X:
         return formatNumberValue(unitTypeString(type));
     case CSSUnitType::CSS_ATTR:
-        return protectedCssAttrValue()->cssText(context);
+        return protect(cssAttrValue())->cssText(context);
     case CSSUnitType::CSS_CALC:
-        return protectedCssCalcValue()->cssText(context);
+        return protect(cssCalcValue())->cssText(context);
     case CSSUnitType::CSS_DIMENSION:
         // FIXME: This isn't correct.
         return formatNumberValue(""_s);
@@ -1147,9 +1147,9 @@ bool CSSPrimitiveValue::equals(const CSSPrimitiveValue& other) const
     case CSSUnitType::CSS_FONT_FAMILY:
         return equal(m_value.string, other.m_value.string);
     case CSSUnitType::CSS_ATTR:
-        return protectedCssAttrValue()->equals(*other.protectedCssAttrValue());
+        return protect(cssAttrValue())->equals(*protect(other.cssAttrValue()));
     case CSSUnitType::CSS_CALC:
-        return protectedCssCalcValue()->equals(*other.protectedCssCalcValue());
+        return protect(cssCalcValue())->equals(*protect(other.cssCalcValue()));
     case CSSUnitType::CSS_IDENT:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_ANGLE:
     case CSSUnitType::CSS_CALC_PERCENTAGE_WITH_LENGTH:

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -176,9 +176,7 @@ public:
 
     WEBCORE_EXPORT String stringValue() const;
     const CSSCalc::Value* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
-    RefPtr<const CSSCalc::Value> protectedCssCalcValue() const { return cssCalcValue(); }
     const CSSAttrValue* cssAttrValue() const { return isAttr() ? m_value.attr : nullptr; }
-    RefPtr<const CSSAttrValue> protectedCssAttrValue() const { return cssAttrValue(); }
 
     String customCSSText(const CSS::SerializationContext&) const;
 

--- a/Source/WebCore/css/CSSProperty.h
+++ b/Source/WebCore/css/CSSProperty.h
@@ -81,7 +81,6 @@ public:
     bool isImportant() const { return m_metadata.m_important; }
 
     CSSValue* value() const { return m_value.ptr(); }
-    Ref<CSSValue> protectedValue() const { return m_value; }
 
     static CSSPropertyID resolveDirectionAwareProperty(CSSPropertyID, WritingMode);
     static CSSPropertyID unresolvePhysicalProperty(CSSPropertyID, WritingMode);

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -147,11 +147,6 @@ void CSSToLengthConversionData::setUsesContainerUnits() const
         m_styleBuilderState->setUsesContainerUnits();
 }
 
-CheckedPtr<Style::BuilderState> CSSToLengthConversionData::protectedStyleBuilderState() const
-{
-    return m_styleBuilderState;
-}
-
 bool CSSToLengthConversionData::evaluationTimeZoomEnabled() const
 {
     ASSERT(m_style);

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -109,7 +109,6 @@ public:
     void setUsesContainerUnits() const;
 
     Style::BuilderState* styleBuilderState() const { return m_styleBuilderState.get(); }
-    CheckedPtr<Style::BuilderState> protectedStyleBuilderState() const;
 
 private:
     const RenderStyle* m_style { nullptr };

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -64,10 +64,9 @@ public:
         const CSSValue* value() const { return m_value; }
         // FIXME: We should try to remove this mutable overload.
         CSSValue* value() { return const_cast<CSSValue*>(m_value); }
-        Ref<CSSValue> protectedValue() const { return const_cast<CSSValue&>(*m_value); }
 
         // FIXME: Remove this.
-        CSSProperty toCSSProperty() const { return CSSProperty(id(), protectedValue(), isImportant() ? IsImportant::Yes : IsImportant::No, m_metadata.m_isSetFromShorthand, m_metadata.m_indexInShorthandsVector, isImplicit() ? IsImplicit::Yes : IsImplicit::No); }
+        CSSProperty toCSSProperty() const { return CSSProperty(id(), protect(*const_cast<CSSValue*>(value())), isImportant() ? IsImportant::Yes : IsImportant::No, m_metadata.m_isSetFromShorthand, m_metadata.m_indexInShorthandsVector, isImplicit() ? IsImplicit::Yes : IsImplicit::No); }
 
     private:
         const StylePropertyMetadata& m_metadata;

--- a/Source/WebCore/css/StyleRule.cpp
+++ b/Source/WebCore/css/StyleRule.cpp
@@ -295,11 +295,6 @@ Ref<StyleRule> StyleRule::copy() const
     return adoptRef(*new StyleRule(*this));
 }
 
-Ref<const StyleProperties> StyleRule::protectedProperties() const
-{
-    return m_properties;
-}
-
 void StyleRule::setProperties(Ref<StyleProperties>&& properties)
 {
     m_properties = WTF::move(properties);

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -125,7 +125,6 @@ public:
 
     const CSSSelectorList& selectorList() const { return m_selectorList; }
     const StyleProperties& properties() const { return m_properties.get(); }
-    Ref<const StyleProperties> protectedProperties() const;
     MutableStyleProperties& mutableProperties();
 
     bool isSplitRule() const { return m_isSplitRule; }

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -154,7 +154,7 @@ std::optional<double> evaluate(const SiblingCount&, const EvaluationOptions& opt
     if (!options.conversionData->styleBuilderState()->element())
         return { };
 
-    return options.conversionData->protectedStyleBuilderState()->siblingCount();
+    return protect(options.conversionData->styleBuilderState())->siblingCount();
 }
 
 std::optional<double> evaluate(const SiblingIndex&, const EvaluationOptions& options)
@@ -164,7 +164,7 @@ std::optional<double> evaluate(const SiblingIndex&, const EvaluationOptions& opt
     if (!options.conversionData->styleBuilderState()->element())
         return { };
 
-    return options.conversionData->protectedStyleBuilderState()->siblingIndex();
+    return protect(options.conversionData->styleBuilderState())->siblingIndex();
 }
 
 std::optional<double> evaluate(const IndirectNode<Sum>& root, const EvaluationOptions& options)
@@ -214,7 +214,7 @@ std::optional<double> evaluate(const IndirectNode<Random>& root, const Evaluatio
             if (!sharingOptions.elementShared.has_value() && !options.conversionData->styleBuilderState()->element())
                 return { };
 
-            return options.conversionData->protectedStyleBuilderState()->lookupCSSRandomBaseValue(
+            return protect(options.conversionData->styleBuilderState())->lookupCSSRandomBaseValue(
                 sharingOptions.identifier,
                 sharingOptions.elementShared
             );
@@ -225,7 +225,7 @@ std::optional<double> evaluate(const IndirectNode<Random>& root, const Evaluatio
                     return raw.value;
                 },
                 [&](const CSS::Number<CSS::ClosedUnitRange>::Calc& calc) -> std::optional<double> {
-                    return calc.evaluate(CSS::Category::Number, *options.conversionData->protectedStyleBuilderState());
+                    return calc.evaluate(CSS::Category::Number, *protect(options.conversionData->styleBuilderState()));
                 }
             );
         }
@@ -250,7 +250,7 @@ std::optional<double> evaluate(const IndirectNode<Anchor>& anchor, const Evaluat
         result = evaluate(*anchor->fallback, options);
 
     if (!result)
-        options.conversionData->protectedStyleBuilderState()->setCurrentPropertyInvalidAtComputedValueTime();
+        protect(options.conversionData->styleBuilderState())->setCurrentPropertyInvalidAtComputedValueTime();
 
     return result;
 }
@@ -276,7 +276,7 @@ std::optional<double> evaluate(const IndirectNode<AnchorSize>& anchorSize, const
         result = evaluate(*anchorSize->fallback, options);
 
     if (!result)
-        options.conversionData->protectedStyleBuilderState()->setCurrentPropertyInvalidAtComputedValueTime();
+        protect(options.conversionData->styleBuilderState())->setCurrentPropertyInvalidAtComputedValueTime();
 
     return result;
 }

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -535,7 +535,7 @@ std::optional<Child> simplify(SiblingCount&, const SimplificationOptions& option
     if (!options.conversionData->styleBuilderState()->element())
         return { };
 
-    return makeChild(Number { .value = static_cast<double>(options.conversionData->protectedStyleBuilderState()->siblingCount()) });
+    return makeChild(Number { .value = static_cast<double>(protect(options.conversionData->styleBuilderState())->siblingCount()) });
 }
 
 std::optional<Child> simplify(SiblingIndex&, const SimplificationOptions& options)
@@ -545,7 +545,7 @@ std::optional<Child> simplify(SiblingIndex&, const SimplificationOptions& option
     if (!options.conversionData->styleBuilderState()->element())
         return { };
 
-    return makeChild(Number { .value = static_cast<double>(options.conversionData->protectedStyleBuilderState()->siblingIndex()) });
+    return makeChild(Number { .value = static_cast<double>(protect(options.conversionData->styleBuilderState())->siblingIndex()) });
 }
 
 std::optional<Child> simplify(Sum& root, const SimplificationOptions& options)
@@ -1335,7 +1335,7 @@ std::optional<Child> simplify(Random& root, const SimplificationOptions& options
                 [&](const Random::SharingOptions& sharingOptions) -> std::optional<double> {
                     if (sharingOptions.elementShared.has_value() && !options.conversionData->styleBuilderState()->element())
                         return { };
-                    return options.conversionData->protectedStyleBuilderState()->lookupCSSRandomBaseValue(
+                    return protect(options.conversionData->styleBuilderState())->lookupCSSRandomBaseValue(
                         sharingOptions.identifier,
                         sharingOptions.elementShared
                     );
@@ -1404,7 +1404,7 @@ std::optional<Child> simplify(Anchor& anchor, const SimplificationOptions& optio
         // If no fallback value is specified, it makes the declaration referencing it invalid at computed-value time."
 
         if (!anchor.fallback)
-            options.conversionData->protectedStyleBuilderState()->setCurrentPropertyInvalidAtComputedValueTime();
+            protect(options.conversionData->styleBuilderState())->setCurrentPropertyInvalidAtComputedValueTime();
 
         // Replace the anchor node with the fallback node.
         return std::exchange(anchor.fallback, { });
@@ -1431,7 +1431,7 @@ std::optional<Child> simplify(AnchorSize& anchorSize, const SimplificationOption
 
     if (!result) {
         if (!anchorSize.fallback)
-            options.conversionData->protectedStyleBuilderState()->setCurrentPropertyInvalidAtComputedValueTime();
+            protect(options.conversionData->styleBuilderState())->setCurrentPropertyInvalidAtComputedValueTime();
 
         return std::exchange(anchorSize.fallback, { });
     }

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -271,7 +271,7 @@ static bool consumeInternalAutoBaseFunction(CSSParserTokenRange& range, CSSPrope
         const auto& autoProperty = autoProperties[index];
         const auto& baseProperty = baseProperties[index];
 
-        Ref value = CSSFunctionValue::create(CSSValueInternalAutoBase, autoProperty.protectedValue(), baseProperty.protectedValue());
+        Ref value = CSSFunctionValue::create(CSSValueInternalAutoBase, protect(*autoProperty.value()), protect(*baseProperty.value()));
         result.addProperty(CSSProperty(autoProperty.metadata(), WTF::move(value)));
     }
 

--- a/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
+++ b/Source/WebCore/css/query/GenericMediaQuerySerialization.cpp
@@ -109,12 +109,12 @@ void serialize(StringBuilder& builder, const Feature& feature)
         }
         serializeIdentifier(feature.name, builder);
 
-        builder.append(": "_s, feature.rightComparison->protectedValue()->cssText(CSS::defaultSerializationContext()));
+        builder.append(": "_s, protect(feature.rightComparison->value)->cssText(CSS::defaultSerializationContext()));
         break;
 
     case Syntax::Range:
         if (feature.leftComparison) {
-            builder.append(feature.leftComparison->protectedValue()->cssText(CSS::defaultSerializationContext()));
+            builder.append(protect(feature.leftComparison->value)->cssText(CSS::defaultSerializationContext()));
             serializeRangeComparisonOperator(feature.leftComparison->op);
         }
 
@@ -122,7 +122,7 @@ void serialize(StringBuilder& builder, const Feature& feature)
 
         if (feature.rightComparison) {
             serializeRangeComparisonOperator(feature.rightComparison->op);
-            builder.append(feature.rightComparison->protectedValue()->cssText(CSS::defaultSerializationContext()));
+            builder.append(protect(feature.rightComparison->value)->cssText(CSS::defaultSerializationContext()));
         }
         break;
     }

--- a/Source/WebCore/css/query/GenericMediaQueryTypes.h
+++ b/Source/WebCore/css/query/GenericMediaQueryTypes.h
@@ -47,8 +47,6 @@ struct FeatureSchema;
 struct Comparison {
     ComparisonOperator op;
     RefPtr<CSSValue> value;
-
-    RefPtr<CSSValue> protectedValue() const { return value; }
 };
 
 struct Feature {

--- a/Source/WebCore/editing/EditingStyle.cpp
+++ b/Source/WebCore/editing/EditingStyle.cpp
@@ -1418,7 +1418,7 @@ void EditingStyle::mergeStyle(const StyleProperties* style, CSSPropertyOverrideM
         }
 
         if (mode == CSSPropertyOverrideMode::OverrideValues || (mode == CSSPropertyOverrideMode::DoNotOverrideValues && !value))
-            mutableStyle->setProperty(property.id(), property.protectedValue(), property.isImportant() ? IsImportant::Yes : IsImportant::No);
+            mutableStyle->setProperty(property.id(), protect(*property.value()), property.isImportant() ? IsImportant::Yes : IsImportant::No);
     }
 
     int oldFontSizeDelta = m_fontSizeDelta;
@@ -1434,7 +1434,7 @@ static Ref<MutableStyleProperties> styleFromMatchedRulesForElement(Element& elem
         return style;
 
     for (auto& matchedRule : Ref { element.styleResolver() }->styleRulesForElement(&element, rulesToInclude))
-        style->mergeAndOverrideOnConflict(matchedRule->protectedProperties());
+        style->mergeAndOverrideOnConflict(protect(matchedRule->properties()));
     
     return style;
 }

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -411,7 +411,7 @@ bool WebVTTParser::checkAndStoreStyleSheet(StringView line)
         if (styleRule->properties().isEmpty())
             continue;
 
-        sanitizedStyleSheetBuilder.append(selectorText, " { "_s, styleRule->protectedProperties()->asText(CSS::defaultSerializationContext()), "  }\n"_s);
+        sanitizedStyleSheetBuilder.append(selectorText, " { "_s, protect(styleRule->properties())->asText(CSS::defaultSerializationContext()), "  }\n"_s);
     }
 
     // It would be more stylish to parse the stylesheet only once instead of serializing a sanitized version.

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -255,7 +255,7 @@ void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL
             auto importURL = document->completeURL(importRule->href());
             if (m_resourceURLs.contains(importURL))
                 continue;
-            serializeCSSStyleSheet(importRule->protectedStyleSheet().get(), importURL);
+            serializeCSSStyleSheet(protect(importRule->styleSheet()).get(), importURL);
         } else if (is<CSSFontFaceRule>(*rule)) {
             // FIXME: Add support for font face rule. It is not clear to me at this point if the actual otf/eot file can
             // be retrieved from the CSSFontFaceRule object.
@@ -295,7 +295,7 @@ void PageSerializer::addImageToResources(CachedImage* image, RenderElement* imag
 
 void PageSerializer::retrieveResourcesForRule(StyleRule& rule, Document* document)
 {
-    retrieveResourcesForProperties(rule.protectedProperties().ptr(), document);
+    retrieveResourcesForProperties(protect(rule.properties()).ptr(), document);
 }
 
 void PageSerializer::retrieveResourcesForProperties(const StyleProperties* styleDeclaration, Document* document)

--- a/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp
@@ -226,7 +226,7 @@ auto toStyle(const CSSCalc::Random::Sharing& randomSharing, const ToStyleConvers
                 ASSERT(options.evaluation.conversionData->styleBuilderState()->element());
             }
 
-            auto baseValue = options.evaluation.conversionData->protectedStyleBuilderState()->lookupCSSRandomBaseValue(
+            auto baseValue = protect(options.evaluation.conversionData->styleBuilderState())->lookupCSSRandomBaseValue(
                 sharingOptions.identifier,
                 sharingOptions.elementShared
             );
@@ -239,7 +239,7 @@ auto toStyle(const CSSCalc::Random::Sharing& randomSharing, const ToStyleConvers
                     return Random::Fixed { raw.value };
                 },
                 [&](const CSS::Number<CSS::ClosedUnitRange>::Calc& calc) -> Random::Fixed {
-                    return Random::Fixed { calc.evaluate(CSS::Category::Number, *options.evaluation.conversionData->protectedStyleBuilderState()) };
+                    return Random::Fixed { calc.evaluate(CSS::Category::Number, *protect(options.evaluation.conversionData->styleBuilderState())) };
                 }
             );
         }

--- a/Source/WebCore/style/values/inline/StyleLineHeight.cpp
+++ b/Source/WebCore/style/values/inline/StyleLineHeight.cpp
@@ -73,7 +73,7 @@ auto CSSValueConversion<LineHeight>::operator()(BuilderState& state, const CSSPr
         if (primitiveValue.isLength())
             fixedValue = primitiveValue.resolveAsLength(conversionData);
         else
-            fixedValue = primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()), zoomFactor());
+            fixedValue = protect(primitiveValue.cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { })->evaluate(state.style().fontDescription().computedSizeForRangeZoomOption(conversionData.rangeZoomOption()), zoomFactor());
 
         if (multiplier != 1.0f)
             fixedValue *= multiplier;

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h
@@ -107,7 +107,7 @@ template<LengthWrapperBaseDerived T> struct CSSValueConversion<T> {
             if (primitiveValue.isCalculatedPercentageWithLength()) {
                 return T {
                     typename T::Calc {
-                        primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })
+                        protect(primitiveValue.cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { })
                     }
                 };
             }

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.h
@@ -85,7 +85,7 @@ template<LengthWrapperBaseDerived T> struct DeprecatedCSSValueConversion<T> {
             if (primitiveValue.isCalculatedPercentageWithLength()) {
                 return T {
                     typename T::Calc {
-                        primitiveValue.protectedCssCalcValue()->createCalculationValue(*conversionData, CSSCalcSymbolTable { })
+                        protect(primitiveValue.cssCalcValue())->createCalculationValue(*conversionData, CSSCalcSymbolTable { })
                     }
                 };
             }

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h
@@ -204,7 +204,7 @@ template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
         if (protectedValue->isPercentage())
             return typename StyleType::Percentage { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
         if (protectedValue->isCalculatedPercentageWithLength())
-            return typename StyleType::Calc { protectedValue->protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
+            return typename StyleType::Calc { protect(protectedValue->cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
         return typename StyleType::Dimension { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
     auto operator()(BuilderState& builderState, const CSSValue& value) -> StyleType
@@ -216,7 +216,7 @@ template<auto R, typename V> struct CSSValueConversion<LengthPercentage<R, V>> {
         if (protectedValue->isPercentage())
             return typename StyleType::Percentage { CSS::clampToRange<R, V>(protectedValue->resolveAsPercentage<V>(conversionData)) };
         if (protectedValue->isCalculatedPercentageWithLength())
-            return typename StyleType::Calc { protectedValue->protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
+            return typename StyleType::Calc { protect(protectedValue->cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
         return typename StyleType::Dimension { CSS::clampToRange<R, V>(protectedValue->resolveAsLength<V>(conversionData)) };
     }
 };

--- a/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
@@ -73,7 +73,7 @@ auto CSSValueConversion<LetterSpacing>::operator()(BuilderState& state, const CS
     if (primitiveValue->isCalculatedPercentageWithLength()) {
         return LetterSpacing {
             typename LetterSpacing::Calc {
-                primitiveValue->protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })
+                protect(primitiveValue->cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { })
             }
         };
     }

--- a/Source/WebCore/style/values/text/StyleWordSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleWordSpacing.cpp
@@ -73,7 +73,7 @@ auto CSSValueConversion<WordSpacing>::operator()(BuilderState& state, const CSSV
     if (primitiveValue->isCalculatedPercentageWithLength()) {
         return WordSpacing {
             typename WordSpacing::Calc {
-                primitiveValue->protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { })
+                protect(primitiveValue->cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { })
             }
         };
     }

--- a/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
+++ b/Source/WebCore/style/values/transforms/StyleTransformFunction.cpp
@@ -67,7 +67,7 @@ static TranslateTransformFunction::LengthPercentage resolveAsTranslateLengthPerc
     if (primitiveValue.isPercentage())
         return TranslateTransformFunction::LengthPercentage::Percentage { static_cast<float>(primitiveValue.resolveAsPercentage<double>(conversionData)) };
     if (primitiveValue.isCalculated())
-        return TranslateTransformFunction::LengthPercentage::Calc { primitiveValue.protectedCssCalcValue()->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
+        return TranslateTransformFunction::LengthPercentage::Calc { protect(primitiveValue.cssCalcValue())->createCalculationValue(conversionData, CSSCalcSymbolTable { }) };
 
     state.setCurrentPropertyInvalidAtComputedValueTime();
     return 0_css_px;


### PR DESCRIPTION
#### 3b2e1cd77ab8b0a9a2ec8d439943a86ea19772e7
<pre>
Reduce use of protected functions in Source/WebCore/css
<a href="https://bugs.webkit.org/show_bug.cgi?id=307126">https://bugs.webkit.org/show_bug.cgi?id=307126</a>

Reviewed by Ryosuke Niwa.

Reduce use of protected functions in Source/WebCore/css and adopt `protect()`
at call sites instead.

* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::ensureLocalFontFacesForFamilyRegistered):
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::CSSFontSelector::fontFaceSet):
(WebCore::CSSFontSelector::addFontFaceRule):
(WebCore::CSSFontSelector::resolveGenericFamily):
(WebCore::CSSFontSelector::fontRangesForFamily):
(WebCore::CSSFontSelector::fallbackFontCount):
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/CSSGridLineValue.cpp:
(WebCore::CSSGridLineValue::equals const):
* Source/WebCore/css/CSSGridLineValue.h:
* Source/WebCore/css/CSSGroupingRule.cpp:
(WebCore::CSSGroupingRule::protectedGroupRule const): Deleted.
(WebCore::CSSGroupingRule::protectedGroupRule): Deleted.
* Source/WebCore/css/CSSGroupingRule.h:
(WebCore::CSSGroupingRule::groupRule):
* Source/WebCore/css/CSSImageSetOptionValue.h:
* Source/WebCore/css/CSSImageSetValue.cpp:
(WebCore::CSSImageSetValue::createStyleImage const):
* Source/WebCore/css/CSSImportRule.cpp:
(WebCore::CSSImportRule::protectedStyleSheet const): Deleted.
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSMediaRule.cpp:
(WebCore::CSSMediaRule::setMediaQueries):
* Source/WebCore/css/CSSPositionTryRule.cpp:
(WebCore::StyleRulePositionTry::StyleRulePositionTry):
(WebCore::CSSPositionTryRule::reattach):
* Source/WebCore/css/CSSPositionTryRule.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::stringValue const):
(WebCore::CSSPrimitiveValue::serializeInternal const):
(WebCore::CSSPrimitiveValue::equals const):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSProperty.h:
(WebCore::CSSProperty::value const):
(WebCore::CSSProperty::protectedValue const): Deleted.
* Source/WebCore/css/CSSToLengthConversionData.cpp:
(WebCore::CSSToLengthConversionData::protectedStyleBuilderState const): Deleted.
* Source/WebCore/css/CSSToLengthConversionData.h:
(WebCore::CSSToLengthConversionData::styleBuilderState const):
* Source/WebCore/css/StyleProperties.h:
(WebCore::StyleProperties::PropertyReference::value):
(WebCore::StyleProperties::PropertyReference::toCSSProperty const):
(WebCore::StyleProperties::PropertyReference::protectedValue const): Deleted.
* Source/WebCore/css/StyleRule.cpp:
(WebCore::StyleRule::protectedProperties const): Deleted.
* Source/WebCore/css/StyleRule.h:
(WebCore::StyleRule::properties const):
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
(WebCore::CSSCalc::evaluate):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::simplify):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeInternalAutoBaseFunction):
* Source/WebCore/css/query/GenericMediaQuerySerialization.cpp:
(WebCore::MQ::serialize):
* Source/WebCore/css/query/GenericMediaQueryTypes.h:
(WebCore::MQ::Comparison::protectedValue const): Deleted.
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::EditingStyle::mergeStyle):
(WebCore::styleFromMatchedRulesForElement):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTParser::checkAndStoreStyleSheet):
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::PageSerializer::serializeCSSStyleSheet):
(WebCore::PageSerializer::retrieveResourcesForRule):
* Source/WebCore/style/calc/StyleCalculationTree+Conversion.cpp:
(WebCore::Style::Calculation::toStyle):
* Source/WebCore/style/values/inline/StyleLineHeight.cpp:
(WebCore::Style::CSSValueConversion&lt;LineHeight&gt;::operator):
* Source/WebCore/style/values/primitives/StyleLengthWrapper+CSSValueConversion.h:
(WebCore::Style::CSSValueConversion&lt;T&gt;::operator()):
* Source/WebCore/style/values/primitives/StyleLengthWrapper+DeprecatedCSSValueConversion.h:
(WebCore::Style::DeprecatedCSSValueConversion&lt;T&gt;::operator()):
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+CSSValueConversion.h:
* Source/WebCore/style/values/text/StyleLetterSpacing.cpp:
(WebCore::Style::CSSValueConversion&lt;LetterSpacing&gt;::operator):
* Source/WebCore/style/values/text/StyleWordSpacing.cpp:
(WebCore::Style::CSSValueConversion&lt;WordSpacing&gt;::operator):
* Source/WebCore/style/values/transforms/StyleTransformFunction.cpp:
(WebCore::Style::resolveAsTranslateLengthPercentage):

Canonical link: <a href="https://commits.webkit.org/306934@main">https://commits.webkit.org/306934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/609a9a4a3573516e04b51bb2475429001705b23b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15293 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151495 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fac8995d-9e9e-475e-b4a5-4cb0c6c1bb68) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15374 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109835 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a105a6d3-8e05-4b2b-979a-efac19243e8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12295 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127784 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90744 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a33ec7ad-f05d-403d-ae9f-31a41a718d3a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11796 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9473 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1494 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153808 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14919 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4912 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117850 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30206 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14174 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70616 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14962 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4032 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14697 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78671 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14905 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->