### PR TITLE
[YARR] Fix stale captures in FixedCount groups in MatchOnly mode

### DIFF
--- a/JSTests/stress/regexp-fixedcount-matchonly-stale-capture.js
+++ b/JSTests/stress/regexp-fixedcount-matchonly-stale-capture.js
@@ -1,0 +1,30 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("Expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// In MatchOnly mode (.test()), captures inside FixedCount groups must be
+// cleared between iterations. The bug: when an earlier alternative succeeds
+// in iteration N+1, a later alternative's capture retains a stale value from
+// iteration N instead of being undefined.
+//
+// /(?:(a)|(b)){2}\2/ on "ba":
+//   iter1: (b) matches → capture[2]="b"
+//   iter2: (a) matches, (b) not attempted → capture[2] should be undefined
+//   \2 → undefined → empty match → true
+
+var re = /(?:(a)|(b)){2}\2/;
+for (var i = 0; i < 200; i++) {
+    re.exec("aabb");
+    re.test("aabb");
+}
+shouldBe(re.exec("ba")[2], undefined);
+shouldBe(re.test("ba"), true);
+
+var re2 = /(?:(a)|(b)){3}\2/;
+for (var i = 0; i < 200; i++) {
+    re2.exec("aabbaa");
+    re2.test("aabbaa");
+}
+shouldBe(re2.exec("baa")[2], undefined);
+shouldBe(re2.test("baa"), true);

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3939,7 +3939,7 @@ class YarrGenerator final : public YarrJITInfo {
                 // Clear nested captures at the start of each iteration.
                 // This is required by ECMAScript spec - capture groups are reset to undefined
                 // at the beginning of each iteration of a quantified group.
-                if (m_compileMode == JITCompileMode::IncludeSubpatterns && term->containsAnyCaptures()) {
+                if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
                     for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
                         clearSubpattern(subpattern);
                 }
@@ -4039,7 +4039,7 @@ class YarrGenerator final : public YarrJITInfo {
                     m_jit.store32(MacroAssembler::TrustedImm32(-1), MacroAssembler::Address(newParenContextReg, ParenContext::matchAmountOffset()));
 
                     // Clear captures at BEGIN (before iteration runs) so each iteration starts fresh.
-                    if (m_compileMode == JITCompileMode::IncludeSubpatterns) {
+                    if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
                         for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
                             clearSubpattern(subpattern);
                     }


### PR DESCRIPTION
#### dea6808af40e843bf36320a12bd09be169960268
<pre>
[YARR] Fix stale captures in FixedCount groups in MatchOnly mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=307127">https://bugs.webkit.org/show_bug.cgi?id=307127</a>

Reviewed by Yusuke Suzuki.

When backreferences are used in MatchOnly mode (.test()), the JIT uses
internal frame storage for subpattern data (m_needsInternalSubpatternOutput).

However, the capture-clearing code at the start of each FixedCount iteration
checked m_compileMode == IncludeSubpatterns instead of shouldRecordSubpatterns(),
so captures were not cleared between iterations in MatchOnly mode.

This caused stale capture values from a previous iteration to be visible to
backreferences. For example, /(?:(a)|(b)){2}\2/.test(&quot;ba&quot;) returned false
instead of true, because capture[2] retained &quot;b&quot; from iteration 1 into
iteration 2 where it should have been undefined.

Test: JSTests/stress/regexp-fixedcount-matchonly-stale-capture.js

* JSTests/stress/regexp-fixedcount-matchonly-stale-capture.js: Added.
(shouldBe):
(re.a):
(re2.a):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/306920@main">https://commits.webkit.org/306920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/51122429556748ee2a115c44506f9b729bf48329

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5724 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151458 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/95973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15912 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109804 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/95973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145733 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12263 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127736 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90713 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1457 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134777 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153771 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3593 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/14882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117819 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14919 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12926 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118152 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30138 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14140 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125023 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14925 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3984 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174073 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78634 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44988 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/14868 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14722 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->