### PR TITLE
Reduce unnecessary ref count churn in WebCore/style

### DIFF
--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -255,7 +255,7 @@ void ChildChangeInvalidation::traverseRemovedElements(Function&& function)
         if (!needsDescendantTraversal)
             continue;
 
-        for (Ref descendant : descendantsOfType<Element>(*toRemove))
+        for (auto& descendant : descendantsOfType<Element>(*toRemove))
             function(descendant);
     }
 }
@@ -283,7 +283,7 @@ void ChildChangeInvalidation::traverseAddedElements(Function&& function)
     if (!needsDescendantTraversal(features))
         return;
 
-    for (Ref descendant : descendantsOfType<Element>(*newElement))
+    for (auto& descendant : descendantsOfType<Element>(*newElement))
         function(descendant);
 }
 

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -44,11 +44,11 @@ HasSelectorFilter::HasSelectorFilter(const Element& element, Type type)
 {
     switch (type) {
     case Type::Descendants:
-        for (Ref descendant : descendantsOfType<Element>(element))
+        for (auto& descendant : descendantsOfType<Element>(element))
             add(descendant);
         break;
     case Type::Children:
-        for (Ref child : childrenOfType<Element>(element))
+        for (auto& child : childrenOfType<Element>(element))
             add(child);
         break;
     }

--- a/Source/WebCore/style/StyleBuilderChecking.h
+++ b/Source/WebCore/style/StyleBuilderChecking.h
@@ -115,7 +115,7 @@ inline auto requiredListDowncast(BuilderState& builderState, const CSSValue& val
         builderState.setCurrentPropertyInvalidAtComputedValueTime();
         return { };
     }
-    for (Ref value : *listValue) {
+    for (auto& value : *listValue) {
         if (!requiredDowncast<ValueType>(builderState, value)) [[unlikely]]
             return { };
     }

--- a/Source/WebCore/style/StyleBuilderCustom.h
+++ b/Source/WebCore/style/StyleBuilderCustom.h
@@ -297,11 +297,11 @@ void applyValueCoordinatedValueListProperty(BuilderState& builderState, CSSValue
 
     size_t i = 0;
     if (RefPtr valueList = dynamicDowncast<CSSValueList>(value)) {
-        for (Ref item : *valueList) {
+        for (auto& item : *valueList) {
             if (i >= list.computedLength())
                 list.append(typename ListType::value_type { });
 
-            set(i, item.get());
+            set(i, item);
             ++i;
         }
     } else {
@@ -674,8 +674,8 @@ inline float BuilderCustom::determineRubyTextSizeMultiplier(BuilderState& builde
         // the bopomofo. This code will go away if we make a special renderer
         // for the tone marks eventually.
         if (RefPtr element = builderState.element()) {
-            for (Ref ancestor : ancestorsOfType<HTMLElement>(*element)) {
-                if (ancestor->hasTagName(HTMLNames::rtTag))
+            for (auto& ancestor : ancestorsOfType<HTMLElement>(*element)) {
+                if (ancestor.hasTagName(HTMLNames::rtTag))
                     return 1.0f;
             }
         }

--- a/Source/WebCore/style/StyleExtractor.cpp
+++ b/Source/WebCore/style/StyleExtractor.cpp
@@ -162,17 +162,17 @@ static inline bool hasValidStyleForProperty(Element& element, CSSPropertyID prop
         return false;
 
     const auto* currentElement = &element;
-    for (Ref ancestor : composedTreeAncestors(element)) {
-        if (ancestor->styleValidity() != Style::Validity::Valid)
+    for (auto& ancestor : composedTreeAncestors(element)) {
+        if (ancestor.styleValidity() != Style::Validity::Valid)
             return false;
 
-        if (isQueryContainer(ancestor.get()))
+        if (isQueryContainer(ancestor))
             return false;
 
-        if (ancestor->directChildNeedsStyleRecalc() && currentElement->styleIsAffectedByPreviousSibling())
+        if (ancestor.directChildNeedsStyleRecalc() && currentElement->styleIsAffectedByPreviousSibling())
             return false;
 
-        currentElement = ancestor.ptr();
+        currentElement = &ancestor;
     }
 
     return true;

--- a/Source/WebCore/style/StyleNameScope.cpp
+++ b/Source/WebCore/style/StyleNameScope.cpp
@@ -53,8 +53,8 @@ auto CSSValueConversion<NameScope>::operator()(BuilderState& state, const CSSVal
         return CSS::Keyword::None { };
 
     CommaSeparatedListHashSet<CustomIdentifier> names;
-    for (Ref item : *list)
-        names.value.add({ AtomString { item->stringValue() } });
+    for (auto& item : *list)
+        names.value.add({ AtomString { item.stringValue() } });
 
     return { WTF::move(names), state.styleScopeOrdinal() };
 }

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -98,8 +98,8 @@ TreeResolver::Scope::Scope(Document& document, Update& update)
     document.setIsResolvingTreeStyle(true);
 
     // Ensure all shadow tree resolvers exist so their construction doesn't depend on traversal.
-    for (Ref shadowRoot : document.inDocumentShadowRoots())
-        const_cast<ShadowRoot&>(shadowRoot.get()).styleScope().resolver();
+    for (auto& shadowRoot : document.inDocumentShadowRoots())
+        const_cast<ShadowRoot&>(shadowRoot).styleScope().resolver();
 
     selectorMatchingState.containerQueryEvaluationState.styleUpdate = &update;
 }
@@ -1176,8 +1176,8 @@ static bool hasLoadingStylesheet(const Style::Scope& styleScope, const Element& 
         return true;
     if (!checkDescendants)
         return false;
-    for (Ref descendant : descendantsOfType<Element>(element)) {
-        if (styleScope.hasPendingSheetInBody(descendant.get()))
+    for (auto& descendant : descendantsOfType<Element>(element)) {
+        if (styleScope.hasPendingSheetInBody(descendant))
             return true;
     };
     return false;

--- a/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
@@ -83,8 +83,8 @@ auto CSSValueConversion<PositionTryFallback>::operator()(BuilderState& state, co
         auto rule = std::optional<ScopedName> { };
         auto tactics = SpaceSeparatedVector<PositionTryFallbackTactic> { };
 
-        for (Ref item : *valueList) {
-            switch (item->valueID()) {
+        for (auto& item : *valueList) {
+            switch (item.valueID()) {
             case CSSValueFlipBlock:
                 tactics.value.append(PositionTryFallbackTactic::FlipBlock);
                 break;
@@ -101,8 +101,8 @@ auto CSSValueConversion<PositionTryFallback>::operator()(BuilderState& state, co
                 tactics.value.append(PositionTryFallbackTactic::FlipY);
                 break;
             case CSSValueInvalid:
-                if (item->isCustomIdent() && !rule) {
-                    rule = ScopedName { AtomString { item->customIdent() }, state.styleScopeOrdinal() };
+                if (item.isCustomIdent() && !rule) {
+                    rule = ScopedName { AtomString { item.customIdent() }, state.styleScopeOrdinal() };
                     break;
                 }
                 [[fallthrough]];

--- a/Source/WebCore/style/values/box/StyleMarginTrim.cpp
+++ b/Source/WebCore/style/values/box/StyleMarginTrim.cpp
@@ -58,8 +58,8 @@ auto CSSValueConversion<MarginTrim>::operator()(BuilderState& state, const CSSVa
         return CSS::Keyword::None { };
 
     MarginTrimSideEnumSet result;
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueBlock:
             result.value.add({ Style::MarginTrimSide::BlockStart, Style::MarginTrimSide::BlockEnd });
             break;

--- a/Source/WebCore/style/values/contain/StyleContain.cpp
+++ b/Source/WebCore/style/values/contain/StyleContain.cpp
@@ -61,8 +61,8 @@ auto CSSValueConversion<Contain>::operator()(BuilderState& state, const CSSValue
         return CSS::Keyword::None { };
 
     ContainValueEnumSet result;
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueSize:
             if (result.contains(ContainValue::InlineSize)) {
                 state.setCurrentPropertyInvalidAtComputedValueTime();

--- a/Source/WebCore/style/values/content/StyleContent.cpp
+++ b/Source/WebCore/style/values/content/StyleContent.cpp
@@ -130,10 +130,10 @@ auto CSSValueConversion<Content>::operator()(BuilderState& state, const CSSValue
             return { };
 
         StringBuilder altTextBuilder;
-        for (Ref item : *altTextList) {
-            if (item->isString())
-                altTextBuilder.append(item->stringValue());
-            else if (RefPtr attr = item->cssAttrValue())
+        for (auto& item : *altTextList) {
+            if (item.isString())
+                altTextBuilder.append(item.stringValue());
+            else if (RefPtr attr = item.cssAttrValue())
                 altTextBuilder.append(processAttrContent(*attr));
         }
         return altTextBuilder.toString();

--- a/Source/WebCore/style/values/fonts/StyleFontFeatureSettings.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontFeatureSettings.cpp
@@ -58,10 +58,10 @@ auto CSSValueConversion<FontFeatureSettings>::operator()(BuilderState& state, co
         return CSS::Keyword::Normal { };
 
     WebCore::FontFeatureSettings platformSettings;
-    for (Ref setting : *list) {
+    for (auto& setting : *list) {
         platformSettings.insert({
-            setting->tag(),
-            toStyleFromCSSValue<FontFeatureSettings::Value>(state, setting->value()).value
+            setting.tag(),
+            toStyleFromCSSValue<FontFeatureSettings::Value>(state, setting.value()).value
         });
     }
 

--- a/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp
@@ -57,7 +57,7 @@ auto CSSValueConversion<FontVariantAlternates>::operator()(BuilderState& state, 
             state.setCurrentPropertyInvalidAtComputedValueTime();
             return false;
         }
-        for (Ref argument : function) {
+        for (auto& argument : function) {
             RefPtr primitiveArgument = dynamicDowncast<CSSPrimitiveValue>(argument);
             if (!primitiveArgument || !primitiveArgument->isCustomIdent()) {
                 state.setCurrentPropertyInvalidAtComputedValueTime();
@@ -86,7 +86,7 @@ auto CSSValueConversion<FontVariantAlternates>::operator()(BuilderState& state, 
 
     auto result = FontVariantAlternates::Platform::Normal();
 
-    for (Ref item : *list) {
+    for (auto& item : *list) {
         if (RefPtr primitive = dynamicDowncast<CSSPrimitiveValue>(item)) {
             switch (primitive->valueID()) {
             case CSSValueHistoricalForms:
@@ -96,7 +96,7 @@ auto CSSValueConversion<FontVariantAlternates>::operator()(BuilderState& state, 
                 state.setCurrentPropertyInvalidAtComputedValueTime();
                 return CSS::Keyword::Normal { };
             }
-        } else if (RefPtr function = dynamicDowncast<CSSFunctionValue>(item.get())) {
+        } else if (RefPtr function = dynamicDowncast<CSSFunctionValue>(item)) {
             switch (function->name()) {
             case CSSValueSwash:
                 if (!processSingleItemFunction(*function, result.valuesRef().swash))

--- a/Source/WebCore/style/values/fonts/StyleFontVariantEastAsian.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontVariantEastAsian.cpp
@@ -54,8 +54,8 @@ auto CSSValueConversion<FontVariantEastAsian>::operator()(BuilderState& state, c
     auto width = FontVariantEastAsianWidth::Normal;
     auto ruby = FontVariantEastAsianRuby::Normal;
 
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueJis78:
             variant = FontVariantEastAsianVariant::Jis78;
             break;

--- a/Source/WebCore/style/values/fonts/StyleFontVariantLigatures.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontVariantLigatures.cpp
@@ -59,8 +59,8 @@ auto CSSValueConversion<FontVariantLigatures>::operator()(BuilderState& state, c
     auto historical = Normal;
     auto contextual = Normal;
 
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueNoCommonLigatures:
             common = No;
             break;

--- a/Source/WebCore/style/values/fonts/StyleFontVariantNumeric.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontVariantNumeric.cpp
@@ -56,8 +56,8 @@ auto CSSValueConversion<FontVariantNumeric>::operator()(BuilderState& state, con
     auto ordinal = FontVariantNumericOrdinal::Normal;
     auto slashedZero = FontVariantNumericSlashedZero::Normal;
 
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueLiningNums:
             figure = FontVariantNumericFigure::LiningNumbers;
             break;

--- a/Source/WebCore/style/values/fonts/StyleFontVariationSettings.cpp
+++ b/Source/WebCore/style/values/fonts/StyleFontVariationSettings.cpp
@@ -61,10 +61,10 @@ auto CSSValueConversion<FontVariationSettings>::operator()(BuilderState& state, 
         return CSS::Keyword::Normal { };
 
     WebCore::FontVariationSettings platformSettings;
-    for (Ref setting : *list) {
+    for (auto& setting : *list) {
         platformSettings.insert({
-            setting->tag(),
-            toStyleFromCSSValue<FontVariationSettings::Value>(state, setting->value()).value
+            setting.tag(),
+            toStyleFromCSSValue<FontVariationSettings::Value>(state, setting.value()).value
         });
     }
 

--- a/Source/WebCore/style/values/grid/StyleGridTemplateList.cpp
+++ b/Source/WebCore/style/values/grid/StyleGridTemplateList.cpp
@@ -154,7 +154,7 @@ auto CSSValueConversion<GridTemplateList>::operator()(BuilderState& state, const
         if (!vectorValue)
             return;
 
-        for (Ref currentValue : *vectorValue) {
+        for (auto& currentValue : *vectorValue) {
             if (RefPtr namesValue = dynamicDowncast<CSSGridLineNamesValue>(currentValue))
                 repeatList.append(Vector<String>(namesValue->names()));
             else {
@@ -199,7 +199,7 @@ auto CSSValueConversion<GridTemplateList>::operator()(BuilderState& state, const
     if (!valueList)
         addOne(value);
     else {
-        for (Ref value : *valueList)
+        for (auto& value : *valueList)
             addOne(value);
     }
 

--- a/Source/WebCore/style/values/masking/StyleMaskBorder.cpp
+++ b/Source/WebCore/style/values/masking/StyleMaskBorder.cpp
@@ -69,8 +69,8 @@ auto CSSValueConversion<MaskBorder>::operator()(BuilderState& state, const CSSVa
     if (!borderImage)
         return result;
 
-    for (Ref current : *borderImage) {
-        if (current->isImage())
+    for (auto& current : *borderImage) {
+        if (current.isImage())
             result.maskBorderSource = toStyleFromCSSValue<MaskBorderSource>(state, current);
         else if (RefPtr slice = dynamicDowncast<CSSBorderImageSliceValue>(current))
             result.maskBorderSlice = toStyleFromCSSValue<MaskBorderSlice>(state, *slice);
@@ -81,7 +81,7 @@ auto CSSValueConversion<MaskBorder>::operator()(BuilderState& state, const CSSVa
                 result.maskBorderWidth = toStyleFromCSSValue<MaskBorderWidth>(state, *width);
             if (RefPtr outset = slashList->item(2))
                 result.maskBorderOutset = toStyleFromCSSValue<MaskBorderOutset>(state, *outset);
-        } else if (current->isPair())
+        } else if (current.isPair())
             result.maskBorderRepeat = toStyleFromCSSValue<MaskBorderRepeat>(state, current);
     }
 

--- a/Source/WebCore/style/values/pointerevents/StyleTouchAction.cpp
+++ b/Source/WebCore/style/values/pointerevents/StyleTouchAction.cpp
@@ -57,8 +57,8 @@ auto CSSValueConversion<TouchAction>::operator()(BuilderState& state, const CSSV
         return CSS::Keyword::Auto { };
 
     TouchActionValueEnumSet result;
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValuePanX:
             result.value.add(TouchActionValue::PanX);
             break;

--- a/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
+++ b/Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp
@@ -94,7 +94,7 @@ RefPtr<PathOperation> CSSValueConversion<RefPtr<PathOperation>>::operator()(Buil
     };
 
     if (RefPtr list = dynamicDowncast<CSSValueList>(value)) {
-        for (Ref currentValue : *list) {
+        for (auto& currentValue : *list) {
             if (!processSingleValue(currentValue))
                 return nullptr;
         }

--- a/Source/WebCore/style/values/shapes/StyleShapeOutside.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeOutside.cpp
@@ -72,7 +72,7 @@ auto CSSValueConversion<ShapeOutside>::operator()(BuilderState& state, const CSS
     };
 
     if (RefPtr list = dynamicDowncast<CSSValueList>(value)) {
-        for (Ref currentValue : *list)
+        for (auto& currentValue : *list)
             processSingleValue(currentValue);
     } else
         processSingleValue(value);

--- a/Source/WebCore/style/values/speech/StyleSpeakAs.cpp
+++ b/Source/WebCore/style/values/speech/StyleSpeakAs.cpp
@@ -56,8 +56,8 @@ auto CSSValueConversion<SpeakAs>::operator()(BuilderState& state, const CSSValue
         return CSS::Keyword::Normal { };
 
     SpeakAsValueEnumSet result;
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueSpellOut:
             result.value.add(SpeakAsValue::SpellOut);
             break;

--- a/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp
@@ -95,7 +95,7 @@ auto CSSValueConversion<TextDecorationLine>::operator()(BuilderState& state, con
     if (RefPtr valueList = dynamicDowncast<CSSValueList>(value)) {
         OptionSet<TextDecorationLine::Flag> flags;
 
-        for (Ref item : *valueList) {
+        for (auto& item : *valueList) {
             RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, item);
             if (!primitiveValue)
                 return invalidValue();

--- a/Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.cpp
@@ -49,8 +49,8 @@ auto CSSValueConversion<TextEmphasisPosition>::operator()(BuilderState& state, c
         return { TextEmphasisPositionValue::Over, TextEmphasisPositionValue::Right };
 
     TextEmphasisPositionValueEnumSet result;
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueOver:
             if (result.contains(TextEmphasisPositionValue::Under)) {
                 state.setCurrentPropertyInvalidAtComputedValueTime();

--- a/Source/WebCore/style/values/text-decoration/StyleTextEmphasisStyle.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextEmphasisStyle.cpp
@@ -110,8 +110,8 @@ auto CSSValueConversion<TextEmphasisStyle>::operator()(BuilderState& state, cons
 
         std::optional<TextEmphasisFill> fill;
         std::optional<TextEmphasisMark> mark;
-        for (Ref item : *list) {
-            auto valueID = item->valueID();
+        for (auto& item : *list) {
+            auto valueID = item.valueID();
             if (valueID == CSSValueFilled || valueID == CSSValueOpen)
                 fill = fromCSSValueID<TextEmphasisFill>(valueID);
             else

--- a/Source/WebCore/style/values/text-decoration/StyleTextUnderlinePosition.cpp
+++ b/Source/WebCore/style/values/text-decoration/StyleTextUnderlinePosition.cpp
@@ -55,8 +55,8 @@ auto CSSValueConversion<TextUnderlinePosition>::operator()(BuilderState& state, 
         return CSS::Keyword::Auto { };
 
     TextUnderlinePositionValueEnumSet result;
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueFromFont:
             if (result.contains(TextUnderlinePositionValue::Under)) {
                 state.setCurrentPropertyInvalidAtComputedValueTime();

--- a/Source/WebCore/style/values/text/StyleHangingPunctuation.cpp
+++ b/Source/WebCore/style/values/text/StyleHangingPunctuation.cpp
@@ -55,8 +55,8 @@ auto CSSValueConversion<HangingPunctuation>::operator()(BuilderState& state, con
         return CSS::Keyword::None { };
 
     HangingPunctuationValueEnumSet result;
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueFirst:
             result.value.add(HangingPunctuationValue::First);
             break;

--- a/Source/WebCore/style/values/text/StyleTextTransform.cpp
+++ b/Source/WebCore/style/values/text/StyleTextTransform.cpp
@@ -59,8 +59,8 @@ auto CSSValueConversion<TextTransform>::operator()(BuilderState& state, const CS
         return CSS::Keyword::None { };
 
     TextTransformValueEnumSet result;
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueCapitalize:
             if (result.containsAny({ TextTransformValue::Uppercase, TextTransformValue::Lowercase })) {
                 state.setCurrentPropertyInvalidAtComputedValueTime();

--- a/Source/WebCore/style/values/will-change/StyleWillChange.cpp
+++ b/Source/WebCore/style/values/will-change/StyleWillChange.cpp
@@ -220,8 +220,8 @@ auto CSSValueConversion<WillChange>::operator()(BuilderState& state, const CSSVa
 
     auto result = WillChangeAnimatableFeatures { };
 
-    for (Ref item : *list) {
-        switch (item->valueID()) {
+    for (auto& item : *list) {
+        switch (item.valueID()) {
         case CSSValueScrollPosition:
             result.addFeature(WillChangeAnimatableFeature::Feature::ScrollPosition);
             break;
@@ -229,8 +229,8 @@ auto CSSValueConversion<WillChange>::operator()(BuilderState& state, const CSSVa
             result.addFeature(WillChangeAnimatableFeature::Feature::Contents);
             break;
         default:
-            if (item->isPropertyID()) {
-                if (auto propertyID = item->propertyID(); isExposed(propertyID, &state.document().settings())) {
+            if (item.isPropertyID()) {
+                if (auto propertyID = item.propertyID(); isExposed(propertyID, &state.document().settings())) {
                     result.addFeature(WillChangeAnimatableFeature::Feature::Property, propertyID);
                     break;
                 }


### PR DESCRIPTION
#### 35165d7e987f4218c451fa1dbf2cdf3c7549779b
<pre>
Reduce unnecessary ref count churn in WebCore/style
<a href="https://bugs.webkit.org/show_bug.cgi?id=307128">https://bugs.webkit.org/show_bug.cgi?id=307128</a>
<a href="https://rdar.apple.com/169764032">rdar://169764032</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::ChildChangeInvalidation::traverseRemovedElements):
(WebCore::Style::ChildChangeInvalidation::traverseAddedElements):
* Source/WebCore/style/HasSelectorFilter.cpp:
(WebCore::Style::HasSelectorFilter::HasSelectorFilter):
* Source/WebCore/style/StyleBuilderChecking.h:
(WebCore::Style::requiredListDowncast):
* Source/WebCore/style/StyleBuilderCustom.h:
(WebCore::Style::applyValueCoordinatedValueListProperty):
(WebCore::Style::BuilderCustom::determineRubyTextSizeMultiplier):
* Source/WebCore/style/StyleExtractor.cpp:
(WebCore::Style::hasValidStyleForProperty):
* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyle):
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):
(WebCore::Style::Invalidator::invalidateShadowParts):
(WebCore::Style::Invalidator::invalidateUserAgentParts):
(WebCore::Style::Invalidator::invalidateInShadowTreeIfNeeded):
(WebCore::Style::Invalidator::invalidateAllStyle):
(WebCore::Style::Invalidator::invalidateHostAndSlottedStyleIfNeeded):
* Source/WebCore/style/StyleNameScope.cpp:
(WebCore::Style::CSSValueConversion&lt;NameScope&gt;::operator):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::Scope::Scope):
(WebCore::Style::hasLoadingStylesheet):
* Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp:
(WebCore::Style::CSSValueConversion&lt;PositionTryFallback&gt;::operator):
* Source/WebCore/style/values/box/StyleMarginTrim.cpp:
(WebCore::Style::CSSValueConversion&lt;MarginTrim&gt;::operator):
* Source/WebCore/style/values/contain/StyleContain.cpp:
(WebCore::Style::CSSValueConversion&lt;Contain&gt;::operator):
* Source/WebCore/style/values/content/StyleContent.cpp:
(WebCore::Style::CSSValueConversion&lt;Content&gt;::operator):
* Source/WebCore/style/values/fonts/StyleFontFeatureSettings.cpp:
(WebCore::Style::CSSValueConversion&lt;FontFeatureSettings&gt;::operator):
* Source/WebCore/style/values/fonts/StyleFontVariantAlternates.cpp:
(WebCore::Style::CSSValueConversion&lt;FontVariantAlternates&gt;::operator):
* Source/WebCore/style/values/fonts/StyleFontVariantEastAsian.cpp:
(WebCore::Style::CSSValueConversion&lt;FontVariantEastAsian&gt;::operator):
* Source/WebCore/style/values/fonts/StyleFontVariantLigatures.cpp:
(WebCore::Style::CSSValueConversion&lt;FontVariantLigatures&gt;::operator):
* Source/WebCore/style/values/fonts/StyleFontVariantNumeric.cpp:
(WebCore::Style::CSSValueConversion&lt;FontVariantNumeric&gt;::operator):
* Source/WebCore/style/values/fonts/StyleFontVariationSettings.cpp:
(WebCore::Style::CSSValueConversion&lt;FontVariationSettings&gt;::operator):
* Source/WebCore/style/values/grid/StyleGridTemplateList.cpp:
(WebCore::Style::CSSValueConversion&lt;GridTemplateList&gt;::operator):
* Source/WebCore/style/values/masking/StyleMaskBorder.cpp:
(WebCore::Style::CSSValueConversion&lt;MaskBorder&gt;::operator):
* Source/WebCore/style/values/pointerevents/StyleTouchAction.cpp:
(WebCore::Style::CSSValueConversion&lt;TouchAction&gt;::operator):
* Source/WebCore/style/values/shapes/StylePathOperationWrappers.cpp:
(WebCore::Style::CSSValueConversion&lt;RefPtr&lt;PathOperation&gt;&gt;::operator):
* Source/WebCore/style/values/shapes/StyleShapeOutside.cpp:
(WebCore::Style::CSSValueConversion&lt;ShapeOutside&gt;::operator):
* Source/WebCore/style/values/speech/StyleSpeakAs.cpp:
(WebCore::Style::CSSValueConversion&lt;SpeakAs&gt;::operator):
* Source/WebCore/style/values/text-decoration/StyleTextDecorationLine.cpp:
(WebCore::Style::CSSValueConversion&lt;TextDecorationLine&gt;::operator):
* Source/WebCore/style/values/text-decoration/StyleTextEmphasisPosition.cpp:
(WebCore::Style::CSSValueConversion&lt;TextEmphasisPosition&gt;::operator):
* Source/WebCore/style/values/text-decoration/StyleTextEmphasisStyle.cpp:
(WebCore::Style::CSSValueConversion&lt;TextEmphasisStyle&gt;::operator):
* Source/WebCore/style/values/text-decoration/StyleTextUnderlinePosition.cpp:
(WebCore::Style::CSSValueConversion&lt;TextUnderlinePosition&gt;::operator):
* Source/WebCore/style/values/text/StyleHangingPunctuation.cpp:
(WebCore::Style::CSSValueConversion&lt;HangingPunctuation&gt;::operator):
* Source/WebCore/style/values/text/StyleTextTransform.cpp:
(WebCore::Style::CSSValueConversion&lt;TextTransform&gt;::operator):
* Source/WebCore/style/values/will-change/StyleWillChange.cpp:
(WebCore::Style::CSSValueConversion&lt;WillChange&gt;::operator):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35165d7e987f4218c451fa1dbf2cdf3c7549779b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15260 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5728 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95977 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144655 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109809 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79135 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145737 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12268 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127746 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90718 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11770 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9448 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1461 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121147 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4212 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153775 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14886 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117823 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14923 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12928 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118156 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14143 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125035 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70583 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14929 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/3995 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14664 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78638 "Found 65 new failures in style/values/fonts/StyleFontVariantNumeric.cpp, style/values/fonts/StyleFontVariationSettings.cpp, style/StyleBuilderChecking.h, style/values/contain/StyleContain.cpp, style/values/content/StyleContent.cpp, style/values/will-change/StyleWillChange.cpp, style/values/fonts/StyleFontVariantEastAsian.cpp, style/StyleExtractor.cpp, style/values/text-decoration/StyleTextEmphasisStyle.cpp, style/values/fonts/StyleFontVariantAlternates.cpp ...") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14872 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14726 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->