### PR TITLE
Add an efficient way to evaluate JavaScript in a custom DOM world wrapper world

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -296,6 +296,7 @@ WTF_EXTERN_C_END
     M(NetworkCacheMiss) \
     M(PLTSubresourceLoading) \
     M(EvaluateJavaScript) \
+    M(EvaluateJavaScriptFromBuffer) \
 
 #define DECLARE_WTF_SIGNPOST_NAME_ENUM(name) WTFOSSignpostName ## name,
 

--- a/Source/WebCore/page/WebKitBuffer.h
+++ b/Source/WebCore/page/WebKitBuffer.h
@@ -36,6 +36,7 @@ class WEBCORE_EXPORT WebKitBuffer : public RefCounted<WebKitBuffer> {
 public:
     virtual ~WebKitBuffer();
 
+    virtual ExceptionOr<String> asUTF8String() const = 0;
     virtual ExceptionOr<String> asUTF16String() const = 0;
     virtual String asLatin1String() const = 0;
 

--- a/Source/WebCore/page/WebKitBuffer.idl
+++ b/Source/WebCore/page/WebKitBuffer.idl
@@ -27,6 +27,7 @@
     LegacyNoInterfaceObject,
     SkipVTableValidation,
 ] interface WebKitBuffer {
+    DOMString asUTF8String();
     DOMString asUTF16String();
     DOMString asLatin1String();
 };

--- a/Source/WebCore/page/WebKitNamespace.h
+++ b/Source/WebCore/page/WebKitNamespace.h
@@ -34,6 +34,7 @@
 
 namespace JSC {
 class JSGlobalObject;
+class JSValue;
 }
 
 namespace WebCore {
@@ -41,6 +42,7 @@ namespace WebCore {
 class Node;
 class UserContentProvider;
 class UserMessageHandlersNamespace;
+class WebKitBuffer;
 class WebKitBufferNamespace;
 class WebKitJSHandle;
 class WebKitSerializedNode;
@@ -56,6 +58,7 @@ public:
 
     UserMessageHandlersNamespace* messageHandlers();
     WebKitBufferNamespace& buffers();
+    JSC::JSValue evaluateScript(JSC::JSGlobalObject&, const String& source, const String& url);
     Ref<WebKitJSHandle> createJSHandle(JSC::Strong<JSC::JSObject>);
 
     struct SerializedNodeInit {

--- a/Source/WebCore/page/WebKitNamespace.idl
+++ b/Source/WebCore/page/WebKitNamespace.idl
@@ -32,6 +32,7 @@
 ] interface WebKitNamespace {
     readonly attribute UserMessageHandlersNamespace? messageHandlers;
     readonly attribute WebKitBufferNamespace buffers;
+    [CallWith=CurrentGlobalObject] any evaluateScript(DOMString source, optional USVString? url = null);
     [EnabledForGlobalObject=allowsJSHandleCreation] WebKitJSHandle createJSHandle(object object);
     [EnabledForWorld=allowNodeSerialization] WebKitSerializedNode serializeNode(Node node, optional WebKitSerializedNodeInit init = {});
 };

--- a/Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.cpp
+++ b/Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.cpp
@@ -42,6 +42,13 @@ SharedMemoryJSBuffer::SharedMemoryJSBuffer(Ref<WebCore::SharedMemory>&& sharedMe
 {
 }
 
+WebCore::ExceptionOr<String> SharedMemoryJSBuffer::asUTF8String() const
+{
+    if (charactersAreAllASCII(m_sharedMemory->span()))
+        return asLatin1String();
+    return String::fromUTF8(m_sharedMemory->span());
+}
+
 WebCore::ExceptionOr<String> SharedMemoryJSBuffer::asUTF16String() const
 {
     if (m_sharedMemory->size() % sizeof(char16_t))

--- a/Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.h
+++ b/Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.h
@@ -41,6 +41,7 @@ public:
 private:
     SharedMemoryJSBuffer(Ref<WebCore::SharedMemory>&&);
 
+    WebCore::ExceptionOr<String> asUTF8String() const final;
     WebCore::ExceptionOr<String> asUTF16String() const final;
     String asLatin1String() const final;
 


### PR DESCRIPTION
#### cf51677710d6defbba1b242e60f6c2cd94818487
<pre>
Add an efficient way to evaluate JavaScript in a custom DOM world wrapper world
<a href="https://bugs.webkit.org/show_bug.cgi?id=307123">https://bugs.webkit.org/show_bug.cgi?id=307123</a>

Reviewed by Ben Nham.

This PR adds two APIs:
 - asUTF8String on WebKitBuffer to get a string encoded in UTF-8.
 - window.webkit.evaluateScript which executes JavaScript in the current world.

Together, these APIs provide an efficient mechanism to share and execute
JavaScript code across multiple WebContent processes.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm

* Source/WTF/wtf/SystemTracing.h:
* Source/WTF/wtf/glib/SysprofAnnotator.h:
* Source/WebCore/page/WebKitBuffer.h:
* Source/WebCore/page/WebKitBuffer.idl:
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::evaluateScript):
* Source/WebCore/page/WebKitNamespace.h:
* Source/WebCore/page/WebKitNamespace.idl:
* Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.cpp:
(WebKit::SharedMemoryJSBuffer::asUTF8String const):
* Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/JSBuffer.mm:
(TEST(JSBuffer, EvaluateScript)):

Canonical link: <a href="https://commits.webkit.org/306985@main">https://commits.webkit.org/306985@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6efb16b489aa769a535ff2e9a6e9e48cc35bba79

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142951 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151625 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2cffd66-eaec-43d6-83e5-b493add2d271) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144818 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16080 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109936 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145900 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90846 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/679337d5-e872-476e-a38e-8bc923eecfa1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11882 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9564 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1624 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134945 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153938 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3761 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5059 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117949 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13053 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118286 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14257 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125240 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70756 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22041 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15092 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4141 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174248 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78803 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45015 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15035 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14889 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->