### PR TITLE
[Site Isolation] Back navigation fails when page contains iframe that navigated cross-site.

### DIFF
--- a/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
@@ -13,6 +13,7 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
         'navigate-to-page2': () => navigateIframeTo("back-iframe-2.html"),
+        'navigate-to-page2-cross-site-iframe': () => navigateIframeTo(crossSiteUrl("back-iframe-2.html")),
         'navigate-to-other': () => navigateTo("back-iframe-other.html"),
         back2: () => history.back(),
     },

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
@@ -4,7 +4,7 @@
 <script src="navigation-utils.js"></script>
 <script>
 
-const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+const page = location.hostname === loopbackAddress ? "samesite" : "crosssite";
 
 window.onload = () => sendMessageToTop("load");
 window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
@@ -13,8 +13,5 @@ window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persist
 </head>
 <body>
 <h1>Iframe Page</h1>
-<script>
-document.getElementById("host").textContent = location.hostname + ":" + location.port;
-</script>
 </body>
 </html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
@@ -12,7 +12,7 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
-        'navigate-to-cross-site': () => navigateIframeTo(`http://${crossSiteHostname}:8000/navigation/resources/cross-site-iframe-nav-page.html`),
+        'navigate-to-cross-site': () => navigateIframeTo(crossSiteUrl('cross-site-iframe-nav-page.html')),
         'navigate-to-other': () => navigateTo("cross-site-iframe-nav-other.html"),
         back2: () => history.back(),
     },

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
@@ -4,7 +4,7 @@
 <script src="navigation-utils.js"></script>
 <script>
 
-const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+const page = location.hostname === loopbackAddress ? "samesite" : "crosssite";
 
 window.onload = () => sendMessageToTop("load");
 window.onpageshow = () => sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
@@ -13,9 +13,5 @@ window.onpageshow = () => sendMessageToTop("pageshow", event.persisted ? "persis
 </head>
 <body>
 <h1>Iframe Page</h1>
-<p id="host"></p>
-<script>
-document.getElementById("host").textContent = location.hostname + ":" + location.port;
-</script>
 </body>
 </html>

--- a/LayoutTests/http/tests/navigation/resources/navigation-utils.js
+++ b/LayoutTests/http/tests/navigation/resources/navigation-utils.js
@@ -1,5 +1,10 @@
-const sameSiteHostname = "127.0.0.1";
-const crossSiteHostname = "localhost";
+const hostname = location.hostname;
+
+const localhost = "localhost";
+const loopbackAddress = "127.0.0.1";
+
+const sameSiteHostname = hostname;
+const crossSiteHostname = hostname === localhost ? loopbackAddress : localhost;
 
 /* `page` must be defined in embedding HTML files */
 function makeMessage(action, arg = "") {
@@ -90,4 +95,10 @@ function navigateTo(url) {
 
 function navigateIframeTo(url) {
     iframeContentWindow().location.href = url;
+}
+
+function crossSiteUrl(path) {
+    const url = new URL(path, location.href);
+    url.hostname = crossSiteHostname;
+    return url.href;
 }

--- a/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache-expected.txt
@@ -1,0 +1,21 @@
+Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Page1 loaded
+Page1 displayed first time.
+Page2 loaded
+Page2 displayed first time.
+Other page loaded
+Other page displayed.
+Page2 loaded
+PASS Page2 displayed twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with back-iframe-popup.html. It has an same-site iframe with page1 loaded initially.
+Navigate iframe to cross-site page2.
+Navigate main frame to other (same-site).
+Go back. (back-iframe-popup.html with iframe showing cross-site page2)
+... and ensures the nested iframe content is correctly restored to page2.

--- a/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html
+++ b/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html
@@ -1,0 +1,93 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/navigation/resources/navigation-utils.js"></script>
+<script>
+
+description("Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.");
+jsTestIsAsync = true;
+
+const page = "opener";
+var popup = null;
+
+window.onload = function() {
+    popup = window.open("/navigation/resources/back-iframe-popup.html");
+}
+
+var page1ShowCount = 0;
+var page2ShowCount = 0;
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    popup: {
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Popup should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+        },
+    },
+    page1: {
+        load: () => debug("Page1 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page1 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page1ShowCount++;
+            if (page1ShowCount == 1) {
+                debug("Page1 displayed first time.");
+                sendMessageToPopup("navigate-to-page2-cross-site-iframe");
+            } else {
+                testFailed("Page1 should be displayed only once.");
+                finishJSTest();
+            }
+        }
+    },
+    page2: {
+        load: () => debug("Page2 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page2 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page2ShowCount++;
+            if (page2ShowCount == 1) {
+                debug("Page2 displayed first time.");
+                sendMessageToPopup("navigate-to-other");
+            } else if (page2ShowCount == 2) {
+                testPassed("Page2 displayed twice.");
+                finishJSTest();
+            } else {
+                testFailed("Page2 should be displayed only twice.");
+                finishJSTest();
+            }
+        }
+    },
+    other: {
+        load: () => debug("Other page loaded"),
+        pageshow: ({arg}) => {
+            debug("Other page displayed.");
+            sendMessageToPopup("back1");
+        }
+    },
+});
+
+</script>
+</head>
+<body>
+<ul>
+    <li>Open a new window with back-iframe-popup.html. It has an same-site iframe with page1 loaded initially.</li>
+    <li>Navigate iframe to cross-site page2.</li>
+    <li>Navigate main frame to other (same-site).</li>
+    <li>Go back. (back-iframe-popup.html with iframe showing cross-site page2)</li>
+</ul>
+<p>... and ensures the nested iframe content is correctly restored to page2.</p>
+</body>
+</html>

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -353,6 +353,19 @@ HistoryItem* HistoryItem::childItemWithDocumentSequenceNumber(long long number)
     return nullptr;
 }
 
+HistoryItem* HistoryItem::childItemForFrame(LocalFrame& frame)
+{
+    if (auto* childItem = childItemWithTarget(frame.tree().uniqueName()))
+        return childItem;
+
+    if (auto index = frame.indexInFrameTreeSiblings()) {
+        ASSERT(index.value() < m_children.size());
+        return m_children[index.value()].ptr();
+    }
+
+    return nullptr;
+}
+
 const Vector<Ref<HistoryItem>>& HistoryItem::children() const
 {
     return m_children;

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -55,6 +55,7 @@ namespace WebCore {
 class CachedPage;
 class Document;
 class FormData;
+class FrameTree;
 class HistoryItem;
 class Image;
 class ResourceRequest;
@@ -164,9 +165,10 @@ public:
     WEBCORE_EXPORT HistoryItem* childItemWithTarget(const AtomString&);
     WEBCORE_EXPORT HistoryItem* childItemWithFrameID(FrameIdentifier);
     HistoryItem* childItemWithDocumentSequenceNumber(long long number);
+    HistoryItem* childItemForFrame(LocalFrame&);
     WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& children() const;
     void clearChildren();
-    
+
     bool shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const;
 
     bool isCurrentDocument(Document&) const;

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -215,8 +215,9 @@ std::optional<uint64_t> Frame::indexInFrameTreeSiblings() const
     if (!tree().parent())
         return std::nullopt;
 
-    for (uint64_t i = 0; i < tree().parent()->tree().childCount(); i++) {
-        if (RefPtr child = tree().parent()->tree().child(i); child->frameID() == this->frameID())
+    const auto& parentTree = tree().parent()->tree();
+    for (uint64_t i = 0; i < parentTree.childCount(); i++) {
+        if (this == parentTree.child(i))
             return i;
     }
 


### PR DESCRIPTION
#### 5fa8be5b7960430ae4f43204fabf76d35695a979
<pre>
[Site Isolation] Back navigation fails when page contains iframe that navigated cross-site.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307121">https://bugs.webkit.org/show_bug.cgi?id=307121</a>
<a href="https://rdar.apple.com/169754535">rdar://169754535</a>

Reviewed by Sihui Liu.

When performing back navigation on a page containing an iframe that navigated cross-site,
the iframe content was incorrectly displayed.

The original code relied solely on matching frames by their uniqueName using childItemWithTarget().
When an iframe navigates cross-site, target name is not preserved across process boundaries,
causing the lookup to fail. This results in the history restoration logic falling back to the
initial page&apos;s content instead of the navigated page.

The fix implements a two-tier lookup strategy for finding child frame history items. If the
name-based lookup fails, it falls back to using the frame&apos;s index in the frame tree to find
the corresponding history item.

Test: http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html

* LayoutTests/http/tests/navigation/resources/back-iframe-popup.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html:
* LayoutTests/http/tests/navigation/resources/navigation-utils.js:
(crossSiteUrl):
* LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html: Added.
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::childItemForFrame):
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURLIntoChildFrame):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::indexInFrameTreeSiblings const):

Canonical link: <a href="https://commits.webkit.org/307081@main">https://commits.webkit.org/307081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fb484dd21eef02804e23fea68882166d1aef042

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143249 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15724 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151925 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96470 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78805d7b-954d-4a19-ae9f-3a563d188db8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110169 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79317 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/102843b3-8436-4542-9286-f63b44db47c4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146198 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12612 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91079 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/047c2b72-37c8-448c-96ca-6b29db1f32a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9811 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1922 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121524 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154236 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15768 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118188 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15805 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13299 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118528 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30383 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14466 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125938 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71160 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15393 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4579 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15127 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79113 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15338 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15189 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->