### PR TITLE
[GFC] Add grid container minimum and maximum sizes to GridLayoutConstraints

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -66,7 +66,12 @@ struct GridDefinition {
 
 struct GridLayoutConstraints {
     std::optional<LayoutUnit> inlineAxisAvailableSpace;
+    std::optional<LayoutUnit> gridContainerInlineMinimumSize;
+    std::optional<LayoutUnit> gridContainerInlineMaximumSize;
+
     std::optional<LayoutUnit> blockAxisAvailableSpace;
+    std::optional<LayoutUnit> gridContainerBlockMinimumSize;
+    std::optional<LayoutUnit> gridContainerBlockMaximumSize;
 };
 
 class GridFormattingContext {


### PR DESCRIPTION
#### e6ff1a5a70036493e4bf8321c68ff77ec5fcef56
<pre>
[GFC] Add grid container minimum and maximum sizes to GridLayoutConstraints
<a href="https://bugs.webkit.org/show_bug.cgi?id=307137">https://bugs.webkit.org/show_bug.cgi?id=307137</a>
<a href="https://rdar.apple.com/169771123">rdar://169771123</a>

Reviewed by Vitor Roriz.

GridLayout will need to know the grid container&apos;s minimum and maximum
sizes in both dimensions during layout. We will need to know if those
values are indefinite or definite as well as what the definite value
would be. For example, we will need to know if the maximum size of the
grid container is definite along with its value during the &quot;Maximize
Tracks,&quot; portion of the track sizing algorithm.

A good place for these values to live is on GridLayoutConstraints since
wthat is also where also put the other inline and block constraints for
GridLayout.

* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
(WebCore::LayoutIntegration::sizeValue):
Helper function to help resolve the minimum and maximum sizes. For now
we just use fixed values since those are trivial to support.

Canonical link: <a href="https://commits.webkit.org/306960@main">https://commits.webkit.org/306960@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b10dc3f6de4e5be5b2e8ac2bc4404bc1af0acc3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142806 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5753 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/95996 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2b9e30a-5383-4f9d-8a24-8f6102e30b09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144673 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15934 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15359 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109820 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79146 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87e7836a-7830-46b5-8612-4021d7869fe0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90729 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da67e53d-b027-425c-ac33-874f7a601961) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9459 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1479 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121160 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4226 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153793 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14904 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117835 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118168 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30231 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14159 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125049 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70601 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14947 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4008 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78656 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14744 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->