### PR TITLE
[Site Isolation] Dispatch pageswap event on navigation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/pageswap-event-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/pageswap-event-expected.txt
@@ -1,0 +1,10 @@
+Tests that pageswap fires when site isolation is enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is "pageswap"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/pageswap-event.html
+++ b/LayoutTests/http/tests/site-isolation/pageswap-event.html
@@ -1,0 +1,41 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!-- This test is adapted from LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub.html -->
+
+<!DOCTYPE html>
+<title>Tests that pageswap fires when site isolation is enabled.</title>
+
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that pageswap fires when site isolation is enabled.");
+jsTestIsAsync = true;
+
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+if (is_test_page) {
+  onload = () => {
+    popup = window.open("?popup");
+  };
+
+  onmessage = (event) => {
+    shouldBeEqualToString("event.data", "pageswap");
+    popup.close();
+    finishJSTest();
+  };
+}
+
+if (is_popup_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      location.href = "http://localhost:8000/site-isolation/pageswap-event.html?new";
+    }));
+  };
+
+  onpageswap = () => window.opener.postMessage("pageswap", "*");
+}
+</script>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2156,6 +2156,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/MediaProducer.h
     page/MemoryRelease.h
     page/ModalContainerTypes.h
+    page/NavigationActivation.h
+    page/NavigationHistoryEntry.h
     page/NavigationNavigationType.h
     page/Navigator.h
     page/NavigatorBase.h

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1442,7 +1442,7 @@ public:
     void queueTaskToDispatchEventOnWindow(TaskSource, Ref<Event>&&);
     void dispatchPageshowEvent(PageshowEventPersistence);
     void dispatchPagehideEvent(PageshowEventPersistence);
-    void dispatchPageswapEvent(bool canTriggerCrossDocumentViewTransition, RefPtr<NavigationActivation>&&);
+    WEBCORE_EXPORT void dispatchPageswapEvent(bool canTriggerCrossDocumentViewTransition, RefPtr<NavigationActivation>&&);
     void transferViewTransitionParams(Document&);
     WEBCORE_EXPORT void enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&&);
     void enqueueHashchangeEvent(const String& oldURL, const String& newURL);

--- a/Source/WebCore/page/NavigationActivation.h
+++ b/Source/WebCore/page/NavigationActivation.h
@@ -41,7 +41,7 @@ public:
         return adoptRef(*new NavigationActivation(type, WTF::move(entry), WTF::move(fromEntry)));
     }
 
-    ~NavigationActivation();
+    WEBCORE_EXPORT ~NavigationActivation();
 
     NavigationNavigationType navigationType() { return m_navigationType; };
     NavigationHistoryEntry* from() const { return m_fromEntry.get(); };

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -104,6 +104,7 @@
 #include <WebCore/LocalFrameInlines.h>
 #include <WebCore/LocalFrameView.h>
 #include <WebCore/MouseEventTypes.h>
+#include <WebCore/NavigationActivation.h>
 #include <WebCore/NodeDocument.h>
 #include <WebCore/OriginAccessPatterns.h>
 #include <WebCore/PluginDocument.h>
@@ -394,12 +395,17 @@ void WebFrame::loadDidCommitInAnotherProcess(std::optional<WebCore::LayerHosting
         return;
     }
 
+    // loadDidCommitInAnotherProcess implies the new frame is cross-origin to the current frame.
+    // Cross-origin navigation doesn't trigger view transitions, and does not provide any activation information.
+    protect(localFrame->document())->dispatchPageswapEvent(/*canTriggerCrossDocumentViewTransition=*/ false, nullptr);
+
     auto invalidator = frameLoaderClient->takeFrameInvalidator();
     RefPtr ownerRenderer = localFrame->ownerRenderer();
     localFrame->setView(nullptr);
 
     if (ownerElement)
         localFrame->disconnectOwnerElement();
+
     auto clientCreator = [protectedThis = Ref { *this }, invalidator = WTF::move(invalidator)] (auto&) mutable {
         return makeUniqueRef<WebRemoteFrameClient>(WTF::move(protectedThis), WTF::move(invalidator));
     };


### PR DESCRIPTION
#### 04a093f390151d1cdbd50604dcaab03ba880b946
<pre>
[Site Isolation] Dispatch pageswap event on navigation
<a href="https://rdar.apple.com/150216569">rdar://150216569</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306447">https://bugs.webkit.org/show_bug.cgi?id=306447</a>

Reviewed by Ryosuke Niwa.

pageswap event is dispatched by FrameLoader::commitProvisionalLoad, which is
only called on same-origin navigation when Site Isolation is enabled. For
cross-origin navigation, WebFrame::loadDidCommitInAnotherProcess is called
instead, so this commit adds code to dispatch pageswap there.

Test: http/tests/site-isolation/pageswap-event.html

* LayoutTests/http/tests/site-isolation/pageswap-event-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/pageswap-event.html: Added.
* Source/WebCore/Headers.cmake:
    - Add headers that exist but were not listed in Headers.cmake.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    - Add headers that exist but were not added to the Xcode project.

* Source/WebCore/dom/Document.h:
* Source/WebCore/page/NavigationActivation.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::loadDidCommitInAnotherProcess):

Canonical link: <a href="https://commits.webkit.org/307047@main">https://commits.webkit.org/307047@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f39d6fc5d338dfe946324709ccdb025935dddac0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143185 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151861 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96406 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b74da084-1608-4f14-ac3b-a59d89df706e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145052 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15741 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110115 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79266 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05dd52c1-58b4-47cc-87ba-7d31ce7247a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12553 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91026 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc36a773-3dfe-4447-8707-5d587680fded) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12036 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9748 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1858 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121455 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4632 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154172 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15665 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5619 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118133 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13236 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30345 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14400 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125819 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15329 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4460 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15063 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79048 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15274 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15125 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->