### PR TITLE
[JSC] Implement Variable Count Parentheses in YarrJIT

### DIFF
--- a/JSTests/stress/regexp-fixedcount-zero-length-content-backtrack.js
+++ b/JSTests/stress/regexp-fixedcount-zero-length-content-backtrack.js
@@ -1,0 +1,24 @@
+// Test that FixedCount patterns with empty alternatives and content backtracking work correctly.
+// Regression test for zero-length match detection in FixedCount content backtracking.
+
+// Pattern from slow.js that was hanging:
+// (?:[^(?!)]||){23}z - FixedCount with 3 alternatives, 2 empty
+if (/(?:[^(?!)]||){23}z/.test("/(?:[^(?!)]||){23}z/"))
+    throw new Error("Should not match");
+
+// FixedCount with empty alternatives - should allow zero-length iterations
+if (!/(?:a||){5}z/.test("aaaz"))
+    throw new Error("Should match: 3 iterations of 'a', 2 of empty, then 'z'");
+
+// Content backtracking should still work for non-empty alternatives
+var result = /(?:a|b){3}c/.exec("abbc");
+if (!result || result[0] !== "abbc")
+    throw new Error("Expected 'abbc', got " + result);
+
+// FixedCount with all empty alternatives followed by required match
+if (!/(?:||){10}z/.test("z"))
+    throw new Error("Should match 'z' after 10 empty iterations");
+
+// Another test: empty alternative should work
+if (!/(?:a|){2}b/.test("b"))
+    throw new Error("Should match: 2 empty iterations then 'b'");

--- a/JSTests/stress/regexp-greedy-nested-quantifier-backtrack.js
+++ b/JSTests/stress/regexp-greedy-nested-quantifier-backtrack.js
@@ -1,0 +1,46 @@
+// Regression test for interpreter bug with nested greedy quantifiers and content backtracking.
+// https://bugs.webkit.org/show_bug.cgi?id=307145
+//
+// The bug occurred in the interpreter when a greedy quantified parentheses dropped below
+// its minimum count during backtracking. Instead of trying content backtracking within
+// earlier iterations (to redistribute characters), it would immediately fail.
+//
+// @runDefault
+// @runNoJIT
+
+function test(pattern, input, expected) {
+    let result = pattern.exec(input);
+    let got = result ? result[0] : null;
+    if (got !== expected)
+        throw new Error("FAIL: pattern " + pattern + " on '" + input + "': expected '" + expected + "', got '" + got + "'");
+}
+
+// These patterns require content backtracking within nested quantifiers.
+// The inner greedy a+ initially consumes too many characters, preventing the
+// outer quantifier from reaching its minimum. Backtracking must redistribute
+// characters across iterations.
+
+// Inner min=2, variable count - the original failing case
+test(/((a+){2,3}){2,3}$/, "aaaaaa", "aaaaaa");
+
+// Similar patterns with different counts
+test(/((a+){2,4}){2,3}$/, "aaaaaa", "aaaaaa");
+test(/((a+){2,3}){2,4}$/, "aaaaaa", "aaaaaa");
+
+// Non-capturing inner group
+test(/((?:a+){2,3}){2,3}$/, "aaaaaa", "aaaaaa");
+
+// Fixed outer, variable inner
+test(/((a+){2,3}){2,2}$/, "aaaaaa", "aaaaaa");
+
+// Three levels of nesting
+test(/(((a+){2}){2}){1,2}$/, "aaaa", "aaaa");
+
+// Ensure normal cases still work
+test(/((a+){1,3}){2,3}$/, "aaaaaa", "aaaaaa");  // inner min=1 (simpler case)
+test(/((a){2,3}){2,3}$/, "aaaaaa", "aaaaaa");   // non-greedy inner content
+
+// Test no-match cases still correctly fail
+test(/((a+){2,3}){2,3}$/, "aaa", null);  // not enough characters
+
+print("PASS: All nested quantifier backtracking tests passed");

--- a/JSTests/stress/regexp-greedy-varcount-minfail.js
+++ b/JSTests/stress/regexp-greedy-varcount-minfail.js
@@ -1,0 +1,49 @@
+//@ runDefault
+
+// Exercises Greedy variable-count parens with min > 0 in heavy-backtracking
+// scenarios that drive Begin.bt's failure exit (where the new op.m_jumps.link
+// lives) and the "decrement and try fewer iterations" success paths. Validates
+// that the JIT codegen for ParenthesesSubpatternBegin.backtrack matches the
+// reference engine.
+
+function shouldBe(actual, expected, label) {
+    let a = JSON.stringify(actual);
+    let e = JSON.stringify(expected);
+    if (a !== e)
+        throw new Error("FAIL " + label + ": expected " + e + " got " + a);
+}
+
+// 1. Min not reachable: pure failure path through Begin.bt.
+shouldBe(/(a+){3,}/.exec("aa"), null, "fail: 2 a's, need 3 iters of a+");
+shouldBe(/(a+){3,5}b/.exec("aab"), null, "fail: 2 a's then b, need 3 iters");
+shouldBe(/(a+){5,}/.exec("aaaa"), null, "fail: 4 a's, need 5 iters");
+
+// 2. Heavy content backtracking driven by post-parens literal mismatch.
+shouldBe(/(a+){2,5}b/.exec("aaaaaab"), ["aaaaaab", "a"], "6 a's + b, min=2 max=5");
+shouldBe(/(a+){3,5}b/.exec("aaaaaab"), ["aaaaaab", "a"], "6 a's + b, min=3 max=5");
+shouldBe(/(a+){3,5}b/.exec("aaaaaaab"), ["aaaaaaab", "a"], "7 a's + b, min=3 max=5");
+
+// 3. Post-parens that requires backtracking down to exactly min.
+shouldBe(/(a+){2,5}aab/.exec("aaaaaab"), ["aaaaaab", "a"], "post-parens consumes aab");
+
+// 4. Multi-alternative inner with min > 0.
+shouldBe(/(a+|b+){2,4}c/.exec("aabbc"), ["aabbc", "bb"], "multi-alt: aa then bb then c");
+shouldBe(/(a+|b+){2,4}c/.exec("aabbbbc"), ["aabbbbc", "bbbb"], "multi-alt: aa then bbbb then c");
+shouldBe(/(a+|b+){3,}/.exec("ab"), null, "multi-alt fail: only 1 alternation");
+
+// 5. Nested greedy with min > 0 at multiple levels.
+shouldBe(/((a+){2,3}){2,3}b/.exec("aaaaaab"), ["aaaaaab", "aa", "a"], "nested {2,3} of {2,3}");
+shouldBe(/((a+){2,4}){2,3}/.exec("aaaaaa"), ["aaaaaa", "aa", "a"], "nested {2,3} inner {2,4}");
+shouldBe(/((a+){2,3}){3,}b/.exec("aab"), null, "nested fail: outer needs 3 iters");
+
+// 6. Greedy with min > 0 followed by another greedy.
+shouldBe(/(a+){2,4}(a+)/.exec("aaaaa"), ["aaaaa", "a", "a"], "two greedies");
+shouldBe(/(a+){2,3}(a*)b/.exec("aaaab"), ["aaaab", "a", ""], "first eats most, second rest");
+
+// 7. Quantified that itself is inside another greedy.
+shouldBe(/((?:a){2,3}b)+c/.exec("aabaaabc"), ["aabaaabc", "aaab"], "outer + over inner {2,3}b");
+shouldBe(/((?:a){2,3}b)+c/.exec("ab"), null, "outer + fail");
+
+// 8. min == max for variable-count form.
+shouldBe(/(a+){3,3}b/.exec("aaab"), ["aaab", "a"], "min == max success");
+shouldBe(/(a+){3,3}b/.exec("aab"), null, "min == max fail");

--- a/JSTests/stress/regexp-greedy-varcount-multialt.js
+++ b/JSTests/stress/regexp-greedy-varcount-multialt.js
@@ -1,0 +1,39 @@
+// Multi-alt variable-count tests that exercise content-backtracking with
+// alternative dispatch. If endOp.m_contentBacktrackEntryLabel were wrong for
+// multi-alt, these would mismatch V8.
+
+function check(re, input, expected, label) {
+    const got = re.exec(input);
+    const a = JSON.stringify(got);
+    const e = JSON.stringify(expected);
+    if (a !== e)
+        throw new Error("FAIL " + label + ": expected " + e + " got " + a);
+}
+
+// Multi-alt with min > 0, content backtrack across alternatives.
+// Iter k may have chosen alt A or alt B; content-bt must visit the correct one.
+
+check(/(?:(?:aa|a)){3,4}b/, "aaab", ["aaab"], "multi-alt: aa|a x 3 then b");
+check(/(?:(?:aa|a)){3,4}b/, "aaaab", ["aaaab"], "multi-alt: needs to mix aa and a");
+check(/(?:(?:aa|a)){2,3}c/, "aaac", ["aaac"], "multi-alt success: aa+a+c or a+aa+c");
+
+// Content-bt within alt forced by post-parens needing more chars.
+check(/(?:(a+|b+)){2,4}xy/, "aabbxy", ["aabbxy", "bb"], "multi-alt: aa, bb, xy");
+check(/(?:(a+|b+)){2,4}xy/, "aaaabbxy", ["aaaabbxy", "bb"], "multi-alt: aaaa, bb, xy");
+check(/(?:(a+|b+)){2,4}bx/, "aaabx", ["aaabx", "a"], "post-parens 'bx' forces a+ to back off");
+
+// Min > max-of-input — pure failure with multi-alt
+check(/(?:(?:aa|a)){5,}b/, "aab", null, "multi-alt fail");
+check(/(?:(a+|b+)){4,}c/, "abc", null, "multi-alt fail with mixed input");
+
+// 3-way alternatives
+check(/(?:(?:abc|ab|a)){2,3}/, "abcab", ["abcab"], "3-way alts");
+check(/(?:(?:abc|ab|a)){2,3}x/, "abcabx", ["abcabx"], "3-way alts with anchor");
+
+// Heavy multi-alt content-bt
+check(/(?:(a|b)){2,4}c/, "abc", ["abc", "b"], "single-char alts, min=2");
+check(/(?:(a|b)){3,5}c/, "ababc", ["ababc", "b"], "single-char alts, min=3");
+check(/(?:(a|b)){4,6}c/, "ababc", ["ababc", "b"], "single-char alts (need 4)");
+
+// Nested multi-alt with min > 0 outer and inner
+check(/((?:a+|b+)){2,3}((?:c+|d+)){2,3}/, "aabbccdd", ["aabbccdd", "bb", "dd"], "nested multi-alt");

--- a/JSTests/stress/regexp-large-quantifier.js
+++ b/JSTests/stress/regexp-large-quantifier.js
@@ -24,4 +24,4 @@ testRegExp("a{0,4294967295}", "a", undefined, "a");
 testRegExp("a{0,4294967296}", "a", undefined, "a");
 testRegExp("^a{0,4294967296}$", "a{0,4294967296}", undefined, undefined);
 testRegExp("(?:a{0,340282366920}?){0,1}a", "aa", undefined, "aa");
-testRegExp("((.{100000000})*.{2100000000})+", "x", "SyntaxError: Invalid regular expression: pattern exceeds string length limits", undefined);
+testRegExp("((.{100000000})*.{2100000000})+", "x", undefined, undefined);

--- a/JSTests/stress/regexp-multialt-content-backtracking.js
+++ b/JSTests/stress/regexp-multialt-content-backtracking.js
@@ -1,0 +1,56 @@
+// Tests for multi-alternative content backtracking in YarrJIT.
+// This tests the interaction between multi-alt NestedAlternative groups
+// and content backtracking for Greedy, NonGreedy, and FixedCount quantifiers.
+
+function shouldBe(actual, expected) {
+    var actualStr = actual === null ? "null" : actual.toString();
+    var expectedStr = expected === null ? "null" : expected.toString();
+    if (actualStr !== expectedStr)
+        throw new Error("Expected " + expectedStr + " but got " + actualStr);
+}
+
+// FixedCount multi-alt content backtracking
+shouldBe(/(?:a+|b){2}c/.exec("abc"), "abc");
+shouldBe(/(?:a+|b){2}c/.exec("aac"), "aac");
+shouldBe(/(?:a+|b){2}c/.exec("aabc"), "aabc");
+shouldBe(/(?:a+|b){2}c/.exec("abbc"), "bbc");
+shouldBe(/(?:a+|b){3}d/.exec("aabd"), "aabd");
+shouldBe(/(?:a+|b+){2}c/.exec("aabbc"), "aabbc");
+shouldBe(/(?:b+|a+){2}c/.exec("aabbac"), "bbac");
+
+// Greedy multi-alt content backtracking
+shouldBe(/(?:a+|b)+c/.exec("abc"), "abc");
+shouldBe(/(?:a+|b)+c/.exec("aac"), "aac");
+shouldBe(/(?:a+|b)+c/.exec("abd"), null);
+shouldBe(/(?:a+|b+)+c/.exec("abd"), null);
+shouldBe(/(?:a+|b)+c/.exec("aabbc"), "aabbc");
+
+// NonGreedy multi-alt content backtracking
+shouldBe(/(?:a+|b){2,4}?c/.exec("abbbbc"), "bbbbc");
+shouldBe(/(?:a+|b){2,4}?c/.exec("abc"), "abc");
+shouldBe(/(?:a+|b){2,4}?c/.exec("aabc"), "aabc");
+shouldBe(/(?:a+|b){1,3}?c/.exec("abc"), "abc");
+shouldBe(/(?:a+|b){1,3}?c/.exec("aac"), "aac");
+
+// Capturing multi-alt content backtracking
+shouldBe(/(a+|b){2}c/.exec("abc"), "abc,b");
+shouldBe(/(a+|b){2}c/.exec("aabc"), "aabc,b");
+shouldBe(/(a+|b){2}c/.exec("aac"), "aac,a");
+shouldBe(/(a+|b+){2}c/.exec("aabbc"), "aabbc,bb");
+shouldBe(/(a+|b){2,4}?c/.exec("abc"), "abc,b");
+shouldBe(/(a+|b){1,3}?c/.exec("abc"), "abc,b");
+
+// 3-alternative groups
+shouldBe(/(?:[^()\s]|\s+(?![\s)])|\([^()]*\))+/.exec("a b (c) d"), "a b (c) d");
+shouldBe(/(?:[^()\s]|\s+(?![\s)])|\([^()]*\))+/.exec("abc"), "abc");
+
+// Complex pattern from prismjs (the one that was crashing)
+var re = /((?:\b|\s|^)(?!(?:as|async|await|break|case|catch|class|const|continue|debugger|default|delete|do|else|enum|export|extends|finally|for|from|function|get|if|implements|import|in|instanceof|interface|let|new|null|of|package|private|protected|public|return|set|static|super|switch|this|throw|try|typeof|undefined|var|void|while|with|yield)(?![$\w\xA0-\uFFFF]))(?:(?!\s)[_$a-zA-Z\xA0-\uFFFF](?:(?!\s)[$\w\xA0-\uFFFF])*\s*)\(\s*|\]\s*\(\s*)(?!\s)(?:[^()\s]|\s+(?![\s)])|\([^()]*\))+(?=\s*\)\s*\{)/;
+shouldBe(re.exec("x(y)"), null);
+shouldBe(re.exec("x(y) {"), "x(y,x(");
+shouldBe(re.exec("foo(a, b) {"), "foo(a, b,foo(");
+shouldBe(re.exec("foo(a, (b,c)) {"), "foo(a, (b,c),foo(");
+
+// Test with substrings (the crash was triggered by specific substrings)
+shouldBe(re.exec("push({})"), null);
+shouldBe(re.exec("push({id: i})"), null);

--- a/JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js
+++ b/JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js
@@ -3,15 +3,22 @@
 
 depth = typeof(depth) === 'undefined' ? 50000 : depth;
 
-let expectedException = "SyntaxError: Invalid regular expression: regular expression too large";
+// Either error message is acceptable: deeply nested parens with a non-zero-min
+// quantifier exceed pattern size limits at compile time. The exact message
+// depends on which limit is hit first ("regular expression too large" via
+// pattern offset overflow vs "too many nested disjunctions" via parser depth).
+let expectedExceptions = [
+    "SyntaxError: Invalid regular expression: regular expression too large",
+    "RangeError: Out of memory: Invalid regular expression: too many nested disjunctions",
+];
 
 function test(source)
 {
     try {
         new RegExp(source);
     } catch (e) {
-        if (e != expectedException)
-            throw "Expected \"" + expectedException + "\", but got \"" + e + "\" for: " + source.slice(0, 30) + "...";
+        if (!expectedExceptions.includes(String(e)))
+            throw "Expected one of [" + expectedExceptions.join(", ") + "], but got \"" + e + "\" for: " + source.slice(0, 30) + "...";
     }
 }
 

--- a/JSTests/stress/regexp-variable-count-native.js
+++ b/JSTests/stress/regexp-variable-count-native.js
@@ -1,0 +1,440 @@
+//@ runDefault
+
+// Tests for native JIT support of variable counted parentheses with non-zero minimum.
+// These patterns are now handled natively by the JIT using FixedCount-style content
+// backtracking, without splitting into FixedCount{min} + Greedy{0,max-min}.
+
+function shouldBe(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// ==== Test 1: Basic greedy pattern with non-zero min ====
+(function() {
+    var re = /(a){2,4}/;
+    shouldBe(re.exec("a"), null, "Single 'a' fails min 2");
+    shouldBe(re.exec("aa"), ["aa", "a"], "Two 'a's matches min 2");
+    shouldBe(re.exec("aaa"), ["aaa", "a"], "Three 'a's matches");
+    shouldBe(re.exec("aaaa"), ["aaaa", "a"], "Four 'a's matches max 4");
+    shouldBe(re.exec("aaaaa"), ["aaaa", "a"], "Five 'a's matches max 4 (greedy)");
+    shouldBe(re.exec(""), null, "Empty string fails");
+})();
+
+// ==== Test 2: Basic non-greedy pattern with non-zero min ====
+(function() {
+    var re = /(a){2,4}?/;
+    shouldBe(re.exec("a"), null, "Single 'a' fails min 2");
+    shouldBe(re.exec("aa"), ["aa", "a"], "Two 'a's matches min 2 (non-greedy stops at min)");
+    shouldBe(re.exec("aaa"), ["aa", "a"], "Three 'a's matches min 2 (non-greedy)");
+    shouldBe(re.exec("aaaa"), ["aa", "a"], "Four 'a's matches min 2 (non-greedy)");
+})();
+
+// ==== Test 3: Greedy with trailing literal (forces backtracking) ====
+(function() {
+    var re = /(a){2,4}b/;
+    shouldBe(re.exec("ab"), null, "One 'a' fails min 2");
+    shouldBe(re.exec("aab"), ["aab", "a"], "Two 'a's matches");
+    shouldBe(re.exec("aaab"), ["aaab", "a"], "Three 'a's matches");
+    shouldBe(re.exec("aaaab"), ["aaaab", "a"], "Four 'a's matches max");
+    shouldBe(re.exec("aaaaab"), ["aaaab", "a"], "Five 'a's - matches 4 from position 1");
+})();
+
+// ==== Test 4: Non-greedy with trailing literal ====
+(function() {
+    var re = /(a){2,4}?b/;
+    shouldBe(re.exec("ab"), null, "One 'a' fails min 2");
+    shouldBe(re.exec("aab"), ["aab", "a"], "Two 'a's matches min");
+    shouldBe(re.exec("aaab"), ["aaab", "a"], "Three 'a's - non-greedy forced to match 3");
+    shouldBe(re.exec("aaaab"), ["aaaab", "a"], "Four 'a's - non-greedy forced to match 4");
+    shouldBe(re.exec("aaaaab"), ["aaaab", "a"], "Five 'a's - matches 4 from position 1");
+})();
+
+// ==== Test 5: Non-capturing group with non-zero min ====
+(function() {
+    var re = /(?:ab){2,4}c/;
+    shouldBe(re.exec("abc"), null, "One 'ab' fails min 2");
+    shouldBe(re.exec("ababc"), ["ababc"], "Two 'ab' matches min");
+    shouldBe(re.exec("abababc"), ["abababc"], "Three 'ab' matches");
+    shouldBe(re.exec("ababababc"), ["ababababc"], "Four 'ab' matches max");
+    shouldBe(re.exec("abababababc"), ["ababababc"], "Five 'ab' - matches 4 from position 2");
+})();
+
+// ==== Test 6: Infinite max with non-zero min ====
+(function() {
+    var re = /(a){2,}/;
+    shouldBe(re.exec("a"), null, "One 'a' fails min 2");
+    shouldBe(re.exec("aa"), ["aa", "a"], "Two 'a's matches min");
+    shouldBe(re.exec("aaaaaaaaa"), ["aaaaaaaaa", "a"], "Many 'a's matches (greedy)");
+})();
+
+// ==== Test 7: Infinite max non-greedy ====
+(function() {
+    var re = /(a){2,}?/;
+    shouldBe(re.exec("a"), null, "One 'a' fails min 2");
+    shouldBe(re.exec("aa"), ["aa", "a"], "Two 'a's matches min");
+    shouldBe(re.exec("aaaaaaaaa"), ["aa", "a"], "Many 'a's matches min (non-greedy)");
+})();
+
+// ==== Test 8: Larger min values ====
+(function() {
+    var re = /(x){5,8}/;
+    shouldBe(re.exec("xxxx"), null, "4 chars fails min 5");
+    shouldBe(re.exec("xxxxx"), ["xxxxx", "x"], "5 chars matches min");
+    shouldBe(re.exec("xxxxxxxx"), ["xxxxxxxx", "x"], "8 chars matches max");
+    shouldBe(re.exec("xxxxxxxxx"), ["xxxxxxxx", "x"], "9 chars matches max 8 (greedy)");
+})();
+
+// ==== Test 9: Nested capturing groups ====
+(function() {
+    var re = /((a)(b)){2,4}/;
+    var result = re.exec("ababab");
+    shouldBe(result[0], "ababab", "Full match");
+    shouldBe(result[1], "ab", "Outer capture (last iteration)");
+    shouldBe(result[2], "a", "Inner capture 1 (last iteration)");
+    shouldBe(result[3], "b", "Inner capture 2 (last iteration)");
+})();
+
+// ==== Test 10: Alternation inside quantified group ====
+(function() {
+    var re = /(a|b){2,4}/;
+    shouldBe(re.exec("a"), null, "One char fails min 2");
+    shouldBe(re.exec("ab"), ["ab", "b"], "Two chars matches");
+    shouldBe(re.exec("ba"), ["ba", "a"], "Two chars matches (other order)");
+    shouldBe(re.exec("abab"), ["abab", "b"], "Four chars matches");
+    shouldBe(re.exec("aaaaa"), ["aaaa", "a"], "Five chars matches max 4");
+})();
+
+// ==== Test 11: Greedy inner content - content backtracking ====
+(function() {
+    var re = /(a+){2}b/;
+    shouldBe(re.exec("ab"), null, "One iteration fails");
+    shouldBe(re.exec("aab"), ["aab", "a"], "Two iterations matches");
+    shouldBe(re.exec("aaab"), ["aaab", "a"], "With extra chars in iteration");
+})();
+
+// ==== Test 12: Multiple quantified groups ====
+(function() {
+    var re = /(x){1,2}(a){2,4}c/;
+    shouldBe(re.exec("xaac"), ["xaac", "x", "a"], "Min matches for both");
+    shouldBe(re.exec("xxaaaac"), ["xxaaaac", "x", "a"], "Max for both");
+    shouldBe(re.exec("xac"), null, "Second group fails min");
+})();
+
+// ==== Test 13: Case insensitive ====
+(function() {
+    var re = /(a){2,4}/i;
+    shouldBe(re.exec("aA"), ["aA", "A"], "Mixed case matches");
+    shouldBe(re.exec("AaAa"), ["AaAa", "a"], "Four mixed case chars");
+})();
+
+// ==== Test 14: Unicode ====
+(function() {
+    var re = /(\u{1F600}){2,4}/u;
+    shouldBe(re.exec("\u{1F600}"), null, "One emoji fails min 2");
+    shouldBe(re.exec("\u{1F600}\u{1F600}"), ["\u{1F600}\u{1F600}", "\u{1F600}"], "Two emojis match");
+})();
+
+// ==== Test 15: Stress test - Greedy ====
+(function() {
+    var re = /(a){2,100}/;
+    for (var i = 0; i < 1000; i++) {
+        var result = re.exec("aaaaaaaaaa"); // 10 a's
+        if (result[0] !== "aaaaaaaaaa" || result[1] !== "a")
+            throw new Error("Stress test 1 failed at iteration " + i);
+    }
+})();
+
+// ==== Test 16: Stress test - NonGreedy ====
+(function() {
+    var re = /(a){2,100}?/;
+    for (var i = 0; i < 1000; i++) {
+        var result = re.exec("aaaaaaaaaa"); // 10 a's
+        if (result[0] !== "aa" || result[1] !== "a")
+            throw new Error("Stress test 2 failed at iteration " + i);
+    }
+})();
+
+// ==== Test 17: Stress test - backtracking ====
+(function() {
+    var re = /(a){2,5}b/;
+    for (var i = 0; i < 1000; i++) {
+        var result = re.exec("aaaab");
+        if (result[0] !== "aaaab" || result[1] !== "a")
+            throw new Error("Stress test 3 failed at iteration " + i);
+    }
+})();
+
+// ==== Test 18: Edge case - min equals max minus 1 ====
+(function() {
+    var re = /(a){3,4}/;
+    shouldBe(re.exec("aa"), null, "Two chars fails min 3");
+    shouldBe(re.exec("aaa"), ["aaa", "a"], "Three chars matches");
+    shouldBe(re.exec("aaaa"), ["aaaa", "a"], "Four chars matches max");
+    shouldBe(re.exec("aaaaa"), ["aaaa", "a"], "Five chars matches max 4");
+})();
+
+// ==== Test 19: Non-greedy forcing backtrack ====
+(function() {
+    var re = /(a){2,5}?aaab/;
+    shouldBe(re.exec("aaaaaab"), ["aaaaaab", "a"], "Non-greedy forced to match 3 a's");
+    shouldBe(re.exec("aaaab"), null, "Too short");
+    shouldBe(re.exec("aaaaab"), ["aaaaab", "a"], "Exact minimum");
+})();
+
+// ==== Test 20: Alternation patterns - the original motivating case ====
+(function() {
+    var re = /(aa|aaaa){2,3}$/;
+    shouldBe(re.exec("aaaaaa"), ["aaaaaa", "aa"], "6 a's: 3x'aa'");
+    shouldBe(re.exec("aaaaaaaa"), ["aaaaaaaa", "aaaa"], "8 a's: 2x'aaaa'");
+    shouldBe(re.exec("aaaa"), ["aaaa", "aa"], "4 a's: 2x'aa'");
+    shouldBe(re.exec("aaa"), null, "3 a's: fails");
+})();
+
+// ==== Test 21: Alternation patterns requiring specific combinations ====
+(function() {
+    var re = /(a|aaa){2}x/;
+    shouldBe(re.exec("aaaax"), ["aaaax", "aaa"], "4 a's + x: 'a'+'aaa'");
+    shouldBe(re.exec("aax"), ["aax", "a"], "2 a's + x: 'a'+'a'");
+    shouldBe(re.exec("ax"), null, "1 a + x: fails");
+})();
+
+// ==== Test 22: Greedy content backtracking with min > 0 ====
+(function() {
+    var re = /(a+){2,4}b/;
+    shouldBe(re.exec("aaab"), ["aaab", "a"], "a+ must split to allow 2 iterations");
+    shouldBe(re.exec("aab"), ["aab", "a"], "2 a's: 'a'+'a'+b");
+    shouldBe(re.exec("ab"), null, "1 a: fails min 2");
+    shouldBe(re.exec("aaaaab"), ["aaaaab", "a"], "5 a's: 4 iterations of a+");
+})();
+
+// ==== Test 23: Content backtracking with fixed count ====
+(function() {
+    var re = /(a+){2}b/;
+    shouldBe(re.exec("aaab"), ["aaab", "a"], "3 a's: need to backtrack a+ to allow 2 iters");
+    shouldBe(re.exec("aab"), ["aab", "a"], "2 a's: exactly 2 iters");
+    shouldBe(re.exec("ab"), null, "1 a: fails");
+})();
+
+// ==== Test 24: Content backtracking with fixed count (3) ====
+(function() {
+    var re = /(a+){3}b/;
+    shouldBe(re.exec("aaab"), ["aaab", "a"], "3 a's: exactly 3 iters of 1 a each");
+    shouldBe(re.exec("aaaab"), ["aaaab", "a"], "4 a's: need to redistribute");
+    shouldBe(re.exec("aab"), null, "2 a's: can't make 3 iters");
+})();
+
+// ==== Test 25: NonGreedy with content backtracking ====
+(function() {
+    var re = /(a+){2,4}?b/;
+    shouldBe(re.exec("aaab"), ["aaab", "a"], "3 a's + b");
+    shouldBe(re.exec("aab"), ["aab", "a"], "2 a's + b");
+    shouldBe(re.exec("ab"), null, "1 a: fails min 2");
+})();
+
+// ==== Test 26: Multi-alternative with content backtracking ====
+(function() {
+    var re = /(a+|b+){2,4}c/;
+    shouldBe(re.exec("aabbc"), ["aabbc", "bb"], "Mixed alternatives");
+    shouldBe(re.exec("abc"), ["abc", "b"], "Single chars");
+    shouldBe(re.exec("ac"), null, "Only 1 iteration: fails");
+})();
+
+// ==== Test 27: Single-char alternatives ====
+(function() {
+    var re = /(a|b|c){2,3}d/;
+    shouldBe(re.exec("abcd"), ["abcd", "c"], "3 iterations");
+    shouldBe(re.exec("abd"), ["abd", "b"], "2 iterations");
+    shouldBe(re.exec("ad"), null, "1 iteration: fails");
+})();
+
+// ==== Test 28: Acceptance at different counts ====
+(function() {
+    var re = /(abc){2,4}abcd/;
+    // 3 iterations + "abcd" suffix requires accepting 3 iterations (not 4)
+    shouldBe(re.exec("abcabcabcabcd"), ["abcabcabcabcd", "abc"], "Accept 3 iters + abcd");
+    shouldBe(re.exec("abcabcabcd"), ["abcabcabcd", "abc"], "Accept 2 iters + abcd");
+    shouldBe(re.exec("abcabcd"), null, "1 iter + abcd: fails min 2");
+})();
+
+// ==== Test 29: Accept 2 iterations with suffix ====
+(function() {
+    var re = /(ab){2,3}abc/;
+    shouldBe(re.exec("abababc"), ["abababc", "ab"], "2 iters of (ab) + abc suffix");
+    shouldBe(re.exec("ababababc"), ["ababababc", "ab"], "3 iters of (ab) + abc suffix");
+    shouldBe(re.exec("ababc"), null, "Too short: 1 iter + abc doesn't meet min 2");
+})();
+
+// ==== Test 30: Mixed fixed and variable count ====
+(function() {
+    var re = /(a){3}(b){2,4}c/;
+    shouldBe(re.exec("aaabbc"), ["aaabbc", "a", "b"], "Fixed 3, var 2");
+    shouldBe(re.exec("aaabbbc"), ["aaabbbc", "a", "b"], "Fixed 3, var 3");
+    shouldBe(re.exec("aaabbbbc"), ["aaabbbbc", "a", "b"], "Fixed 3, var 4");
+    shouldBe(re.exec("aabbc"), null, "Fails fixed 3");
+    shouldBe(re.exec("aaabc"), null, "Fails var min 2");
+})();
+
+// ==== Test 31: Global flag ====
+(function() {
+    var re = /(a){2,4}/g;
+    var str = "aa aaa aaaa a aaaaa";
+    var matches = str.match(re);
+    shouldBe(matches.length, 4, "Should find 4 matches");
+    shouldBe(matches[0], "aa", "First match");
+    shouldBe(matches[1], "aaa", "Second match");
+    shouldBe(matches[2], "aaaa", "Third match");
+    shouldBe(matches[3], "aaaa", "Fourth match (from 5 a's)");
+})();
+
+// ==== Test 32: Replace ====
+(function() {
+    var re = /(a){2,4}/g;
+    var result = "aa aaa aaaa a".replace(re, "X");
+    shouldBe(result, "X X X a", "Replace should work correctly");
+})();
+
+// ==== Test 33: Infinite max with content backtracking ====
+(function() {
+    var re = /(a+){2,}b/;
+    shouldBe(re.exec("aaab"), ["aaab", "a"], "3 a's: a+ splits for 2 iters + b");
+    shouldBe(re.exec("aab"), ["aab", "a"], "2 a's: 2 iters of 1 a each + b");
+    shouldBe(re.exec("ab"), null, "1 a: fails min 2");
+    shouldBe(re.exec("aaaaab"), ["aaaaab", "a"], "5 a's + b");
+})();
+
+// ==== Test 34: Longer alternatives ====
+(function() {
+    var re = /(ab|abab){2,3}$/;
+    shouldBe(re.exec("abababab"), ["abababab", "abab"], "8 chars: 2x'abab'");
+    shouldBe(re.exec("abab"), ["abab", "ab"], "4 chars: 2x'ab'");
+    shouldBe(re.exec("ab"), null, "2 chars: 1x'ab', fails min 2");
+})();
+
+// ==== Test 35: Non-capturing with content backtracking ====
+(function() {
+    var re = /(?:a+){2,4}b/;
+    shouldBe(re.exec("aaab"), ["aaab"], "3 a's + b");
+    shouldBe(re.exec("aab"), ["aab"], "2 a's + b");
+    shouldBe(re.exec("ab"), null, "1 a: fails");
+})();
+
+// ==== Test 36: Nested quantifiers ====
+(function() {
+    var re = /((?:ab)+){2,3}c/;
+    shouldBe(re.exec("ababababc"), ["ababababc", "ab"], "Nested: last iter captures 'ab'");
+    shouldBe(re.exec("ababc"), ["ababc", "ab"], "Nested: 2 outer iters");
+})();
+
+// ==== Test 37: Backreferences with min > 0 ====
+(function() {
+    var re = /(a+)\1{2,3}/;
+    shouldBe(re.exec("aaaaaa"), ["aaaaaa", "aa"], "Backref: 'aa' repeated 3 times");
+})();
+
+// ==== Test 38: Verify JIT and interpreter agree ====
+// Run many times to trigger JIT compilation
+(function() {
+    for (var i = 0; i < 1000; i++) {
+        var re = /(aa|aaaa){2,3}$/;
+        var result = re.exec("aaaaaa");
+        if (!result || result[0] !== "aaaaaa" || result[1] !== "aa")
+            throw new Error("JIT/interpreter mismatch at iteration " + i + ": " + JSON.stringify(result ? Array.from(result) : null));
+    }
+})();
+
+// ==== Test 39: Complex alternation requiring backtrack ====
+(function() {
+    var re = /(a|aa|aaa){2,3}$/;
+    shouldBe(re.exec("aaaa"), ["aaaa", "aa"], "4 a's: 'aa'+'aa'");
+    shouldBe(re.exec("aaa"), ["aaa", "a"], "3 a's: 'a'+'a'+'a' or 'a'+'aa'");
+    shouldBe(re.exec("aa"), ["aa", "a"], "2 a's: 'a'+'a'");
+    shouldBe(re.exec("a"), null, "1 a: fails min 2");
+})();
+
+// ==== Test 40: Greedy with inner content backtracking ====
+(function() {
+    var re = /(a+){2,4}aab/;
+    shouldBe(re.exec("aaaab"), ["aaaab", "a"], "Need to save 'aab' for suffix");
+    shouldBe(re.exec("aaaaab"), ["aaaaab", "a"], "More a's to distribute");
+})();
+
+// ==== Test 41: NonGreedy inner with min > 0 ====
+(function() {
+    var re = /(a+?){2,4}b/;
+    shouldBe(re.exec("aaab"), ["aaab", "a"], "Non-greedy inner");
+    shouldBe(re.exec("aab"), ["aab", "a"], "Non-greedy inner: 2 iters");
+})();
+
+// ==== Test 42: Zero-length inner match (min == 0, Greedy) ====
+// (a?)* - inner can match empty string. min=0, so zero-length exit immediately.
+(function() {
+    shouldBe(/(a?)*b/.exec("b"), ["b", undefined], "(a?)*b on 'b': capture undefined");
+    shouldBe(/(a?)*b/.exec("ab"), ["ab", "a"], "(a?)*b on 'ab': capture 'a'");
+    shouldBe(/(a?)*b/.exec("aab"), ["aab", "a"], "(a?)*b on 'aab': capture 'a'");
+})();
+
+// ==== Test 43: Zero-length inner match (min > 0, Greedy) ====
+// (a?)+ / (a?){1,2} - inner can match empty, forced iterations counted.
+(function() {
+    shouldBe(/(a?)+b/.exec("b"), ["b", ""], "(a?)+b on 'b': capture '' (forced iter)");
+    shouldBe(/(a?)+b/.exec("ab"), ["ab", "a"], "(a?)+b on 'ab': capture 'a'");
+    shouldBe(/(a?)+b/.exec("aab"), ["aab", "a"], "(a?)+b on 'aab': capture 'a'");
+
+    shouldBe(/(a?){1,2}b/.exec("b"), ["b", ""], "(a?){1,2}b on 'b'");
+    shouldBe(/(a?){1,2}b/.exec("ab"), ["ab", "a"], "(a?){1,2}b on 'ab'");
+    shouldBe(/(a?){1,2}b/.exec("aab"), ["aab", "a"], "(a?){1,2}b on 'aab'");
+
+    shouldBe(/(a?){2,3}b/.exec("b"), ["b", ""], "(a?){2,3}b on 'b'");
+    shouldBe(/(a?){2,3}b/.exec("ab"), ["ab", ""], "(a?){2,3}b on 'ab'");
+    shouldBe(/(a?){2,3}b/.exec("aab"), ["aab", "a"], "(a?){2,3}b on 'aab'");
+    shouldBe(/(a?){2,3}b/.exec("aaab"), ["aaab", "a"], "(a?){2,3}b on 'aaab'");
+
+    shouldBe(/(a?){1,}b/.exec("b"), ["b", ""], "(a?){1,}b on 'b'");
+    shouldBe(/(a?){1,}b/.exec("ab"), ["ab", "a"], "(a?){1,}b on 'ab'");
+})();
+
+// ==== Test 44: Zero-length inner match (a*) ====
+(function() {
+    shouldBe(/(a*){2,3}b/.exec("b"), ["b", ""], "(a*){2,3}b on 'b'");
+    shouldBe(/(a*){2,3}b/.exec("ab"), ["ab", ""], "(a*){2,3}b on 'ab'");
+    shouldBe(/(a*){2,3}b/.exec("aab"), ["aab", ""], "(a*){2,3}b on 'aab'");
+})();
+
+// ==== Test 45: Zero-length inner match (NonGreedy) ====
+(function() {
+    shouldBe(/(a?){1,2}?b/.exec("b"), ["b", ""], "(a?){1,2}?b on 'b'");
+    shouldBe(/(a?){1,2}?b/.exec("ab"), ["ab", "a"], "(a?){1,2}?b on 'ab'");
+    shouldBe(/(a?){2,3}?b/.exec("b"), ["b", ""], "(a?){2,3}?b on 'b'");
+    shouldBe(/(a?){2,3}?b/.exec("ab"), ["ab", ""], "(a?){2,3}?b on 'ab'");
+    shouldBe(/(a?){2,3}?b/.exec("aab"), ["aab", "a"], "(a?){2,3}?b on 'aab'");
+})();
+
+// ==== Test 46: Zero-length inner match (min == 0, NonGreedy) ====
+(function() {
+    shouldBe(/(a?)*?b/.exec("b"), ["b", undefined], "(a?)*?b on 'b'");
+    shouldBe(/(a?)*?b/.exec("ab"), ["ab", "a"], "(a?)*?b on 'ab'");
+})();
+
+// ==== Test 47: Zero-length with alternatives ====
+(function() {
+    shouldBe(/(a|){1,2}b/.exec("b"), ["b", ""], "(a|){1,2}b on 'b'");
+    shouldBe(/(a|){1,2}b/.exec("ab"), ["ab", "a"], "(a|){1,2}b on 'ab'");
+    shouldBe(/(a|){1,2}b/.exec("aab"), ["aab", "a"], "(a|){1,2}b on 'aab'");
+})();
+
+// ==== Test 48: Zero-length stress test with JIT ====
+(function() {
+    for (var i = 0; i < 1000; i++) {
+        shouldBe(/(a?){1,2}b/.exec("ab"), ["ab", "a"], "JIT stress (a?){1,2}b on 'ab' iter " + i);
+        shouldBe(/(a?)+b/.exec("b"), ["b", ""], "JIT stress (a?)+b on 'b' iter " + i);
+        shouldBe(/(a?)*b/.exec("ab"), ["ab", "a"], "JIT stress (a?)*b on 'ab' iter " + i);
+    }
+})();
+
+// ==== Test 49: Multiple capture groups with zero-length ====
+(function() {
+    shouldBe(/(a?)(b?){1,2}c/.exec("c"), ["c", "", ""], "(a?)(b?){1,2}c on 'c'");
+    shouldBe(/(a?)(b?){1,2}c/.exec("abc"), ["abc", "a", "b"], "(a?)(b?){1,2}c on 'abc'");
+    shouldBe(/(a?)(b?){1,2}c/.exec("ac"), ["ac", "a", ""], "(a?)(b?){1,2}c on 'ac'");
+    shouldBe(/(a?)(b?){1,2}c/.exec("bc"), ["bc", "", "b"], "(a?)(b?){1,2}c on 'bc'");
+})();

--- a/JSTests/stress/regexp-variable-counted-parentheses-with-min.js
+++ b/JSTests/stress/regexp-variable-counted-parentheses-with-min.js
@@ -275,3 +275,82 @@ function shouldBe(actual, expected, message) {
             throw new Error("(a){3}b should match 'aaab' within 'aaaab'");
     }
 })();
+
+// Test 23: validatorjs IPv6 pattern fragment - capturing groups with {1,N}
+// Multiple sibling capturing parens with non-zero min trigger the
+// no-IR-expansion path in YarrPattern (m_hasCopiedParenSubexpressions guard);
+// the JIT must handle min > 0 && min != max for capturing groups directly.
+(function() {
+    var re = /^(:(?:[0-9a-fA-F]{1,4})){1,7}$/;
+    for (var i = 0; i < 1000; i++) {
+        var result = re.exec(":a");
+        if (!result || result[0] !== ":a") throw new Error("Test 23a iter " + i);
+        result = re.exec(":a:b:c:d:e:f:7");
+        if (!result || result[0] !== ":a:b:c:d:e:f:7") throw new Error("Test 23b iter " + i);
+        if (re.exec(":") !== null) throw new Error("Test 23c iter " + i);
+        if (re.exec("a") !== null) throw new Error("Test 23d iter " + i);
+        if (re.exec(":a:b:c:d:e:f:g:h") !== null) throw new Error("Test 23e iter " + i);
+    }
+})();
+
+// Test 24: Nested capturing min>0 inside outer min>0 (mirrors locale RFC 5646
+// `(x(-[A-Za-z0-9]{1,8})+)`). Outer is FixedCount(1) with capturing inner that's
+// (...){1,inf}. The inner BEGIN.bt count<min retry-via-content-backtrack path
+// must not lose the outer capture.
+(function() {
+    var re = /^(x(-[A-Za-z0-9]{1,8})+)$/;
+    for (var i = 0; i < 1000; i++) {
+        var result = re.exec("x-abc");
+        if (!result || result[1] !== "x-abc" || result[2] !== "-abc")
+            throw new Error("Test 24a iter " + i);
+        result = re.exec("x-a-b-c");
+        if (!result || result[1] !== "x-a-b-c" || result[2] !== "-c")
+            throw new Error("Test 24b iter " + i);
+        if (re.exec("x") !== null) throw new Error("Test 24c iter " + i);
+        if (re.exec("-abc") !== null) throw new Error("Test 24d iter " + i);
+    }
+})();
+
+// Test 25: Nested non-capturing min>0 - /(?:(?:ab)+){2,}/ requires the outer
+// BEGIN.bt to backtrack INTO the prior iter's content (via END's content
+// backtrack entry) rather than fail when count < min. With "abab", the outer
+// needs to break iter 1 into a single (ab) so iter 2 can match.
+(function() {
+    var re = /^(?:(?:ab)+){2,}$/;
+    for (var i = 0; i < 1000; i++) {
+        if (!re.test("abab")) throw new Error("Test 25a iter " + i);
+        if (!re.test("ababab")) throw new Error("Test 25b iter " + i);
+        if (!re.test("abababab")) throw new Error("Test 25c iter " + i);
+        if (re.test("ab")) throw new Error("Test 25d iter " + i);
+        if (re.test("aba")) throw new Error("Test 25e iter " + i);
+        if (re.test("ababa")) throw new Error("Test 25f iter " + i);
+    }
+})();
+
+// Test 26: Non-greedy with capturing and min > 0
+// /(((a){2})+){2,}?z/ exercises NonGreedy mandatory phase with deeply nested
+// capturing parens — exposed by the yarr-jit-fixedcount-paren-context-free-on-skip suite.
+(function() {
+    var re = /(((a){2})+){2,}?z/;
+    for (var i = 0; i < 1000; i++) {
+        var result = re.exec("aaaaz");
+        if (!result || result[0] !== "aaaaz" || result[1] !== "aa" || result[2] !== "aa" || result[3] !== "a")
+            throw new Error("Test 26a iter " + i);
+        result = re.exec("aaaaaaz");
+        if (!result || result[0] !== "aaaaaaz")
+            throw new Error("Test 26b iter " + i);
+        if (re.exec("aaz") !== null) throw new Error("Test 26c iter " + i);
+        if (re.exec("z") !== null) throw new Error("Test 26d iter " + i);
+    }
+})();
+
+// Test 27: + on capturing group (= {1,inf}) — ensure simple cases still work
+(function() {
+    var re = /^(a)+$/;
+    for (var i = 0; i < 1000; i++) {
+        var result = re.exec("aaa");
+        if (!result || result[0] !== "aaa" || result[1] !== "a")
+            throw new Error("Test 27a iter " + i);
+        if (re.exec("") !== null) throw new Error("Test 27b iter " + i);
+    }
+})();

--- a/JSTests/stress/regress-159954.js
+++ b/JSTests/stress/regress-159954.js
@@ -1,11 +1,10 @@
-// Regression test for 159954.  This test should not crash or throw an exception.
+// Regression test for 159954.  This test should not crash.
 
-function testRegExp(regexpExpression)
+function testRegExpThrows(regexpExpression)
 {
     try {
         let result = eval(regexpExpression);
-
-        throw "Expected \"" + regexpExpression + "\" to throw and it didn't";
+        throw "Expected \"" + regexpExpression + "\" to throw and it didn't, got: " + JSON.stringify(result);
     } catch (e) {
         if (e != "SyntaxError: Invalid regular expression: pattern exceeds string length limits")
             throw e;
@@ -13,11 +12,21 @@ function testRegExp(regexpExpression)
     }
 }
 
-testRegExp("/a{2147483649,2147483650}a{2147483649,2147483650}/.exec('aaaa')");
-testRegExp("/a{2147483649,2147483650}a{2147483649,2147483650}/.exec('aa')");
-testRegExp("/(?:\1{2147483649,2147483650})+/.exec('123')");
-testRegExp("/([^]{2147483648,2147483651}(?:.){2})+?/.exec('xxx')");
-testRegExp("/(\u0004\W\u0f0b+?$[\xa7\t\t-\ue118\f]{2147483648,2147483648})+.+?/u.exec('testing')");
-testRegExp("/(.{2147483649,2147483652})+?/g.exec('xxx')");
-testRegExp("/(?:(?:[\D]{2147483649})+?.)*?/igmy.exec('123\\n123')");
-testRegExp("/(?:\1{2147483648,})+?/m.exec('xxx')");
+function testRegExpResult(regexpExpression, expectedResult)
+{
+    let result = eval(regexpExpression);
+    if (JSON.stringify(result) !== JSON.stringify(expectedResult))
+        throw "Expected \"" + regexpExpression + "\" to return " + JSON.stringify(expectedResult) + ", got: " + JSON.stringify(result);
+}
+
+// These patterns cause offset overflow and should throw
+testRegExpThrows("/a{2147483649,2147483650}a{2147483649,2147483650}/.exec('aaaa')");
+testRegExpThrows("/a{2147483649,2147483650}a{2147483649,2147483650}/.exec('aa')");
+
+// These patterns are now supported with variable count parentheses and return valid results
+testRegExpResult("/(?:\\1{2147483649,2147483650})+/.exec('123')", null);
+testRegExpResult("/([^]{2147483648,2147483651}(?:.){2})+?/.exec('xxx')", null);
+testRegExpResult("/(\\u0004\\W\\u0f0b+?$[\\xa7\\t\\t-\\ue118\\f]{2147483648,2147483648})+.+?/u.exec('testing')", null);
+testRegExpResult("/(.{2147483649,2147483652})+?/g.exec('xxx')", null);
+testRegExpResult("/(?:(?:[\\D]{2147483649})+?.)*?/igmy.exec('123\\n123')", [""]);
+testRegExpResult("/(?:\\1{2147483648,})+?/m.exec('xxx')", null);

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -1583,20 +1583,43 @@ public:
                 popParenthesesDisjunctionContext(backTrack);
                 freeParenthesesDisjunctionContext(context);
 
-                if (backTrack->matchAmount < term.atom.quantityMinCount) {
-                    while (backTrack->matchAmount) {
-                        context = backTrack->lastContext;
-                        resetMatches(term, context);
-                        popParenthesesDisjunctionContext(backTrack);
-                        freeParenthesesDisjunctionContext(context);
-                    }
-
-                    input.setPos(backTrack->begin);
-                    return result;
-                }
-
                 if (result != JSRegExpResult::NoMatch)
                     return result;
+
+                // When matchAmount falls below the minimum, do not give up immediately:
+                // try parenthesesDoBacktrack on the remaining contexts to find an
+                // alternative match distribution that allows us to reach min, then
+                // refill back up to min.
+                //
+                // For example, /((a+){2,3}){2,3}$/  matched against  "aaaaaa",
+                // `a+` will drain all input and this makes {2,3}'s `2` count failed.
+                // But instead of immediately saying "this is failed", we should backtrack `a+`,
+                // reducing drained count of `a`, and then the parentheses succeeds.
+                if (backTrack->matchAmount < term.atom.quantityMinCount) {
+                    result = parenthesesDoBacktrack(term, backTrack);
+                    if (result != JSRegExpResult::Match)
+                        return result;
+
+                    // Now content-backtracking succeeded. We will try to match up to min-count.
+                    while (backTrack->matchAmount < term.atom.quantityMinCount) {
+                        context = allocParenthesesDisjunctionContext(disjunctionBody, output, term);
+                        if (!context) [[unlikely]]
+                            return JSRegExpResult::ErrorNoMemory;
+                        result = matchDisjunction(disjunctionBody, context->getDisjunctionContext());
+                        if (result == JSRegExpResult::Match)
+                            appendParenthesesDisjunctionContext(backTrack, context);
+                        else {
+                            resetMatches(term, context);
+                            freeParenthesesDisjunctionContext(context);
+
+                            if (result != JSRegExpResult::NoMatch)
+                                return result;
+                            result = parenthesesDoBacktrack(term, backTrack);
+                            if (result != JSRegExpResult::Match)
+                                return result;
+                        }
+                    }
+                }
             }
 
             if (backTrack->matchAmount) {

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -3998,9 +3998,11 @@ class YarrGenerator final : public YarrJITInfo {
                     op.m_returnAddress = storeToFrameWithPatch(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
                 }
 
-                if (term->quantityType != QuantifierType::FixedCount && !m_ops[op.m_previousOp].m_alternative->m_minimumSize) {
+                if (term->quantityType != QuantifierType::FixedCount && !term->quantityMinCount && !m_ops[op.m_previousOp].m_alternative->m_minimumSize) {
                     // If the previous alternative matched without consuming characters then
                     // backtrack to try to match while consumming some input.
+                    // For VariableMin (min > 0) we skip this check; the abort-to-interpreter
+                    // branch at ParenthesesSubpatternEnd handles forced empty iterations.
                     op.m_zeroLengthMatch = m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(term->frameLocation * sizeof(void*)));
                 }
 
@@ -4064,9 +4066,12 @@ class YarrGenerator final : public YarrJITInfo {
                     op.m_returnAddress = storeToFrameWithPatch(parenthesesFrameLocation + BackTrackInfoParentheses::returnAddressIndex());
                 }
 
-                // Zero-length match check: only for non-FixedCount (unchanged from original behavior).
-                // FixedCount patterns have their own backtracking handling and don't need this.
-                if (term->quantityType != QuantifierType::FixedCount && !m_ops[op.m_previousOp].m_alternative->m_minimumSize) {
+                // Zero-length match check: only for non-FixedCount with min == 0.
+                // FixedCount has its own backtracking handling. For VariableMin
+                // (Greedy/NonGreedy with min > 0) we want forced empty iterations
+                // to satisfy quantityMinCount; that's handled by the abort-to-interpreter
+                // branch in ParenthesesSubpatternEnd's forward emission.
+                if (term->quantityType != QuantifierType::FixedCount && !term->quantityMinCount && !m_ops[op.m_previousOp].m_alternative->m_minimumSize) {
                     // If the previous alternative matched without consuming characters then
                     // backtrack to try to match while consumming some input.
                     op.m_zeroLengthMatch = m_jit.branch32(MacroAssembler::Equal, m_regs.index, frameAddress().withOffset(term->frameLocation * sizeof(void*)));
@@ -4302,8 +4307,10 @@ class YarrGenerator final : public YarrJITInfo {
                 // Greedy: Store beginIndex for empty match detection. We try to match as many
                 //   iterations as possible, then backtrack to try fewer if needed.
                 //
-                // NonGreedy: Initially skip the subpattern (set beginIndex = -1 and jump to end).
-                //   On backtrack, we'll re-enter here to try matching the subpattern.
+                // NonGreedy: With min == 0, initially skip the subpattern (set beginIndex = -1
+                //   and jump to end); on backtrack, we'll re-enter here to try matching the
+                //   subpattern. With min > 0, fall through to run min mandatory iterations
+                //   first, then lazily stop (END.forward enforces the mandatory-loop part).
                 //
                 // FixedCount: Must match exactly N times. Mark the new ParenContext as "incomplete"
                 //   (matchAmount = -1) so BEGIN.bt can skip failed iterations during backtracking.
@@ -4312,8 +4319,10 @@ class YarrGenerator final : public YarrJITInfo {
                 // FIXME: for capturing parens, could use the index in the capture array?
                 switch (term->quantityType) {
                 case QuantifierType::NonGreedy: {
-                    storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
-                    op.m_jumps.append(m_jit.jump());
+                    if (!term->quantityMinCount) {
+                        storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
+                        op.m_jumps.append(m_jit.jump());
+                    }
                     break;
                 }
                 case QuantifierType::Greedy: {
@@ -4430,7 +4439,10 @@ class YarrGenerator final : public YarrJITInfo {
                 }
                 case QuantifierType::NonGreedy: {
                     // For NonGreedy parentheses, link the jump from before the subpattern to here.
-                    YarrOp& beginOp = m_ops[op.m_previousOp];
+                    // For min > 0, run min mandatory iterations before lazily falling through:
+                    // if matchAmount < min, loop back to BEGIN.reentry to run another iteration.
+                    if (term->quantityMinCount)
+                        m_jit.branch32(MacroAssembler::Below, countTemporary, MacroAssembler::Imm32(term->quantityMinCount)).linkTo(beginOp.m_reentry, &m_jit);
                     beginOp.m_jumps.link(&m_jit);
                     defineReentryLabel(op);
                     break;
@@ -5298,35 +5310,77 @@ class YarrGenerator final : public YarrJITInfo {
                 const MacroAssembler::RegisterID countTemporary = m_regs.regT0;
                 loadFromFrame(parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex(), countTemporary);
 
-                MacroAssembler::Jump zeroLengthMatch = m_jit.branchTest32(MacroAssembler::Zero, countTemporary);
+                // We can accept fewer iterations only if count >= min: the next
+                // bt step's restore would land us at "count actual iterations" worth
+                // of position (since restoreParenContext gives state pre-iter (k+1) =
+                // post-iter k where k = count).
+                //
+                // For min == 0 we keep the existing count == 0 branch so the Greedy
+                // "accept zero" / NonGreedy "fail" paths still work and we avoid an
+                // unsigned underflow on the decrement.
+                //
+                // For min > 0 with count < min: we can't accept the current count,
+                // but we may still be able to find a valid match by backtracking into the
+                // latest iter's content (via END.contentBacktrackEntryLabel) — e.g. for
+                // /(?:(?:ab)+){2,}/ against "abab", the outer needs to break iter 1 into
+                // smaller pieces so iter 2 can match.
+                YarrOp& endOp = m_ops[op.m_nextOp];
+                MacroAssembler::Jump cannotAcceptFewer = term->quantityMinCount
+                    ? m_jit.branch32(MacroAssembler::Below, countTemporary, MacroAssembler::Imm32(term->quantityMinCount))
+                    : m_jit.branchTest32(MacroAssembler::Zero, countTemporary);
 
-                // matchAmount > 0: decrement count and try fewer iterations
+                // count >= min (or > 0 for min == 0). So mandatory requirement is still passing.
+                // Decrement and try fewer iterations.
                 m_jit.sub32(MacroAssembler::TrustedImm32(1), countTemporary);
                 storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
-                m_jit.jump(m_ops[op.m_nextOp].m_reentry);
+                m_jit.jump(endOp.m_reentry);
 
-                zeroLengthMatch.link(&m_jit);
+                cannotAcceptFewer.link(&m_jit);
+                if (term->quantityMinCount) {
+                    // count_loaded < min: can't accept this many iterations. If count > 0
+                    // try retrying the latest iter's content via END's content backtrack;
+                    // if count == 0 there's no prior iter to retry, so propagate failure.
+                    MacroAssembler::Jump noIterToRetry = m_jit.branchTest32(MacroAssembler::Zero, countTemporary);
 
-                // Clear the flag in the stackframe indicating we didn't run through the subpattern.
-                storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
+                    // count > 0: decrement count (END.forward will re-increment after a
+                    // successful retry) and jump to content backtrack entry. The earlier
+                    // restoreParenContext already left m_regs.index at the end of iter k.
+                    m_jit.sub32(MacroAssembler::TrustedImm32(1), countTemporary);
+                    storeToFrame(countTemporary, parenthesesFrameLocation + BackTrackInfoParentheses::matchAmountIndex());
+                    ASSERT(endOp.m_op == YarrOpCode::ParenthesesSubpatternEnd);
+                    ASSERT(endOp.m_contentBacktrackEntryLabel.isSet());
+                    m_jit.jump(endOp.m_contentBacktrackEntryLabel);
 
-                switch (term->quantityType) {
-                case QuantifierType::Greedy: {
-                    // If Greedy, jump to the end.
-                    m_jit.jump(m_ops[op.m_nextOp].m_reentry);
-                    // A backtrack from after the parentheses, when skipping the subpattern,
-                    // will jump back to here.
+                    // Now we are not able to try any backtracking. So parentheses with min-count gets complete failure.
+                    // We need to clear the state, and go back to the further former backtracking.
+                    noIterToRetry.link(&m_jit);
                     op.m_jumps.link(&m_jit);
-                    break;
-                }
-                case QuantifierType::NonGreedy: {
-                    break;
-                }
-                case QuantifierType::FixedCount: {
-                    // This case is handled above with early break
-                    RELEASE_ASSERT_NOT_REACHED();
-                    break;
-                }
+                    if (shouldRecordSubpatterns() && term->containsAnyCaptures()) {
+                        for (unsigned subpattern = term->parentheses.subpatternId; subpattern <= term->parentheses.lastSubpatternId; subpattern++)
+                            clearSubpattern(subpattern);
+                    }
+                } else {
+                    // Clear the flag in the stackframe indicating we didn't run through the subpattern.
+                    storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
+
+                    switch (term->quantityType) {
+                    case QuantifierType::Greedy: {
+                        // If Greedy, jump to the end.
+                        m_jit.jump(endOp.m_reentry);
+                        // A backtrack from after the parentheses, when skipping the subpattern,
+                        // will jump back to here.
+                        op.m_jumps.link(&m_jit);
+                        break;
+                    }
+                    case QuantifierType::NonGreedy: {
+                        break;
+                    }
+                    case QuantifierType::FixedCount: {
+                        // This case is handled above with early break
+                        RELEASE_ASSERT_NOT_REACHED();
+                        break;
+                    }
+                    }
                 }
 
                 storeToFrame(MacroAssembler::TrustedImm32(-1), parenthesesFrameLocation + BackTrackInfoParentheses::beginIndex());
@@ -5498,18 +5552,6 @@ class YarrGenerator final : public YarrJITInfo {
 
         if (!isSafeToRecurse()) [[unlikely]] {
             m_failureReason = JITFailureReason::ParenthesisNestedTooDeep;
-            return;
-        }
-
-        // We can currently only compile quantity 1 subpatterns that are
-        // not copies. We generate a copy in the case of a range quantifier,
-        // e.g. /(?:x){3,9}/, or /(?:x)+/ (These are effectively expanded to
-        // /(?:x){3,3}(?:x){0,6}/ and /(?:x)(?:x)*/ respectively). The problem
-        // comes where the subpattern is capturing, in which case we would
-        // need to restore the capture from the first subpattern upon a
-        // failure in the second.
-        if (term->quantityMinCount && term->quantityMinCount != term->quantityMaxCount) {
-            m_failureReason = JITFailureReason::VariableCountedParenthesisWithNonZeroMinimum;
             return;
         }
 
@@ -7731,9 +7773,6 @@ static void dumpCompileFailure(JITFailureReason failure)
         break;
     case JITFailureReason::Lookbehind:
         dataLog("Can't JIT a pattern containing lookbehinds\n");
-        break;
-    case JITFailureReason::VariableCountedParenthesisWithNonZeroMinimum:
-        dataLog("Can't JIT a pattern containing a variable counted parenthesis with a non-zero minimum\n");
         break;
     case JITFailureReason::ParenthesizedSubpattern:
         dataLog("Can't JIT a pattern containing parenthesized subpatterns\n");

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -59,7 +59,6 @@ enum class JITFailureReason : uint8_t {
     DecodeSurrogatePair,
     BackReference,
     Lookbehind,
-    VariableCountedParenthesisWithNonZeroMinimum,
     ParenthesizedSubpattern,
     ParenthesisNestedTooDeep,
     ExecutableMemoryAllocationFailure,

--- a/Source/JavaScriptCore/yarr/YarrPattern.cpp
+++ b/Source/JavaScriptCore/yarr/YarrPattern.cpp
@@ -1741,9 +1741,19 @@ public:
 
         if (min == max)
             term.quantify(min, max, QuantifierType::FixedCount);
-        else if (!min || (term.type == PatternTerm::Type::ParenthesesSubpattern && m_pattern.m_hasCopiedParenSubexpressions))
+        else if (!min
+            || (term.type == PatternTerm::Type::ParenthesesSubpattern
+                && (m_pattern.m_hasCopiedParenSubexpressions || term.matchDirection() == Forward))) {
+            // Forward-direction parenthesized subpatterns with non-zero minimum are kept
+            // as a single PatternTerm with quantityMinCount > 0; YarrJIT compiles these
+            // natively (see opCompileParenthesesSubpattern) without splitting into
+            // FixedCount{min} + Greedy/NonGreedy{0,max-min}. The split would deep-copy
+            // the disjunction subtree, which can hit OffsetTooLarge / pattern-size limits
+            // for very large bounds (e.g. (?:x){2147483648,...}). Backward parens
+            // (lookbehinds) still use the expansion path; the JIT's right-to-left
+            // backtracking machinery hasn't been generalized for single-term VariableMin.
             term.quantify(min, max, greedy ? QuantifierType::Greedy : QuantifierType::NonGreedy);
-        else {
+        } else {
             if (term.matchDirection() == Forward) {
                 term.quantify(min, min, QuantifierType::FixedCount);
                 auto copied = copyTerm(term, /* filterStartsWithBOL */ false);


### PR DESCRIPTION
#### 6646c49f2a7b64b914fb29eed508b172b15c7c68
<pre>
[JSC] Implement Variable Count Parentheses in YarrJIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=307145">https://bugs.webkit.org/show_bug.cgi?id=307145</a>
<a href="https://rdar.apple.com/problem/169778246">rdar://problem/169778246</a>

Reviewed by Yijia Huang.

This patch adds JIT support for {m,n} parentheses quantifiers with m &gt; 0 (e.g. /(a){3,5}/).
Previously the JIT compiled only {0,N} (Greedy/NonGreedy) and {N,N} (FixedCount).

The implementation extends the existing variable-count (Greedy/NonGreedy) model.
ParenContext save-at-BEGIN, address-based alt dispatch, and the natural
backtracking-state alt-chain.

Forward direction:
- Greedy: unchanged shape — keep iterating up to max.
- NonGreedy: skip the initial-skip-jump when min &gt; 0 (we must run min mandatory iterations).
  End.fwd loops back to BEGIN while count &lt; min.
- Both: an iter that matched zero characters punts to the interpreter.

Backward direction:
- count &gt;= min (or count &gt; 0 for min == 0): decrement count
  and jump to End.reentry - accept fewer iterations.
- count &lt; min and count &gt; 0: jump to End.contentBacktrackEntryLabel
  to retry the latest remaining iter&apos;s content with different alternatives.
  This is what enforces min: without it, accept-fewer plus a trivially-succeeding
  post-parens would return matches with fewer than min iterations.
- count == 0 (with min &gt; 0): the parens fail: clear captures, fall
  through to backtrack propagation.
- End.bt&apos;s case bodies are unchanged.

Tests: JSTests/stress/regexp-fixedcount-zero-length-content-backtrack.js
       JSTests/stress/regexp-greedy-nested-quantifier-backtrack.js
       JSTests/stress/regexp-multialt-content-backtracking.js
       JSTests/stress/regexp-variable-count-native.js

* JSTests/stress/regexp-fixedcount-zero-length-content-backtrack.js: Added.
(result):
* JSTests/stress/regexp-greedy-nested-quantifier-backtrack.js: Added.
(test):
* JSTests/stress/regexp-greedy-varcount-minfail.js: Added.
(shouldBe):
* JSTests/stress/regexp-greedy-varcount-multialt.js: Added.
(check):
* JSTests/stress/regexp-large-quantifier.js:
* JSTests/stress/regexp-multialt-content-backtracking.js: Added.
(shouldBe):
* JSTests/stress/regexp-quantify-atom-copy-term-out-of-stack.js:
(test):
* JSTests/stress/regexp-variable-count-native.js: Added.
(shouldBe):
(re):
(re.a):
(i.re):
(i.shouldBe):
(shouldBe.a):
* JSTests/stress/regexp-variable-counted-parentheses-with-min.js:
(re):
* JSTests/stress/regress-159954.js:
(testRegExpThrows):
(testRegExpResult):
(testRegExp): Deleted.
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::backtrackParentheses):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::dumpCompileFailure):
* Source/JavaScriptCore/yarr/YarrJIT.h:
* Source/JavaScriptCore/yarr/YarrPattern.cpp:
(JSC::Yarr::YarrPatternConstructor::quantifyAtom):

Canonical link: <a href="https://commits.webkit.org/314383@main">https://commits.webkit.org/314383@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5333b6343ac27776dfae44aa9f9f5411c8ba77d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165983 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/39473 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/33054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/39899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/175029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168942 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/39899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/175029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/39899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/39477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/23170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/158140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/39899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/26825 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/26876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/28531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/177563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/39542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/39477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/177563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/40230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/148620 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102821 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25263 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/40230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/38741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111815 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/38138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/3570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/38383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/38281 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->