### PR TITLE
[JSC] Limit rope traversal depth in `tryJSSubstringImpl`

### DIFF
--- a/JSTests/microbenchmarks/deep-rope-slice.js
+++ b/JSTests/microbenchmarks/deep-rope-slice.js
@@ -1,0 +1,7 @@
+let n = 10000;
+let s = '';
+for (let i = 0; i < n; i++)
+    s += 'A';
+
+for (let i = 0; i < n; i++)
+    s.slice(i, i + 1);

--- a/JSTests/microbenchmarks/shallow-rope-slice.js
+++ b/JSTests/microbenchmarks/shallow-rope-slice.js
@@ -1,0 +1,6 @@
+// Shallow rope slice benchmark (regression check)
+let s = 'A'.repeat(25000) + 'B'.repeat(25000);
+let n = 50000;
+
+for (let i = 0; i < n; i++)
+    s.slice(i, i + 1);

--- a/JSTests/stress/deep-rope-string-slice.js
+++ b/JSTests/stress/deep-rope-string-slice.js
@@ -1,0 +1,48 @@
+//@ runDefault
+
+// Deep rope construction
+function makeDeepRope(n) {
+    let s = '';
+    for (let i = 0; i < n; i++)
+        s += String.fromCharCode(65 + (i % 26)); // 'A'-'Z' cycling
+    return s;
+}
+
+// Build a reference flat string for comparison
+function makeFlat(n) {
+    let chars = [];
+    for (let i = 0; i < n; i++)
+        chars.push(String.fromCharCode(65 + (i % 26)));
+    return chars.join('');
+}
+
+let size = 10000;
+let rope = makeDeepRope(size);
+let flat = makeFlat(size);
+
+// Correctness: slice results must match flat string
+for (let i = 0; i < size; i += 100) {
+    let len = Math.min(5, size - i);
+    let ropeSlice = rope.slice(i, i + len);
+    let flatSlice = flat.slice(i, i + len);
+    if (ropeSlice !== flatSlice)
+        throw new Error(`Mismatch at ${i}: '${ropeSlice}' vs '${flatSlice}'`);
+}
+
+// Cross-fiber slices (various lengths spanning potential fiber boundaries)
+for (let len = 1; len <= 10; len++) {
+    for (let i = 0; i < size - len; i += 97) {
+        let ropeSlice = rope.slice(i, i + len);
+        let flatSlice = flat.slice(i, i + len);
+        if (ropeSlice !== flatSlice)
+            throw new Error(`Cross-fiber mismatch at ${i}, len=${len}: '${ropeSlice}' vs '${flatSlice}'`);
+    }
+}
+
+// Edge cases
+if (rope.slice(0, 0) !== '')
+    throw new Error('Empty slice failed');
+if (rope.slice(0, size) !== flat)
+    throw new Error('Full slice failed');
+if (rope.slice(size - 1, size) !== flat.slice(size - 1, size))
+    throw new Error('Last char slice failed');


### PR DESCRIPTION
#### 93f2fd68619bf07e0e12c2c78995ff5399e2c117
<pre>
[JSC] Limit rope traversal depth in `tryJSSubstringImpl`
<a href="https://bugs.webkit.org/show_bug.cgi?id=307146">https://bugs.webkit.org/show_bug.cgi?id=307146</a>

Reviewed by Yusuke Suzuki.

Deep rope strings constructed by repeated concatenation (e.g. s += &apos;A&apos;)
produce a degenerate rope tree of depth n. Each slice call traverses
from root to leaf in O(n), so n slices become O(n²)

In fact, an issue have been reported to Bun where its performance is
significantly inferior to that of Node.js due to this[1]

Convert the tail-recursive implementation to a bounded loop with a
maximum traversal depth of 16. When the limit is exceeded, return
nullptr so that the existing fallback in jsSubstring triggers
resolveRope, flattening the string and making subsequent slices O(1).

The results from the local JetStream were neutral.

Also after inserting debug logs and measuring the depth across the entire
JetStream3, I found that over 95% of the more than 15,000,000 calls to
tryJSSubstringImpl had a depth of 0, while it reached 8 only a single time.

                            TipOfTree                  Patched

deep-rope-slice          58.3524+-0.8240     ^      0.3460+-0.0127        ^ definitely 168.6446x faster
shallow-rope-slice        0.4714+-0.0262            0.4465+-0.0244          might be 1.0556x faster

[1]: <a href="https://github.com/oven-sh/bun/issues/26682">https://github.com/oven-sh/bun/issues/26682</a>

Tests: JSTests/microbenchmarks/deep-rope-slice.js
       JSTests/microbenchmarks/shallow-rope-slice.js
       JSTests/stress/deep-rope-string-slice.js

* JSTests/microbenchmarks/deep-rope-slice.js: Added.
* JSTests/microbenchmarks/shallow-rope-slice.js: Added.
* JSTests/stress/deep-rope-string-slice.js: Added.
(makeDeepRope):
(makeFlat):
* Source/JavaScriptCore/runtime/JSString.h:
(JSC::tryJSSubstringImpl):
(JSC::jsSubstring):

Canonical link: <a href="https://commits.webkit.org/306936@main">https://commits.webkit.org/306936@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2dec76b94e29ac903f2dbf62185e3733a738dc2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5770 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151489 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15368 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109830 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90739 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9469 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1488 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134809 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153802 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3625 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14913 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4899 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117846 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14950 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12950 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118179 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30208 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14170 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70610 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14956 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4028 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174112 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78665 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44995 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14899 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14753 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->