### PR TITLE
Reduce usage of protectedFoo() style in place of protect() in WebCore/editing

### DIFF
--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -31,7 +31,6 @@
 #include <WebCore/DocumentSyncData.h>
 #include <WebCore/Element.h>
 #include <WebCore/ExtensionStyleSheets.h>
-#include <WebCore/FrameSelection.h>
 #include <WebCore/NodeIterator.h>
 #include <WebCore/ReportingScope.h>
 #include <WebCore/SecurityOrigin.h>
@@ -137,12 +136,6 @@ inline ReportingScope& Document::reportingScope() const
 inline Ref<DocumentSyncData> Document::syncData()
 {
     return m_syncData.get();
-}
-
-// FIXME: Move to FrameSelectionInlines.h
-RefPtr<Document> FrameSelection::protectedDocument() const
-{
-    return m_document.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/editing/AlternativeTextController.h
+++ b/Source/WebCore/editing/AlternativeTextController.h
@@ -138,8 +138,6 @@ private:
     void applyAlternativeTextToRange(const SimpleRange&, const String&, AlternativeTextType, OptionSet<DocumentMarkerType>);
     AlternativeTextClient* alternativeTextClient();
 #endif
-    Ref<Document> protectedDocument() const { return m_document.get(); }
-
     void removeCorrectionIndicatorMarkers();
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;

--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -120,7 +120,6 @@ public:
     void apply();
     bool isFirstCommand(EditCommand* command) { return !m_commands.isEmpty() && m_commands.first() == command; }
     EditCommandComposition* composition() const;
-    RefPtr<EditCommandComposition> protectedComposition() const { return composition(); }
     Ref<EditCommandComposition> ensureComposition();
 
     virtual bool isTypingCommand() const;

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -497,11 +497,11 @@ void DeleteSelectionCommand::insertBlockPlaceholderForTableCellIfNeeded(Element&
 void DeleteSelectionCommand::removeNodeUpdatingStates(Node& node, ShouldAssumeContentIsAlwaysEditable shouldAssumeContentIsAlwaysEditable)
 {
     if (&node == m_startBlock) {
-        auto prev = VisiblePosition(firstPositionInNode(protectedStartBlock().get())).previous();
+        auto prev = VisiblePosition(firstPositionInNode(protect(m_startBlock).get())).previous();
         if (!prev.isNull() && !isEndOfBlock(prev))
             m_needPlaceholder = true;
     } else if (&node == m_endBlock) {
-        auto next = VisiblePosition(lastPositionInNode(protectedEndBlock().get())).next();
+        auto next = VisiblePosition(lastPositionInNode(protect(m_endBlock).get())).next();
         if (!next.isNull() && !isStartOfBlock(next))
             m_needPlaceholder = true;
     }

--- a/Source/WebCore/editing/DeleteSelectionCommand.h
+++ b/Source/WebCore/editing/DeleteSelectionCommand.h
@@ -76,10 +76,6 @@ private:
     void removeNodeUpdatingStates(Node&, ShouldAssumeContentIsAlwaysEditable);
     void insertBlockPlaceholderForTableCellIfNeeded(Element&);
 
-    RefPtr<Node> protectedStartBlock() const { return m_startBlock; }
-    RefPtr<Node> protectedEndBlock() const { return m_endBlock; }
-    RefPtr<Node> protectedEndTableRow() const { return m_endTableRow; }
-
     bool m_hasSelectionToDelete;
     bool m_smartDelete;
     bool m_mergeBlocksAfterDelete;

--- a/Source/WebCore/editing/EditingStyle.h
+++ b/Source/WebCore/editing/EditingStyle.h
@@ -109,8 +109,6 @@ public:
     WEBCORE_EXPORT ~EditingStyle();
 
     MutableStyleProperties* style() const { return m_mutableStyle.get(); }
-    RefPtr<MutableStyleProperties> protectedStyle() const;
-    RefPtr<MutableStyleProperties> protectedStyle();
     Ref<MutableStyleProperties> styleWithResolvedTextDecorations() const;
     std::optional<WritingDirection> textDirection() const;
     bool isEmpty() const;

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -662,7 +662,7 @@ void Editor::deleteSelectionWithSmartDelete(bool smartDelete, EditAction editing
 
 void Editor::clearText()
 {
-    ClearTextCommand::CreateAndApply(protectedDocument());
+    ClearTextCommand::CreateAndApply(protect(document()));
 }
 
 void Editor::pasteAsPlainText(const String& pastingText, bool smartReplace)
@@ -913,7 +913,7 @@ RefPtr<Node> Editor::insertOrderedList()
     if (!canEditRichly())
         return nullptr;
         
-    auto newList = InsertListCommand::insertList(protectedDocument(), InsertListCommand::Type::OrderedList);
+    auto newList = InsertListCommand::insertList(protect(document()), InsertListCommand::Type::OrderedList);
     revealSelectionAfterEditingOperation();
     return newList;
 }
@@ -923,7 +923,7 @@ RefPtr<Node> Editor::insertUnorderedList()
     if (!canEditRichly())
         return nullptr;
         
-    auto newList = InsertListCommand::insertList(protectedDocument(), InsertListCommand::Type::UnorderedList);
+    auto newList = InsertListCommand::insertList(protect(document()), InsertListCommand::Type::UnorderedList);
     revealSelectionAfterEditingOperation();
     return newList;
 }
@@ -983,7 +983,7 @@ void Editor::decreaseSelectionListLevel()
 
 void Editor::removeFormattingAndStyle()
 {
-    RemoveFormatCommand::create(protectedDocument())->apply();
+    RemoveFormatCommand::create(protect(document()))->apply();
 }
 
 void Editor::clearLastEditCommand() 
@@ -1308,13 +1308,13 @@ void Editor::appliedEditing(CompositeEditCommand& command)
 
 bool Editor::willUnapplyEditing(const EditCommandComposition& composition) const
 {
-    TypingCommand::closeTyping(protectedDocument());
+    TypingCommand::closeTyping(protect(document()));
     return dispatchBeforeInputEvents(composition.startingRootEditableElement(), composition.endingRootEditableElement(), "historyUndo"_s, IsInputMethodComposing::No);
 }
 
 void Editor::unappliedEditing(EditCommandComposition& composition)
 {
-    protectedDocument()->updateLayout();
+    protect(document())->updateLayout();
 
     notifyTextFromControls(composition.startingRootEditableElement(), composition.endingRootEditableElement());
 
@@ -1343,7 +1343,7 @@ bool Editor::willReapplyEditing(const EditCommandComposition& composition) const
 
 void Editor::reappliedEditing(EditCommandComposition& composition)
 {
-    protectedDocument()->updateLayout();
+    protect(document())->updateLayout();
 
     notifyTextFromControls(composition.startingRootEditableElement(), composition.endingRootEditableElement());
 
@@ -1395,7 +1395,7 @@ void Editor::clear()
     if (m_compositionNode) {
         m_compositionNode = nullptr;
         if (CheckedPtr client = this->client())
-            client->discardedComposition(protectedDocument());
+            client->discardedComposition(protect(document()));
     }
     m_customCompositionUnderlines.clear();
     m_customCompositionHighlights.clear();
@@ -1534,7 +1534,7 @@ bool Editor::insertParagraphSeparator()
 bool Editor::insertParagraphSeparatorInQuotedContent()
 {
     // FIXME: Why is this missing calls to canEdit, canEditRichly, etc.?
-    TypingCommand::insertParagraphSeparatorInQuotedContent(protectedDocument());
+    TypingCommand::insertParagraphSeparatorInQuotedContent(protect(document()));
     revealSelectionAfterEditingOperation();
     return true;
 }
@@ -1766,7 +1766,7 @@ void Editor::simplifyMarkup(Node* startNode, Node* endNode)
         pastEndNode = NodeTraversal::next(*endNode);
     }
     
-    SimplifyMarkupCommand::create(protectedDocument(), startNode, pastEndNode.get())->apply();
+    SimplifyMarkupCommand::create(protect(document()), startNode, pastEndNode.get())->apply();
 }
 
 void Editor::copyURL(const URL& url, const String& title)
@@ -2351,7 +2351,7 @@ String Editor::compositionText() const
     if (!m_compositionNode)
         return { };
 
-    return protectedCompositionNode()->data().substring(m_compositionStart, m_compositionEnd - m_compositionStart);
+    return protect(compositionNode())->data().substring(m_compositionStart, m_compositionEnd - m_compositionStart);
 }
 
 bool Editor::hasDeadKeyComposition() const
@@ -3894,7 +3894,7 @@ RefPtr<TextPlaceholderElement> Editor::insertTextPlaceholder(const IntSize& size
 #if ENABLE(WRITING_TOOLS)
     // For Writing Tools, we need the snapshot of the last inserted placeholder.
     if (auto placeholderRange = makeRangeSelectingNode(placeholder.get()))
-        protectedDocument()->page()->chrome().client().saveSnapshotOfTextPlaceholderForAnimation(*placeholderRange);
+        document->page()->chrome().client().saveSnapshotOfTextPlaceholderForAnimation(*placeholderRange);
 #endif
 
     return placeholder;

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -215,7 +215,6 @@ public:
     CompositeEditCommand* lastEditCommand() { return m_lastEditCommand.get(); }
 
     Document& document() const { return m_document; }
-    Ref<Document> protectedDocument() const { return m_document; }
 
     WEBCORE_EXPORT void ref() const;
     WEBCORE_EXPORT void deref() const;
@@ -448,7 +447,6 @@ public:
 
     // getting international text input composition state (for use by LegacyInlineTextBox)
     Text* compositionNode() const { return m_compositionNode.get(); }
-    RefPtr<Text> protectedCompositionNode() const { return m_compositionNode; }
     unsigned compositionStart() const { return m_compositionStart; }
     unsigned compositionEnd() const { return m_compositionEnd; }
     bool compositionUsesCustomUnderlines() const { return !m_customCompositionUnderlines.isEmpty(); }

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -354,7 +354,6 @@ private:
     void caretAnimationDidUpdate(CaretAnimator&) final;
 
     Document* NODELETE document() final;
-    inline RefPtr<Document> protectedDocument() const; // Defined in DocumentInlines.h
 
     Node* caretNode() final;
 

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp
@@ -84,7 +84,7 @@ void InsertParagraphSeparatorCommand::calculateStyleBeforeInsertion(const Positi
         return;
 
     m_style = EditingStyle::create(position, EditingStyle::PropertiesToInclude::EditingPropertiesInEffect);
-    protectedStyle()->mergeTypingStyle(*position.document());
+    protect(m_style)->mergeTypingStyle(*position.document());
 }
 
 void InsertParagraphSeparatorCommand::applyStyleAfterInsertion(Node* originalEnclosingBlock)

--- a/Source/WebCore/editing/InsertParagraphSeparatorCommand.h
+++ b/Source/WebCore/editing/InsertParagraphSeparatorCommand.h
@@ -52,8 +52,6 @@ private:
 
     bool preservesTypingStyle() const override;
 
-    RefPtr<EditingStyle> protectedStyle() const { return m_style; }
-
     RefPtr<EditingStyle> m_style;
 
     bool m_mustUseDefaultParagraphElement;

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp
@@ -66,7 +66,7 @@ void ReplaceNodeWithSpanCommand::doApply()
         return;
     if (!m_spanElement)
         m_spanElement = HTMLSpanElement::create(protect(m_elementToReplace->document()));
-    swapInNodePreservingAttributesAndChildren(protectedSpanElement().releaseNonNull(), m_elementToReplace);
+    swapInNodePreservingAttributesAndChildren(protect(spanElement()).releaseNonNull(), m_elementToReplace);
 }
 
 void ReplaceNodeWithSpanCommand::doUnapply()

--- a/Source/WebCore/editing/ReplaceNodeWithSpanCommand.h
+++ b/Source/WebCore/editing/ReplaceNodeWithSpanCommand.h
@@ -52,8 +52,6 @@ private:
     void doApply() override;
     void doUnapply() override;
 
-    RefPtr<HTMLElement> protectedSpanElement() const { return m_spanElement; }
-    
 #ifndef NDEBUG
     void getNodesInCommand(NodeSet&) override;
 #endif

--- a/Source/WebCore/editing/ReplaceRangeWithTextCommand.cpp
+++ b/Source/WebCore/editing/ReplaceRangeWithTextCommand.cpp
@@ -79,7 +79,7 @@ String ReplaceRangeWithTextCommand::inputEventData() const
 RefPtr<DataTransfer> ReplaceRangeWithTextCommand::inputEventDataTransfer() const
 {
     if (!isEditingTextAreaOrTextInput())
-        return DataTransfer::createForInputEvent(m_text, serializeFragment(*protectedTextFragment(), SerializedNodes::SubtreeIncludingNode));
+        return DataTransfer::createForInputEvent(m_text, serializeFragment(*protect(m_textFragment), SerializedNodes::SubtreeIncludingNode));
 
     return CompositeEditCommand::inputEventDataTransfer();
 }

--- a/Source/WebCore/editing/ReplaceRangeWithTextCommand.h
+++ b/Source/WebCore/editing/ReplaceRangeWithTextCommand.h
@@ -46,8 +46,6 @@ private:
     RefPtr<DataTransfer> inputEventDataTransfer() const final;
     Vector<Ref<StaticRange>> targetRanges() const final;
 
-    RefPtr<DocumentFragment> protectedTextFragment() const { return m_textFragment; }
-
     SimpleRange m_rangeToBeReplaced;
     RefPtr<DocumentFragment> m_textFragment;
     String m_text;

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -125,8 +125,6 @@ private:
     
     void insertNodeBefore(Node&, Node& refNode);
 
-    RefPtr<DocumentFragment> protectedFragment() const { return m_fragment; }
-
     RefPtr<DocumentFragment> m_fragment;
     bool m_hasInterchangeNewlineAtStart;
     bool m_hasInterchangeNewlineAtEnd;
@@ -321,7 +319,7 @@ Ref<HTMLElement> ReplacementFragment::insertFragmentForTestRendering(Node* rootN
     Ref document = rootNode->document();
     auto holder = createDefaultParagraphElement(document.get());
 
-    holder->appendChild(protectedFragment().releaseNonNull());
+    holder->appendChild(protect(fragment()).releaseNonNull());
     rootNode->appendChild(holder);
     document->updateLayoutIgnorePendingStylesheets();
 
@@ -335,7 +333,7 @@ void ReplacementFragment::restoreAndRemoveTestRenderingNodesToFragment(StyledEle
     
     while (RefPtr<Node> node = holder->firstChild()) {
         holder->removeChild(*node);
-        protectedFragment()->appendChild(*node);
+        protect(fragment())->appendChild(*node);
     }
 
     removeNode(*holder);
@@ -1442,8 +1440,8 @@ void ReplaceSelectionCommand::doApply()
         applyCommandToComposite(SimplifyMarkupCommand::create(document(), insertedNodes.firstNodeInserted(), insertedNodes.pastLastLeaf()));
 
     // Setup m_startOfInsertedContent and m_endOfInsertedContent. This should be the last two lines of code that access insertedNodes.
-    m_startOfInsertedContent = firstPositionInOrBeforeNode(insertedNodes.protectedFirstNodeInserted().get());
-    m_endOfInsertedContent = lastPositionInOrAfterNode(insertedNodes.protectedLastLeafInserted().get());
+    m_startOfInsertedContent = firstPositionInOrBeforeNode(protect(insertedNodes.firstNodeInserted()).get());
+    m_endOfInsertedContent = lastPositionInOrAfterNode(protect(insertedNodes.lastLeafInserted()).get());
 
     // Determine whether or not we should merge the end of inserted content with what's after it before we do
     // the start merge so that the start merge doesn't effect our decision.
@@ -1853,7 +1851,7 @@ void ReplaceSelectionCommand::updateNodesInserted(Node *node)
 ReplacementFragment* ReplaceSelectionCommand::ensureReplacementFragment()
 {
     if (!m_replacementFragment)
-        m_replacementFragment = makeUnique<ReplacementFragment>(protectedDocumentFragment(), endingSelection());
+        m_replacementFragment = makeUnique<ReplacementFragment>(protect(m_documentFragment), endingSelection());
     return m_replacementFragment.get();
 }
 

--- a/Source/WebCore/editing/ReplaceSelectionCommand.h
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.h
@@ -77,13 +77,11 @@ private:
 
         bool isEmpty() { return !m_firstNodeInserted; }
         Node* firstNodeInserted() const { return m_firstNodeInserted.get(); }
-        RefPtr<Node> protectedFirstNodeInserted() const { return m_firstNodeInserted; }
         Node* lastLeafInserted() const
         {
             ASSERT(m_lastNodeInserted);
             return m_lastNodeInserted->lastDescendant();
         }
-        RefPtr<Node> protectedLastLeafInserted() const { return lastLeafInserted(); }
         Node* pastLastLeaf() const
         {
             ASSERT(m_lastNodeInserted);
@@ -130,8 +128,6 @@ private:
     void updateDirectionForStartOfInsertedContentIfNeeded(const InsertedNodes&);
 
     void removeForegroundColorsInDarkModeIfNeeded(const InsertedNodes&);
-
-    RefPtr<DocumentFragment> protectedDocumentFragment() const { return m_documentFragment; }
 
     VisibleSelection m_visibleSelectionForInsertedText;
     Position m_startOfInsertedContent;

--- a/Source/WebCore/editing/SpellChecker.cpp
+++ b/Source/WebCore/editing/SpellChecker.cpp
@@ -203,7 +203,7 @@ void SpellChecker::requestExtendedCheckingFor(Ref<SpellCheckRequest>&& request, 
     request->setCheckerAndIdentifier(this, identifier);
     request->setExistingResults(results);
 
-    client()->requestExtendedCheckingOfString(WTF::move(request), protectedDocument()->selection().selection());
+    client()->requestExtendedCheckingOfString(WTF::move(request), protect(document())->selection().selection());
 }
 
 void SpellChecker::invokeRequest(Ref<SpellCheckRequest>&& request)
@@ -212,7 +212,7 @@ void SpellChecker::invokeRequest(Ref<SpellCheckRequest>&& request)
     if (!client())
         return;
     m_processingRequest = WTF::move(request);
-    client()->requestCheckingOfString(*m_processingRequest, protectedDocument()->selection().selection());
+    client()->requestCheckingOfString(*m_processingRequest, protect(document())->selection().selection());
 }
 
 void SpellChecker::enqueueRequest(Ref<SpellCheckRequest>&& request)
@@ -263,11 +263,11 @@ void SpellChecker::didCheck(TextCheckingRequestIdentifier identifier, const Vect
             return;
         VisibleSelection selection = VisibleSelection(*range);
         SetForScope isRecheckingForScope(m_inRecheck, true);
-        protectedDocument()->editor().markMisspellingsAndBadGrammar(selection);
+        protect(document())->editor().markMisspellingsAndBadGrammar(selection);
         return;
     }
 
-    protectedDocument()->editor().markAndReplaceFor(*m_processingRequest, results);
+    protect(document())->editor().markAndReplaceFor(*m_processingRequest, results);
 
     if (!m_lastProcessedIdentifier || *m_lastProcessedIdentifier < identifier)
         m_lastProcessedIdentifier = identifier;
@@ -278,11 +278,6 @@ void SpellChecker::didCheck(TextCheckingRequestIdentifier identifier, const Vect
 }
 
 Document& SpellChecker::document() const
-{
-    return m_editor->document();
-}
-
-Ref<Document> SpellChecker::protectedDocument() const
 {
     return m_editor->document();
 }

--- a/Source/WebCore/editing/SpellChecker.h
+++ b/Source/WebCore/editing/SpellChecker.h
@@ -103,7 +103,6 @@ private:
     void didCheck(TextCheckingRequestIdentifier, const Vector<TextCheckingResult>&, const Vector<TextCheckingResult>&, const std::optional<SimpleRange>&);
 
     Document& document() const;
-    Ref<Document> protectedDocument() const;
 
     WeakRef<Editor> m_editor;
     Markable<TextCheckingRequestIdentifier> m_lastRequestIdentifier;

--- a/Source/WebCore/editing/SpellingCorrectionCommand.cpp
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.cpp
@@ -118,7 +118,7 @@ void SpellingCorrectionCommand::doApply()
     applyCommandToComposite(SpellingCorrectionRecordUndoCommand::create(document.copyRef(), m_corrected, m_correction));
 #endif
 
-    applyCommandToComposite(ReplaceSelectionCommand::create(WTF::move(document), protectedCorrectionFragment(), ReplaceSelectionCommand::MatchStyle, EditAction::Paste));
+    applyCommandToComposite(ReplaceSelectionCommand::create(WTF::move(document), protect(m_correctionFragment), ReplaceSelectionCommand::MatchStyle, EditAction::Paste));
 }
 
 String SpellingCorrectionCommand::inputEventData() const
@@ -137,7 +137,7 @@ Vector<Ref<StaticRange>> SpellingCorrectionCommand::targetRanges() const
 RefPtr<DataTransfer> SpellingCorrectionCommand::inputEventDataTransfer() const
 {
     if (!isEditingTextAreaOrTextInput())
-        return DataTransfer::createForInputEvent(m_correction, serializeFragment(*protectedCorrectionFragment(), SerializedNodes::SubtreeIncludingNode));
+        return DataTransfer::createForInputEvent(m_correction, serializeFragment(*protect(m_correctionFragment), SerializedNodes::SubtreeIncludingNode));
 
     return CompositeEditCommand::inputEventDataTransfer();
 }

--- a/Source/WebCore/editing/SpellingCorrectionCommand.h
+++ b/Source/WebCore/editing/SpellingCorrectionCommand.h
@@ -44,8 +44,6 @@ private:
     Vector<Ref<StaticRange>> targetRanges() const final;
     RefPtr<DataTransfer> inputEventDataTransfer() const final;
 
-    RefPtr<DocumentFragment> protectedCorrectionFragment() const { return m_correctionFragment; }
-
     SimpleRange m_rangeToBeCorrected;
     VisibleSelection m_selectionToBeCorrected;
     RefPtr<DocumentFragment> m_correctionFragment;

--- a/Source/WebCore/editing/SplitElementCommand.cpp
+++ b/Source/WebCore/editing/SplitElementCommand.cpp
@@ -108,7 +108,7 @@ void SplitElementCommand::doReapply()
 #ifndef NDEBUG
 void SplitElementCommand::getNodesInCommand(NodeSet& nodes)
 {
-    addNodeAndDescendants(protectedElement1().get(), nodes);
+    addNodeAndDescendants(protect(m_element1).get(), nodes);
     addNodeAndDescendants(m_element2.ptr(), nodes);
     addNodeAndDescendants(Ref { m_atChild }.ptr(), nodes);
 }

--- a/Source/WebCore/editing/SplitElementCommand.h
+++ b/Source/WebCore/editing/SplitElementCommand.h
@@ -48,8 +48,6 @@ private:
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    RefPtr<Element> protectedElement1() const { return m_element1; }
-
     RefPtr<Element> m_element1;
     const Ref<Element> m_element2;
     const Ref<Node> m_atChild;

--- a/Source/WebCore/editing/SplitTextNodeCommand.cpp
+++ b/Source/WebCore/editing/SplitTextNodeCommand.cpp
@@ -65,7 +65,7 @@ void SplitTextNodeCommand::doApply()
     m_text1 = Text::create(document(), WTF::move(prefixText));
     ASSERT(m_text1);
     if (CheckedPtr markers = document().markersIfExists())
-        markers->copyMarkers(m_text2, { 0, m_offset }, *protectedText1());
+        markers->copyMarkers(m_text2, { 0, m_offset }, *protect(m_text1));
 
     insertText1AndTrimText2();
 }
@@ -103,7 +103,7 @@ void SplitTextNodeCommand::doReapply()
 void SplitTextNodeCommand::insertText1AndTrimText2()
 {
     Ref text2 = m_text2;
-    if (protect(text2->parentNode())->insertBefore(*protectedText1(), text2.copyRef()).hasException())
+    if (protect(text2->parentNode())->insertBefore(*protect(m_text1), text2.copyRef()).hasException())
         return;
     text2->deleteData(0, m_offset);
 }
@@ -112,7 +112,7 @@ void SplitTextNodeCommand::insertText1AndTrimText2()
 
 void SplitTextNodeCommand::getNodesInCommand(NodeSet& nodes)
 {
-    addNodeAndDescendants(protectedText1().get(), nodes);
+    addNodeAndDescendants(protect(m_text1).get(), nodes);
     addNodeAndDescendants(m_text2.ptr(), nodes);
 }
 

--- a/Source/WebCore/editing/SplitTextNodeCommand.h
+++ b/Source/WebCore/editing/SplitTextNodeCommand.h
@@ -50,8 +50,6 @@ private:
     void getNodesInCommand(NodeSet&) override;
 #endif
 
-    RefPtr<Text> protectedText1() const { return m_text1; }
-
     RefPtr<Text> m_text1;
     const Ref<Text> m_text2;
     unsigned m_offset;

--- a/Source/WebCore/editing/TextIterator.h
+++ b/Source/WebCore/editing/TextIterator.h
@@ -111,7 +111,6 @@ public:
     StringView text() const LIFETIME_BOUND { ASSERT(!atEnd()); return m_text; }
     WEBCORE_EXPORT SimpleRange range() const;
     WEBCORE_EXPORT Node* node() const;
-    RefPtr<Node> protectedCurrentNode() const;
 
     const TextIteratorCopyableText& copyableText() const { ASSERT(!atEnd()); return m_copyableText; }
     void appendTextToStringBuilder(StringBuilder& builder) const { copyableText().appendToStringBuilder(builder); }
@@ -137,8 +136,6 @@ private:
     void revertToRemainingTextRun();
 
     Node* baseNodeForEmittingNewLine() const;
-
-    RefPtr<Node> protectedStartContainer() const { return m_startContainer; }
 
     const TextIteratorBehaviors m_behaviors;
 
@@ -201,7 +198,6 @@ public:
     StringView text() const LIFETIME_BOUND { ASSERT(!atEnd()); return m_text; }
     WEBCORE_EXPORT SimpleRange range() const;
     Node* node() const { ASSERT(!atEnd()); return m_node.get(); }
-    RefPtr<Node> protectedNode() const { return m_node.get(); }
 
 private:
     void exitNode();

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -349,7 +349,7 @@ void TypingCommand::postTextStateChangeNotificationForDeletion(const VisibleSele
     VisiblePositionIndexRange range;
     range.startIndex.value = indexForVisiblePosition(selection.visibleStart(), range.startIndex.scope);
     range.endIndex.value = indexForVisiblePosition(selection.visibleEnd(), range.endIndex.scope);
-    protectedComposition()->setRangeDeletedByUnapply(range);
+    protect(composition())->setRangeDeletedByUnapply(range);
 }
 
 bool TypingCommand::willApplyCommand()
@@ -547,7 +547,7 @@ void TypingCommand::insertTextAndNotifyAccessibility(const String& text, bool se
     AccessibilityReplacedText replacedText(document().selection().selection());
     insertText(text, selectInsertedText);
     replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditType::Typing, text, document().selection().selection());
-    protectedComposition()->setRangeDeletedByUnapply(replacedText.replacedRange());
+    protect(composition())->setRangeDeletedByUnapply(replacedText.replacedRange());
 }
 
 void TypingCommand::insertTextRunWithoutNewlines(const String& text, bool selectInsertedText)
@@ -580,7 +580,7 @@ void TypingCommand::insertLineBreakAndNotifyAccessibility()
     AccessibilityReplacedText replacedText(document().selection().selection());
     insertLineBreak();
     replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditType::Typing, "\n"_s, document().selection().selection());
-    protectedComposition()->setRangeDeletedByUnapply(replacedText.replacedRange());
+    protect(composition())->setRangeDeletedByUnapply(replacedText.replacedRange());
 }
 
 void TypingCommand::insertParagraphSeparator()
@@ -600,7 +600,7 @@ void TypingCommand::insertParagraphSeparatorAndNotifyAccessibility()
     AccessibilityReplacedText replacedText(document().selection().selection());
     insertParagraphSeparator();
     replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditType::Typing, "\n"_s, document().selection().selection());
-    protectedComposition()->setRangeDeletedByUnapply(replacedText.replacedRange());
+    protect(composition())->setRangeDeletedByUnapply(replacedText.replacedRange());
 }
 
 void TypingCommand::insertParagraphSeparatorInQuotedContent()
@@ -624,7 +624,7 @@ void TypingCommand::insertParagraphSeparatorInQuotedContentAndNotifyAccessibilit
     AccessibilityReplacedText replacedText(document().selection().selection());
     insertParagraphSeparatorInQuotedContent();
     replacedText.postTextStateChangeNotification(document().existingAXObjectCache(), AXTextEditType::Typing, "\n"_s, document().selection().selection());
-    protectedComposition()->setRangeDeletedByUnapply(replacedText.replacedRange());
+    protect(composition())->setRangeDeletedByUnapply(replacedText.replacedRange());
 }
 
 bool TypingCommand::makeEditableRootEmpty()

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -681,11 +681,6 @@ Element* VisibleSelection::rootEditableElement() const
     return editableRootForPosition(start());
 }
 
-RefPtr<Element> VisibleSelection::protectedRootEditableElement() const
-{
-    return rootEditableElement();
-}
-
 Node* VisibleSelection::nonBoundaryShadowTreeRootNode() const
 {
     return start().deprecatedNode() && !start().deprecatedNode()->isShadowRoot() ? start().deprecatedNode()->nonBoundaryShadowTreeRootNode() : nullptr;

--- a/Source/WebCore/editing/VisibleSelection.h
+++ b/Source/WebCore/editing/VisibleSelection.h
@@ -117,7 +117,6 @@ public:
     WEBCORE_EXPORT std::optional<SimpleRange> toNormalizedRange() const;
 
     WEBCORE_EXPORT Element* rootEditableElement() const;
-    WEBCORE_EXPORT RefPtr<Element> protectedRootEditableElement() const;
     WEBCORE_EXPORT bool isContentEditable() const;
     WEBCORE_EXPORT bool hasEditableStyle() const;
     WEBCORE_EXPORT bool isContentRichlyEditable() const;

--- a/Source/WebCore/editing/WebContentReader.cpp
+++ b/Source/WebCore/editing/WebContentReader.cpp
@@ -37,7 +37,7 @@ void WebContentReader::addFragment(Ref<DocumentFragment>&& newFragment)
     if (!m_fragment)
         m_fragment = WTF::move(newFragment);
     else
-        protectedFragment()->appendChild(newFragment);
+        protect(fragment())->appendChild(newFragment);
 }
 
 bool FrameWebContentReader::shouldSanitize() const

--- a/Source/WebCore/editing/WebContentReader.h
+++ b/Source/WebCore/editing/WebContentReader.h
@@ -45,7 +45,6 @@ public:
     }
 
     LocalFrame& frame() const { return m_frame; }
-    Ref<LocalFrame> protectedFrame() const { return m_frame; }
 
 protected:
     bool shouldSanitize() const;
@@ -74,7 +73,6 @@ public:
     void addFragment(Ref<DocumentFragment>&&);
     RefPtr<DocumentFragment> takeFragment() { return std::exchange(m_fragment, nullptr); }
     DocumentFragment* fragment() const { return m_fragment.get(); }
-    RefPtr<DocumentFragment> protectedFragment() const { return m_fragment; }
 
     bool madeFragmentFromPlainText() const { return m_madeFragmentFromPlainText; }
 

--- a/Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp
+++ b/Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp
@@ -88,7 +88,7 @@ void WrapContentsInDummySpanCommand::doReapply()
 void WrapContentsInDummySpanCommand::getNodesInCommand(NodeSet& nodes)
 {
     addNodeAndDescendants(m_element.ptr(), nodes);
-    addNodeAndDescendants(protectedDummySpan().get(), nodes);
+    addNodeAndDescendants(protect(m_dummySpan).get(), nodes);
 }
 #endif
 

--- a/Source/WebCore/editing/WrapContentsInDummySpanCommand.h
+++ b/Source/WebCore/editing/WrapContentsInDummySpanCommand.h
@@ -46,8 +46,6 @@ private:
     void doReapply() override;
     void executeApply();
 
-    RefPtr<HTMLElement> protectedDummySpan() const { return m_dummySpan; }
-
 #ifndef NDEBUG
     void getNodesInCommand(NodeSet&) override;
 #endif

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -954,7 +954,7 @@ bool WebContentReader::readDataBuffer(SharedBuffer& buffer, const String& type, 
         m_fragment = document->createDocumentFragment();
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    protectedFragment()->appendChild(attachmentForData(frame, buffer, type, name, preferredPresentationSize));
+    protect(fragment())->appendChild(attachmentForData(frame, buffer, type, name, preferredPresentationSize));
 #else
     UNUSED_PARAM(type);
     UNUSED_PARAM(name);

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -182,7 +182,7 @@ void HTMLAnchorElement::defaultEventHandler(Event& event)
             // for the LiveWhenNotFocused editable link behavior
             auto& eventNames = WebCore::eventNames();
             if (auto* mouseEvent = dynamicDowncast<MouseEvent>(event); event.type() == eventNames.mousedownEvent && mouseEvent && mouseEvent->button() != MouseButton::Right && document().frame()) {
-                setRootEditableElementForSelectionOnMouseDown(document().frame()->selection().selection().protectedRootEditableElement().get());
+                setRootEditableElementForSelectionOnMouseDown(protect(document().frame()->selection().selection().rootEditableElement()).get());
                 m_wasShiftKeyDownOnMouseDown = mouseEvent->shiftKey();
             } else if (event.type() == eventNames.mouseoverEvent) {
                 // These are cleared on mouseover and not mouseout because their values are needed for drag events,


### PR DESCRIPTION
#### c36bb965e12b5c9d40731f745c4f8cd626c2d474
<pre>
Reduce usage of protectedFoo() style in place of protect() in WebCore/editing
<a href="https://bugs.webkit.org/show_bug.cgi?id=307148">https://bugs.webkit.org/show_bug.cgi?id=307148</a>
<a href="https://rdar.apple.com/169782362">rdar://169782362</a>

Reviewed by Ryosuke Niwa.

Use protect() style in place of protectedFoo() style.

No change of functionality.

* Source/WebCore/dom/DocumentInlines.h:
(WebCore::FrameSelection::protectedDocument const): Deleted.
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::startAlternativeTextUITimer):
(WebCore::AlternativeTextController::stopPendingCorrection):
(WebCore::AlternativeTextController::isSpellingMarkerAllowed const):
(WebCore::AlternativeTextController::applyAutocorrectionBeforeTypingIfAppropriate):
(WebCore::AlternativeTextController::respondToUnappliedSpellCorrection):
(WebCore::AlternativeTextController::timerFired):
(WebCore::AlternativeTextController::canEnableAutomaticSpellingCorrection const):
(WebCore::AlternativeTextController::respondToChangedSelection):
(WebCore::AlternativeTextController::processMarkersOnTextToBeReplacedByResult):
(WebCore::AlternativeTextController::applyAlternativeTextToRange):
(WebCore::AlternativeTextController::removeCorrectionIndicatorMarkers):
(WebCore::AlternativeTextController::insertDictatedText):
(WebCore::AlternativeTextController::applyDictationAlternative):
* Source/WebCore/editing/AlternativeTextController.h:
* Source/WebCore/editing/CompositeEditCommand.h:
(WebCore::CompositeEditCommand::protectedComposition const): Deleted.
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
(WebCore::DeleteSelectionCommand::removeNodeUpdatingStates):
* Source/WebCore/editing/DeleteSelectionCommand.h:
(WebCore::DeleteSelectionCommand::protectedStartBlock const): Deleted.
(WebCore::DeleteSelectionCommand::protectedEndBlock const): Deleted.
(WebCore::DeleteSelectionCommand::protectedEndTableRow const): Deleted.
* Source/WebCore/editing/EditingStyle.cpp:
(WebCore::HTMLElementEquivalent::propertyExistsInStyle const):
(WebCore::HTMLElementEquivalent::valueIsPresentInStyle const):
(WebCore::HTMLFontWeightEquivalent::valueIsPresentInStyle const):
(WebCore::HTMLAttributeEquivalent::valueIsPresentInStyle const):
(WebCore::EditingStyle::EditingStyle):
(WebCore::EditingStyle::setProperty):
(WebCore::EditingStyle::styleWithResolvedTextDecorations const):
(WebCore::EditingStyle::overrideTypingStyleAt):
(WebCore::EditingStyle::copy const):
(WebCore::EditingStyle::removeBlockProperties):
(WebCore::EditingStyle::mergeTypingStyle):
(WebCore::EditingStyle::mergeInlineAndImplicitStyleOfElement):
(WebCore::EditingStyle::removeStyleInContextNotOverridenByMatchedRules):
(WebCore::EditingStyle::forceDisplayInline):
(WebCore::EditingStyle::addDisplayContents):
(WebCore::EditingStyle::isFloating):
(WebCore::EditingStyle::legacyFontSize const):
(WebCore::EditingStyle::styleAtSelectionStart):
(WebCore::EditingStyle::inverseTransformColorIfNeeded):
(WebCore::StyleChange::StyleChange):
(WebCore::StyleChange::operator==):
(WebCore::EditingStyle::protectedStyle): Deleted.
(WebCore::EditingStyle::protectedStyle const): Deleted.
* Source/WebCore/editing/EditingStyle.h:
(WebCore::EditingStyle::style const):
* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::clearText):
(WebCore::Editor::insertOrderedList):
(WebCore::Editor::insertUnorderedList):
(WebCore::Editor::removeFormattingAndStyle):
(WebCore::Editor::willUnapplyEditing const):
(WebCore::Editor::unappliedEditing):
(WebCore::Editor::reappliedEditing):
(WebCore::Editor::clear):
(WebCore::Editor::insertParagraphSeparatorInQuotedContent):
(WebCore::Editor::simplifyMarkup):
(WebCore::Editor::compositionText const):
(WebCore::Editor::insertTextPlaceholder):
* Source/WebCore/editing/Editor.h:
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/editing/InsertParagraphSeparatorCommand.cpp:
(WebCore::InsertParagraphSeparatorCommand::calculateStyleBeforeInsertion):
* Source/WebCore/editing/InsertParagraphSeparatorCommand.h:
(WebCore::InsertParagraphSeparatorCommand::protectedStyle const): Deleted.
* Source/WebCore/editing/ReplaceNodeWithSpanCommand.cpp:
(WebCore::ReplaceNodeWithSpanCommand::doApply):
* Source/WebCore/editing/ReplaceNodeWithSpanCommand.h:
(WebCore::ReplaceNodeWithSpanCommand::protectedSpanElement const): Deleted.
* Source/WebCore/editing/ReplaceRangeWithTextCommand.cpp:
(WebCore::ReplaceRangeWithTextCommand::inputEventDataTransfer const):
* Source/WebCore/editing/ReplaceRangeWithTextCommand.h:
(WebCore::ReplaceRangeWithTextCommand::protectedTextFragment const): Deleted.
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::ReplacementFragment::insertFragmentForTestRendering):
(WebCore::ReplacementFragment::restoreAndRemoveTestRenderingNodesToFragment):
(WebCore::ReplaceSelectionCommand::doApply):
(WebCore::ReplaceSelectionCommand::ensureReplacementFragment):
(WebCore::ReplacementFragment::protectedFragment const): Deleted.
* Source/WebCore/editing/ReplaceSelectionCommand.h:
(WebCore::ReplaceSelectionCommand::InsertedNodes::firstNodeInserted const):
(WebCore::ReplaceSelectionCommand::InsertedNodes::lastLeafInserted const):
(WebCore::ReplaceSelectionCommand::InsertedNodes::protectedFirstNodeInserted const): Deleted.
(WebCore::ReplaceSelectionCommand::InsertedNodes::protectedLastLeafInserted const): Deleted.
(WebCore::ReplaceSelectionCommand::protectedDocumentFragment const): Deleted.
* Source/WebCore/editing/SpellChecker.cpp:
(WebCore::SpellChecker::requestExtendedCheckingFor):
(WebCore::SpellChecker::invokeRequest):
(WebCore::SpellChecker::didCheck):
(WebCore::SpellChecker::protectedDocument const): Deleted.
* Source/WebCore/editing/SpellChecker.h:
* Source/WebCore/editing/SpellingCorrectionCommand.cpp:
(WebCore::SpellingCorrectionCommand::doApply):
(WebCore::SpellingCorrectionCommand::inputEventDataTransfer const):
* Source/WebCore/editing/SpellingCorrectionCommand.h:
(WebCore::SpellingCorrectionCommand::protectedCorrectionFragment const): Deleted.
* Source/WebCore/editing/SplitElementCommand.cpp:
(WebCore::SplitElementCommand::getNodesInCommand):
* Source/WebCore/editing/SplitElementCommand.h:
(WebCore::SplitElementCommand::protectedElement1 const): Deleted.
* Source/WebCore/editing/SplitTextNodeCommand.cpp:
(WebCore::SplitTextNodeCommand::doApply):
(WebCore::SplitTextNodeCommand::insertText1AndTrimText2):
(WebCore::SplitTextNodeCommand::getNodesInCommand):
* Source/WebCore/editing/SplitTextNodeCommand.h:
(WebCore::SplitTextNodeCommand::protectedText1 const): Deleted.
* Source/WebCore/editing/TextIterator.cpp:
(WebCore::TextIterator::advance):
(WebCore::TextIterator::handleTextNode):
(WebCore::TextIterator::handleTextRun):
(WebCore::TextIterator::handleReplacedElement):
(WebCore::TextIterator::shouldRepresentNodeOffsetZero):
(WebCore::TextIterator::exitNode):
(WebCore::SimplifiedBackwardsTextIterator::advance):
(WebCore::TextIterator::protectedCurrentNode const): Deleted.
* Source/WebCore/editing/TextIterator.h:
(WebCore::SimplifiedBackwardsTextIterator::node const):
(WebCore::TextIterator::protectedStartContainer const): Deleted.
(WebCore::SimplifiedBackwardsTextIterator::protectedNode const): Deleted.
* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::postTextStateChangeNotificationForDeletion):
(WebCore::TypingCommand::insertTextAndNotifyAccessibility):
(WebCore::TypingCommand::insertLineBreakAndNotifyAccessibility):
(WebCore::TypingCommand::insertParagraphSeparatorAndNotifyAccessibility):
(WebCore::TypingCommand::insertParagraphSeparatorInQuotedContentAndNotifyAccessibility):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::protectedRootEditableElement const): Deleted.
* Source/WebCore/editing/VisibleSelection.h:
* Source/WebCore/editing/WebContentReader.cpp:
(WebCore::WebContentReader::addFragment):
* Source/WebCore/editing/WebContentReader.h:
(WebCore::FrameWebContentReader::frame const):
(WebCore::FrameWebContentReader::protectedFrame const): Deleted.
* Source/WebCore/editing/WrapContentsInDummySpanCommand.cpp:
(WebCore::WrapContentsInDummySpanCommand::getNodesInCommand):
* Source/WebCore/editing/WrapContentsInDummySpanCommand.h:
(WebCore::WrapContentsInDummySpanCommand::protectedDummySpan const): Deleted.
* Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm:
(WebCore::WebContentReader::readDataBuffer):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::defaultEventHandler):

Canonical link: <a href="https://commits.webkit.org/307890@main">https://commits.webkit.org/307890@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bff5df204bcc19db5e929220813af0b8bcc2009c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145276 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153948 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98913 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147151 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18440 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17849 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111709 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80184 "Exiting early after 60 failures. 15366 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/073a5867-5e9b-461b-8ab6-ccd17029c513) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14074 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130490 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92609 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1dfd6f31-4c49-4d2d-982c-00bd58bec8be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13426 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11185 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1394 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156260 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119716 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17808 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14862 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120051 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30893 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73496 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15819 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6763 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17429 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81208 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17166 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17374 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17229 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->