### PR TITLE
[LBSE] Fix text opacity issues

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -290,7 +290,6 @@ imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-004b.svg         
 imported/w3c/web-platform-tests/svg/styling/invalidation/nth-child-of-class.svg                        [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/invalidation/nth-last-child-of-class.svg                   [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/dominant-baseline-hanging-small-font-size.svg        [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/text/reftests/opacity.svg                                          [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-path-transformed-002.html                       [ ImageOnlyFailure ]
 
 # <foreignObject> issues
@@ -306,7 +305,6 @@ svg/custom/focus-ring.svg [ ImageOnlyFailure ]
 
 # Text rendering visually different
 svg/W3C-SVG-1.1/text-text-05-t.svg                 [ ImageOnlyFailure ]
-svg/W3C-SVG-1.1/text-text-08-b.svg                 [ ImageOnlyFailure ]
 svg/hittest/text-multiple-dx-values.svg            [ ImageOnlyFailure ]
 svg/hittest/text-with-multiple-tspans.svg          [ ImageOnlyFailure ]
 svg/hittest/text-with-text-path.svg                [ ImageOnlyFailure ]
@@ -327,10 +325,6 @@ svg/css/mix-blend-mode-opacity-root.svg    [ ImageOnlyFailure ]
 # Non-scaling stroke issues
 svg/zoom/page/non-scaling-stroke-textRendering-default.svg            [ ImageOnlyFailure ]
 svg/zoom/page/non-scaling-stroke-textRendering-geometricPrecision.svg [ ImageOnlyFailure ]
-
-# Opacity issues
-svg/custom/text-image-opacity.svg [ ImageOnlyFailure ]
-svg/text/text-text-08-b.svg       [ ImageOnlyFailure ]
 
 # <use> issues
 svg/W3C-SVG-1.2-Tiny/struct-use-recursion-01-t.svg [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -121,21 +121,23 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
             isolateMaskForBlending = graphicsElement->shouldIsolateBlending();
     }
 
-    if (opacity < 1 || hasBlendMode || isolateMaskForBlending || hasIsolation) {
-        FloatRect repaintRect = m_renderer->repaintRectInLocalCoordinates();
-        m_paintInfo->context().clip(repaintRect);
-
+    if (!(renderer.document().settings().layerBasedSVGEngineEnabled() && is<RenderSVGText>(renderer))) {
         if (opacity < 1 || hasBlendMode || isolateMaskForBlending || hasIsolation) {
+            FloatRect repaintRect = m_renderer->repaintRectInLocalCoordinates();
+            m_paintInfo->context().clip(repaintRect);
 
-            if (hasBlendMode)
-                m_paintInfo->context().setCompositeOperation(m_paintInfo->context().compositeOperation(), style.blendMode());
+            if (opacity < 1 || hasBlendMode || isolateMaskForBlending || hasIsolation) {
 
-            m_paintInfo->context().beginTransparencyLayer(opacity);
+                if (hasBlendMode)
+                    m_paintInfo->context().setCompositeOperation(m_paintInfo->context().compositeOperation(), style.blendMode());
 
-            if (hasBlendMode)
-                m_paintInfo->context().setCompositeOperation(m_paintInfo->context().compositeOperation(), BlendMode::Normal);
+                m_paintInfo->context().beginTransparencyLayer(opacity);
 
-            m_renderingFlags |= EndOpacityLayer;
+                if (hasBlendMode)
+                    m_paintInfo->context().setCompositeOperation(m_paintInfo->context().compositeOperation(), BlendMode::Normal);
+
+                m_renderingFlags |= EndOpacityLayer;
+            }
         }
     }
 


### PR DESCRIPTION
#### 5688d36d24f3494da6a5de601dbe473df50948ed
<pre>
[LBSE] Fix text opacity issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=307152">https://bugs.webkit.org/show_bug.cgi?id=307152</a>

Reviewed by Nikolas Zimmermann.

In Legacy SVG RenderSVGText gets no layer and RenderSVGText is responsible for
opacity/blending through SVGRenderingContext::prepareToRenderSVGContent.

In LBSE the call to SVGRenderingContext::prepareToRenderSVGContent is still being
used, but also RenderLayer::beginTransparencyLayers is used (since RenderSVGText requires
a layer), causing two transparancy layers to be applied and visually text that is too bright.

To fix this, skip the SVGRenderingContext::prepareToRenderSVGContent transparancy layer
logic in LBSE for RenderSVGText.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::SVGRenderingContext::prepareToRenderSVGContent):

Canonical link: <a href="https://commits.webkit.org/306968@main">https://commits.webkit.org/306968@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/80aeb7e710e2a125e3d4843deea53007d0c59e4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142868 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151542 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96061 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15421 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109873 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79177 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90782 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11831 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9513 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1541 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121214 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153855 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14966 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117889 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15003 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12997 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118223 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30234 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14213 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125178 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70665 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15009 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4088 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14744 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78720 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14806 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->