### PR TITLE
REGRESSION(306778@main): [EGL] Cannot instantiate contexts with EGL 1.4 or older

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -137,7 +137,7 @@ public:
     };
 
 private:
-    static EGLContext createContextForEGLVersion(EGLDisplay, EGLConfig, EGLContext);
+    static EGLContext createEGLContext(GLDisplay&, EGLConfig, EGLContext);
 
     static std::unique_ptr<GLContext> createWindowContext(GLDisplay&, Target, GLNativeWindowType, EGLContext sharingContext);
     static std::unique_ptr<GLContext> createSurfacelessContext(GLDisplay&, Target, EGLContext sharingContext);

--- a/Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp
@@ -80,7 +80,7 @@ std::unique_ptr<GLContext> GLContext::createWPEContext(GLDisplay& display, EGLCo
         return nullptr;
     }
 
-    EGLContext context = createContextForEGLVersion(eglDisplay, config, sharingContext);
+    auto context = createEGLContext(display, config, sharingContext);
     if (context == EGL_NO_CONTEXT) {
         RELEASE_LOG_INFO(Compositing, "Cannot create EGL WPE context: %s\n", lastErrorString());
         wpe_renderer_backend_egl_offscreen_target_destroy(target);


### PR DESCRIPTION
#### b1e8c0b53520a627f1af9ba9c29c68154a639dc4
<pre>
REGRESSION(306778@main): [EGL] Cannot instantiate contexts with EGL 1.4 or older
<a href="https://bugs.webkit.org/show_bug.cgi?id=307154">https://bugs.webkit.org/show_bug.cgi?id=307154</a>

Reviewed by Nikolas Zimmermann.

Use EGL_CONTEXT_FLAGS_KHR+EGL_CONTEXT_OPENGL_DEBUG_BIT_KHR for EGL 1.4
or older when creating EGL contexts. Previously EGL_CONTEXT_OPENGL_DEBUG
was used unconditionally, which was introduced in EGL 1.5, and would
make context creation fail for older versions.

While at it, rename createContextForEGLVersion() to createEGLContext().
The former name implied that the EGL version would be passed as a
parameter, which was not the case. At any rate, the EGL version can
be checked from the GLDisplay so arrange to pass that instead of the
plain EGLDisplay.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::createWindowContext):
(WebCore::GLContext::createSurfacelessContext):
(WebCore::GLContext::createPbufferContext):
(WebCore::GLContext::createEGLContext):
(WebCore::GLContext::createContextForEGLVersion): Deleted.
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebCore/platform/graphics/egl/GLContextLibWPE.cpp:
(WebCore::GLContext::createWPEContext):

Canonical link: <a href="https://commits.webkit.org/306935@main">https://commits.webkit.org/306935@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cbdc8578959bed5811d780ea9a93886cd9c37d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15321 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5840 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151523 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15402 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/109854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145798 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90763 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1522 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153836 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14947 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4948 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117870 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12978 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118204 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30207 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14193 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125129 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14990 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4050 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14725 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/78699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14933 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14787 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->