### PR TITLE
[GStreamer] Video rendering support for Qualcomm decoder

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -641,6 +641,7 @@ const GLContext::GLExtensions& GLContext::glExtensions() const
         m_glExtensions.EXT_unpack_subimage = isExtensionSupported(extensionsString, "GL_EXT_unpack_subimage");
         m_glExtensions.APPLE_sync = isExtensionSupported(extensionsString, "GL_APPLE_sync");
         m_glExtensions.OES_packed_depth_stencil = isExtensionSupported(extensionsString, "GL_OES_packed_depth_stencil");
+        m_glExtensions.EXT_YUV_target = isExtensionSupported(extensionsString, "GL_EXT_YUV_target");
     });
     return m_glExtensions;
 }

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -101,6 +101,7 @@ public:
         bool EXT_unpack_subimage { false };
         bool APPLE_sync { false };
         bool OES_packed_depth_stencil { false };
+        bool EXT_YUV_target { false };
     };
     const GLExtensions& glExtensions() const;
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -62,6 +62,7 @@ public:
 #endif
         UseBGRALayout = 1 << 5,
         NearestFiltering = 1 << 6,
+        ExternalOESRenderTarget = 1 << 7,
     };
 
     static Ref<BitmapTexture> create(const IntSize& size, OptionSet<Flags> flags = { })
@@ -121,6 +122,8 @@ private:
     void clearIfNeeded();
     void createFboIfNeeded();
 
+    void determineRenderTargetAndBinding();
+
     GLenum textureFormat() const;
     void createTexture();
     void allocateTexture();
@@ -131,6 +134,8 @@ private:
     OptionSet<Flags> m_flags;
     IntSize m_size;
     GLuint m_id { 0 };
+    GLenum m_renderTarget { GL_TEXTURE_2D };
+    GLenum m_binding { GL_TEXTURE_BINDING_2D };
     GLuint m_fbo { 0 };
     GLuint m_depthBufferObject { 0 };
     GLuint m_stencilBufferObject { 0 };

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.cpp
@@ -936,8 +936,8 @@ void TextureMapper::drawTexturedQuadWithProgram(TextureMapperShaderProgram& prog
         glUniform1i(textureAndSampler.second, i);
 
         if (repeatWrap) {
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
+            glTexParameteri(target, GL_TEXTURE_WRAP_S, GL_REPEAT);
+            glTexParameteri(target, GL_TEXTURE_WRAP_T, GL_REPEAT);
         }
     }
 
@@ -956,8 +956,8 @@ void TextureMapper::drawTexturedQuadWithProgram(TextureMapperShaderProgram& prog
     if (repeatWrap) {
         for (auto& textureAndSampler : texturesAndSamplers) {
             glBindTexture(target, textureAndSampler.first);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-            glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+            glTexParameteri(target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+            glTexParameteri(target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
         }
     }
 }
@@ -1582,6 +1582,13 @@ void TextureMapper::drawTextureExternalOES(GLuint texture, OptionSet<TextureMapp
     flags.add(TextureMapperFlags::ShouldUseExternalOESTextureRect);
     Ref<TextureMapperShaderProgram> program = data().getShaderProgram(TextureMapperShaderProgram::Option::TextureExternalOES);
     drawTexturedQuadWithProgram(program.get(), { { texture, program->externalOESTextureLocation() } }, flags, targetRect, modelViewMatrix, opacity);
+}
+
+void TextureMapper::drawTextureExternalOESYUV(GLuint texture, OptionSet<TextureMapperFlags> flags, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity)
+{
+    flags.add(TextureMapperFlags::ShouldUseExternalOESTextureRect);
+    Ref<TextureMapperShaderProgram> program = data().getShaderProgram(TextureMapperShaderProgram::Option::TextureExternalOESYUV);
+    drawTexturedQuadWithProgram(program.get(), { { texture, program->externalOESYUVTextureLocation() } }, flags, targetRect, modelViewMatrix, opacity);
 }
 
 Ref<TextureMapperGPUBuffer> TextureMapper::acquireBufferFromPool(size_t size, TextureMapperGPUBuffer::Type type)

--- a/Source/WebCore/platform/graphics/texmap/TextureMapper.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapper.h
@@ -86,6 +86,7 @@ public:
     void drawTextureSemiPlanarYUV(const std::array<GLuint, 2>& textures, bool uvReversed, const std::array<GLfloat, 16>& yuvToRgbMatrix, OptionSet<TextureMapperFlags>, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, TransferFunction, AllEdgesExposed = AllEdgesExposed::Yes);
     void drawTexturePackedYUV(GLuint texture, const std::array<GLfloat, 16>& yuvToRgbMatrix, OptionSet<TextureMapperFlags>, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float opacity, TransferFunction, AllEdgesExposed = AllEdgesExposed::Yes);
     void drawTextureExternalOES(GLuint texture, OptionSet<TextureMapperFlags>, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
+    void drawTextureExternalOESYUV(GLuint texture, OptionSet<TextureMapperFlags>, const FloatRect&, const TransformationMatrix& modelViewMatrix, float opacity);
     void drawSolidColor(const FloatRect&, const TransformationMatrix&, const Color&, bool);
     void clearColor(const Color&);
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h
@@ -62,7 +62,8 @@ namespace WebCore {
     macro(samplerA)                               \
     macro(mask)                                   \
     macro(contentTexture)                         \
-    macro(externalOESTexture)
+    macro(externalOESTexture)                     \
+    macro(externalOESYUVTexture)
 
 #define TEXMAP_VARIABLES(macro) \
     TEXMAP_ATTRIBUTE_VARIABLES(macro) \
@@ -111,6 +112,7 @@ public:
         AlphaToShadow    = 1L << 27,
         ToneMapPQ        = 1L << 28,
         ClampUVBounds    = 1L << 29,
+        TextureExternalOESYUV = 1L << 30,
     };
 
     enum class VariableID {

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h
@@ -28,18 +28,31 @@
 #if USE(COORDINATED_GRAPHICS)
 #include "CoordinatedPlatformLayerBuffer.h"
 
+#if USE(GSTREAMER) && USE(GBM)
+#include "GRefPtrGStreamer.h"
+#endif
+
 namespace WebCore {
 
 class CoordinatedPlatformLayerBufferExternalOES final : public CoordinatedPlatformLayerBuffer {
 public:
     static std::unique_ptr<CoordinatedPlatformLayerBufferExternalOES> create(unsigned textureID, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
     CoordinatedPlatformLayerBufferExternalOES(unsigned textureID, const IntSize&, OptionSet<TextureMapperFlags>, std::unique_ptr<GLFence>&&);
+#if USE(GSTREAMER) && USE(GBM)
+    static std::unique_ptr<CoordinatedPlatformLayerBufferExternalOES> create(GRefPtr<GstBuffer>&&, uint32_t fourcc, const IntSize&, OptionSet<TextureMapperFlags>);
+    CoordinatedPlatformLayerBufferExternalOES(GRefPtr<GstBuffer>&&, uint32_t fourcc, const IntSize&, OptionSet<TextureMapperFlags>);
+#endif
+
     virtual ~CoordinatedPlatformLayerBufferExternalOES();
 
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
     unsigned m_textureID { 0 };
+#if USE(GSTREAMER) && USE(GBM)
+    uint32_t m_fourcc { 0 };
+    GRefPtr<GstBuffer> m_buffer;
+#endif
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### c8a6727eec001e27fb9d2fb9cc3fc8af2b1e7f69
<pre>
[GStreamer] Video rendering support for Qualcomm decoder
<a href="https://bugs.webkit.org/show_bug.cgi?id=307151">https://bugs.webkit.org/show_bug.cgi?id=307151</a>

Reviewed by Xabier Rodriguez-Calvar and Nikolas Zimmermann.

The buffers produced by the Qualcomm decoder contain a single GstMemory which stores the
GBM FD pointing to the decoded frame. The frame format is YUV (NV12). As this is stored
in a single memory the existing DMABuf/YUV layer buffers cannot be used for rendering. So
we rely on the EXT_YUV_target OpenGL ES extension to convert it to a RGB texture for
rendering.

Manually tested on a device shipping the Qualcomm GStreamer decoder.

* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::glExtensions const):
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebCore/platform/graphics/gstreamer/VideoFrameGStreamer.cpp:
(WebCore::videoFormatToDRMFourcc):
(WebCore::VideoFrameGStreamer::infoFromCaps):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::determineRenderTargetAndBinding):
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::createTexture):
(WebCore::BitmapTexture::allocateTexture):
(WebCore::BitmapTexture::allocateTextureFromMemoryMappedGPUBuffer):
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::updateContents):
(WebCore::BitmapTexture::createFboIfNeeded):
(WebCore::BitmapTexture::bindAsSurface):
(WebCore::BitmapTexture::copyFromExternalTexture):
(WebCore::BitmapTexture::colorConvertFlags const):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/TextureMapper.cpp:
(WebCore::TextureMapper::drawTexturedQuadWithProgram):
(WebCore::TextureMapper::drawTextureExternalOESYUV):
* Source/WebCore/platform/graphics/texmap/TextureMapper.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:
(WebCore::STRINGIFY):
(WebCore::TextureMapperShaderProgram::create):
* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp:
(WebCore::CoordinatedPlatformLayerBufferExternalOES::create):
(WebCore::CoordinatedPlatformLayerBufferExternalOES::CoordinatedPlatformLayerBufferExternalOES):
(WebCore::CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::createBufferIfNeeded):

Canonical link: <a href="https://commits.webkit.org/307174@main">https://commits.webkit.org/307174@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ac1b66d24046af4452aabb4cd147299f47479a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16107 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7751 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152293 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16784 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110452 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146589 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12897 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129080 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91369 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12373 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10094 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2295 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121816 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5628 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154605 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16154 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118457 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118812 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30445 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14757 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126835 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71568 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15775 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5404 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15510 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15722 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->