### PR TITLE
setCodecPreferences should accept codecs regardless of mimeType case

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences-expected.txt
@@ -21,6 +21,6 @@ PASS setCodecPreferences() can remove rtx
 PASS setCodecPreferences() can remove red
 PASS setCodecPreferences() can remove ulpfec
 PASS setCodecPreferences() filters on receiver and prefers receiver order
-FAIL setCodecPreferences should accept audio codecs regardless of mimeType case promise_test: Unhandled rejection with value: object "InvalidModificationError: RTCRtpCodecCapability bad mimeType"
-FAIL setCodecPreferences should accept video codecs regardless of mimeType case promise_test: Unhandled rejection with value: object "InvalidModificationError: RTCRtpCodecCapability bad mimeType"
+PASS setCodecPreferences should accept audio codecs regardless of mimeType case
+PASS setCodecPreferences should accept video codecs regardless of mimeType case
 

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -88,9 +88,9 @@ bool LibWebRTCRtpTransceiverBackend::stopped() const
 static inline ExceptionOr<webrtc::RtpCodecCapability> toRtpCodecCapability(const RTCRtpCodecCapability& codec)
 {
     webrtc::RtpCodecCapability rtcCodec;
-    if (codec.mimeType.startsWith("video/"_s))
+    if (codec.mimeType.startsWithIgnoringASCIICase("video/"_s))
         rtcCodec.kind = webrtc::MediaType::VIDEO;
-    else if (codec.mimeType.startsWith("audio/"_s))
+    else if (codec.mimeType.startsWithIgnoringASCIICase("audio/"_s))
         rtcCodec.kind = webrtc::MediaType::AUDIO;
     else
         return Exception { ExceptionCode::InvalidModificationError, "RTCRtpCodecCapability bad mimeType"_s };


### PR DESCRIPTION
#### 34bbf22dba3fecd32b5229351158766d095d9904
<pre>
setCodecPreferences should accept codecs regardless of mimeType case
<a href="https://bugs.webkit.org/show_bug.cgi?id=307157">https://bugs.webkit.org/show_bug.cgi?id=307157</a>
<a href="https://rdar.apple.com/169789074">rdar://169789074</a>

Reviewed by Youenn Fablet.

This patch aligns WebKit with Gecko / Firefox.

Use case-insensitive comparison when checking mimeType prefix in
toRtpCodecCapability to accept codecs with any case variation
(e.g., &quot;video/VP8&quot;, &quot;VIDEO/vp8&quot;, &quot;Video/Vp8&quot;).

* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCRtpTransceiverBackend.cpp:
(WebCore::toRtpCodecCapability):
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpTransceiver-setCodecPreferences-expected.txt: Progressions

Canonical link: <a href="https://commits.webkit.org/307062@main">https://commits.webkit.org/307062@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/451624bbff1ae7f02ba9cbc176a93ed3d6421eae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142843 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5828 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96035 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c16e41e-e944-41f5-b649-70c78c71eee9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109848 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79165 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c36159e6-ba03-4941-94b2-e33d6a01df18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145792 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12310 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127797 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90757 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a91db741-0247-4132-9ab5-970608741431) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11809 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9489 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1516 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121189 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4294 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153830 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117864 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12972 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118198 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30359 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14188 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70638 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14984 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4046 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14719 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78693 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14927 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->