### PR TITLE
Add the support for [[clang::annotate_type("webkit.nodelete")]] and use it in DOM code

### DIFF
--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -568,6 +568,7 @@
 #define SUPPRESS_RETAINPTR_CTOR_ADOPT \
     IGNORE_CLANG_STATIC_ANALYZER_WARNINGS_ATTRIBUTE("alpha.webkit.RetainPtrCtorAdoptChecker")
 #define CLANG_POINTER_CONVERSION [[clang::annotate_type("webkit.pointerconversion")]]
+#define CLANG_NODELETE [[clang::annotate_type("webkit.nodelete")]]
 #else
 #define SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE
 #define SUPPRESS_UNRETAINED_LOCAL
@@ -575,6 +576,7 @@
 #define SUPPRESS_UNRETAINED_MEMBER
 #define SUPPRESS_RETAINPTR_CTOR_ADOPT
 #define CLANG_POINTER_CONVERSION
+#define CLANG_NODELETE
 #endif
 
 // To suppress webkit.RefCntblBaseVirtualDtor, use NoVirtualDestructorBase instead.

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -327,8 +327,8 @@ public:
     WEBCORE_EXPORT Element* parentElementInComposedTree() const;
     Element* parentOrShadowHostElement() const;
     inline void setParentNode(ContainerNode*);
-    inline Node& rootNode() const;
-    WEBCORE_EXPORT Node& traverseToRootNode() const;
+    inline Node& CLANG_NODELETE rootNode() const;
+    WEBCORE_EXPORT Node& CLANG_NODELETE traverseToRootNode() const;
     Node& shadowIncludingRoot() const;
 
     struct GetRootNodeOptions {

--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -31,6 +31,7 @@ import sys
 WEBKIT_CHECKERS = [
     'alpha.webkit.ForwardDeclChecker',
     'alpha.webkit.MemoryUnsafeCastChecker',
+    'alpha.webkit.NoDeleteChecker',
     'alpha.webkit.NoUncheckedPtrMemberChecker',
     'alpha.webkit.NoUnretainedMemberChecker',
     'alpha.webkit.RetainPtrCtorAdoptChecker',


### PR DESCRIPTION
#### 868af336a43ad2887c8197cd8272de08972dc9fd
<pre>
Add the support for [[clang::annotate_type(&quot;webkit.nodelete&quot;)]] and use it in DOM code
<a href="https://bugs.webkit.org/show_bug.cgi?id=307156">https://bugs.webkit.org/show_bug.cgi?id=307156</a>

Reviewed by Chris Dumez.

This PR introduces the support for specifying new clang specific type attribute
[[clang::annotate_type(&quot;webkit.nodelete&quot;)]] which denotes a given function is &quot;trivial&quot;
and doesn&apos;t trigger a destruction of an object.

This PR also enables alpha.webkit.NoDeleteChecker which verifies that the function
with this annotation is actually &quot;trivial&quot;.

Finally, this PR also deploys this new annotation in some DOM code as an example.

* Source/WTF/wtf/Compiler.h:
* Source/WebCore/dom/Node.h:
* Tools/Scripts/build-and-analyze:

Canonical link: <a href="https://commits.webkit.org/306948@main">https://commits.webkit.org/306948@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/382e59af256b282898d8049b7acfc792a0d7c6e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142845 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96037 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/161c3916-b33d-4276-b31e-2e634044493e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144712 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15973 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109851 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12318 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127805 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90760 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d64dcf0e-137d-4c13-a9b5-d757cc39f53a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11816 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9493 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1518 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134839 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153832 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3655 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14943 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117867 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/14980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118201 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14197 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125135 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70640 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22023 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/14986 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4054 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174142 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14721 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78695 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/44997 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14783 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->