### PR TITLE
Reduce use of protected functions in Source/WebCore/rendering

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMathMLElement.cpp
@@ -61,7 +61,7 @@ AccessibilityRole AccessibilityMathMLElement::determineAccessibilityRole()
     if (m_ariaRole != AccessibilityRole::Unknown)
         return m_ariaRole;
 
-    if (WebCore::elementName(m_renderer->protectedNode().get()) == ElementName::MathML_math)
+    if (WebCore::elementName(protect(m_renderer->node()).get()) == ElementName::MathML_math)
         return AccessibilityRole::DocumentMath;
 
     // It's not clear which role a platform should choose for a math element.

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -1867,7 +1867,7 @@ static bool layoutOverflowRectContainsAllDescendants(const RenderBox& renderBox)
         for (CheckedRef viewPositionedOutOfFlowBox : *viewPositionedOutOfFlowBoxes) {
             if (viewPositionedOutOfFlowBox.ptr() == &renderBox)
                 continue;
-            if (viewPositionedOutOfFlowBox->isFixedPositioned() && renderBox.element()->contains(viewPositionedOutOfFlowBox->protectedElement().get()))
+            if (viewPositionedOutOfFlowBox->isFixedPositioned() && renderBox.element()->contains(protect(viewPositionedOutOfFlowBox->element()).get()))
                 return false;
         }
     }
@@ -1883,7 +1883,7 @@ static bool layoutOverflowRectContainsAllDescendants(const RenderBox& renderBox)
             for (CheckedRef outOfFlowBox : *outOfFlowBoxes) {
                 if (outOfFlowBox.ptr() == &renderBox)
                     continue;
-                if (renderBox.protectedElement()->contains(outOfFlowBox->protectedElement().get()))
+                if (protect(renderBox.element())->contains(protect(outOfFlowBox->element()).get()))
                     return false;
             }
         }

--- a/Source/WebCore/dom/MouseRelatedEvent.cpp
+++ b/Source/WebCore/dom/MouseRelatedEvent.cpp
@@ -218,7 +218,7 @@ void MouseRelatedEvent::computeRelativePosition()
             renderer = renderer->parent();
 
         // Update the target node to point to the SVG root.
-        return std::pair { renderer, renderer->protectedNode() };
+        return std::pair { renderer, protect(renderer->node()) };
     };
 
     // Compute coordinates that are based on the target.

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -366,7 +366,7 @@ static AtomString effectiveViewTransitionName(RenderLayerModelObject& renderer, 
 
             Ref element = *renderer.element();
             if (scope == &Style::Scope::forNode(element) && element->hasID())
-                return makeAtomString("-ua-id-"_s, renderer.protectedElement()->getIdAttribute());
+                return makeAtomString("-ua-id-"_s, protect(renderer.element())->getIdAttribute());
 
             if (isCrossDocument)
                 return nullAtom();

--- a/Source/WebCore/editing/RenderedPosition.cpp
+++ b/Source/WebCore/editing/RenderedPosition.cpp
@@ -208,9 +208,9 @@ Position RenderedPosition::positionAtLeftBoundaryOfBiDiRun() const
     ASSERT(atLeftBoundaryOfBidiRun());
 
     if (atLeftmostOffsetInBox())
-        return makeDeprecatedLegacyPosition(m_renderer->protectedNode().get(), m_offset);
+        return makeDeprecatedLegacyPosition(protect(m_renderer->node()).get(), m_offset);
 
-    return makeDeprecatedLegacyPosition(nextLeafOnLine()->renderer().protectedNode().get(), nextLeafOnLine()->leftmostCaretOffset());
+    return makeDeprecatedLegacyPosition(protect(nextLeafOnLine()->renderer().node()).get(), nextLeafOnLine()->leftmostCaretOffset());
 }
 
 Position RenderedPosition::positionAtRightBoundaryOfBiDiRun() const
@@ -218,9 +218,9 @@ Position RenderedPosition::positionAtRightBoundaryOfBiDiRun() const
     ASSERT(atRightBoundaryOfBidiRun());
 
     if (atRightmostOffsetInBox())
-        return makeDeprecatedLegacyPosition(m_renderer->protectedNode().get(), m_offset);
+        return makeDeprecatedLegacyPosition(protect(m_renderer->node()).get(), m_offset);
 
-    return makeDeprecatedLegacyPosition(previousLeafOnLine()->renderer().protectedNode().get(), previousLeafOnLine()->rightmostCaretOffset());
+    return makeDeprecatedLegacyPosition(protect(previousLeafOnLine()->renderer().node()).get(), previousLeafOnLine()->rightmostCaretOffset());
 }
 
 IntRect RenderedPosition::absoluteRect(CaretRectMode caretRectMode) const

--- a/Source/WebCore/editing/VisiblePosition.cpp
+++ b/Source/WebCore/editing/VisiblePosition.cpp
@@ -253,7 +253,7 @@ Position VisiblePosition::leftVisuallyDistinctCandidate() const
             break;
         }
 
-        p = makeDeprecatedLegacyPosition(renderer->protectedNode().get(), offset);
+        p = makeDeprecatedLegacyPosition(protect(renderer->node()).get(), offset);
 
         if ((p.isCandidate() && p.downstream() != downstreamStart) || p.atStartOfTree() || p.atEndOfTree())
             return p;
@@ -422,7 +422,7 @@ Position VisiblePosition::rightVisuallyDistinctCandidate() const
             break;
         }
 
-        p = makeDeprecatedLegacyPosition(renderer->protectedNode().get(), offset);
+        p = makeDeprecatedLegacyPosition(protect(renderer->node()).get(), offset);
 
         if ((p.isCandidate() && p.downstream() != downstreamStart) || p.atStartOfTree() || p.atEndOfTree())
             return p;

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1055,7 +1055,7 @@ static RefPtr<Node> highestAncestorToWrapMarkup(const Position& start, const Pos
 
     RefPtr checkAncestor = specialCommonAncestor ? specialCommonAncestor : RefPtr { &commonAncestor };
     if (checkAncestor->renderer() && checkAncestor->renderer()->containingBlock()) {
-        RefPtr newSpecialCommonAncestor = highestEnclosingNodeOfType(firstPositionInNode(checkAncestor.get()), &isElementPresentational, CanCrossEditingBoundary, checkAncestor->renderer()->containingBlock()->protectedElement().get());
+        RefPtr newSpecialCommonAncestor = highestEnclosingNodeOfType(firstPositionInNode(checkAncestor.get()), &isElementPresentational, CanCrossEditingBoundary, protect(checkAncestor->renderer()->containingBlock()->element()).get());
         if (newSpecialCommonAncestor)
             specialCommonAncestor = WTF::move(newSpecialCommonAncestor);
     }

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -111,7 +111,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderSliderContainer);
 RenderBox::LogicalExtentComputedValues RenderSliderContainer::computeLogicalHeight(LayoutUnit logicalHeight, LayoutUnit logicalTop) const
 {
     ASSERT(element()->shadowHost());
-    Ref input = downcast<HTMLInputElement>(*protectedElement()->shadowHost());
+    Ref input = downcast<HTMLInputElement>(*protect(element())->shadowHost());
     bool isVertical = hasVerticalAppearance(input);
 
     if (input->renderer()->isRenderSlider() && !isVertical && input->hasDataList()) {
@@ -137,7 +137,7 @@ RenderBox::LogicalExtentComputedValues RenderSliderContainer::computeLogicalHeig
 void RenderSliderContainer::layout()
 {
     ASSERT(element()->shadowHost());
-    Ref input = downcast<HTMLInputElement>(*protectedElement()->shadowHost());
+    Ref input = downcast<HTMLInputElement>(*protect(element())->shadowHost());
     bool isVertical = hasVerticalAppearance(input);
     CheckedRef mutableStyle = this->mutableStyle();
     mutableStyle->setFlexDirection(isVertical && writingMode().isHorizontal() ? FlexDirection::Column : FlexDirection::Row);

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -182,7 +182,7 @@ static bool gridItemHasValidWidth(const Style::PreferredSize& width)
 
 static bool canComputeAutomaticInlineSize(const RenderBox& gridItem, const StyleSelfAlignmentData& usedJustifySelf)
 {
-    return usedJustifySelf.position() == ItemPosition::Normal && !gridItem.protectedElement()->isReplaced() && !gridItem.style().hasAspectRatio();
+    return usedJustifySelf.position() == ItemPosition::Normal && !protect(gridItem.element())->isReplaced() && !gridItem.style().hasAspectRatio();
 }
 
 static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& renderGrid, ReasonCollectionMode reasonCollectionMode)

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -1353,7 +1353,7 @@ bool LineLayout::hitTest(const HitTestRequest& request, HitTestResult& result, c
             continue;
         
         renderer.updateHitTestResult(result, flow().flipForWritingMode(locationInContainer.point() - toLayoutSize(accumulatedOffset)));
-        if (result.addNodeToListBasedTestResult(renderer.protectedNodeForHitTest().get(), request, locationInContainer, boxRect) == HitTestProgress::Stop)
+        if (result.addNodeToListBasedTestResult(protect(renderer.nodeForHitTest()).get(), request, locationInContainer, boxRect) == HitTestProgress::Stop)
             return true;
     }
 

--- a/Source/WebCore/page/AutoscrollController.cpp
+++ b/Source/WebCore/page/AutoscrollController.cpp
@@ -134,7 +134,7 @@ void AutoscrollController::updateAutoscrollRenderer()
 
 #if ENABLE(PAN_SCROLLING)
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent };
-    HitTestResult hitTest = m_autoscrollRenderer->protectedFrame()->eventHandler().hitTestResultAtPoint(m_panScrollStartPos, hitType);
+    HitTestResult hitTest = protect(m_autoscrollRenderer->frame())->eventHandler().hitTestResultAtPoint(m_panScrollStartPos, hitType);
 
     if (auto* nodeAtPoint = hitTest.innerNode())
         renderer = nodeAtPoint->renderer();
@@ -236,7 +236,7 @@ void AutoscrollController::startPanScrolling(RenderBox& scrollable, const IntPoi
     if (RefPtr view = scrollable.frame().view())
         view->addPanScrollIcon(lastKnownMousePosition);
 
-    scrollable.protectedFrame()->eventHandler().didPanScrollStart();
+    protect(scrollable.frame())->eventHandler().didPanScrollStart();
     startAutoscrollTimer();
 }
 #else

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -267,7 +267,7 @@ DragEventTargetData DragController::performDragOperation(DragData&& dragData, Lo
     if (RefPtr document = m_documentUnderMouse)
         shouldOpenExternalURLsPolicy = document->shouldOpenExternalURLsPolicyToPropagate();
 
-    if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(EventHandler::subframeForTargetNode(hitTestResult.protectedTargetNode().get())))
+    if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(EventHandler::subframeForTargetNode(protect(hitTestResult.targetNode()).get())))
         return { remoteFrame->frameID() };
 
     if (m_dragDestinationActionMask.contains(DragDestinationAction::DHTML) && dragIsHandledByDocument(m_dragHandlingMethod) && frame.view()) {

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -1419,7 +1419,7 @@ HitTestResult EventHandler::hitTestResultAtPoint(const LayoutPoint& point, Optio
     HitTestRequest request(hitType);
     document->hitTest(request, result);
     if (!request.readOnly())
-        protect(frame->document())->updateHoverActiveState(request, result.protectedTargetElement().get());
+        protect(frame->document())->updateHoverActiveState(request, protect(result.targetElement()).get());
 
     RefPtr innerNode = result.innerNode();
     if (request.disallowsUserAgentShadowContent()
@@ -2885,7 +2885,7 @@ DragEventTargetData EventHandler::performDragAndDrop(const PlatformMouseEvent& e
     });
 
     Ref frame = m_frame.get();
-    RefPtr subframe = EventHandler::subframeForTargetNode(result.protectedTargetNode().get());
+    RefPtr subframe = EventHandler::subframeForTargetNode(protect(result.targetNode()).get());
     bool preventedDefault = false;
 #if PLATFORM(COCOA) && ENABLE(DRAG_SUPPORT)
     if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(subframe)) {
@@ -3576,7 +3576,7 @@ HandleUserInputEventResult EventHandler::handleWheelEventInternal(const Platform
 
     if (element) {
         if (isOverWidget) {
-            if (RefPtr remoteSubframe = dynamicDowncast<RemoteFrame>(subframeForTargetNode(result.protectedTargetNode().get()))) {
+            if (RefPtr remoteSubframe = dynamicDowncast<RemoteFrame>(subframeForTargetNode(protect(result.targetNode()).get()))) {
                 if (auto wheelEventDataForRemoteFrame = userInputEventDataForRemoteFrame(remoteSubframe.get(), result.doublePointInInnerNodeFrame()))
                     return *wheelEventDataForRemoteFrame;
             } else if (RefPtr widget = widgetForElement(*element)) {
@@ -4701,7 +4701,7 @@ bool EventHandler::handleDrag(const MouseEventWithHitTestResults& event, CheckDr
         HitTestResult result(m_mouseDownContentsPosition);
         protect(frame->document())->hitTest(OptionSet<HitTestRequest::Type> { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::DisallowUserAgentShadowContent }, result);
         if (RefPtr page = frame->page())
-            setDragStateSource(page->dragController().draggableElement(frame.ptr(), result.protectedTargetElement().get(), m_mouseDownContentsPosition, dragState()).get());
+            setDragStateSource(page->dragController().draggableElement(frame.ptr(), protect(result.targetElement()).get(), m_mouseDownContentsPosition, dragState()).get());
 
         if (!draggedElement())
             m_mouseDownMayStartDrag = false; // no element is draggable

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4560,21 +4560,21 @@ void LocalFrameView::scrollToPendingTextFragmentRange()
 
         static constexpr OptionSet hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowVisibleChildFrameContentOnly };
         auto result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects.first().center()), hitType);
-        if (!intersects(range, *result.protectedTargetNode()))
+        if (!intersects(range, *protect(result.targetNode())))
             return;
 
         if (textRects.size() >= 2) {
             result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects[1].center()), hitType);
-            if (!intersects(range, *result.protectedTargetNode()))
+            if (!intersects(range, *protect(result.targetNode())))
                 return;
         }
 
         if (textRects.size() >= 4) {
             result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects.last().center()), hitType);
-            if (!intersects(range, *result.protectedTargetNode()))
+            if (!intersects(range, *protect(result.targetNode())))
                 return;
             result = localMainFrame->eventHandler().hitTestResultAtPoint(LayoutPoint(textRects[textRects.size() - 2].center()), hitType);
-            if (!intersects(range, *result.protectedTargetNode()))
+            if (!intersects(range, *protect(result.targetNode())))
                 return;
         }
         if (m_haveCreatedTextIndicator)

--- a/Source/WebCore/page/MouseEventWithHitTestResults.h
+++ b/Source/WebCore/page/MouseEventWithHitTestResults.h
@@ -38,7 +38,7 @@ public:
     bool isOverLink() const;
     bool isOverWidget() const { return m_hitTestResult.isOverWidget(); }
     Node* targetNode() const { return m_hitTestResult.targetNode(); }
-    RefPtr<Node> protectedTargetNode() const  { return m_hitTestResult.protectedTargetNode(); }
+    RefPtr<Node> protectedTargetNode() const { return m_hitTestResult.targetNode(); }
 
 private:
     PlatformMouseEvent m_event;

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -208,12 +208,12 @@ bool EventHandler::passWidgetMouseDownEventToWidget(const MouseEventWithHitTestR
     // just pass currentEvent down to the widget, we don't want to call it for events that
     // don't correspond to Cocoa events. The mousedown/ups will have already been passed on as
     // part of the pressed/released handling.
-    return passMouseDownEventToWidget(target->protectedWidget().get());
+    return passMouseDownEventToWidget(protect(target->widget()).get());
 }
 
 bool EventHandler::passWidgetMouseDownEventToWidget(RenderWidget* renderWidget)
 {
-    return passMouseDownEventToWidget(renderWidget->protectedWidget().get());
+    return passMouseDownEventToWidget(protect(renderWidget->widget()).get());
 }
 
 static bool lastEventIsMouseUp()

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1221,7 +1221,7 @@ static void extractRenderedTokens(Vector<TokenAndBlockOffset>& tokensAndOffsets,
     };
 
     if (CheckedPtr frameRenderer = dynamicDowncast<RenderIFrame>(*renderer)) {
-        if (RefPtr contentDocument = frameRenderer->protectedIframeElement()->contentDocument())
+        if (RefPtr contentDocument = protect(frameRenderer->iframeElement())->contentDocument())
             extractRenderedTokens(tokensAndOffsets, *contentDocument, direction);
         return;
     }
@@ -1264,7 +1264,7 @@ static void extractRenderedTokens(Vector<TokenAndBlockOffset>& tokensAndOffsets,
         }
 
         if (CheckedPtr frameRenderer = dynamicDowncast<RenderIFrame>(descendant)) {
-            if (RefPtr contentDocument = frameRenderer->protectedIframeElement()->contentDocument())
+            if (RefPtr contentDocument = protect(frameRenderer->iframeElement())->contentDocument())
                 extractRenderedTokens(tokensAndOffsets, *contentDocument, direction);
             continue;
         }

--- a/Source/WebCore/rendering/CSSFilterRenderer.cpp
+++ b/Source/WebCore/rendering/CSSFilterRenderer.cpp
@@ -88,7 +88,7 @@ CSSFilterRenderer::CSSFilterRenderer(Vector<Ref<FilterFunction>>&& functions, co
 
 static RefPtr<SVGFilterElement> referenceFilterElement(const Style::FilterReference& filterReference, RenderElement& renderer)
 {
-    RefPtr filterElement = ReferencedSVGResources::referencedFilterElement(renderer.protectedTreeScopeForSVGReferences(), filterReference);
+    RefPtr filterElement = ReferencedSVGResources::referencedFilterElement(protect(renderer.treeScopeForSVGReferences()), filterReference);
 
     if (!filterElement) {
         LOG_WITH_STREAM(Filters, stream << " buildReferenceFilter: failed to find filter renderer, adding pending resource " << filterReference.url);

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -901,11 +901,6 @@ Vector<String> HitTestResult::dictationAlternatives() const
     return frame->editor().dictationAlternativesForMarker(*marker);
 }
 
-RefPtr<Node> HitTestResult::protectedTargetNode() const
-{
-    return innerNode();
-}
-
 Element* HitTestResult::targetElement() const
 {
     for (RefPtr node = m_innerNode.get(); node; node = node->parentInComposedTree()) {
@@ -913,11 +908,6 @@ Element* HitTestResult::targetElement() const
             return element;
     }
     return nullptr;
-}
-
-RefPtr<Element> HitTestResult::protectedTargetElement() const
-{
-    return targetElement();
 }
 
 Element* HitTestResult::innerNonSharedElement() const
@@ -970,16 +960,6 @@ void HitTestResult::toggleEnhancedFullscreenForVideo() const
     else
         videoElement->webkitSetPresentationMode(HTMLVideoElement::VideoPresentationMode::PictureInPicture);
 #endif
-}
-
-RefPtr<Node> HitTestResult::protectedInnerNonSharedNode() const
-{
-    return innerNonSharedNode();
-}
-
-RefPtr<Element> HitTestResult::protectedURLElement() const
-{
-    return URLElement();
 }
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -65,13 +65,11 @@ public:
 
     void setInnerNonSharedNode(Node*);
     Node* innerNonSharedNode() const { return m_innerNonSharedNode.get(); }
-    WEBCORE_EXPORT RefPtr<Node> protectedInnerNonSharedNode() const;
 
     WEBCORE_EXPORT Element* innerNonSharedElement() const;
 
     void setURLElement(Element*);
     Element* URLElement() const { return m_innerURLElement.get(); }
-    WEBCORE_EXPORT RefPtr<Element> protectedURLElement() const;
 
     void setScrollbar(RefPtr<Scrollbar>&&);
     Scrollbar* scrollbar() const { return m_scrollbar.get(); }
@@ -172,9 +170,7 @@ public:
     Vector<String> dictationAlternatives() const;
 
     Node* targetNode() const { return innerNode(); }
-    WEBCORE_EXPORT RefPtr<Node> protectedTargetNode() const;
     WEBCORE_EXPORT Element* targetElement() const;
-    RefPtr<Element> protectedTargetElement() const;
 
 private:
     NodeSet& mutableListBasedTestResult(); // See above.

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -1096,7 +1096,7 @@ void RenderBlock::paintCaret(PaintInfo& paintInfo, const LayoutPoint& paintOffse
 
         bool isContentEditable = page().dragCaretController().isContentEditable();
         if (shouldPaintCaret(caretPainter, isContentEditable))
-            page().dragCaretController().paintDragCaret(protectedFrame().ptr(), paintInfo.context(), paintOffset);
+            page().dragCaretController().paintDragCaret(protect(frame()).ptr(), paintInfo.context(), paintOffset);
 
         break;
     }
@@ -1165,7 +1165,7 @@ void RenderBlock::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOffs
         if (paintInfo.paintBehavior.contains(PaintBehavior::EventRegionIncludeBackground) && visibleToHitTesting()) {
             auto borderShape = BorderShape::shapeForBorderRect(style(), borderRect);
             LOG_WITH_STREAM(EventRegions, stream << "RenderBlock " << *this << " uniting region " << borderShape.deprecatedRoundedRect() << " event listener types " << style().eventListenerRegionTypes());
-            bool overrideUserModifyIsEditable = isRenderTextControl() && downcast<RenderTextControl>(*this).protectedTextFormControlElement()->isInnerTextElementEditable();
+            bool overrideUserModifyIsEditable = isRenderTextControl() && protect(downcast<RenderTextControl>(*this).textFormControlElement())->isInnerTextElementEditable();
             paintInfo.eventRegionContext()->unite(borderShape.deprecatedPixelSnappedRoundedRect(document->deviceScaleFactor()), *this, style(), overrideUserModifyIsEditable);
         }
 
@@ -1323,7 +1323,7 @@ bool RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType(con
         || isBlockBoxWithPotentiallyScrollableOverflow()
         || style.usedContain().contains(Style::ContainValue::Layout)
         || style.containerType() != ContainerType::Normal
-        || WebCore::shouldApplyPaintContainment(style, *protectedElement())
+        || WebCore::shouldApplyPaintContainment(style, *protect(element()))
         || (style.isDisplayBlockLevel() && !style.blockStepSize().isNone());
 }
 
@@ -2059,7 +2059,7 @@ bool RenderBlock::nodeAtPoint(const HitTestRequest& request, HitTestResult& resu
         && visibleToHitTesting(request) && isPointInOverflowControl(result, locationInContainer.point(), adjustedLocation)) {
         updateHitTestResult(result, locationInContainer.point() - localOffset);
         // FIXME: isPointInOverflowControl() doesn't handle rect-based tests yet.
-        if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer) == HitTestProgress::Stop)
+        if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer) == HitTestProgress::Stop)
            return true;
     }
 
@@ -2086,7 +2086,7 @@ bool RenderBlock::nodeAtPoint(const HitTestRequest& request, HitTestResult& resu
         LayoutRect boundsRect(adjustedLocation, size());
         if (visibleToHitTesting(request) && locationInContainer.intersects(boundsRect)) {
             updateHitTestResult(result, flipForWritingMode(locationInContainer.point() - localOffset));
-            if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
+            if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
                 return true;
         }
     }
@@ -2120,7 +2120,7 @@ static inline bool isEditingBoundary(RenderElement* ancestor, RenderBox& child)
     ASSERT(!ancestor || ancestor->nonPseudoElement());
     ASSERT(child.nonPseudoElement());
     return !ancestor || !ancestor->parent() || (ancestor->hasLayer() && ancestor->parent()->isRenderView())
-        || ancestor->protectedNonPseudoElement()->hasEditableStyle() == child.protectedNonPseudoElement()->hasEditableStyle();
+        || protect(ancestor->nonPseudoElement())->hasEditableStyle() == protect(child.nonPseudoElement())->hasEditableStyle();
 }
 
 // FIXME: This function should go on RenderObject as an instance method. Then

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -255,6 +255,7 @@ public:
 
     void boundingRects(Vector<LayoutRect>&, const LayoutPoint& accumulatedOffset) const override;
     void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const override;
+    Node* nodeForHitTest() const override;
 
     PaintInfo paintInfoForBlockChildren(const PaintInfo&) const;
 
@@ -349,8 +350,6 @@ private:
     void paintSelection(PaintInfo&, const LayoutPoint&);
     void paintCaret(PaintInfo&, const LayoutPoint&, CaretType);
     void paintCarets(PaintInfo&, const LayoutPoint&);
-
-    Node* nodeForHitTest() const override;
 
     virtual bool hitTestContents(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction);
     // FIXME-BLOCKFLOW: Remove virtualization when all callers have moved to RenderBlockFlow

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -3758,7 +3758,7 @@ PositionWithAffinity RenderBlockFlow::positionForPointWithInlineChildren(const L
         }
     }
 
-    bool moveCaretToBoundary = protect(protectedFrame()->editor())->behavior().shouldMoveCaretToHorizontalBoundaryWhenPastTopOrBottom();
+    bool moveCaretToBoundary = protect(protect(frame())->editor())->behavior().shouldMoveCaretToHorizontalBoundaryWhenPastTopOrBottom();
 
     if (!moveCaretToBoundary && !closestBox && lastLineBoxWithChildren) {
         // y coordinate is below last root line box, pretend we hit it
@@ -3922,7 +3922,7 @@ void RenderBlockFlow::invalidateLineLayout(InvalidationReason invalidationReason
     switch (invalidationReason) {
     case InvalidationReason::InternalMove:
         if (AXObjectCache* cache = protect(document())->existingAXObjectCache())
-            cache->deferRecomputeIsIgnored(protectedElement().get());
+            cache->deferRecomputeIsIgnored(protect(element()).get());
         break;
     case InvalidationReason::ContentChange: {
         // Since we eagerly remove the display content here, repaints issued between this invalidation (triggered by style change/content mutation) and the subsequent layout would produce empty rects.
@@ -4445,7 +4445,7 @@ void RenderBlockFlow::adjustComputedFontSizes(float size, float visibleWidth)
             float candidateNewSize = roundf(std::min(minFontSize, specifiedSize * lineTextMultiplier));
 
             if (candidateNewSize > specifiedSize && candidateNewSize != fontDescription.computedSize() && text.textNode() && oldStyle.textSizeAdjust().isAuto())
-                protect(document())->textAutoSizing().addTextNode(*text.protectedTextNode(), candidateNewSize);
+                protect(document())->textAutoSizing().addTextNode(*protect(text.textNode()), candidateNewSize);
         }
 
         descendant = RenderObjectTraversal::nextSkippingChildren(text, this);

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -1665,7 +1665,7 @@ bool RenderBox::nodeAtPoint(const HitTestRequest& request, HitTestResult& result
             return false;
 
         updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
-        if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
+        if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
             return true;
     }
 
@@ -2109,7 +2109,7 @@ void RenderBox::imageChanged(WrappedImagePtr image, const IntRect*)
     if (styleImage && isNonEmpty) {
         incrementVisuallyNonEmptyPixelCountIfNeeded(flooredIntSize(styleImage->imageSize(this, style().usedZoom())));
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(styleable->protectedElement().get(), styleImage->cachedImage());
+            protect(document())->didLoadImage(protect(styleable->element).get(), styleImage->cachedImage());
     }
 
     if (!isComposited())

--- a/Source/WebCore/rendering/RenderBoxInlines.h
+++ b/Source/WebCore/rendering/RenderBoxInlines.h
@@ -244,7 +244,7 @@ inline LayoutUnit resolveHeightForRatio(LayoutUnit borderAndPaddingLogicalWidth,
 
 inline bool isSkippedContentRoot(const RenderBox& renderBox)
 {
-    return renderBox.element() && WebCore::isSkippedContentRoot(renderBox.style(), *renderBox.protectedElement());
+    return renderBox.element() && WebCore::isSkippedContentRoot(renderBox.style(), *protect(renderBox.element()));
 }
 
 inline bool RenderBox::backgroundIsKnownToBeObscured(const LayoutPoint& paintOffset)

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -567,7 +567,7 @@ bool RenderElement::repaintBeforeStyleChange(Style::Difference diff, const Rende
 
 void RenderElement::initializeStyle()
 {
-    Style::loadPendingResources(m_style, protect(document()), protectedElement().get());
+    Style::loadPendingResources(m_style, protect(document()), protect(element()).get());
 
     styleWillChange(Style::DifferenceResult::NewStyle, style());
     m_hasInitializedStyle = true;
@@ -615,7 +615,7 @@ void RenderElement::setStyle(RenderStyle&& style, Style::DifferenceResult minima
     diff.result = std::max(diff.result, minimalStyleDifference);
     diff = adjustStyleDifference(diff);
 
-    Style::loadPendingResources(style, protect(document()), protectedElement().get());
+    Style::loadPendingResources(style, protect(document()), protect(element()).get());
 
     auto didRepaint = repaintBeforeStyleChange(diff, m_style, style);
     styleWillChange(diff, style);
@@ -823,9 +823,9 @@ void RenderElement::moveLayers(RenderLayer& newParent)
 
 RenderLayer* RenderElement::layerParent() const
 {
-    ASSERT_IMPLIES(isInTopLayerOrBackdrop(style(), protectedElement().get()), hasLayer());
+    ASSERT_IMPLIES(isInTopLayerOrBackdrop(style(), protect(element()).get()), hasLayer());
 
-    if (hasLayer() && isInTopLayerOrBackdrop(style(), protectedElement().get()))
+    if (hasLayer() && isInTopLayerOrBackdrop(style(), protect(element()).get()))
         return view().layer();
 
     return parent()->enclosingLayer();
@@ -919,13 +919,13 @@ void RenderElement::styleWillChange(Style::Difference diff, const RenderStyle& n
         bool contentVisibilityChanged = oldStyle && oldStyle->contentVisibility() != newStyle.contentVisibility();
         if (contentVisibilityChanged) {
             if (oldStyle->contentVisibility() == ContentVisibility::Auto)
-                ContentVisibilityDocumentState::unobserve(*protectedElement());
+                ContentVisibilityDocumentState::unobserve(*protect(element()));
             auto wasSkippedContent = oldStyle->contentVisibility() == ContentVisibility::Hidden ? IsSkippedContent::Yes : IsSkippedContent::No;
             auto isSkippedContent = newStyle.contentVisibility() == ContentVisibility::Hidden ? IsSkippedContent::Yes : IsSkippedContent::No;
             ContentVisibilityDocumentState::updateAnimations(*element(), wasSkippedContent, isSkippedContent);
         }
         if ((contentVisibilityChanged || !oldStyle) && newStyle.contentVisibility() == ContentVisibility::Auto)
-            ContentVisibilityDocumentState::observe(*protectedElement());
+            ContentVisibilityDocumentState::observe(*protect(element()));
     };
 
     if (oldStyle) {
@@ -1119,7 +1119,7 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
 
 #if !PLATFORM(IOS_FAMILY)
     if (oldStyle && oldStyle->cursor() != style().cursor())
-        protectedFrame()->eventHandler().scheduleCursorUpdate();
+        protect(frame())->eventHandler().scheduleCursorUpdate();
 #endif
 
     bool hadOutlineAuto = oldStyle && oldStyle->outlineStyle() == OutlineStyle::Auto;
@@ -1239,7 +1239,7 @@ void RenderElement::willBeDestroyed()
         checkedView()->removeRendererWithPausedImageAnimations(*this);
 
     if (style().contentVisibility() == ContentVisibility::Auto && element())
-        ContentVisibilityDocumentState::unobserve(*protectedElement());
+        ContentVisibilityDocumentState::unobserve(*protect(element()));
 }
 
 void RenderElement::setNeedsOutOfFlowMovementLayout(const RenderStyle* oldStyle)
@@ -1714,7 +1714,7 @@ VisibleInViewportState RenderElement::imageFrameAvailable(CachedImage& image, Im
         imageChanged(&image, changeRect);
 
     if (element() && image.image()->isBitmapImage())
-        protectedElement()->dispatchWebKitImageReadyEventForTesting();
+        protect(element())->dispatchWebKitImageReadyEventForTesting();
 
     return isVisible ? VisibleInViewportState::Yes : VisibleInViewportState::No;
 }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -97,9 +97,7 @@ public:
 
     // This is null for anonymous renderers.
     inline Element* element() const; // Defined in RenderElementInlines.h
-    inline RefPtr<Element> protectedElement() const; // Defined in RenderElementInlines.h
     inline Element* nonPseudoElement() const; // Defined in RenderElementInlines.h
-    inline RefPtr<Element> protectedNonPseudoElement() const; // Defined in RenderElementInlines.h
     inline Element* generatingElement() const; // Defined in RenderElementInlines.h
 
     RenderObject* firstChild() const { return m_firstChild.get(); }

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -32,9 +32,7 @@ namespace WebCore {
 inline Overflow RenderElement::effectiveOverflowBlockDirection() const { return writingMode().isHorizontal() ? effectiveOverflowY() : effectiveOverflowX(); }
 inline Overflow RenderElement::effectiveOverflowInlineDirection() const { return writingMode().isHorizontal() ? effectiveOverflowX() : effectiveOverflowY(); }
 inline Element* RenderElement::element() const { return downcast<Element>(RenderObject::node()); }
-inline RefPtr<Element> RenderElement::protectedElement() const { return element(); }
 inline Element* RenderElement::nonPseudoElement() const { return downcast<Element>(RenderObject::nonPseudoNode()); }
-inline RefPtr<Element> RenderElement::protectedNonPseudoElement() const { return nonPseudoElement(); }
 
 inline bool RenderElement::isFixedPositioned() const
 {

--- a/Source/WebCore/rendering/RenderIFrame.cpp
+++ b/Source/WebCore/rendering/RenderIFrame.cpp
@@ -58,11 +58,6 @@ HTMLIFrameElement& RenderIFrame::iframeElement() const
     return downcast<HTMLIFrameElement>(RenderFrameBase::frameOwnerElement());
 }
 
-Ref<HTMLIFrameElement> RenderIFrame::protectedIframeElement() const
-{
-    return iframeElement();
-}
-
 bool RenderIFrame::requiresLayer() const
 {
     return RenderFrameBase::requiresLayer() || style().resize() != Style::Resize::None;

--- a/Source/WebCore/rendering/RenderIFrame.h
+++ b/Source/WebCore/rendering/RenderIFrame.h
@@ -39,7 +39,6 @@ public:
     virtual ~RenderIFrame();
 
     HTMLIFrameElement& iframeElement() const;
-    Ref<HTMLIFrameElement> protectedIframeElement() const;
 
 private:
     void frameOwnerElement() const = delete;

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -343,7 +343,7 @@ void RenderImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
 
     if (auto* image = cachedImage(); image && image->currentFrameIsComplete(this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(styleable->protectedElement().get(), image);
+            protect(document())->didLoadImage(protect(styleable->element).get(), image);
     }
 }
 

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -65,7 +65,7 @@ void RenderImageResource::setCachedImage(CachedResourceHandle<CachedImage>&& new
         return;
 
     if (m_cachedImage && m_renderer && m_cachedImageRemoveClientIsNeeded)
-        m_cachedImage->removeClient(m_renderer->protectedCachedImageClient());
+        m_cachedImage->removeClient(protect(m_renderer->cachedImageClient()));
     if (!m_renderer) {
         // removeClient may have destroyed the renderer.
         return;
@@ -75,7 +75,7 @@ void RenderImageResource::setCachedImage(CachedResourceHandle<CachedImage>&& new
     if (!m_cachedImage)
         return;
 
-    m_cachedImage->addClient(renderer()->protectedCachedImageClient());
+    m_cachedImage->addClient(protect(renderer()->cachedImageClient()));
     if (m_cachedImage->errorOccurred())
         renderer()->imageChanged(m_cachedImage.get());
 }
@@ -112,7 +112,7 @@ void RenderImageResource::setContainerContext(const IntSize& imageContainerSize,
 {
     if (!m_cachedImage || !m_renderer)
         return;
-    m_cachedImage->setContainerContextForClient(m_renderer->protectedCachedImageClient(), imageContainerSize, m_renderer->style().usedZoom(), imageURL);
+    m_cachedImage->setContainerContextForClient(protect(m_renderer->cachedImageClient()), imageContainerSize, m_renderer->style().usedZoom(), imageURL);
 }
 
 LayoutSize RenderImageResource::imageSize(float multiplier, CachedImage::SizeType type) const

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -881,7 +881,7 @@ void RenderInline::imageChanged(WrappedImagePtr image, const IntRect*)
     RefPtr styleImage = Style::findLayerUsedImage(style().backgroundLayers(), image, isNonEmpty);
     if (styleImage && isNonEmpty) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(styleable->protectedElement().get(), styleImage->cachedImage());
+            protect(document())->didLoadImage(protect(styleable->element).get(), styleImage->cachedImage());
     }
 
     // FIXME: We can do better.

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -187,7 +187,6 @@ public:
     String name() const;
 
     inline Page& page() const; // Defined in RenderLayerInlines.h
-    inline Ref<Page> protectedPage() const; // Defined in RenderLayerInlines.h
     RenderLayerModelObject& renderer() const { return m_renderer; }
     RenderBox* renderBox() const { return dynamicDowncast<RenderBox>(renderer()); }
 

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -532,7 +532,6 @@ private:
     FloatRect visibleRectForLayerFlushing() const;
     
     Page& page() const;
-    Ref<Page> protectedPage() const;
 
     GraphicsLayerFactory* graphicsLayerFactory() const;
     ScrollingCoordinator* scrollingCoordinator() const;

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -40,7 +40,6 @@ inline bool RenderLayer::overlapBoundsIncludeChildren() const { return hasFilter
 inline bool RenderLayer::preserves3D() const { return renderer().style().preserves3D(); }
 inline int RenderLayer::zIndex() const { return renderer().style().usedZIndex().tryValue().value_or(0).value; }
 inline Page& RenderLayer::page() const { return renderer().page(); }
-inline Ref<Page> RenderLayer::protectedPage() const { return renderer().page(); }
 
 #if HAVE(CORE_MATERIAL)
 inline bool RenderLayer::hasAppleVisualEffect() const { return renderer().hasAppleVisualEffect(); }

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -390,7 +390,7 @@ void RenderLayerScrollableArea::scrollTo(const ScrollPosition& position)
 
         // Update regions, scrolling may change the clip of a particular region.
         protect(renderer.document())->invalidateRenderingDependentRegions();
-        DebugPageOverlays::didLayout(renderer.protectedFrame());
+        DebugPageOverlays::didLayout(protect(renderer.frame()));
     }
 
     Ref frame = renderer.frame();
@@ -1972,7 +1972,7 @@ LayoutRect RenderLayerScrollableArea::scrollRectToVisible(const LayoutRect& abso
 
     auto revealRect = getRectToExposeForScrollIntoView(layerBounds, localExposeRect, options.alignX, options.alignY, localVisiblityRect);
     auto scrollPositionOptions = ScrollPositionChangeOptions::createProgrammatic();
-    if (!box->frame().eventHandler().autoscrollInProgress() && box->element() && useSmoothScrolling(options.behavior, box->protectedElement().get()))
+    if (!box->frame().eventHandler().autoscrollInProgress() && box->element() && useSmoothScrolling(options.behavior, protect(box->element()).get()))
         scrollPositionOptions.animated = ScrollIsAnimated::Yes;
     if (auto result = updateScrollPositionForScrollIntoView(scrollPositionOptions, revealRect, localExposeRect))
         return result.value();

--- a/Source/WebCore/rendering/RenderMeter.cpp
+++ b/Source/WebCore/rendering/RenderMeter.cpp
@@ -49,8 +49,8 @@ HTMLMeterElement* RenderMeter::meterElement() const
     if (auto* meterElement = dynamicDowncast<HTMLMeterElement>(*element()))
         return meterElement;
 
-    ASSERT(protectedElement()->shadowHost());
-    return downcast<HTMLMeterElement>(protectedElement()->shadowHost());
+    ASSERT(protect(element())->shadowHost());
+    return downcast<HTMLMeterElement>(protect(element())->shadowHost());
 }
 
 void RenderMeter::updateLogicalWidth()

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -824,7 +824,7 @@ void RenderObject::collectSelectionGeometries(Vector<SelectionGeometry>& geometr
     }
 
     for (auto& quad : quads)
-        geometries.append(SelectionGeometry(quad, HTMLElement::selectionRenderingBehavior(protectedNode().get()), isHorizontalWritingMode(), checkedView()->pageNumberForBlockProgressionOffset(quad.enclosingBoundingBox().x())));
+        geometries.append(SelectionGeometry(quad, HTMLElement::selectionRenderingBehavior(protect(node()).get()), isHorizontalWritingMode(), checkedView()->pageNumberForBlockProgressionOffset(quad.enclosingBoundingBox().x())));
 }
 
 IntRect RenderObject::absoluteBoundingBoxRect(bool useTransforms, bool* wasFixed) const
@@ -1877,11 +1877,6 @@ Node* RenderObject::nodeForHitTest() const
             node = renderer->element();
     }
     return node;
-}
-
-RefPtr<Node> RenderObject::protectedNodeForHitTest() const
-{
-    return nodeForHitTest();
 }
 
 void RenderObject::updateHitTestResult(HitTestResult& result, const LayoutPoint& point) const

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -741,18 +741,13 @@ public:
     bool isRooted() const;
 
     inline Node* node() const; // Defined in RenderObjectNode.h
-    inline RefPtr<Node> protectedNode() const; // Defined in RenderObjectNode.h
 
     inline Node* nonPseudoNode() const; // Defined in RenderObjectNode.h
 
     inline Document& document() const; // Defined in RenderObjectDocument.h
-    inline Ref<Document> protectedDocument() const; // Defined in RenderObjectDocument.h
     inline TreeScope& treeScopeForSVGReferences() const; // Defined in RenderObjectInlines.h
-    inline Ref<TreeScope> protectedTreeScopeForSVGReferences() const; // Defined in RenderObjectInlines.h
     inline LocalFrame& frame() const; // Defined in RenderObjectInlines.h
-    inline Ref<LocalFrame> protectedFrame() const; // Defined in RenderObjectInlines.h
     inline Page& page() const; // Defined in RenderObjectInlines.h
-    inline Ref<Page> protectedPage() const; // Defined in RenderObjectInlines.h
     inline Settings& settings() const; // Defined in RenderObjectInlines.h
 
     // Returns the object containing this one. Can be different from parent for positioned elements.
@@ -798,7 +793,6 @@ public:
 
     bool hitTest(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestFilter = HitTestAll);
     virtual Node* nodeForHitTest() const;
-    RefPtr<Node> protectedNodeForHitTest() const;
     virtual void updateHitTestResult(HitTestResult&, const LayoutPoint&) const;
 
     virtual bool nodeAtPoint(const HitTestRequest&, HitTestResult&, const HitTestLocation& locationInContainer, const LayoutPoint& accumulatedOffset, HitTestAction);
@@ -1073,7 +1067,6 @@ public:
     virtual void imageContentChanged(CachedImage&) { }
     virtual void scheduleRenderingUpdateForImage(CachedImage&) { }
     CachedImageClient& cachedImageClient() const;
-    Ref<CachedImageClient> protectedCachedImageClient() const { return cachedImageClient(); }
 
     // Map points and quads through elements, potentially via 3d transforms. You should never need to call these directly; use
     // localToAbsolute/absoluteToLocal methods instead.

--- a/Source/WebCore/rendering/RenderObjectDocument.h
+++ b/Source/WebCore/rendering/RenderObjectDocument.h
@@ -34,7 +34,6 @@
 namespace WebCore {
 
 inline Document& RenderObject::document() const { return m_node.get().document(); }
-inline Ref<Document> RenderObject::protectedDocument() const { return document(); }
 
 inline bool RenderObject::isDocumentElementRenderer() const
 {

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -49,19 +49,9 @@ inline const RenderStyle& RenderObject::firstLineStyle() const
     return downcast<RenderElement>(*this).firstLineStyle();
 }
 
-inline Ref<TreeScope> RenderObject::protectedTreeScopeForSVGReferences() const
-{
-    return treeScopeForSVGReferences();
-}
-
 inline LocalFrame& RenderObject::frame() const
 {
     return *document().frame();
-}
-
-inline Ref<LocalFrame> RenderObject::protectedFrame() const
-{
-    return frame();
 }
 
 inline Page& RenderObject::page() const
@@ -70,11 +60,6 @@ inline Page& RenderObject::page() const
     // so it's safe to assume Frame::page() is non-null as long as there are live RenderObjects.
     ASSERT(frame().page());
     return *frame().page();
-}
-
-inline Ref<Page> RenderObject::protectedPage() const
-{
-    return page();
 }
 
 inline Settings& RenderObject::settings() const

--- a/Source/WebCore/rendering/RenderObjectNode.h
+++ b/Source/WebCore/rendering/RenderObjectNode.h
@@ -51,11 +51,6 @@ inline Node* RenderObject::node() const
     return m_node.ptr();
 }
 
-inline RefPtr<Node> RenderObject::protectedNode() const
-{
-    return node();
-}
-
 inline bool RenderObject::isBody() const { return node() && node()->hasTagName(HTMLNames::bodyTag); }
 inline bool RenderObject::isHR() const { return node() && node()->hasTagName(HTMLNames::hrTag); }
 inline bool RenderObject::isPseudoElement() const { return node() && node()->isPseudoElement(); }

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -82,12 +82,12 @@ void RenderSearchField::willBeDestroyed()
 
 inline HTMLElement* RenderSearchField::resultsButtonElement() const
 {
-    return protectedInputElement()->resultsButtonElement();
+    return protect(inputElement())->resultsButtonElement();
 }
 
 inline HTMLElement* RenderSearchField::cancelButtonElement() const
 {
-    return protectedInputElement()->cancelButtonElement();
+    return protect(inputElement())->cancelButtonElement();
 }
 
 void RenderSearchField::showPopup()
@@ -98,7 +98,7 @@ void RenderSearchField::showPopup()
 
 
     if (!m_searchPopup)
-        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protectedInputElement()->inputType()));
+        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protect(inputElement())->inputType()));
 
     Ref popup = *m_searchPopup;
     if (!popup->enabled())
@@ -106,16 +106,16 @@ void RenderSearchField::showPopup()
 
     m_searchPopupIsVisible = true;
 
-    auto recentSearches = downcast<SearchInputType>(*protectedInputElement()->inputType()).recentSearches();
+    auto recentSearches = downcast<SearchInputType>(*protect(inputElement())->inputType()).recentSearches();
     const AtomString& name = autosaveName();
     popup->loadRecentSearches(name, recentSearches);
 
     // Trim the recent searches list if the maximum size has changed since we last saved.
 
-    if (static_cast<int>(recentSearches.size()) > protectedInputElement()->maxResults()) {
+    if (static_cast<int>(recentSearches.size()) > protect(inputElement())->maxResults()) {
         do {
             recentSearches.removeLast();
-        } while (static_cast<int>(recentSearches.size()) > protectedInputElement()->maxResults());
+        } while (static_cast<int>(recentSearches.size()) > protect(inputElement())->maxResults());
 
         popup->saveRecentSearches(name, recentSearches);
     }
@@ -153,9 +153,9 @@ LayoutUnit RenderSearchField::computeControlLogicalHeight(LayoutUnit lineHeight,
 std::span<const RecentSearch> RenderSearchField::recentSearches()
 {
     if (!m_searchPopup)
-        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protectedInputElement()->inputType()));
+        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protect(inputElement())->inputType()));
 
-    auto& recentSearches = downcast<SearchInputType>(*protectedInputElement()->inputType()).recentSearches();
+    auto& recentSearches = downcast<SearchInputType>(*protect(inputElement())->inputType()).recentSearches();
 
     const AtomString& name = autosaveName();
     protectedSearchPopup()->loadRecentSearches(name, recentSearches);
@@ -192,18 +192,18 @@ void RenderSearchField::updateCancelButtonVisibility() const
 
 Visibility RenderSearchField::visibilityForCancelButton() const
 {
-    return (style().usedVisibility() == Visibility::Hidden || protectedInputElement()->value()->isEmpty()) ? Visibility::Hidden : Visibility::Visible;
+    return (style().usedVisibility() == Visibility::Hidden || protect(inputElement())->value()->isEmpty()) ? Visibility::Hidden : Visibility::Visible;
 }
 
 const AtomString& RenderSearchField::autosaveName() const
 {
-    return protectedInputElement()->attributeWithoutSynchronization(nameAttr);
+    return protect(inputElement())->attributeWithoutSynchronization(nameAttr);
 }
 
 void RenderSearchField::updatePopup(const AtomString& name, const Vector<RecentSearch>& searchItems)
 {
     if (!m_searchPopup)
-        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protectedInputElement()->inputType()));
+        m_searchPopup = page().chrome().createSearchPopupMenu(downcast<SearchInputType>(*protect(inputElement())->inputType()));
     protectedSearchPopup()->saveRecentSearches(name, searchItems);
 }
 

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -1744,7 +1744,7 @@ bool RenderTable::nodeAtPoint(const HitTestRequest& request, HitTestResult& resu
     LayoutRect boundsRect(adjustedLocation, size());
     if (visibleToHitTesting(request) && (action == HitTestBlockBackground || action == HitTestChildBlockBackground) && locationInContainer.intersects(boundsRect)) {
         updateHitTestResult(result, flipForWritingMode(locationInContainer.point() - toLayoutSize(adjustedLocation)));
-        if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
+        if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
             return true;
     }
 

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -61,7 +61,6 @@ public:
     const Layout::InlineTextBox* layoutBox() const;
 
     WEBCORE_EXPORT Text* textNode() const;
-    RefPtr<Text> protectedTextNode() const { return textNode(); }
 
     const RenderStyle& style() const;
     // FIXME: Remove checkedStyle once https://github.com/llvm/llvm-project/pull/142485 lands. This is a false positive.

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -57,11 +57,6 @@ HTMLTextFormControlElement& RenderTextControl::textFormControlElement() const
     return downcast<HTMLTextFormControlElement>(nodeForNonAnonymous());
 }
 
-Ref<HTMLTextFormControlElement> RenderTextControl::protectedTextFormControlElement() const
-{
-    return textFormControlElement();
-}
-
 RefPtr<TextControlInnerTextElement> RenderTextControl::innerTextElement() const
 {
     return textFormControlElement().innerTextElement();

--- a/Source/WebCore/rendering/RenderTextControl.h
+++ b/Source/WebCore/rendering/RenderTextControl.h
@@ -37,7 +37,6 @@ public:
     virtual ~RenderTextControl();
 
     WEBCORE_EXPORT HTMLTextFormControlElement& textFormControlElement() const;
-    WEBCORE_EXPORT Ref<HTMLTextFormControlElement> protectedTextFormControlElement() const;
 
 #if PLATFORM(IOS_FAMILY)
     bool canScroll() const;

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.cpp
@@ -510,11 +510,6 @@ HTMLInputElement& RenderTextControlSingleLine::inputElement() const
     return downcast<HTMLInputElement>(RenderTextControl::textFormControlElement());
 }
 
-Ref<HTMLInputElement> RenderTextControlSingleLine::protectedInputElement() const
-{
-    return downcast<HTMLInputElement>(RenderTextControl::textFormControlElement());
-}
-
 RenderTextControlInnerBlock* RenderTextControlSingleLine::innerTextRenderer() const
 {
     return innerTextElement() ? innerTextElement()->renderer() : nullptr;

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -43,7 +43,6 @@ protected:
     HTMLElement* containerElement() const;
     HTMLElement* innerBlockElement() const;
     HTMLInputElement& inputElement() const;
-    Ref<HTMLInputElement> protectedInputElement() const;
 
 private:
     void textFormControlElement() const = delete;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -610,7 +610,7 @@ static void updateSliderTrackPartForRenderer(SliderTrackPart& sliderTrackPart, c
 
 static void updateSwitchThumbPartForRenderer(SwitchThumbPart& switchThumbPart, const RenderElement& renderer)
 {
-    Ref input = downcast<HTMLInputElement>(*renderer.protectedNode()->shadowHost());
+    Ref input = downcast<HTMLInputElement>(*protect(renderer.element())->shadowHost());
     ASSERT(input->isSwitch());
 
     switchThumbPart.setIsOn(input->isSwitchVisuallyOn());
@@ -619,7 +619,7 @@ static void updateSwitchThumbPartForRenderer(SwitchThumbPart& switchThumbPart, c
 
 static void updateSwitchTrackPartForRenderer(SwitchTrackPart& switchTrackPart, const RenderElement& renderer)
 {
-    Ref input = downcast<HTMLInputElement>(*renderer.protectedNode()->shadowHost());
+    Ref input = downcast<HTMLInputElement>(*protect(renderer.element())->shadowHost());
     ASSERT(input->isSwitch());
 
     switchTrackPart.setIsOn(input->isSwitchVisuallyOn());

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -245,7 +245,7 @@ LayoutUnit RenderView::clientLogicalWidthForFixedPosition() const
 {
     Ref frameView = this->frameView();
     if (frameView->fixedElementsLayoutRelativeToFrame())
-        return LayoutUnit((isHorizontalWritingMode() ? frameView->visibleWidth() : frameView->visibleHeight()) / frameView->protectedFrame()->frameScaleFactor());
+        return LayoutUnit((isHorizontalWritingMode() ? frameView->visibleWidth() : frameView->visibleHeight()) / protect(frameView->frame())->frameScaleFactor());
 
 #if PLATFORM(IOS_FAMILY)
     if (frameView->useCustomFixedPositionLayoutRect())
@@ -262,7 +262,7 @@ LayoutUnit RenderView::clientLogicalHeightForFixedPosition() const
 {
     Ref frameView = this->frameView();
     if (frameView->fixedElementsLayoutRelativeToFrame())
-        return LayoutUnit((isHorizontalWritingMode() ? frameView->visibleHeight() : frameView->visibleWidth()) / frameView->protectedFrame()->frameScaleFactor());
+        return LayoutUnit((isHorizontalWritingMode() ? frameView->visibleHeight() : frameView->visibleWidth()) / protect(frameView->frame())->frameScaleFactor());
 
 #if PLATFORM(IOS_FAMILY)
     if (frameView->useCustomFixedPositionLayoutRect())

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -63,10 +63,8 @@ public:
     virtual ~RenderWidget();
 
     inline HTMLFrameOwnerElement& frameOwnerElement() const; // Defined in RenderWidgetInlines.h
-    inline Ref<HTMLFrameOwnerElement> protectedFrameOwnerElement() const; // Defined in RenderWidgetInlines.h
 
     Widget* widget() const { return m_widget.get(); }
-    RefPtr<Widget> protectedWidget() const { return m_widget; }
     WEBCORE_EXPORT void setWidget(RefPtr<Widget>&&);
 
     static RenderWidget* find(const Widget&);

--- a/Source/WebCore/rendering/RenderWidgetInlines.h
+++ b/Source/WebCore/rendering/RenderWidgetInlines.h
@@ -41,9 +41,4 @@ inline HTMLFrameOwnerElement& RenderWidget::frameOwnerElement() const
     return downcast<HTMLFrameOwnerElement>(nodeForNonAnonymous());
 }
 
-inline Ref<HTMLFrameOwnerElement> RenderWidget::protectedFrameOwnerElement() const
-{
-    return frameOwnerElement();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -3693,7 +3693,7 @@ bool RenderThemeCocoa::paintSearchFieldCancelButtonForVectorBasedControls(const 
     glyphPath.transform(transform);
 
     auto isEnabled = true;
-    if (RefPtr input = dynamicDowncast<HTMLInputElement>(box.protectedNode().get()->shadowHost()))
+    if (RefPtr input = dynamicDowncast<HTMLInputElement>(protect(box.element())->shadowHost()))
         isEnabled = !input->isDisabledFormControl();
 
     const auto styleColorOptions = box.styleColorOptions();

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.cpp
@@ -70,7 +70,7 @@ void RenderSVGBlock::updateFromStyle()
 
 bool RenderSVGBlock::needsHasSVGTransformFlags() const
 {
-    return protectedGraphicsElement()->hasTransformRelatedAttributes();
+    return protect(graphicsElement())->hasTransformRelatedAttributes();
 }
 
 void RenderSVGBlock::boundingRects(Vector<LayoutRect>& rects, const LayoutPoint& accumulatedOffset) const

--- a/Source/WebCore/rendering/svg/RenderSVGBlock.h
+++ b/Source/WebCore/rendering/svg/RenderSVGBlock.h
@@ -31,7 +31,6 @@ class RenderSVGBlock : public RenderBlockFlow {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGBlock);
 public:
     inline SVGGraphicsElement& graphicsElement() const;
-    inline Ref<SVGGraphicsElement> protectedGraphicsElement() const;
 
 protected:
     RenderSVGBlock(Type, SVGGraphicsElement&, RenderStyle&&);

--- a/Source/WebCore/rendering/svg/RenderSVGBlockInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGBlockInlines.h
@@ -35,10 +35,5 @@ inline SVGGraphicsElement& RenderSVGBlock::graphicsElement() const
     return downcast<SVGGraphicsElement>(nodeForNonAnonymous());
 }
 
-inline Ref<SVGGraphicsElement> RenderSVGBlock::protectedGraphicsElement() const
-{
-    return graphicsElement();
-}
-
 } // namespace WebCore
 

--- a/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGContainer.cpp
@@ -178,7 +178,7 @@ bool RenderSVGContainer::nodeAtPoint(const HitTestRequest& request, HitTestResul
     for (auto* child = lastChild(); child; child = child->previousSibling()) {
         if (!child->hasLayer() && child->nodeAtPoint(request, result, locationInContainer, adjustedLocation, hitTestAction)) {
             updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
-            if (result.addNodeToListBasedTestResult(child->protectedNode().get(), request, locationInContainer, visualOverflowRect) == HitTestProgress::Stop)
+            if (result.addNodeToListBasedTestResult(protect(child->node()).get(), request, locationInContainer, visualOverflowRect) == HitTestProgress::Stop)
                 return true;
         }
     }
@@ -186,7 +186,7 @@ bool RenderSVGContainer::nodeAtPoint(const HitTestRequest& request, HitTestResul
     // Accessibility wants to return SVG containers, if appropriate.
     if (request.type() & HitTestRequest::Type::AccessibilityHitTest && m_objectBoundingBox.contains(localPoint)) {
         updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
-        if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer, visualOverflowRect) == HitTestProgress::Stop)
+        if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, visualOverflowRect) == HitTestProgress::Stop)
             return true;
     }
 

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -55,11 +55,6 @@ SVGForeignObjectElement& RenderSVGForeignObject::foreignObjectElement() const
     return downcast<SVGForeignObjectElement>(RenderSVGBlock::graphicsElement());
 }
 
-Ref<SVGForeignObjectElement> RenderSVGForeignObject::protectedForeignObjectElement() const
-{
-    return foreignObjectElement();
-}
-
 void RenderSVGForeignObject::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
     if (!shouldPaintSVGRenderer(paintInfo))
@@ -132,7 +127,7 @@ void RenderSVGForeignObject::updateFromStyle()
 
 void RenderSVGForeignObject::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
-    applySVGTransform(transform, protectedForeignObjectElement(), style, boundingBox, std::nullopt, std::nullopt, options);
+    applySVGTransform(transform, protect(foreignObjectElement()), style, boundingBox, std::nullopt, std::nullopt, options);
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
@@ -39,7 +39,6 @@ public:
     virtual ~RenderSVGForeignObject();
 
     SVGForeignObjectElement& foreignObjectElement() const;
-    Ref<SVGForeignObjectElement> protectedForeignObjectElement() const;
 
     void paint(PaintInfo&, const LayoutPoint&) override;
 

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -73,11 +73,6 @@ SVGImageElement& RenderSVGImage::imageElement() const
     return downcast<SVGImageElement>(RenderSVGModelObject::element());
 }
 
-Ref<SVGImageElement> RenderSVGImage::protectedImageElement() const
-{
-    return imageElement();
-}
-
 FloatRect RenderSVGImage::calculateObjectBoundingBox() const
 {
     LayoutSize intrinsicSize;
@@ -213,7 +208,7 @@ void RenderSVGImage::paintForeground(PaintInfo& paintInfo, const LayoutPoint& pa
 
     FloatRect contentBoxRect = borderBoxRectEquivalent();
     FloatRect replacedContentRect(0, 0, image->width(), image->height());
-    protectedImageElement()->preserveAspectRatio().transformRect(contentBoxRect, replacedContentRect);
+    protect(imageElement())->preserveAspectRatio().transformRect(contentBoxRect, replacedContentRect);
 
     contentBoxRect.moveBy(paintOffset);
 
@@ -231,7 +226,7 @@ void RenderSVGImage::paintForeground(PaintInfo& paintInfo, const LayoutPoint& pa
 
         auto localVisibleRect = visibleRect;
         localVisibleRect.moveBy(-paintOffset);
-        protect(document())->didPaintImage(protectedImageElement().get(), cachedImage(), localVisibleRect);
+        protect(document())->didPaintImage(protect(imageElement()).get(), cachedImage(), localVisibleRect);
     }
 }
 
@@ -268,7 +263,7 @@ bool RenderSVGImage::nodeAtPoint(const HitTestRequest& request, HitTestResult& r
         if (hitRules.canHitFill) {
             if (m_objectBoundingBox.contains(localPoint)) {
                 updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
-                if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer, visualOverflowRect) == HitTestProgress::Stop)
+                if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, visualOverflowRect) == HitTestProgress::Stop)
                     return true;
             }
         }
@@ -365,11 +360,11 @@ void RenderSVGImage::imageChanged(WrappedImagePtr newImage, const IntRect* rect)
     repaintOrMarkForLayout(rect);
 
     if (CheckedPtr cache = document().existingAXObjectCache())
-        cache->deferRecomputeIsIgnoredIfNeeded(protectedImageElement().ptr());
+        cache->deferRecomputeIsIgnoredIfNeeded(protect(imageElement()).ptr());
 
     if (auto* image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(styleable->protectedElement().get(), image);
+            protect(document())->didLoadImage(protect(styleable->element).get(), image);
     }
 }
 
@@ -418,12 +413,12 @@ bool RenderSVGImage::bufferForeground(PaintInfo& paintInfo, const LayoutPoint& p
 
 bool RenderSVGImage::needsHasSVGTransformFlags() const
 {
-    return protectedImageElement()->hasTransformRelatedAttributes();
+    return protect(imageElement())->hasTransformRelatedAttributes();
 }
 
 void RenderSVGImage::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
-    applySVGTransform(transform, protectedImageElement(), style, boundingBox, std::nullopt, std::nullopt, options);
+    applySVGTransform(transform, protect(imageElement()), style, boundingBox, std::nullopt, std::nullopt, options);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -40,7 +40,6 @@ public:
     virtual ~RenderSVGImage();
 
     SVGImageElement& imageElement() const;
-    Ref<SVGImageElement> protectedImageElement() const;
 
     RenderImageResource& imageResource() { return m_imageResource; }
     const RenderImageResource& imageResource() const { return m_imageResource; }

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -314,7 +314,7 @@ Path RenderSVGModelObject::computeClipPath(AffineTransform& transform) const
     if (layer()->isTransformed())
         transform.multiply(layer()->currentTransform(Style::TransformResolver::individualTransformOperations).toAffineTransform());
 
-    if (RefPtr useElement = dynamicDowncast<SVGUseElement>(protectedElement())) {
+    if (RefPtr useElement = dynamicDowncast<SVGUseElement>(protect(element()))) {
         if (CheckedPtr clipChildRenderer = useElement->rendererClipChild())
             transform.multiply(downcast<RenderLayerModelObject>(*clipChildRenderer).checkedLayer()->currentTransform(Style::TransformResolver::individualTransformOperations).toAffineTransform());
         if (RefPtr clipChild = useElement->clipChild())

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -82,7 +82,7 @@ RefPtr<SVGGraphicsElement> RenderSVGResourceClipper::shouldApplyPathClipping() c
 {
     if (currentClippingMode() == ClippingMode::MaskClipping)
         return nullptr;
-    return protectedClipPathElement()->shouldApplyPathClipping();
+    return protect(clipPathElement())->shouldApplyPathClipping();
 }
 
 void RenderSVGResourceClipper::applyPathClipping(GraphicsContext& context, const RenderLayerModelObject& targetRenderer, const FloatRect& objectBoundingBox, SVGGraphicsElement& graphicsElement)
@@ -222,7 +222,7 @@ FloatRect RenderSVGResourceClipper::resourceBoundingBox(const RenderObject& obje
 
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
-    auto clipContentRepaintRect = protectedClipPathElement()->calculateClipContentRepaintRect(repaintRectCalculation);
+    auto clipContentRepaintRect = protect(clipPathElement())->calculateClipContentRepaintRect(repaintRectCalculation);
     if (clipPathUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
         AffineTransform contentTransform;
         contentTransform.translate(targetBoundingBox.location());
@@ -241,12 +241,12 @@ void RenderSVGResourceClipper::updateFromStyle()
 void RenderSVGResourceClipper::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());
-    applySVGTransform(transform, protectedClipPathElement(), style, boundingBox, std::nullopt, std::nullopt, options);
+    applySVGTransform(transform, protect(clipPathElement()), style, boundingBox, std::nullopt, std::nullopt, options);
 }
 
 bool RenderSVGResourceClipper::needsHasSVGTransformFlags() const
 {
-    return protectedClipPathElement()->hasTransformRelatedAttributes();
+    return protect(clipPathElement())->hasTransformRelatedAttributes();
 }
 
 void RenderSVGResourceClipper::styleDidChange(Style::Difference diff, const RenderStyle* oldStyle)

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.h
@@ -36,8 +36,6 @@ public:
     RenderSVGResourceClipper(SVGClipPathElement&, RenderStyle&&);
     virtual ~RenderSVGResourceClipper();
 
-    inline Ref<SVGClipPathElement> protectedClipPathElement() const;
-
     RefPtr<SVGGraphicsElement> shouldApplyPathClipping() const;
     void applyPathClipping(GraphicsContext&, const RenderLayerModelObject& targetRenderer, const FloatRect& objectBoundingBox, SVGGraphicsElement&);
     void applyMaskClipping(PaintInfo&, const RenderLayerModelObject& targetRenderer, const FloatRect& objectBoundingBox);
@@ -47,6 +45,7 @@ public:
     bool hitTestClipContent(const FloatRect&, const LayoutPoint&);
 
     inline SVGUnitTypes::SVGUnitType clipPathUnits() const;
+    inline SVGClipPathElement& clipPathElement() const;
 
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipperInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipperInlines.h
@@ -30,14 +30,14 @@
 
 namespace WebCore {
 
-inline Ref<SVGClipPathElement> RenderSVGResourceClipper::protectedClipPathElement() const
+inline SVGClipPathElement& RenderSVGResourceClipper::clipPathElement() const
 {
     return downcast<SVGClipPathElement>(nodeForNonAnonymous());
 }
 
 inline SVGUnitTypes::SVGUnitType RenderSVGResourceClipper::clipPathUnits() const
 {
-    return protectedClipPathElement()->clipPathUnits();
+    return protect(clipPathElement())->clipPathUnits();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp
@@ -71,7 +71,7 @@ void RenderSVGResourceContainer::styleDidChange(Style::Difference diff, const Re
 void RenderSVGResourceContainer::idChanged()
 {
     // Remove old id, that is guaranteed to be present in cache.
-    m_id = protectedElement()->getIdAttribute();
+    m_id = protect(element())->getIdAttribute();
 
     registerResource();
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilter.h
@@ -41,7 +41,6 @@ public:
     virtual ~RenderSVGResourceFilter();
 
     inline SVGFilterElement& filterElement() const;
-    inline Ref<SVGFilterElement> protectedFilterElement() const;
 
     inline SVGUnitTypes::SVGUnitType filterUnits() const;
     inline SVGUnitTypes::SVGUnitType primitiveUnits() const;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterInlines.h
@@ -37,11 +37,6 @@ inline SVGFilterElement& RenderSVGResourceFilter::filterElement() const
     return downcast<SVGFilterElement>(RenderSVGResourceContainer::element());
 }
 
-inline Ref<SVGFilterElement> RenderSVGResourceFilter::protectedFilterElement() const
-{
-    return filterElement();
-}
-
 inline SVGUnitTypes::SVGUnitType RenderSVGResourceFilter::filterUnits() const
 {
     return filterElement().filterUnits();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h
@@ -38,7 +38,6 @@ public:
     virtual ~RenderSVGResourceLinearGradient();
 
     inline SVGLinearGradientElement& linearGradientElement() const;
-    inline Ref<SVGLinearGradientElement> protectedLinearGradientElement() const;
 
     SVGUnitTypes::SVGUnitType gradientUnits() const final { return m_attributes ? m_attributes.value().gradientUnits() : SVGUnitTypes::SVG_UNIT_TYPE_UNKNOWN; }
     AffineTransform gradientTransform() const final { return m_attributes ? m_attributes.value().gradientTransform() : identity; }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradientInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceLinearGradientInlines.h
@@ -35,9 +35,4 @@ inline SVGLinearGradientElement& RenderSVGResourceLinearGradient::linearGradient
     return downcast<SVGLinearGradientElement>(RenderSVGResourceContainer::element());
 }
 
-inline Ref<SVGLinearGradientElement> RenderSVGResourceLinearGradient::protectedLinearGradientElement() const
-{
-    return linearGradientElement();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarker.h
@@ -48,7 +48,6 @@ private:
     ASCIILiteral renderName() const final { return "RenderSVGResourceMarker"_s; }
 
     inline SVGMarkerElement& markerElement() const;
-    inline Ref<SVGMarkerElement> protectedMarkerElement() const;
     inline FloatPoint referencePoint() const;
     inline std::optional<float> angle() const;
     inline SVGMarkerUnitsType markerUnits() const;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h
@@ -29,11 +29,6 @@ inline SVGMarkerElement& RenderSVGResourceMarker::markerElement() const
     return downcast<SVGMarkerElement>(RenderSVGResourceContainer::element());
 }
 
-inline Ref<SVGMarkerElement> RenderSVGResourceMarker::protectedMarkerElement() const
-{
-    return markerElement();
-}
-
 FloatPoint RenderSVGResourceMarker::referencePoint() const
 {
     Ref markerElement = this->markerElement();
@@ -50,12 +45,12 @@ std::optional<float> RenderSVGResourceMarker::angle() const
 
 SVGMarkerUnitsType RenderSVGResourceMarker::markerUnits() const
 {
-    return protectedMarkerElement()->markerUnits();
+    return protect(markerElement())->markerUnits();
 }
 
 bool RenderSVGResourceMarker::hasReverseStart() const
 {
-    return protectedMarkerElement()->orientType() == SVGMarkerOrientAutoStartReverse;
+    return protect(markerElement())->orientType() == SVGMarkerOrientAutoStartReverse;
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp
@@ -183,7 +183,7 @@ bool RenderSVGResourceMasker::drawContentIntoContext(GraphicsContext& context, c
     // Eventually adjust the mask image context according to the target objectBoundingBox.
     AffineTransform maskContentTransformation;
 
-    if (protectedMaskElement()->maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
+    if (protect(maskElement())->maskContentUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
         maskContentTransformation.translate(objectBoundingBox.location());
         maskContentTransformation.scale(objectBoundingBox.size());
     }

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMasker.h
@@ -38,7 +38,6 @@ public:
     virtual ~RenderSVGResourceMasker();
 
     inline SVGMaskElement& maskElement() const;
-    inline Ref<SVGMaskElement> protectedMaskElement() const;
 
     void applyMask(PaintInfo&, const RenderLayerModelObject& targetRenderer, const LayoutPoint& adjustedPaintOffset);
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceMaskerInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceMaskerInlines.h
@@ -35,19 +35,14 @@ inline SVGMaskElement& RenderSVGResourceMasker::maskElement() const
     return downcast<SVGMaskElement>(RenderSVGResourceContainer::element());
 }
 
-inline Ref<SVGMaskElement> RenderSVGResourceMasker::protectedMaskElement() const
-{
-    return maskElement();
-}
-
 SVGUnitTypes::SVGUnitType RenderSVGResourceMasker::maskUnits() const
 {
-    return protectedMaskElement()->maskUnits();
+    return protect(maskElement())->maskUnits();
 }
 
 SVGUnitTypes::SVGUnitType RenderSVGResourceMasker::maskContentUnits() const
 {
-    return protectedMaskElement()->maskContentUnits();
+    return protect(maskElement())->maskContentUnits();
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp
@@ -94,7 +94,7 @@ RefPtr<Pattern> RenderSVGResourcePattern::buildPattern(GraphicsContext& context,
         // Compute all necessary transformations to build the tile image & the pattern.
         FloatRect tileBoundaries;
         AffineTransform tileImageTransform;
-        if (!buildTileImageTransform(renderer, *m_attributes, protectedPatternElement(), tileBoundaries, tileImageTransform))
+        if (!buildTileImageTransform(renderer, *m_attributes, protect(patternElement()), tileBoundaries, tileImageTransform))
             return nullptr;
 
         // Ignore 2D rotation, as it doesn't affect the size of the tile.

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePattern.h
@@ -36,7 +36,6 @@ public:
     virtual ~RenderSVGResourcePattern();
 
     inline SVGPatternElement& patternElement() const;
-    inline Ref<SVGPatternElement> protectedPatternElement() const;
 
     bool prepareFillOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) final;
     bool prepareStrokeOperation(GraphicsContext&, const RenderLayerModelObject&, const RenderStyle&) final;

--- a/Source/WebCore/rendering/svg/RenderSVGResourcePatternInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourcePatternInlines.h
@@ -35,11 +35,6 @@ inline SVGPatternElement& RenderSVGResourcePattern::patternElement() const
     return downcast<SVGPatternElement>(RenderSVGResourceContainer::element());
 }
 
-inline Ref<SVGPatternElement> RenderSVGResourcePattern::protectedPatternElement() const
-{
-    return patternElement();
-}
-
 static inline FloatRect calculatePatternBoundaries(const PatternAttributes& attributes, const FloatRect& objectBoundingBox, const SVGPatternElement& patternElement)
 {
     return SVGLengthContext::resolveRectangle(&patternElement, attributes.patternUnits(), objectBoundingBox, attributes.x(), attributes.y(), attributes.width(), attributes.height());

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -475,7 +475,7 @@ bool RenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
         LayoutRect boundsRect(adjustedLocation, size());
         if (locationInContainer.intersects(boundsRect)) {
             updateHitTestResult(result, flipForWritingMode(locationInContainer.point() - toLayoutSize(adjustedLocation)));
-            if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
+            if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
                 return true;
         }
     }

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -178,7 +178,7 @@ bool RenderSVGShape::setupNonScalingStrokeContext(AffineTransform& strokeTransfo
 
 AffineTransform RenderSVGShape::nonScalingStrokeTransform() const
 {
-    return protectedGraphicsElement()->getScreenCTM(SVGLocatable::DisallowStyleUpdate);
+    return protect(graphicsElement())->getScreenCTM(SVGLocatable::DisallowStyleUpdate);
 }
 
 void RenderSVGShape::fillShape(const RenderStyle& style, GraphicsContext& context)
@@ -313,7 +313,7 @@ bool RenderSVGShape::nodeAtPoint(const HitTestRequest& request, HitTestResult& r
 
         if (hitRules.canHitStroke && (style().hasStroke() || !hitRules.requireStroke) && strokeContains(localPoint, hitRules.requireStroke)) {
             updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
-            if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer, strokeBoundingBox()) == HitTestProgress::Stop)
+            if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, strokeBoundingBox()) == HitTestProgress::Stop)
                 return true;
             return false;
         }
@@ -321,7 +321,7 @@ bool RenderSVGShape::nodeAtPoint(const HitTestRequest& request, HitTestResult& r
         if ((hitRules.canHitFill && (style().hasFill() || !hitRules.requireFill) && fillContains(localPoint, hitRules.requireFill, fillRule))
             || (hitRules.canHitBoundingBox && m_fillBoundingBox.contains(localPoint))) {
             updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
-            if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer, m_fillBoundingBox) == HitTestProgress::Stop)
+            if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, m_fillBoundingBox) == HitTestProgress::Stop)
                 return true;
             return false;
         }
@@ -390,7 +390,7 @@ FloatRect RenderSVGShape::calculateApproximateStrokeBoundingBox() const
 
 float RenderSVGShape::strokeWidth() const
 {
-    SVGLengthContext lengthContext(protectedGraphicsElement().ptr());
+    SVGLengthContext lengthContext(protect(graphicsElement()).ptr());
     auto strokeWidth = lengthContext.valueForLength(style().strokeWidth(), style().usedZoomForLength());
     return std::isnan(strokeWidth) ? 0 : strokeWidth;
 }
@@ -423,7 +423,7 @@ Path& RenderSVGShape::ensurePath()
 
 std::unique_ptr<Path> RenderSVGShape::createPath() const
 {
-    return makeUnique<Path>(pathFromGraphicsElement(protectedGraphicsElement()));
+    return makeUnique<Path>(pathFromGraphicsElement(protect(graphicsElement())));
 }
 
 void RenderSVGShape::styleWillChange(Style::Difference diff, const RenderStyle& newStyle)
@@ -439,12 +439,12 @@ void RenderSVGShape::styleWillChange(Style::Difference diff, const RenderStyle& 
 
 bool RenderSVGShape::needsHasSVGTransformFlags() const
 {
-    return protectedGraphicsElement()->hasTransformRelatedAttributes();
+    return protect(graphicsElement())->hasTransformRelatedAttributes();
 }
 
 void RenderSVGShape::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
-    applySVGTransform(transform, protectedGraphicsElement(), style, boundingBox, std::nullopt, std::nullopt, options);
+    applySVGTransform(transform, protect(graphicsElement()), style, boundingBox, std::nullopt, std::nullopt, options);
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -65,7 +65,6 @@ public:
     virtual ~RenderSVGShape();
 
     inline SVGGraphicsElement& graphicsElement() const;
-    inline Ref<SVGGraphicsElement> protectedGraphicsElement() const;
 
     void setNeedsShapeUpdate() { m_needsShapeUpdate = true; }
 

--- a/Source/WebCore/rendering/svg/RenderSVGShapeInlines.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShapeInlines.h
@@ -42,9 +42,4 @@ inline SVGGraphicsElement& RenderSVGShape::graphicsElement() const
     return downcast<SVGGraphicsElement>(RenderSVGModelObject::element());
 }
 
-inline Ref<SVGGraphicsElement> RenderSVGShape::protectedGraphicsElement() const
-{
-    return graphicsElement();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -91,11 +91,6 @@ SVGTextElement& RenderSVGText::textElement() const
     return downcast<SVGTextElement>(RenderSVGBlock::graphicsElement());
 }
 
-Ref<SVGTextElement> RenderSVGText::protectedTextElement() const
-{
-    return textElement();
-}
-
 bool RenderSVGText::isChildAllowed(const RenderObject& child, const RenderStyle&) const
 {
     auto isEmptySVGInlineText = [](const RenderObject* object) {
@@ -754,7 +749,7 @@ bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTest
                     continue;
 
                 renderer.updateHitTestResult(result, locationInContainer.point() - toLayoutSize(accumulatedOffset));
-                if (result.addNodeToListBasedTestResult(renderer.protectedNodeForHitTest().get(), request, locationInContainer, rect) == HitTestProgress::Stop)
+                if (result.addNodeToListBasedTestResult(protect(renderer.nodeForHitTest()).get(), request, locationInContainer, rect) == HitTestProgress::Stop)
                     return true;
             }
         }
@@ -773,7 +768,7 @@ bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTest
 void RenderSVGText::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     ASSERT(document().settings().layerBasedSVGEngineEnabled());
-    applySVGTransform(transform, protectedTextElement(), style, boundingBox, std::nullopt, std::nullopt, options);
+    applySVGTransform(transform, protect(textElement()), style, boundingBox, std::nullopt, std::nullopt, options);
 }
 
 PositionWithAffinity RenderSVGText::positionForPoint(const LayoutPoint& pointInContents, HitTestSource source, const RenderFragmentContainer* fragment)

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -47,7 +47,6 @@ public:
     virtual ~RenderSVGText();
 
     SVGTextElement& textElement() const;
-    Ref<SVGTextElement> protectedTextElement() const;
 
     bool isChildAllowed(const RenderObject&, const RenderStyle&) const override;
 

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp
@@ -48,11 +48,6 @@ SVGGraphicsElement& RenderSVGTransformableContainer::graphicsElement() const
     return downcast<SVGGraphicsElement>(RenderSVGContainer::element());
 }
 
-Ref<SVGGraphicsElement> RenderSVGTransformableContainer::protectedGraphicsElement() const
-{
-    return graphicsElement();
-}
-
 inline SVGUseElement* associatedUseElement(SVGGraphicsElement& element)
 {
     // If we're either the renderer for a <use> element, or for any <g> element inside the shadow
@@ -98,7 +93,7 @@ void RenderSVGTransformableContainer::updateLayerTransform()
 void RenderSVGTransformableContainer::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
     auto postTransform = m_supplementalLayerTransform.isIdentity() ? std::nullopt : std::make_optional(m_supplementalLayerTransform);
-    applySVGTransform(transform, protectedGraphicsElement(), style, boundingBox, std::nullopt, postTransform, options);
+    applySVGTransform(transform, protect(graphicsElement()), style, boundingBox, std::nullopt, postTransform, options);
 }
 
 }

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
@@ -41,7 +41,6 @@ private:
 
     void element() const = delete;
     SVGGraphicsElement& graphicsElement() const;
-    Ref<SVGGraphicsElement> protectedGraphicsElement() const;
 
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
     void updateLayerTransform() final;

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp
@@ -63,11 +63,6 @@ SVGSVGElement& RenderSVGViewportContainer::svgSVGElement() const
     return downcast<SVGSVGElement>(RenderSVGContainer::element());
 }
 
-Ref<SVGSVGElement> RenderSVGViewportContainer::protectedSVGSVGElement() const
-{
-    return svgSVGElement();
-}
-
 FloatPoint RenderSVGViewportContainer::computeViewportLocation() const
 {
     if (isOutermostSVGViewportContainer())
@@ -161,7 +156,7 @@ void RenderSVGViewportContainer::updateLayerTransform()
 
 void RenderSVGViewportContainer::applyTransform(TransformationMatrix& transform, const RenderStyle& style, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption> options) const
 {
-    applySVGTransform(transform, protectedSVGSVGElement(), style, boundingBox, m_supplementalLayerTransform.isIdentity() ? std::nullopt : std::make_optional(m_supplementalLayerTransform), std::nullopt, options);
+    applySVGTransform(transform, protect(svgSVGElement()), style, boundingBox, m_supplementalLayerTransform.isIdentity() ? std::nullopt : std::make_optional(m_supplementalLayerTransform), std::nullopt, options);
 }
 
 LayoutRect RenderSVGViewportContainer::overflowClipRect(const LayoutPoint& location, OverlayScrollbarSizeRelevancy, PaintPhase) const

--- a/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGViewportContainer.h
@@ -39,7 +39,6 @@ public:
     virtual ~RenderSVGViewportContainer();
 
     SVGSVGElement& svgSVGElement() const;
-    Ref<SVGSVGElement> protectedSVGSVGElement() const;
     FloatRect viewport() const { return { { }, viewportSize() }; }
     FloatSize viewportSize() const { return m_viewport.size(); }
 

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -514,7 +514,7 @@ bool SVGRenderSupport::pointInClippingArea(const RenderElement& renderer, const 
 
 void SVGRenderSupport::applyStrokeStyleToContext(GraphicsContext& context, const RenderStyle& style, const RenderElement& renderer)
 {
-    auto element = dynamicDowncast<SVGElement>(renderer.protectedElement());
+    auto element = dynamicDowncast<SVGElement>(protect(renderer.element()));
     if (!element) {
         ASSERT_NOT_REACHED();
         return;

--- a/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp
@@ -239,7 +239,7 @@ void writeSVGPaintingFeatures(TextStream& ts, const RenderElement& renderer, Opt
     if (auto* shape = dynamicDowncast<LegacyRenderSVGShape>(renderer)) {
         Color fallbackColor;
         if (auto* strokePaintingResource = LegacyRenderSVGResource::strokePaintingResource(const_cast<LegacyRenderSVGShape&>(*shape), shape->style(), fallbackColor))
-            writeSVGStrokePaintingResource(ts, renderer, *strokePaintingResource, shape->protectedGraphicsElement());
+            writeSVGStrokePaintingResource(ts, renderer, *strokePaintingResource, protect(shape->graphicsElement()));
 
         if (auto* fillPaintingResource = LegacyRenderSVGResource::fillPaintingResource(const_cast<LegacyRenderSVGShape&>(*shape), shape->style(), fallbackColor))
             writeSVGFillPaintingResource(ts, renderer, *fillPaintingResource);
@@ -248,7 +248,7 @@ void writeSVGPaintingFeatures(TextStream& ts, const RenderElement& renderer, Opt
     } else if (auto* shape = dynamicDowncast<RenderSVGShape>(renderer)) {
         Color fallbackColor;
         if (auto* strokePaintingResource = LegacyRenderSVGResource::strokePaintingResource(const_cast<RenderSVGShape&>(*shape), shape->style(), fallbackColor))
-            writeSVGStrokePaintingResource(ts, renderer, *strokePaintingResource, shape->protectedGraphicsElement());
+            writeSVGStrokePaintingResource(ts, renderer, *strokePaintingResource, protect(shape->graphicsElement()));
 
         if (auto* fillPaintingResource = LegacyRenderSVGResource::fillPaintingResource(const_cast<RenderSVGShape&>(*shape), shape->style(), fallbackColor))
             writeSVGFillPaintingResource(ts, renderer, *fillPaintingResource);
@@ -321,7 +321,7 @@ void writeSVGGraphicsElement(TextStream& ts, const SVGGraphicsElement& svgElemen
 static TextStream& operator<<(TextStream& ts, const LegacyRenderSVGShape& shape)
 {
     writePositionAndStyle(ts, shape);
-    writeSVGGraphicsElement(ts, shape.protectedGraphicsElement());
+    writeSVGGraphicsElement(ts, protect(shape.graphicsElement()));
     return ts;
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp
@@ -247,7 +247,7 @@ bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, H
     for (RenderObject* child = lastChild(); child; child = child->previousSibling()) {
         if (child->nodeAtFloatPoint(request, result, localPoint, hitTestAction)) {
             updateHitTestResult(result, LayoutPoint(localPoint));
-            if (result.addNodeToListBasedTestResult(child->protectedNode().get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
+            if (result.addNodeToListBasedTestResult(protect(child->node()).get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
                 return true;
         }
     }
@@ -255,7 +255,7 @@ bool LegacyRenderSVGContainer::nodeAtFloatPoint(const HitTestRequest& request, H
     // Accessibility wants to return SVG containers, if appropriate.
     if (request.type() & HitTestRequest::Type::AccessibilityHitTest && objectBoundingBox().contains(localPoint)) {
         updateHitTestResult(result, LayoutPoint(localPoint));
-        if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
+        if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
             return true;
     }
     

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -265,7 +265,7 @@ bool LegacyRenderSVGImage::nodeAtFloatPoint(const HitTestRequest& request, HitTe
         if (hitRules.canHitFill) {
             if (m_objectBoundingBox.contains(localPoint)) {
                 updateHitTestResult(result, LayoutPoint(localPoint));
-                if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
+                if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
                     return true;
             }
         }
@@ -298,7 +298,7 @@ void LegacyRenderSVGImage::imageChanged(WrappedImagePtr, const IntRect*)
 
     if (auto* image = imageResource().cachedImage(); image && image->currentFrameIsComplete(this)) {
         if (auto styleable = Styleable::fromRenderer(*this))
-            protect(document())->didLoadImage(styleable->protectedElement().get(), image);
+            protect(document())->didLoadImage(protect(styleable->element).get(), image);
     }
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -232,9 +232,4 @@ void LegacyRenderSVGModelObject::addFocusRingRects(Vector<LayoutRect>&, const La
 {
 }
 
-Ref<SVGElement> LegacyRenderSVGModelObject::protectedElement() const
-{
-    return element();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
@@ -66,7 +66,6 @@ public:
     static bool checkEnclosure(RenderElement*, const FloatRect&);
 
     SVGElement& element() const { return downcast<SVGElement>(nodeForNonAnonymous()); }
-    Ref<SVGElement> protectedElement() const;
 
     virtual void addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint& additionalOffset, const RenderLayerModelObject* paintContainer = nullptr) const;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp
@@ -157,7 +157,7 @@ static void removeFromCacheAndInvalidateDependencies(RenderElement& renderer, bo
             clipper->removeClientFromCacheAndMarkForInvalidation(renderer);
     }
 
-    auto svgElement = dynamicDowncast<SVGElement>(renderer.protectedElement());
+    auto svgElement = dynamicDowncast<SVGElement>(protect(renderer.element()));
     if (!svgElement)
         return;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -264,7 +264,7 @@ bool LegacyRenderSVGResourceClipper::drawContentIntoMaskImage(ImageBuffer& maskI
     view().frameView().setPaintBehavior(oldBehavior | PaintBehavior::RenderingSVGClipOrMask);
 
     // Draw all clipPath children into a global mask.
-    for (Ref child : childrenOfType<SVGElement>(protectedClipPathElement())) {
+    for (Ref child : childrenOfType<SVGElement>(protect(clipPathElement()))) {
         auto renderer = child->renderer();
         if (!renderer)
             continue;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h
@@ -64,7 +64,6 @@ public:
     virtual ~LegacyRenderSVGResourceClipper();
 
     inline SVGClipPathElement& clipPathElement() const;
-    inline Ref<SVGClipPathElement> protectedClipPathElement() const;
 
     void removeAllClientsFromCache() override;
     void removeClientFromCache(RenderElement&) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipperInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipperInlines.h
@@ -35,14 +35,9 @@ inline SVGClipPathElement& LegacyRenderSVGResourceClipper::clipPathElement() con
     return downcast<SVGClipPathElement>(nodeForNonAnonymous());
 }
 
-inline Ref<SVGClipPathElement> LegacyRenderSVGResourceClipper::protectedClipPathElement() const
-{
-    return clipPathElement();
-}
-
 inline SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceClipper::clipPathUnits() const
 {
-    return protectedClipPathElement()->clipPathUnits();
+    return protect(clipPathElement())->clipPathUnits();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp
@@ -53,7 +53,7 @@ LegacyRenderSVGResourceFilter::~LegacyRenderSVGResourceFilter() = default;
 
 bool LegacyRenderSVGResourceFilter::isIdentity() const
 {
-    return SVGFilterRenderer::isIdentity(protectedFilterElement());
+    return SVGFilterRenderer::isIdentity(protect(filterElement()));
 }
 
 void LegacyRenderSVGResourceFilter::removeAllClientsFromCache()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h
@@ -61,7 +61,6 @@ public:
     virtual ~LegacyRenderSVGResourceFilter();
 
     inline SVGFilterElement& filterElement() const;
-    inline Ref<SVGFilterElement> protectedFilterElement() const;
     bool isIdentity() const;
 
     void removeAllClientsFromCache() override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterInlines.h
@@ -35,19 +35,14 @@ inline SVGFilterElement& LegacyRenderSVGResourceFilter::filterElement() const
     return downcast<SVGFilterElement>(LegacyRenderSVGResourceContainer::element());
 }
 
-inline Ref<SVGFilterElement> LegacyRenderSVGResourceFilter::protectedFilterElement() const
-{
-    return filterElement();
-}
-
 inline SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceFilter::filterUnits() const
 {
-    return protectedFilterElement()->filterUnits();
+    return protect(filterElement())->filterUnits();
 }
 
 inline SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceFilter::primitiveUnits() const
 {
-    return protectedFilterElement()->primitiveUnits();
+    return protect(filterElement())->primitiveUnits();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.cpp
@@ -38,17 +38,17 @@ LegacyRenderSVGResourceLinearGradient::~LegacyRenderSVGResourceLinearGradient() 
 bool LegacyRenderSVGResourceLinearGradient::collectGradientAttributes()
 {
     m_attributes = LinearGradientAttributes();
-    return protectedLinearGradientElement()->collectGradientAttributes(m_attributes);
+    return protect(linearGradientElement())->collectGradientAttributes(m_attributes);
 }
 
 FloatPoint LegacyRenderSVGResourceLinearGradient::startPoint(const LinearGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolvePoint(protectedLinearGradientElement().ptr(), attributes.gradientUnits(), attributes.x1(), attributes.y1());
+    return SVGLengthContext::resolvePoint(protect(linearGradientElement()).ptr(), attributes.gradientUnits(), attributes.x1(), attributes.y1());
 }
 
 FloatPoint LegacyRenderSVGResourceLinearGradient::endPoint(const LinearGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolvePoint(protectedLinearGradientElement().ptr(), attributes.gradientUnits(), attributes.x2(), attributes.y2());
+    return SVGLengthContext::resolvePoint(protect(linearGradientElement()).ptr(), attributes.gradientUnits(), attributes.x2(), attributes.y2());
 }
 
 Ref<Gradient> LegacyRenderSVGResourceLinearGradient::buildGradient(const RenderStyle& style) const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h
@@ -35,7 +35,6 @@ public:
     virtual ~LegacyRenderSVGResourceLinearGradient();
 
     inline SVGLinearGradientElement& linearGradientElement() const;
-    inline Ref<SVGLinearGradientElement> protectedLinearGradientElement() const;
 
     FloatPoint startPoint(const LinearGradientAttributes&) const;
     FloatPoint endPoint(const LinearGradientAttributes&) const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradientInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradientInlines.h
@@ -36,9 +36,4 @@ inline SVGLinearGradientElement& LegacyRenderSVGResourceLinearGradient::linearGr
     return downcast<SVGLinearGradientElement>(LegacyRenderSVGResourceGradient::gradientElement());
 }
 
-inline Ref<SVGLinearGradientElement> LegacyRenderSVGResourceLinearGradient::protectedLinearGradientElement() const
-{
-    return linearGradientElement();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp
@@ -95,7 +95,7 @@ std::optional<float> LegacyRenderSVGResourceMarker::angle() const
 
 AffineTransform LegacyRenderSVGResourceMarker::markerTransformation(const FloatPoint& origin, float autoAngle, float strokeWidth) const
 {
-    bool useStrokeWidth = protectedMarkerElement()->markerUnits() == SVGMarkerUnitsType::StrokeWidth;
+    bool useStrokeWidth = protect(markerElement())->markerUnits() == SVGMarkerUnitsType::StrokeWidth;
 
     AffineTransform transform;
     transform.translate(origin);
@@ -132,7 +132,7 @@ AffineTransform LegacyRenderSVGResourceMarker::markerContentTransformation(const
 
 AffineTransform LegacyRenderSVGResourceMarker::viewportTransform() const
 {
-    return protectedMarkerElement()->viewBoxToViewTransform(m_viewport.width(), m_viewport.height());
+    return protect(markerElement())->viewBoxToViewTransform(m_viewport.width(), m_viewport.height());
 }
 
 void LegacyRenderSVGResourceMarker::calcViewport()

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h
@@ -37,7 +37,6 @@ public:
     virtual ~LegacyRenderSVGResourceMarker();
 
     inline SVGMarkerElement& markerElement() const;
-    inline Ref<SVGMarkerElement> protectedMarkerElement() const;
 
     void removeAllClientsFromCache() override { }
     void removeClientFromCache(RenderElement&) override { }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarkerInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarkerInlines.h
@@ -36,14 +36,9 @@ inline SVGMarkerElement& LegacyRenderSVGResourceMarker::markerElement() const
     return downcast<SVGMarkerElement>(LegacyRenderSVGResourceContainer::element());
 }
 
-inline Ref<SVGMarkerElement> LegacyRenderSVGResourceMarker::protectedMarkerElement() const
-{
-    return markerElement();
-}
-
 inline SVGMarkerUnitsType LegacyRenderSVGResourceMarker::markerUnits() const
 {
-    return protectedMarkerElement()->markerUnits();
+    return protect(markerElement())->markerUnits();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h
@@ -45,7 +45,6 @@ public:
     virtual ~LegacyRenderSVGResourceMasker();
 
     inline SVGMaskElement& maskElement() const;
-    inline Ref<SVGMaskElement> protectedMaskElement() const;
 
     void removeAllClientsFromCache() override;
     void removeClientFromCache(RenderElement&) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMaskerInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMaskerInlines.h
@@ -36,19 +36,14 @@ inline SVGMaskElement& LegacyRenderSVGResourceMasker::maskElement() const
     return downcast<SVGMaskElement>(LegacyRenderSVGResourceContainer::element());
 }
 
-inline Ref<SVGMaskElement> LegacyRenderSVGResourceMasker::protectedMaskElement() const
-{
-    return maskElement();
-}
-
 SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceMasker::maskUnits() const
 {
-    return protectedMaskElement()->maskUnits();
+    return protect(maskElement())->maskUnits();
 }
 
 SVGUnitTypes::SVGUnitType LegacyRenderSVGResourceMasker::maskContentUnits() const
 {
-    return protectedMaskElement()->maskContentUnits();
+    return protect(maskElement())->maskContentUnits();
 }
 
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp
@@ -52,11 +52,6 @@ SVGPatternElement& LegacyRenderSVGResourcePattern::patternElement() const
     return downcast<SVGPatternElement>(LegacyRenderSVGResourceContainer::element());
 }
 
-Ref<SVGPatternElement> LegacyRenderSVGResourcePattern::protectedPatternElement() const
-{
-    return patternElement();
-}
-
 void LegacyRenderSVGResourcePattern::removeAllClientsFromCache()
 {
     m_patternMap.clear();
@@ -107,7 +102,7 @@ PatternData* LegacyRenderSVGResourcePattern::buildPattern(RenderElement& rendere
     // Compute all necessary transformations to build the tile image & the pattern.
     FloatRect tileBoundaries;
     AffineTransform tileImageTransform;
-    if (!buildTileImageTransform(renderer, m_attributes, protectedPatternElement(), tileBoundaries, tileImageTransform))
+    if (!buildTileImageTransform(renderer, m_attributes, protect(patternElement()), tileBoundaries, tileImageTransform))
         return nullptr;
 
     auto absoluteTransform = SVGRenderingContext::calculateTransformationToOutermostCoordinateSystem(renderer);
@@ -159,7 +154,7 @@ auto LegacyRenderSVGResourcePattern::applyResource(RenderElement& renderer, cons
     ASSERT(!resourceMode.isEmpty());
 
     if (m_shouldCollectPatternAttributes) {
-        protectedPatternElement()->synchronizeAllAttributes();
+        protect(patternElement())->synchronizeAllAttributes();
 
         m_attributes = PatternAttributes();
         collectPatternAttributes(m_attributes);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
@@ -47,7 +47,6 @@ public:
     virtual ~LegacyRenderSVGResourcePattern();
 
     SVGPatternElement& patternElement() const;
-    Ref<SVGPatternElement> protectedPatternElement() const;
 
     void removeAllClientsFromCache() override;
     void removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp
@@ -39,27 +39,27 @@ LegacyRenderSVGResourceRadialGradient::~LegacyRenderSVGResourceRadialGradient() 
 bool LegacyRenderSVGResourceRadialGradient::collectGradientAttributes()
 {
     m_attributes = RadialGradientAttributes();
-    return protectedRadialGradientElement()->collectGradientAttributes(m_attributes);
+    return protect(radialGradientElement())->collectGradientAttributes(m_attributes);
 }
 
 FloatPoint LegacyRenderSVGResourceRadialGradient::centerPoint(const RadialGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolvePoint(protectedRadialGradientElement().ptr(), attributes.gradientUnits(), attributes.cx(), attributes.cy());
+    return SVGLengthContext::resolvePoint(protect(radialGradientElement()).ptr(), attributes.gradientUnits(), attributes.cx(), attributes.cy());
 }
 
 FloatPoint LegacyRenderSVGResourceRadialGradient::focalPoint(const RadialGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolvePoint(protectedRadialGradientElement().ptr(), attributes.gradientUnits(), attributes.fx(), attributes.fy());
+    return SVGLengthContext::resolvePoint(protect(radialGradientElement()).ptr(), attributes.gradientUnits(), attributes.fx(), attributes.fy());
 }
 
 float LegacyRenderSVGResourceRadialGradient::radius(const RadialGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolveLength(protectedRadialGradientElement().ptr(), attributes.gradientUnits(), attributes.r());
+    return SVGLengthContext::resolveLength(protect(radialGradientElement()).ptr(), attributes.gradientUnits(), attributes.r());
 }
 
 float LegacyRenderSVGResourceRadialGradient::focalRadius(const RadialGradientAttributes& attributes) const
 {
-    return SVGLengthContext::resolveLength(protectedRadialGradientElement().ptr(), attributes.gradientUnits(), attributes.fr());
+    return SVGLengthContext::resolveLength(protect(radialGradientElement()).ptr(), attributes.gradientUnits(), attributes.fr());
 }
 
 Ref<Gradient> LegacyRenderSVGResourceRadialGradient::buildGradient(const RenderStyle& style) const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h
@@ -35,7 +35,6 @@ public:
     virtual ~LegacyRenderSVGResourceRadialGradient();
 
     inline SVGRadialGradientElement& radialGradientElement() const;
-    inline Ref<SVGRadialGradientElement> protectedRadialGradientElement() const;
 
     FloatPoint centerPoint(const RadialGradientAttributes&) const;
     FloatPoint focalPoint(const RadialGradientAttributes&) const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradientInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradientInlines.h
@@ -36,9 +36,4 @@ inline SVGRadialGradientElement& LegacyRenderSVGResourceRadialGradient::radialGr
     return downcast<SVGRadialGradientElement>(LegacyRenderSVGResourceGradient::gradientElement());
 }
 
-inline Ref<SVGRadialGradientElement> LegacyRenderSVGResourceRadialGradient::protectedRadialGradientElement() const
-{
-    return radialGradientElement();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -79,11 +79,6 @@ SVGSVGElement& LegacyRenderSVGRoot::svgSVGElement() const
     return downcast<SVGSVGElement>(nodeForNonAnonymous());
 }
 
-Ref<SVGSVGElement> LegacyRenderSVGRoot::protectedSVGSVGElement() const
-{
-    return svgSVGElement();
-}
-
 bool LegacyRenderSVGRoot::hasIntrinsicAspectRatio() const
 {
     return computeIntrinsicAspectRatio();
@@ -132,7 +127,7 @@ FloatSize LegacyRenderSVGRoot::preferredAspectRatio() const
 
 bool LegacyRenderSVGRoot::isEmbeddedThroughSVGImage() const
 {
-    return isInSVGImage(protectedSVGSVGElement().ptr());
+    return isInSVGImage(protect(svgSVGElement()).ptr());
 }
 
 bool LegacyRenderSVGRoot::isEmbeddedThroughFrameContainingSVGDocument() const
@@ -532,7 +527,7 @@ bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResu
             // FIXME: nodeAtFloatPoint() doesn't handle rect-based hit tests yet.
             if (child->nodeAtFloatPoint(request, result, localPoint, hitTestAction)) {
                 updateHitTestResult(result, pointInBorderBox);
-                if (result.addNodeToListBasedTestResult(child->protectedNode().get(), request, locationInContainer) == HitTestProgress::Stop)
+                if (result.addNodeToListBasedTestResult(protect(child->node()).get(), request, locationInContainer) == HitTestProgress::Stop)
                     return true;
             }
         }
@@ -542,12 +537,12 @@ bool LegacyRenderSVGRoot::nodeAtPoint(const HitTestRequest& request, HitTestResu
     if ((hitTestAction == HitTestBlockBackground || hitTestAction == HitTestChildBlockBackground) && visibleToHitTesting(request)) {
         // Only return true here, if the last hit testing phase 'BlockBackground' is executed. If we'd return true in the 'Foreground' phase,
         // hit testing would stop immediately. For SVG only trees this doesn't matter. Though when we have a <foreignObject> subtree we need
-        // to be able to detect hits on the background of a <div> element. If we'd return true here in the 'Foreground' phase, we are not able 
+        // to be able to detect hits on the background of a <div> element. If we'd return true here in the 'Foreground' phase, we are not able
         // to detect these hits anymore.
         LayoutRect boundsRect(accumulatedOffset + location(), size());
         if (locationInContainer.intersects(boundsRect)) {
             updateHitTestResult(result, pointInBorderBox);
-            if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
+            if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, boundsRect) == HitTestProgress::Stop)
                 return true;
         }
     }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -41,7 +41,6 @@ public:
     virtual ~LegacyRenderSVGRoot();
 
     SVGSVGElement& svgSVGElement() const;
-    Ref<SVGSVGElement> protectedSVGSVGElement() const;
 
     bool isEmbeddedThroughSVGImage() const;
     bool isEmbeddedThroughFrameContainingSVGDocument() const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -198,7 +198,7 @@ bool LegacyRenderSVGShape::setupNonScalingStrokeContext(AffineTransform& strokeT
 
 AffineTransform LegacyRenderSVGShape::nonScalingStrokeTransform() const
 {
-    return protectedGraphicsElement()->getScreenCTM(SVGLocatable::DisallowStyleUpdate);
+    return protect(graphicsElement())->getScreenCTM(SVGLocatable::DisallowStyleUpdate);
 }
 
 void LegacyRenderSVGShape::fillShape(const RenderStyle& style, GraphicsContext& originalContext)
@@ -362,7 +362,7 @@ bool LegacyRenderSVGShape::nodeAtFloatPoint(const HitTestRequest& request, HitTe
             || (hitRules.canHitFill && (style().hasFill() || !hitRules.requireFill) && fillContains(localPoint, hitRules.requireFill, fillRule))
             || (hitRules.canHitBoundingBox && objectBoundingBox().contains(localPoint))) {
             updateHitTestResult(result, LayoutPoint(localPoint));
-            if (result.addNodeToListBasedTestResult(protectedNodeForHitTest().get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
+            if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
                 return true;
         }
     }
@@ -495,7 +495,7 @@ Path& LegacyRenderSVGShape::ensurePath()
 
 std::unique_ptr<Path> LegacyRenderSVGShape::createPath() const
 {
-    return makeUnique<Path>(pathFromGraphicsElement(protectedGraphicsElement()));
+    return makeUnique<Path>(pathFromGraphicsElement(protect(graphicsElement())));
 }
 
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -62,7 +62,6 @@ public:
     virtual ~LegacyRenderSVGShape();
 
     inline SVGGraphicsElement& graphicsElement() const;
-    inline Ref<SVGGraphicsElement> protectedGraphicsElement() const;
 
     void setNeedsShapeUpdate() { m_needsShapeUpdate = true; }
     void setNeedsBoundariesUpdate() final { m_needsBoundariesUpdate = true; }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShapeInlines.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShapeInlines.h
@@ -41,9 +41,4 @@ inline SVGGraphicsElement& LegacyRenderSVGShape::graphicsElement() const
     return downcast<SVGGraphicsElement>(LegacyRenderSVGModelObject::element());
 }
 
-inline Ref<SVGGraphicsElement> LegacyRenderSVGShape::protectedGraphicsElement() const
-{
-    return graphicsElement();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -302,7 +302,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
         auto* linkedResource = getRenderSVGResourceContainerById(document, id);
         if (!linkedResource)
             treeScope->addPendingSVGResource(id, element);
-        else if (isChainableResource(element, linkedResource->protectedElement()))
+        else if (isChainableResource(element, protect(linkedResource->element())))
             ensureResources(foundResources).setLinkedResource(linkedResource);
     }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleHitTestResult.cpp
@@ -52,12 +52,12 @@ Ref<InjectedBundleHitTestResult> InjectedBundleHitTestResult::create(const HitTe
 
 RefPtr<InjectedBundleNodeHandle> InjectedBundleHitTestResult::nodeHandle() const
 {
-    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.protectedInnerNonSharedNode().get());
+    return InjectedBundleNodeHandle::getOrCreate(protect(m_hitTestResult.innerNonSharedNode()).get());
 }
 
 RefPtr<InjectedBundleNodeHandle> InjectedBundleHitTestResult::urlElementHandle() const
 {
-    return InjectedBundleNodeHandle::getOrCreate(m_hitTestResult.protectedURLElement().get());
+    return InjectedBundleNodeHandle::getOrCreate(protect(m_hitTestResult.URLElement()).get());
 }
 
 RefPtr<WebFrame> InjectedBundleHitTestResult::frame() const

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -761,7 +761,7 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FrameIdentifier f
 
     WebHitTestResultData immediateActionResult(hitTestResult, { });
 
-    auto subframe = EventHandler::subframeForTargetNode(hitTestResult.protectedTargetNode().get());
+    auto subframe = EventHandler::subframeForTargetNode(protect(hitTestResult.targetNode()).get());
     if (RefPtr remoteFrame = dynamicDowncast<RemoteFrame>(subframe).get()) {
         if (RefPtr remoteFrameView = remoteFrame->view()) {
             immediateActionResult.remoteUserInputEventData = RemoteUserInputEventData {


### PR DESCRIPTION
#### 87a81bb59720927ccd19ee336876bf4d51de6753
<pre>
Reduce use of protected functions in Source/WebCore/rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=307153">https://bugs.webkit.org/show_bug.cgi?id=307153</a>

Reviewed by Ryosuke Niwa and Alan Baradlay.

* Source/WebCore/accessibility/AccessibilityMathMLElement.cpp:
(WebCore::AccessibilityMathMLElement::determineAccessibilityRole):
* Source/WebCore/dom/Element.cpp:
(WebCore::layoutOverflowRectContainsAllDescendants):
* Source/WebCore/dom/MouseRelatedEvent.cpp:
(WebCore::MouseRelatedEvent::computeRelativePosition):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::effectiveViewTransitionName):
* Source/WebCore/editing/RenderedPosition.cpp:
(WebCore::RenderedPosition::positionAtLeftBoundaryOfBiDiRun const):
(WebCore::RenderedPosition::positionAtRightBoundaryOfBiDiRun const):
* Source/WebCore/editing/VisiblePosition.cpp:
(WebCore::VisiblePosition::leftVisuallyDistinctCandidate const):
(WebCore::VisiblePosition::rightVisuallyDistinctCandidate const):
* Source/WebCore/editing/markup.cpp:
(WebCore::highestAncestorToWrapMarkup):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::RenderSliderContainer::computeLogicalHeight const):
(WebCore::RenderSliderContainer::layout):
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
(WebCore::LayoutIntegration::LineLayout::hitTest):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::performDragOperation):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::hitTestResultAtPoint const):
(WebCore::EventHandler::performDragAndDrop):
(WebCore::EventHandler::handleWheelEventInternal):
(WebCore::EventHandler::handleDrag):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scrollToPendingTextFragmentRange):
* Source/WebCore/page/MouseEventWithHitTestResults.h:
(WebCore::MouseEventWithHitTestResults::protectedTargetNode const):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::passWidgetMouseDownEventToWidget):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRenderedTokens):
* Source/WebCore/rendering/CSSFilterRenderer.cpp:
(WebCore::referenceFilterElement):
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::protectedTargetNode const): Deleted.
(WebCore::HitTestResult::protectedTargetElement const): Deleted.
(WebCore::HitTestResult::protectedInnerNonSharedNode const): Deleted.
(WebCore::HitTestResult::protectedURLElement const): Deleted.
* Source/WebCore/rendering/HitTestResult.h:
(WebCore::HitTestResult::innerNonSharedNode const):
(WebCore::HitTestResult::URLElement const):
(WebCore::HitTestResult::targetNode const):
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::paintCaret):
(WebCore::RenderBlock::paintObject):
(WebCore::RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType const):
(WebCore::RenderBlock::nodeAtPoint):
(WebCore::isEditingBoundary):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::RenderBlockFlow::positionForPointWithInlineChildren):
(WebCore::RenderBlockFlow::invalidateLineLayout):
(WebCore::RenderBlockFlow::adjustComputedFontSizes):
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::nodeAtPoint):
(WebCore::RenderBox::imageChanged):
* Source/WebCore/rendering/RenderBoxInlines.h:
(WebCore::isSkippedContentRoot):
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::initializeStyle):
(WebCore::RenderElement::setStyle):
(WebCore::RenderElement::layerParent const):
(WebCore::RenderElement::styleWillChange):
(WebCore::RenderElement::styleDidChange):
(WebCore::RenderElement::willBeDestroyed):
(WebCore::RenderElement::imageFrameAvailable):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderElementInlines.h:
(WebCore::RenderElement::element const):
(WebCore::RenderElement::nonPseudoElement const):
(WebCore::RenderElement::protectedElement const): Deleted.
(WebCore::RenderElement::protectedNonPseudoElement const): Deleted.
* Source/WebCore/rendering/RenderIFrame.cpp:
(WebCore::RenderIFrame::protectedIframeElement const): Deleted.
* Source/WebCore/rendering/RenderIFrame.h:
* Source/WebCore/rendering/RenderImage.cpp:
(WebCore::RenderImage::imageChanged):
* Source/WebCore/rendering/RenderImageResource.cpp:
(WebCore::RenderImageResource::setCachedImage):
(WebCore::RenderImageResource::setContainerContext):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::imageChanged):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::scheduleRenderingUpdate):
(WebCore::RenderLayerCompositor::updateCompositingLayers):
(WebCore::RenderLayerCompositor::layerBecameNonComposited):
(WebCore::RenderLayerCompositor::updateCompositingForLayerTreeAsTextDump):
(WebCore::frameContentsRenderView):
(WebCore::RenderLayerCompositor::isLayerForIFrameWithScrollCoordinatedContents const):
(WebCore::RenderLayerCompositor::updateLayerForOverhangAreasBackgroundColor):
(WebCore::RenderLayerCompositor::updateScrollingNodeForScrollingRole):
(WebCore::RenderLayerCompositor::protectedPage const): Deleted.
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderLayerInlines.h:
(WebCore::RenderLayer::page const):
(WebCore::RenderLayer::protectedPage const): Deleted.
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::scrollTo):
(WebCore::RenderLayerScrollableArea::scrollRectToVisible):
* Source/WebCore/rendering/RenderMedia.cpp:
(WebCore::RenderMedia::layout):
(WebCore::RenderMedia::styleDidChange):
* Source/WebCore/rendering/RenderMedia.h:
* Source/WebCore/rendering/RenderMediaInlines.h:
(WebCore::RenderMedia::protectedMediaElement const): Deleted.
* Source/WebCore/rendering/RenderMeter.cpp:
(WebCore::RenderMeter::meterElement const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::collectSelectionGeometries):
(WebCore::RenderObject::protectedNodeForHitTest const): Deleted.
* Source/WebCore/rendering/RenderObject.h:
(WebCore::RenderObject::protectedCachedImageClient const): Deleted.
* Source/WebCore/rendering/RenderObjectDocument.h:
(WebCore::RenderObject::document const):
(WebCore::RenderObject::protectedDocument const): Deleted.
* Source/WebCore/rendering/RenderObjectInlines.h:
(WebCore::RenderObject::protectedTreeScopeForSVGReferences const): Deleted.
(WebCore::RenderObject::protectedFrame const): Deleted.
(WebCore::RenderObject::protectedPage const): Deleted.
* Source/WebCore/rendering/RenderObjectNode.h:
(WebCore::RenderObject::protectedNode const): Deleted.
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::resultsButtonElement const):
(WebCore::RenderSearchField::cancelButtonElement const):
(WebCore::RenderSearchField::showPopup):
(WebCore::RenderSearchField::recentSearches):
(WebCore::RenderSearchField::visibilityForCancelButton const):
(WebCore::RenderSearchField::autosaveName const):
(WebCore::RenderSearchField::updatePopup):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::nodeAtPoint):
* Source/WebCore/rendering/RenderText.h:
(WebCore::RenderText::protectedTextNode const): Deleted.
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::textFormControlElement const):
(WebCore::RenderTextControl::protectedTextFormControlElement const): Deleted.
* Source/WebCore/rendering/RenderTextControl.h:
* Source/WebCore/rendering/RenderTextControlSingleLine.cpp:
(WebCore::RenderTextControlSingleLine::protectedInputElement const): Deleted.
* Source/WebCore/rendering/RenderTextControlSingleLine.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::updateSwitchThumbPartForRenderer):
(WebCore::updateSwitchTrackPartForRenderer):
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::willBeDestroyed):
(WebCore::RenderVideo::visibleInViewportStateChanged):
(WebCore::RenderVideo::intrinsicSizeChanged):
(WebCore::RenderVideo::updateIntrinsicSize):
(WebCore::RenderVideo::imageChanged):
(WebCore::RenderVideo::shouldDisplayVideo const):
(WebCore::RenderVideo::supportsAcceleratedRendering const):
(WebCore::RenderVideo::acceleratedRenderingStateChanged):
(WebCore::RenderVideo::requiresImmediateCompositing const):
(WebCore::RenderVideo::hasVideoMetadata const):
(WebCore::RenderVideo::hasPosterFrameSize const):
(WebCore::RenderVideo::protectedVideoElement const): Deleted.
* Source/WebCore/rendering/RenderVideo.h:
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::clientLogicalWidthForFixedPosition const):
(WebCore::RenderView::clientLogicalHeightForFixedPosition const):
* Source/WebCore/rendering/RenderWidget.h:
(WebCore::RenderWidget::widget const):
(WebCore::RenderWidget::protectedWidget const): Deleted.
* Source/WebCore/rendering/RenderWidgetInlines.h:
(WebCore::RenderWidget::protectedFrameOwnerElement const): Deleted.
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::paintSearchFieldCancelButtonForVectorBasedControls):
* Source/WebCore/rendering/svg/RenderSVGBlock.cpp:
(WebCore::RenderSVGBlock::needsHasSVGTransformFlags const):
* Source/WebCore/rendering/svg/RenderSVGBlock.h:
* Source/WebCore/rendering/svg/RenderSVGBlockInlines.h:
(WebCore::RenderSVGBlock::protectedGraphicsElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGContainer.cpp:
(WebCore::RenderSVGContainer::nodeAtPoint):
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
(WebCore::RenderSVGForeignObject::applyTransform const):
(WebCore::RenderSVGForeignObject::protectedForeignObjectElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/RenderSVGImage.cpp:
(WebCore::RenderSVGImage::paintForeground):
(WebCore::RenderSVGImage::nodeAtPoint):
(WebCore::RenderSVGImage::imageChanged):
(WebCore::RenderSVGImage::needsHasSVGTransformFlags const):
(WebCore::RenderSVGImage::applyTransform const):
(WebCore::RenderSVGImage::protectedImageElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::RenderSVGModelObject::computeClipPath const):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::shouldApplyPathClipping const):
(WebCore::RenderSVGResourceClipper::resourceBoundingBox):
(WebCore::RenderSVGResourceClipper::applyTransform const):
(WebCore::RenderSVGResourceClipper::needsHasSVGTransformFlags const):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/RenderSVGResourceClipperInlines.h:
(WebCore::RenderSVGResourceClipper::clipPathElement const):
(WebCore::RenderSVGResourceClipper::clipPathUnits const):
(WebCore::RenderSVGResourceClipper::protectedClipPathElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceContainer.cpp:
(WebCore::RenderSVGResourceContainer::idChanged):
* Source/WebCore/rendering/svg/RenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/RenderSVGResourceFilterInlines.h:
(WebCore::RenderSVGResourceFilter::protectedFilterElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradient.h:
* Source/WebCore/rendering/svg/RenderSVGResourceLinearGradientInlines.h:
(WebCore::RenderSVGResourceLinearGradient::protectedLinearGradientElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMarkerInlines.h:
(WebCore::RenderSVGResourceMarker::markerUnits const):
(WebCore::RenderSVGResourceMarker::hasReverseStart const):
(WebCore::RenderSVGResourceMarker::protectedMarkerElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.cpp:
(WebCore::RenderSVGResourceMasker::drawContentIntoContext):
* Source/WebCore/rendering/svg/RenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/RenderSVGResourceMaskerInlines.h:
(WebCore::RenderSVGResourceMasker::maskUnits const):
(WebCore::RenderSVGResourceMasker::maskContentUnits const):
(WebCore::RenderSVGResourceMasker::protectedMaskElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.cpp:
(WebCore::RenderSVGResourcePattern::buildPattern):
* Source/WebCore/rendering/svg/RenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/RenderSVGResourcePatternInlines.h:
(WebCore::RenderSVGResourcePattern::protectedPatternElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::nodeAtPoint):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::nonScalingStrokeTransform const):
(WebCore::RenderSVGShape::nodeAtPoint):
(WebCore::RenderSVGShape::strokeWidth const):
(WebCore::RenderSVGShape::createPath const):
(WebCore::RenderSVGShape::needsHasSVGTransformFlags const):
(WebCore::RenderSVGShape::applyTransform const):
* Source/WebCore/rendering/svg/RenderSVGShape.h:
* Source/WebCore/rendering/svg/RenderSVGShapeInlines.h:
(WebCore::RenderSVGShape::protectedGraphicsElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::hitTestInlineChildren):
(WebCore::RenderSVGText::applyTransform const):
(WebCore::RenderSVGText::protectedTextElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.cpp:
(WebCore::RenderSVGTransformableContainer::applyTransform const):
(WebCore::RenderSVGTransformableContainer::protectedGraphicsElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::applyTransform const):
(WebCore::RenderSVGViewportContainer::protectedSVGSVGElement const): Deleted.
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::applyStrokeStyleToContext):
* Source/WebCore/rendering/svg/SVGRenderTreeAsText.cpp:
(WebCore::writeSVGPaintingFeatures):
(WebCore::operator&lt;&lt;):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGContainer.cpp:
(WebCore::LegacyRenderSVGContainer::nodeAtFloatPoint):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp:
(WebCore::LegacyRenderSVGImage::nodeAtFloatPoint):
(WebCore::LegacyRenderSVGImage::imageChanged):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::protectedElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h:
(WebCore::LegacyRenderSVGModelObject::element const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResource.cpp:
(WebCore::removeFromCacheAndInvalidateDependencies):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::drawContentIntoMaskImage):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipperInlines.h:
(WebCore::LegacyRenderSVGResourceClipper::clipPathUnits const):
(WebCore::LegacyRenderSVGResourceClipper::protectedClipPathElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.cpp:
(WebCore::LegacyRenderSVGResourceFilter::isIdentity const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilter.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterInlines.h:
(WebCore::LegacyRenderSVGResourceFilter::filterUnits const):
(WebCore::LegacyRenderSVGResourceFilter::primitiveUnits const):
(WebCore::LegacyRenderSVGResourceFilter::protectedFilterElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.cpp:
(WebCore::LegacyRenderSVGResourceLinearGradient::collectGradientAttributes):
(WebCore::LegacyRenderSVGResourceLinearGradient::startPoint const):
(WebCore::LegacyRenderSVGResourceLinearGradient::endPoint const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceLinearGradientInlines.h:
(WebCore::LegacyRenderSVGResourceLinearGradient::protectedLinearGradientElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.cpp:
(WebCore::LegacyRenderSVGResourceMarker::markerTransformation const):
(WebCore::LegacyRenderSVGResourceMarker::viewportTransform const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarker.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMarkerInlines.h:
(WebCore::LegacyRenderSVGResourceMarker::markerUnits const):
(WebCore::LegacyRenderSVGResourceMarker::protectedMarkerElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMasker.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceMaskerInlines.h:
(WebCore::LegacyRenderSVGResourceMasker::maskUnits const):
(WebCore::LegacyRenderSVGResourceMasker::maskContentUnits const):
(WebCore::LegacyRenderSVGResourceMasker::protectedMaskElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.cpp:
(WebCore::LegacyRenderSVGResourcePattern::buildPattern):
(WebCore::LegacyRenderSVGResourcePattern::applyResource):
(WebCore::LegacyRenderSVGResourcePattern::protectedPatternElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.cpp:
(WebCore::LegacyRenderSVGResourceRadialGradient::collectGradientAttributes):
(WebCore::LegacyRenderSVGResourceRadialGradient::centerPoint const):
(WebCore::LegacyRenderSVGResourceRadialGradient::focalPoint const):
(WebCore::LegacyRenderSVGResourceRadialGradient::radius const):
(WebCore::LegacyRenderSVGResourceRadialGradient::focalRadius const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceRadialGradientInlines.h:
(WebCore::LegacyRenderSVGResourceRadialGradient::protectedRadialGradientElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::isEmbeddedThroughSVGImage const):
(WebCore::LegacyRenderSVGRoot::nodeAtPoint):
(WebCore::LegacyRenderSVGRoot::protectedSVGSVGElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::nonScalingStrokeTransform const):
(WebCore::LegacyRenderSVGShape::nodeAtFloatPoint):
(WebCore::LegacyRenderSVGShape::createPath const):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShapeInlines.h:
(WebCore::LegacyRenderSVGShape::protectedGraphicsElement const): Deleted.
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::SVGResources::buildCachedResources):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::performImmediateActionHitTestAtLocation):

Canonical link: <a href="https://commits.webkit.org/307020@main">https://commits.webkit.org/307020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67a302d364f1d991061fc5ff0d078538a3bacec8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143063 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15538 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151737 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b2c405f-d2f4-47bc-9fe9-38a7fe3d9b36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144930 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16198 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110015 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3a97918c-59ed-484b-871b-e1af0e27052e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12468 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127987 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90926 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/966e05ec-e7ab-4f95-8d03-6d8966bb5554) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11949 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9647 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1736 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4528 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154050 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15300 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5196 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118034 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118375 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30328 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14314 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125372 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70868 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15207 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4249 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14941 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78926 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15152 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->