### PR TITLE
Reinstate equality function

### DIFF
--- a/Source/WebKit/UIProcess/StdlibExtras.swift
+++ b/Source/WebKit/UIProcess/StdlibExtras.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if compiler(>=6.2)
+#if compiler(>=6.2.3)
 
 // FIXME (rdar://164119356): Move parts of StdLibExtras.swift into WTF
 // (those parts which are not specific to WebKit-level types) - and enable
@@ -121,4 +121,4 @@ struct CxxRefVectorIterator<Vec: CxxRefVector>: Sequence, IteratorProtocol {
 
 #endif // ENABLE_BACK_FORWARD_LIST_SWIFT
 
-#endif // compiler(>=6.2)
+#endif // compiler(>=6.2.3)

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if compiler(>=6.2)
+#if compiler(>=6.2.3)
 
 #if ENABLE_BACK_FORWARD_LIST_SWIFT
 
@@ -103,6 +103,13 @@ private func messageCheckCompletion(
         return true
     }
     return false
+}
+
+// FIXME(rdar://130765784): We should be able use the built-in ===, but AnyObject currently excludes foreign reference types
+@_expose(!Cxx) // rdar://169474185
+func === (_ lhs: WebKit.WebBackForwardListItem, _ rhs: WebKit.WebBackForwardListItem) -> Bool {
+    // Safety: Swift represents all reference types, including foreign reference types, as raw pointers
+    unsafe unsafeBitCast(lhs, to: UnsafeRawPointer.self) == unsafeBitCast(rhs, to: UnsafeRawPointer.self)
 }
 
 final class WebBackForwardList {
@@ -357,4 +364,4 @@ final class WebBackForwardList {
 
 #endif // ENABLE_BACK_FORWARD_LIST_SWIFT
 
-#endif // compiler(>=6.2)
+#endif // compiler(>=6.2.3)


### PR DESCRIPTION
#### 1e76561512726404f756c7960d3d23ed6b56503d
<pre>
Reinstate equality function
<a href="https://bugs.webkit.org/show_bug.cgi?id=307163">https://bugs.webkit.org/show_bug.cgi?id=307163</a>
<a href="https://rdar.apple.com/169799223">rdar://169799223</a>

Reviewed by Richard Robinson.

Part of the Web Back Forward List Swift code was a func === implementation to
allow comparison of C++ types by identity. This relied on an @_expose(!Cxx)
attribute to avoid exposing this back to C++; that was not supported on some
Swift versions between 6.2.0 and 6.2.3. We therefore had to tempoararily remove
that function to fix a build failure. Reinstate the function, but bump our
Swift conditional compilation guards to 6.2.3 so that it does not attempt to
parse this attribute.

Canonical link: <a href="https://commits.webkit.org/306981@main">https://commits.webkit.org/306981@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b24c4555d03f9932bea8351c804b42490677ec6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5873 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151539 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96057 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a7300cf-ddf4-4d7a-870e-1778195c1208) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109869 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79178 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6b5329a-57be-4f51-ab26-f226f4f7c315) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12331 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90778 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a715438-8c6a-4a93-a121-37c6f1fe10fb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11829 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9510 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1538 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121211 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153852 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14963 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4982 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117885 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15000 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12994 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118219 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30259 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14210 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125164 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70660 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15006 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4078 "Found 5 new test failures: http/tests/cookies/same-site/popup-same-site-with-post-form.html http/tests/misc/mask-image-accept.html http/tests/storageAccess/deny-storage-access-under-opener-ephemeral.html http/tests/webshare/webshare-allow-attribute-share.https.html http/tests/websocket/connection-refusal-in-frame-resource-load-statistics.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14741 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78715 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14949 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->