### PR TITLE
Immersive API should only work in the top-level frame

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions-expected.txt
@@ -1,0 +1,7 @@
+
+FAIL document.immersiveEnabled is true on top-level document assert_true: document.immersiveEnabled should be true on top-level document expected true got false
+PASS document.immersiveEnabled is false on iframe document
+PASS requestImmersive rejects with InvalidAccessError in iframe
+PASS requestImmersive error message is correct for iframe
+PASS immersiveerror event fires for iframe restriction
+

--- a/LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>&lt;model> immersive iframe restrictions</title>
+<script src="../../imported/w3c/web-platform-tests/resources/testdriver.js"></script>
+<script src="../../resources/testdriver-vendor.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/model-element-test-utils.js"></script>
+<script src="../resources/model-utils.js"></script>
+<body>
+<script>
+
+promise_test(async t => {
+    assert_true('immersiveEnabled' in document, 'document.immersiveEnabled should exist');
+    assert_true(document.immersiveEnabled, 'document.immersiveEnabled should be true on top-level document');
+}, 'document.immersiveEnabled is true on top-level document');
+
+promise_test(async t => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    t.add_cleanup(() => iframe.remove());
+
+    assert_false(iframe.contentDocument.immersiveEnabled, 'document.immersiveEnabled should be false in iframe');
+}, 'document.immersiveEnabled is false on iframe document');
+
+promise_test(async t => {
+    const iframe = document.createElement('iframe');
+    iframe.srcdoc = `
+        <model>
+            <source src="../resources/cube.usdz">
+        </model>
+    `;
+    document.body.appendChild(iframe);
+    t.add_cleanup(() => iframe.remove());
+    await new Promise(resolve => iframe.onload = resolve);
+
+    const model = iframe.contentDocument.querySelector('model');
+
+    await test_driver.bless("immersive", () => {}, iframe.contentWindow);
+
+    await promise_rejects_dom(t, 'InvalidAccessError', iframe.contentWindow.DOMException,
+        model.requestImmersive(),
+        'requestImmersive should reject with InvalidAccessError in iframe'
+    );
+}, 'requestImmersive rejects with InvalidAccessError in iframe');
+
+promise_test(async t => {
+    const iframe = document.createElement('iframe');
+    iframe.srcdoc = `
+        <model>
+            <source src="../resources/cube.usdz">
+        </model>
+    `;
+    document.body.appendChild(iframe);
+    t.add_cleanup(() => iframe.remove());
+    await new Promise(resolve => iframe.onload = resolve);
+
+    const model = iframe.contentDocument.querySelector('model');
+
+    let errorMessage;
+    await test_driver.bless("immersive", () => {}, iframe.contentWindow);
+
+    try {
+        await model.requestImmersive();
+    } catch (e) {
+        errorMessage = e.message;
+    }
+
+    assert_equals(errorMessage, 'Immersive API is only available in top-level frames.',
+        'Error message should indicate iframe restriction');
+}, 'requestImmersive error message is correct for iframe');
+
+promise_test(async t => {
+    const iframe = document.createElement('iframe');
+    iframe.srcdoc = `
+        <model>
+            <source src="../resources/cube.usdz">
+        </model>
+    `;
+    document.body.appendChild(iframe);
+    t.add_cleanup(() => iframe.remove());
+    await new Promise(resolve => iframe.onload = resolve);
+
+    const model = iframe.contentDocument.querySelector('model');
+
+    let errorFired = false;
+    model.addEventListener('immersiveerror', () => { errorFired = true; });
+
+    await test_driver.bless("immersive", () => {}, iframe.contentWindow);
+    await promise_rejects_dom(t, 'InvalidAccessError', iframe.contentWindow.DOMException,
+        model.requestImmersive(),
+        'requestImmersive should reject with InvalidAccessError in iframe'
+    );
+
+    await t.step_wait(() => errorFired, 'immersiveerror event should fire');
+}, 'immersiveerror event fires for iframe restriction');
+
+</script>
+</body>


### PR DESCRIPTION
#### 8062e71631724793be5c84591fb16aa259d3c433
<pre>
Immersive API should only work in the top-level frame
<a href="https://bugs.webkit.org/show_bug.cgi?id=307165">https://bugs.webkit.org/show_bug.cgi?id=307165</a>
<a href="https://rdar.apple.com/168498448">rdar://168498448</a>

Reviewed by Etienne Segonzac.

Restrict the API usage to the top level frame with additional checks in DocumentImmersive

Test: model-element/immersive/model-element-immersive-iframe-restrictions.html
Add tests to ensure that the immersive API is only available from the top level frame

* LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions-expected.txt: Added.
The first test fails but this is expected and will be fixed with a follow up: <a href="https://rdar.apple.com/168579137">rdar://168579137</a>

* LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions.html: Added.
* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::DocumentImmersive::immersiveEnabled):
(WebCore::DocumentImmersive::requestImmersive):

Canonical link: <a href="https://commits.webkit.org/307169@main">https://commits.webkit.org/307169@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ddee85eb159d08c5abf47940f3037d7a0970eb0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15339 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151541 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96059 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144734 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15995 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109872 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79176 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12332 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127832 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90781 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11830 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9512 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1540 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121212 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4345 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153854 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14965 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4989 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117888 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15002 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12996 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118222 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30443 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14212 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125171 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70664 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15008 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4082 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14743 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78717 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14951 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14805 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->