### PR TITLE
[AutoFill Debugging] Shorten file URLs to include filtered path components only

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -18,6 +18,7 @@ root
 		link,url='example.com','Plain link'
 		link,url='example.com/2','Plain link (2)'
 		link,url='example.com/3','Plain link (3)'
+		link,url='/Users/test/cat.png','Local file'
 	section
 		image,src='image',alt='SVG data URL'
 		image,src='image2',alt='PNG data URL'
@@ -46,6 +47,7 @@ root
 [Plain link](example.com)
 [Plain link \(2\)](example.com/2)
 [Plain link \(3\)](example.com/3)
+[Local file](/Users/test/cat.png)
 ![SVG data URL](image)
 ![PNG data URL](image2)
 ![Long image path](vacation-2024-summer-beach.jpg)

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
@@ -49,6 +49,7 @@ a, img {
         <a href="https://example.com/d2fb0de6-daf3-42d7-b219-1a243d872156?cid=b3029797">Plain link</a>
         <a href="https://example.com/7e61b3f7-8d81-4225-8d68-f646f977ce33?cid=63e3d9fb0bf5">Plain link (2)</a>
         <a href="https://example.com/b3029797-1fb8-4edf-97bd-63e3d9fb0bf5?cid=4edf97bd">Plain link (3)</a>
+        <a href="file:///Users/test/089bac2e873e45608912886c4e028584/cat.png">Local file</a>
     </section>
     <section class="test-section" title="Images">
         <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='100' height='100'%3E%3Ccircle cx='50' cy='50' r='40' fill='red'/%3E%3C/svg%3E" alt="SVG data URL">

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -456,6 +456,9 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
 
                 auto shortenedURLString = [&] {
                     auto shortenedURL = StringEntropyHelpers::removeHighEntropyComponents(url);
+                    if (shortenedURL.protocolIsFile())
+                        return shortenedURL.path().toString();
+
                     auto shortenedString = shortenedURL.string();
                     if (!shortenedURL.protocolIsInHTTPFamily())
                         return shortenedString;


### PR DESCRIPTION
#### 4f5b16a319610df850cebd752664d9e1852fd858
<pre>
[AutoFill Debugging] Shorten file URLs to include filtered path components only
<a href="https://bugs.webkit.org/show_bug.cgi?id=307167">https://bugs.webkit.org/show_bug.cgi?id=307167</a>
<a href="https://rdar.apple.com/169803664">rdar://169803664</a>

Reviewed by Megan Gardner and Richard Robinson.

Adjust the URL shortening heuristic to handle file URLs by leaving behind only the path; e.g. from
something like:

`file:///Users/test/089bac2e873e45608912886c4e028584/cat.png`

...to just:

`/Users/test/cat.png`

* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractItemData):

Canonical link: <a href="https://commits.webkit.org/306958@main">https://commits.webkit.org/306958@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dd75fbaf133d77ed2c56a5f1d3eee49b54e2a21

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151543 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23ff6475-60c5-493d-b232-11aab7b15938) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144736 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/15997 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109874 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145818 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127838 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90783 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b31094f-7b40-4ae8-84b1-de5b39c7ff84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11832 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9514 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1542 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121215 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4353 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153856 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/14967 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/4997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117890 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15004 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/12998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118224 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30227 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14215 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125179 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70666 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15010 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4089 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14745 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78721 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/14953 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->