### PR TITLE
[macOS] Create a sandbox include file for the WebContent process

### DIFF
--- a/Source/WebKit/DerivedSources.make
+++ b/Source/WebKit/DerivedSources.make
@@ -392,6 +392,11 @@ GENERATED_MESSAGES_FILES_AS_PATTERNS := $(call to-pattern, $(GENERATED_MESSAGES_
 MESSAGES_IN_FILES := $(addsuffix .messages.in,$(MESSAGE_RECEIVERS))
 
 SANDBOX_IMPORT_DIR=$(SDKROOT)/usr/local/share/sandbox/profiles/embedded/imports
+ifeq ($(RC_XBS),YES)
+	RC_XBS_PREPROCESSOR_FLAG=-DRC_XBS=1
+else
+	RC_XBS_PREPROCESSOR_FLAG=-DRC_XBS=0
+endif
 
 .PHONY : all
 
@@ -477,7 +482,7 @@ NOTIFICATION_ALLOW_LISTS = \
 
 %.sb : %.sb.in $(NOTIFICATION_ALLOW_LISTS)
 	@echo Pre-processing $* sandbox profile...
-	grep -o '^[^;]*' $< | $(CC) $(SANITIZE_FLAGS) $(SDK_FLAGS) $(TARGET_TRIPLE_FLAGS) $(SANDBOX_DEFINES) $(TEXT_PREPROCESSOR_FLAGS) $(FRAMEWORK_FLAGS) $(HEADER_FLAGS) $(EXTERNAL_FLAGS) -include "wtf/Platform.h" - > $@.tmp
+	grep -o '^[^;]*' $< | $(CC) $(RC_XBS_PREPROCESSOR_FLAG) $(SANITIZE_FLAGS) $(SDK_FLAGS) $(TARGET_TRIPLE_FLAGS) $(SANDBOX_DEFINES) $(TEXT_PREPROCESSOR_FLAGS) $(FRAMEWORK_FLAGS) $(HEADER_FLAGS) $(EXTERNAL_FLAGS) -include "wtf/Platform.h" - > $@.tmp
 	$(WebKit2)/Scripts/compile-sandbox.sh $@.tmp $* $(SDK_NAME) $(SANDBOX_IMPORT_DIR)
 	mv $@.tmp $@
 

--- a/Source/WebKit/Shared/Sandbox/macOS/webcontent-defines.sb
+++ b/Source/WebKit/Shared/Sandbox/macOS/webcontent-defines.sb
@@ -1,0 +1,378 @@
+; Copyright (C) 2026 Apple Inc. All rights reserved.
+;
+; Redistribution and use in source and binary forms, with or without
+; modification, are permitted provided that the following conditions
+; are met:
+; 1. Redistributions of source code must retain the above copyright
+;    notice, this list of conditions and the following disclaimer.
+; 2. Redistributions in binary form must reproduce the above copyright
+;    notice, this list of conditions and the following disclaimer in the
+;    documentation and/or other materials provided with the distribution.
+;
+; THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+; THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+; PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+; BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+; THE POSSIBILITY OF SUCH DAMAGE.
+
+(define (IOAcceleratorMessageFilter)
+    (apply-message-filter
+        (deny (with message "IOAccelerator")
+            iokit-async-external-method
+            iokit-external-method)
+        (allow iokit-async-external-method)
+        (allow iokit-external-method)
+        (allow iokit-external-trap)
+    ))
+
+(define (IOSurfaceRootUserClientMessageFilter)
+    (apply-message-filter
+        (deny (with message "IOSurfaceRootUserClient")
+            iokit-async-external-method
+            iokit-external-method)
+        (allow iokit-async-external-method)
+        (allow iokit-external-method)
+        (allow iokit-external-trap)
+    ))
+
+(define (AppleAVDUserClientMessageFilter)
+    (apply-message-filter
+        (deny (with message "AppleAVDUserClient")
+            iokit-async-external-method
+            iokit-external-method
+            iokit-external-trap)))
+
+(define (IOSurfaceAcceleratorClientMessageFilter)
+    (apply-message-filter
+        (deny (with message "IOSurfaceAcceleratorClient")
+            iokit-async-external-method
+            iokit-external-trap)
+        (allow iokit-external-method
+            (iokit-method-number 1))))
+
+(define (IOMobileFramebufferUserClientMessageFilter)
+    (apply-message-filter
+        (deny (with message "IOMobileFramebufferUserClient")
+            iokit-async-external-method
+            iokit-external-trap)
+        (allow iokit-external-method
+            (iokit-method-number 8 28))))
+
+(define (allow-iokit-open-service)
+    (allow iokit-open-service (iokit-user-client-class "IOSurfaceRoot"))
+    (allow iokit-open-service (iokit-registry-entry-class
+        "AGPM"
+        "AppleAPFSContainer"
+        "AppleM2ScalerCSCDriver"
+        "AppleVideoToolboxParavirtualizationDriver"
+        "IOAccelerator")))
+
+(define (allow-system-graphics-iokit)
+    ;; OpenCL
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "IOAccelerator"))
+            (IOAcceleratorMessageFilter))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "IOAccelerator"))))
+
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "IOAccelerationUserClient"))
+            (apply-message-filter
+                (deny
+                    iokit-async-external-method
+                    iokit-external-trap
+                    iokit-external-method)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "IOAccelerationUserClient"))))
+
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "IOSurfaceRootUserClient"))
+            (IOSurfaceRootUserClientMessageFilter))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "IOSurfaceRootUserClient"))))
+
+    ;; This is needed for Encrypted Media on some hardware (MacMini8,1 for example)
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleIntelMEUserClient"))
+            (apply-message-filter
+                (deny (with message "AppleIntelMEUserClient") iokit-external-method)
+                (allow iokit-external-method
+                    (iokit-method-number 120))
+                (deny
+                    iokit-async-external-method
+                    iokit-external-trap)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleIntelMEUserClient"))))
+
+    ;; This is needed for Encrypted Media on some hardware (MacMini8,1 for example)
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleSNBFBUserClient"))
+            (apply-message-filter
+                (deny (with message "AppleSNBFBUserClient") iokit-external-method)
+                (allow iokit-external-method
+                    (iokit-method-number 120))
+                (deny
+                    iokit-async-external-method
+                    iokit-external-trap)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleSNBFBUserClient"))))
+
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleGraphicsControlClient"))
+            (apply-message-filter
+                (deny (with message "AppleGraphicsControlClient")
+                    iokit-async-external-method
+                    iokit-external-method)
+                (allow iokit-external-method
+                    (iokit-method-number 0 1 3 11))
+                (deny iokit-external-trap)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleGraphicsControlClient"))))
+
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleGraphicsPolicyClient"))
+            (apply-message-filter
+                (deny
+                    iokit-async-external-method
+                    iokit-external-trap
+                    iokit-external-method)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleGraphicsPolicyClient"))))
+    ;; OpenGL
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleMGPUPowerControlClient"))
+            (apply-message-filter
+                (deny (with message "AppleMGPUPowerControlClient") iokit-external-method)
+                (allow iokit-external-method
+                    (iokit-method-number 0 1 3))
+                (deny
+                    iokit-async-external-method
+                    iokit-external-trap)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-registry-entry-class "AppleMGPUPowerControlClient")))))
+
+(define (allow-iokit-with-extension)
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "AppleUpstreamUserClient"))
+            (apply-message-filter
+                (deny (with message "AppleUpstreamUserClient")
+                    iokit-external-method)
+                (allow iokit-external-method
+                    (iokit-method-number 0 1 3 4 5))
+                (deny
+                    iokit-async-external-method
+                    iokit-external-trap)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "AppleUpstreamUserClient"))))
+
+    ;; <rdar://problem/10427451> && <rdar://problem/10808817>
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "AudioAUUC"))
+            (apply-message-filter
+                (deny (with message "AudioAUUC")
+                    iokit-external-method)
+                (allow iokit-external-method
+                    (iokit-method-number 0 1 3 4 5))
+                (deny
+                    iokit-async-external-method
+                    iokit-external-trap)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "AudioAUUC"))))
+
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "IOAudioControlUserClient"))
+            (apply-message-filter
+                (deny
+                    iokit-async-external-method
+                    iokit-external-trap
+                    iokit-external-method)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "IOAudioControlUserClient"))))
+
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "IOAudioEngineUserClient"))
+            (apply-message-filter
+                (deny
+                    iokit-async-external-method
+                    iokit-external-trap
+                    iokit-external-method)))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (extension "com.apple.webkit.extension.iokit")
+                (iokit-user-client-class "IOAudioEngineUserClient")))))
+
+(define (allow-iokit-with-extension-arm64)
+    (when (equal? (param "CPU") "arm64")
+        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (extension "com.apple.webkit.extension.iokit")
+                    (iokit-user-client-class
+                        "AppleAVDUserClient")) ;; <rdar://problem/60088861>
+                (AppleAVDUserClientMessageFilter))
+            ; else
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (extension "com.apple.webkit.extension.iokit")
+                    (iokit-user-client-class "AppleAVDUserClient"))))
+
+        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (extension "com.apple.webkit.extension.iokit")
+                    (iokit-user-client-class "IOMobileFramebufferUserClient"))
+                (IOMobileFramebufferUserClientMessageFilter))
+            ; else
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (extension "com.apple.webkit.extension.iokit")
+                    (iokit-user-client-class "IOMobileFramebufferUserClient"))))
+
+        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (extension "com.apple.webkit.extension.iokit")
+                    (iokit-user-client-class "IOSurfaceAcceleratorClient")) ;; <rdar://problem/63696732>
+                (IOSurfaceAcceleratorClientMessageFilter))
+            ; else
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (extension "com.apple.webkit.extension.iokit")
+                    (iokit-user-client-class
+                        "IOSurfaceAcceleratorClient")))))) ;; <rdar://problem/63696732>
+
+(define (allow-iokit-without-extension)
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (require-not (extension "com.apple.webkit.extension.iokit"))
+                (iokit-registry-entry-class "IOSurfaceRootUserClient"))
+            (IOSurfaceRootUserClientMessageFilter))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (require-not (extension "com.apple.webkit.extension.iokit"))
+                (iokit-registry-entry-class "IOSurfaceRootUserClient"))))
+
+    (when (equal? (param "CPU") "arm64")
+        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (require-not (extension "com.apple.webkit.extension.iokit"))
+                    (iokit-user-client-class "AppleAVDUserClient"))
+                (AppleAVDUserClientMessageFilter))
+            ; else
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (require-not (extension "com.apple.webkit.extension.iokit"))
+                    (iokit-user-client-class "AppleAVDUserClient"))))
+
+        (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (require-not (extension "com.apple.webkit.extension.iokit"))
+                    (iokit-user-client-class "IOSurfaceAcceleratorClient"))
+                (IOSurfaceAcceleratorClientMessageFilter))
+            ; else
+            (allow IOKIT_OPEN_USER_CLIENT
+                (require-all
+                    (require-not (extension "com.apple.webkit.extension.iokit"))
+                    (iokit-user-client-class "IOSurfaceAcceleratorClient")))))
+
+    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (require-not (extension "com.apple.webkit.extension.iokit"))
+                (iokit-connection "IOAccelerator"))
+            (IOAcceleratorMessageFilter))
+        ; else
+        (allow IOKIT_OPEN_USER_CLIENT
+            (require-all
+                (require-not (extension "com.apple.webkit.extension.iokit"))
+                (iokit-connection "IOAccelerator")))))
+
+(define (allow-metal-compiler-service)
+    (allow mach-lookup
+#if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+        (require-all
+            (extension "com.apple.webkit.extension.mach")
+            (xpc-service-name "com.apple.MTLCompilerService"))))
+#else
+        (xpc-service-name "com.apple.MTLCompilerService")))
+#endif

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -8523,6 +8523,7 @@
 		E350A7C82934F75F00A06C29 /* common.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = common.sb; sourceTree = "<group>"; };
 		E350A7DF29364D3800A06C29 /* util.sb */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = util.sb; sourceTree = "<group>"; };
 		E3607DE92C7FE92200956766 /* WKDownloadDelegatePrivate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKDownloadDelegatePrivate.h; sourceTree = "<group>"; };
+		E361284B2F3668E000F85DA8 /* webcontent-defines.sb */ = {isa = PBXFileReference; lastKnownFileType = text; path = "webcontent-defines.sb"; sourceTree = "<group>"; };
 		E36A00E129CF4EBA00AC4E8A /* TextTrackRepresentationCocoa.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TextTrackRepresentationCocoa.h; sourceTree = "<group>"; };
 		E36A00E229CF7AC000AC4E8A /* TextTrackRepresentationCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = TextTrackRepresentationCocoa.mm; sourceTree = "<group>"; };
 		E36D701A27B709ED006531B7 /* WebAttachmentElementClient.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebAttachmentElementClient.h; sourceTree = "<group>"; };
@@ -17329,6 +17330,7 @@
 			isa = PBXGroup;
 			children = (
 				E3C2BC93289CF8FB00ACC3E9 /* common.sb */,
+				E361284B2F3668E000F85DA8 /* webcontent-defines.sb */,
 			);
 			path = macOS;
 			sourceTree = "<group>";

--- a/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
+++ b/Source/WebKit/WebProcess/com.apple.WebProcess.sb.in
@@ -22,6 +22,7 @@
 ; THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "Shared/Sandbox/macOS/common.sb"
+#include "Shared/Sandbox/macOS/webcontent-defines.sb"
 #include "Shared/Sandbox/preferences.sb"
 
 
@@ -33,9 +34,9 @@
 
 #define FALSE #f
 
-(define (webcontent_gpu_sandbox_extensions_blocking)
-#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140400
-    (and (equal? (param "CPU") "arm64") (not (uid 0)))
+(define webcontent_gpu_sandbox_extensions_blocking?
+#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 140400 && defined(RC_XBS) && RC_XBS == 1
+    (equal? (param "CPU") "arm64")
 #else
     FALSE
 #endif
@@ -59,14 +60,8 @@
 
 (allow process-info-rusage (target self))
 
-(when (not (webcontent_gpu_sandbox_extensions_blocking))
-    (allow iokit-open-service (iokit-user-client-class "IOSurfaceRoot"))
-    (allow iokit-open-service (iokit-registry-entry-class
-        "AGPM"
-        "AppleAPFSContainer"
-        "AppleM2ScalerCSCDriver"
-        "AppleVideoToolboxParavirtualizationDriver"
-        "IOAccelerator")))
+(when (not webcontent_gpu_sandbox_extensions_blocking?)
+    (allow-iokit-open-service))
 
 (deny iokit-open-service (with no-report) (iokit-registry-entry-class "AppleJPEGDriver"))
 
@@ -169,49 +164,6 @@
     (ipc-posix-name-prefix "apple.cfprefs."))
 #endif
 
-(define (IOAcceleratorMessageFilter)
-    (apply-message-filter
-        (deny (with message "IOAccelerator")
-            iokit-async-external-method
-            iokit-external-method)
-        (allow iokit-async-external-method)
-        (allow iokit-external-method)
-        (allow iokit-external-trap)
-    ))
-
-(define (IOSurfaceRootUserClientMessageFilter)
-    (apply-message-filter
-        (deny (with message "IOSurfaceRootUserClient")
-            iokit-async-external-method
-            iokit-external-method)
-        (allow iokit-async-external-method)
-        (allow iokit-external-method)
-        (allow iokit-external-trap)
-    ))
-
-(define (AppleAVDUserClientMessageFilter)
-    (apply-message-filter
-        (deny (with message "AppleAVDUserClient")
-            iokit-async-external-method
-            iokit-external-method
-            iokit-external-trap)))
-
-(define (IOSurfaceAcceleratorClientMessageFilter)
-    (apply-message-filter
-        (deny (with message "IOSurfaceAcceleratorClient")
-            iokit-async-external-method
-            iokit-external-trap)
-        (allow iokit-external-method
-            (iokit-method-number 1))))
-
-(define (IOMobileFramebufferUserClientMessageFilter)
-    (apply-message-filter
-        (deny (with message "IOMobileFramebufferUserClient")
-            iokit-async-external-method
-            iokit-external-trap)
-        (allow iokit-external-method
-            (iokit-method-number 8 28))))
-
 ;;; (system-graphics) - Allow access to graphics hardware.
 (define (system-graphics)
     ;; Preferences
@@ -224,85 +176,8 @@
     (deny file-read*
         (prefix "/private/var/db/CVMS/cvmsCodeSignObj"))
 
-    (when (not (webcontent_gpu_sandbox_extensions_blocking))
-    ;; OpenCL
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "IOAccelerator"))
-            (IOAcceleratorMessageFilter))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "IOAccelerator"))))
-
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "IOAccelerationUserClient"))
-            (apply-message-filter
-                (deny
-                    iokit-async-external-method
-                    iokit-external-trap
-                    iokit-external-method)))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "IOAccelerationUserClient"))))
-
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "IOSurfaceRootUserClient"))
-            (IOSurfaceRootUserClientMessageFilter))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "IOSurfaceRootUserClient"))))
-
-    ;; This is needed for Encrypted Media on some hardware (MacMini8,1 for example)
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleIntelMEUserClient"))
-            (apply-message-filter
-                (deny (with message "AppleIntelMEUserClient") iokit-external-method)
-                (allow iokit-external-method
-                    (iokit-method-number 120))
-                (deny
-                    iokit-async-external-method
-                    iokit-external-trap)))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleIntelMEUserClient"))))
-
-    ;; This is needed for Encrypted Media on some hardware (MacMini8,1 for example)
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleSNBFBUserClient"))
-            (apply-message-filter
-                (deny (with message "AppleSNBFBUserClient") iokit-external-method)
-                (allow iokit-external-method
-                    (iokit-method-number 120))
-                (deny
-                    iokit-async-external-method
-                    iokit-external-trap)))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleSNBFBUserClient")))))
+    (when (not webcontent_gpu_sandbox_extensions_blocking?)
+        (allow-system-graphics-iokit))
 
     ;; QuartzCore
 #if PLATFORM(MAC)
@@ -314,59 +189,6 @@
             (extension "com.apple.webkit.extension.iokit")
             (iokit-registry-entry-class "AGPMClient")))
 #endif
-
-    (when (not (webcontent_gpu_sandbox_extensions_blocking))
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleGraphicsControlClient"))
-            (apply-message-filter
-                (deny (with message "AppleGraphicsControlClient")
-                    iokit-async-external-method
-                    iokit-external-method)
-                (allow iokit-external-method
-                    (iokit-method-number 0 1 3 11))
-                (deny iokit-external-trap)))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleGraphicsControlClient"))))
-
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleGraphicsPolicyClient"))
-            (apply-message-filter
-                (deny
-                    iokit-async-external-method
-                    iokit-external-trap
-                    iokit-external-method)))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleGraphicsPolicyClient"))))
-    ;; OpenGL
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleMGPUPowerControlClient"))
-            (apply-message-filter
-                (deny (with message "AppleMGPUPowerControlClient") iokit-external-method)
-                (allow iokit-external-method
-                    (iokit-method-number 0 1 3))
-                (deny
-                    iokit-async-external-method
-                    iokit-external-trap)))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-registry-entry-class "AppleMGPUPowerControlClient")))))
 
     ;; GPU bundles
     (allow file-read*
@@ -954,118 +776,9 @@
 (deny IOKIT_OPEN_USER_CLIENT (with no-report)
     (iokit-user-client-class "AppleJPEGDriverUserClient"))
 
-(when (not (webcontent_gpu_sandbox_extensions_blocking))
-(if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (extension "com.apple.webkit.extension.iokit")
-            (iokit-user-client-class "AppleUpstreamUserClient"))
-        (apply-message-filter
-            (deny (with message "AppleUpstreamUserClient")
-                iokit-external-method)
-            (allow iokit-external-method
-                (iokit-method-number 0 1 3 4 5))
-            (deny
-                iokit-async-external-method
-                iokit-external-trap)))
-    ; else
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (extension "com.apple.webkit.extension.iokit")
-            (iokit-user-client-class "AppleUpstreamUserClient"))))
-
-;; <rdar://problem/10427451> && <rdar://problem/10808817>
-(if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (extension "com.apple.webkit.extension.iokit")
-            (iokit-user-client-class "AudioAUUC"))
-        (apply-message-filter
-            (deny (with message "AudioAUUC")
-                iokit-external-method)
-            (allow iokit-external-method
-                (iokit-method-number 0 1 3 4 5))
-            (deny
-                iokit-async-external-method
-                iokit-external-trap)))
-    ; else
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (extension "com.apple.webkit.extension.iokit")
-            (iokit-user-client-class "AudioAUUC"))))
-
-(if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (extension "com.apple.webkit.extension.iokit")
-            (iokit-user-client-class "IOAudioControlUserClient"))
-        (apply-message-filter
-            (deny
-                iokit-async-external-method
-                iokit-external-trap
-                iokit-external-method)))
-    ; else
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (extension "com.apple.webkit.extension.iokit")
-            (iokit-user-client-class "IOAudioControlUserClient"))))
-
-(if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (extension "com.apple.webkit.extension.iokit")
-            (iokit-user-client-class "IOAudioEngineUserClient"))
-        (apply-message-filter
-            (deny
-                iokit-async-external-method
-                iokit-external-trap
-                iokit-external-method)))
-    ; else
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (extension "com.apple.webkit.extension.iokit")
-            (iokit-user-client-class "IOAudioEngineUserClient")))))
-
-;; <rdar://problem/60088861>
-(when (not (webcontent_gpu_sandbox_extensions_blocking))
-(when (equal? (param "CPU") "arm64")
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-user-client-class
-                    "AppleAVDUserClient"))
-            (AppleAVDUserClientMessageFilter))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-user-client-class "AppleAVDUserClient"))))
-
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-user-client-class "IOMobileFramebufferUserClient"))
-            (IOMobileFramebufferUserClientMessageFilter))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-user-client-class "IOMobileFramebufferUserClient"))))
-
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-user-client-class "IOSurfaceAcceleratorClient")) ;; <rdar://problem/63696732>
-            (IOSurfaceAcceleratorClientMessageFilter))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (extension "com.apple.webkit.extension.iokit")
-                (iokit-user-client-class
-                    "IOSurfaceAcceleratorClient")))))) ;; <rdar://problem/63696732>
+(when (not webcontent_gpu_sandbox_extensions_blocking?)
+    (allow-iokit-with-extension)
+    (allow-iokit-with-extension-arm64))
 
 ;; Audio
 (allow ipc-posix-shm-read* ipc-posix-shm-write-data
@@ -1144,15 +857,8 @@
     (global-name "com.apple.lsd.modifydb"))
 
 ;; <rdar://problem/47268166>
-(when (not (webcontent_gpu_sandbox_extensions_blocking))
-(allow mach-lookup
-#if !PLATFORM(MAC) || __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
-    (require-all
-        (extension "com.apple.webkit.extension.mach")
-        (xpc-service-name "com.apple.MTLCompilerService"))))
-#else
-    (xpc-service-name "com.apple.MTLCompilerService")))
-#endif
+(when (not webcontent_gpu_sandbox_extensions_blocking?)
+    (allow-metal-compiler-service))
 
 (deny mach-lookup (with no-report)
     (global-name "com.apple.CoreServices.coreservicesd")
@@ -1921,55 +1627,8 @@
         (allow syscall-mach (machtrap-number MSC_mach_msg2_trap))))
 #endif // HAVE(SANDBOX_MESSAGE_FILTERING)
 
-(when (not (webcontent_gpu_sandbox_extensions_blocking))
-(if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (require-not (extension "com.apple.webkit.extension.iokit"))
-            (iokit-registry-entry-class "IOSurfaceRootUserClient"))
-        (IOSurfaceRootUserClientMessageFilter))
-    ; else
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (require-not (extension "com.apple.webkit.extension.iokit"))
-            (iokit-registry-entry-class "IOSurfaceRootUserClient"))))
-
-(when (equal? (param "CPU") "arm64")
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (require-not (extension "com.apple.webkit.extension.iokit"))
-                (iokit-user-client-class "AppleAVDUserClient"))
-            (AppleAVDUserClientMessageFilter))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (require-not (extension "com.apple.webkit.extension.iokit"))
-                (iokit-user-client-class "AppleAVDUserClient"))))
-
-    (if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (require-not (extension "com.apple.webkit.extension.iokit"))
-                (iokit-user-client-class "IOSurfaceAcceleratorClient"))
-            (IOSurfaceAcceleratorClientMessageFilter))
-        ; else
-        (allow IOKIT_OPEN_USER_CLIENT
-            (require-all
-                (require-not (extension "com.apple.webkit.extension.iokit"))
-                (iokit-user-client-class "IOSurfaceAcceleratorClient")))))
-
-(if (equal? (param "ENABLE_SANDBOX_MESSAGE_FILTER") "YES")
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (require-not (extension "com.apple.webkit.extension.iokit"))
-            (iokit-connection "IOAccelerator"))
-        (IOAcceleratorMessageFilter))
-    ; else
-    (allow IOKIT_OPEN_USER_CLIENT
-        (require-all
-            (require-not (extension "com.apple.webkit.extension.iokit"))
-            (iokit-connection "IOAccelerator")))))
+(when (not webcontent_gpu_sandbox_extensions_blocking?)
+    (allow-iokit-without-extension))
 
 (deny IOKIT_OPEN_USER_CLIENT
     (require-all
@@ -1996,7 +1655,7 @@
         (require-not (extension "com.apple.webkit.extension.iokit"))
         (iokit-user-client-class "RootDomainUserClient")))
 
-(when (webcontent_gpu_sandbox_extensions_blocking)
+(when webcontent_gpu_sandbox_extensions_blocking?
     (deny iokit-open-service (with telemetry))
     (deny iokit-open-user-client (with telemetry)))
 


### PR DESCRIPTION
#### bc44f0df0f00ecd6564e5f94545b19f65dcecbf4
<pre>
[macOS] Create a sandbox include file for the WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=307179">https://bugs.webkit.org/show_bug.cgi?id=307179</a>
<a href="https://rdar.apple.com/169814965">rdar://169814965</a>

Reviewed by Sihui Liu.

Refactor the macOS WebContent sandbox by adding a include files for defines.
This patch also fixes an issue with an incorrect boolean expression.
Additionally, we only want to apply a compile time check for production builds
in order to support some development scenarios, so we pass a new flag to the
preprocessing step of the sandboxes.

* Source/WebKit/DerivedSources.make:
* Source/WebKit/Shared/Sandbox/macOS/webcontent-defines.sb: Added.
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/com.apple.WebProcess.sb.in:

Canonical link: <a href="https://commits.webkit.org/307194@main">https://commits.webkit.org/307194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a107f3b577abdf99792be73209a27746a03869dc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143146 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15621 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6602 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151821 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96367 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/709e8509-2a9b-4c39-a1c4-14087e0dc022) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110087 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79248 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6231cd4-4b74-4347-8f7f-94fe0475dd52) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146095 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12517 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90998 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/787f8e25-872b-496b-9da2-af510a9e9ff9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12000 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9715 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1819 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121415 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154133 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15584 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5578 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118102 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15581 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13203 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118442 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14367 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125780 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71003 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22154 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15290 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4424 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15024 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79009 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15235 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15086 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->