### PR TITLE
[GFC] Introduce AxisConstraint for grid layout constraints

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/FreeSpaceScenario.h
+++ b/Source/WebCore/layout/formattingContexts/grid/FreeSpaceScenario.h
@@ -38,9 +38,9 @@ enum class FreeSpaceScenario : uint8_t {
     // Flex tracks distribute available space using findSizeOfFr().
     Definite,
 
-    // Scenario 3: Free space is indefinite (e.g., max-content sizing).
+    // Scenario 3: Free space is infinite or sizing under max-content constraint.
     // Flex tracks compute from max-content contributions.
-    Indefinite
+    MaxContent
 };
 
 } // namespace Layout

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -169,7 +169,6 @@ static Style::GridTemplateList gridTemplateListWithPercentagesConvertedToAuto(co
 void GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
 {
     auto unplacedGridItems = constructUnplacedGridItems();
-
     CheckedRef gridStyle = root().style();
 
     GridAutoFlowOptions autoFlowOptions {

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -69,7 +69,7 @@ private:
 
     static TrackSizingFunctionsList trackSizingFunctions(size_t implicitGridTracksCount, const Vector<Style::GridTrackSize> gridTemplateTrackSizes);
 
-    UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&, const GridLayoutConstraints&, FreeSpaceScenario columnFreeSpaceScenario, FreeSpaceScenario rowFreeSpaceScenario) const;
+    UsedTrackSizes performGridSizingAlgorithm(const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&, const GridLayoutConstraints&) const;
 
     std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const GridAreaSizes&) const;
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -354,8 +354,8 @@ TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, co
         if (freeSpaceScenario == FreeSpaceScenario::MinContent)
             return;
 
-        // Otherwise, if the free space is an indefinite length:
-        if (freeSpaceScenario == FreeSpaceScenario::Indefinite) {
+        // Otherwise, if sizing the grid container under a max-content constraint:
+        if (freeSpaceScenario == FreeSpaceScenario::MaxContent) {
             // FIXME: Implement indefinite free space (spec §11.7 Scenario 3).
             // Compute flex fraction based on max-content contributions.
             ASSERT(!availableGridSpace);


### PR DESCRIPTION
#### 90e5dba04b2e976ef4a238415c4b34472324e12a
<pre>
[GFC] Introduce AxisConstraint for grid layout constraints
<a href="https://bugs.webkit.org/show_bug.cgi?id=307177">https://bugs.webkit.org/show_bug.cgi?id=307177</a>
&lt;<a href="https://rdar.apple.com/169813212">rdar://169813212</a>&gt;

Reviewed by Sammy Gill.

Replace weak optional-based GridLayoutConstraints with a strong type that
makes illegal constraint states unrepresentable at compile time.

Also rename FreeSpaceScenario::Indefinite to MaxContent for clarity, as it
represents infinite available space where flex tracks size from max-content.

* Source/WebCore/layout/formattingContexts/grid/FreeSpaceScenario.h:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::layout):
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h:
(WebCore::Layout::AxisConstraint::minContent):
(WebCore::Layout::AxisConstraint::maxContent):
(WebCore::Layout::AxisConstraint::definite):
(WebCore::Layout::AxisConstraint::scenario const):
(WebCore::Layout::AxisConstraint::availableSpace const):
(WebCore::Layout::AxisConstraint::containerMinimumSize const):
(WebCore::Layout::AxisConstraint::containerMaximumSize const):
(WebCore::Layout::AxisConstraint::AxisConstraint):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::layout):
(WebCore::Layout::GridLayout::performGridSizingAlgorithm const):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp:
(WebCore::LayoutIntegration::constraintsForGridContent):

Canonical link: <a href="https://commits.webkit.org/306994@main">https://commits.webkit.org/306994@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/695afe1b072b0061880d28dfa80db3b4f7d64e93

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15485 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6048 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151686 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed36a95d-4035-4f46-a25a-586211452491) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16141 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109976 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c81d4db-8262-4470-9f8a-f2b72e438c7b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145961 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12431 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127929 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90887 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e34d29a-94ff-458a-b5ae-9298e9a9c447) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9598 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1685 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153999 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15110 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5116 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117992 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118333 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14286 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125297 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70817 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22047 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15153 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4185 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14888 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78883 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15096 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14950 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->