### PR TITLE
[GFC] Unify duplicate margin computation logic in GridLayout

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -416,29 +416,33 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& pla
     return { columnSizes, rowSizes };
 }
 
+// Helper to compute margins from axis sizes
+static UsedMargins computeMarginsForAxis(const auto& axisSizes, const Style::ZoomFactor& zoomFactor)
+{
+    auto marginStart = [&] -> LayoutUnit {
+        if (auto fixedMarginStart = axisSizes.marginStart.tryFixed())
+            return LayoutUnit { fixedMarginStart->resolveZoom(zoomFactor) };
+
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return { };
+    };
+
+    auto marginEnd = [&] -> LayoutUnit {
+        if (auto fixedMarginEnd = axisSizes.marginEnd.tryFixed())
+            return LayoutUnit { fixedMarginEnd->resolveZoom(zoomFactor) };
+
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return { };
+    };
+
+    return UsedMargins { marginStart(), marginEnd() };
+}
+
 // https://drafts.csswg.org/css-grid-1/#auto-margins
 Vector<UsedMargins> GridLayout::computeInlineMargins(const PlacedGridItems& placedGridItems, const Style::ZoomFactor& zoomFactor)
 {
     return placedGridItems.map([&zoomFactor](const PlacedGridItem& placedGridItem) {
-        auto& inlineAxisSizes = placedGridItem.inlineAxisSizes();
-
-        auto marginStart = [&] -> LayoutUnit {
-            if (auto fixedMarginStart = inlineAxisSizes.marginStart.tryFixed())
-                return LayoutUnit { fixedMarginStart->resolveZoom(zoomFactor) };
-
-            ASSERT_NOT_IMPLEMENTED_YET();
-            return { };
-        };
-
-        auto marginEnd = [&] -> LayoutUnit {
-            if (auto fixedMarginEnd = inlineAxisSizes.marginEnd.tryFixed())
-                return LayoutUnit { fixedMarginEnd->resolveZoom(zoomFactor) };
-
-            ASSERT_NOT_IMPLEMENTED_YET();
-            return { };
-        };
-
-        return UsedMargins { marginStart(), marginEnd() };
+        return computeMarginsForAxis(placedGridItem.inlineAxisSizes(), zoomFactor);
     });
 }
 
@@ -446,25 +450,7 @@ Vector<UsedMargins> GridLayout::computeInlineMargins(const PlacedGridItems& plac
 Vector<UsedMargins> GridLayout::computeBlockMargins(const PlacedGridItems& placedGridItems, const Style::ZoomFactor& zoomFactor)
 {
     return placedGridItems.map([&zoomFactor](const PlacedGridItem& placedGridItem) {
-        auto& blockAxisSizes = placedGridItem.blockAxisSizes();
-
-        auto marginStart = [&] -> LayoutUnit {
-            if (auto fixedMarginStart = blockAxisSizes.marginStart.tryFixed())
-                return LayoutUnit { fixedMarginStart->resolveZoom(zoomFactor) };
-
-            ASSERT_NOT_IMPLEMENTED_YET();
-            return { };
-        };
-
-        auto marginEnd = [&] -> LayoutUnit {
-            if (auto fixedMarginEnd = blockAxisSizes.marginEnd.tryFixed())
-                return LayoutUnit { fixedMarginEnd->resolveZoom(zoomFactor) };
-
-            ASSERT_NOT_IMPLEMENTED_YET();
-            return { };
-        };
-
-        return UsedMargins { marginStart(), marginEnd() };
+        return computeMarginsForAxis(placedGridItem.blockAxisSizes(), zoomFactor);
     });
 }
 


### PR DESCRIPTION
#### e6c06e224925bc374c4605c927ea61d409b4b7b3
<pre>
[GFC] Unify duplicate margin computation logic in GridLayout
<a href="https://bugs.webkit.org/show_bug.cgi?id=307180">https://bugs.webkit.org/show_bug.cgi?id=307180</a>
&lt;<a href="https://rdar.apple.com/169815804">rdar://169815804</a>&gt;

Reviewed by Sammy Gill.

Extract duplicate code between computeInlineMargins() and
computeBlockMargins(). No behavior change, just a refactor.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::computeMarginsForAxis):
(WebCore::Layout::GridLayout::computeInlineMargins):
(WebCore::Layout::GridLayout::computeBlockMargins):

Canonical link: <a href="https://commits.webkit.org/306988@main">https://commits.webkit.org/306988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01398a7ab36d47c36342ac113570d35e041ca217

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5945 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151590 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96109 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66aa291d-af67-417c-8b06-e6b34760f5fb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16045 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15469 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109909 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79190 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfaa409f-596b-46ab-a932-7a8e22de4ce9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145865 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12364 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90820 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ab51f21-f8de-4714-81c6-e6832f8623f4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11862 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9543 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1589 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153903 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15014 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117925 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118262 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30260 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14238 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125210 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70721 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15057 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4120 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14792 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15000 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14854 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->