### PR TITLE
Convert 16 bit Strings into 8-bit Strings in FastPathParser if chars are 8-bit convertible

### DIFF
--- a/LayoutTests/fast/dom/innerHTML-16bit-to-8bit-compression-expected.txt
+++ b/LayoutTests/fast/dom/innerHTML-16bit-to-8bit-compression-expected.txt
@@ -1,0 +1,49 @@
+Test that innerHTML 16-bit to 8-bit string compression preserves text content correctness for mixed ASCII/Latin-1 and non-Latin-1 content
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+
+Test 0: 16-bit source that uses scalar match
+PASS Text node contains: "H"
+
+Test 1: Pure ASCII text with 16-bit source
+PASS Text node contains: "Hello cat"
+
+Test 2: Pure Cyrillic text (no compression expected)
+PASS Text node contains: "Электронная гранитная шляпа"
+
+Test 3: Mixed ASCII and Cyrillic content
+PASS Text node contains: "Product:"
+PASS Text node contains: "Ноутбук"
+
+Test 4: Latin-1 accented characters
+PASS Text node contains: "café résumé señor naïve"
+
+Test 5: Japanese and English mixed content
+PASS Text node contains: "日本語"
+PASS Text node contains: "Test"
+
+Test 6: Chinese and English mixed content
+PASS Text node contains: "中文"
+PASS Text node contains: "English"
+
+Test 7: Emoji and ASCII text
+PASS Text node contains: "Delete"
+PASS Text node contains: "😀🎉"
+
+Test 8: Whitespace and indentation preservation
+PASS Text node contains: "Item 1"
+PASS Text node contains: "Пункт 2"
+
+Test 9: Nested elements with mixed text nodes
+PASS Text node contains: "Start"
+PASS Text node contains: "中间"
+PASS Text node contains: "End"
+
+Test 10: Long ASCII text
+PASS Text node contains: "This is a longer piece of text that should be compressed to 8-bit storage."
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/dom/innerHTML-16bit-to-8bit-compression.html
+++ b/LayoutTests/fast/dom/innerHTML-16bit-to-8bit-compression.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+<div id="container"></div>
+<script>
+description("Test that innerHTML 16-bit to 8-bit string compression preserves text content correctness for mixed ASCII/Latin-1 and non-Latin-1 content");
+
+function testTextContent(testDescription, html, expectedTexts) {
+    debug("");
+    debug(testDescription);
+
+    var container = document.getElementById('container');
+    container.innerHTML = html;
+
+    // Get all text nodes from the container's children
+    var walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, null, false);
+    var actualTexts = [];
+    var node;
+    while (node = walker.nextNode()) {
+        var text = node.nodeValue.trim();
+        if (text.length > 0) {
+            actualTexts.push(text);
+        }
+    }
+
+    for (var i = 0; i < expectedTexts.length; i++) {
+        var found = false;
+        for (var j = 0; j < actualTexts.length; j++) {
+            if (actualTexts[j] === expectedTexts[i]) {
+                found = true;
+                break;
+            }
+        }
+        if (found) {
+            testPassed("Text node contains: " + JSON.stringify(expectedTexts[i]));
+        } else {
+            testFailed("Text node should contain: " + JSON.stringify(expectedTexts[i]) + " but got: " + JSON.stringify(actualTexts));
+        }
+    }
+    container.innerHTML = '';
+}
+testTextContent(
+    "Test 0: 16-bit source that uses scalar match",
+    '<p>H</p>日',
+    ['H']
+);
+
+// Test 1: Pure ASCII with 16-bit source
+// The trailing 日 forces JavaScript to create a 16-bit string
+testTextContent(
+    "Test 1: Pure ASCII text with 16-bit source",
+    '<div>Hello cat</div>日',
+    ['Hello cat']
+);
+
+// Test 2: Pure non-Latin-1 Cyrillic text
+// All characters > 0xFF, should not compress
+testTextContent(
+    "Test 2: Pure Cyrillic text (no compression expected)",
+    '<div>Электронная гранитная шляпа</div>',
+    ['Электронная гранитная шляпа']
+);
+
+// Test 3: Mixed ASCII and Cyrillic in same parse
+// ASCII should compress to 8-bit, Cyrillic stays 16-bit
+testTextContent(
+    "Test 3: Mixed ASCII and Cyrillic content",
+    '<div>Product:</div><div>Ноутбук</div>日',
+    ['Product:', 'Ноутбук']
+);
+
+// Test 4: Latin-1 extended characters (accented)
+// All characters 0x00-0xFF, should compress to 8-bit
+testTextContent(
+    "Test 4: Latin-1 accented characters",
+    '<div>café résumé señor naïve</div>日',
+    ['café résumé señor naïve']
+);
+
+// Test 5: CJK (Japanese) characters
+// Mixed Japanese (16-bit) and English (8-bit)
+testTextContent(
+    "Test 5: Japanese and English mixed content",
+    '<div>日本語</div><div>Test</div>',
+    ['日本語', 'Test']
+);
+
+// Test 6: CJK (Chinese) characters
+// Mixed Chinese (16-bit) and English (8-bit)
+testTextContent(
+    "Test 6: Chinese and English mixed content",
+    '<span>中文</span><span>English</span>',
+    ['中文', 'English']
+);
+
+// Test 7: Emoji and high Unicode
+// Emoji stays 16-bit, ASCII text compresses
+testTextContent(
+    "Test 7: Emoji and ASCII text",
+    '<button>Delete</button><span>😀🎉</span>',
+    ['Delete', '😀🎉']
+);
+
+// Test 8: Whitespace preservation with indentation
+// Whitespace should be preserved and compressed to 8-bit
+testTextContent(
+    "Test 8: Whitespace and indentation preservation",
+    '<ul>\n    <li>Item 1</li>\n    <li>Пункт 2</li>\n</ul>',
+    ['Item 1', 'Пункт 2']
+);
+
+// Test 9: Nested elements with multiple mixed text nodes
+// Multiple text nodes, some compress, some stay 16-bit
+testTextContent(
+    "Test 9: Nested elements with mixed text nodes",
+    '<div><span>Start</span><b>中间</b><i>End</i></div>日',
+    ['Start', '中间', 'End']
+);
+
+// Test 10: Long ASCII text with 16-bit source
+testTextContent(
+    "Test 10: Long ASCII text",
+    '<p>This is a longer piece of text that should be compressed to 8-bit storage.</p>日',
+    ['This is a longer piece of text that should be compressed to 8-bit storage.']
+);
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -369,12 +369,15 @@ private:
         std::span<const CharacterType> text;
         String escapedText;
         bool isWhitespacePattern = false;
-
+        bool is8Bit = false;
         ALWAYS_INLINE String tryUseWhitespaceCache() const {
             // subtract 1 to exclude the starting '\n' char from the space count
             if (isWhitespacePattern && text.size() - 1 <= NewlineThenWhitespaceStringsTable::maxSpaceCount)
                 return NewlineThenWhitespaceStringsTable::getCachedWhitespace(text.size() - 1);
-
+            if constexpr (sizeof(CharacterType) == 2) {
+                if (is8Bit)
+                    return String::make8Bit(text);
+            }
             return String(text);
         }
 
@@ -616,16 +619,23 @@ private:
 
             if (!m_parsingBuffer.hasCharactersRemaining() || *m_parsingBuffer == '<') {
                 unsigned length = m_parsingBuffer.position() - start.data();
-                return { start.first(length), String(), true };
+                return { start.first(length), String(), true, true };
             }
             // SIMD scan does not rely on the current m_parsingBuffer's position. No need to reset position here.
         }
 
+        // Accumulate upper bytes to detect if all characters are 8-bit representable
+        simde_uint8x16_t upperBytesAccum = SIMD::splat8(0);
+
         auto scalarMatch = [&](auto character) ALWAYS_INLINE_LAMBDA {
+            if constexpr (sizeof(CharacterType) == 2) {
+                if (character > 0xFF)
+                    upperBytesAccum = SIMD::splat8(1);
+            }
             return character == '<' || character == '&' || character == '\r' || character == '\0';
         };
 
-        auto vectorEquals8Bit = [&](auto input) ALWAYS_INLINE_LAMBDA {
+        auto vectorMatchesSpecialChar = [&](auto input) ALWAYS_INLINE_LAMBDA {
             // https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/
             // By looking up the table via lower 4bit, we can identify the category.
             // '\0' => 0000 0000
@@ -640,7 +650,7 @@ private:
         std::span<const CharacterType> cursor;
         if constexpr (sizeof(CharacterType) == 1) {
             auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
-                return SIMD::findFirstNonZeroIndex(vectorEquals8Bit(input));
+                return SIMD::findFirstNonZeroIndex(vectorMatchesSpecialChar(input));
             };
             auto* it = SIMD::find(start, vectorMatch, scalarMatch);
             cursor = start.subspan(it - start.data());
@@ -648,7 +658,16 @@ private:
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
             auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
                 constexpr simde_uint8x16_t zeros = SIMD::splat8(0);
-                return SIMD::findFirstNonZeroIndex(SIMD::bitAnd(vectorEquals8Bit(input.val[0]), SIMD::equal(input.val[1], zeros)));
+                auto matchResult = SIMD::findFirstNonZeroIndex(SIMD::bitAnd(vectorMatchesSpecialChar(input.val[0]), SIMD::equal(input.val[1], zeros)));
+                if (matchResult) {
+                    // Only check positions before the delimiter for possible 8-bit conversion.
+                    // Mask: [FF,FF,...,00,00,...] keeps positions < matchResult, zeros the rest.
+                    constexpr simde_uint8x16_t indices = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 };
+                    auto mask = simde_vcltq_u8(indices, SIMD::splat8(*matchResult));
+                    upperBytesAccum = SIMD::bitOr(SIMD::bitAnd(input.val[1], mask), upperBytesAccum);
+                } else
+                    upperBytesAccum = SIMD::bitOr(input.val[1], upperBytesAccum);
+                return matchResult;
             };
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             auto* it = SIMD::findInterleaved(start, vectorMatch, scalarMatch);
@@ -673,7 +692,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
             return { std::span<const CharacterType>(), String() };
         }
 
-        return { start.first(length), String() };
+        return { start.first(length), String(), false, !SIMD::isNonZero(upperBytesAccum) };
     }
 
     // Slow-path of `scanText()`, which supports escape sequences by copying to a
@@ -783,7 +802,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                     return character == quoteChar || character == '&' || character == '\r' || character == '\0';
                 };
 
-                auto vectorEquals8Bit = [&](auto input) ALWAYS_INLINE_LAMBDA {
+                auto vectorMatchesSpecialChar = [&](auto input) ALWAYS_INLINE_LAMBDA {
                     // https://lemire.me/blog/2024/06/08/scan-html-faster-with-simd-instructions-chrome-edition/
                     // By looking up the table via lower 4bit, we can identify the category.
                     // '\0' => 0000 0000
@@ -804,7 +823,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
                 if constexpr (sizeof(CharacterType) == 1) {
                     auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
-                        return SIMD::findFirstNonZeroIndex(vectorEquals8Bit(input));
+                        return SIMD::findFirstNonZeroIndex(vectorMatchesSpecialChar(input));
                     };
                     auto* it = SIMD::find(span, vectorMatch, scalarMatch);
                     return span.subspan(it - span.data());
@@ -812,7 +831,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
                     auto vectorMatch = [&](auto input) ALWAYS_INLINE_LAMBDA {
                         constexpr simde_uint8x16_t zeros = SIMD::splat8(0);
-                        return SIMD::findFirstNonZeroIndex(SIMD::bitAnd(vectorEquals8Bit(input.val[0]), SIMD::equal(input.val[1], zeros)));
+                        return SIMD::findFirstNonZeroIndex(SIMD::bitAnd(vectorMatchesSpecialChar(input.val[0]), SIMD::equal(input.val[1], zeros)));
                     };
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
                     auto* it = SIMD::findInterleaved(span, vectorMatch, scalarMatch);


### PR DESCRIPTION
#### d76514ba077feb27290b42d0191091a6617a1b59
<pre>
Convert 16 bit Strings into 8-bit Strings in FastPathParser if chars are 8-bit convertible
<a href="https://bugs.webkit.org/show_bug.cgi?id=307181">https://bugs.webkit.org/show_bug.cgi?id=307181</a>
<a href="https://rdar.apple.com/169750580">rdar://169750580</a>

Reviewed by NOBODY (OOPS!).

When the fast path parser receives a 16-bit source string (due to any non-ASCII character),
all text nodes are constructed as 16-bit even if certain text nodes that will be created from
source string contain only ASCII.
Example: &apos;&lt;div&gt;Hello&lt;/div&gt;日&apos;

This change detects 8-bit representable text during parsing of a 16-bit source string without adding significant
work. The SIMD path already checks upper bytes while scanning for special
characters. By accumulating these with OR, we know if text content fits just in 8 bits.
Use String::make8Bit() for 50% memory savings for the string of that text node.

Impact is neutral on SP3 (only helps compress whitespace of newlines in 16 bit source strings)
but slightly helps sites that are mixing ASCII and non-ASCII content.

Inspired by Chrome&apos;s fast parser.

Test: fast/dom/innerHTML-16bit-to-8bit-compression.html

* LayoutTests/fast/dom/innerHTML-16bit-to-8bit-compression-expected.txt: Added.
* LayoutTests/fast/dom/innerHTML-16bit-to-8bit-compression.html: Added.
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::ScanTextResult::tryUseWhitespaceCache const):
(WebCore::HTMLFastPathParser::scanText):
(WebCore::HTMLFastPathParser::scanAttributeValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d76514ba077feb27290b42d0191091a6617a1b59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142919 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151593 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96112 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79191 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145868 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12367 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127872 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90822 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11865 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9544 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1592 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121248 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153906 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15017 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117927 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13031 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118264 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14243 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70724 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15060 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4126 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14795 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78771 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15003 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14857 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->