### PR TITLE
Introduce `HTMLSelectElement::usesMenuListDeprecated()`

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -671,7 +671,7 @@ Ref<AccessibilityRenderObject> AXObjectCache::createObjectFromRenderer(RenderObj
         return AccessibilityMathMLElement::create(AXID::generate(), renderer, *this, isAnonymousOperator);
 #endif
 
-    if (RefPtr select = dynamicDowncast<HTMLSelectElement>(node); select && select->usesMenuList())
+    if (RefPtr select = dynamicDowncast<HTMLSelectElement>(node); select && select->usesMenuListDeprecated())
         return AccessibilityMenuList::create(AXID::generate(), renderer, *this);
 
     // Progress indicator.
@@ -796,7 +796,7 @@ AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation
         if (!select)
             return nullptr;
         RefPtr<AccessibilityObject> object;
-        if (select->usesMenuList()) {
+        if (select->usesMenuListDeprecated()) {
             if (!optionElement || !select->renderer())
                 return nullptr;
             object = AccessibilityMenuListOption::create(AXID::generate(), *optionElement, *this);

--- a/Source/WebCore/accessibility/AccessibilityMenuList.cpp
+++ b/Source/WebCore/accessibility/AccessibilityMenuList.cpp
@@ -109,7 +109,7 @@ bool AccessibilityMenuList::isCollapsed() const
 
 #if !PLATFORM(IOS_FAMILY)
     RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(element());
-    return !(selectElement && selectElement->usesMenuList() && selectElement->popupIsVisible());
+    return !(selectElement && selectElement->usesMenuListDeprecated() && selectElement->popupIsVisible());
 #else
     return true;
 #endif

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -833,7 +833,7 @@ void AccessibilityNodeObject::addChildren()
 #else
     // For listbox selects, use listItems() to get option elements instead of
     // composedTreeChildren which would return shadow DOM content.
-    if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(node); selectElement && !selectElement->usesMenuList()) {
+    if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(node); selectElement && !selectElement->usesMenuListDeprecated()) {
         for (const auto& listItem : selectElement->listItems()) {
             if (listItem)
                 addChild(cache->getOrCreate(*listItem));
@@ -911,7 +911,7 @@ AXCoreObject::AccessibilityChildrenVector AccessibilityNodeObject::visibleChildr
     }
 
     // For HTMLSelectElement with arbitrary renderer use the size attribute as approximation.
-    if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(node()); selectElement && !selectElement->usesMenuList()) {
+    if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(node()); selectElement && !selectElement->usesMenuListDeprecated()) {
         const auto& children = const_cast<AccessibilityNodeObject*>(this)->unignoredChildren();
         AccessibilityChildrenVector result;
         unsigned visibleCount = selectElement->size();

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -806,7 +806,7 @@ String AccessibilityRenderObject::stringValue() const
     }
 
     // For menu list select elements, get the selected option's aria-label or label.
-    if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(node()); selectElement && selectElement->usesMenuList()) {
+    if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(node()); selectElement && selectElement->usesMenuListDeprecated()) {
         int selectedIndex = selectElement->selectedIndex();
         const auto& listItems = selectElement->listItems();
         if (selectedIndex >= 0 && static_cast<size_t>(selectedIndex) < listItems.size()) {
@@ -1254,7 +1254,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     // Ignore popup menu items because AppKit does.
     if (RefPtr node = this->node()) {
         for (Ref ancestor : ancestorsOfType<HTMLSelectElement>(*node)) {
-            if (ancestor->usesMenuList())
+            if (ancestor->usesMenuListDeprecated())
                 return true;
         }
     }
@@ -2403,7 +2403,7 @@ bool AccessibilityRenderObject::renderObjectIsObservable(RenderObject& renderer)
         return true;
 
     // Element-based check for HTMLSelectElement listbox.
-    if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(*element); selectElement && !selectElement->usesMenuList())
+    if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(*element); selectElement && !selectElement->usesMenuListDeprecated())
         return true;
 
     // Textboxes should send out notifications.
@@ -2513,7 +2513,7 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
         return AccessibilityRole::TextArea;
     // Element-based check for HTMLSelectElement with any renderer.
     if (RefPtr selectElement = dynamicDowncast<HTMLSelectElement>(node)) {
-        if (selectElement->usesMenuList())
+        if (selectElement->usesMenuListDeprecated())
             return selectElement->multiple() ? AccessibilityRole::ListBox : AccessibilityRole::PopUpButton;
         return AccessibilityRole::ListBox;
     }

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -94,7 +94,7 @@ bool HTMLOptGroupElement::isDisabledFormControl() const
 bool HTMLOptGroupElement::isFocusable() const
 {
     RefPtr select = ownerSelectElement();
-    if (select && select->usesMenuList())
+    if (select && select->usesMenuListDeprecated())
         return false;
     return HTMLElement::isFocusable();
 }

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -124,7 +124,7 @@ void HTMLOptionElement::removedFromAncestor(RemovalType removalType, ContainerNo
 bool HTMLOptionElement::isFocusable() const
 {
     RefPtr select = ownerSelectElement();
-    if (select && select->usesMenuList())
+    if (select && select->usesMenuListDeprecated())
         return false;
     return HTMLElement::isFocusable();
 }
@@ -151,7 +151,7 @@ void HTMLOptionElement::setText(String&& text)
     // index to the first item if the select is single selection with a menu list. We attempt to
     // preserve the selected item.
     RefPtr select = ownerSelectElement();
-    bool selectIsMenuList = select && select->usesMenuList();
+    bool selectIsMenuList = select && select->usesMenuListDeprecated();
     int oldSelectedIndex = selectIsMenuList ? select->selectedIndex() : -1;
 
     setTextContent(WTF::move(text));

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -78,6 +78,9 @@ public:
 
     bool usesMenuList() const;
 
+    // This method is deprecated because the return value doesn't match the rendering on iOS for multiple selects.
+    bool usesMenuListDeprecated() const;
+
     using OptionOrOptGroupElement = Variant<RefPtr<HTMLOptionElement>, RefPtr<HTMLOptGroupElement>>;
     using HTMLElementOrInt = Variant<RefPtr<HTMLElement>, int>;
     WEBCORE_EXPORT ExceptionOr<void> add(const OptionOrOptGroupElement&, const std::optional<HTMLElementOrInt>& before);

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -439,7 +439,7 @@ StyleAppearance RenderTheme::autoAppearanceForElement(RenderStyle& style, const 
 #if PLATFORM(IOS_FAMILY)
         return StyleAppearance::MenulistButton;
 #else
-        return select->usesMenuList() ? StyleAppearance::Menulist : StyleAppearance::Listbox;
+        return select->usesMenuListDeprecated() ? StyleAppearance::Menulist : StyleAppearance::Listbox;
 #endif
     }
 


### PR DESCRIPTION
#### 807fbd915d536ae9184999aa17d905464e29218a
<pre>
Introduce `HTMLSelectElement::usesMenuListDeprecated()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=307187">https://bugs.webkit.org/show_bug.cgi?id=307187</a>
<a href="https://rdar.apple.com/169820542">rdar://169820542</a>

Reviewed by Aditya Keerthi.

Introduce a new deprecated variant of `usesMenuList()` and fix the non-deprecated variant to match the logic in `createElementRenderer()` (which actually dictates rendering).

The deprecated variant will be gradually removed over future PRs.

No behavior change.

* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::createObjectFromRenderer):
(WebCore::AXObjectCache::getOrCreateSlow):
* Source/WebCore/accessibility/AccessibilityMenuList.cpp:
(WebCore::AccessibilityMenuList::isCollapsed const):
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
(WebCore::AccessibilityNodeObject::addChildren):
(WebCore::AccessibilityNodeObject::visibleChildren):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::stringValue const):
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
(WebCore::AccessibilityRenderObject::renderObjectIsObservable const):
(WebCore::AccessibilityRenderObject::determineAccessibilityRole):
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::isFocusable const):
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::isFocusable const):
(WebCore::HTMLOptionElement::setText):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::optionSelectedByUser):
(WebCore::HTMLSelectElement::usesMenuList const):
(WebCore::HTMLSelectElement::usesMenuListDeprecated const):
(WebCore::HTMLSelectElement::createElementRenderer):
(WebCore::HTMLSelectElement::childShouldCreateRenderer const):
(WebCore::HTMLSelectElement::saveLastSelection):
(WebCore::HTMLSelectElement::listBoxOnChange):
(WebCore::HTMLSelectElement::dispatchChangeEventForMenuList):
(WebCore::HTMLSelectElement::scrollToSelection):
(WebCore::HTMLSelectElement::optionSelectionStateChanged):
(WebCore::HTMLSelectElement::selectOption):
(WebCore::HTMLSelectElement::dispatchFocusEvent):
(WebCore::HTMLSelectElement::dispatchBlurEvent):
(WebCore::HTMLSelectElement::parseMultipleAttribute):
(WebCore::HTMLSelectElement::typeAheadFind):
(WebCore::HTMLSelectElement::accessKeySetSelectedIndex):
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::autoAppearanceForElement const):

Canonical link: <a href="https://commits.webkit.org/306971@main">https://commits.webkit.org/306971@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/391667f67e49290fe89b6aae18a2908a56dfc65f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142923 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15395 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5953 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151597 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/539b85c6-d53b-423d-85ef-b1df515cd6c2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144790 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109914 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a05a665-f3ee-419d-8d44-5d523ce231cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145872 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12373 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90825 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b558492a-2ce9-49d2-8ff1-91b6a51a3305) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11872 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9548 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1596 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4389 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153910 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/15021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5034 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117930 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13035 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118267 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30236 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14244 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125215 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15064 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4125 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14799 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78775 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14861 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->