### PR TITLE
[LOL] Add get_argument/argument_count bytecodes

### DIFF
--- a/Source/JavaScriptCore/jit/SimpleRegisterAllocator.h
+++ b/Source/JavaScriptCore/jit/SimpleRegisterAllocator.h
@@ -112,6 +112,13 @@ public:
         }
     }
 
+    void flush(JITBackend& backend, const RegisterBinding& binding)
+    {
+        flushIf(backend, [&](Register, const RegisterBinding& b) ALWAYS_INLINE_LAMBDA {
+            return b == binding;
+        });
+    }
+
     void flushAllRegisters(JITBackend& backend)
     {
         flushIf(backend, [&](Register, const RegisterBinding&) ALWAYS_INLINE_LAMBDA { return true; });

--- a/Source/JavaScriptCore/lol/LOLJIT.h
+++ b/Source/JavaScriptCore/lol/LOLJIT.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2025-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,6 +65,8 @@ namespace JSC::LOL {
     macro(op_resolve_scope) \
     macro(op_get_from_scope) \
     macro(op_put_to_scope) \
+    macro(op_get_argument) \
+    macro(op_argument_count) \
     macro(op_lshift) \
     macro(op_to_number) \
     macro(op_to_string) \


### PR DESCRIPTION
#### dd56e0f5b991ffa76e256b29cfd5ddc0efe047d0
<pre>
[LOL] Add get_argument/argument_count bytecodes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307183">https://bugs.webkit.org/show_bug.cgi?id=307183</a>
<a href="https://rdar.apple.com/169816899">rdar://169816899</a>

Reviewed by Yijia Huang.

Only interesting bit is if the argument is already accessed then we have
to flush it. In theory we could do something more efficient here but
I don&apos;t think any real builtin code uses aliased arguments like this.

No new tests, no behavior change. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/307129@main">https://commits.webkit.org/307129@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a3ab890f0bc5c02dea4a485b70303a272af11904

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/5970 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151611 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96130 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/958cc750-b9c9-4670-897a-4a233e114497) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16066 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15491 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109924 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79193 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f5cb46d-5195-43de-b629-cba654a15954) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12385 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127880 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90835 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a387011-23e9-488f-b5d0-0141fc216a4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11880 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9553 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1610 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134931 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121263 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153924 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3747 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15035 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5048 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117939 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13042 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118276 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14248 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70742 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22124 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15078 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4134 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174234 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14813 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78789 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45013 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15021 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14875 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->