### PR TITLE
Avoid linear search in executeSingleClassNameSelectorData

### DIFF
--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -206,6 +206,9 @@ inline Ref<SpaceSplitStringData> SpaceSplitStringData::create(const AtomString& 
     ASSERT(static_cast<unsigned>(tokenInitializer.nextMemoryBucket() - tokenArray.data()) == tokenCount);
     ASSERT(reinterpret_cast<const char*>(tokenInitializer.nextMemoryBucket()) - reinterpret_cast<const char*>(spaceSplitStringData.ptr()) == static_cast<ptrdiff_t>(sizeToAllocate));
 
+    for (auto& token : spaceSplitStringData->tokenArray())
+        spaceSplitStringData->m_bloomFilter.add(token);
+
     return spaceSplitStringData;
 }
 

--- a/Source/WebCore/dom/SpaceSplitString.h
+++ b/Source/WebCore/dom/SpaceSplitString.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <algorithm>
+#include <wtf/BloomFilter.h>
 #include <wtf/MainThread.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMalloc.h>
@@ -41,6 +42,8 @@ public:
 
     bool contains(const AtomString& string)
     {
+        if (!m_bloomFilter.mayContain(string))
+            return false;
         auto tokens = tokenArray();
         return std::ranges::find(tokens, string) != tokens.end();
     }
@@ -95,6 +98,7 @@ private:
     AtomString m_keyString;
     unsigned m_refCount;
     unsigned m_size;
+    BloomFilter<8> m_bloomFilter;
     AtomString m_tokens[0];
 };
 


### PR DESCRIPTION
#### 94b927b3b593e4fe8637b021533d1359aebe1a9a
<pre>
Avoid linear search in executeSingleClassNameSelectorData
<a href="https://bugs.webkit.org/show_bug.cgi?id=307194">https://bugs.webkit.org/show_bug.cgi?id=307194</a>
<a href="https://rdar.apple.com/168262496">rdar://168262496</a>

Reviewed by NOBODY (OOPS!).

SpaceSplitString::contains() does a linear scan through the token array,
which is expensive for elements with many class names. Add a
BloomFilter&lt;8&gt; to SpaceSplitStringData to reject non-matching
queries in O(1).

No change in behavior.

* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::SpaceSplitStringData::create):
* Source/WebCore/dom/SpaceSplitString.h:
(WebCore::SpaceSplitStringData::contains):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/94b927b3b593e4fe8637b021533d1359aebe1a9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143008 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15481 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151682 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96229 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144875 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109978 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79209 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145957 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12433 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127930 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90889 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11924 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9599 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1681 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4472 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153995 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15193 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117996 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15143 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118336 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14289 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125298 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70813 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15149 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4186 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14884 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78860 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15102 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14946 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->