### PR TITLE
[EWS] Recognize a macOS deployment target config parameter for back-deployed builds

### DIFF
--- a/Tools/CISupport/ews-build/config.json
+++ b/Tools/CISupport/ews-build/config.json
@@ -308,6 +308,7 @@
       "name": "macOS-Sequoia-Release-Build-EWS", "shortname": "mac", "icon": "buildOnly",
       "factory": "macOSBuildFactory", "platform": "mac-sequoia",
       "configuration": "release", "architectures": ["x86_64", "arm64"],
+      "deployment_target": "15.4",
       "rebuild_without_change_on_builder": true,
       "triggers": ["api-tests-mac-ews", "macos-sequoia-release-wk1-tests-ews", "macos-sequoia-release-wk2-tests-ews", "macos-sequoia-release-wk2-intel-tests-ews", "macos-release-wk2-stress-tests-ews"],
       "workernames": ["ews101", "ews102", "ews103", "ews105", "ews116", "ews117", "ews118", "ews119", "ews120", "ews141", "ews145", "ews147", "ews148", "ews161", "ews162"]

--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -33,9 +33,9 @@ class Factory(factory.BuildFactory):
     branches = None
     requiresUserValidation = False
 
-    def __init__(self, platform, configuration=None, architectures=None, buildOnly=True, triggers=None, triggered_by=None, remotes=None, additionalArguments=None, checkRelevance=False, rebuild_without_change_on_builder=False, **kwargs):
+    def __init__(self, platform, configuration=None, architectures=None, buildOnly=True, triggers=None, triggered_by=None, remotes=None, additionalArguments=None, checkRelevance=False, rebuild_without_change_on_builder=False, deployment_target=None, **kwargs):
         factory.BuildFactory.__init__(self)
-        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=buildOnly, triggers=triggers, triggered_by=triggered_by, remotes=remotes, additionalArguments=additionalArguments, rebuild_without_change_on_builder=rebuild_without_change_on_builder))
+        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=buildOnly, triggers=triggers, triggered_by=triggered_by, remotes=remotes, additionalArguments=additionalArguments, rebuild_without_change_on_builder=rebuild_without_change_on_builder, deployment_target=deployment_target))
         if checkRelevance:
             self.addStep(CheckChangeRelevance())
         self.addStep(ValidateChange(branches=self.branches))
@@ -136,8 +136,8 @@ class WebKitPyFactory(Factory):
 class BuildFactory(Factory):
     skipUpload = False
 
-    def __init__(self, platform, configuration=None, architectures=None, triggers=None, additionalArguments=None, checkRelevance=False, rebuild_without_change_on_builder=False, **kwargs):
-        Factory.__init__(self, platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, triggers=triggers, additionalArguments=additionalArguments, checkRelevance=checkRelevance, rebuild_without_change_on_builder=rebuild_without_change_on_builder)
+    def __init__(self, platform, configuration=None, architectures=None, triggers=None, additionalArguments=None, checkRelevance=False, rebuild_without_change_on_builder=False, deployment_target=None, **kwargs):
+        Factory.__init__(self, platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, triggers=triggers, additionalArguments=additionalArguments, checkRelevance=checkRelevance, rebuild_without_change_on_builder=rebuild_without_change_on_builder, deployment_target=deployment_target)
         self.addStep(KillOldProcesses())
         if platform == 'gtk':
             self.addStep(InstallGtkDependencies())
@@ -346,9 +346,9 @@ class ServicesFactory(Factory):
 
 
 class CommitQueueFactory(factory.BuildFactory):
-    def __init__(self, platform, configuration=None, architectures=None, additionalArguments=None, **kwargs):
+    def __init__(self, platform, configuration=None, architectures=None, additionalArguments=None, deployment_target=None, **kwargs):
         factory.BuildFactory.__init__(self)
-        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, triggers=None, remotes=None, additionalArguments=additionalArguments))
+        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, triggers=None, remotes=None, additionalArguments=additionalArguments, deployment_target=deployment_target))
         self.addStep(ValidateChange(verifycqplus=True))
         self.addStep(ValidateCommitterAndReviewer())
         self.addStep(PrintConfiguration())
@@ -380,9 +380,9 @@ class CommitQueueFactory(factory.BuildFactory):
 
 
 class MergeQueueFactoryBase(factory.BuildFactory):
-    def __init__(self, platform, configuration=None, architectures=None, additionalArguments=None, **kwargs):
+    def __init__(self, platform, configuration=None, architectures=None, additionalArguments=None, deployment_target=None, **kwargs):
         super(MergeQueueFactoryBase, self).__init__()
-        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, triggers=None, remotes=None, additionalArguments=additionalArguments))
+        self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, triggers=None, remotes=None, additionalArguments=additionalArguments, deployment_target=deployment_target))
         self.addStep(ValidateChange(verifyMergeQueue=True, verifyNoDraftForMergeQueue=True, enableSkipEWSLabel=False))
         self.addStep(DetermineLabelOwner())
         self.addStep(ValidateCommitterAndReviewer())

--- a/Tools/CISupport/ews-build/loadConfig.py
+++ b/Tools/CISupport/ews-build/loadConfig.py
@@ -75,7 +75,7 @@ def loadBuilderConfig(c, is_test_mode_enabled=False, setup_main_schedulers=True,
         if 'icon' in builder:
             del builder['icon']
         factorykwargs = {}
-        for key in ['platform', 'configuration', 'architectures', 'triggers', 'remotes', 'additionalArguments', 'runTests', 'triggered_by', 'rebuild_without_change_on_builder']:
+        for key in ['platform', 'configuration', 'architectures', 'triggers', 'remotes', 'additionalArguments', 'runTests', 'triggered_by', 'rebuild_without_change_on_builder', 'deployment_target']:
             value = builder.pop(key, None)
             if value:
                 factorykwargs[key] = value

--- a/Tools/CISupport/ews-build/loadConfig_unittest.py
+++ b/Tools/CISupport/ews-build/loadConfig_unittest.py
@@ -58,8 +58,9 @@ class ConfigDotJSONTest(unittest.TestCase):
     def test_builder_keys(self):
         config = self.get_config()
         valid_builder_keys = ['additionalArguments', 'architectures', 'builddir', 'configuration', 'description',
-                              'defaultProperties', 'env', 'factory', 'icon', 'locks', 'name', 'platform', 'properties',
-                              'rebuild_without_change_on_builder', 'remotes', 'runTests', 'shortname', 'tags', 'triggers', 'triggered_by', 'workernames', 'workerbuilddir']
+                              'defaultProperties', 'deployment_target', 'env', 'factory', 'icon', 'locks', 'name',
+                              'platform', 'properties', 'rebuild_without_change_on_builder', 'remotes', 'runTests',
+                              'shortname', 'tags', 'triggers', 'triggered_by', 'workernames', 'workerbuilddir']
         for builder in config.get('builders', []):
             for key in builder:
                 self.assertTrue(key in valid_builder_keys, 'Unexpected key "{}" for builder {}'.format(key, builder.get('name')))
@@ -125,6 +126,13 @@ class ConfigDotJSONTest(unittest.TestCase):
         for builder in config['builders']:
             if builder.get('rebuild_without_change_on_builder'):
                 self.assertTrue(builder.get('triggers'), f'rebuild_without_change_on_builder should only be set on builders with triggers, but found on: {builder["name"]}')
+
+    def test_deployment_target_on_intended_queues(self):
+        config = self.get_config()
+        for builder in config['builders']:
+            if builder.get('deployment_target'):
+                self.assertTrue(builder.get('factory') == 'macOSBuildFactory',
+                                f'custom deployment target only implemented for macOS builders, but found on "{builder["name"]}" with factory "{builder["factory"]}"')
 
 
 class TagsForBuilderTest(unittest.TestCase):

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -655,7 +655,7 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
     description = ['configuring build']
     descriptionDone = ['Configured build']
 
-    def __init__(self, platform, configuration, architectures, buildOnly, triggers, remotes, additionalArguments, triggered_by=None, rebuild_without_change_on_builder=False):
+    def __init__(self, platform, configuration, architectures, buildOnly, triggers, remotes, additionalArguments, triggered_by=None, rebuild_without_change_on_builder=False, deployment_target=None):
         super().__init__()
         self.platform = platform
         if platform != 'jsc-only':
@@ -669,6 +669,7 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
         self.remotes = remotes
         self.additionalArguments = additionalArguments
         self.rebuild_without_change_on_builder = rebuild_without_change_on_builder
+        self.deployment_target = deployment_target
 
     @defer.inlineCallbacks
     def run(self):
@@ -693,6 +694,8 @@ class ConfigureBuild(buildstep.BuildStep, AddToLogMixin):
             self.setProperty('additionalArguments', self.additionalArguments, 'config.json')
         if self.rebuild_without_change_on_builder:
             self.setProperty('rebuild_without_change_on_builder', self.rebuild_without_change_on_builder, 'config.json')
+        if self.deployment_target:
+            self.setProperty('deployment_target', self.deployment_target, 'config.json')
 
         self.add_patch_id_url()
         yield self.add_pr_details()
@@ -2965,6 +2968,7 @@ class Trigger(trigger.Trigger):
         properties_to_pass['retry_count'] = properties.Property('retry_count', default=0)
         properties_to_pass['os_version_builder'] = properties.Property('os_version', default='')
         properties_to_pass['xcode_version_builder'] = properties.Property('xcode_version', default='')
+        properties_to_pass['deployment_target_builder'] = properties.Property('deployment_target')
         properties_to_pass['parent_buildnumber'] = properties.Property('buildnumber')
         properties_to_pass['parent_builderid'] = properties.Property('builderid')
         properties_to_pass['rebuild_without_change_on_builder'] = properties.Property('rebuild_without_change_on_builder', default=False)
@@ -3377,6 +3381,9 @@ class CompileWebKit(shell.Compile, AddToLogMixin, ShellMixin):
                 # this much faster than full debug info, and crash logs still have line numbers.
                 # Some projects (namely lldbWebKitTester) require full debug info, and may override this.
                 build_command += ['DEBUG_INFORMATION_FORMAT=dwarf-with-dsym', 'CLANG_DEBUG_INFORMATION_LEVEL=$(WK_OVERRIDE_DEBUG_INFORMATION_LEVEL:default=line-tables-only)']
+            deployment_target = self.getProperty('deployment_target')
+            if deployment_target and platform == 'mac':
+                build_command += [f'MACOSX_DEPLOYMENT_TARGET={deployment_target}']
 
         build_command += customBuildFlag(platform, self.getProperty('fullPlatform'))
 
@@ -6706,17 +6713,32 @@ class PrintConfiguration(steps.ShellSequence, ShellMixin):
         self.setProperty('os_version', os_version)
         self.setProperty('os_name', os_name)
         self.setProperty('xcode_version', xcode_version)
+
+        deployment_target_builder = self.getProperty('deployment_target_builder')
         os_version_builder = self.getProperty('os_version_builder', '')
         xcode_version_builder = self.getProperty('xcode_version_builder', '')
-        os_major_version_mismatch = os_version and os_version_builder and (os_version.split('.')[:2] != os_version_builder.split('.')[:2])
-        xcode_version_mismatch = xcode_version and xcode_version_builder and (xcode_version != xcode_version_builder)
 
-        if os_major_version_mismatch or xcode_version_mismatch:
-            message = f'Error: OS/SDK version mismatch, please inform an admin.'
-            detailed_message = message + f' Builder: OS={os_version_builder}, Xcode={xcode_version_builder}; Tester: OS={os_version}, Xcode={xcode_version}'
-            print(f'\n{detailed_message}')
-            self.build.stopBuild(reason=detailed_message, results=FAILURE)
-            self.build.buildFinished([message], FAILURE)
+        os_major, os_minor = os_version.split('.')[:2] if '.' in os_version else (os_version, '0')
+        if deployment_target_builder:
+            # Compare the builder's deployment target with the machine's OS
+            # version.
+            dt_major, dt_minor = deployment_target_builder.split('.')[:2]
+            if dt_major != os_major or dt_minor > os_minor:
+                message = f'Error: Builder deploys to {deployment_target_builder}, but this machine is running {os_version}'
+                details = message + ('\nPossible configuration issue. Either this machine should be upgraded to the '
+                                     'deployment OS or newer, or the build configuration should change to target the '
+                                     'intended testing OS.')
+                self.build.stopBuild(reason=details, results=FAILURE)
+                self.build.buildFinished([message], FAILURE)
+        elif os_version_builder and xcode_version_builder:
+            ob_major, ob_minor = os_version_builder.split('.')[:2]
+            xb_major, xb_minor = xcode_version_builder.split('.')[:2]
+            xc_major, xc_minor = xcode_version.split('.')[:2]
+            if (os_major, os_minor) != (ob_major, ob_minor) or (xc_major, xc_minor) != (xb_major, xb_minor):
+                message = f'Error: OS/SDK version mismatch, please inform an admin.'
+                detailed_message = message + f' Builder: OS={os_version_builder}, Xcode={xcode_version_builder}; Tester: OS={os_version}, Xcode={xcode_version}'
+                self.build.stopBuild(reason=detailed_message, results=FAILURE)
+                self.build.buildFinished([message], FAILURE)
 
     def getResultSummary(self):
         if self.results not in [SUCCESS, WARNINGS, EXCEPTION]:

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -145,6 +145,9 @@ class BuildStepMixinAdditions(BuildStepMixin, TestReactorMixin):
     def tear_down_test_build_step(self):
         shutil.rmtree(self._temp_directory)
 
+    def fakeStopBuild(self, reason, results):
+        pass
+
     def fakeBuildFinished(self, text, results):
         self.build.text = text
         self.build.results = results
@@ -158,6 +161,7 @@ class BuildStepMixinAdditions(BuildStepMixin, TestReactorMixin):
         self.build.terminate = False
         self.build.stopped = False
         self.build.executedSteps = self.executedSteps
+        self.build.stopBuild = self.fakeStopBuild
         self.build.buildFinished = self.fakeBuildFinished
         self._expected_added_urls = []
         self._expected_sources = None
@@ -1285,6 +1289,24 @@ class TestCompileWebKit(BuildStepMixinAdditions, unittest.TestCase):
                         timeout=3600,
                         log_environ=False,
                         command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'perl Tools/Scripts/build-webkit --release --architecture "x86_64 arm64" -hideShellScriptEnvironment WK_VALIDATE_DEPENDENCIES=YES 2>&1 | perl Tools/Scripts/filter-build-webkit -logfile build-log.txt'],
+                        )
+            .exit(0),
+        )
+        self.expect_outcome(result=SUCCESS, state_string='Compiled WebKit')
+        return self.run_step()
+
+    def test_success_deployment_target(self):
+        self.setup_step(CompileWebKit())
+        self.setProperty('platform', 'mac')
+        self.setProperty('fullPlatform', 'mac-sequoia')
+        self.setProperty('configuration', 'release')
+        self.setProperty('architecture', 'arm64')
+        self.setProperty('deployment_target', '15.4')
+        self.expectRemoteCommands(
+            ExpectShell(workdir='wkdir',
+                        timeout=3600,
+                        log_environ=False,
+                        command=['/bin/bash', '--posix', '-o', 'pipefail', '-c', 'perl Tools/Scripts/build-webkit --release --architecture "arm64" -hideShellScriptEnvironment WK_VALIDATE_DEPENDENCIES=YES MACOSX_DEPLOYMENT_TARGET=15.4 2>&1 | perl Tools/Scripts/filter-build-webkit -logfile build-log.txt'],
                         )
             .exit(0),
         )
@@ -6105,12 +6127,7 @@ class TestPrintConfiguration(BuildStepMixinAdditions, unittest.TestCase):
     def tearDown(self):
         return self.tear_down_test_build_step()
 
-    def test_success_mac(self):
-        self.setup_step(PrintConfiguration())
-        self.setProperty('buildername', 'macOS-Sequoia-Release-WK2-Tests-EWS')
-        self.setProperty('platform', 'mac-sequoia')
-
-        self.expectRemoteCommands(
+    mac_remote_commands = [
             ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, log_environ=False).exit(0)
             .log('stdio', stdout='ews150.apple.com'),
             ExpectShell(command=['df', '-hl'], workdir='wkdir', timeout=60, log_environ=False).exit(0)
@@ -6121,39 +6138,35 @@ class TestPrintConfiguration(BuildStepMixinAdditions, unittest.TestCase):
             ExpectShell(command=['date'], workdir='wkdir', timeout=60, log_environ=False).exit(0)
             .log('stdio', stdout='Tue Apr  9 15:30:52 PDT 2019'),
             ExpectShell(command=['sw_vers'], workdir='wkdir', timeout=60, log_environ=False).exit(0)
-            .log('stdio', stdout='''ProductName:	macOS
-ProductVersion:	15.0
-BuildVersion:	24A335'''),
+            .log('stdio', stdout='''\
+ProductName:		macOS
+ProductVersion:		15.7.3
+BuildVersion:		24G419
+'''),
             ExpectShell(command=['system_profiler', 'SPSoftwareDataType', 'SPHardwareDataType'], workdir='wkdir', timeout=60, log_environ=False).exit(0)
             .log('stdio', stdout='Configuration version: Software: System Software Overview: System Version: macOS 11.4 (20F71) Kernel Version: Darwin 20.5.0 Boot Volume: Macintosh HD Boot Mode: Normal Computer Name: bot1020 User Name: WebKit Build Worker (buildbot) Secure Virtual Memory: Enabled System Integrity Protection: Enabled Time since boot: 27 seconds Hardware: Hardware Overview: Model Name: Mac mini Model Identifier: Macmini8,1 Processor Name: 6-Core Intel Core i7 Processor Speed: 3.2 GHz Number of Processors: 1 Total Number of Cores: 6 L2 Cache (per Core): 256 KB L3 Cache: 12 MB Hyper-Threading Technology: Enabled Memory: 32 GB System Firmware Version: 1554.120.19.0.0 (iBridge: 18.16.14663.0.0,0) Serial Number (system): C07DXXXXXXXX Hardware UUID: F724DE6E-706A-5A54-8D16-000000000000 Provisioning UDID: E724DE6E-006A-5A54-8D16-000000000000 Activation Lock Status: Disabled Xcode 12.5 Build version 12E262'),
             ExpectShell(command=['cat', '/usr/share/zoneinfo/+VERSION'], workdir='wkdir', timeout=60, log_environ=False).exit(0),
             ExpectShell(command=['xcodebuild', '-sdk', '-version'], workdir='wkdir', timeout=60, log_environ=False)
-            .log('stdio', stdout='''MacOSX15.sdk - macOS 15.0 (macosx15.0)
-SDKVersion: 15.0
-Path: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.sdk
-PlatformVersion: 15.0
+            .log('stdio', stdout='''\
+MacOSX26.2.sdk - macOS 26.2 (macosx26.2)
+SDKVersion: 26.2
+Path: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX26.2.sdk
+PlatformVersion: 26.2
 PlatformPath: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform
-BuildID: E7931D9A-726E-11EF-B57C-DCEFEEF80074
-ProductBuildVersion: 24A336
-ProductCopyright: 1983-2024 Apple Inc.
+BuildID: 05A94E40-D000-11F0-8431-777054EDFE1B
+ProductBuildVersion: 25C57
+ProductCopyright: 1983-2025 Apple Inc.
 ProductName: macOS
-ProductUserVisibleVersion: 15.0
-ProductVersion: 15.0
-iOSSupportVersion: 18.0
+ProductUserVisibleVersion: 26.2
+ProductVersion: 26.2
+iOSSupportVersion: 26.2
 
-Xcode 16.0
-Build version 16A242d''')
+Xcode 26.2
+Build version 17C52''')
             .exit(0),
-        )
-        self.expect_outcome(result=SUCCESS, state_string='OS: Sequoia (15.0), Xcode: 16.0')
-        return self.run_step()
+    ]
 
-    def test_success_ios_simulator(self):
-        self.setup_step(PrintConfiguration())
-        self.setProperty('buildername', 'Apple-iOS-17-Simulator-Release-WK2-Tests')
-        self.setProperty('platform', 'ios-simulator-17')
-
-        self.expectRemoteCommands(
+    ios_remote_commands = [
             ExpectShell(command=['hostname'], workdir='wkdir', timeout=60, log_environ=False).exit(0)
             .log('stdio', stdout='ews152.apple.com'),
             ExpectShell(command=['df', '-hl'], workdir='wkdir', timeout=60, log_environ=False).exit(0)
@@ -6185,9 +6198,70 @@ ProductVersion: 17.5
 Xcode 15.4
 Build version 15F31d''')
             .exit(0),
-        )
+    ]
+
+    def test_success_mac(self):
+        self.setup_step(PrintConfiguration())
+        self.setProperty('buildername', 'macOS-Sequoia-Release-WK2-Tests-EWS')
+        self.setProperty('platform', 'mac-sequoia')
+
+        self.expectRemoteCommands(*self.mac_remote_commands)
+        self.expect_outcome(result=SUCCESS, state_string='OS: Sequoia (15.7.3), Xcode: 26.2')
+        return self.run_step()
+
+    @defer.inlineCallbacks
+    def test_failure_deployment_target_different_major_version(self):
+        self.setup_step(PrintConfiguration())
+        self.setProperty('buildername', 'macOS-Sequoia-Release-WK2-Tests')
+        self.setProperty('platform', 'mac-sequoia')
+        self.setProperty('deployment_target_builder', '14.0')
+
+        self.expectRemoteCommands(*self.mac_remote_commands)
+
+        # Configuration step will have completed successfully but stopped the
+        # build with a cancellation text.
+        self.expect_outcome(result=SUCCESS, state_string='OS: Sequoia (15.7.3), Xcode: 26.2')
+        rc = yield self.run_step()
+        self.assertEqual(self.build.results, FAILURE)
+        self.assertIn('Error: Builder deploys to 14.0, but this machine is running 15.7.3', self.build.text)
+        return rc
+
+    def test_success_deployment_target_earlier_minor_release(self):
+        self.setup_step(PrintConfiguration())
+        self.setProperty('buildername', 'macOS-Sequoia-Release-WK2-Tests')
+        self.setProperty('platform', 'mac-sequoia')
+        self.setProperty('deployment_target_builder', '15.4')
+
+        self.expectRemoteCommands(*self.mac_remote_commands)
+        self.expect_outcome(result=SUCCESS, state_string='OS: Sequoia (15.7.3), Xcode: 26.2')
+        return self.run_step()
+
+    def test_success_ios_simulator(self):
+        self.setup_step(PrintConfiguration())
+        self.setProperty('buildername', 'Apple-iOS-17-Simulator-Release-WK2-Tests')
+        self.setProperty('platform', 'ios-simulator-17')
+
+        self.expectRemoteCommands(*self.ios_remote_commands)
         self.expect_outcome(result=SUCCESS, state_string='OS: Sonoma (14.5), Xcode: 15.4')
         return self.run_step()
+
+    @defer.inlineCallbacks
+    def test_failure_ios_version_mismatch(self):
+        self.setup_step(PrintConfiguration())
+        self.setProperty('buildername', 'Apple-iOS-17-Simulator-Release-WK2-Tests')
+        self.setProperty('platform', 'ios-simulator-17')
+        self.setProperty('os_version_builder', '26.0')
+        self.setProperty('xcode_version_builder', '26.0')
+
+        self.expectRemoteCommands(*self.ios_remote_commands)
+
+        # Configuration step will have completed successfully but stopped the
+        # build with a cancellation text.
+        self.expect_outcome(result=SUCCESS, state_string='OS: Sonoma (14.5), Xcode: 15.4')
+        rc = yield self.run_step()
+        self.assertEqual(self.build.results, FAILURE)
+        self.assertIn('Error: OS/SDK version mismatch, please inform an admin.', self.build.text)
+        return rc
 
     def test_success_webkitpy(self):
         self.setup_step(PrintConfiguration())
@@ -10788,8 +10862,7 @@ class TestTrigger(BuildStepMixinAdditions, unittest.TestCase):
         self.assertIn('architecture', props)
         self.assertIn('codebase', props)
         self.assertIn('retry_count', props)
-        self.assertIn('os_version_builder', props)
-        self.assertIn('xcode_version_builder', props)
+        self.assertIn('deployment_target_builder', props)
         self.assertIn('ews_revision', props)
         self.assertIn('parent_buildnumber', props)
         self.assertIn('parent_builderid', props)


### PR DESCRIPTION
#### f4f384ccff9af49ceafa8352c6f8fbeb865cef3c
<pre>
[EWS] Recognize a macOS deployment target config parameter for back-deployed builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=307195">https://bugs.webkit.org/show_bug.cgi?id=307195</a>
<a href="https://rdar.apple.com/151877838">rdar://151877838</a>

Reviewed by Ryan Haddad.

In EWS, add an optional `deployment_target` field to config.json. Store
it as a property of the build and plumb it through to the build-webkit
line, where it is used to override the MACOSX_DEPLOYMENT_TARGET build
setting.

When deployment target is set, use it to perform the builder/tester
configuration check, instead of comparing OS and Xcode version. Testers
must be running an OS version that is at least as recent as the
deployment target, in the same major release.

Set the deployment target for the existing Sequoia queues.

* Tools/CISupport/ews-build/config.json:
* Tools/CISupport/ews-build/factories.py:
(Factory.__init__):
(BuildFactory.__init__):
(CommitQueueFactory.__init__):
(MergeQueueFactoryBase.__init__):
* Tools/CISupport/ews-build/loadConfig.py:
(loadBuilderConfig):
* Tools/CISupport/ews-build/loadConfig_unittest.py:
(ConfigDotJSONTest.test_builder_keys):
(ConfigDotJSONTest.test_deployment_target_on_intended_queues):
* Tools/CISupport/ews-build/steps.py:
(ConfigureBuild.__init__):
(ConfigureBuild.run):
(Trigger.propertiesToPassToTriggers):
(CompileWebKit.run):
(PrintConfiguration.parseAndValidate):
* Tools/CISupport/ews-build/steps_unittest.py:
(BuildStepMixinAdditions.fakeStopBuild):
(BuildStepMixinAdditions.setup_step): Add a callable stopBuild() to
  FakeBuild which does nothing. The test checks the state set by
  buildFinished(). AFAICT, the FakeBuild + FakeMaster do not establish
  enough internal state for the native build interruption logic to work.

Canonical link: <a href="https://commits.webkit.org/309626@main">https://commits.webkit.org/309626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3ed70a0b440c2b44fce8564d9a3015ce07c08bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24028 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/17598 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159994 "Failed to checkout and rebase branch from PR 58076") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153138 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24459 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/24274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/159994 "Failed to checkout and rebase branch from PR 58076") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154225 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/159994 "Failed to checkout and rebase branch from PR 58076") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/24274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7839 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127625 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/13642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/162466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/15212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/162466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/150665 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23829 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/24274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/162466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23819 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/135438 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80300 "Failed to checkout and rebase branch from PR 58076") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23238 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/20056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12203 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/23429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/23141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/23293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/23195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->