### PR TITLE
Add a unit test using WebTransport from a service worker

### DIFF
--- a/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm
@@ -402,7 +402,7 @@ void NetworkTransportSession::setupDatagramConnection(CompletionHandler<void(std
     RetainPtr webtransportOptions = adoptNS(nw_webtransport_create_options());
     if (!webtransportOptions) {
         ASSERT_NOT_REACHED();
-        return;
+        return completionHandler(std::nullopt);
     }
     nw_webtransport_options_set_is_unidirectional(webtransportOptions.get(), false);
     nw_webtransport_options_set_is_datagram(webtransportOptions.get(), true);
@@ -412,7 +412,7 @@ void NetworkTransportSession::setupDatagramConnection(CompletionHandler<void(std
     m_datagramConnection = adoptNS(nw_connection_group_extract_connection(m_connectionGroup.get(), nil, webtransportOptions.get()));
     if (!m_datagramConnection) {
         ASSERT_NOT_REACHED();
-        return;
+        return completionHandler(std::nullopt);
     }
 
     auto creationCompletionHandler = [completionHandler = WTF::move(completionHandler)] (bool success) mutable {


### PR DESCRIPTION
#### 68fbc9b1a74d96560882dcc0039e2abd38ad5542
<pre>
Add a unit test using WebTransport from a service worker
<a href="https://bugs.webkit.org/show_bug.cgi?id=307200">https://bugs.webkit.org/show_bug.cgi?id=307200</a>
<a href="https://rdar.apple.com/169829155">rdar://169829155</a>

Reviewed by Tim Nguyen.

I wrote this while investigating <a href="https://rdar.apple.com/168599027">rdar://168599027</a>
and it&apos;s unique enough to add significant useful test coverage.
Also, add some missing completion handler calls in branches that
should never be taken.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm

* Source/WebKit/NetworkProcess/webtransport/cocoa/NetworkTransportSessionCocoa.mm:
(WebKit::NetworkTransportSession::setupDatagramConnection):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebTransport.mm:
(TestWebKitAPI::TEST(WebTransport, ServiceWorker)):
(TestWebKitAPI::TEST(WebTransport, CreateStreamsBeforeReady)): Deleted.
(TestWebKitAPI::TEST(WebTransport, DISABLED_CSP)): Deleted.
(TestWebKitAPI::TEST(WebTransport, ServerCertificateHashes)): Deleted.
(TestWebKitAPI::TEST(WebTransport, ServerConnectionTermination)): Deleted.
(TestWebKitAPI::TEST(WebTransport, BackForwardCache)): Deleted.
(TestWebKitAPI::TEST(WebTransport, ServerDrain)): Deleted.
(TestWebKitAPI::TEST(WebTransport, DISABLED_ClientStreamAborts)): Deleted.
(TestWebKitAPI::TEST(WebTransport, DISABLED_ServerStreamAborts)): Deleted.

Canonical link: <a href="https://commits.webkit.org/307006@main">https://commits.webkit.org/307006@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d549d4753b3b343105137e8eb6cc23abc0540df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143026 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15501 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6075 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151700 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144893 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109989 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/390af396-3090-420f-8f69-265626366798) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127952 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90900 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0facb29e-2c8c-4c9c-bfb6-267cfb2d4cca) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9619 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1699 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121329 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154013 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/15197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5140 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118006 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/15166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13109 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118346 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70831 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22056 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15170 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4207 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14904 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78889 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15115 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14966 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->