### PR TITLE
[ARMv7] Disable caches to reduce memory footprint

### DIFF
--- a/Source/JavaScriptCore/assembler/AssemblerBuffer.h
+++ b/Source/JavaScriptCore/assembler/AssemblerBuffer.h
@@ -123,6 +123,8 @@ namespace JSC {
             // from initialization
             poisonInlineBuffer();
 #endif
+            if constexpr (is32Bit())
+                return;
             if constexpr (type == AssemblerDataType::Code)
                 takeBufferIfLarger(*threadSpecificAssemblerData());
 #if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
@@ -185,14 +187,16 @@ namespace JSC {
 
         ~AssemblerDataImpl()
         {
-            if constexpr (type == AssemblerDataType::Code)
-                threadSpecificAssemblerData()->takeBufferIfLarger(*this);
+            if constexpr (!is32Bit()) {
+                if constexpr (type == AssemblerDataType::Code)
+                    threadSpecificAssemblerData()->takeBufferIfLarger(*this);
 #if ENABLE(JIT_SIGN_ASSEMBLER_BUFFER)
-            if constexpr (type == AssemblerDataType::Hashes)
-                threadSpecificAssemblerHashes()->takeBufferIfLarger(*this);
+                if constexpr (type == AssemblerDataType::Hashes)
+                    threadSpecificAssemblerHashes()->takeBufferIfLarger(*this);
 #else
-            static_assert(type != AssemblerDataType::Hashes);
+                static_assert(type != AssemblerDataType::Hashes);
 #endif
+            }
             clear();
         }
 

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -539,8 +539,8 @@ bool hasCapacityToUseLargeGigacage();
     \
     v(Bool, useSuperSampler, false, Normal, nullptr) \
     \
-    v(Bool, useSourceProviderCache, true, Normal, "If false, the parser will not use the source provider cache. It's good to verify everything works when this is false. Because the cache is so successful, it can mask bugs."_s) \
-    v(Bool, useCodeCache, true, Normal, "If false, the unlinked byte code cache will not be used."_s) \
+    v(Bool, useSourceProviderCache, is64Bit(), Normal, "If false, the parser will not use the source provider cache. It's good to verify everything works when this is false. Because the cache is so successful, it can mask bugs."_s) \
+    v(Bool, useCodeCache, is64Bit(), Normal, "If false, the unlinked byte code cache will not be used."_s) \
     \
     v(Bool, useWasm, canUseWasm(), Normal, "Expose the Wasm global object."_s) \
     \

--- a/Tools/Scripts/run-jsc-stress-tests
+++ b/Tools/Scripts/run-jsc-stress-tests
@@ -633,6 +633,7 @@ $isSIMDPlatform = $isWasmPlatform && ($architecture == "arm64" || $architecture 
 
 $skipLockdown = false
 $skipMiniMode = false
+$skipBytecodeCache = false
 
 if $platform == "watchos"
     $jitTests = false
@@ -647,6 +648,7 @@ if $architecture == "arm"
     $isFTLPlatform = false
     $isWasmPlatform = false
     $skipLockdown = true
+    $skipBytecodeCache = true
 end
 
 # This is meant for skipping execution of tests than require a lot of address
@@ -1593,7 +1595,7 @@ def defaultRunConfig(config, subsetOptions, *optionalTestSpecificOptions)
         defaultQuickRunConfig(config, *optionalTestSpecificOptions)
     else
         runDefaultConfig(config, *optionalTestSpecificOptions)
-        runBytecodeCacheConfig(config, *optionalTestSpecificOptions)
+        runBytecodeCacheConfig(config, *optionalTestSpecificOptions) unless $skipBytecodeCache
         runMiniModeConfig(config, *optionalTestSpecificOptions) unless $skipMiniMode
         runLockdownConfig(config, *optionalTestSpecificOptions) unless $skipLockdown or $skipModes.include?(:lockdown)
         if $jitTests


### PR DESCRIPTION
#### 9590f432200c3efe6dfccc61c3b07e532cdacb95
<pre>
[ARMv7] Disable caches to reduce memory footprint
<a href="https://bugs.webkit.org/show_bug.cgi?id=307206">https://bugs.webkit.org/show_bug.cgi?id=307206</a>

Reviewed by NOBODY (OOPS!).

These caches don&apos;t make sense on devices where we are almost always
hitting memory pressure anyway.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a87f5ca735a504433c6fdb21b900488721d8dfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8245 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97252 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17174 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110748 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79598 "Exiting early after 60 failures. 15463 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13163 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91667 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12628 "Found 4 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-initial-focus-display-animation.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10361 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/129 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136004 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122099 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154995 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4821 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7104 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118759 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16580 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119114 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15017 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127260 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71965 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16166 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5706 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175300 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15900 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79945 "Failed to build and analyze WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45201 "Found 3 new JSC stress test failures: stress/bytecode-cache-cached-string-impl.js.bytecode-cache, stress/bytecode-cache-run-string.js.bytecode-cache, stress/bytecode-cache-shared-code-block.js.bytecode-cache (failure)") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16111 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15966 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->