### PR TITLE
[JSC] Fix non-unified builds

### DIFF
--- a/Source/JavaScriptCore/API/JSCallbackObject.h
+++ b/Source/JavaScriptCore/API/JSCallbackObject.h
@@ -33,9 +33,10 @@
 #if defined(JSC_GLIB_API_ENABLED)
 #include "JSAPIWrapperGlobalObject.h"
 #endif
+#include "JSGlobalObject.h"
+#include "JSObject.h"
 #include "JSObjectRef.h"
 #include "JSValueRef.h"
-#include "JSObject.h"
 #include <wtf/PlatformCallingConventions.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/b3/B3LowerToAir.cpp
+++ b/Source/JavaScriptCore/b3/B3LowerToAir.cpp
@@ -2133,11 +2133,13 @@ private:
         return test(width, resCond, leftPromise, rightPromise);
     }
 
+#if CPU(ARM64)
     // ARM64 conditional compare (ccmp) optimization.
     // Converts chains of comparisons like (a == b && c == d) into ccmp instruction sequences.
     // This reduces branches and can improve performance by avoiding branch mispredictions.
 
     static constexpr unsigned maxCompareChainSize = 4;
+#endif
 
     class CompareChainNode {
         WTF_MAKE_TZONE_ALLOCATED(CompareChainNode);

--- a/Source/JavaScriptCore/debugger/DebuggerParseData.cpp
+++ b/Source/JavaScriptCore/debugger/DebuggerParseData.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "DebuggerParseData.h"
 
+#include "JSCJSValueInlines.h"
 #include "Parser.h"
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -29,6 +29,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "ArrayPrototype.h"
+#include "CacheableIdentifierInlines.h"
 #include "CodeBlock.h"
 #include "CodeBlockWithJITType.h"
 #include "DFGBackwardsCFG.h"

--- a/Source/JavaScriptCore/parser/Nodes.cpp
+++ b/Source/JavaScriptCore/parser/Nodes.cpp
@@ -28,6 +28,7 @@
 #include "NodeConstructors.h"
 
 #include "ExecutableInfo.h"
+#include "JSCJSValueInlines.h"
 #include "ModuleScopeData.h"
 #include <wtf/Assertions.h>
 

--- a/Source/JavaScriptCore/parser/SourceProviderCache.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCache.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/ImplementationVisibility.h>
 #include <JavaScriptCore/SourceProviderCacheItem.h>
 #include <wtf/HashMap.h>
 #include <wtf/RefCounted.h>

--- a/Source/JavaScriptCore/runtime/AggregateError.cpp
+++ b/Source/JavaScriptCore/runtime/AggregateError.cpp
@@ -27,7 +27,7 @@
 #include "AggregateError.h"
 
 #include "CommonIdentifiers.h"
-#include "JSArray.h"
+#include "JSArrayInlines.h"
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSPromiseCombinatorsContext.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseCombinatorsContext.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "JSCell.h"
+#include "VM.h"
 
 namespace JSC {
 

--- a/Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.h
+++ b/Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "JSCell.h"
+#include "VM.h"
 
 namespace JSC {
 


### PR DESCRIPTION
#### cde67df1e4bac94bc726e94241d9c54b6b392c0c
<pre>
[JSC] Fix non-unified builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=307208">https://bugs.webkit.org/show_bug.cgi?id=307208</a>

Reviewed by Patrick Griffis.

The main changes are adding missing header inclusions. Where needed
(and possible) a header is replaced by the corresponding *Inlines.h
one.

* Source/JavaScriptCore/API/JSCallbackObject.h: Fix includes.
* Source/JavaScriptCore/b3/B3LowerToAir.cpp: Guard maxCompareChainSize
with CPU(ARM64), to avoid an unused-variable warning in other target
architectures that do not use the constant.
* Source/JavaScriptCore/debugger/DebuggerParseData.cpp: Fix includes.
* Source/JavaScriptCore/dfg/DFGGraph.cpp: Ditto.
* Source/JavaScriptCore/parser/Nodes.cpp: Ditto.
* Source/JavaScriptCore/parser/SourceProviderCache.h: Ditto.
* Source/JavaScriptCore/runtime/AggregateError.cpp: Ditto.
* Source/JavaScriptCore/runtime/JSPromiseCombinatorsContext.h: Ditto.
* Source/JavaScriptCore/runtime/JSPromiseCombinatorsGlobalContext.h: Ditto.

Canonical link: <a href="https://commits.webkit.org/307014@main">https://commits.webkit.org/307014@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/56e53f2b301cbf44d3ebc0b6f9920da967a2e9d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/142987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109956 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79206 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145936 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127909 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90866 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9582 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1660 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/134981 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4445 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153974 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3797 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15085 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/117973 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13072 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118315 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30325 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14271 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125271 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70792 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15128 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4163 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174284 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14863 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78839 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45019 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15100 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14925 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->