### PR TITLE
[MacOS] http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/tests/resources/document-leak-test.js
+++ b/LayoutTests/http/tests/resources/document-leak-test.js
@@ -39,17 +39,18 @@ function iframeSentMessage(message)
     if (frameDocumentIDs.length == allFrames.length) {
         handle = setInterval(() => {
             gc();
+            if (++checkCount > 10) {
+                clearInterval(handle);
+                testFailed("All iframe documents leaked.");
+                finishJSTest();
+                return;
+            }
             for (const documentID of frameDocumentIDs) {
                 if (!internals.isDocumentAlive(documentID)) {
                     clearInterval(handle);
                     testPassed("The iframe document didn't leak.");
                     finishJSTest();
                     return;
-                }
-                if (++checkCount > 10) {
-                    clearInterval(handle);
-                    testFailed("All iframe documents leaked.");
-                    finishJSTest();
                 }
             }
         }, 10);


### PR DESCRIPTION
#### 082d3ef252654c632aadab61ecf319cc35ce6b14
<pre>
[MacOS] http/tests/geolocation/geolocation-get-current-position-does-not-leak.https.html is a flaky text failure
<a href="https://rdar.apple.com/169827162">rdar://169827162</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307196">https://bugs.webkit.org/show_bug.cgi?id=307196</a>

Reviewed by Ryan Reno.

The checkCount logic should track the number of interval iterations (GC attempts), not the total number of document checks.
The counter should be incremented once per interval, outside the document loop, giving the GC multiple chances (10 attempts) to
collect documents regardless of how many frames are being tested.

* LayoutTests/http/tests/resources/document-leak-test.js:

Canonical link: <a href="https://commits.webkit.org/307117@main">https://commits.webkit.org/307117@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ceeca15b4a309fe0387aba84f14b460668b8b50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143377 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15851 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152044 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96614 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110266 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146337 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128890 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91176 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12221 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9937 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2045 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121654 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5383 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154354 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15903 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6410 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118285 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13411 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118626 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30409 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14574 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126575 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71314 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15520 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5220 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15257 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15470 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->