### PR TITLE
[Scroll anchoring] Prepare for a new implementation of ScrollAnchoringController

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6243,11 +6243,6 @@ imported/w3c/web-platform-tests/workers/modules/dedicated-worker-import-csp.html
 # due to how MessagePort::dispatchMessages() is implemented.
 imported/w3c/web-platform-tests/workers/shared-worker-name-via-options.html [ Failure Pass ]
 
-webkit.org/b/242983 imported/w3c/web-platform-tests/css/css-scroll-anchoring/fullscreen-crash.html [ Skip ]
-webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/heuristic-with-offset-update-from-scroll-event-listener.html [ Skip ]
-webkit.org/b/261849 imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction.html [ Skip ]
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-inside-textarea.tentative.html [ Pass Failure ]
-
 # Some Trusted Types tests are flaky due to subtest ordering
 webkit.org/b/274089 imported/w3c/web-platform-tests/trusted-types/trusted-types-from-literal.tentative.html [ Pass Failure ]
 webkit.org/b/266630 imported/w3c/web-platform-tests/trusted-types/trusted-types-navigation.html [ Pass Failure ]
@@ -6305,12 +6300,6 @@ webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activatio
 webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers.html [ Skip ]
 webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyy.html?dialog [ Skip ]
 
-# These tests are image failures
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-000.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/vertical-rl-viewport-size-change-001.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/nested-overflow-subtree-layout-vertical.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/nested-overflow-subtree-layout.html [ Skip ]
-
 # uncategorized dialog element failures
 webkit.org/b/286022 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-close-via-attribute.tentative.html [ Skip ]
 
@@ -6357,6 +6346,11 @@ imported/w3c/web-platform-tests/streams/transferable/gc-crash.html [ Skip ]
 webkit.org/b/241104 fast/block/fill-available-with-no-specified-containing-block-height.html [ ImageOnlyFailure ]
 webkit.org/b/241104 fast/block/fill-available-with-absolute-position.html [ ImageOnlyFailure ]
 webkit.org/b/241104 fast/css/fill-available-with-percent-height-no-quirk.html [ ImageOnlyFailure ]
+
+# temporarily disable all scroll anchoring tests
+imported/w3c/web-platform-tests/css/css-scroll-anchoring [ Skip ]
+# affected by scroll anchoring.
+http/tests/site-isolation/mouse-events/scrolled-mainframe.html [ Skip ]
 
 # compute-kind-widget-generated failures (webkit.org/b/243899)
 imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-button-border-block-end-color-001.html [ ImageOnlyFailure ]
@@ -6488,8 +6482,6 @@ imported/w3c/web-platform-tests/content-security-policy/inheritance/history-ifra
 imported/w3c/web-platform-tests/cookies/domain/domain-attribute-idn-host.sub.https.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-font-loading/font-face-reject.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-fonts/test_datafont_same_origin.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-inside-iframe.html [ Skip ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/reading-scroll-forces-anchoring.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-scroll-snap/input/keyboard.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-values/dynamic-viewport-units-rule-cache.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-variables/variable-reference-refresh.html [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -3794,17 +3794,6 @@ webkit.org/b/240918 [ Debug ] fast/loader/user-style-sheet-resource-load-callbac
 
 webkit.org/b/241253 fast/text/bulgarian-system-language-shaping.html [ Pass ]
 
-# These tests have different results or fail on iOS
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/adjustments-in-scroll-event-handler.tentative.html
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-002.html
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-003.html
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/contenteditable-insert-line-at-top.tentative.html
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/device-pixel-adjustment.html
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/history-restore-anchors.html
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/infinite-scroll-event.tentative.html
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-001.html
-webkit.org/b/306639 imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-002.html
-
 webkit.org/b/258184 [ Debug ] media/track/track-webvtt-no-snap-to-lines-overlap.html [ Pass Crash ]
 
 # Accessibility bold only exists on iOS.
@@ -8259,8 +8248,6 @@ webkit.org/b/297674 [ Release ] http/wpt/mediarecorder/MediaRecorder-matroska-AV
 webkit.org/b/295435 compositing/layer-creation/overlap-animation-container.html [ Pass Failure ]
 
 imported/w3c/web-platform-tests/css/css-break/block-in-inline-012.html [ ImageOnlyFailure ]
-
-webkit.org/b/300905 imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html [ Pass Failure ]
 
 webkit.org/b/298269 [ Release ] imported/w3c/web-platform-tests/html/anonymous-iframe/session-storage.tentative.https.window.html [ Pass Failure ]
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3177,11 +3177,6 @@ auto Document::updateLayout(OptionSet<LayoutOptions> layoutOptions, const Elemen
     if (layoutOptions.contains(LayoutOptions::RunPostLayoutTasksSynchronously) && view())
         protect(view())->flushAnyPendingPostLayoutTasks();
 
-    if (layoutOptions.contains(LayoutOptions::IgnorePendingStylesheets)) {
-        if (RefPtr frameView = view())
-            frameView->adjustScrollAnchoringPositionForScrollableAreas();
-    }
-
     m_ignorePendingStylesheets = oldIgnore;
     return result;
 }
@@ -5953,7 +5948,6 @@ void Document::runScrollSteps()
         if (scrollAnimationsInProgress)
             protect(page())->scheduleRenderingUpdate({ RenderingUpdateStep::Scroll });
 
-        frameView->updateScrollAnchoringElementsForScrollableAreas();
         frameView->adjustScrollAnchoringPositionForScrollableAreas();
     }
 

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -738,7 +738,9 @@ public:
 
     void dequeueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);
     void queueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);
-    void updateScrollAnchoringElementsForScrollableAreas();
+    void clearScrollAnchorsInScrollableAreas();
+
+    void updateScrollAnchoringBeforeLayoutForScrollableAreas();
     void adjustScrollAnchoringPositionForScrollableAreas();
     ScrollAnchoringController* scrollAnchoringController() const final { return m_scrollAnchoringController.get(); }
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -27,16 +27,23 @@
 #include "ScrollAnchoringController.h"
 
 #include "ContainerNodeInlines.h"
+#include "Editing.h"
 #include "ElementChildIteratorInlines.h"
 #include "ElementIterator.h"
 #include "HTMLHtmlElement.h"
+#include "LegacyRenderSVGModelObject.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "NodeInlines.h"
+#include "RenderBlockFlow.h"
 #include "RenderBox.h"
-#include "RenderLayerScrollableArea.h"
+#include "RenderBoxInlines.h"
 #include "RenderElementInlines.h"
+#include "RenderIterator.h"
+#include "RenderLayerScrollableArea.h"
 #include "RenderObjectInlines.h"
+#include "RenderSVGModelObject.h"
+#include "RenderText.h"
 #include "RenderView.h"
 #include "TypedElementDescendantIteratorInlines.h"
 #include <wtf/SetForScope.h>
@@ -49,349 +56,94 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ScrollAnchoringController);
 
 ScrollAnchoringController::ScrollAnchoringController(ScrollableArea& owningScroller)
     : m_owningScrollableArea(owningScroller)
-{ }
+{
+}
 
 ScrollAnchoringController::~ScrollAnchoringController()
 {
-    invalidateAnchorElement();
+    invalidate();
+}
+
+bool ScrollAnchoringController::shouldMaintainScrollAnchor() const
+{
+    CheckedPtr scrollerBox = scrollableAreaBox();
+    if (!scrollerBox)
+        return false;
+
+    // Maybe only check the block direction.
+    if (!scrollerBox->hasScrollableOverflowX() && !scrollerBox->hasScrollableOverflowY())
+        return false;
+
+    if (scrollerBox->style().overflowAnchor() == OverflowAnchor::None)
+        return false;
+
+    // FIXME: RTL: only check the block direction.
+    if (!m_owningScrollableArea->scrollOffset().y())
+        return false;
+
+    return true;
 }
 
 LocalFrameView& ScrollAnchoringController::frameView()
 {
     if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(m_owningScrollableArea.get()))
         return renderLayerScrollableArea->layer().renderer().view().frameView();
+
     return downcast<LocalFrameView>(downcast<ScrollView>(m_owningScrollableArea));
 }
 
-static bool elementIsScrollableArea(const Element& element, const ScrollableArea& scrollableArea)
+RenderBox* ScrollAnchoringController::scrollableAreaBox() const
 {
-    return element.renderBox() && element.renderBox()->layer() && element.renderBox()->layer()->scrollableArea() == &scrollableArea;
-}
+    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(m_owningScrollableArea.get()))
+        return renderLayerScrollableArea->layer().renderBox();
 
-static Element* elementForScrollableArea(ScrollableArea& scrollableArea)
-{
-    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(scrollableArea))
-        return renderLayerScrollableArea->layer().renderer().element();
-    if (auto* document = downcast<LocalFrameView>(downcast<ScrollView>(scrollableArea)).frame().document())
-        return document->documentElement();
+    if (RefPtr frameView = dynamicDowncast<LocalFrameView>(downcast<ScrollView>(m_owningScrollableArea.get())))
+        return frameView->renderView();
+
     return nullptr;
 }
 
-void ScrollAnchoringController::invalidateAnchorElement()
+void ScrollAnchoringController::clearAnchor(bool)
 {
-    if (m_midUpdatingScrollPositionForAnchorElement)
-        return;
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::invalidateAnchorElement() invalidating anchor for frame: " << frameView() << " for scroller: " << m_owningScrollableArea);
-    if (!m_anchorElement) {
-        if (RefPtr element = elementForScrollableArea(m_owningScrollableArea)) {
-            if (auto* renderer = element->renderer()) {
-                CheckedPtr controller = RenderObject::searchParentChainForScrollAnchoringController(*renderer);
-                if (controller && controller->isInScrollAnchoringAncestorChain(*renderer))
-                    controller->invalidateAnchorElement();
-            }
-        }
+}
+
+void ScrollAnchoringController::invalidate()
+{
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " invalidateAnchorElement() invalidating anchor for frame: " << frameView() << " for scroller: " << m_owningScrollableArea);
+
+    m_anchorObject = nullptr;
+    m_lastAnchorOffset = { };
+
+    if (m_isQueuedForScrollPositionUpdate) {
+        m_isQueuedForScrollPositionUpdate = false;
+        frameView().dequeueScrollableAreaForScrollAnchoringUpdate(m_owningScrollableArea);
     }
-    m_anchorElement = nullptr;
-    m_lastOffsetForAnchorElement = { };
-    m_isQueuedForScrollPositionUpdate = false;
-    frameView().dequeueScrollableAreaForScrollAnchoringUpdate(m_owningScrollableArea);
 }
 
-static IntRect boundingRectForScrollableArea(ScrollableArea& scrollableArea)
+void ScrollAnchoringController::notifyChildHadSuppressingStyleChange(RenderElement&)
 {
-    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(scrollableArea))
-        return renderLayerScrollableArea->layer().renderer().absoluteBoundingBoxRect();
-
-    return IntRect(downcast<LocalFrameView>(downcast<ScrollView>(scrollableArea)).layoutViewportRect());
 }
 
-FloatPoint ScrollAnchoringController::computeOffsetFromOwningScroller(RenderObject& candidate)
+void ScrollAnchoringController::chooseAnchorElement(Document&)
 {
-    // TODO: investigate this for zoom/rtl
-    return FloatPoint(candidate.absoluteBoundingBoxRect().location() - boundingRectForScrollableArea(m_owningScrollableArea).location());
+    UNUSED_PARAM(m_isUpdatingScrollPositionForAnchoring);
+    UNUSED_PARAM(m_isQueuedForScrollPositionUpdate);
+    UNUSED_PARAM(m_anchoringSuppressedByStyleChange);
+    UNUSED_PARAM(m_shouldSuppressScrollPositionUpdate);
 }
 
-void ScrollAnchoringController::notifyChildHadSuppressingStyleChange()
+// https://drafts.csswg.org/css-scroll-anchoring/#suppression-triggers
+bool ScrollAnchoringController::anchoringSuppressedByStyleChange() const
 {
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::notifyChildHadSuppressingStyleChange() for scroller: " << m_owningScrollableArea);
-
-    m_shouldSuppressScrollPositionUpdate = true;
-}
-
-bool ScrollAnchoringController::isInScrollAnchoringAncestorChain(const RenderObject& object)
-{
-    RefPtr iterElement = m_anchorElement.get();
-    while (iterElement) {
-        if (auto* renderer = iterElement->renderer()) {
-            LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::isInScrollAnchoringAncestorChain() checking for : " <<object << " current Element: " << *iterElement);
-            if (&object == renderer)
-                return true;
-        }
-        if (iterElement && elementIsScrollableArea(*iterElement, m_owningScrollableArea))
-            break;
-        iterElement = iterElement->parentElementInComposedTree();
-    }
     return false;
 }
 
-static RefPtr<Element> anchorElementForPriorityCandidate(Element* element)
+void ScrollAnchoringController::updateBeforeLayout()
 {
-    while (element) {
-        if (auto renderer = element->renderer()) {
-            if (!renderer->isAnonymousBlock() && (!renderer->isInline() || renderer->isAtomicInlineLevelBox()))
-                return element;
-        }
-        SUPPRESS_UNCOUNTED_LOCAL element = element->parentElement();
-    }
-    return nullptr;
-}
-
-static ScrollAnchoringController* scrollAnchoringControllerForElement(Element& element)
-{
-    if (auto renderer = element.renderer()) {
-        if (renderer->hasLayer()) {
-            if (CheckedPtr layer = downcast<RenderLayerModelObject>(*renderer).layer()) {
-                if (auto scrollableArea = layer->scrollableArea())
-                    return scrollableArea->scrollAnchoringController();
-            }
-        }
-    }
-    return nullptr;
-}
-
-// This function ensures that each element in the chain from the priorityCandidateElement to the parentController are viable according to
-// ScrollAnchoringController::examineAnchorCandidate and that none of them are maintaining an anchor element.
-static bool canIncludeElementInPriorityCandidateChain(Element& element, Element& priorityCandidateElement, ScrollAnchoringController& parentController)
-{
-    auto candidateResult = parentController.examineAnchorCandidate(element);
-    auto elementsController = scrollAnchoringControllerForElement(element);
-    return !(candidateResult == CandidateExaminationResult::Exclude || (&element == &priorityCandidateElement && candidateResult == CandidateExaminationResult::Skip) || (elementsController && elementsController->anchorElement()));
-}
-
-bool ScrollAnchoringController::didFindPriorityCandidate(Document& document)
-{
-    auto viablePriorityCandidateForElement = [this](Element* element) -> RefPtr<Element> {
-        RefPtr candidateElement = anchorElementForPriorityCandidate(element);
-        if (!candidateElement || candidateElement == elementForScrollableArea(m_owningScrollableArea))
-            return nullptr;
-
-        RefPtr iterElement = candidateElement;
-
-        while (iterElement && iterElement.get() != elementForScrollableArea(m_owningScrollableArea)) {
-            if (!canIncludeElementInPriorityCandidateChain(*iterElement, *candidateElement, *this))
-                return nullptr;
-            iterElement = iterElement->parentElement();
-        }
-
-        // Ensure that candidateElement is a child of m_owningScrollableArea
-        if (iterElement.get() != elementForScrollableArea(m_owningScrollableArea))
-            return nullptr;
-        return candidateElement;
-    };
-
-    // TODO: need to check if focused element is text editable
-    // TODO: need to figure out how to get element that is the current find-in-page element (look into FindController)
-    if (RefPtr priorityCandidate = viablePriorityCandidateForElement(document.focusedElement())) {
-        m_anchorElement = priorityCandidate;
-        m_lastOffsetForAnchorElement = computeOffsetFromOwningScroller(*m_anchorElement->renderer());
-        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::viablePriorityCandidateForElement() found priority candidate: " << *priorityCandidate << " for element: " << ValueOrNull(elementForScrollableArea(m_owningScrollableArea)));
-        return true;
-    }
-    return false;
-}
-
-static bool absolutePositionedElementOutsideScroller(RenderElement& renderer, ScrollableArea& scroller)
-{
-    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(scroller); renderLayerScrollableArea && renderer.hasLayer()) {
-        if (CheckedPtr layerForRenderer = downcast<RenderLayerModelObject>(renderer).layer())
-            return !layerForRenderer->ancestorLayerIsInContainingBlockChain(renderLayerScrollableArea->layer());
-    }
-    return false;
-}
-
-static bool canDescendIntoElement(Element& element)
-{
-    if (auto* scrollAnchoringController = scrollAnchoringControllerForElement(element))
-        return !scrollAnchoringController->anchorElement();
-    return false;
-}
-
-CandidateExaminationResult ScrollAnchoringController::examineAnchorCandidate(Element& element)
-{
-    if (elementForScrollableArea(m_owningScrollableArea) && elementForScrollableArea(m_owningScrollableArea)->nodeIdentifier() == element.nodeIdentifier())
-        return CandidateExaminationResult::Skip;
-
-    auto containingRect = boundingRectForScrollableArea(m_owningScrollableArea);
-    RefPtr document = frameView().frame().document();
-
-    if (RefPtr element = elementForScrollableArea(m_owningScrollableArea)) {
-        if (auto* box = element->renderBox()) {
-            LayoutRect paddedLayerBounds(containingRect);
-            paddedLayerBounds.contract(box->scrollPaddingForViewportRect(paddedLayerBounds));
-            LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::examineAnchorCandidate() contracted rect: "<< IntRect(paddedLayerBounds));
-            containingRect = IntRect(paddedLayerBounds);
-        }
-    }
-
-    auto isExcludedSubtree = [this](RenderElement* renderer, bool intersects) {
-        return renderer->style().overflowAnchor() == OverflowAnchor::None || renderer->isStickilyPositioned() || renderer->isFixedPositioned() || renderer->isPseudoElement() || renderer->isAnonymousBlock() || (renderer->isAbsolutelyPositioned() && absolutePositionedElementOutsideScroller(*renderer, m_owningScrollableArea)) || (!intersects && renderer->style().usedContain().contains(Style::ContainValue::Paint));
-    };
-
-    if (auto renderer = element.renderer()) {
-        // TODO: figure out how to get scrollable area for renderer to check if it is maintaining scroll anchor
-        auto boxRect = renderer->absoluteBoundingBoxRect();
-        bool intersects = containingRect.intersects(boxRect);
-
-        if (isExcludedSubtree(renderer, intersects))
-            return CandidateExaminationResult::Exclude;
-
-        if (&element == document->bodyOrFrameset() || is<HTMLHtmlElement>(&element) || (renderer->isInline() && !renderer->isAtomicInlineLevelBox()))
-            return CandidateExaminationResult::Skip;
-
-        if (!boxRect.width() || !boxRect.height())
-            return CandidateExaminationResult::Skip;
-
-        if (containingRect.contains(boxRect))
-            return CandidateExaminationResult::Select;
-
-        auto isScrollingNode = false;
-        if (auto* renderBox = dynamicDowncast<RenderBox>(renderer))
-            isScrollingNode = renderBox->hasPotentiallyScrollableOverflow();
-
-        if (intersects)
-            return !isScrollingNode || canDescendIntoElement(element) ? CandidateExaminationResult::Descend : CandidateExaminationResult::Select;
-
-        if (isScrollingNode)
-            return CandidateExaminationResult::Exclude;
-    }
-    return CandidateExaminationResult::Skip;
-}
-
-#if !LOG_DISABLED
-static TextStream& operator<<(TextStream& ts, CandidateExaminationResult result)
-{
-    switch (result) {
-    case CandidateExaminationResult::Exclude:
-        ts << "Exclude"_s;
-        break;
-    case CandidateExaminationResult::Select:
-        ts << "Select"_s;
-        break;
-    case CandidateExaminationResult::Descend:
-        ts << "Descend"_s;
-        break;
-    case CandidateExaminationResult::Skip:
-        ts << "Skip"_s;
-        break;
-    }
-    return ts;
-}
-#endif
-
-Element* ScrollAnchoringController::findAnchorElementRecursive(Element* element)
-{
-    if (!element)
-        return nullptr;
-
-    auto result = examineAnchorCandidate(*element);
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::findAnchorElementRecursive() element: "<< *element<<" examination result: " << result);
-
-    switch (result) {
-    case CandidateExaminationResult::Select:
-        return element;
-    case CandidateExaminationResult::Exclude:
-        return nullptr;
-    case CandidateExaminationResult::Skip:
-    case CandidateExaminationResult::Descend: {
-        for (Ref child : childrenOfType<Element>(*element)) {
-            if (auto* anchorElement = findAnchorElementRecursive(child.ptr()))
-                return anchorElement;
-        }
-        break;
-    }
-    }
-    if (result == CandidateExaminationResult::Skip)
-        return nullptr;
-    return element;
-}
-
-void ScrollAnchoringController::chooseAnchorElement(Document& document)
-{
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::chooseAnchorElement() starting findAnchorElementRecursive: for element: " << ValueOrNull(elementForScrollableArea(m_owningScrollableArea)));
-
-    if (didFindPriorityCandidate(document))
-        return;
-
-    RefPtr<Element> anchorElement;
-
-    if (!m_anchorElement) {
-        anchorElement = findAnchorElementRecursive(elementForScrollableArea(m_owningScrollableArea));
-        if (!anchorElement)
-            return;
-    }
-
-    m_anchorElement = anchorElement;
-    m_lastOffsetForAnchorElement = computeOffsetFromOwningScroller(*m_anchorElement->renderer());
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::chooseAnchorElement() found anchor node: " << *anchorElement << " offset: " << computeOffsetFromOwningScroller(*m_anchorElement->renderer()));
-}
-
-void ScrollAnchoringController::updateAnchorElement()
-{
-    if (m_owningScrollableArea->scrollPosition().isZero() || m_isQueuedForScrollPositionUpdate || frameView().layoutContext().layoutPhase() != LocalFrameViewLayoutContext::LayoutPhase::OutsideLayout)
-        return;
-
-    RefPtr document = frameView().frame().document();
-    if (!document)
-        return;
-
-    if (m_anchorElement && !m_anchorElement->renderer())
-        invalidateAnchorElement();
-
-    if (!m_anchorElement) {
-        chooseAnchorElement(*document);
-        if (!m_anchorElement)
-            return;
-    }
-    m_isQueuedForScrollPositionUpdate = true;
-    frameView().queueScrollableAreaForScrollAnchoringUpdate(m_owningScrollableArea);
 }
 
 void ScrollAnchoringController::adjustScrollPositionForAnchoring()
 {
-    auto queued = std::exchange(m_isQueuedForScrollPositionUpdate, false);
-    auto suppressed = std::exchange(m_shouldSuppressScrollPositionUpdate, false);
-    if (!m_anchorElement || !queued)
-        return;
-
-    auto* renderer = m_anchorElement->renderer();
-    if (!renderer || suppressed) {
-        invalidateAnchorElement();
-        updateAnchorElement();
-        if (suppressed)
-            LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::updateScrollPosition() suppressing scroll adjustment for frame: " << frameView() << " for scroller: " << m_owningScrollableArea);
-        return;
-    }
-    SetForScope midUpdatingScrollPositionForAnchorElement(m_midUpdatingScrollPositionForAnchorElement, true);
-
-    FloatSize adjustment = computeOffsetFromOwningScroller(*renderer) - m_lastOffsetForAnchorElement;
-    if (!adjustment.isZero()) {
-        if (m_owningScrollableArea->isUserScrollInProgress()) {
-            invalidateAnchorElement();
-            updateAnchorElement();
-            return;
-        }
-        auto newScrollPosition = m_owningScrollableArea->scrollPosition() + IntPoint(adjustment.width(), adjustment.height());
-        RELEASE_LOG(ScrollAnchoring, "ScrollAnchoringController::updateScrollPosition() is main frame: %d, is main scroller: %d, adjusting from: (%d, %d) to: (%d, %d)",  frameView().frame().isMainFrame(), !m_owningScrollableArea->isRenderLayer(), m_owningScrollableArea->scrollPosition().x(), m_owningScrollableArea->scrollPosition().y(), newScrollPosition.x(), newScrollPosition.y());
-        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::updateScrollPosition() for scroller element: " << ValueOrNull(elementForScrollableArea(m_owningScrollableArea)) << " anchor node: " << *m_anchorElement << "adjusting from: " << m_owningScrollableArea->scrollPosition() << " to: " << newScrollPosition);
-
-        auto options = ScrollPositionChangeOptions::createProgrammatic();
-        options.originalScrollDelta = adjustment;
-        auto oldScrollType = m_owningScrollableArea->currentScrollType();
-        m_owningScrollableArea->setCurrentScrollType(ScrollType::Programmatic);
-        if (!m_owningScrollableArea->requestScrollToPosition(newScrollPosition, options))
-            m_owningScrollableArea->scrollToPositionWithoutAnimation(newScrollPosition);
-        m_owningScrollableArea->setCurrentScrollType(oldScrollType);
-    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollAnimator.cpp
+++ b/Source/WebCore/platform/ScrollAnimator.cpp
@@ -248,7 +248,7 @@ bool ScrollAnimator::handleTouchEvent(const PlatformTouchEvent&)
 
 static void notifyScrollAnchoringControllerOfScroll(ScrollableArea& scrollableArea)
 {
-    scrollableArea.updateScrollAnchoringElement();
+    scrollableArea.clearScrollAnchor();
 }
 
 void ScrollAnimator::setCurrentPosition(const FloatPoint& position, NotifyScrollableArea notify)

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -261,7 +261,9 @@ void ScrollableArea::scrollPositionChanged(const ScrollPosition& position)
     if (scrollPosition() != oldPosition) {
         scrollbarsController().notifyContentAreaScrolled(scrollPosition() - oldPosition);
 
-        updateScrollAnchoringElement();
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollableArea::scrollPositionChanged() from " << oldPosition << " to " << scrollPosition() << " - clearing scroll anchor");
+        clearScrollAnchor();
+
         updateAnchorPositionedAfterScroll();
     }
 }
@@ -282,16 +284,10 @@ void ScrollableArea::stopKeyboardScrollAnimation()
     scrollAnimator().stopKeyboardScrollAnimation();
 }
 
-void ScrollableArea::updateScrollAnchoringElement(ComputeNewScrollAnchor computeNewScrollAnchor)
+void ScrollableArea::clearScrollAnchor(IncludeAncestors includeAncestors)
 {
-    CheckedPtr controller = scrollAnchoringController();
-    if (!controller)
-        return;
-
-    if (computeNewScrollAnchor == ComputeNewScrollAnchor::Yes)
-        controller->invalidateAnchorElement();
-
-    controller->updateAnchorElement();
+    if (CheckedPtr controller = scrollAnchoringController())
+        controller->clearAnchor(includeAncestors == IncludeAncestors::Yes);
 }
 
 void ScrollableArea::adjustScrollAnchoringPosition()

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -441,7 +441,12 @@ public:
         No,
         Yes
     };
-    void updateScrollAnchoringElement(ComputeNewScrollAnchor = ComputeNewScrollAnchor::Yes);
+
+    enum class IncludeAncestors : bool {
+        No,
+        Yes
+    };
+    void clearScrollAnchor(IncludeAncestors = IncludeAncestors::No);
     void adjustScrollAnchoringPosition();
     virtual ScrollAnchoringController* scrollAnchoringController() const { return nullptr; }
 

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1129,12 +1129,9 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
         issueRepaintForOutlineAuto(hasOutlineAuto ? outlineStyleForRepaint().usedOutlineSize() : oldStyle->usedOutlineSize());
     }
 
-    bool shouldCheckIfInAncestorChain = false;
-    if (settings().cssScrollAnchoringEnabled() && (style().outOfFlowPositionStyleDidChange(oldStyle) || (shouldCheckIfInAncestorChain = style().scrollAnchoringSuppressionStyleDidChange(oldStyle)))) {
-        LOG_WITH_STREAM(ScrollAnchoring, stream << "RenderElement::styleDidChange() " << diff << " found node with style change: " << *this << " from: " << oldStyle->position() <<" to: " << style().position());
-        auto* controller = searchParentChainForScrollAnchoringController(*this);
-        if (controller && (!shouldCheckIfInAncestorChain || (shouldCheckIfInAncestorChain && controller->isInScrollAnchoringAncestorChain(*this))))
-            controller->notifyChildHadSuppressingStyleChange();
+    if (settings().cssScrollAnchoringEnabled() && style().scrollAnchoringSuppressionStyleDidChange(oldStyle)) {
+        // FIXME: Need to set a bit to store whether this change should suppress scroll anchoring.
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "RenderElement::styleDidChange: scroll anchoring suppression style change on " << *this);
     }
 
     // FIXME: First line change on the block comes in as equal on inline boxes.


### PR DESCRIPTION
#### bcce947b9ada12db19fd0fe1ac65849d63301786
<pre>
[Scroll anchoring] Prepare for a new implementation of ScrollAnchoringController
<a href="https://bugs.webkit.org/show_bug.cgi?id=307205">https://bugs.webkit.org/show_bug.cgi?id=307205</a>
<a href="https://rdar.apple.com/169832293">rdar://169832293</a>

Reviewed by Tim Nguyen.

Prepare for a new implementation of Scroll Anchoring by gutting ScrollAnchoringController,
but fixing up some hooks in other parts of the code that call into it.

Various places that called `updateScrollAnchoring()` now do `clearScrollAnchor()`
because that&apos;s more descriptive of what happens (the anchor is recomputed before
the next layout).

One critical new hook is the &quot;before layout&quot; hook in `LocalFrameView::willDoLayout()`;
this is the point at which we&apos;ll compute the current scroll offset, to be adjusted
after layout, in `performPostLayoutTasks()`.

Temporarily skip all scroll-anchoring tests while things are in flux.

* LayoutTests/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::updateLayout):
(WebCore::Document::runScrollSteps):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::willDoLayout):
(WebCore::LocalFrameView::setLayoutViewportOverrideRect):
(WebCore::LocalFrameView::scrollOffsetChangedViaPlatformWidgetImpl):
(WebCore::LocalFrameView::performPostLayoutTasks):
(WebCore::LocalFrameView::clearScrollAnchorsInScrollableAreas):
(WebCore::LocalFrameView::updateScrollAnchoringBeforeLayoutForScrollableAreas):
(WebCore::LocalFrameView::scheduleResizeEventIfNeeded):
(WebCore::LocalFrameView::updateScrollAnchoringElementsForScrollableAreas): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::ScrollAnchoringController):
(WebCore::ScrollAnchoringController::~ScrollAnchoringController):
(WebCore::ScrollAnchoringController::shouldMaintainScrollAnchor const):
(WebCore::ScrollAnchoringController::frameView):
(WebCore::ScrollAnchoringController::scrollableAreaBox const):
(WebCore::ScrollAnchoringController::clearAnchor):
(WebCore::ScrollAnchoringController::invalidate):
(WebCore::ScrollAnchoringController::notifyChildHadSuppressingStyleChange):
(WebCore::ScrollAnchoringController::chooseAnchorElement):
(WebCore::ScrollAnchoringController::anchoringSuppressedByStyleChange const):
(WebCore::ScrollAnchoringController::updateBeforeLayout):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
(WebCore::elementIsScrollableArea): Deleted.
(WebCore::elementForScrollableArea): Deleted.
(WebCore::ScrollAnchoringController::invalidateAnchorElement): Deleted.
(WebCore::boundingRectForScrollableArea): Deleted.
(WebCore::ScrollAnchoringController::computeOffsetFromOwningScroller): Deleted.
(WebCore::ScrollAnchoringController::isInScrollAnchoringAncestorChain): Deleted.
(WebCore::anchorElementForPriorityCandidate): Deleted.
(WebCore::scrollAnchoringControllerForElement): Deleted.
(WebCore::canIncludeElementInPriorityCandidateChain): Deleted.
(WebCore::ScrollAnchoringController::didFindPriorityCandidate): Deleted.
(WebCore::absolutePositionedElementOutsideScroller): Deleted.
(WebCore::canDescendIntoElement): Deleted.
(WebCore::ScrollAnchoringController::examineAnchorCandidate): Deleted.
(WebCore::operator&lt;&lt;): Deleted.
(WebCore::ScrollAnchoringController::findAnchorElementRecursive): Deleted.
(WebCore::ScrollAnchoringController::updateAnchorElement): Deleted.
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
(WebCore::ScrollAnchoringController::hasAnchorElement const):
(WebCore::ScrollAnchoringController::anchorElement const): Deleted.
* Source/WebCore/platform/ScrollAnimator.cpp:
(WebCore::notifyScrollAnchoringControllerOfScroll):
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollPositionChanged):
(WebCore::ScrollableArea::clearScrollAnchor):
(WebCore::ScrollableArea::updateScrollAnchoringElement): Deleted.
* Source/WebCore/platform/ScrollableArea.h:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleDidChange):

Canonical link: <a href="https://commits.webkit.org/307007@main">https://commits.webkit.org/307007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/39a1363144a2439e5108248a77d97d98e59b823d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143087 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/15562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151761 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c3707c0-f08b-4f5b-b1ea-667a4535e246) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16222 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110038 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/318f5f95-64ec-42a7-ba29-fcf6cba71511) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90948 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b16cb8e2-b550-44eb-a4f3-b400f4ad5c36) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1760 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121375 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/4559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154074 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/15386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5399 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118054 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/15382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13154 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118395 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30322 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125592 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70920 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15231 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4334 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14965 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78950 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15027 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->