### PR TITLE
[iOS] Separate the media source from MediaDeviceRoute

### DIFF
--- a/Source/WebCore/SourcesCocoa.txt
+++ b/Source/WebCore/SourcesCocoa.txt
@@ -285,7 +285,7 @@ platform/audio/cocoa/SpatialAudioExperienceHelper.mm @nonARC
 platform/audio/cocoa/WebAudioBufferList.cpp
 platform/audio/ios/AudioOutputUnitAdaptorIOS.cpp @no-unify
 platform/audio/ios/AudioSessionIOS.mm @nonARC @no-unify
-platform/audio/ios/MediaDeviceRoute.mm @nonARC
+platform/audio/ios/MediaDeviceRoute.mm @nonARC @no-unify
 platform/audio/ios/MediaDeviceRouteController.mm @nonARC
 platform/audio/ios/MediaSessionHelperIOS.mm @nonARC @no-unify
 platform/audio/ios/MediaSessionManagerIOS.mm @nonARC @no-unify

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -39,7 +39,7 @@
 #include <wtf/WeakPtr.h>
 #include <wtf/text/WTFString.h>
 
-OBJC_CLASS WebMediaDeviceRoute;
+OBJC_CLASS WebMediaSourceObserver;
 
 namespace WebCore {
 
@@ -99,22 +99,15 @@ class MediaDeviceRouteClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaD
 public:
     virtual ~MediaDeviceRouteClient() = default;
 
-    virtual void minValueDidChange(MediaDeviceRoute&) = 0;
-    virtual void maxValueDidChange(MediaDeviceRoute&) = 0;
+    virtual void timeRangeDidChange(MediaDeviceRoute&) = 0;
+    virtual void readyDidChange(MediaDeviceRoute&) = 0;
+    virtual void bufferingDidChange(MediaDeviceRoute&) = 0;
+    virtual void playbackErrorDidChange(MediaDeviceRoute&) = 0;
+    virtual void hasAudioDidChange(MediaDeviceRoute&) = 0;
     virtual void currentValueDidChange(MediaDeviceRoute&) = 0;
-    virtual void segmentsDidChange(MediaDeviceRoute&) = 0;
-    virtual void currentSegmentDidChange(MediaDeviceRoute&) = 0;
-    virtual void isPlayingDidChange(MediaDeviceRoute&) = 0;
+    virtual void playingDidChange(MediaDeviceRoute&) = 0;
     virtual void playbackSpeedDidChange(MediaDeviceRoute&) = 0;
     virtual void scanSpeedDidChange(MediaDeviceRoute&) = 0;
-    virtual void stateDidChange(MediaDeviceRoute&) = 0;
-    virtual void supportedModesDidChange(MediaDeviceRoute&) = 0;
-    virtual void playbackTypeDidChange(MediaDeviceRoute&) = 0;
-    virtual void playbackErrorDidChange(MediaDeviceRoute&) = 0;
-    virtual void currentAudioOptionDidChange(MediaDeviceRoute&) = 0;
-    virtual void currentSubtitleOptionDidChange(MediaDeviceRoute&) = 0;
-    virtual void optionsDidChange(MediaDeviceRoute&) = 0;
-    virtual void hasAudioDidChange(MediaDeviceRoute&) = 0;
     virtual void mutedDidChange(MediaDeviceRoute&) = 0;
     virtual void volumeDidChange(MediaDeviceRoute&) = 0;
 };
@@ -134,40 +127,35 @@ public:
 
     void loadURL(const URL&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);
 
-    float minValue() const;
-    float maxValue() const;
-    float currentValue() const;
-    Vector<MediaTimelineSegment> segments() const;
-    std::optional<MediaTimelineSegment> currentSegment() const;
-    bool isPlaying() const;
-    double playbackSpeed() const;
-    double scanSpeed() const;
-    MediaPlaybackSourceState state() const;
-    OptionSet<MediaPlaybackSourceSupportedMode> supportedModes() const;
-    OptionSet<MediaPlaybackSourcePlaybackType> playbackType() const;
+    MediaTimeRange timeRange() const;
+    bool ready() const;
+    bool buffering() const;
     std::optional<MediaPlaybackSourceError> playbackError() const;
-    std::optional<MediaSelectionOption> currentAudioOption() const;
-    std::optional<MediaSelectionOption> currentSubtitleOption() const;
-    Vector<MediaSelectionOption> options() const;
     bool hasAudio() const;
+    MediaTime currentValue() const;
+    bool playing() const;
+    float playbackSpeed() const;
+    float scanSpeed() const;
     bool muted() const;
-    double volume() const;
+    float volume() const;
 
-    void setCurrentValue(float);
-    void setIsPlaying(bool);
-    void setPlaybackSpeed(double);
-    void setScanSpeed(double);
-    void setCurrentAudioOption(std::optional<MediaSelectionOption>);
-    void setCurrentSubtitleOption(std::optional<MediaSelectionOption>);
+    void setCurrentValue(MediaTime);
+    void setPlaying(bool);
+    void setPlaybackSpeed(float);
+    void setScanSpeed(float);
     void setMuted(bool);
-    void setVolume(double);
+    void setVolume(float);
 
 private:
     explicit MediaDeviceRoute(WebMediaDevicePlatformRoute *);
 
     WTF::UUID m_identifier;
-    RetainPtr<WebMediaDeviceRoute> m_route;
+    RetainPtr<WebMediaDevicePlatformRoute> m_platformRoute;
+    RetainPtr<WebMediaSourceObserver> m_mediaSourceObserver;
     WeakPtr<MediaDeviceRouteClient> m_client;
+#if HAVE(AVROUTING_FRAMEWORK)
+    RetainPtr<WebMediaDevicePlatformRouteSession> m_routeSession;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -28,31 +28,24 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
-#import <WebKitAdditions/MediaDeviceRouteAdditions.mm>
+#import <pal/avfoundation/MediaTimeAVFoundation.h>
 #import <wtf/TZoneMallocInlines.h>
 
 #define FOR_EACH_READONLY_KEY_PATH(Macro) \
-    Macro(minValue, MinValue, float) \
-    Macro(maxValue, MaxValue, float) \
-    Macro(segments, Segments, Vector<MediaTimelineSegment>) \
-    Macro(currentSegment, CurrentSegment, std::optional<MediaTimelineSegment>) \
-    Macro(state, State, MediaPlaybackSourceState) \
-    Macro(supportedModes, SupportedModes, OptionSet<MediaPlaybackSourceSupportedMode>) \
-    Macro(playbackType, PlaybackType, OptionSet<MediaPlaybackSourcePlaybackType>) \
+    Macro(timeRange, TimeRange, MediaTimeRange) \
+    Macro(ready, Ready, bool) \
+    Macro(buffering, Buffering, bool) \
     Macro(playbackError, PlaybackError, std::optional<MediaPlaybackSourceError>) \
-    Macro(options, Options, Vector<MediaSelectionOption>) \
     Macro(hasAudio, HasAudio, bool) \
 \
 
 #define FOR_EACH_READWRITE_KEY_PATH(Macro) \
-    Macro(currentValue, CurrentValue, float) \
-    Macro(isPlaying, IsPlaying, bool) \
-    Macro(playbackSpeed, PlaybackSpeed, double) \
-    Macro(scanSpeed, ScanSpeed, double) \
-    Macro(currentAudioOption, CurrentAudioOption, std::optional<MediaSelectionOption>) \
-    Macro(currentSubtitleOption, CurrentSubtitleOption, std::optional<MediaSelectionOption>) \
+    Macro(currentValue, CurrentValue, MediaTime) \
+    Macro(playing, Playing, bool) \
+    Macro(playbackSpeed, PlaybackSpeed, float) \
+    Macro(scanSpeed, ScanSpeed, float) \
     Macro(muted, Muted, bool) \
-    Macro(volume, Volume, double) \
+    Macro(volume, Volume, float) \
 \
 
 #define FOR_EACH_KEY_PATH(Macro) \
@@ -61,11 +54,11 @@
 \
 
 #define ADD_OBSERVER(KeyPath, SetterSuffix, Type) \
-    [_platformRoute addObserver:self forKeyPath:@#KeyPath options:0 context:WebMediaDeviceRouteObserverContext]; \
+    [_mediaSource addObserver:self forKeyPath:@#KeyPath options:0 context:WebMediaSourceObserverContext]; \
 \
 
 #define REMOVE_OBSERVER(KeyPath, SetterSuffix, Type) \
-    [_platformRoute removeObserver:self forKeyPath:@#KeyPath context:WebMediaDeviceRouteObserverContext]; \
+    [_mediaSource removeObserver:self forKeyPath:@#KeyPath context:WebMediaSourceObserverContext]; \
 \
 
 #define OBSERVE_VALUE(KeyPath, SetterSuffix, Type) \
@@ -81,65 +74,57 @@
 #define DEFINE_GETTER(KeyPath, SetterSuffix, Type) \
     Type MediaDeviceRoute::KeyPath() const \
     { \
-        return convert([[m_route platformRoute] KeyPath]); \
+        return convert([m_mediaSourceObserver mediaSource].KeyPath); \
     } \
 \
 
 #define DEFINE_SETTER(KeyPath, SetterSuffix, Type) \
     void MediaDeviceRoute::set##SetterSuffix(Type KeyPath) \
     { \
-        [[m_route platformRoute] set##SetterSuffix:convert(WTF::move(KeyPath))]; \
+        [[m_mediaSourceObserver mediaSource] set##SetterSuffix:convert(WTF::move(KeyPath))]; \
     } \
 \
 
 NS_ASSUME_NONNULL_BEGIN
 
-static void* WebMediaDeviceRouteObserverContext = &WebMediaDeviceRouteObserverContext;
+static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
 
-@interface WebMediaSelectionOption : NSObject <AVMediaSelectionOptionSource>
-@end
-
-@interface WebMediaSelectionOption ()
-@property (nonatomic, copy) NSString *displayName;
-@property (nonatomic, copy) NSString *identifier;
-@property (nonatomic) AVMediaOptionType type;
-@property (nonatomic, copy) NSString *extendedLanguageTag;
-@end
-
-@implementation WebMediaSelectionOption
-@end
-
-@interface WebMediaDeviceRoute : NSObject
+@interface WebMediaSourceObserver : NSObject
 + (instancetype)new NS_UNAVAILABLE;
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route platformRoute:(WebMediaDevicePlatformRoute *)platformRoute NS_DESIGNATED_INITIALIZER;
-@property (nonatomic, readonly, strong) WebMediaDevicePlatformRoute *platformRoute;
+- (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route NS_DESIGNATED_INITIALIZER;
+@property (nonatomic, nullable, strong) AVMediaSource *mediaSource;
 @end
 
-@implementation WebMediaDeviceRoute {
+@implementation WebMediaSourceObserver {
     WeakPtr<WebCore::MediaDeviceRoute> _route;
-    RetainPtr<WebMediaDevicePlatformRoute> _platformRoute;
+    RetainPtr<AVMediaSource> _mediaSource;
 }
 
-- (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route platformRoute:(WebMediaDevicePlatformRoute *)platformRoute
+- (instancetype)initWithRoute:(WebCore::MediaDeviceRoute&)route
 {
     if (!(self = [super init]))
         return nil;
 
     _route = route;
-    _platformRoute = platformRoute;
-    FOR_EACH_KEY_PATH(ADD_OBSERVER)
     return self;
 }
 
-- (WebMediaDevicePlatformRoute *)platformRoute
+- (AVMediaSource * _Nullable)mediaSource
 {
-    return _platformRoute.get();
+    return _mediaSource.get();
+}
+
+- (void)setMediaSource:(AVMediaSource * _Nullable)mediaSource
+{
+    FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
+    _mediaSource = mediaSource;
+    FOR_EACH_KEY_PATH(ADD_OBSERVER)
 }
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary *)change context:(nullable void*)context
 {
-    if (context != WebMediaDeviceRouteObserverContext) {
+    if (context != WebMediaSourceObserverContext) {
         [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
         return;
     }
@@ -156,9 +141,13 @@ static void* WebMediaDeviceRouteObserverContext = &WebMediaDeviceRouteObserverCo
 
 @end
 
+NS_ASSUME_NONNULL_END
+
+#import <WebKitAdditions/MediaDeviceRouteAdditions.mm>
+
 namespace WebCore {
 
-static double convert(double value)
+static float convert(float value)
 {
     return value;
 }
@@ -168,90 +157,20 @@ static bool convert(bool value)
     return value;
 }
 
-static MediaTimelineSegment::Type convert(AVMediaTimelineSegmentType segmentType)
+static CMTime convert(MediaTime time)
 {
-    switch (segmentType) {
-    case AVMediaTimelineSegmentTypePrimary:
-        return MediaTimelineSegment::Type::Primary;
-    case AVMediaTimelineSegmentTypeSecondary:
-        return MediaTimelineSegment::Type::Secondary;
-    }
+    return PAL::toCMTime(time);
+}
 
-    RELEASE_ASSERT_NOT_REACHED();
+static MediaTime convert(CMTime time)
+{
+    return PAL::toMediaTime(time);
 }
 
 static MediaTimeRange convert(CMTimeRange timeRange)
 {
     MediaTime start = PAL::toMediaTime(timeRange.start);
     return { WTF::move(start), start + PAL::toMediaTime(timeRange.duration) };
-}
-
-static std::optional<MediaTimelineSegment> convert(id<AVMediaTimelineSegment> _Nullable segment)
-{
-    if (!segment)
-        return std::nullopt;
-
-    return MediaTimelineSegment {
-        convert(segment.type),
-        segment.isMarked,
-        segment.requiresLinearPlayback,
-        convert(segment.timeRange),
-        segment.identifier,
-    };
-}
-
-static Vector<MediaTimelineSegment> convert(NSArray<AVMediaTimelineSegment> * _Nullable segments)
-{
-    Vector<MediaTimelineSegment> result;
-
-    for (id<AVMediaTimelineSegment> segment in segments)
-        result.append(*convert(segment));
-
-    return result;
-}
-
-static MediaPlaybackSourceState convert(AVMediaPlaybackSourceState state)
-{
-    switch (state) {
-    case AVMediaPlaybackSourceStateReady:
-        return MediaPlaybackSourceState::Ready;
-    case AVMediaPlaybackSourceStateLoading:
-        return MediaPlaybackSourceState::Loading;
-    case AVMediaPlaybackSourceStateSeeking:
-        return MediaPlaybackSourceState::Seeking;
-    case AVMediaPlaybackSourceStateScanning:
-        return MediaPlaybackSourceState::Scanning;
-    case AVMediaPlaybackSourceStateScrubbing:
-        return MediaPlaybackSourceState::Scrubbing;
-    }
-
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-static OptionSet<MediaPlaybackSourceSupportedMode> convert(AVMediaPlaybackSourceSupportedMode supportedModes)
-{
-    OptionSet<MediaPlaybackSourceSupportedMode> result;
-
-    if (supportedModes & AVMediaPlaybackSourceSupportedModeScanForward)
-        result.add(MediaPlaybackSourceSupportedMode::ScanForward);
-    if (supportedModes & AVMediaPlaybackSourceSupportedModeScanBackward)
-        result.add(MediaPlaybackSourceSupportedMode::ScanBackward);
-    if (supportedModes & AVMediaPlaybackSourceSupportedModeSeek)
-        result.add(MediaPlaybackSourceSupportedMode::Seek);
-
-    return result;
-}
-
-static OptionSet<MediaPlaybackSourcePlaybackType> convert(AVMediaPlaybackSourcePlaybackType playbackType)
-{
-    OptionSet<MediaPlaybackSourcePlaybackType> result;
-
-    if (playbackType & AVMediaPlaybackSourcePlaybackTypeRegular)
-        result.add(MediaPlaybackSourcePlaybackType::Regular);
-    if (playbackType & AVMediaPlaybackSourcePlaybackTypeLive)
-        result.add(MediaPlaybackSourcePlaybackType::Live);
-
-    return result;
 }
 
 static std::optional<MediaPlaybackSourceError> convert(NSError * _Nullable error)
@@ -266,67 +185,6 @@ static std::optional<MediaPlaybackSourceError> convert(NSError * _Nullable error
     };
 }
 
-static MediaSelectionOption::Type convert(AVMediaOptionType type)
-{
-    switch (type) {
-    case AVMediaOptionTypeAudio:
-        return MediaSelectionOption::Type::Audio;
-    case AVMediaOptionTypeLegible:
-        return MediaSelectionOption::Type::Legible;
-    }
-
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-static AVMediaOptionType convert(MediaSelectionOption::Type type)
-{
-    switch (type) {
-    case MediaSelectionOption::Type::Audio:
-        return AVMediaOptionTypeAudio;
-    case MediaSelectionOption::Type::Legible:
-        return AVMediaOptionTypeLegible;
-    }
-
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-static std::optional<MediaSelectionOption> convert(id<AVMediaSelectionOptionSource> _Nullable option)
-{
-    if (!option)
-        return std::nullopt;
-
-    return MediaSelectionOption {
-        option.displayName,
-        option.identifier,
-        convert(option.type),
-        option.extendedLanguageTag,
-    };
-}
-
-static id<AVMediaSelectionOptionSource> _Nullable convert(const std::optional<MediaSelectionOption>& option)
-{
-    if (!option)
-        return nil;
-
-    RetainPtr result = adoptNS([[WebMediaSelectionOption alloc] init]);
-    [result setDisplayName:option->displayName.createNSString().get()];
-    [result setIdentifier:option->identifier.createNSString().get()];
-    [result setType:convert(option->type)];
-    [result setExtendedLanguageTag:option->extendedLanguageTag.createNSString().get()];
-
-    return result.autorelease();
-}
-
-static Vector<MediaSelectionOption> convert(NSArray<AVMediaSelectionOptionSource> * _Nullable options)
-{
-    Vector<MediaSelectionOption> result;
-
-    for (id<AVMediaSelectionOptionSource> option in options)
-        result.append(*convert(option));
-
-    return result;
-}
-
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaDeviceRoute);
 
 Ref<MediaDeviceRoute> MediaDeviceRoute::create(WebMediaDevicePlatformRoute *platformRoute)
@@ -336,23 +194,27 @@ Ref<MediaDeviceRoute> MediaDeviceRoute::create(WebMediaDevicePlatformRoute *plat
 
 MediaDeviceRoute::MediaDeviceRoute(WebMediaDevicePlatformRoute *platformRoute)
     : m_identifier { WTF::UUID::createVersion4() }
-    , m_route { adoptNS([[WebMediaDeviceRoute alloc] initWithRoute:*this platformRoute:platformRoute]) }
+    , m_platformRoute { platformRoute }
+    , m_mediaSourceObserver { adoptNS([[WebMediaSourceObserver alloc] initWithRoute:*this]) }
 {
 }
 
 WebMediaDevicePlatformRoute *MediaDeviceRoute::platformRoute() const
 {
-    return [m_route platformRoute];
+    return m_platformRoute.get();
 }
 
-MediaDeviceRoute::~MediaDeviceRoute() = default;
+MediaDeviceRoute::~MediaDeviceRoute()
+{
+#if HAVE(AVROUTING_FRAMEWORK)
+    [m_routeSession stop];
+#endif
+}
 
 FOR_EACH_KEY_PATH(DEFINE_GETTER)
 FOR_EACH_READWRITE_KEY_PATH(DEFINE_SETTER)
 
 } // namespace WebCore
-
-NS_ASSUME_NONNULL_END
 
 #undef FOR_EACH_READONLY_KEY_PATH
 #undef FOR_EACH_READWRITE_KEY_PATH

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h
@@ -38,7 +38,7 @@
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/Vector.h>
 
-OBJC_CLASS WebMediaDeviceRouteController;
+OBJC_CLASS WebMediaDeviceRouteObserver;
 
 namespace WebCore {
 
@@ -70,10 +70,10 @@ public:
 private:
     MediaDeviceRouteController();
 
-    RetainPtr<WebMediaDeviceRouteController> m_controller;
     ThreadSafeWeakPtr<MediaDeviceRouteControllerClient> m_client;
     Vector<Ref<MediaDeviceRoute>> m_activeRoutes;
 #if HAVE(AVROUTING_FRAMEWORK)
+    RetainPtr<WebMediaDeviceRouteObserver> m_routeObserver;
     RetainPtr<WebMediaDevicePlatformRouteController> m_platformController;
 #endif
 };

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm
@@ -28,6 +28,7 @@
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
+#import "MediaDeviceRoute.h"
 #import "MediaStrategy.h"
 #import "PlatformStrategies.h"
 #import <WebKitAdditions/MediaDeviceRouteControllerAdditions.mm>
@@ -44,13 +45,12 @@ MediaDeviceRouteController& MediaDeviceRouteController::singleton()
 
 MediaDeviceRouteController::MediaDeviceRouteController()
 #if HAVE(AVROUTING_FRAMEWORK)
-    : m_controller { adoptNS([[WebMediaDeviceRouteController alloc] init]) }
-    , m_platformController { [WebMediaDevicePlatformRouteControllerClass sharedRoutingSystemController] }
+    : m_routeObserver { adoptNS([[WebMediaDeviceRouteObserver alloc] init]) }
+    , m_platformController { [WebMediaDevicePlatformRouteControllerClass sharedController] }
 #endif
 {
 #if HAVE(AVROUTING_FRAMEWORK)
-    ASSERT([m_platformController systemDelegate] == nil);
-    [m_platformController setSystemDelegate:m_controller.get()];
+    [m_platformController addObserver:m_routeObserver.get()];
 #endif
 }
 

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
@@ -74,15 +74,6 @@ String MediaPlaybackTargetWirelessPlayback::deviceName() const
     return { };
 }
 
-void MediaPlaybackTargetWirelessPlayback::loadURL(const URL& url, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&& completionHandler)
-{
-    RefPtr route = m_route;
-    if (!route)
-        return completionHandler(makeUnexpected(MediaDeviceRouteLoadURLError::NoRoute));
-
-    route->loadURL(url, WTF::move(completionHandler));
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
@@ -30,6 +30,7 @@
 #include <WebCore/MediaDeviceRouteLoadURLResult.h>
 #include <WebCore/MediaPlaybackTarget.h>
 #include <wtf/Forward.h>
+#include <wtf/RefPtr.h>
 #include <wtf/UUID.h>
 
 namespace WebCore {
@@ -46,8 +47,6 @@ public:
     WEBCORE_EXPORT std::optional<WTF::UUID> identifier() const;
 
     MediaDeviceRoute* route() const;
-
-    void loadURL(const URL&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);
 
 private:
     MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&&, bool hasActiveRoute);

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -172,7 +172,7 @@ void MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded()
     if (!playbackTarget)
         return;
 
-    playbackTarget->loadURL(m_url, [weakThis = ThreadSafeWeakPtr { *this }](const MediaDeviceRouteLoadURLResult& result) {
+    Ref { *playbackTarget->route() }->loadURL(m_url, [weakThis = ThreadSafeWeakPtr { *this }](const MediaDeviceRouteLoadURLResult& result) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h
@@ -49,6 +49,10 @@ public:
 
     RetainPtr<AVOutputContext> outputContext() const { return m_outputContext.get(); }
 
+#if HAVE(AVROUTING_FRAMEWORK)
+    bool hasAirPlayDevice() const;
+#endif
+
 private:
     explicit MediaPlaybackTargetCocoa(RetainPtr<AVOutputContext>&&);
 

--- a/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm
@@ -30,6 +30,10 @@
 
 #import <pal/spi/cocoa/AVFoundationSPI.h>
 
+#if HAVE(AVROUTING_FRAMEWORK)
+#import <WebKitAdditions/MediaPlaybackTargetCocoaAdditions.h>
+#endif
+
 #import <pal/cocoa/AVFoundationSoftLink.h>
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.mm
@@ -33,6 +33,7 @@
 #import "FilterImage.h"
 #import <CoreImage/CIFilterBuiltins.h>
 #import <CoreImage/CoreImage.h>
+#import <simd/simd.h>
 #import <wtf/MathExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -36,7 +36,7 @@ class MockMediaDeviceRouteURLCallback;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface WebMockMediaDeviceRoute : NSObject <WebMediaDevicePlatformRoute>
+@interface WebMockMediaDeviceRoute : NSObject <AVMediaSource, WebMediaDevicePlatformRoute>
 @property (nonatomic, nullable, setter=setURLCallback:) WebCore::MockMediaDeviceRouteURLCallback* urlCallback;
 @end
 

--- a/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
+++ b/Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm
@@ -72,6 +72,7 @@ MediaPlaybackTargetContextSerialized::MediaPlaybackTargetContextSerialized(const
         m_contextID = downcast<MediaPlaybackTargetSerialized>(target).context().contextID();
         m_contextType = downcast<MediaPlaybackTargetSerialized>(target).context().contextType();
 #endif
+        m_identifier = downcast<MediaPlaybackTargetSerialized>(target).context().identifier();
     }
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
     else if (is<MediaPlaybackTargetWirelessPlayback>(target))


### PR DESCRIPTION
#### 7c66118ac988633d26ce8c03d6742ffac88e58aa
<pre>
[iOS] Separate the media source from MediaDeviceRoute
<a href="https://bugs.webkit.org/show_bug.cgi?id=307212">https://bugs.webkit.org/show_bug.cgi?id=307212</a>
<a href="https://rdar.apple.com/169838632">rdar://169838632</a>

Reviewed by Eric Carlson.

Conceptually the media source and the media device route are different entities, but prior to this
change we assumed that a MediaDeviceRoute was a media source. Separated these concepts for better
organization.

* Source/WebCore/SourcesCocoa.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(-[WebMediaSourceObserver initWithRoute:]):
(-[WebMediaSourceObserver mediaSource]):
(-[WebMediaSourceObserver setMediaSource:]):
(-[WebMediaSourceObserver observeValueForKeyPath:ofObject:change:context:]):
(WebCore::convert):
(WebCore::MediaDeviceRoute::platformRoute const):
(WebCore::MediaDeviceRoute::~MediaDeviceRoute):
(-[WebMediaDeviceRoute initWithRoute:platformRoute:]): Deleted.
(-[WebMediaDeviceRoute platformRoute]): Deleted.
(-[WebMediaDeviceRoute observeValueForKeyPath:ofObject:change:context:]): Deleted.
(-[WebMediaDeviceRoute dealloc]): Deleted.
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRouteController.mm:
(WebCore::MediaDeviceRouteController::MediaDeviceRouteController):
* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(-[WebMediaSessionHelper activeOutputDeviceDidChange:]):
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp:
(WebCore::MediaPlaybackTargetWirelessPlayback::loadURL): Deleted.
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h:
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded):
* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.h:
* Source/WebCore/platform/graphics/avfoundation/MediaPlaybackTargetCocoa.mm:
* Source/WebCore/platform/graphics/coreimage/FEConvolveMatrixCoreImageApplier.mm:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
(-[WebMockMediaDeviceRoute startWithURL:completionHandler:]):
(-[WebMockMediaDeviceRoute startApplicationWithURL:launchType:withCompletionHandler:]): Deleted.
* Source/WebKit/Platform/cocoa/MediaPlaybackTargetContextSerialized.mm:

Canonical link: <a href="https://commits.webkit.org/306986@main">https://commits.webkit.org/306986@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f5ffcb03afe760b61aba562febd868d43502f3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143002 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/15475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/6036 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151676 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f70a2b5d-1930-4884-b46e-789f95aa070f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15556 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/109969 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d62c05cd-7144-4572-b3f2-3274e8c5f46d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12421 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127922 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90880 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60f16df3-9946-4149-a75b-a81e64d17328) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1675 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/4462 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/153989 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/15100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/5107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/117984 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/15137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13083 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118326 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/125288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/70807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22043 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/15143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/4177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/14878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/78854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/14940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->