### PR TITLE
NavigationEvent#canIntercept is true when navigating to a different port

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-event-canintercept-cross-port-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-event-canintercept-cross-port-expected.txt
@@ -1,0 +1,3 @@
+
+PASS canIntercept should be false for cross-port navigations
+

--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-event-canintercept-cross-port.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-event-canintercept-cross-port.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Navigation API: canIntercept should be false for cross-port navigations</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+promise_test(async t => {
+  const currentPort = location.port || (location.protocol === 'https:' ? '443' : '80');
+  const otherPort = currentPort === '8800' ? '8000' : '8800';
+  const targetURL = `${location.protocol}//${location.hostname}:${otherPort}/`;
+  
+  const navigatePromise = new Promise((resolve) => {
+    navigation.addEventListener("navigate", t.step_func(event => {
+      // Cross-port navigation should have canIntercept === false
+      assert_equals(event.canIntercept, false, 
+        `canIntercept should be false when navigating from port ${currentPort} to port ${otherPort}`);
+      
+      // Prevent the actual navigation
+      event.preventDefault();
+      resolve();
+    }), { once: true });
+  });
+  
+  // Trigger the cross-port navigation
+  const anchor = document.createElement('a');
+  anchor.href = targetURL;
+  document.body.appendChild(anchor);
+  anchor.click();
+  
+  await navigatePromise;
+}, "canIntercept should be false for cross-port navigations");
+</script>
+</body>

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -820,6 +820,14 @@ static bool documentCanHaveURLRewritten(const Document& document, const URL& tar
     if (!isSameSite && !isSameOrigin)
         return false;
 
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten
+    if (documentURL.protocol() != targetURL.protocol()
+        || documentURL.user() != targetURL.user()
+        || documentURL.password() != targetURL.password()
+        || documentURL.host() != targetURL.host()
+        || documentURL.port() != targetURL.port())
+        return false;
+
     if (targetURL.protocolIsInHTTPFamily())
         return true;
 


### PR DESCRIPTION
#### 850ce3163e55ebaa33f712d05681e5522b518806
<pre>
NavigationEvent#canIntercept is true when navigating to a different port
<a href="https://bugs.webkit.org/show_bug.cgi?id=307197">https://bugs.webkit.org/show_bug.cgi?id=307197</a>
<a href="https://rdar.apple.com/169845691">rdar://169845691</a>

Reviewed by Basuke Suzuki.

The canIntercept property was incorrectly returning true when navigating
between different ports on the same host (e.g., localhost:3000 to
localhost:3001). According to the spec [1], canIntercept should be false when
the document URL and target URL differ in scheme, username, password,
host, or port components.

The bug was in documentCanHaveURLRewritten(), which returned true for any
HTTP(s) URL without checking if the port (or other components) matched
between the document and target URLs.

This patch fixes by adding explicit checks for scheme, username, password,
host, and port equality before allowing URL rewriting.

[1] <a href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten">https://html.spec.whatwg.org/multipage/nav-history-apis.html#can-have-its-url-rewritten</a>

* Source/WebCore/page/Navigation.cpp:
(WebCore::documentCanHaveURLRewritten):
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-event-canintercept-cross-port-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/navigate-event-canintercept-cross-port.html: Added.

Canonical link: <a href="https://commits.webkit.org/307316@main">https://commits.webkit.org/307316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30f68b7d91293a14d7ca9cb6baa497b2e4685618

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144019 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152689 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145894 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17180 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16591 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110743 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146982 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129405 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91662 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/135 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6050 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155001 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118757 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16586 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13906 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119112 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30528 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15006 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127261 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16172 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5707 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/15906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16117 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15972 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->