### PR TITLE
Remove release assert in WebTransportSession constructor

### DIFF
--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -133,7 +133,7 @@ bool NetworkProcessConnection::dispatchMessage(IPC::Connection& connection, IPC:
         protect(WebProcess::singleton().fileSystemStorageConnection())->didReceiveMessage(connection, decoder);
         return true;
     }
-    if (decoder.messageReceiverName() == Messages::WebTransportSession::messageReceiverName() && WebProcess::singleton().isWebTransportEnabled()) {
+    if (decoder.messageReceiverName() == Messages::WebTransportSession::messageReceiverName()) {
         if (RefPtr webTransportSession = WebProcess::singleton().webTransportSession(WebTransportSessionIdentifier(decoder.destinationID())))
             webTransportSession->didReceiveMessage(connection, decoder);
         return true;

--- a/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
+++ b/Source/WebKit/WebProcess/Network/WebTransportSession.cpp
@@ -61,7 +61,6 @@ WebTransportSession::WebTransportSession(Ref<IPC::Connection>&& connection, Thre
     , m_client(WTF::move(client))
     , m_identifier(identifier)
 {
-    RELEASE_ASSERT(WebProcess::singleton().isWebTransportEnabled());
     WebProcess::singleton().addWebTransportSession(m_identifier, *this);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7508,11 +7508,6 @@ void WebPage::setSmartInsertDeleteEnabled(bool enabled)
     }
 }
 
-bool WebPage::isWebTransportEnabled() const
-{
-    return m_page->settings().webTransportEnabled();
-}
-
 bool WebPage::isSelectTrailingWhitespaceEnabled() const
 {
     return m_page->settings().selectTrailingWhitespaceEnabled();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1353,8 +1353,6 @@ public:
     bool isSmartInsertDeleteEnabled();
     void setSmartInsertDeleteEnabled(bool);
 
-    bool isWebTransportEnabled() const;
-
     bool isSelectTrailingWhitespaceEnabled() const;
     void setSelectTrailingWhitespaceEnabled(bool);
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -800,17 +800,6 @@ bool WebProcess::areAllPagesSuspended() const
     return true;
 }
 
-void WebProcess::updateIsWebTransportEnabled()
-{
-    for (auto& page : m_pageMap.values()) {
-        if (page->isWebTransportEnabled()) {
-            m_isWebTransportEnabled = true;
-            return;
-        }
-    }
-    m_isWebTransportEnabled = false;
-}
-
 void WebProcess::updateIsBroadcastChannelEnabled()
 {
     if (m_isBroadcastChannelEnabled)
@@ -1039,7 +1028,6 @@ void WebProcess::createWebPage(PageIdentifier pageID, WebPageCreationParameters&
         // Balanced by an enableTermination in removeWebPage.
         disableTermination();
         updateCPULimit();
-        updateIsWebTransportEnabled();
         updateIsBroadcastChannelEnabled();
 
 #if OS(LINUX)
@@ -1070,7 +1058,6 @@ void WebProcess::removeWebPage(PageIdentifier pageID)
 
     enableTermination();
     updateCPULimit();
-    updateIsWebTransportEnabled();
     updateIsBroadcastChannelEnabled();
 
 #if OS(LINUX)

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -246,7 +246,6 @@ public:
     void removeWebPage(WebCore::PageIdentifier);
     WebPage* focusedWebPage() const;
     bool hasEverHadAnyWebPages() const { return m_hasEverHadAnyWebPages; }
-    bool isWebTransportEnabled() const { return m_isWebTransportEnabled; }
     bool isBroadcastChannelEnabled() const { return m_isBroadcastChannelEnabled; }
 
     InjectedBundle* injectedBundle() const { return m_injectedBundle.get(); }
@@ -918,7 +917,6 @@ private:
 
     HashMap<StorageAreaMapIdentifier, WeakPtr<StorageAreaMap>> m_storageAreaMaps;
 
-    void updateIsWebTransportEnabled();
     void updateIsBroadcastChannelEnabled();
     
     // Prewarmed WebProcesses do not have an associated sessionID yet, which is why this is an optional.
@@ -956,7 +954,6 @@ private:
     bool m_imageAnimationEnabled { true };
     bool m_hasEverHadAnyWebPages { false };
     bool m_hasPendingAccessibilityUnsuspension { false };
-    bool m_isWebTransportEnabled { false };
     bool m_isBroadcastChannelEnabled { false };
 
 #if ENABLE(ACCESSIBILITY_NON_BLINKING_CURSOR)


### PR DESCRIPTION
#### 2ebfc079030081bd40f425e5a434c8f64d4406cb
<pre>
Remove release assert in WebTransportSession constructor
<a href="https://bugs.webkit.org/show_bug.cgi?id=307216">https://bugs.webkit.org/show_bug.cgi?id=307216</a>
<a href="https://rdar.apple.com/168599027">rdar://168599027</a>

Reviewed by Tim Nguyen.

The assertion fires when a WebTransportSession is created in a service worker
in a process that has not seen a WebPage with WebTransport enabled.
The checks are no longer needed or useful because WebTransport is enabled by
default everywhere where COMPLETE_WEB_TRANSPORT is on.

The assertion could be hit by running WebTransport tests multiple times:

run-webkit-tests --iterations 10 LayoutTests/imported/w3c/web-platform-tests/webtransport
...
imported/w3c/web-platform-tests/webtransport/idlharness.https.any.serviceworker.html failed unexpectedly (ServiceWorkerProcess crashed [pid=81833])

Many thanks to David Kilzer for assistance in analyzing this bug.

* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::dispatchMessage):
* Source/WebKit/WebProcess/Network/WebTransportSession.cpp:
(WebKit::WebTransportSession::WebTransportSession):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::isWebTransportEnabled const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::createWebPage):
(WebKit::WebProcess::removeWebPage):
(WebKit::WebProcess::updateIsWebTransportEnabled): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/307004@main">https://commits.webkit.org/307004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c2aa44dfbf2b87c962c3acd81bf99e11d52f613c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15503 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151702 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fcbb5c4-20e6-4f09-8337-6d63b6d3a8d1) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15584 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/109991 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f43cdd0-6db4-4fba-8e34-29b2285f6af8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/145977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12450 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/127955 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90902 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00952e60-51bb-466e-8b48-ca31f38efb82) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9621 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1701 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121332 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154015 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/15199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118008 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/15170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13112 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118348 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125319 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70833 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22053 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15172 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4210 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14906 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78891 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/14968 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->