### PR TITLE
[AppKit Gestures] Add support for handling right clicks during text selection

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/AudioToolboxSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/AudioToolboxSPI.h
@@ -48,11 +48,13 @@ struct AudioFormatVorbisModeInfo {
 };
 typedef struct AudioFormatVorbisModeInfo AudioFormatVorbisModeInfo;
 
-enum SpatialAudioSourceID : UInt32;
-static constexpr UInt32 kSpatialAudioSource_Multichannel = 'mlti';
-static constexpr UInt32 kSpatialAudioSource_MonoOrStereo = 'most';
-static constexpr UInt32 kSpatialAudioSource_BinauralForHeadphones = 'binh';
-static constexpr UInt32 kSpatialAudioSource_Unknown = '?src';
+typedef CF_ENUM(UInt32, SpatialAudioSourceID)
+{
+    kSpatialAudioSource_Multichannel          = 'mlti',
+    kSpatialAudioSource_MonoOrStereo          = 'most',
+    kSpatialAudioSource_BinauralForHeadphones = 'binh',
+    kSpatialAudioSource_Unknown               = '?src'
+};
 
 enum SpatialContentTypeID : UInt32;
 static constexpr UInt32 kAudioSpatialContentType_Audiovisual = 'moov';

--- a/Source/WebKit/Platform/cocoa/FloatRectCG.swift
+++ b/Source/WebKit/Platform/cocoa/FloatRectCG.swift
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT
+
+import Foundation
+internal import WebCore_Private
+
+extension CGRect {
+    /// Creates a `CGRect` from a `FloatRect`.
+    ///
+    /// - Parameter rect: The rect to convert.
+    init(_ rect: WebCore.FloatRect) {
+        self = .init(x: CGFloat(rect.x()), y: CGFloat(rect.y()), width: CGFloat(rect.width()), height: CGFloat(rect.height()))
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT

--- a/Source/WebKit/Platform/cocoa/IntRectCG.swift
+++ b/Source/WebKit/Platform/cocoa/IntRectCG.swift
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+
+#if HAVE_APPKIT_GESTURES_SUPPORT
+
+import Foundation
+internal import WebCore_Private
+
+extension CGRect {
+    /// Creates a `CGRect` from an `IntRect`.
+    ///
+    /// - Parameter rect: The rect to convert.
+    init(_ rect: WebCore.IntRect) {
+        self = .init(x: Int(rect.x()), y: Int(rect.y()), width: Int(rect.width()), height: Int(rect.height()))
+    }
+}
+
+#endif // HAVE_APPKIT_GESTURES_SUPPORT

--- a/Source/WebKit/Shared/NativeWebMouseEvent.h
+++ b/Source/WebKit/Shared/NativeWebMouseEvent.h
@@ -67,7 +67,7 @@ namespace WebKit {
 class NativeWebMouseEvent : public WebMouseEvent {
 public:
 #if USE(APPKIT)
-    NativeWebMouseEvent(NSEvent *, NSEvent *lastPressureEvent, NSView *);
+    NativeWebMouseEvent(NSEvent *, NSEvent *lastPressureEvent, NSView *, WebMouseEventInputSource);
 #elif PLATFORM(GTK)
     NativeWebMouseEvent(const NativeWebMouseEvent&);
     NativeWebMouseEvent(GdkEvent*, int, std::optional<WebCore::FloatSize>);

--- a/Source/WebKit/Shared/mac/NativeWebMouseEventMac.mm
+++ b/Source/WebKit/Shared/mac/NativeWebMouseEventMac.mm
@@ -32,8 +32,8 @@
 
 namespace WebKit {
 
-NativeWebMouseEvent::NativeWebMouseEvent(NSEvent *event, NSEvent *lastPressureEvent, NSView *view)
-    : WebMouseEvent(WebEventFactory::createWebMouseEvent(event, lastPressureEvent, view))
+NativeWebMouseEvent::NativeWebMouseEvent(NSEvent *event, NSEvent *lastPressureEvent, NSView *view, WebMouseEventInputSource inputSource)
+    : WebMouseEvent(WebEventFactory::createWebMouseEvent(event, lastPressureEvent, view, inputSource))
     , m_nativeEvent(event)
 {
 }

--- a/Source/WebKit/Shared/mac/WebEventFactory.h
+++ b/Source/WebKit/Shared/mac/WebEventFactory.h
@@ -47,7 +47,7 @@ namespace WebKit {
 class WebEventFactory {
 public:
 #if USE(APPKIT)
-    static WebMouseEvent createWebMouseEvent(NSEvent *, NSEvent *lastPressureEvent, NSView *windowView);
+    static WebMouseEvent createWebMouseEvent(NSEvent *, NSEvent *lastPressureEvent, NSView *windowView, WebMouseEventInputSource);
     static WebWheelEvent createWebWheelEvent(NSEvent *, NSView *windowView);
     static WebKeyboardEvent createWebKeyboardEvent(NSEvent *, bool handledByInputMethod, bool replacesSoftSpace, const Vector<WebCore::KeypressCommand>&);
     static bool shouldBeHandledAsContextClick(const WebCore::PlatformMouseEvent&);

--- a/Source/WebKit/Shared/mac/WebEventFactory.mm
+++ b/Source/WebKit/Shared/mac/WebEventFactory.mm
@@ -91,7 +91,7 @@ bool WebEventFactory::shouldBeHandledAsContextClick(const WebCore::PlatformMouse
     return (static_cast<NSMenuType>(event.menuTypeForEvent()) == NSMenuTypeContextMenu);
 }
 
-WebMouseEvent WebEventFactory::createWebMouseEvent(NSEvent *event, NSEvent *lastPressureEvent, NSView *windowView)
+WebMouseEvent WebEventFactory::createWebMouseEvent(NSEvent *event, NSEvent *lastPressureEvent, NSView *windowView, WebMouseEventInputSource inputSource)
 {
     NSPoint position = WebCore::pointForEvent(event, windowView);
     NSPoint globalPosition = WebCore::globalPointForEvent(event);
@@ -125,7 +125,7 @@ WebMouseEvent WebEventFactory::createWebMouseEvent(NSEvent *event, NSEvent *last
 
     auto unadjustedMovementDelta = WebCore::unadjustedMovementForEvent(event);
 
-    return WebMouseEvent({ type, modifiers, timestamp, WTF::UUID::createVersion4() }, button, buttons, WebCore::DoublePoint(position), WebCore::DoublePoint(globalPosition), deltaX, deltaY, deltaZ, clickCount, force, WebMouseEventInputSource::Hardware, WebMouseEventSyntheticClickType::NoTap, eventNumber, menuTypeForEvent, GestureWasCancelled::No, unadjustedMovementDelta);
+    return WebMouseEvent({ type, modifiers, timestamp, WTF::UUID::createVersion4() }, button, buttons, WebCore::DoublePoint(position), WebCore::DoublePoint(globalPosition), deltaX, deltaY, deltaZ, clickCount, force, inputSource, WebMouseEventSyntheticClickType::NoTap, eventNumber, menuTypeForEvent, GestureWasCancelled::No, unadjustedMovementDelta);
 }
 
 WebWheelEvent WebEventFactory::createWebWheelEvent(NSEvent *event, NSView *windowView)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2262,6 +2262,13 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
     return _page.get();
 }
 
+#if PLATFORM(MAC)
+- (WebKit::WebViewImpl *)_impl
+{
+    return _impl.get();
+}
+#endif // PLATFORM(MAC)
+
 #if ENABLE(SCREEN_TIME)
 - (STWebpageController *)_screenTimeWebpageController
 {
@@ -3789,15 +3796,6 @@ struct WKWebViewData {
 {
     self._protectedPage->scrollToEdge(toRectEdges(edge), animated ? WebCore::ScrollIsAnimated::Yes : WebCore::ScrollIsAnimated::No);
 }
-
-#if PLATFORM(MAC)
-
-- (WebKit::WebViewImpl *)_impl
-{
-    return _impl.get();
-}
-
-#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -646,6 +646,9 @@ struct PerWebProcessState {
 - (WKPageRef)_pageForTesting;
 - (NakedPtr<WebKit::WebPageProxy>)_page;
 - (RefPtr<WebKit::WebPageProxy>)_protectedPage;
+#if PLATFORM(MAC)
+- (WebKit::WebViewImpl * _Null_unspecified)_impl;
+#endif
 #if ENABLE(SCREEN_TIME)
 - (nullable STWebpageController *)_screenTimeWebpageController;
 #if PLATFORM(MAC)
@@ -669,10 +672,6 @@ struct PerWebProcessState {
 @property (nonatomic, setter=_setHasActiveNowPlayingSession:) BOOL _hasActiveNowPlayingSession;
 
 @property (nonatomic, readonly) RetainPtr<WKWebView> _horizontallyAttachedInspectorWebView;
-
-#if PLATFORM(MAC)
-- (WebKit::WebViewImpl *)_impl;
-#endif
 
 @end
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h
@@ -27,6 +27,7 @@
 
 #if PLATFORM(IOS_FAMILY)
 
+#import "UIKitSPI.h"
 #import "WKBaseScrollView.h"
 #import "WKWebViewInternal.h"
 
@@ -37,8 +38,6 @@
 #import <wtf/spi/cocoa/NSObjCRuntimeSPI.h>
 
 #endif // !__has_feature(modules) || WK_SUPPORTS_SWIFT_OBJCXX_INTEROP
-
-#import "UIKitSPI.h"
 
 @class WKBEScrollViewScrollUpdate;
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -557,12 +557,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
 - (void)mouseDown:(NSEvent *)event
 {
-    _impl->mouseDown(event);
+    _impl->mouseDown(event, WebKit::WebMouseEventInputSource::Hardware);
 }
 
 - (void)mouseUp:(NSEvent *)event
 {
-    _impl->mouseUp(event);
+    _impl->mouseUp(event, WebKit::WebMouseEventInputSource::Hardware);
 }
 
 - (void)mouseDragged:(NSEvent *)event

--- a/Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift
+++ b/Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift
@@ -29,3 +29,39 @@ typealias URL = Foundation.URL
 struct UncheckedSendableKeyPathBox<Root, Value>: @unchecked Sendable {
     let keyPath: KeyPath<Root, Value>
 }
+
+extension Comparable {
+    /// Returns this comparable value clamped to the given limiting range.
+    ///
+    /// - Parameter limits: The range to clamp the bounds of this value.
+    /// - Returns: A value guaranteed to be in the range `[limits.lowerBound, limits.upperBound]`
+    func clamped(to limits: ClosedRange<Self>) -> Self {
+        min(max(self, limits.lowerBound), limits.upperBound)
+    }
+}
+
+extension CGPoint {
+    /// Returns the euclidean distance between this point and `point`.
+    ///
+    /// - Parameter point: A point to compute the distance to.
+    /// - Returns: The distance between this point and `point`.
+    func distance(to point: CGPoint) -> Double {
+        let distanceSquared = (x - point.x) * (x - point.x) + (y - point.y) * (y - point.y)
+        return distanceSquared.squareRoot()
+    }
+}
+
+extension CGRect {
+    /// Determines the closest distance between this rect and `point` using whichever edge is nearest.
+    ///
+    /// - Parameter point: A point to compute the distance to.
+    /// - Returns: The closest distance between this rect and `point`. If `point` is contained within this rect, `0` is returned.
+    func distance(to point: CGPoint) -> Double {
+        // Clamp the point coordinates to the rectangle's bounds
+        let closestX = point.x.clamped(to: minX...maxX)
+        let closestY = point.y.clamped(to: minY...maxY)
+
+        let closestPoint = CGPoint(x: closestX, y: closestY)
+        return point.distance(to: closestPoint)
+    }
+}

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -32,6 +32,7 @@
 #include "GPUProcessConnectionIdentifier.h"
 #include "MessageReceiverMap.h"
 #include "NetworkProcessProxy.h"
+#include "PageClient.h"
 #include "ProcessLauncher.h"
 #include "ProcessThrottler.h"
 #include "RemoteWorkerInitializationData.h"
@@ -125,7 +126,6 @@ class AudioSessionRoutingArbitratorProxy;
 class FrameState;
 class JavaScriptEvaluationResult;
 class ModelProcessProxy;
-class PageClient;
 class ProvisionalPageProxy;
 class RemotePageProxy;
 class SuspendedPageProxy;

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -269,8 +269,8 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     RetainPtr mouseDown = [NSEvent mouseEventWithType:NSEventTypeLeftMouseDown location:location modifierFlags:modifierFlags timestamp:timestamp windowNumber:windowNumber context:NULL eventNumber:0 clickCount:1 pressure:1.0];
     RetainPtr mouseUp = [NSEvent mouseEventWithType:NSEventTypeLeftMouseUp location:location modifierFlags:modifierFlags timestamp:timestamp windowNumber:windowNumber context:NULL eventNumber:0 clickCount:1 pressure:0.0];
 
-    viewImpl->mouseDown(mouseDown.get());
-    viewImpl->mouseUp(mouseUp.get());
+    viewImpl->mouseDown(mouseDown.get(), WebKit::WebMouseEventInputSource::Automation);
+    viewImpl->mouseUp(mouseUp.get(), WebKit::WebMouseEventInputSource::Automation);
 }
 
 - (void)doubleClickGestureRecognized:(NSGestureRecognizer *)gesture

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -565,7 +565,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             eventNumber:0
             clickCount:0
             pressure:0];
-        WebKit::NativeWebMouseEvent webEvent(fakeEvent.get(), nil, webView.get());
+        WebKit::NativeWebMouseEvent webEvent(fakeEvent.get(), nil, webView.get(), WebKit::WebMouseEventInputSource::Hardware);
         page->handleMouseEvent(webEvent);
     }
     page->flushDeferredResizeEvents();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -37,6 +37,7 @@
 #include "ImageAnalysisUtilities.h"
 #include "PDFPluginIdentifier.h"
 #include "WKLayoutMode.h"
+#include "WebMouseEvent.h"
 #include <WebCore/DOMPasteAccess.h>
 #include <WebCore/FocusDirection.h>
 #include <WebCore/HTMLMediaElementIdentifier.h>
@@ -694,8 +695,8 @@ public:
     bool hasFlagsChangedEventMonitor();
 
     void mouseMoved(NSEvent *);
-    void mouseDown(NSEvent *);
-    void mouseUp(NSEvent *);
+    void mouseDown(NSEvent *, WebMouseEventInputSource);
+    void mouseUp(NSEvent *, WebMouseEventInputSource);
     void mouseDragged(NSEvent *);
     void mouseEntered(NSEvent *);
     void mouseExited(NSEvent *);
@@ -914,14 +915,14 @@ private:
     Vector<WebCore::KeypressCommand> collectKeyboardLayoutCommandsForEvent(NSEvent *);
     void interpretKeyEvent(NSEvent *, void(^completionHandler)(BOOL handled, const Vector<WebCore::KeypressCommand>&));
 
-    void nativeMouseEventHandler(NSEvent *);
-    void nativeMouseEventHandlerInternal(NSEvent *);
-    
+    void nativeMouseEventHandler(NSEvent *, WebMouseEventInputSource);
+    void nativeMouseEventHandlerInternal(NSEvent *, WebMouseEventInputSource);
+
     void scheduleMouseDidMoveOverElement(NSEvent *);
 
     void mouseMovedInternal(NSEvent *);
-    void mouseDownInternal(NSEvent *);
-    void mouseUpInternal(NSEvent *);
+    void mouseDownInternal(NSEvent *, WebMouseEventInputSource);
+    void mouseUpInternal(NSEvent *, WebMouseEventInputSource);
     void mouseDraggedInternal(NSEvent *);
 
     void handleProcessSwapOrExit();

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -168,6 +168,8 @@
 		07438C722D4C645600BD1E68 /* _WebKit_SwiftUI.framework in Product Dependencies */ = {isa = PBXBuildFile; fileRef = 07275C4F2D00C934002315A5 /* _WebKit_SwiftUI.framework */; };
 		0744DA552CE05FE400AACC81 /* WebKitInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 0744DA542CE05FE400AACC81 /* WebKitInternal.h */; };
 		074A6FC72D5F1FAF0027F958 /* KeyEventInterpretationContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 074A6FC52D5F1DEA0027F958 /* KeyEventInterpretationContext.h */; };
+		074D6A652F385435006089F6 /* IntRectCG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074D6A642F38542D006089F6 /* IntRectCG.swift */; };
+		074D6A672F3854F0006089F6 /* FloatRectCG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074D6A662F3854D7006089F6 /* FloatRectCG.swift */; };
 		074E75FE1DF2211900D318EC /* UserMediaProcessManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 074E75FB1DF1FD1300D318EC /* UserMediaProcessManager.h */; };
 		074E87E12CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074E87E02CF8EA3D0059E469 /* WebPage+NavigationDeciding.swift */; };
 		074F34812CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h in Headers */ = {isa = PBXBuildFile; fileRef = 074F34802CC5F7D500CA5301 /* WKIntelligenceTextEffectCoordinator.h */; };
@@ -3391,6 +3393,8 @@
 		074A6FC52D5F1DEA0027F958 /* KeyEventInterpretationContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = KeyEventInterpretationContext.h; sourceTree = "<group>"; };
 		074A6FC62D5F1DEA0027F958 /* KeyEventInterpretationContext.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = KeyEventInterpretationContext.cpp; sourceTree = "<group>"; };
 		074A6FC82D5F20190027F958 /* KeyEventInterpretationContext.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = KeyEventInterpretationContext.serialization.in; sourceTree = "<group>"; };
+		074D6A642F38542D006089F6 /* IntRectCG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntRectCG.swift; sourceTree = "<group>"; };
+		074D6A662F3854D7006089F6 /* FloatRectCG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatRectCG.swift; sourceTree = "<group>"; };
 		074E75FB1DF1FD1300D318EC /* UserMediaProcessManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UserMediaProcessManager.h; sourceTree = "<group>"; };
 		074E75FC1DF2002400D318EC /* UserMediaProcessManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = UserMediaProcessManager.cpp; sourceTree = "<group>"; };
 		074E76001DF7075D00D318EC /* MediaDeviceSandboxExtensions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MediaDeviceSandboxExtensions.cpp; sourceTree = "<group>"; };
@@ -13457,8 +13461,10 @@
 				A1D615622B06BBAB002D0E19 /* ExtensionCapability.h */,
 				A141DF512B07054900E80B2D /* ExtensionCapabilityGrant.h */,
 				A141DF532B07069700E80B2D /* ExtensionCapabilityGrant.mm */,
+				074D6A662F3854D7006089F6 /* FloatRectCG.swift */,
 				F4351B9D25EEC84C00D63892 /* ImageAnalysisUtilities.h */,
 				F4351B9F25EEC87800D63892 /* ImageAnalysisUtilities.mm */,
+				074D6A642F38542D006089F6 /* IntRectCG.swift */,
 				BCE0937614FB128B001138D9 /* LayerHostingContext.h */,
 				BCE0937514FB128B001138D9 /* LayerHostingContext.mm */,
 				515A0C532E8284AC00D0B56C /* LayerHostingContextManager.h */,
@@ -21668,6 +21674,7 @@
 				CDCDC99E248FE8DA00A69522 /* EndowmentStateTracker.mm in Sources */,
 				E31586CE2AD610F30062ED2A /* ExtensionEventHandler.mm in Sources */,
 				E34DAD392B753FA700FABEE2 /* ExtensionProcess.mm in Sources */,
+				074D6A672F3854F0006089F6 /* FloatRectCG.swift in Sources */,
 				079A4DA72D72CEDC00CA387F /* Foundation+Extras.swift in Sources */,
 				CDA93DB122F8BCF400490A69 /* FullscreenTouchSecheuristicParameters.cpp in Sources */,
 				86760A6B28DB30DE00D07D06 /* GeneratedSerializers.mm in Sources */,
@@ -21675,6 +21682,7 @@
 				522F792928D50EBB0069B45B /* HidService.mm in Sources */,
 				2749F6442146561B008380BF /* InjectedBundleNodeHandle.cpp in Sources */,
 				2749F6452146561E008380BF /* InjectedBundleRangeHandle.cpp in Sources */,
+				074D6A652F385435006089F6 /* IntRectCG.swift in Sources */,
 				5CF250AF2EE06491006A7172 /* IPCTesterReceiver.swift in Sources */,
 				5C448C662EE06E11008931C7 /* IPCTesterReceiverMessageReceiver.swift in Sources */,
 				1C0F05BE2CFA5D2E007D1F62 /* JSWebExtensionAPIUnified.mm in Sources */,


### PR DESCRIPTION
#### 5e608f7de576d40578115982983ba1b9d4177f67
<pre>
[AppKit Gestures] Add support for handling right clicks during text selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=307217">https://bugs.webkit.org/show_bug.cgi?id=307217</a>
<a href="https://rdar.apple.com/169853467">rdar://169853467</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Implement the following behavior:
- Click within a selection -&gt; a context menu is presented, and the selection remains as a range
- Click and hold on a word -&gt; a context menu is presented, and the selection becomes a range
- Click on a word, then click near the same location as the first one -&gt; a context menu is presented, and the selection remains a caret
- Click on a word, then click at the location of the caret -&gt; a context menu is presented, and the selection remains a caret

* Source/WebCore/PAL/pal/spi/cocoa/AudioToolboxSPI.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _impl]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.h:

Additional infrastructure support for Swift-Cxx interop

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::sendContextMenuEvent):

- Like iOS, disallow a click from changing the selection when it&apos;s input source is `Automation`, since
the platform will handle changing the selection in this case.
- Also like iOS, don&apos;t let right-clicking result in the selection changing to select the word that is being right-clicked.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/platform/graphics/cg/FloatRectCG.swift: Copied from Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift.
* Source/WebCore/platform/graphics/cg/IntRectCG.swift: Copied from Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift.
* Source/WebKit/UIProcess/Cocoa/Foundation+Extras.swift:
(Comparable.clamped(to:)):
(CGPoint.distance(to:)):
(CGRect.distance(to:)):

- Add convenience extension functions for CGRects and CGPoints.

* Source/WebKit/Shared/NativeWebMouseEvent.h:
* Source/WebKit/Shared/mac/NativeWebMouseEventMac.mm:
(WebKit::NativeWebMouseEvent::NativeWebMouseEvent):
* Source/WebKit/Shared/mac/WebEventFactory.h:
* Source/WebKit/Shared/mac/WebEventFactory.mm:
(WebKit::WebEventFactory::createWebMouseEvent):
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView mouseDown:]):
(-[WKWebView mouseUp:]):
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController singleClickGestureRecognized:]):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
(-[WKFullScreenWindowController finishedEnterFullScreenAnimation:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::acceptsFirstMouse):
(WebKit::WebViewImpl::shouldDelayWindowOrderingForEvent):
(WebKit::WebViewImpl::scheduleMouseDidMoveOverElement):
(WebKit::WebViewImpl::pressureChangeWithEvent):
(WebKit::WebViewImpl::nativeMouseEventHandler):
(WebKit::WebViewImpl::nativeMouseEventHandlerInternal):
(WebKit::WebViewImpl::mouseEntered):
(WebKit::WebViewImpl::mouseExited):
(WebKit::WebViewImpl::otherMouseDown):
(WebKit::WebViewImpl::otherMouseDragged):
(WebKit::WebViewImpl::otherMouseUp):
(WebKit::WebViewImpl::rightMouseDown):
(WebKit::WebViewImpl::rightMouseDragged):
(WebKit::WebViewImpl::rightMouseUp):
(WebKit::WebViewImpl::mouseMovedInternal):
(WebKit::WebViewImpl::mouseDownInternal):
(WebKit::WebViewImpl::mouseUpInternal):
(WebKit::WebViewImpl::mouseDraggedInternal):
(WebKit::WebViewImpl::mouseDown):
(WebKit::WebViewImpl::mouseUp):

- Add more support for propagating the mouse input source throughout event handling.

* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.isTextSelected(at:)):
(WKTextSelectionController.handleClick(at:)):
(WKTextSelectionController.handleClickInternal(at:)):
(WKTextSelectionController.showContextMenu(at:)):

- Implement the context menu behaviors.

Canonical link: <a href="https://commits.webkit.org/307127@main">https://commits.webkit.org/307127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/10f61fba4e25322cbc10bf6059f73c91c2d5717e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143415 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7500 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152080 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/915e6dd8-11ef-4fb1-877b-bc6b64215778) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145290 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/16573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15984 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110286 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40405f59-b45f-4af3-9051-17f9da3cd4aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146378 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/16573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91198 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d80b6523-b73e-42bc-b9f2-761b8ac3a2ab) 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/142741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/16573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9959 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2082 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135403 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/16573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5408 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154392 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4221 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15943 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6444 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118307 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/142820 "Passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15979 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13447 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118649 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30415 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14608 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126607 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71357 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15564 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5238 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174701 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79278 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45101 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15511 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15363 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->