### PR TITLE
`appearance: base-select` should not affect non-select elements

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -678,7 +678,6 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-color.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-restore.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/picker-and-slotted.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/appearance-base-select-other-elements.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-many-options.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-multiple-size-1.tentative.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
@@ -4,7 +4,6 @@
     <style>
         select {
             all: unset; /* Remove all UA styles */
-            appearance: none;
             background-color: green;
             color: white;
         }
@@ -12,7 +11,7 @@
 </head>
 <body>
     <div style="color: orange">This text should be orange (default)</div>
-    <div style="color: blue">This text should be blue (base-select on non-select)</div>
+    <div style="color: orange">This text should be orange (base-select on non-select)</div>
     <div style="color: blue">This text should be blue (base)</div>
 
     <select><option>This select should be green with white text. (base-select)</option></select>

--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
@@ -19,7 +19,7 @@
         }
     </style>
     <div>This text should be orange (default)</div>
-    <div style="appearance: base-select">This text should be blue (base-select on non-select)</div>
+    <div style="appearance: base-select">This text should be orange (base-select on non-select)</div>
     <div style="appearance: base">This text should be blue (base)</div>
 
     <select style="appearance: base-select"><option>This select should be green with white text. (base-select)</option></select>

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -131,8 +131,14 @@ StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, cons
 
     auto appearance = style.usedAppearance();
     if (appearance == StyleAppearance::BaseSelect) {
-        style.setUsedAppearance(StyleAppearance::Base);
-        return StyleAppearance::Base;
+        if (is<HTMLSelectElement>(element)) [[likely]] {
+            style.setUsedAppearance(StyleAppearance::Base);
+            return StyleAppearance::Base;
+        }
+
+        // `appearance: base-select` behaves like `auto` on non-select elements.
+        style.setUsedAppearance(autoAppearance);
+        return autoAppearance;
     }
 
     if (appearance == autoAppearance)

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -43,6 +43,7 @@
 #include "ComputedStyleDependencies.h"
 #include "Document.h"
 #include "HTMLElement.h"
+#include "HTMLSelectElement.h"
 #include "PaintWorkletGlobalScope.h"
 #include "RenderStyle+GettersInlines.h"
 #include "RenderStyle+SettersInlines.h"
@@ -561,7 +562,7 @@ Ref<CSSValue> Builder::resolveInternalAutoBaseFunction(CSSValue& value)
         return value;
 
     // usedAppearance() is inaccurate at this stage of style resolution, check against both `appearance: base-select` & `appearance: base`.
-    bool isAppearanceBase = m_state->style().appearance() == StyleAppearance::Base || m_state->style().appearance() == StyleAppearance::BaseSelect;
+    bool isAppearanceBase = m_state->style().appearance() == StyleAppearance::Base || (is<HTMLSelectElement>(m_state->element()) && m_state->style().appearance() == StyleAppearance::BaseSelect);
     RefPtr result = const_cast<CSSValue*>(isAppearanceBase ? functionValue->item(1) : functionValue->item(0));
 
     if (!result)


### PR DESCRIPTION
#### 8565b7c3d1c372b275e3eedc51f638341913d1db
<pre>
`appearance: base-select` should not affect non-select elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=307221">https://bugs.webkit.org/show_bug.cgi?id=307221</a>
<a href="https://rdar.apple.com/169858852">rdar://169858852</a>

Reviewed by Simon Fraser.

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html:
* LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::adjustAppearanceForElement const):
* Source/WebCore/style/StyleBuilder.cpp:
(WebCore::Style::Builder::resolveInternalAutoBaseFunction):

Canonical link: <a href="https://commits.webkit.org/307025@main">https://commits.webkit.org/307025@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c6cea3b57c31373ff922e8e1cde1e0e572fb204

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143139 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15614 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151814 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6cbd9326-3a15-4c90-9149-1897d8b5b6ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16274 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110079 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ef290f9-bea3-46dd-93b8-24d20f4e59fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12514 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90990 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdf70795-da1d-4ec8-8cc1-33a9b0f1fa9f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11997 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9710 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1812 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121411 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4595 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154126 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15540 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118096 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15518 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118436 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14360 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125775 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70996 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22068 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15283 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4419 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15017 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79002 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15228 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15079 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->