### PR TITLE
[JSC] Add ArithMod(Int52Use, Int52Use) in DFG / FTL

### DIFF
--- a/JSTests/stress/int52-arith-mod-with-overflow-unchecked.js
+++ b/JSTests/stress/int52-arith-mod-with-overflow-unchecked.js
@@ -1,0 +1,266 @@
+// Test Int52 ArithMod with Arith::Unchecked mode.
+// When the result of Int52 modulo feeds into bitwise operations (like | 0),
+// backward propagation clears NodeBytecodeNeedsNaNOrInfinity and NodeBytecodeNeedsNegZero,
+// enabling Arith::Unchecked mode which avoids OSR exits on division-by-zero
+// and negative-zero results.
+
+// ===== Basic Int52 mod with | 0 (Arith::Unchecked path) =====
+
+// The | 0 consumer clears NeedsNaNOrInfinity and NeedsNegZero on ArithMod,
+// so ArithMod(Int52, Int52) gets Arith::Unchecked mode.
+function modInt52BitOr(a, b) {
+    return (a % b) | 0;
+}
+noInline(modInt52BitOr);
+
+// Basic Int52 mod with | 0
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52BitOr(2147483648, 7);
+    if (result !== (2147483648 % 7))
+        throw "FAIL: modInt52BitOr basic, got " + result + " expected " + (2147483648 % 7);
+}
+
+// Negative numerator
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52BitOr(-4503599627370496, 1000000007);
+    let expected = (-4503599627370496 % 1000000007) | 0;
+    if (result !== expected)
+        throw "FAIL: modInt52BitOr negative numerator, got " + result + " expected " + expected;
+}
+
+// Large Int52 values
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52BitOr(4503599627370495, 97);
+    let expected = (4503599627370495 % 97) | 0;
+    if (result !== expected)
+        throw "FAIL: modInt52BitOr large values, got " + result + " expected " + expected;
+}
+
+// ===== Division by zero with | 0 (Arith::Unchecked, should NOT OSR exit) =====
+
+// In Arith::Unchecked mode, division by zero should return 0 (via chillMod)
+// instead of triggering an OSR exit.
+function modInt52DivByZeroBitOr(a, b) {
+    return (a % b) | 0;
+}
+noInline(modInt52DivByZeroBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    // Alternate between normal mod and division by zero to stress the JIT.
+    if (i % 2 === 0) {
+        let result = modInt52DivByZeroBitOr(2147483648, 7);
+        if (result !== (2147483648 % 7))
+            throw "FAIL: modInt52DivByZeroBitOr normal case, got " + result;
+    } else {
+        // x % 0 in JS produces NaN, NaN | 0 = 0.
+        // With Arith::Unchecked, chillMod returns 0 for zero denominator,
+        // then | 0 produces 0. Same result.
+        let result = modInt52DivByZeroBitOr(2147483648, 0);
+        if (result !== 0)
+            throw "FAIL: modInt52DivByZeroBitOr div-by-zero, got " + result + " expected 0";
+    }
+}
+
+// Pure division by zero case: ensure it doesn't trap or OSR exit excessively.
+function modInt52AlwaysZeroDivisorBitOr(a) {
+    return (a % 0) | 0;
+}
+noInline(modInt52AlwaysZeroDivisorBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52AlwaysZeroDivisorBitOr(2147483648 + i);
+    if (result !== 0)
+        throw "FAIL: modInt52AlwaysZeroDivisorBitOr, got " + result + " expected 0";
+}
+
+// ===== Negative zero with | 0 (Arith::Unchecked, -0 | 0 = 0) =====
+
+// When the result is -0, | 0 converts it to +0.
+// In Arith::Unchecked mode, we don't need to check for negative zero at all.
+function modInt52NegZeroBitOr(a, b) {
+    return (a % b) | 0;
+}
+noInline(modInt52NegZeroBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    // -2^31 % 2^31 would be -0, but | 0 makes it +0 = 0.
+    let result = modInt52NegZeroBitOr(-2147483648, 2147483648);
+    if (result !== 0)
+        throw "FAIL: modInt52NegZeroBitOr, got " + result + " expected 0";
+}
+
+// Larger Int52 negative zero case
+for (let i = 0; i < testLoopCount; i++) {
+    // -2^40 % 2^40 would be -0, but | 0 makes it 0.
+    let result = modInt52NegZeroBitOr(-1099511627776, 1099511627776);
+    if (result !== 0)
+        throw "FAIL: modInt52NegZeroBitOr large, got " + result + " expected 0";
+}
+
+// ===== Int52 mod with other bitwise operators (also Arith::Unchecked) =====
+
+function modInt52BitAnd(a, b) {
+    return (a % b) & 0x7FFFFFFF;
+}
+noInline(modInt52BitAnd);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52BitAnd(4503599627370495, 97);
+    let expected = (4503599627370495 % 97) & 0x7FFFFFFF;
+    if (result !== expected)
+        throw "FAIL: modInt52BitAnd, got " + result + " expected " + expected;
+}
+
+function modInt52BitXor(a, b) {
+    return (a % b) ^ 0;
+}
+noInline(modInt52BitXor);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52BitXor(2147483648, 7);
+    let expected = (2147483648 % 7) ^ 0;
+    if (result !== expected)
+        throw "FAIL: modInt52BitXor, got " + result + " expected " + expected;
+}
+
+function modInt52BitShift(a, b) {
+    return (a % b) >> 0;
+}
+noInline(modInt52BitShift);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52BitShift(4503599627370495, 1000000007);
+    let expected = (4503599627370495 % 1000000007) >> 0;
+    if (result !== expected)
+        throw "FAIL: modInt52BitShift, got " + result + " expected " + expected;
+}
+
+// ===== Int52 mod with LogicalNot (clears NeedsNaNOrInfinity for Mod/Div) =====
+
+// LogicalNot clears NodeBytecodeNeedsNaNOrInfinity when its child is ArithMod/ArithDiv.
+// This is because Mod/Div from integer inputs only produce NaN (never Infinity),
+// and ToBoolean(NaN) = false = ToBoolean(0), so chillMod returning 0 for NaN is correct.
+function modInt52LogicalNot(a, b) {
+    return !(a % b);
+}
+noInline(modInt52LogicalNot);
+
+// Non-zero remainder: !(nonzero) = false
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52LogicalNot(2147483648, 7);
+    if (result !== false)
+        throw "FAIL: modInt52LogicalNot non-zero, got " + result + " expected false";
+}
+
+// Zero remainder: !(0) = true
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52LogicalNot(2147483648, 2147483648);
+    if (result !== true)
+        throw "FAIL: modInt52LogicalNot zero remainder, got " + result + " expected true";
+}
+
+// Division by zero: NaN case, chillMod returns 0, !(0) = true.
+// In JS: x % 0 = NaN, !NaN = true. So the result should be true.
+function modInt52LogicalNotDivByZero(a, b) {
+    return !(a % b);
+}
+noInline(modInt52LogicalNotDivByZero);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (i % 2 === 0) {
+        let result = modInt52LogicalNotDivByZero(2147483648, 7);
+        if (result !== false)
+            throw "FAIL: modInt52LogicalNotDivByZero normal, got " + result + " expected false";
+    } else {
+        let result = modInt52LogicalNotDivByZero(2147483648, 0);
+        if (result !== true)
+            throw "FAIL: modInt52LogicalNotDivByZero div-by-zero, got " + result + " expected true";
+    }
+}
+
+// Negative zero with LogicalNot: !(-0) = true, !(+0) = true.
+// Both are correctly handled regardless of negative zero optimization.
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52LogicalNot(-1099511627776, 1099511627776);
+    if (result !== true)
+        throw "FAIL: modInt52LogicalNot neg zero, got " + result + " expected true";
+}
+
+// ===== Combined: Int52 mod in arithmetic then bitwise (NeedsNaNOrInfinity propagation) =====
+
+// (a % b + c) | 0
+// ArithAdd propagates NeedsNaNOrInfinity to its children (ArithMod),
+// but | 0 clears NeedsNaNOrInfinity. So ArithMod still gets Unchecked if ArithAdd also doesn't need it.
+function modInt52AddBitOr(a, b, c) {
+    return ((a % b) + c) | 0;
+}
+noInline(modInt52AddBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modInt52AddBitOr(4503599627370495, 97, 42);
+    let expected = ((4503599627370495 % 97) + 42) | 0;
+    if (result !== expected)
+        throw "FAIL: modInt52AddBitOr, got " + result + " expected " + expected;
+}
+
+// ===== Varying inputs to prevent constant folding =====
+
+function modInt52VaryingBitOr(a, b) {
+    return (a % b) | 0;
+}
+noInline(modInt52VaryingBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let a = 2147483648 + i;
+    let b = 7 + (i % 13);
+    let result = modInt52VaryingBitOr(a, b);
+    let expected = (a % b) | 0;
+    if (result !== expected)
+        throw "FAIL: modInt52VaryingBitOr at i=" + i + ", got " + result + " expected " + expected;
+}
+
+// Varying inputs with occasional zero divisor
+function modInt52VaryingZeroBitOr(a, b) {
+    return (a % b) | 0;
+}
+noInline(modInt52VaryingZeroBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let a = 2147483648 + i;
+    // Every 1000th iteration, divisor is 0
+    let b = (i % 1000 === 0) ? 0 : (7 + (i % 13));
+    let result = modInt52VaryingZeroBitOr(a, b);
+    let expected = (a % b) | 0;
+    if (result !== expected)
+        throw "FAIL: modInt52VaryingZeroBitOr at i=" + i + ", got " + result + " expected " + expected;
+}
+
+// ===== CheckOverflow mode (NeedsNaNOrInfinity cleared, but NegZero needed) =====
+// When LogicalNot is NOT present and only NeedsNaNOrInfinity is cleared but NegZero is still needed,
+// we get Arith::CheckOverflow (not Unchecked).
+// This happens when the child is Mod/Div under LogicalNot but negative zero is still observable
+// through other uses. This is a more complex scenario.
+
+// ===== Stress test: many different Int52 values through Unchecked path =====
+
+function modInt52StressBitOr(a, b) {
+    return (a % b) | 0;
+}
+noInline(modInt52StressBitOr);
+
+let int52Values = [
+    2147483648, -2147483649, 4294967296, -4294967296,
+    1099511627776, -1099511627776, 4503599627370495, -4503599627370496,
+    2251799813685247, -2251799813685248, 8589934592, -8589934592
+];
+
+let divisors = [1, -1, 2, -2, 7, -7, 97, 1000000007, 2147483647, 2147483648];
+
+for (let i = 0; i < testLoopCount; i++) {
+    let a = int52Values[i % int52Values.length];
+    let b = divisors[i % divisors.length];
+    let result = modInt52StressBitOr(a, b);
+    let expected = (a % b) | 0;
+    if (result !== expected)
+        throw "FAIL: modInt52StressBitOr a=" + a + " b=" + b + ", got " + result + " expected " + expected;
+}

--- a/JSTests/stress/int52-arith-mod.js
+++ b/JSTests/stress/int52-arith-mod.js
@@ -1,0 +1,518 @@
+// Test Int52 modulo operation with comprehensive edge cases
+function moduloInt52(a, b) {
+    return a % b;
+}
+noInline(moduloInt52);
+
+// Int52 values (exceed Int32 max of 2147483647)
+let large = 2147483648;  // 2^31
+let expected = large % 7;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = moduloInt52(large, 7);
+    if (result !== expected)
+        throw "FAIL: int52 modulo basic case, got " + result + " expected " + expected;
+}
+
+// Larger Int52 values
+let larger = 4503599627370496;  // 2^52
+let largerExpected = larger % 1000000007;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = moduloInt52(larger, 1000000007);
+    if (result !== largerExpected)
+        throw "FAIL: int52 modulo large case, got " + result + " expected " + largerExpected;
+}
+
+// Negative Int52
+let negative = -2147483649;
+let negExpected = negative % 10;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = moduloInt52(negative, 10);
+    if (result !== negExpected)
+        throw "FAIL: int52 modulo negative numerator, got " + result + " expected " + negExpected;
+}
+
+// Test with negative divisor
+let negDivisorExpected = large % -7;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = moduloInt52(large, -7);
+    if (result !== negDivisorExpected)
+        throw "FAIL: int52 modulo negative divisor, got " + result + " expected " + negDivisorExpected;
+}
+
+// Test both negative
+let bothNegExpected = negative % -7;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = moduloInt52(negative, -7);
+    if (result !== bothNegExpected)
+        throw "FAIL: int52 modulo both negative, got " + result + " expected " + bothNegExpected;
+}
+
+// Test AnyIntAsDouble case - values stored as doubles but represent integers
+// This tests the modShouldSpeculateInt52 logic for AnyIntAsDouble prediction.
+function moduloAnyIntAsDouble(a, b) {
+    // Force values to be doubles by doing floating point operations
+    // that result in integer values (AnyIntAsDouble prediction).
+    return (a * 1.0) % (b * 1.0);
+}
+noInline(moduloAnyIntAsDouble);
+
+// Test with Int52-range values that come from double operations
+let doubleInt52 = 2147483648.0;  // 2^31 as double
+let doubleExpected = doubleInt52 % 7;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = moduloAnyIntAsDouble(doubleInt52, 7);
+    if (result !== doubleExpected)
+        throw "FAIL: AnyIntAsDouble modulo case, got " + result + " expected " + doubleExpected;
+}
+
+// Test with computed Int52 values that start as doubles
+function moduloComputedInt52(x) {
+    // x will be a double, but represents an integer
+    let largeValue = x * 2147483648;  // Will be Int52-range
+    return largeValue % 1000000007;
+}
+noInline(moduloComputedInt52);
+
+let computedExpected = (2 * 2147483648) % 1000000007;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = moduloComputedInt52(2);
+    if (result !== computedExpected)
+        throw "FAIL: computed Int52 modulo case, got " + result + " expected " + computedExpected;
+}
+
+// ===== Negative Zero Tests =====
+// In JavaScript, -X % Y where X is divisible by Y produces -0
+
+function checkNegativeZero(value, testName) {
+    if (value !== 0)
+        throw "FAIL: " + testName + " should be zero, got " + value;
+    if (1 / value !== -Infinity)
+        throw "FAIL: " + testName + " should be -0, got " + (1/value);
+}
+
+function checkPositiveZero(value, testName) {
+    if (value !== 0)
+        throw "FAIL: " + testName + " should be zero, got " + value;
+    if (1 / value !== Infinity)
+        throw "FAIL: " + testName + " should be +0, got " + (1/value);
+}
+
+// Test -0 with Int52 values (avoid constant folding with arguments)
+function modNegZero1(a, b) {
+    return a % b;
+}
+noInline(modNegZero1);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modNegZero1(-2147483648, 2147483648);  // Int52 boundary: -2^31 % 2^31 = -0
+    checkNegativeZero(result, "modNegZero1: -2147483648 % 2147483648");
+}
+
+// More -0 cases with different Int52 values
+function modNegZero2(a, b) {
+    return a % b;
+}
+noInline(modNegZero2);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modNegZero2(-4294967296, 2147483648);  // -2^32 % 2^31 = -0
+    checkNegativeZero(result, "modNegZero2: -4294967296 % 2147483648");
+}
+
+// Test -0 with larger Int52 values
+function modNegZero3(a, b) {
+    return a % b;
+}
+noInline(modNegZero3);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modNegZero3(-1099511627776, 1099511627776);  // -2^40 % 2^40 = -0
+    checkNegativeZero(result, "modNegZero3: -1099511627776 % 1099511627776");
+}
+
+// Test -0 with negative divisor produces -0
+function modNegZero4(a, b) {
+    return a % b;
+}
+noInline(modNegZero4);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modNegZero4(-2147483648, -2147483648);  // -2^31 % -2^31 = -0
+    checkNegativeZero(result, "modNegZero4: -2147483648 % -2147483648");
+}
+
+// Test +0 with positive numerator
+function modPosZero1(a, b) {
+    return a % b;
+}
+noInline(modPosZero1);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modPosZero1(2147483648, 2147483648);  // 2^31 % 2^31 = +0
+    checkPositiveZero(result, "modPosZero1: 2147483648 % 2147483648");
+}
+
+// Test +0 with positive numerator and negative divisor
+function modPosZero2(a, b) {
+    return a % b;
+}
+noInline(modPosZero2);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modPosZero2(4294967296, -2147483648);  // 2^32 % -2^31 = +0
+    checkPositiveZero(result, "modPosZero2: 4294967296 % -2147483648");
+}
+
+// ===== Edge Cases with Int52 Boundaries =====
+
+// Test with MIN_INT52 equivalent values
+function modMinInt52(a, b) {
+    return a % b;
+}
+noInline(modMinInt52);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modMinInt52(-4503599627370496, 1000000007);  // -2^52 % prime
+    let expected = -4503599627370496 % 1000000007;
+    if (result !== expected)
+        throw "FAIL: modMinInt52, got " + result + " expected " + expected;
+}
+
+// Test with MAX_INT52 equivalent values
+function modMaxInt52(a, b) {
+    return a % b;
+}
+noInline(modMaxInt52);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modMaxInt52(4503599627370495, 1000000007);  // 2^52-1 % prime
+    let expected = 4503599627370495 % 1000000007;
+    if (result !== expected)
+        throw "FAIL: modMaxInt52, got " + result + " expected " + expected;
+}
+
+// Test modulo by -1 (always produces -0 for negative, +0 for positive)
+function modByNegOne(a) {
+    return a % -1;
+}
+noInline(modByNegOne);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modByNegOne(-2147483649);
+    checkNegativeZero(result, "modByNegOne: -2147483649 % -1");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modByNegOne(2147483649);
+    checkPositiveZero(result, "modByNegOne: 2147483649 % -1");
+}
+
+// Test modulo by 1 (always produces +0 for positive, -0 for negative)
+function modByOne(a) {
+    return a % 1;
+}
+noInline(modByOne);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modByOne(-2147483649);
+    checkNegativeZero(result, "modByOne: -2147483649 % 1");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modByOne(2147483649);
+    checkPositiveZero(result, "modByOne: 2147483649 % 1");
+}
+
+// ===== Mixed positive/negative with various divisors =====
+
+function modMixed1(a, b) {
+    return a % b;
+}
+noInline(modMixed1);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modMixed1(-9007199254740991, 3);  // -(2^53-1) % 3
+    let expected = -9007199254740991 % 3;
+    if (result !== expected)
+        throw "FAIL: modMixed1, got " + result + " expected " + expected;
+}
+
+function modMixed2(a, b) {
+    return a % b;
+}
+noInline(modMixed2);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modMixed2(9007199254740991, -3);  // (2^53-1) % -3
+    let expected = 9007199254740991 % -3;
+    if (result !== expected)
+        throw "FAIL: modMixed2, got " + result + " expected " + expected;
+}
+
+// Test with prime numbers as divisors (common in hash functions)
+function modPrime1(a, b) {
+    return a % b;
+}
+noInline(modPrime1);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modPrime1(1099511627776, 2147483647);  // 2^40 % (2^31-1)
+    let expected = 1099511627776 % 2147483647;
+    if (result !== expected)
+        throw "FAIL: modPrime1, got " + result + " expected " + expected;
+}
+
+// Test with powers of 2 (different optimization path possible)
+function modPowerOfTwo(a, b) {
+    return a % b;
+}
+noInline(modPowerOfTwo);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modPowerOfTwo(4503599627370495, 1073741824);  // (2^52-1) % 2^30
+    let expected = 4503599627370495 % 1073741824;
+    if (result !== expected)
+        throw "FAIL: modPowerOfTwo, got " + result + " expected " + expected;
+}
+
+// Test with small divisor and large Int52 numerator
+function modSmallDivisor(a, b) {
+    return a % b;
+}
+noInline(modSmallDivisor);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modSmallDivisor(4503599627370495, 97);  // (2^52-1) % 97
+    let expected = 4503599627370495 % 97;
+    if (result !== expected)
+        throw "FAIL: modSmallDivisor, got " + result + " expected " + expected;
+}
+
+// Test consecutive Int52 values
+function modConsecutive(a, b) {
+    return a % b;
+}
+noInline(modConsecutive);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modConsecutive(2147483649, 2147483648);  // (2^31+1) % 2^31 = 1
+    let expected = 2147483649 % 2147483648;
+    if (result !== expected)
+        throw "FAIL: modConsecutive, got " + result + " expected " + expected;
+}
+
+// Test with negative zero as intermediate (numerator is negative, result would be zero)
+function modIntermediateNegZero(a, b) {
+    return a % b;
+}
+noInline(modIntermediateNegZero);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modIntermediateNegZero(-8589934592, 4294967296);  // -2^33 % 2^32 = -0
+    checkNegativeZero(result, "modIntermediateNegZero: -8589934592 % 4294967296");
+}
+
+// ===== NEW: Additional Edge Cases =====
+
+// Test exactly at Int52 boundaries
+function modExactMinInt52(a, b) {
+    return a % b;
+}
+noInline(modExactMinInt52);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modExactMinInt52(-2251799813685248, 7);  // MIN_INT52 % 7
+    let expected = -2251799813685248 % 7;
+    if (result !== expected)
+        throw "FAIL: modExactMinInt52, got " + result + " expected " + expected;
+}
+
+function modExactMaxInt52(a, b) {
+    return a % b;
+}
+noInline(modExactMaxInt52);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modExactMaxInt52(2251799813685247, 7);  // MAX_INT52 % 7
+    let expected = 2251799813685247 % 7;
+    if (result !== expected)
+        throw "FAIL: modExactMaxInt52, got " + result + " expected " + expected;
+}
+
+// Test MIN_INT52 % MIN_INT52 = -0
+function modMinByMin(a, b) {
+    return a % b;
+}
+noInline(modMinByMin);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modMinByMin(-2251799813685248, -2251799813685248);
+    checkNegativeZero(result, "modMinByMin: MIN_INT52 % MIN_INT52");
+}
+
+// Test MAX_INT52 % MAX_INT52 = +0
+function modMaxByMax(a, b) {
+    return a % b;
+}
+noInline(modMaxByMax);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modMaxByMax(2251799813685247, 2251799813685247);
+    checkPositiveZero(result, "modMaxByMax: MAX_INT52 % MAX_INT52");
+}
+
+// Test values just above Int32 MAX to ensure Int52 path is taken
+function modJustAboveInt32(a, b) {
+    return a % b;
+}
+noInline(modJustAboveInt32);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modJustAboveInt32(2147483648, 1000000007);  // 2^31 % prime
+    let expected = 2147483648 % 1000000007;
+    if (result !== expected)
+        throw "FAIL: modJustAboveInt32, got " + result + " expected " + expected;
+}
+
+// Test values just below Int32 MIN to ensure Int52 path is taken
+function modJustBelowInt32Min(a, b) {
+    return a % b;
+}
+noInline(modJustBelowInt32Min);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modJustBelowInt32Min(-2147483649, 1000000007);  // -(2^31+1) % prime
+    let expected = -2147483649 % 1000000007;
+    if (result !== expected)
+        throw "FAIL: modJustBelowInt32Min, got " + result + " expected " + expected;
+}
+
+// Test with Fibonacci-like large numbers
+function modFibonacci(a, b) {
+    return a % b;
+}
+noInline(modFibonacci);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modFibonacci(2971215073, 1836311903);  // F44 % F43
+    let expected = 2971215073 % 1836311903;
+    if (result !== expected)
+        throw "FAIL: modFibonacci, got " + result + " expected " + expected;
+}
+
+// Test modulo that produces maximum negative result
+function modMaxNegativeResult(a, b) {
+    return a % b;
+}
+noInline(modMaxNegativeResult);
+
+for (let i = 0; i < testLoopCount; i++) {
+    // -2251799813685247 % -2251799813685248 = -2251799813685247 (largest negative remainder)
+    let result = modMaxNegativeResult(-2251799813685247, -2251799813685248);
+    let expected = -2251799813685247 % -2251799813685248;
+    if (result !== expected)
+        throw "FAIL: modMaxNegativeResult, got " + result + " expected " + expected;
+}
+
+// Test modulo that produces maximum positive result
+function modMaxPositiveResult(a, b) {
+    return a % b;
+}
+noInline(modMaxPositiveResult);
+
+for (let i = 0; i < testLoopCount; i++) {
+    // 2251799813685247 % 2251799813685248 = 2251799813685247 (largest positive remainder)
+    let result = modMaxPositiveResult(2251799813685247, 2251799813685248);
+    let expected = 2251799813685247 % 2251799813685248;
+    if (result !== expected)
+        throw "FAIL: modMaxPositiveResult, got " + result + " expected " + expected;
+}
+
+// Test with divisor = 2 (simple pattern, often optimized)
+function modByTwo(a) {
+    return a % 2;
+}
+noInline(modByTwo);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modByTwo(4503599627370495);  // (2^52-1) % 2 = 1
+    if (result !== 1)
+        throw "FAIL: modByTwo odd, got " + result;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modByTwo(4503599627370496);  // 2^52 % 2 = 0
+    checkPositiveZero(result, "modByTwo even");
+}
+
+// Test with very small negative divisor
+function modByNegTwo(a) {
+    return a % -2;
+}
+noInline(modByNegTwo);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modByNegTwo(-4503599627370495);  // -(2^52-1) % -2 = -1
+    if (result !== -1)
+        throw "FAIL: modByNegTwo odd, got " + result;
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modByNegTwo(-4503599627370496);  // -2^52 % -2 = -0
+    checkNegativeZero(result, "modByNegTwo even");
+}
+
+// Test Mersenne-like numbers (2^n - 1)
+function modMersenne(a, b) {
+    return a % b;
+}
+noInline(modMersenne);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = modMersenne(2199023255551, 2147483647);  // (2^41-1) % (2^31-1)
+    let expected = 2199023255551 % 2147483647;
+    if (result !== expected)
+        throw "FAIL: modMersenne, got " + result + " expected " + expected;
+}
+
+// Test with alternating large values
+function modAlternating(a, b) {
+    return a % b;
+}
+noInline(modAlternating);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let a_val = (i % 2 === 0) ? 1099511627776 : -1099511627776;  // ±2^40
+    let result = modAlternating(a_val, 1000000007);
+    let expected = a_val % 1000000007;
+    if (result !== expected)
+        throw "FAIL: modAlternating iteration " + i + ", got " + result + " expected " + expected;
+}
+
+// Test pattern that stresses negative zero with varying numerators
+function modNegZeroPattern(a, b) {
+    return a % b;
+}
+noInline(modNegZeroPattern);
+
+let divisorsForNegZero = [2147483648, 4294967296, 1099511627776, 2251799813685248];
+for (let divisor of divisorsForNegZero) {
+    for (let i = 0; i < 100000; i++) {
+        let result = modNegZeroPattern(-divisor, divisor);
+        checkNegativeZero(result, "modNegZeroPattern: -" + divisor + " % " + divisor);
+    }
+}
+
+// Test result = divisor - 1 (common case)
+function modAlmostDivisor(a, b) {
+    return a % b;
+}
+noInline(modAlmostDivisor);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let divisor = 1000000007;
+    let result = modAlmostDivisor(2000000013, divisor);  // (2*divisor - 1) % divisor = divisor - 1
+    let expected = 1000000006;
+    if (result !== expected)
+        throw "FAIL: modAlmostDivisor, got " + result + " expected " + expected;
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1304,17 +1304,21 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         case Int32Use:
             setNonCellTypeForNode(node, SpecInt32Only);
             break;
+        case Int52RepUse:
+            ASSERT(node->op() == ArithMod);
+            setNonCellTypeForNode(node, SpecInt52Any);
+            break;
         case DoubleRepUse:
             if (node->op() == ArithDiv) {
-                setNonCellTypeForNode(node, 
+                setNonCellTypeForNode(node,
                     typeOfDoubleQuotient(
                         forNode(node->child1()).m_type, forNode(node->child2()).m_type));
             } else {
-                setNonCellTypeForNode(node, 
+                setNonCellTypeForNode(node,
                     typeOfDoubleBinaryOp(
                         forNode(node->child1()).m_type, forNode(node->child2()).m_type));
             }
-            
+
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -522,6 +522,23 @@ private:
             break;
         }
 
+        case LogicalNot: {
+            switch (node->child1()->op()) {
+            case ValueMod:
+            case ArithMod:
+            case ValueDiv:
+            case ArithDiv:
+                // We can clear this flag since Mod and Div never produces Infinity. It is only NaN.
+                flags &= ~NodeBytecodeNeedsNaNOrInfinity;
+                break;
+            default:
+                break;
+            }
+            flags &= ~NodeBytecodeNeedsNegZero;
+            node->child1()->mergeFlags(flags);
+            break;
+        }
+
         case MultiGetByVal:
         case EnumeratorGetByVal:
         case GetByVal:

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -482,13 +482,13 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case ArithAdd:
-    case ArithMod:
     case DoubleAsInt32:
     case UInt32ToNumber:
         def(PureValue(node, node->arithMode()));
         return;
 
     case ArithDiv:
+    case ArithMod:
     case ArithMul:
     case ArithSub:
         switch (node->binaryUseKind()) {

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -132,7 +132,20 @@ private:
             fixupArithDivInt32(node, leftChild, rightChild);
             return;
         }
-        
+
+        if ((node->op() == ArithMod || node->op() == ValueMod) && m_graph.modShouldSpeculateInt52(node)) {
+            fixEdge<Int52RepUse>(leftChild);
+            fixEdge<Int52RepUse>(rightChild);
+            if (bytecodeCanIgnoreNaNAndInfinity(node->arithNodeFlags()) && bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+                node->setArithMode(Arith::Unchecked);
+            else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+                node->setArithMode(Arith::CheckOverflow);
+            else
+                node->setArithMode(Arith::CheckOverflowAndNegativeZero);
+            node->setResult(NodeResultInt52);
+            return;
+        }
+
         fixDoubleOrBooleanEdge(leftChild);
         fixDoubleOrBooleanEdge(rightChild);
         node->setResult(NodeResultDouble);

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -528,6 +528,8 @@ private:
                     && isFullNumberOrBooleanSpeculationExpectingDefined(right)) {
                     if (m_graph.binaryArithShouldSpeculateInt32(node, m_pass))
                         changed |= mergePrediction(SpecInt32Only);
+                    else if ((op == ValueMod || op == ArithMod) && m_graph.modShouldSpeculateInt52(node))
+                        changed |= mergePrediction(SpecInt52Any);
                     else
                         changed |= mergePrediction(SpecBytecodeDouble);
                 } else if ((op == ValueDiv || op == ValueMod) && isBigIntSpeculation(left) && isBigIntSpeculation(right))
@@ -853,16 +855,17 @@ private:
         case ArithDiv: {
             SpeculatedType left = node->child1()->prediction();
             SpeculatedType right = node->child2()->prediction();
-                
+
             DoubleBallot ballot;
-                
+
             if (isFullNumberSpeculation(left)
                 && isFullNumberSpeculation(right)
-                && !m_graph.binaryArithShouldSpeculateInt32(node, m_pass))
+                && !m_graph.binaryArithShouldSpeculateInt32(node, m_pass)
+                && !((node->op() == ArithMod || node->op() == ValueMod) && m_graph.modShouldSpeculateInt52(node)))
                 ballot = VoteDouble;
             else
                 ballot = VoteValue;
-                
+
             m_graph.voteNode(node->child1(), ballot, weight);
             m_graph.voteNode(node->child2(), ballot, weight);
             break;


### PR DESCRIPTION
#### 49a21e7ff3275bd5b493b4ada222a04abec26ece
<pre>
[JSC] Add ArithMod(Int52Use, Int52Use) in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=307222">https://bugs.webkit.org/show_bug.cgi?id=307222</a>
<a href="https://rdar.apple.com/169859804">rdar://169859804</a>

Reviewed by Sosuke Suzuki.

fmod is extraordinary slow compared to int modulo operations, even if we
include double -&gt; int conversions. This means that it is really worth
trying using int modulo operation when inputs are likely integers.

DFG / FTL already monitors inputs can be SpecAnyIntAsDouble, which means
Double but having Int52 integer. So we add ArithMod(Int52Use, Int52Use)
code generation in DFG / FTL, which puts speculation, type conversion
and doing Int52 modulo instead of Double modulo.

We are doing this optimization attempt more aggressively than
ArithAdd(Int52Use, Int52Use). The reason is the different tradeoff:
ArithAdd case has much more severe tradeoff between

    DoubleToInt52Cost + DoubleToInt52Cost + AddInt52Cost v.s. AddDoubleCost

But ArithMod case,

    DoubleToInt52Cost + DoubleToInt52Cost + ModInt52Cost v.s. ModDoubleCost

And ModDoubleCost is dramatically higher than the ModInt52 cases. Thus
we can try more aggressively.

Test: JSTests/stress/int52-arith-mod.js

* JSTests/stress/int52-arith-mod-with-overflow-unchecked.js: Added.
(modInt52BitOr):
(modInt52DivByZeroBitOr):
(modInt52AlwaysZeroDivisorBitOr):
(modInt52NegZeroBitOr):
(modInt52BitAnd):
(modInt52BitXor):
(modInt52BitShift):
(modInt52LogicalNot):
(modInt52LogicalNotDivByZero):
(modInt52AddBitOr):
(modInt52VaryingBitOr):
(modInt52VaryingZeroBitOr):
(modInt52StressBitOr):
* JSTests/stress/int52-arith-mod.js: Added.
(moduloInt52):
(moduloAnyIntAsDouble):
(moduloComputedInt52):
(checkNegativeZero):
(checkPositiveZero):
(modNegZero1):
(modNegZero2):
(modNegZero3):
(modNegZero4):
(modPosZero1):
(modPosZero2):
(modMinInt52):
(modMaxInt52):
(modByNegOne):
(modByOne):
(modMixed1):
(modMixed2):
(modPrime1):
(modPowerOfTwo):
(modSmallDivisor):
(modConsecutive):
(modIntermediateNegZero):
(modExactMinInt52):
(modExactMaxInt52):
(modMinByMin):
(modMaxByMax):
(modJustAboveInt32):
(modJustBelowInt32Min):
(modFibonacci):
(modMaxNegativeResult):
(modMaxPositiveResult):
(modByTwo):
(modByNegTwo):
(modMersenne):
(modAlternating):
(modNegZeroPattern):
(modAlmostDivisor):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupArithDiv):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArithMod):

Canonical link: <a href="https://commits.webkit.org/307022@main">https://commits.webkit.org/307022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd9868c7628cd4f0231f63922dc2e1177c0e2bc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143137 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15612 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6583 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151812 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27618f26-e0a4-4172-9933-d146d5d64a59) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110080 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/845af551-5203-4e69-b5d9-aef9d215a237) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146086 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12515 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128097 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90991 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/210c0634-ed48-4bd5-b47c-20412120086d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9709 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1810 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135136 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4594 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154124 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3949 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15522 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5571 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118095 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15508 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13197 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118435 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14358 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125774 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70994 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22066 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15281 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4418 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174434 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15015 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79000 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45045 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15226 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15077 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->