### PR TITLE
RTCRtpSender should allow maxFramerate of 0

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-maxFramerate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-maxFramerate-expected.txt
@@ -10,7 +10,7 @@ PASS setParameters() with maxFramerate undefined->16 should succeed with RTCRtpT
 PASS setParameters() with maxFramerate undefined->16 should succeed without RTCRtpTransceiverInit
 FAIL setParameters() with maxFramerate 24->undefined should succeed with RTCRtpTransceiverInit assert_equals: expected (undefined) undefined but got (number) 24
 FAIL setParameters() with maxFramerate 24->undefined should succeed without RTCRtpTransceiverInit assert_equals: expected (undefined) undefined but got (number) 24
-FAIL setParameters() with maxFramerate 0->16 should succeed with RTCRtpTransceiverInit promise_test: Unhandled rejection with value: object "RangeError: maxFrameRate is below or equal 0"
+PASS setParameters() with maxFramerate 0->16 should succeed with RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate 0->16 should succeed without RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate 24->0 should succeed with RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate 24->0 should succeed without RTCRtpTransceiverInit

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -2,7 +2,7 @@
  * Copyright (C) 2012 Google Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (C) 2015, 2016 Ericsson AB. All rights reserved.
- * Copyright (C) 2017-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -210,8 +210,8 @@ static std::optional<Exception> validateSendEncodings(Vector<RTCRtpEncodingParam
         if (encoding.scaleResolutionDownBy && *encoding.scaleResolutionDownBy < 1)
             return Exception { ExceptionCode::RangeError, "scaleResolutionDownBy is below 1"_s };
 
-        if (encoding.maxFramerate && *encoding.maxFramerate <= 0)
-            return Exception { ExceptionCode::RangeError, "maxFrameRate is below or equal 0"_s };
+        if (encoding.maxFramerate && *encoding.maxFramerate < 0)
+            return Exception { ExceptionCode::RangeError, "maxFrameRate is below 0"_s };
 
         if (hasAnyScaleResolutionDownBy) {
             if (!encoding.scaleResolutionDownBy)


### PR DESCRIPTION
#### 3fba1c94c15004376e9a903346d7863a2ce305d2
<pre>
RTCRtpSender should allow maxFramerate of 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=307227">https://bugs.webkit.org/show_bug.cgi?id=307227</a>
<a href="https://rdar.apple.com/169863687">rdar://169863687</a>

Reviewed by Philippe Normand.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and
Web Specification [1].

This patch updates our validation from &lt;= to just &lt; since we should just
reject negative values. Previously, we were also rejecting when maxFramerate
was &apos;0&apos;, which is not aligned with below specification referenced:

&quot;Verify that the value of each maxFramerate member in sendEncodings that
is defined is greater than 0.0.&quot;

[1] <a href="https://w3c.github.io/webrtc-pc/#dfn-addtransceiver-sendencodings-validation-steps">https://w3c.github.io/webrtc-pc/#dfn-addtransceiver-sendencodings-validation-steps</a>

* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::validateSendEncodings):
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-maxFramerate-expected.txt: Progression

Canonical link: <a href="https://commits.webkit.org/307034@main">https://commits.webkit.org/307034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53e23b7812b732eb8cd1ffc1181a960c45057f46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143186 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151862 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96407 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1b49c8f-3909-4010-8cda-daa6fa0b0755) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145053 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110114 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f6d5ff72-a3cb-4560-bfc9-8e71e588b059) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91025 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ddee1cf-1903-47ac-bbaa-720946634cb6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12035 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9747 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1859 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121454 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154173 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15666 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118134 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13235 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118474 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30336 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14399 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125818 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71061 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15330 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4459 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79049 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15275 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15126 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->