### PR TITLE
Latest Swift toolchain cannot build WebKit due to an error in TestWebKitAPI

### DIFF
--- a/Tools/Scripts/build-and-analyze
+++ b/Tools/Scripts/build-and-analyze
@@ -175,8 +175,13 @@ def main(args):
         make_command.extend(['GCC_PREPROCESSOR_ADDITIONS={}'.format(args.preprocessor_additions)])
     if args.scheme:
         make_command.extend(['SCHEME={}'.format(args.scheme)])
+    xcodebuild_args = {}
     if args.toolchains:
-        make_command.extend(["""ARGS='TOOLCHAINS="{}"'""".format(args.toolchains)])
+        xcodebuild_args['TOOLCHAINS'] = args.toolchains
+    if args.swift_conditions:
+        xcodebuild_args['SWIFT_ACTIVE_COMPILATION_CONDITIONS'] = args.swift_conditions
+    if len(xcodebuild_args):
+        make_command.extend(['ARGS={}'.format(' '.join(["{}=\"{}\"".format(key, xcodebuild_args[key]) for key in xcodebuild_args]))])
 
     commands = [
         [set_webkit_config_path, '--{}'.format(args.configuration)],
@@ -235,6 +240,8 @@ def parse_args():
                         help='Xcode scheme to use when performing Build and Analyze.')
     parser.add_argument('--preprocessor-additions', default=None,
                         help='Additional preprocessor macros.')
+    parser.add_argument('--swift-conditions', default=None,
+                        help='Additional Swift active compilation conditions.')
     parser.add_argument('--dry-run', default=False,
                         action='store_true', help='Output the command instead of executing it.')
     parser.add_argument('--configuration', default='debug', choices=['debug', 'release'], dest='configuration', help='Set the build configuration (default: debug).')

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift
@@ -21,7 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2)
+// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2) && !SWIFT_WEBKIT_TOOLCHAIN
 
 import Testing
 import WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WKWebViewSwiftOverlayTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WKWebViewSwiftOverlayTests.swift
@@ -21,7 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(Testing) && compiler(>=6.2)
+// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
+#if canImport(Testing) && compiler(>=6.2) && !SWIFT_WEBKIT_TOOLCHAIN
 
 import Testing
 import WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift
@@ -21,7 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2)
+// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2) && !SWIFT_WEBKIT_TOOLCHAIN
 
 import Testing
 @_spi(Testing) import WebKit

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift
@@ -21,7 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2)
+// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2) && !SWIFT_WEBKIT_TOOLCHAIN
 
 import SwiftUI
 import Observation

--- a/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift
@@ -21,7 +21,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2)
+// FIXME: Remove !SWIFT_WEBKIT_TOOLCHAIN once Swift toolchain is fixed (see webkit.org/b/307344).
+#if ENABLE_SWIFTUI && canImport(Testing) && compiler(>=6.2) && !SWIFT_WEBKIT_TOOLCHAIN
 
 import Testing
 @_spi(Testing) import WebKit


### PR DESCRIPTION
#### 63f150f71811b244be1809398ece9f52dabb5059
<pre>
Latest Swift toolchain cannot build WebKit due to an error in TestWebKitAPI
<a href="https://bugs.webkit.org/show_bug.cgi?id=307230">https://bugs.webkit.org/show_bug.cgi?id=307230</a>

Reviewed by Geoffrey Garen and David Kilzer.

This PR works around a Swift compiler bug affecting TestWebKitAPI by disabling
some Swift tests when using the latest Swift toolchain built for WebKit.

To distinguish this variant of Swift toolchain, this PR adds new option
--swift-conditions to set active compilation conditions.

An active compilation condition of SWIFT_WEBKIT_TOOLCHAIN is used to enable
the workaround with our locally built Swift toolchain. The Swift toolchain bug
is tracked by webkit.org/b/307344.

* Tools/Scripts/build-and-analyze:
(main):
(parse_args):
* Tools/TestWebKitAPI/Tests/WebKit Swift/URLSchemeHandlerTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit Swift/WKWebViewSwiftOverlayTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageNavigationTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTests.swift:
* Tools/TestWebKitAPI/Tests/WebKit Swift/WebPageTransferableTests.swift:

Canonical link: <a href="https://commits.webkit.org/307099@main">https://commits.webkit.org/307099@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/296c96e6000cc9d2531470a6422fec3730700da0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152047 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/87324a50-f8e7-4dd5-ba71-0bf68a383e22) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16519 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15940 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110270 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146340 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/12740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/128896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91181 "Failed to checkout and rebase branch from PR 58108") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95420689-be1b-4ca0-a8fa-30bf1f02c8c6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9942 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2048 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154357 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15906 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118289 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13415 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118630 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14589 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71323 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22109 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15523 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15264 "Failed to checkout and rebase branch from PR 58108") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79244 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15478 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15326 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->