### PR TITLE
[GStreamer][WebRTC] Ports range configuration support

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h
@@ -47,7 +47,8 @@ class RealtimeOutgoingVideoSourceGStreamer;
 class GStreamerPeerConnectionBackend final : public PeerConnectionBackend {
     WTF_MAKE_TZONE_ALLOCATED(GStreamerPeerConnectionBackend);
 public:
-    explicit GStreamerPeerConnectionBackend(RTCPeerConnection&);
+    using UDPPortsRange = std::optional<std::pair<int, int>>;
+    explicit GStreamerPeerConnectionBackend(RTCPeerConnection&, UDPPortsRange&&);
     ~GStreamerPeerConnectionBackend();
 
     GStreamerRtpSenderBackend& backendFromRTPSender(RTCRtpSender&);
@@ -116,6 +117,9 @@ private:
     bool isReconfiguring() const { return m_isReconfiguring; }
 
     void tearDown();
+
+    UDPPortsRange udpPortsRange() const { return m_udpPortsRange; }
+    UDPPortsRange m_udpPortsRange;
 
     Ref<GStreamerMediaEndpoint> m_endpoint;
     bool m_isLocalDescriptionSet { false };

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.cpp
@@ -29,6 +29,7 @@
 #include "AV1Utilities.h"
 #include "ContentType.h"
 #include "HEVCUtilities.h"
+#include "Logging.h"
 #include "PlatformMediaCapabilitiesDecodingInfo.h"
 #include "PlatformMediaCapabilitiesEncodingInfo.h"
 #include "PlatformMediaDecodingConfiguration.h"
@@ -460,7 +461,7 @@ void WebRTCProvider::setPortAllocatorRange(StringView range)
 
     auto components = range.toStringWithoutCopying().split(':');
     if (components.size() != 2) [[unlikely]] {
-        WTFLogAlways("Invalid format for UDP port range. Should be \"min-port:max-port\"");
+        RELEASE_LOG_ERROR(WebRTC, "Invalid format for UDP port range. Should be \"min-port:max-port\"");
         ASSERT_NOT_REACHED();
         return;
     }
@@ -468,18 +469,23 @@ void WebRTCProvider::setPortAllocatorRange(StringView range)
     auto minPort = WTF::parseInteger<int>(components[0]);
     auto maxPort = WTF::parseInteger<int>(components[1]);
     if (!minPort || !maxPort) {
-        WTFLogAlways("Invalid format for UDP port range. Should be \"min-port:max-port\"");
+        RELEASE_LOG_ERROR(WebRTC, "Invalid format for UDP port range. Should be \"min-port:max-port\"");
         ASSERT_NOT_REACHED();
         return;
     }
 
     if (*minPort < 0) {
-        WTFLogAlways("Invalid value for UDP minimum port value: %d", *minPort);
+        RELEASE_LOG_ERROR(WebRTC, "Invalid value for UDP minimum port value: %d", *minPort);
         return;
     }
 
     if (*maxPort < 0) {
-        WTFLogAlways("Invalid value for UDP maximum port value: %d", *maxPort);
+        RELEASE_LOG_ERROR(WebRTC, "Invalid value for UDP maximum port value: %d", *maxPort);
+        return;
+    }
+
+    if (*minPort >= *maxPort) {
+        RELEASE_LOG_ERROR(WebRTC, "UDP maximum port should greater than minimum port.");
         return;
     }
 
@@ -489,6 +495,11 @@ void WebRTCProvider::setPortAllocatorRange(StringView range)
 std::optional<std::pair<int, int>> WebRTCProvider::portAllocatorRange() const
 {
     return m_portAllocatorRange;
+}
+
+bool WebRTCProvider::isWebCoreGStreamerWebRTCProvider() const
+{
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediastream/WebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/WebRTCProvider.h
@@ -85,6 +85,8 @@ public:
     virtual bool isLibWebRTCProvider() const { return false; }
     virtual bool isWebCoreLibWebRTCProvider() const { return false; }
 
+    virtual bool isWebCoreGStreamerWebRTCProvider() const;
+
 protected:
 #if ENABLE(WEB_RTC)
     std::optional<RTCRtpCapabilities>& audioDecodingCapabilities();

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp
@@ -24,8 +24,8 @@
 #include "GStreamerWebRTCProvider.h"
 
 #include "ContentType.h"
+#include "GStreamerCommon.h"
 #include "GStreamerRegistryScanner.h"
-#include "NotImplemented.h"
 #include "PlatformMediaCapabilitiesDecodingInfo.h"
 #include "PlatformMediaCapabilitiesEncodingInfo.h"
 #include "PlatformMediaDecodingConfiguration.h"
@@ -43,6 +43,10 @@ UniqueRef<WebRTCProvider> WebRTCProvider::create()
 
 bool WebRTCProvider::webRTCAvailable()
 {
+    if (!isGStreamerPluginAvailable("webrtc"_s)) {
+        g_printerr("GstWebRTC plugin not found. Make sure to install gst-plugins-bad >= 1.20 with the webrtc plugin enabled.\n");
+        return false;
+    }
     return true;
 }
 
@@ -63,6 +67,11 @@ std::optional<RTCRtpCapabilities> GStreamerWebRTCProvider::senderCapabilities(co
     if (kind == "video"_s)
         return videoEncodingCapabilities();
     return { };
+}
+
+bool GStreamerWebRTCProvider::isWebCoreGStreamerWebRTCProvider() const
+{
+    return true;
 }
 
 void GStreamerWebRTCProvider::initializeAudioEncodingCapabilities()

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.h
@@ -33,6 +33,8 @@ public:
     std::optional<RTCRtpCapabilities> receiverCapabilities(const String& kind) final;
     std::optional<RTCRtpCapabilities> senderCapabilities(const String& kind) final;
 
+    bool isWebCoreGStreamerWebRTCProvider() const final;
+
 private:
     void initializeAudioDecodingCapabilities() final;
     void initializeVideoDecodingCapabilities() final;
@@ -43,4 +45,8 @@ private:
 
 } // namespace WebCore
 
-#endif
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebCore::GStreamerWebRTCProvider)
+static bool isType(const WebCore::WebRTCProvider& provider) { return provider.isWebCoreGStreamerWebRTCProvider(); }
+SPECIALIZE_TYPE_TRAITS_END()
+
+#endif // USE(GSTREAMER_WEBRTC)

--- a/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
+++ b/Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h
@@ -114,6 +114,8 @@ inline UniqueRef<LibWebRTCProvider> createLibWebRTCProvider(WebPage&)
 
 } // namespace WebKit
 
+#if USE(LIBWEBRTC)
 SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::LibWebRTCProvider) \
 static bool isType(const WebCore::WebRTCProvider& provider) { return provider.isLibWebRTCProvider(); } \
 SPECIALIZE_TYPE_TRAITS_END()
+#endif


### PR DESCRIPTION
#### cad9c7845f3c1640d303b8f38399a9b7e76420f4
<pre>
[GStreamer][WebRTC] Ports range configuration support
<a href="https://bugs.webkit.org/show_bug.cgi?id=307232">https://bugs.webkit.org/show_bug.cgi?id=307232</a>

Reviewed by Xabier Rodriguez-Calvar.

The ports range supplied in web settings is now passed on to GStreamer&apos;s webrtcbin which relays it
to its underlying ICE agent.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerMediaEndpoint.cpp:
(WebCore::GStreamerMediaEndpoint::initializePipeline):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.cpp:
(WebCore::createGStreamerPeerConnectionBackend):
(WebCore::GStreamerPeerConnectionBackend::GStreamerPeerConnectionBackend):
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerPeerConnectionBackend.h:
* Source/WebCore/platform/mediastream/WebRTCProvider.cpp:
(WebCore::WebRTCProvider::setPortAllocatorRange):
* Source/WebCore/platform/mediastream/WebRTCProvider.h:
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.cpp:
(WebCore::WebRTCProvider::webRTCAvailable):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerWebRTCProvider.h:
(isType):
* Source/WebKit/WebProcess/Network/webrtc/LibWebRTCProvider.h:

Canonical link: <a href="https://commits.webkit.org/307077@main">https://commits.webkit.org/307077@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e25f95e3f10b9219f2683144939b9db237ac38fd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143347 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15822 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7414 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152023 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15903 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110255 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146296 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/12712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/128879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91164 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12182 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2021 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/5348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154334 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15866 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/6344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118271 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15903 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13388 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118612 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30369 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14549 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126549 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15491 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5209 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15225 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79211 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15436 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15287 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->