### PR TITLE
Reduce use of protected functions in Source/WebCore/html

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
+++ b/Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h
@@ -57,7 +57,7 @@ struct GPUExternalTextureDescriptor : public GPUObjectDescriptorBase {
                     return playerIdentifier;
                 RefPtr<WebCore::VideoFrame> result;
                 if (videoElement->player())
-                    result = videoElement->protectedPlayer()->videoFrameForCurrentTime();
+                    result = protect(videoElement->player())->videoFrameForCurrentTime();
                 return result;
             },
             [&](const RefPtr<WebCodecsVideoFrame> videoFrame) -> WebGPU::VideoSourceIdentifier {

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -289,7 +289,7 @@ void MediaControlsHost::updateCaptionDisplaySizes(ForceUpdate force)
 
 bool MediaControlsHost::allowsInlineMediaPlayback() const
 {
-    return !protectedMediaElement()->protectedMediaSession()->requiresFullscreenForVideoPlayback();
+    return !protect(protectedMediaElement()->mediaSession())->requiresFullscreenForVideoPlayback();
 }
 
 bool MediaControlsHost::supportsFullscreen() const
@@ -309,7 +309,7 @@ bool MediaControlsHost::isInMediaDocument() const
 
 bool MediaControlsHost::userGestureRequired() const
 {
-    return !protectedMediaElement()->protectedMediaSession()->playbackStateChangePermitted(MediaPlaybackState::Playing);
+    return !protect(protectedMediaElement()->mediaSession())->playbackStateChangePermitted(MediaPlaybackState::Playing);
 }
 
 bool MediaControlsHost::shouldForceControlsDisplay() const

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -2115,7 +2115,7 @@ private:
                     return true;
                 }
                 write(dataLength);
-                write(data->data().protectedArrayBufferView()->span());
+                write(protect(data->data().arrayBufferView())->span());
                 write(data->colorSpace());
                 return true;
             }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -2063,7 +2063,7 @@ static void showSubTreeAcrossFrame(const Node* node, const Node* markedNode, con
     node->showNode();
     if (!node->isShadowRoot()) {
         if (auto* frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(node))
-            showSubTreeAcrossFrame(frameOwner->protectedContentDocument().get(), markedNode, makeString(indent, '\t'));
+            showSubTreeAcrossFrame(protect(frameOwner->contentDocument()).get(), markedNode, makeString(indent, '\t'));
         if (RefPtr shadowRoot = node->shadowRoot())
             showSubTreeAcrossFrame(shadowRoot.get(), markedNode, makeString(indent, '\t'));
     }

--- a/Source/WebCore/html/BaseButtonInputType.cpp
+++ b/Source/WebCore/html/BaseButtonInputType.cpp
@@ -59,7 +59,7 @@ RenderPtr<RenderElement> BaseButtonInputType::createInputRenderer(RenderStyle&& 
 {
     ASSERT(element());
     // FIXME: https://github.com/llvm/llvm-project/pull/142471 Moving style is not unsafe.
-    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderButton>(*protectedElement(), WTF::move(style));
+    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderButton>(*protect(element()), WTF::move(style));
 }
 
 bool BaseButtonInputType::storesValueSeparateFromAttribute()

--- a/Source/WebCore/html/BaseCheckableInputType.cpp
+++ b/Source/WebCore/html/BaseCheckableInputType.cpp
@@ -56,7 +56,7 @@ FormControlState BaseCheckableInputType::saveFormControlState() const
 void BaseCheckableInputType::restoreFormControlState(const FormControlState& state)
 {
     ASSERT(element());
-    protectedElement()->setChecked(state[0] == onAtom());
+    protect(element())->setChecked(state[0] == onAtom());
 }
 
 bool BaseCheckableInputType::appendFormData(DOMFormData& formData) const
@@ -74,7 +74,7 @@ auto BaseCheckableInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldC
     const String& key = event.keyIdentifier();
     if (key == "U+0020"_s) {
         ASSERT(element());
-        protectedElement()->setActive(true);
+        protect(element())->setActive(true);
         // No setDefaultHandled(), because IE dispatches a keypress in this case
         // and the caller will only dispatch a keypress if we don't call setDefaultHandled().
         return ShouldCallBaseEventHandler::No;
@@ -99,7 +99,7 @@ bool BaseCheckableInputType::canSetStringValue() const
 bool BaseCheckableInputType::accessKeyAction(bool sendMouseEvents)
 {
     ASSERT(element());
-    return InputType::accessKeyAction(sendMouseEvents) || protectedElement()->dispatchSimulatedClick(0, sendMouseEvents ? SendMouseUpDownEvents : SendNoEvents);
+    return InputType::accessKeyAction(sendMouseEvents) || protect(element())->dispatchSimulatedClick(0, sendMouseEvents ? SendMouseUpDownEvents : SendNoEvents);
 }
 
 ValueOrReference<String> BaseCheckableInputType::fallbackValue() const
@@ -115,7 +115,7 @@ bool BaseCheckableInputType::storesValueSeparateFromAttribute()
 void BaseCheckableInputType::setValue(const String& sanitizedValue, bool, TextFieldEventBehavior, TextControlSetValueSelection)
 {
     ASSERT(element());
-    protectedElement()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
+    protect(element())->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
 }
 
 void BaseCheckableInputType::fireInputAndChangeEvents()

--- a/Source/WebCore/html/BaseClickableWithKeyInputType.cpp
+++ b/Source/WebCore/html/BaseClickableWithKeyInputType.cpp
@@ -86,13 +86,13 @@ bool BaseClickableWithKeyInputType::accessKeyAction(HTMLInputElement& element, b
 auto BaseClickableWithKeyInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseEventHandler
 {
     ASSERT(element());
-    return handleKeydownEvent(*protectedElement(), event);
+    return handleKeydownEvent(*protect(element()), event);
 }
 
 void BaseClickableWithKeyInputType::handleKeypressEvent(KeyboardEvent& event)
 {
     ASSERT(element());
-    handleKeypressEvent(*protectedElement(), event);
+    handleKeypressEvent(*protect(element()), event);
 }
 
 void BaseClickableWithKeyInputType::handleKeyupEvent(KeyboardEvent& event)
@@ -104,7 +104,7 @@ bool BaseClickableWithKeyInputType::accessKeyAction(bool sendMouseEvents)
 {
     InputType::accessKeyAction(sendMouseEvents);
     ASSERT(element());
-    return accessKeyAction(*protectedElement(), sendMouseEvents);
+    return accessKeyAction(*protect(element()), sendMouseEvents);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -143,7 +143,7 @@ WallTime BaseDateAndTimeInputType::valueAsDate() const
 ExceptionOr<void> BaseDateAndTimeInputType::setValueAsDate(WallTime value) const
 {
     ASSERT(element());
-    protectedElement()->setValue(serializeWithMilliseconds(value.secondsSinceEpoch().milliseconds()));
+    protect(element())->setValue(serializeWithMilliseconds(value.secondsSinceEpoch().milliseconds()));
     return { };
 }
 
@@ -174,14 +174,14 @@ WallTime BaseDateAndTimeInputType::accessibilityValueAsDate() const
 double BaseDateAndTimeInputType::valueAsDouble() const
 {
     ASSERT(element());
-    const Decimal value = parseToNumber(protectedElement()->value(), Decimal::nan());
+    const Decimal value = parseToNumber(protect(element())->value(), Decimal::nan());
     return value.isFinite() ? value.toDouble() : DateComponents::invalidMilliseconds();
 }
 
 ExceptionOr<void> BaseDateAndTimeInputType::setValueAsDecimal(const Decimal& newValue, TextFieldEventBehavior eventBehavior) const
 {
     ASSERT(element());
-    protectedElement()->setValue(serialize(newValue), eventBehavior);
+    protect(element())->setValue(serialize(newValue), eventBehavior);
     return { };
 }
 
@@ -193,13 +193,13 @@ bool BaseDateAndTimeInputType::typeMismatchFor(const String& value) const
 bool BaseDateAndTimeInputType::typeMismatch() const
 {
     ASSERT(element());
-    return typeMismatchFor(protectedElement()->value());
+    return typeMismatchFor(protect(element())->value());
 }
 
 bool BaseDateAndTimeInputType::hasBadInput() const
 {
     ASSERT(element());
-    return protectedElement()->value()->isEmpty() && m_dateTimeEditElement && protectedDateTimeEditElement()->editableFieldsHaveValues();
+    return protect(element())->value()->isEmpty() && m_dateTimeEditElement && protect(m_dateTimeEditElement)->editableFieldsHaveValues();
 }
 
 Decimal BaseDateAndTimeInputType::defaultValueForStepUp() const
@@ -233,7 +233,7 @@ String BaseDateAndTimeInputType::serializeWithComponents(const DateComponents& d
 {
     ASSERT(element());
     Decimal step;
-    if (!protectedElement()->getAllowedValueStep(&step) || step.remainder(msecPerMinute).isZero())
+    if (!protect(element())->getAllowedValueStep(&step) || step.remainder(msecPerMinute).isZero())
         return date.toString();
     if (step.remainder(msecPerSecond).isZero())
         return date.toString(SecondFormat::Second);
@@ -252,14 +252,14 @@ String BaseDateAndTimeInputType::localizeValue(const String& proposedValue) cons
         return proposedValue;
 
     ASSERT(element());
-    String localized = protectedElement()->locale().formatDateTime(*date);
+    String localized = protect(element())->locale().formatDateTime(*date);
     return localized.isEmpty() ? proposedValue : localized;
 }
 
 String BaseDateAndTimeInputType::visibleValue() const
 {
     ASSERT(element());
-    return localizeValue(protectedElement()->value());
+    return localizeValue(protect(element())->value());
 }
 
 ValueOrReference<String> BaseDateAndTimeInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
@@ -282,7 +282,7 @@ bool BaseDateAndTimeInputType::shouldRespectListAttribute()
 bool BaseDateAndTimeInputType::valueMissing(const String& value) const
 {
     ASSERT(element());
-    return protectedElement()->isMutable() && element()->isRequired() && value.isEmpty();
+    return protect(element())->isMutable() && element()->isRequired() && value.isEmpty();
 }
 
 bool BaseDateAndTimeInputType::isKeyboardFocusable(const FocusEventData&) const
@@ -295,7 +295,7 @@ bool BaseDateAndTimeInputType::isKeyboardFocusable(const FocusEventData&) const
 bool BaseDateAndTimeInputType::isMouseFocusable() const
 {
     ASSERT(element());
-    return protectedElement()->isTextFormControlFocusable();
+    return protect(element())->isTextFormControlFocusable();
 }
 
 bool BaseDateAndTimeInputType::shouldHaveSecondField(const DateComponents& date) const
@@ -328,7 +328,7 @@ void BaseDateAndTimeInputType::setValue(const String& value, bool valueChanged, 
 void BaseDateAndTimeInputType::handleDOMActivateEvent(Event& event)
 {
     ASSERT(element());
-    if (!element()->renderer() || !protectedElement()->isMutable() || !UserGestureIndicator::processingUserGesture())
+    if (!element()->renderer() || !protect(element())->isMutable() || !UserGestureIndicator::processingUserGesture())
         return;
 
     m_pickerWasActivatedByKeyboard = is<KeyboardEvent>(event);
@@ -448,9 +448,9 @@ void BaseDateAndTimeInputType::updateInnerTextValue()
         layoutParameters.dateTimeFormat = layoutParameters.fallbackDateTimeFormat;
 
     if (date)
-        protectedDateTimeEditElement()->setValueAsDate(layoutParameters, *date);
+        protect(m_dateTimeEditElement)->setValueAsDate(layoutParameters, *date);
     else
-        protectedDateTimeEditElement()->setEmptyValue(layoutParameters);
+        protect(m_dateTimeEditElement)->setEmptyValue(layoutParameters);
 }
 
 bool BaseDateAndTimeInputType::hasCustomFocusLogic() const
@@ -504,7 +504,7 @@ bool BaseDateAndTimeInputType::isPresentingAttachedView() const
 auto BaseDateAndTimeInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseEventHandler
 {
     ASSERT(element());
-    return BaseClickableWithKeyInputType::handleKeydownEvent(*protectedElement(), event);
+    return BaseClickableWithKeyInputType::handleKeydownEvent(*protect(element()), event);
 }
 
 void BaseDateAndTimeInputType::handleKeypressEvent(KeyboardEvent& event)
@@ -515,7 +515,7 @@ void BaseDateAndTimeInputType::handleKeypressEvent(KeyboardEvent& event)
         return;
 
     ASSERT(element());
-    BaseClickableWithKeyInputType::handleKeypressEvent(*protectedElement(), event);
+    BaseClickableWithKeyInputType::handleKeypressEvent(*protect(element()), event);
 }
 
 void BaseDateAndTimeInputType::handleKeyupEvent(KeyboardEvent& event)
@@ -542,7 +542,7 @@ void BaseDateAndTimeInputType::handleFocusEvent(Node* oldFocusedNode, FocusDirec
 
     } else {
         // If the element received focus in any other direction, transfer focus to the first focusable child.
-        protectedDateTimeEditElement()->focusByOwner();
+        protect(m_dateTimeEditElement)->focusByOwner();
     }
 }
 
@@ -550,7 +550,7 @@ bool BaseDateAndTimeInputType::accessKeyAction(bool sendMouseEvents)
 {
     InputType::accessKeyAction(sendMouseEvents);
     ASSERT(element());
-    return BaseClickableWithKeyInputType::accessKeyAction(*protectedElement(), sendMouseEvents);
+    return BaseClickableWithKeyInputType::accessKeyAction(*protect(element()), sendMouseEvents);
 }
 
 void BaseDateAndTimeInputType::didBlurFromControl()
@@ -566,7 +566,7 @@ void BaseDateAndTimeInputType::didChangeValueFromControl()
 {
     Ref input = *element();
 
-    String value = sanitizeValue(protectedDateTimeEditElement()->value());
+    String value = sanitizeValue(protect(m_dateTimeEditElement)->value());
     bool valueChanged = !equalIgnoringNullity(value, input->value());
 
     InputType::setValue(value, valueChanged, DispatchNoEvent, DoNotSet);
@@ -621,19 +621,19 @@ bool BaseDateAndTimeInputType::isEditControlOwnerDisabled() const
 bool BaseDateAndTimeInputType::isEditControlOwnerReadOnly() const
 {
     ASSERT(element());
-    return protectedElement()->isReadOnly();
+    return protect(element())->isReadOnly();
 }
 
 AtomString BaseDateAndTimeInputType::localeIdentifier() const
 {
     ASSERT(element());
-    return protectedElement()->effectiveLang();
+    return protect(element())->effectiveLang();
 }
 
 void BaseDateAndTimeInputType::didChooseValue(StringView value)
 {
     ASSERT(element());
-    protectedElement()->setValue(value.toString(), DispatchInputAndChangeEvent);
+    protect(element())->setValue(value.toString(), DispatchInputAndChangeEvent);
 }
 
 bool BaseDateAndTimeInputType::setupDateTimeChooserParameters(DateTimeChooserParameters& parameters)

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -154,8 +154,6 @@ private:
 
     void showPicker() override;
 
-    RefPtr<DateTimeEditElement> protectedDateTimeEditElement() const { return m_dateTimeEditElement; };
-
     RefPtr<DateTimeChooser> m_dateTimeChooser;
     RefPtr<DateTimeEditElement> m_dateTimeEditElement;
 

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -138,7 +138,7 @@ void CheckboxInputType::handleMouseMoveEvent(MouseEvent& event)
     ASSERT(element());
     ASSERT(!element()->isDisabledFormControl());
 
-    if (!event.isTrusted() || !isSwitch() || !protectedElement()->renderer()) {
+    if (!event.isTrusted() || !isSwitch() || !protect(element())->renderer()) {
         stopSwitchPointerTracking();
         return;
     }
@@ -293,7 +293,7 @@ void CheckboxInputType::stopSwitchPointerTracking()
     if (!isSwitchPointerTracking())
         return;
 
-    if (RefPtr frame = protect(protectedElement()->document())->frame())
+    if (RefPtr frame = protect(protect(element())->document())->frame())
         frame->eventHandler().setCapturingMouseEventsElement(nullptr);
     m_hasSwitchVisuallyOnChanged = false;
     m_switchPointerTrackingLogicalLeftPositionStart = { };
@@ -316,7 +316,7 @@ void CheckboxInputType::disabledStateChanged()
         return;
 
     ASSERT(element());
-    if (protectedElement()->isDisabledFormControl()) {
+    if (protect(element())->isDisabledFormControl()) {
         stopSwitchAnimation(SwitchAnimationType::VisuallyOn);
         stopSwitchAnimation(SwitchAnimationType::Held);
         stopSwitchPointerTracking();
@@ -324,7 +324,7 @@ void CheckboxInputType::disabledStateChanged()
 
 #if ENABLE(TOUCH_EVENTS)
     if (isSwitch())
-        protectedElement()->updateTouchEventHandler();
+        protect(element())->updateTouchEventHandler();
 #endif
 }
 

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -140,7 +140,7 @@ ColorInputType::~ColorInputType()
 bool ColorInputType::isMouseFocusable() const
 {
     ASSERT(element());
-    return protectedElement()->isTextFormControlFocusable();
+    return protect(element())->isTextFormControlFocusable();
 }
 
 bool ColorInputType::isKeyboardFocusable(const FocusEventData&) const
@@ -171,7 +171,7 @@ bool ColorInputType::supportsRequired() const
 ValueOrReference<String> ColorInputType::fallbackValue() const
 {
     ASSERT(element());
-    return serializeColorValue(Color::black, *protectedElement());
+    return serializeColorValue(Color::black, *protect(element()));
 }
 
 ValueOrReference<String> ColorInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
@@ -208,7 +208,7 @@ void ColorInputType::createShadowSubtree()
     Ref wrapperElement = HTMLDivElement::create(document);
     Ref colorSwatch = HTMLDivElement::create(document);
 
-    Ref shadowRoot = *protectedElement()->userAgentShadowRoot();
+    Ref shadowRoot = *protect(element())->userAgentShadowRoot();
     ScriptDisallowedScope::EventAllowedScope eventAllowedScope { shadowRoot };
     shadowRoot->appendChild(ContainerNode::ChildChange::Source::Parser, wrapperElement);
 
@@ -318,7 +318,7 @@ void ColorInputType::didChooseColor(const Color& color)
 void ColorInputType::didEndChooser()
 {
     m_chooser = nullptr;
-    if (CheckedPtr renderer = protectedElement()->renderer())
+    if (CheckedPtr renderer = protect(element())->renderer())
         renderer->repaint();
 }
 
@@ -340,7 +340,7 @@ void ColorInputType::updateColorSwatch()
 HTMLElement* ColorInputType::shadowColorSwatch() const
 {
     ASSERT(element());
-    RefPtr shadow = protectedElement()->userAgentShadowRoot();
+    RefPtr shadow = protect(element())->userAgentShadowRoot();
     if (!shadow)
         return nullptr;
 
@@ -366,7 +366,7 @@ std::optional<FrameIdentifier> ColorInputType::rootFrameID() const
 bool ColorInputType::supportsAlpha() const
 {
     ASSERT(element());
-    return protectedElement()->alpha();
+    return protect(element())->alpha();
 }
 
 Vector<Color> ColorInputType::suggestedColors() const
@@ -386,7 +386,7 @@ Vector<Color> ColorInputType::suggestedColors() const
 void ColorInputType::selectColor(StringView string)
 {
     ASSERT(element());
-    if (auto color = parseColorValue(string, *protectedElement()))
+    if (auto color = parseColorValue(string, *protect(element())))
         didChooseColor(*color);
 }
 

--- a/Source/WebCore/html/EmailInputType.cpp
+++ b/Source/WebCore/html/EmailInputType.cpp
@@ -68,7 +68,7 @@ bool EmailInputType::typeMismatchFor(const String& value) const
     ASSERT(element());
     if (value.isEmpty())
         return false;
-    if (!protectedElement()->multiple())
+    if (!protect(element())->multiple())
         return !isValidEmailAddress(value);
     for (auto& address : value.splitAllowingEmptyEntries(',')) {
         if (!isValidEmailAddress(StringView(address).trim(isASCIIWhitespace<char16_t>)))
@@ -80,13 +80,13 @@ bool EmailInputType::typeMismatchFor(const String& value) const
 bool EmailInputType::typeMismatch() const
 {
     ASSERT(element());
-    return typeMismatchFor(protectedElement()->value());
+    return typeMismatchFor(protect(element())->value());
 }
 
 String EmailInputType::typeMismatchText() const
 {
     ASSERT(element());
-    return protectedElement()->multiple() ? validationMessageTypeMismatchForMultipleEmailText() : validationMessageTypeMismatchForEmailText();
+    return protect(element())->multiple() ? validationMessageTypeMismatchForMultipleEmailText() : validationMessageTypeMismatchForEmailText();
 }
 
 bool EmailInputType::supportsSelectionAPI() const
@@ -115,7 +115,7 @@ ValueOrReference<String> EmailInputType::sanitizeValue(const String& proposedVal
     }
 
     ASSERT(element());
-    if (!protectedElement()->multiple())
+    if (!protect(element())->multiple())
         return noLineBreakValue.trim(isASCIIWhitespace);
     Vector<String> addresses = noLineBreakValue.splitAllowingEmptyEntries(',');
     StringBuilder strippedValue;

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -151,14 +151,14 @@ bool FileInputType::valueMissing(const String& value) const
 String FileInputType::valueMissingText() const
 {
     ASSERT(element());
-    return protectedElement()->multiple() ? validationMessageValueMissingForMultipleFileText() : validationMessageValueMissingForFileText();
+    return protect(element())->multiple() ? validationMessageValueMissingForMultipleFileText() : validationMessageValueMissingForFileText();
 }
 
 void FileInputType::handleDOMActivateEvent(Event& event)
 {
     ASSERT(element());
 
-    if (protectedElement()->isDisabledFormControl())
+    if (protect(element())->isDisabledFormControl())
         return;
 
     if (!UserGestureIndicator::processingUserGesture())
@@ -173,7 +173,7 @@ void FileInputType::showPicker()
     ASSERT(element());
     if (auto* chrome = this->chrome()) {
         applyFileChooserSettings();
-        chrome->runOpenPanel(*element()->document().protectedFrame(), *protectedFileChooser());
+        chrome->runOpenPanel(*element()->document().protectedFrame(), *protect(m_fileChooser));
     }
 }
 
@@ -186,7 +186,7 @@ RenderPtr<RenderElement> FileInputType::createInputRenderer(RenderStyle&& style)
 {
     ASSERT(element());
     // FIXME: https://github.com/llvm/llvm-project/pull/142471 Moving style is not unsafe.
-    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderFileUploadControl>(*protectedElement(), WTF::move(style));
+    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderFileUploadControl>(*protect(element()), WTF::move(style));
 }
 
 bool FileInputType::canSetStringValue() const
@@ -205,7 +205,7 @@ String FileInputType::firstElementPathForInputValue() const
     // decided to try to parse the value by looking for backslashes
     // (because that's what Windows file paths use). To be compatible
     // with that code, we make up a fake path for the file.
-    return makeString("C:\\fakepath\\"_s, protectedFiles()->file(0).name());
+    return makeString("C:\\fakepath\\"_s, protect(files())->file(0).name());
 }
 
 void FileInputType::setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection)
@@ -214,7 +214,7 @@ void FileInputType::setValue(const String&, bool valueChanged, TextFieldEventBeh
     if (!valueChanged)
         return;
     
-    protectedFiles()->clear();
+    protect(files())->clear();
     m_icon = nullptr;
     ASSERT(element());
     Ref element = *this->element();
@@ -300,7 +300,7 @@ FileChooserSettings FileInputType::fileChooserSettings() const
     settings.allowsMultipleFiles = element->hasAttributeWithoutSynchronization(multipleAttr);
     settings.acceptMIMETypes = element->acceptMIMETypes();
     settings.acceptFileExtensions = element->acceptFileExtensions();
-    settings.selectedFiles = protectedFiles()->paths();
+    settings.selectedFiles = protect(files())->paths();
 #if ENABLE(MEDIA_CAPTURE)
     settings.mediaCaptureType = element->mediaCaptureType();
 #endif
@@ -363,7 +363,7 @@ void FileInputType::setFiles(RefPtr<FileList>&& files, RequestIcon shouldRequest
     element->updateValidity();
 
     if (shouldRequestIcon == RequestIcon::Yes)
-        requestIcon(protectedFiles()->paths());
+        requestIcon(protect(this->files())->paths());
 
     if (CheckedPtr renderer = element->renderer())
         renderer->repaint();
@@ -419,7 +419,7 @@ void FileInputType::filesChosen(const Vector<String>& paths, const Vector<String
     ASSERT(element());
     ASSERT(!paths.isEmpty());
 
-    size_t size = protectedElement()->hasAttributeWithoutSynchronization(multipleAttr) ? paths.size() : 1;
+    size_t size = protect(element())->hasAttributeWithoutSynchronization(multipleAttr) ? paths.size() : 1;
 
     Vector<FileChooserFileInfo> files(size, [&](size_t i) {
         return FileChooserFileInfo { paths[i], i < replacementPaths.size() ? replacementPaths[i] : nullString(), { } };
@@ -431,7 +431,7 @@ void FileInputType::filesChosen(const Vector<String>& paths, const Vector<String
 void FileInputType::fileChoosingCancelled()
 {
     ASSERT(element());
-    protectedElement()->dispatchCancelEvent();
+    protect(element())->dispatchCancelEvent();
 }
 
 void FileInputType::didCreateFileList(Ref<FileList>&& fileList, RefPtr<Icon>&& icon)
@@ -526,7 +526,7 @@ String FileInputType::defaultToolTip() const
     unsigned listSize = m_fileList->length();
     if (!listSize) {
         ASSERT(element());
-        if (protectedElement()->multiple())
+        if (protect(element())->multiple())
             return fileButtonNoFilesSelectedLabel();
         return fileButtonNoFileSelectedLabel();
     }

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -56,8 +56,7 @@ public:
     virtual ~FileInputType();
 
     String firstElementPathForInputValue() const; // Checked first, before internal storage or the value attribute.
-    FileList& files() { return m_fileList; }
-    Ref<FileList> protectedFiles() const { return m_fileList; }
+    FileList& files() const { return m_fileList; }
     void setFiles(RefPtr<FileList>&&, WasSetByJavaScript);
 
     static std::pair<Vector<FileChooserFileInfo>, String> filesFromFormControlState(const FormControlState&);
@@ -107,8 +106,6 @@ private:
     bool allowsDirectories() const;
 
     bool dirAutoUsesValue() const final;
-
-    RefPtr<FileChooser> protectedFileChooser() const { return m_fileChooser; }
 
     RefPtr<FileChooser> m_fileChooser;
     std::unique_ptr<FileIconLoader> m_fileIconLoader;

--- a/Source/WebCore/html/FormAssociatedCustomElement.cpp
+++ b/Source/WebCore/html/FormAssociatedCustomElement.cpp
@@ -163,7 +163,7 @@ void FormAssociatedCustomElement::didChangeForm()
     ASSERT(m_element->isDefinedCustomElement());
     ValidatedFormListedElement::didChangeForm();
     if (!belongsToFormThatIsBeingDestroyed())
-        CustomElementReactionQueue::enqueueFormAssociatedCallbackIfNeeded(asProtectedHTMLElement().get(), protectedForm().get());
+        CustomElementReactionQueue::enqueueFormAssociatedCallbackIfNeeded(asProtectedHTMLElement().get(), protect(form()).get());
 }
 
 void FormAssociatedCustomElement::willUpgrade()

--- a/Source/WebCore/html/FormAssociatedElement.h
+++ b/Source/WebCore/html/FormAssociatedElement.h
@@ -40,7 +40,6 @@ public:
     virtual void formWillBeDestroyed() { m_form = nullptr; }
 
     HTMLFormElement* form() const { return m_form; }
-    RefPtr<HTMLFormElement> protectedForm() const { return m_form; }
     virtual RefPtr<HTMLFormElement> formForBindings() const;
 
     void setForm(RefPtr<HTMLFormElement>&&);

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -733,7 +733,7 @@ ExceptionOr<UncachedString> HTMLCanvasElement::toDataURL(const String& mimeType,
     if (auto url = document->quirks().advancedPrivacyProtectionSubstituteDataURLForScriptWithFeatures(lastFillText(), width(), height()); !url.isNull()) {
         RELEASE_LOG(FingerprintingMitigation, "HTMLCanvasElement::toDataURL: Quirking returned URL for identified fingerprinting script");
         auto consoleMessage = "Detected fingerprinting script. Quirking value returned from HTMLCanvasElement.toDataURL()"_s;
-        protectedCanvasBaseScriptExecutionContext()->addConsoleMessage(MessageSource::Rendering, MessageLevel::Info, consoleMessage);
+        protect(canvasBaseScriptExecutionContext())->addConsoleMessage(MessageSource::Rendering, MessageLevel::Info, consoleMessage);
         return UncachedString { url };
     }
     RefPtr buffer = makeRenderingResultsAvailable();

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -180,7 +180,6 @@ private:
     bool usesContentsAsLayerContents() const;
 
     ScriptExecutionContext* canvasBaseScriptExecutionContext() const final { return HTMLElement::scriptExecutionContext(); }
-    RefPtr<ScriptExecutionContext> protectedCanvasBaseScriptExecutionContext() const { return canvasBaseScriptExecutionContext(); }
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;
 

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -78,7 +78,6 @@ public:
     inline NodeListInvalidationType invalidationType() const;
     inline CollectionType type() const;
     ContainerNode& ownerNode() const { return m_ownerNode; }
-    Ref<ContainerNode> protectedOwnerNode() const { return m_ownerNode; }
     inline ContainerNode& rootNode() const;
     inline void invalidateCacheForAttribute(const QualifiedName& attributeName);
     WEBCORE_EXPORT virtual void invalidateCacheForDocument(Document&);

--- a/Source/WebCore/html/HTMLFormControlsCollection.cpp
+++ b/Source/WebCore/html/HTMLFormControlsCollection.cpp
@@ -62,7 +62,7 @@ std::optional<Variant<RefPtr<RadioNodeList>, RefPtr<Element>>> HTMLFormControlsC
     if (namedItems.size() == 1)
         return Variant<RefPtr<RadioNodeList>, RefPtr<Element>> { RefPtr<Element> { WTF::move(namedItems[0]) } };
 
-    return Variant<RefPtr<RadioNodeList>, RefPtr<Element>> { RefPtr<RadioNodeList> { protectedOwnerNode()->radioNodeList(name) } };
+    return Variant<RefPtr<RadioNodeList>, RefPtr<Element>> { RefPtr<RadioNodeList> { protect(ownerNode())->radioNodeList(name) } };
 }
 
 static unsigned findFormListedElement(const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& elements, const Element& element)

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -201,7 +201,7 @@ void HTMLFrameElementBase::setLocation(const String& str)
 void HTMLFrameElementBase::setLocation(JSC::JSGlobalObject& state, const String& newLocation)
 {
     if (WTF::protocolIsJavaScript(newLocation)) {
-        if (!BindingSecurity::shouldAllowAccessToNode(state, protectedContentDocument().get()))
+        if (!BindingSecurity::shouldAllowAccessToNode(state, protect(contentDocument()).get()))
             return;
     }
 

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -43,7 +43,6 @@ public:
     RefPtr<Frame> protectedContentFrame() const;
     WEBCORE_EXPORT WindowProxy* contentWindow() const;
     WEBCORE_EXPORT Document* contentDocument() const;
-    RefPtr<Document> protectedContentDocument() const { return contentDocument(); }
 
     WEBCORE_EXPORT void setContentFrame(Frame&);
     void clearContentFrame();

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -186,9 +186,7 @@ public:
     HTMLElement* resultsButtonElement() const;
     HTMLElement* cancelButtonElement() const;
     HTMLElement* sliderThumbElement() const;
-    RefPtr<HTMLElement> protectedSliderThumbElement() const { return sliderThumbElement(); }
     HTMLElement* sliderTrackElement() const;
-    RefPtr<HTMLElement> protectedSliderTrackElement() const { return sliderTrackElement(); }
     HTMLElement* placeholderElement() const final;
     WEBCORE_EXPORT HTMLElement* autoFillButtonElement() const;
     WEBCORE_EXPORT HTMLElement* dataListButtonElement() const;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -195,7 +195,6 @@ public:
     void deref() const final { HTMLElement::deref(); }
 
     MediaPlayer* player() const { return m_player.get(); }
-    RefPtr<MediaPlayer> protectedPlayer() const { return m_player; }
     WEBCORE_EXPORT std::optional<MediaPlayerIdentifier> playerIdentifier() const;
 
     virtual bool isVideo() const { return false; }
@@ -510,7 +509,7 @@ public:
     // of one of them here.
     using HTMLElement::scriptExecutionContext;
 
-    bool didPassCORSAccessCheck() const { return m_player && protectedPlayer()->didPassCORSAccessCheck(); }
+    bool didPassCORSAccessCheck() const { return m_player && protect(player())->didPassCORSAccessCheck(); }
     bool taintsOrigin(const SecurityOrigin&) const;
     
     WEBCORE_EXPORT bool isFullscreen() const override;
@@ -579,7 +578,6 @@ public:
     MediaPlayer::Preload effectivePreloadValue() const;
     MediaElementSession* mediaSessionIfExists() const { return m_mediaSession.get(); }
     WEBCORE_EXPORT MediaElementSession& mediaSession() const;
-    Ref<MediaElementSession> protectedMediaSession() const { return mediaSession(); }
 
     void pageScaleFactorChanged();
     void userInterfaceLayoutDirectionChanged();
@@ -1502,6 +1500,11 @@ private:
 
 String convertEnumerationToString(HTMLMediaElement::AutoplayEventPlaybackState);
 String convertEnumerationToString(HTMLMediaElement::SpeechSynthesisState);
+
+inline HTMLMediaElement* MediaElementSession::element() const
+{
+    return m_element.get();
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/HTMLTableRowsCollection.cpp
+++ b/Source/WebCore/html/HTMLTableRowsCollection.cpp
@@ -166,7 +166,7 @@ Ref<HTMLTableRowsCollection> HTMLTableRowsCollection::create(HTMLTableElement& t
 
 Element* HTMLTableRowsCollection::customElementAfter(Element* previous) const
 {
-    return rowAfter(protectedTableElement().get(), downcast<HTMLTableRowElement>(previous));
+    return rowAfter(protect(tableElement()), downcast<HTMLTableRowElement>(previous));
 }
 
 }

--- a/Source/WebCore/html/HTMLTableRowsCollection.h
+++ b/Source/WebCore/html/HTMLTableRowsCollection.h
@@ -53,7 +53,7 @@ class HTMLTableRowsCollection final : public CachedHTMLCollection<HTMLTableRowsC
 public:
     static Ref<HTMLTableRowsCollection> create(HTMLTableElement&, CollectionType);
 
-    Ref<HTMLTableElement> protectedTableElement() const { return downcast<HTMLTableElement>(ownerNode()); }
+    HTMLTableElement& tableElement() const { return downcast<HTMLTableElement>(ownerNode()); }
 
     static HTMLTableRowElement* rowAfter(HTMLTableElement&, HTMLTableRowElement*);
     static HTMLTableRowElement* lastRow(HTMLTableElement&);

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -46,7 +46,6 @@ public:
 
     DocumentFragment& fragmentForInsertion() const;
     DocumentFragment& content() const;
-    Ref<DocumentFragment> protectedContent() const { return content(); }
     DocumentFragment* contentIfAvailable() const;
 
     const AtomString& shadowRootMode() const;

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -161,7 +161,7 @@ private:
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
     bool isVideo() const final { return true; }
-    bool hasVideo() const final { return player() && protectedPlayer()->hasVideo(); }
+    bool hasVideo() const final { return player() && protect(player())->hasVideo(); }
     bool supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenMode) const final;
     bool isURLAttribute(const Attribute&) const final;
     const AtomString& imageSourceURL() const final;

--- a/Source/WebCore/html/HiddenInputType.cpp
+++ b/Source/WebCore/html/HiddenInputType.cpp
@@ -64,7 +64,7 @@ FormControlState HiddenInputType::saveFormControlState() const
 void HiddenInputType::restoreFormControlState(const FormControlState& state)
 {
     ASSERT(element());
-    protectedElement()->setAttributeWithoutSynchronization(valueAttr, AtomString { state[0] });
+    protect(element())->setAttributeWithoutSynchronization(valueAttr, AtomString { state[0] });
 }
 
 RenderPtr<RenderElement> HiddenInputType::createInputRenderer(RenderStyle&&)
@@ -91,7 +91,7 @@ bool HiddenInputType::storesValueSeparateFromAttribute()
 void HiddenInputType::setValue(const String& sanitizedValue, bool, TextFieldEventBehavior, TextControlSetValueSelection)
 {
     ASSERT(element());
-    protectedElement()->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
+    protect(element())->setAttributeWithoutSynchronization(valueAttr, AtomString { sanitizedValue });
 }
 
 bool HiddenInputType::appendFormData(DOMFormData& formData) const

--- a/Source/WebCore/html/ImageDataArray.h
+++ b/Source/WebCore/html/ImageDataArray.h
@@ -51,9 +51,8 @@ public:
     size_t length() const;
 
     JSC::ArrayBufferView& arrayBufferView() const { return m_arrayBufferView.get(); }
-    Ref<JSC::ArrayBufferView> protectedArrayBufferView() const { return m_arrayBufferView; }
-    auto byteLength() const { return protectedArrayBufferView()->byteLength(); }
-    auto isDetached() const { return protectedArrayBufferView()->isDetached(); }
+    auto byteLength() const { return protect(arrayBufferView())->byteLength(); }
+    auto isDetached() const { return protect(arrayBufferView())->isDetached(); }
 
     Ref<JSC::Uint8ClampedArray> asUint8ClampedArray() const;
     Ref<JSC::Float16Array> asFloat16Array() const;

--- a/Source/WebCore/html/ImageInputType.cpp
+++ b/Source/WebCore/html/ImageInputType.cpp
@@ -111,7 +111,7 @@ RenderPtr<RenderElement> ImageInputType::createInputRenderer(RenderStyle&& style
 {
     ASSERT(element());
     // FIXME: https://github.com/llvm/llvm-project/pull/142471 Moving style is not unsafe.
-    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderImage>(RenderObject::Type::Image, *protectedElement(), WTF::move(style));
+    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderImage>(RenderObject::Type::Image, *protect(element()), WTF::move(style));
 }
 
 void ImageInputType::attributeChanged(const QualifiedName& name)
@@ -135,7 +135,7 @@ void ImageInputType::attach()
     BaseButtonInputType::attach();
 
     ASSERT(element());
-    Ref imageLoader = protectedElement()->ensureImageLoader();
+    Ref imageLoader = protect(element())->ensureImageLoader();
     imageLoader->updateFromElement();
 
     CheckedPtr renderer = downcast<RenderImage>(element()->renderer());

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -273,14 +273,14 @@ FormControlState InputType::saveFormControlState() const
 void InputType::restoreFormControlState(const FormControlState& state)
 {
     ASSERT(element());
-    protectedElement()->setValue(state[0]);
+    protect(element())->setValue(state[0]);
 }
 
 bool InputType::isFormDataAppendable() const
 {
     ASSERT(element());
     // There is no form data unless there's a name for non-image types.
-    return !protectedElement()->name().isEmpty();
+    return !protect(element())->name().isEmpty();
 }
 
 bool InputType::appendFormData(DOMFormData& formData) const
@@ -598,13 +598,13 @@ RenderPtr<RenderElement> InputType::createInputRenderer(RenderStyle&& style)
 {
     ASSERT(element());
     // FIXME: https://github.com/llvm/llvm-project/pull/142471 Moving style is not unsafe.
-    SUPPRESS_UNCOUNTED_ARG return RenderPtr<RenderElement>(RenderElement::createFor(*protectedElement(), WTF::move(style)));
+    SUPPRESS_UNCOUNTED_ARG return RenderPtr<RenderElement>(RenderElement::createFor(*protect(element()), WTF::move(style)));
 }
 
 void InputType::blur()
 {
     ASSERT(element());
-    protectedElement()->defaultBlur();
+    protect(element())->defaultBlur();
 }
 
 void InputType::createShadowSubtree()
@@ -614,7 +614,7 @@ void InputType::createShadowSubtree()
 void InputType::removeShadowSubtree()
 {
     ASSERT(element());
-    RefPtr root = protectedElement()->userAgentShadowRoot();
+    RefPtr root = protect(element())->userAgentShadowRoot();
     if (!root)
         return;
 
@@ -681,7 +681,7 @@ bool InputType::isKeyboardFocusable(const FocusEventData& focusEventData) const
 bool InputType::isMouseFocusable() const
 {
     ASSERT(element());
-    return protectedElement()->isTextFormControlMouseFocusable();
+    return protect(element())->isTextFormControlMouseFocusable();
 }
 
 bool InputType::shouldUseInputMethod() const
@@ -700,7 +700,7 @@ void InputType::handleBlurEvent()
 bool InputType::accessKeyAction(bool)
 {
     ASSERT(element());
-    protectedElement()->focus({ { }, { }, SelectionRestorationMode::SelectAll });
+    protect(element())->focus({ { }, { }, SelectionRestorationMode::SelectAll });
     return false;
 }
 
@@ -803,7 +803,7 @@ String InputType::localizeValue(const String& proposedValue) const
 String InputType::visibleValue() const
 {
     ASSERT(element());
-    return protectedElement()->value();
+    return protect(element())->value();
 }
 
 bool InputType::isEmptyValue() const
@@ -1157,7 +1157,7 @@ RefPtr<TextControlInnerTextElement> InputType::innerTextElementCreatingShadowSub
 String InputType::resultForDialogSubmit() const
 {
     ASSERT(element());
-    return protectedElement()->value();
+    return protect(element())->value();
 }
 
 void InputType::createShadowSubtreeIfNeeded()
@@ -1166,7 +1166,7 @@ void InputType::createShadowSubtreeIfNeeded()
         return;
     // FIXME: Remove protectedThis once all the callsites protect InputType.
     Ref protectedThis { *this };
-    protectedElement()->ensureUserAgentShadowRoot();
+    protect(element())->ensureUserAgentShadowRoot();
     m_hasCreatedShadowSubtree = true;
     createShadowSubtree();
 }
@@ -1177,7 +1177,7 @@ bool InputType::hasTouchEventHandler() const
 #if ENABLE(IOS_TOUCH_EVENTS)
     if (isSwitch()) {
         ASSERT(element());
-        return !protectedElement()->isDisabledFormControl();
+        return !protect(element())->isDisabledFormControl();
     }
 #else
     if (isRangeControl())

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -405,7 +405,6 @@ protected:
     }
 
     HTMLInputElement* element() const { return m_element; }
-    RefPtr<HTMLInputElement> protectedElement() const { return m_element; }
     Chrome* chrome() const;
     Decimal parseToNumberOrNaN(const String&) const;
 

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -211,11 +211,6 @@ MediaElementSession::~MediaElementSession()
 #endif
 }
 
-RefPtr<HTMLMediaElement> MediaElementSession::protectedElement() const
-{
-    return m_element.get();
-}
-
 void MediaElementSession::addMediaUsageManagerSessionIfNecessary()
 {
 #if ENABLE(MEDIA_USAGE)

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -156,8 +156,7 @@ public:
     WEBCORE_EXPORT void removeBehaviorRestriction(BehaviorRestrictions);
     bool hasBehaviorRestriction(BehaviorRestrictions restriction) const { return restriction & m_restrictions; }
 
-    WeakPtr<HTMLMediaElement> element() const { return m_element; }
-    RefPtr<HTMLMediaElement> protectedElement() const;
+    inline HTMLMediaElement* element() const; // Defined in HTMLMediaElement.h.
 
     bool wantsToObserveViewportVisibilityForMediaControls() const;
     bool wantsToObserveViewportVisibilityForAutoplay() const;

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -70,7 +70,7 @@ DateComponentsType MonthInputType::dateType() const
 WallTime MonthInputType::valueAsDate() const
 {
     ASSERT(element());
-    auto date = parseToDateComponents(protectedElement()->value().get());
+    auto date = parseToDateComponents(protect(element())->value().get());
     if (!date)
         return WallTime::nan();
     double msec = date->millisecondsSinceEpoch();

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -107,7 +107,7 @@ const AtomString& NumberInputType::formControlType() const
 void NumberInputType::setValue(const String& sanitizedValue, bool valueChanged, TextFieldEventBehavior eventBehavior, TextControlSetValueSelection selection)
 {
     ASSERT(element());
-    if (!valueChanged && sanitizedValue.isEmpty() && !protectedElement()->innerTextValue().isEmpty())
+    if (!valueChanged && sanitizedValue.isEmpty() && !protect(element())->innerTextValue().isEmpty())
         updateInnerTextValue();
     TextFieldInputType::setValue(sanitizedValue, valueChanged, eventBehavior, selection);
 }
@@ -115,20 +115,20 @@ void NumberInputType::setValue(const String& sanitizedValue, bool valueChanged, 
 double NumberInputType::valueAsDouble() const
 {
     ASSERT(element());
-    return parseToDoubleForNumberType(protectedElement()->value().get());
+    return parseToDoubleForNumberType(protect(element())->value().get());
 }
 
 ExceptionOr<void> NumberInputType::setValueAsDouble(double newValue, TextFieldEventBehavior eventBehavior) const
 {
     ASSERT(element());
-    protectedElement()->setValue(serializeForNumberType(newValue), eventBehavior);
+    protect(element())->setValue(serializeForNumberType(newValue), eventBehavior);
     return { };
 }
 
 ExceptionOr<void> NumberInputType::setValueAsDecimal(const Decimal& newValue, TextFieldEventBehavior eventBehavior) const
 {
     ASSERT(element());
-    protectedElement()->setValue(serializeForNumberType(newValue), eventBehavior);
+    protect(element())->setValue(serializeForNumberType(newValue), eventBehavior);
     return { };
 }
 
@@ -140,7 +140,7 @@ bool NumberInputType::typeMismatchFor(const String& value) const
 bool NumberInputType::typeMismatch() const
 {
     ASSERT(element());
-    ASSERT(!typeMismatchFor(protectedElement()->value()));
+    ASSERT(!typeMismatchFor(protect(element())->value()));
     return false;
 }
 
@@ -301,7 +301,7 @@ float NumberInputType::decorationWidth(float inputWidth) const
     ASSERT(element());
 
     float width = 0;
-    RefPtr spinButton = protectedElement()->innerSpinButtonElement();
+    RefPtr spinButton = protect(element())->innerSpinButtonElement();
     if (CheckedPtr spinRenderer = spinButton ? spinButton->renderBox() : nullptr) {
         width += spinRenderer->borderAndPaddingLogicalWidth();
 
@@ -399,7 +399,7 @@ void NumberInputType::handleBeforeTextInsertedEvent(BeforeTextInsertedEvent& eve
     auto normalizedText = normalizeFullWidthNumberChars(event.text()).get();
     LOG(Editing, "normalizeFullWidthNumberChars() -> [%s]", normalizedText.utf8().data());
 
-    auto localizedText = protectedElement()->locale().convertFromLocalizedNumber(normalizedText);
+    auto localizedText = protect(element())->locale().convertFromLocalizedNumber(normalizedText);
 
     // If the cleaned up text doesn't match input text, don't insert partial input
     // since it could be an incorrect paste.
@@ -541,13 +541,13 @@ String NumberInputType::localizeValue(const String& proposedValue) const
     if (proposedValue.find(isE) != notFound)
         return proposedValue;
     ASSERT(element());
-    return protectedElement()->locale().convertToLocalizedNumber(proposedValue);
+    return protect(element())->locale().convertToLocalizedNumber(proposedValue);
 }
 
 String NumberInputType::visibleValue() const
 {
     ASSERT(element());
-    return localizeValue(protectedElement()->value());
+    return localizeValue(protect(element())->value());
 }
 
 String NumberInputType::convertFromVisibleValue(const String& visibleValue) const
@@ -558,7 +558,7 @@ String NumberInputType::convertFromVisibleValue(const String& visibleValue) cons
     if (visibleValue.find(isE) != notFound)
         return visibleValue;
     ASSERT(element());
-    return protectedElement()->locale().convertFromLocalizedNumber(visibleValue);
+    return protect(element())->locale().convertFromLocalizedNumber(visibleValue);
 }
 
 ValueOrReference<String> NumberInputType::sanitizeValue(const String& proposedValue LIFETIME_BOUND) const
@@ -573,7 +573,7 @@ ValueOrReference<String> NumberInputType::sanitizeValue(const String& proposedVa
 bool NumberInputType::hasBadInput() const
 {
     ASSERT(element());
-    String standardValue = convertFromVisibleValue(protectedElement()->innerTextValue());
+    String standardValue = convertFromVisibleValue(protect(element())->innerTextValue());
     return !standardValue.isEmpty() && !std::isfinite(parseToDoubleForNumberType(standardValue));
 }
 

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -100,13 +100,13 @@ const AtomString& RangeInputType::formControlType() const
 double RangeInputType::valueAsDouble() const
 {
     ASSERT(element());
-    return parseToDoubleForNumberType(protectedElement()->value().get());
+    return parseToDoubleForNumberType(protect(element())->value().get());
 }
 
 ExceptionOr<void> RangeInputType::setValueAsDecimal(const Decimal& newValue, TextFieldEventBehavior eventBehavior) const
 {
     ASSERT(element());
-    protectedElement()->setValue(serialize(newValue), eventBehavior);
+    protect(element())->setValue(serialize(newValue), eventBehavior);
     return { };
 }
 
@@ -283,7 +283,7 @@ HTMLElement* RangeInputType::sliderTrackElement() const
     if (!hasCreatedShadowSubtree())
         return nullptr;
 
-    RefPtr root = protectedElement()->userAgentShadowRoot();
+    RefPtr root = protect(element())->userAgentShadowRoot();
     ASSERT(root);
     ASSERT(is<SliderContainerElement>(root->firstChild())); // container
     ASSERT(root->firstChild()->firstChild()); // track
@@ -317,7 +317,7 @@ RenderPtr<RenderElement> RangeInputType::createInputRenderer(RenderStyle&& style
 {
     ASSERT(element());
     // FIXME: https://github.com/llvm/llvm-project/pull/142471 Moving style is not unsafe.
-    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderSlider>(*protectedElement(), WTF::move(style));
+    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderSlider>(*protect(element()), WTF::move(style));
 }
 
 Decimal RangeInputType::parseToNumber(const String& src, const Decimal& defaultValue) const

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -118,7 +118,7 @@ PopupMenuStyle SearchInputType::itemStyle(unsigned) const
 PopupMenuStyle SearchInputType::menuStyle() const
 {
     auto defaultStyle = RenderStyle::create();
-    CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protectedElement()->renderer());
+    CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protect(element())->renderer());
     CheckedRef style = renderer ? renderer->style() : defaultStyle;
     return PopupMenuStyle(
         style->visitedDependentColorApplyingColorFilter(),
@@ -152,24 +152,24 @@ int SearchInputType::clientInsetRight() const
 
 LayoutUnit SearchInputType::clientPaddingLeft() const
 {
-    CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protectedElement()->renderer());
+    CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protect(element())->renderer());
     return renderer ? renderer->clientPaddingLeft() : 0_lu;
 }
 
 LayoutUnit SearchInputType::clientPaddingRight() const
 {
-    CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protectedElement()->renderer());
+    CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protect(element())->renderer());
     return renderer ? renderer->clientPaddingRight() : 0_lu;
 }
 
 FontSelector* SearchInputType::fontSelector() const
 {
-    return &protect(protectedElement()->document())->fontSelector();
+    return &protect(protect(element())->document())->fontSelector();
 }
 
 HostWindow* SearchInputType::hostWindow() const
 {
-    if (CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protectedElement()->renderer()))
+    if (CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protect(element())->renderer()))
         return renderer->hostWindow();
     return nullptr;
 }
@@ -186,7 +186,7 @@ int SearchInputType::listSize() const
 
 void SearchInputType::popupDidHide()
 {
-    if (CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protectedElement()->renderer()))
+    if (CheckedPtr renderer = dynamicDowncast<RenderSearchField>(protect(element())->renderer()))
         renderer->popupDidHide();
 }
 
@@ -209,7 +209,7 @@ bool SearchInputType::itemIsSelected(unsigned) const
 #if !PLATFORM(COCOA)
 void SearchInputType::setTextFromItem(unsigned listIndex)
 {
-    protectedElement()->setValue(itemText(listIndex));
+    protect(element())->setValue(itemText(listIndex));
 }
 #endif
 
@@ -268,7 +268,7 @@ RenderPtr<RenderElement> SearchInputType::createInputRenderer(RenderStyle&& styl
 {
     ASSERT(element());
     // FIXME: https://github.com/llvm/llvm-project/pull/142471 Moving style is not unsafe.
-    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderSearchField>(*protectedElement(), WTF::move(style));
+    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderSearchField>(*protect(element()), WTF::move(style));
 }
 
 const AtomString& SearchInputType::formControlType() const
@@ -385,7 +385,7 @@ float SearchInputType::decorationWidth(float) const
 
 void SearchInputType::setValue(const String& sanitizedValue, bool valueChanged, TextFieldEventBehavior eventBehavior, TextControlSetValueSelection selection)
 {
-    bool emptinessChanged = valueChanged && sanitizedValue.isEmpty() != protectedElement()->value()->isEmpty();
+    bool emptinessChanged = valueChanged && sanitizedValue.isEmpty() != protect(element())->value()->isEmpty();
 
     BaseTextInputType::setValue(sanitizedValue, valueChanged, eventBehavior, selection);
 

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -100,13 +100,13 @@ bool TextFieldInputType::isKeyboardFocusable(const FocusEventData&) const
     if (element()->isReadOnly())
         return false;
 #endif
-    return protectedElement()->isTextFormControlFocusable();
+    return protect(element())->isTextFormControlFocusable();
 }
 
 bool TextFieldInputType::isMouseFocusable() const
 {
     ASSERT(element());
-    return protectedElement()->isTextFormControlFocusable();
+    return protect(element())->isTextFormControlFocusable();
 }
 
 bool TextFieldInputType::isEmptyValue() const
@@ -197,7 +197,7 @@ void TextFieldInputType::handleClickEvent(MouseEvent&)
 void TextFieldInputType::showPicker()
 {
 #if !PLATFORM(IOS_FAMILY)
-    if (protectedElement()->hasDataList())
+    if (protect(element())->hasDataList())
         displaySuggestions(DataListSuggestionActivationType::ControlClicked);
 #endif
 }
@@ -222,7 +222,7 @@ auto TextFieldInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallB
 void TextFieldInputType::handleKeydownEventForSpinButton(KeyboardEvent& event)
 {
     ASSERT(element());
-    if (!protectedElement()->isMutable())
+    if (!protect(element())->isMutable())
         return;
     if (m_suggestionPicker)
         return;
@@ -246,7 +246,7 @@ void TextFieldInputType::forwardEvent(Event& event)
     if (isFocusEvent || isBlurEvent)
         capsLockStateMayHaveChanged();
     if (event.isMouseEvent() || isFocusEvent || isBlurEvent)
-        protectedElement()->forwardEvent(event);
+        protect(element())->forwardEvent(event);
 }
 
 void TextFieldInputType::elementDidBlur()
@@ -286,7 +286,7 @@ void TextFieldInputType::handleBlurEvent()
 {
     InputType::handleBlurEvent();
     ASSERT(element());
-    protectedElement()->endEditing();
+    protect(element())->endEditing();
 }
 
 bool TextFieldInputType::shouldSubmitImplicitly(Event& event)
@@ -300,7 +300,7 @@ RenderPtr<RenderElement> TextFieldInputType::createInputRenderer(RenderStyle&& s
 {
     ASSERT(element());
     // FIXME: https://github.com/llvm/llvm-project/pull/142471 Moving style is not unsafe.
-    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderTextControlSingleLine>(RenderObject::Type::TextControlSingleLine, *protectedElement(), WTF::move(style));
+    SUPPRESS_UNCOUNTED_ARG return createRenderer<RenderTextControlSingleLine>(RenderObject::Type::TextControlSingleLine, *protect(element()), WTF::move(style));
 }
 
 bool TextFieldInputType::needsContainer() const
@@ -311,13 +311,13 @@ bool TextFieldInputType::needsContainer() const
 bool TextFieldInputType::shouldHaveSpinButton() const
 {
     ASSERT(element());
-    return RenderTheme::singleton().shouldHaveSpinButton(*protectedElement());
+    return RenderTheme::singleton().shouldHaveSpinButton(*protect(element()));
 }
 
 bool TextFieldInputType::shouldHaveCapsLockIndicator() const
 {
     ASSERT(element());
-    return RenderTheme::singleton().shouldHaveCapsLockIndicator(*protectedElement());
+    return RenderTheme::singleton().shouldHaveCapsLockIndicator(*protect(element()));
 }
 
 void TextFieldInputType::createShadowSubtree()
@@ -745,7 +745,7 @@ void TextFieldInputType::focusAndSelectSpinButtonOwner()
 bool TextFieldInputType::shouldSpinButtonRespondToMouseEvents() const
 {
     ASSERT(element());
-    return protectedElement()->isMutable();
+    return protect(element())->isMutable();
 }
 
 bool TextFieldInputType::shouldDrawCapsLockIndicator() const
@@ -978,7 +978,7 @@ Vector<DataListSuggestion> TextFieldInputType::suggestions()
 
 void TextFieldInputType::didSelectDataListOption(const String& selectedOption)
 {
-    protectedElement()->setValue(selectedOption, DispatchInputAndChangeEvent);
+    protect(element())->setValue(selectedOption, DispatchInputAndChangeEvent);
 }
 
 void TextFieldInputType::didCloseSuggestions()

--- a/Source/WebCore/html/URLInputType.cpp
+++ b/Source/WebCore/html/URLInputType.cpp
@@ -55,7 +55,7 @@ bool URLInputType::typeMismatchFor(const String& value) const
 bool URLInputType::typeMismatch() const
 {
     ASSERT(element());
-    return typeMismatchFor(protectedElement()->value());
+    return typeMismatchFor(protect(element())->value());
 }
 
 String URLInputType::typeMismatchText() const

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -64,7 +64,6 @@ public:
     WEBCORE_EXPORT void deref() const;
 
     CanvasBase& canvasBase() const { return m_canvas; }
-    Ref<CanvasBase> protectedCanvasBase() const { return m_canvas.get(); }
 
     bool is2dBase() const { return is2d() || isOffscreen2d() || isPaint(); }
     bool is2d() const { return m_type == Type::CanvasElement2D; }

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp
@@ -234,7 +234,7 @@ void CanvasRenderingContext2D::setFontWithoutUpdatingStyle(const String& newFont
 
 inline TextDirection CanvasRenderingContext2D::toTextDirection(Direction direction, const RenderStyle** computedStyle) const
 {
-    auto* style = computedStyle || direction == Direction::Inherit ? protectedCanvas()->existingComputedStyle() : nullptr;
+    auto* style = computedStyle || direction == Direction::Inherit ? protect(canvas())->existingComputedStyle() : nullptr;
     if (computedStyle)
         *computedStyle = style;
     switch (direction) {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2D.h
@@ -41,7 +41,6 @@ public:
     virtual ~CanvasRenderingContext2D();
 
     HTMLCanvasElement& canvas() const { return downcast<HTMLCanvasElement>(canvasBase()); }
-    Ref<HTMLCanvasElement> protectedCanvas() const { return canvas(); }
 
     void drawFocusIfNeeded(Element&);
     void drawFocusIfNeeded(Path2D&, Element&);

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp
@@ -72,7 +72,7 @@ void PlaceholderRenderingContextSource::setPlaceholderBuffer(ImageBuffer& imageB
         RefPtr placeholder = weakPlaceholder.get();
         if (!placeholder)
             return;
-        RefPtr imageBuffer = SerializedImageBuffer::sinkIntoImageBuffer(WTF::move(buffer), protect(placeholder->protectedCanvas()->scriptExecutionContext())->graphicsClient());
+        RefPtr imageBuffer = SerializedImageBuffer::sinkIntoImageBuffer(WTF::move(buffer), protect(protect(placeholder->canvas())->scriptExecutionContext())->graphicsClient());
         if (!imageBuffer)
             return;
         Ref source = placeholder->source();

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -67,7 +67,6 @@ public:
     static std::unique_ptr<PlaceholderRenderingContext> create(HTMLCanvasElement&);
 
     HTMLCanvasElement& canvas() const;
-    Ref<HTMLCanvasElement> protectedCanvas() const { return canvas(); }
     IntSize size() const;
     void setPlaceholderBuffer(Ref<ImageBuffer>&&, bool originClean, bool opaque);
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -296,10 +296,10 @@ RefPtr<WebGLBuffer> WebGL2RenderingContext::validateBufferDataTarget(ASCIILitera
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, functionName, "no buffer"_s);
         return nullptr;
     }
-    if (protectedBoundTransformFeedback()->hasBoundIndexedTransformFeedbackBuffer(buffer.get())) {
+    if (protect(m_boundTransformFeedback.get())->hasBoundIndexedTransformFeedbackBuffer(buffer.get())) {
         ASSERT(buffer != m_boundVertexArrayObject->getElementArrayBuffer());
         if (m_boundIndexedUniformBuffers.contains(buffer)
-            || protectedBoundVertexArrayObject()->hasArrayBuffer(buffer.get())
+            || protect(m_boundVertexArrayObject.get())->hasArrayBuffer(buffer.get())
             || buffer == m_boundArrayBuffer
             || buffer == m_boundCopyReadBuffer
             || buffer == m_boundCopyWriteBuffer
@@ -332,7 +332,7 @@ bool WebGL2RenderingContext::validateAndCacheBufferBinding(const AbstractLocker&
         m_boundCopyWriteBuffer = buffer;
         break;
     case GraphicsContextGL::ELEMENT_ARRAY_BUFFER:
-        protectedBoundVertexArrayObject()->setElementArrayBuffer(locker, buffer);
+        protect(m_boundVertexArrayObject.get())->setElementArrayBuffer(locker, buffer);
         break;
     case GraphicsContextGL::PIXEL_PACK_BUFFER:
         m_boundPixelPackBuffer = buffer;
@@ -1558,7 +1558,7 @@ void WebGL2RenderingContext::vertexAttribIPointer(GCGLuint index, GCGLint size, 
     }
     GCGLsizei bytesPerElement = size * typeSize;
 
-    protectedBoundVertexArrayObject()->setVertexAttribState(locker, index, bytesPerElement, size, type, false, stride, static_cast<GCGLintptr>(offset), true, RefPtr { m_boundArrayBuffer.get() }.get());
+    protect(m_boundVertexArrayObject.get())->setVertexAttribState(locker, index, bytesPerElement, size, type, false, stride, static_cast<GCGLintptr>(offset), true, RefPtr { m_boundArrayBuffer.get() }.get());
     graphicsContextGL()->vertexAttribIPointer(index, size, type, stride, offset);
 }
 
@@ -1652,7 +1652,7 @@ void WebGL2RenderingContext::drawBuffers(const Vector<GCGLenum>& buffers)
                 return;
             }
         }
-        protectedFramebufferBinding()->drawBuffers(buffers);
+        protect(m_framebufferBinding.get())->drawBuffers(buffers);
     }
 }
 
@@ -2286,7 +2286,7 @@ void WebGL2RenderingContext::resumeTransformFeedback()
     if (isContextLost())
         return;
 
-    if (!protectedBoundTransformFeedback()->validateProgramForResume(m_currentProgram.get())) {
+    if (!protect(m_boundTransformFeedback.get())->validateProgramForResume(m_currentProgram.get())) {
         synthesizeGLError(GraphicsContextGL::INVALID_OPERATION, "resumeTransformFeedback"_s, "the current program is not the same as when beginTransformFeedback was called"_s);
         return;
     }
@@ -2339,7 +2339,7 @@ bool WebGL2RenderingContext::setIndexedBufferBinding(ASCIILiteral functionName, 
 
     switch (target) {
     case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER:
-        protectedBoundTransformFeedback()->setBoundIndexedTransformFeedbackBuffer(locker, index, buffer);
+        protect(m_boundTransformFeedback.get())->setBoundIndexedTransformFeedbackBuffer(locker, index, buffer);
         break;
     case GraphicsContextGL::UNIFORM_BUFFER:
         m_boundIndexedUniformBuffers[index] = buffer;
@@ -2379,7 +2379,7 @@ WebGLAny WebGL2RenderingContext::getIndexedParameter(GCGLenum target, GCGLuint i
     switch (target) {
     case GraphicsContextGL::TRANSFORM_FEEDBACK_BUFFER_BINDING: {
         WebGLBuffer* buffer;
-        bool success = protectedBoundTransformFeedback()->getBoundIndexedTransformFeedbackBuffer(index, &buffer);
+        bool success = protect(m_boundTransformFeedback.get())->getBoundIndexedTransformFeedbackBuffer(index, &buffer);
         if (!success) {
             synthesizeGLError(GraphicsContextGL::INVALID_VALUE, "getIndexedParameter"_s, "index out of range"_s);
             return nullptr;
@@ -3529,7 +3529,7 @@ void WebGL2RenderingContext::uncacheDeletedBuffer(const AbstractLocker& locker, 
     REMOVE_BUFFER_FROM_BINDING(m_boundPixelUnpackBuffer);
     REMOVE_BUFFER_FROM_BINDING(m_boundTransformFeedbackBuffer);
     REMOVE_BUFFER_FROM_BINDING(m_boundUniformBuffer);
-    protectedBoundTransformFeedback()->unbindBuffer(locker, *buffer);
+    protect(m_boundTransformFeedback.get())->unbindBuffer(locker, *buffer);
 
     for (auto& boundBuffer : m_boundIndexedUniformBuffers) {
         if (boundBuffer == buffer)

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -317,10 +317,6 @@ private:
     };
     void updateBuffersToAutoClear(ClearBufferCaller, GCGLenum buffer, GCGLint drawbuffer);
 
-    RefPtr<WebGLTransformFeedback> protectedBoundTransformFeedback() const { return m_boundTransformFeedback; }
-    RefPtr<WebGLVertexArrayObjectBase> protectedBoundVertexArrayObject() const { return m_boundVertexArrayObject; }
-    RefPtr<WebGLFramebuffer> protectedFramebufferBinding() const { return m_framebufferBinding; }
-
     WebGLBindingPoint<WebGLFramebuffer> m_readFramebufferBinding;
     WebGLBindingPoint<WebGLTransformFeedback> m_boundTransformFeedback;
     RefPtr<WebGLTransformFeedback> m_defaultTransformFeedback;

--- a/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
+++ b/Source/WebCore/html/canvas/WebGLDrawBuffers.cpp
@@ -78,7 +78,7 @@ void WebGLDrawBuffers::drawBuffersWEBGL(const Vector<GCGLenum>& buffers)
                 return;
             }
         }
-        context->protectedFramebufferBinding()->drawBuffers(buffers);
+        protect(context->m_framebufferBinding.get())->drawBuffers(buffers);
     }
 }
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -1028,9 +1028,6 @@ private:
     void maybeRestoreContextSoon(Seconds timeout = 0_s);
     void maybeRestoreContext();
 
-    RefPtr<WebGLVertexArrayObjectBase> protectedBoundVertexArrayObject() const { return m_boundVertexArrayObject; }
-    RefPtr<WebGLFramebuffer> protectedFramebufferBinding() const { return m_framebufferBinding; }
-
     ExceptionOr<void> texImageSource(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& inputSourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, ImageBitmap& source);
     ExceptionOr<void> texImageSource(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& inputSourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, ImageData& source);
     ExceptionOr<void> texImageSource(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& inputSourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, HTMLImageElement& source);

--- a/Source/WebCore/html/canvas/WebGLSync.cpp
+++ b/Source/WebCore/html/canvas/WebGLSync.cpp
@@ -97,7 +97,7 @@ bool WebGLSync::isSignaled() const
 
 void WebGLSync::scheduleAllowCacheUpdate(WebGLRenderingContextBase& context)
 {
-    context.protectedCanvasBase()->queueTaskKeepingObjectAlive(TaskSource::WebGL, [protectedThis = Ref { *this }](auto&) {
+    protect(context.canvasBase())->queueTaskKeepingObjectAlive(TaskSource::WebGL, [protectedThis = Ref { *this }](auto&) {
         protectedThis->m_allowCacheUpdate = true;
     });
 }

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -75,10 +75,6 @@ struct HTMLConstructionSiteTask {
         return downcast<ContainerNode>(child.get());
     }
 
-    Ref<ContainerNode> protectedNonNullParent() const { return *parent; }
-    Ref<Node> protectedNonNullChild() const { return *child; }
-    Ref<Node> protectedNonNullNextChild() const { return *nextChild; }
-
     Operation operation;
     RefPtr<ContainerNode> parent;
     RefPtr<Node> nextChild;
@@ -166,13 +162,11 @@ public:
     bool isEmpty() const { return !m_openElements.stackDepth(); }
     Element& currentElement() const { return m_openElements.top(); }
     ContainerNode& currentNode() const { return m_openElements.topNode(); }
-    Ref<ContainerNode> protectedCurrentNode() const { return m_openElements.topNode(); }
     ElementName currentElementName() const { return m_openElements.topElementName(); }
     HTMLStackItem& currentStackItem() const { return m_openElements.topStackItem(); }
     HTMLStackItem* oneBelowTop() const { return m_openElements.oneBelowTop(); }
     TreeScope& treeScopeForCurrentNode();
     Document& ownerDocumentForCurrentNode();
-    Ref<Document> protectedOwnerDocumentForCurrentNode() { return ownerDocumentForCurrentNode(); }
     HTMLElementStack& openElements() const { return m_openElements; }
     HTMLFormattingElementList& activeFormattingElements() const { return m_activeFormattingElements; }
     bool currentIsRootNode() { return &m_openElements.topNode() == &m_openElements.rootNode(); }

--- a/Source/WebCore/html/parser/HTMLElementStack.h
+++ b/Source/WebCore/html/parser/HTMLElementStack.h
@@ -55,7 +55,6 @@ public:
         ~ElementRecord();
 
         Element& element() const { return m_item.element(); }
-        Ref<Element> protectedElement() const { return m_item.element(); }
         ContainerNode& node() const { return m_item.node(); }
         ElementName elementName() const { return m_item.elementName(); }
         HTMLStackItem& stackItem() { return m_item; }

--- a/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
+++ b/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
@@ -210,7 +210,7 @@ void HTMLFormattingElementList::ensureNoahsArkCondition(HTMLStackItem& newItem)
     // however, that we will spin the loop more than once because of how the
     // formatting element list gets permuted.
     for (size_t i = kNoahsArkCapacity - 1; i < candidates.size(); ++i)
-        remove(candidates[i]->protectedElement());
+        remove(protect(candidates[i]->element()));
 }
 
 #if ENABLE(TREE_DEBUGGING)

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -161,7 +161,7 @@ public:
         if (!type)
             return nullptr;
 
-        if (m_tagId == TagId::Link && !LinkLoader::isSupportedType(type.value(), m_typeAttribute, protectedDocument()))
+        if (m_tagId == TagId::Link && !LinkLoader::isSupportedType(type.value(), m_typeAttribute, protect(m_document)))
             return nullptr;
 
         // Do not preload if lazyload is possible but metadata fetch is disabled.
@@ -393,7 +393,7 @@ private:
             if (m_linkIsStyleSheet)
                 return CachedResource::Type::CSSStyleSheet;
             if (m_linkIsPreload)
-                return LinkLoader::resourceTypeFromAsAttribute(m_asAttribute, protectedDocument());
+                return LinkLoader::resourceTypeFromAsAttribute(m_asAttribute, protect(m_document));
             break;
         case TagId::Meta:
         case TagId::Unknown:
@@ -423,8 +423,6 @@ private:
 
         return true;
     }
-
-    Ref<Document> protectedDocument() const { return m_document.get(); }
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     TagId m_tagId;

--- a/Source/WebCore/html/parser/HTMLStackItem.h
+++ b/Source/WebCore/html/parser/HTMLStackItem.h
@@ -53,7 +53,6 @@ public:
 
     ContainerNode& node() const { return *m_node; }
     Element& element() const { return downcast<Element>(node()); }
-    Ref<Element> protectedElement() const { return element(); }
     Element* elementOrNull() const { return downcast<Element>(m_node.get()); }
 
     const AtomString& localName() const { return isElement() ? element().localName() : nullAtom(); }

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -1694,7 +1694,7 @@ void HTMLTreeBuilder::callTheAdoptionAgency(AtomHTMLToken& token)
             // 4.13.5.
             auto* nodeEntry = m_tree.activeFormattingElements().find(node->element());
             if (!nodeEntry) {
-                m_tree.openElements().remove(node->protectedElement());
+                m_tree.openElements().remove(protect(node->element()));
                 node = nullptr;
                 continue;
             }

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -149,8 +149,8 @@ void RenderSliderContainer::layout()
         mutableStyle->setDirection(TextDirection::LTR);
     }
 
-    CheckedPtr thumb = input->sliderThumbElement() ? input->protectedSliderThumbElement()->renderBox() : nullptr;
-    CheckedPtr track = input->sliderTrackElement() ? input->protectedSliderTrackElement()->renderBox() : nullptr;
+    CheckedPtr thumb = input->sliderThumbElement() ? protect(input->sliderThumbElement())->renderBox() : nullptr;
+    CheckedPtr track = input->sliderTrackElement() ? protect(input->sliderTrackElement())->renderBox() : nullptr;
     // Force a layout to reset the position of the thumb so the code below doesn't move the thumb to the wrong place.
     // FIXME: Make a custom Render class for the track and move the thumb positioning code there.
     if (track)
@@ -247,7 +247,7 @@ void SliderThumbElement::setPositionFromPoint(const LayoutPoint& absolutePoint)
         return;
 
     ASSERT(input->sliderTrackElement());
-    CheckedPtr trackRenderer = input->protectedSliderTrackElement()->renderBox();
+    CheckedPtr trackRenderer = protect(input->sliderTrackElement())->renderBox();
     if (!trackRenderer)
         return;
 

--- a/Source/WebCore/html/track/AudioTrack.cpp
+++ b/Source/WebCore/html/track/AudioTrack.cpp
@@ -98,7 +98,7 @@ void AudioTrack::setPrivate(AudioTrackPrivate& trackPrivate)
     addClientToTrackPrivateBase(*this, trackPrivate);
 
 #if !RELEASE_LOG_DISABLED
-    trackPrivate.setLogger(protectedLogger(), logIdentifier());
+    trackPrivate.setLogger(protect(logger()), logIdentifier());
 #endif
 
     updateKindFromPrivate();

--- a/Source/WebCore/html/track/DataCue.cpp
+++ b/Source/WebCore/html/track/DataCue.cpp
@@ -104,7 +104,7 @@ DataCue::~DataCue() = default;
 RefPtr<ArrayBuffer> DataCue::data() const
 {
     if (m_platformValue)
-        return protectedPlatformValue()->data();
+        return protect(platformValue())->data();
 
     if (!m_data)
         return nullptr;
@@ -135,7 +135,7 @@ bool DataCue::cueContentsMatch(const TextTrackCue& cue) const
     RefPtr otherPlatformValue = dataCue->platformValue();
     if ((otherPlatformValue && !m_platformValue) || (!otherPlatformValue && m_platformValue))
         return false;
-    if (m_platformValue && !protectedPlatformValue()->isEqual(*otherPlatformValue))
+    if (m_platformValue && !protect(platformValue())->isEqual(*otherPlatformValue))
         return false;
 
     JSC::JSValue thisValue = valueOrNull();
@@ -151,7 +151,7 @@ bool DataCue::cueContentsMatch(const TextTrackCue& cue) const
 JSC::JSValue DataCue::value(JSC::JSGlobalObject& state) const
 {
     if (m_platformValue)
-        return protectedPlatformValue()->deserialize(&state);
+        return protect(platformValue())->deserialize(&state);
 
     if (m_value)
         return m_value.get();

--- a/Source/WebCore/html/track/DataCue.h
+++ b/Source/WebCore/html/track/DataCue.h
@@ -57,7 +57,6 @@ public:
     ExceptionOr<void> setData(JSC::ArrayBuffer*);
 
     const SerializedPlatformDataCue* platformValue() const { return m_platformValue.get(); }
-    RefPtr<const SerializedPlatformDataCue> protectedPlatformValue() const { return m_platformValue.get(); }
 
     JSC::JSValue value(JSC::JSGlobalObject&) const;
     void setValue(JSC::JSGlobalObject&, JSC::JSValue);

--- a/Source/WebCore/html/track/InbandDataTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandDataTextTrack.cpp
@@ -93,8 +93,8 @@ void InbandDataTextTrack::addDataCue(const MediaTime& start, const MediaTime& en
 
 RefPtr<DataCue> InbandDataTextTrack::findIncompleteCue(const SerializedPlatformDataCue& cueToFind)
 {
-    auto index = m_incompleteCueMap.findIf([&](const auto& cue) {
-        return cueToFind.isEqual(Ref { *cue->protectedPlatformValue() });
+    auto index = m_incompleteCueMap.findIf([&](const Ref<DataCue>& cue) {
+        return cueToFind.isEqual(*protect(cue->platformValue()));
     });
 
     if (index == notFound)

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -85,7 +85,6 @@ public:
 #if !RELEASE_LOG_DISABLED
     virtual void setLogger(const Logger&, uint64_t);
     const Logger& logger() const final { ASSERT(m_logger); return *m_logger.get(); }
-    Ref<const Logger> protectedLogger() const { return logger(); }
     uint64_t logIdentifier() const final { return m_logIdentifier; }
     WTFLogChannel& logChannel() const final;
 #endif

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -514,7 +514,7 @@ RefPtr<DocumentFragment> VTTCue::getCueAsHTML()
         return nullptr;
 
     auto clonedFragment = DocumentFragment::create(*document);
-    copyWebVTTNodeToDOMTree(*protectedWebVTTNodeTree(), clonedFragment);
+    copyWebVTTNodeToDOMTree(*protect(m_webVTTNodeTree), clonedFragment);
     return clonedFragment;
 }
 
@@ -533,7 +533,7 @@ RefPtr<DocumentFragment> VTTCue::createCueRenderingTree()
     // The cloned fragment is never exposed to author scripts so it's safe to dispatch events here.
     ScriptDisallowedScope::EventAllowedScope allowedScope(clonedFragment);
 
-    protectedWebVTTNodeTree()->cloneChildNodes(*document, nullptr, clonedFragment);
+    protect(m_webVTTNodeTree)->cloneChildNodes(*document, nullptr, clonedFragment);
     return clonedFragment;
 }
 

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -260,8 +260,6 @@ private:
     void pauseSpeaking() final;
     void cancelSpeaking() final;
 
-    RefPtr<DocumentFragment> protectedWebVTTNodeTree() const { return m_webVTTNodeTree.get(); }
-
 #if !RELEASE_LOG_DISABLED
     const Logger& logger() const final { return *m_logger; }
     uint64_t logIdentifier() const final;

--- a/Source/WebCore/html/track/VideoTrack.cpp
+++ b/Source/WebCore/html/track/VideoTrack.cpp
@@ -82,7 +82,7 @@ void VideoTrack::setPrivate(VideoTrackPrivate& trackPrivate)
     m_private = trackPrivate;
     addClientToTrackPrivateBase(*this, trackPrivate);
 #if !RELEASE_LOG_DISABLED
-    trackPrivate.setLogger(protectedLogger().get(), logIdentifier());
+    trackPrivate.setLogger(protect(logger()), logIdentifier());
 #endif
 
     trackPrivate.setSelected(m_selected);

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -520,7 +520,6 @@ private:
     void constructTreeFromToken(Document&);
 
     WebVTTNodeType currentType() const { return m_typeStack.isEmpty() ? WebVTTNodeTypeNone : m_typeStack.last(); }
-    RefPtr<ContainerNode> protectedCurrentNode() const { return m_currentNode.get(); }
 
     WebVTTToken m_token;
     Vector<WebVTTNodeType> m_typeStack;
@@ -700,7 +699,7 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
 
     switch (m_token.type()) {
     case WebVTTTokenTypes::Character: {
-        protectedCurrentNode()->parserAppendChild(Text::create(document, String { m_token.characters() }));
+        protect(m_currentNode)->parserAppendChild(Text::create(document, String { m_token.characters() }));
         break;
     }
     case WebVTTTokenTypes::StartTag: {
@@ -723,7 +722,7 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
             m_languageStack.append(m_token.annotation());
             child->setAttributeWithoutSynchronization(WebVTTElement::langAttributeName(), m_languageStack.last());
         }
-        protectedCurrentNode()->parserAppendChild(child);
+        protect(m_currentNode)->parserAppendChild(child);
         m_currentNode = WTF::move(child);
         m_typeStack.append(nodeType);
         break;
@@ -760,7 +759,7 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
     case WebVTTTokenTypes::TimestampTag: {
         MediaTime parsedTimeStamp;
         if (WebVTTParser::collectTimeStamp(m_token.characters(), parsedTimeStamp))
-            protectedCurrentNode()->parserAppendChild(ProcessingInstruction::create(document, "timestamp"_s, serializeTimestamp(parsedTimeStamp.toDouble())));
+            protect(m_currentNode)->parserAppendChild(ProcessingInstruction::create(document, "timestamp"_s, serializeTimestamp(parsedTimeStamp.toDouble())));
         break;
     }
     default:

--- a/Source/WebCore/inspector/InspectorNodeFinder.cpp
+++ b/Source/WebCore/inspector/InspectorNodeFinder.cpp
@@ -92,7 +92,7 @@ void InspectorNodeFinder::searchUsingDOMTreeTraversal(Node& parentNode)
             if (matchesElement(downcast<Element>(*node)))
                 m_results.add(node);
             if (RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(*node))
-                performSearch(frameOwner->protectedContentDocument().get());
+                performSearch(protect(frameOwner->contentDocument()).get());
             break;
         default:
             break;

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -2049,7 +2049,7 @@ Ref<Inspector::Protocol::DOM::Node> InspectorDOMAgent::buildObjectForNode(Node* 
         }
 
         if (RefPtr templateElement = dynamicDowncast<HTMLTemplateElement>(*element))
-            value->setTemplateContent(buildObjectForNode(templateElement->protectedContent().ptr(), 0));
+            value->setTemplateContent(buildObjectForNode(protect(templateElement->content()).ptr(), 0));
 
         if (is<HTMLStyleElement>(element) || (is<HTMLScriptElement>(element) && !element->hasAttributeWithoutSynchronization(HTMLNames::srcAttr)))
             value->setContentSecurityPolicyHash(computeContentSecurityPolicySHA256Hash(*element));

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -3149,7 +3149,7 @@ RefPtr<HTMLMediaElement> Page::bestMediaElementForRemoteControls(MediaElementSes
         if (!mediaElementSession)
             return false;
 
-        RefPtr element = mediaElementSession->element().get();
+        RefPtr element = mediaElementSession->element();
         if (!element)
             return false;
 
@@ -3157,7 +3157,7 @@ RefPtr<HTMLMediaElement> Page::bestMediaElementForRemoteControls(MediaElementSes
     }, purpose);
 
     if (RefPtr mediaElementSession = dynamicDowncast<MediaElementSession>(selectedSession.get()))
-        return mediaElementSession->protectedElement();
+        return mediaElementSession->element();
 
     return nullptr;
 }

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -102,7 +102,7 @@ void RenderSlider::computePreferredLogicalWidths()
 
 bool RenderSlider::inDragMode() const
 {
-    return protect(element())->protectedSliderThumbElement()->active();
+    return protect(protect(element())->sliderThumbElement())->active();
 }
 
 double RenderSlider::valueRatio() const

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4689,7 +4689,7 @@ Vector<String> Internals::mediaResponseContentRanges(HTMLMediaElement& media)
 void Internals::simulateAudioInterruption(HTMLMediaElement& element)
 {
 #if USE(GSTREAMER)
-    element.protectedPlayer()->simulateAudioInterruption();
+    protect(element.player())->simulateAudioInterruption();
 #else
     UNUSED_PARAM(element);
 #endif

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -894,7 +894,7 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
         return;
 
     if (RefPtr templateElement = dynamicDowncast<HTMLTemplateElement>(newElement))
-        pushCurrentNode(&templateElement->protectedContent().get());
+        pushCurrentNode(&protect(templateElement->content()).get());
     else
         pushCurrentNode(newElement.ptr());
 


### PR DESCRIPTION
#### 2295e5dad4df5c406c221fb5a1ffb085462170fa
<pre>
Reduce use of protected functions in Source/WebCore/html
<a href="https://bugs.webkit.org/show_bug.cgi?id=307231">https://bugs.webkit.org/show_bug.cgi?id=307231</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/WebGPU/GPUExternalTextureDescriptor.h:
(WebCore::GPUExternalTextureDescriptor::mediaIdentifierForSource):
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::allowsInlineMediaPlayback const):
(WebCore::MediaControlsHost::userGestureRequired const):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpIfTerminal):
* Source/WebCore/dom/Node.cpp:
(WebCore::showSubTreeAcrossFrame):
* Source/WebCore/html/BaseButtonInputType.cpp:
(WebCore::BaseButtonInputType::createInputRenderer):
* Source/WebCore/html/BaseCheckableInputType.cpp:
(WebCore::BaseCheckableInputType::restoreFormControlState):
(WebCore::BaseCheckableInputType::handleKeydownEvent):
(WebCore::BaseCheckableInputType::accessKeyAction):
(WebCore::BaseCheckableInputType::setValue):
* Source/WebCore/html/BaseClickableWithKeyInputType.cpp:
(WebCore::BaseClickableWithKeyInputType::handleKeydownEvent):
(WebCore::BaseClickableWithKeyInputType::handleKeypressEvent):
(WebCore::BaseClickableWithKeyInputType::accessKeyAction):
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::setValueAsDate const):
(WebCore::BaseDateAndTimeInputType::valueAsDouble const):
(WebCore::BaseDateAndTimeInputType::setValueAsDecimal const):
(WebCore::BaseDateAndTimeInputType::typeMismatch const):
(WebCore::BaseDateAndTimeInputType::hasBadInput const):
(WebCore::BaseDateAndTimeInputType::serializeWithComponents const):
(WebCore::BaseDateAndTimeInputType::localizeValue const):
(WebCore::BaseDateAndTimeInputType::visibleValue const):
(WebCore::BaseDateAndTimeInputType::valueMissing const):
(WebCore::BaseDateAndTimeInputType::isMouseFocusable const):
(WebCore::BaseDateAndTimeInputType::handleDOMActivateEvent):
(WebCore::BaseDateAndTimeInputType::updateInnerTextValue):
(WebCore::BaseDateAndTimeInputType::handleKeydownEvent):
(WebCore::BaseDateAndTimeInputType::handleKeypressEvent):
(WebCore::BaseDateAndTimeInputType::handleFocusEvent):
(WebCore::BaseDateAndTimeInputType::accessKeyAction):
(WebCore::BaseDateAndTimeInputType::didChangeValueFromControl):
(WebCore::BaseDateAndTimeInputType::isEditControlOwnerReadOnly const):
(WebCore::BaseDateAndTimeInputType::localeIdentifier const):
(WebCore::BaseDateAndTimeInputType::didChooseValue):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
(WebCore::BaseDateAndTimeInputType::protectedDateTimeEditElement const): Deleted.
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::handleMouseMoveEvent):
(WebCore::CheckboxInputType::stopSwitchPointerTracking):
(WebCore::CheckboxInputType::disabledStateChanged):
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::ColorInputType::isMouseFocusable const):
(WebCore::ColorInputType::fallbackValue const):
(WebCore::ColorInputType::createShadowSubtree):
(WebCore::ColorInputType::didEndChooser):
(WebCore::ColorInputType::shadowColorSwatch const):
(WebCore::ColorInputType::supportsAlpha const):
(WebCore::ColorInputType::selectColor):
* Source/WebCore/html/EmailInputType.cpp:
(WebCore::EmailInputType::typeMismatchFor const):
(WebCore::EmailInputType::typeMismatch const):
(WebCore::EmailInputType::typeMismatchText const):
(WebCore::EmailInputType::sanitizeValue const):
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::valueMissingText const):
(WebCore::FileInputType::handleDOMActivateEvent):
(WebCore::FileInputType::showPicker):
(WebCore::FileInputType::createInputRenderer):
(WebCore::FileInputType::firstElementPathForInputValue const):
(WebCore::FileInputType::setValue):
(WebCore::FileInputType::fileChooserSettings const):
(WebCore::FileInputType::setFiles):
(WebCore::FileInputType::filesChosen):
(WebCore::FileInputType::fileChoosingCancelled):
(WebCore::FileInputType::defaultToolTip const):
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/html/FormAssociatedCustomElement.cpp:
(WebCore::FormAssociatedCustomElement::didChangeForm):
* Source/WebCore/html/FormAssociatedElement.h:
(WebCore::FormAssociatedElement::form const):
(WebCore::FormAssociatedElement::protectedForm const): Deleted.
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::toDataURL):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLCollection.h:
(WebCore::HTMLCollection::ownerNode const):
(WebCore::HTMLCollection::protectedOwnerNode const): Deleted.
* Source/WebCore/html/HTMLFormControlsCollection.cpp:
(WebCore::HTMLFormControlsCollection::namedItemOrItems const):
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::setLocation):
* Source/WebCore/html/HTMLFrameOwnerElement.h:
(WebCore::HTMLFrameOwnerElement::protectedContentDocument const): Deleted.
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::mediaElementSessionInfoForSession):
(WebCore::HTMLMediaElement::isNowPlayingEligible const):
(WebCore::HTMLMediaElement::nowPlayingInfo const):
(WebCore::HTMLMediaElement::registerWithDocument):
(WebCore::HTMLMediaElement::prepareForDocumentSuspension):
(WebCore::HTMLMediaElement::resumeFromDocumentSuspension):
(WebCore::HTMLMediaElement::attributeChanged):
(WebCore::HTMLMediaElement::checkPlaybackTargetCompatibility):
(WebCore::HTMLMediaElement::maybeUpdatePlayerPreload const):
(WebCore::HTMLMediaElement::mediaPlayerNetworkStateChanged):
(WebCore::HTMLMediaElement::mediaPlayerReadyStateChanged):
(WebCore::HTMLMediaElement::setReadyState):
(WebCore::HTMLMediaElement::seekWithTolerance):
(WebCore::HTMLMediaElement::play):
(WebCore::HTMLMediaElement::pause):
(WebCore::HTMLMediaElement::setVolume):
(WebCore::HTMLMediaElement::setVolumeLocked):
(WebCore::HTMLMediaElement::beginScrubbing):
(WebCore::HTMLMediaElement::mediaPlayerDidAddAudioTrack):
(WebCore::HTMLMediaElement::addAudioTrack):
(WebCore::HTMLMediaElement::addTextTrack):
(WebCore::HTMLMediaElement::addVideoTrack):
(WebCore::HTMLMediaElement::mediaPlayerTimeChanged):
(WebCore::HTMLMediaElement::addBehaviorRestrictionsOnEndIfNecessary):
(WebCore::HTMLMediaElement::seekToPlaybackPositionEndedTimerFired):
(WebCore::HTMLMediaElement::mediaPlayerRateChanged):
(WebCore::HTMLMediaElement::mediaEngineWasUpdated):
(WebCore::HTMLMediaElement::mediaPlayerCharacteristicChanged):
(WebCore::HTMLMediaElement::playPlayer):
(WebCore::HTMLMediaElement::visibilityStateChanged):
(WebCore::HTMLMediaElement::webkitShowPlaybackTargetPicker):
(WebCore::HTMLMediaElement::wirelessRoutesAvailableDidChange):
(WebCore::HTMLMediaElement::enqueuePlaybackTargetAvailabilityChangedEvent):
(WebCore::HTMLMediaElement::remoteHasAvailabilityCallbacksChanged):
(WebCore::HTMLMediaElement::playbackTargetType const):
(WebCore::HTMLMediaElement::removeEventListener):
(WebCore::HTMLMediaElement::exitFullscreen):
(WebCore::HTMLMediaElement::configureMediaControls):
(WebCore::HTMLMediaElement::mediaPlayerIsFullscreenPermitted const):
(WebCore::HTMLMediaElement::removeBehaviorRestrictionsAfterFirstUserGesture):
(WebCore::HTMLMediaElement::updateMediaState):
(WebCore::HTMLMediaElement::mediaState const):
(WebCore::HTMLMediaElement::purgeBufferedDataIfPossible):
(WebCore::HTMLMediaElement::allowsMediaDocumentInlinePlaybackChanged):
(WebCore::HTMLMediaElement::updateShouldPlay):
(WebCore::HTMLMediaElement::canProduceAudioChanged):
* Source/WebCore/html/HTMLMediaElement.h:
(WebCore::HTMLMediaElement::player const):
(WebCore::HTMLMediaElement::didPassCORSAccessCheck const):
(WebCore::MediaElementSession::element const):
(WebCore::HTMLMediaElement::protectedPlayer const): Deleted.
(WebCore::HTMLMediaElement::protectedMediaSession const): Deleted.
* Source/WebCore/html/HTMLTableRowsCollection.cpp:
(WebCore::HTMLTableRowsCollection::customElementAfter const):
* Source/WebCore/html/HTMLTableRowsCollection.h:
* Source/WebCore/html/HTMLTemplateElement.h:
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/html/HiddenInputType.cpp:
(WebCore::HiddenInputType::restoreFormControlState):
(WebCore::HiddenInputType::setValue):
* Source/WebCore/html/ImageDataArray.h:
(WebCore::ImageDataArray::byteLength const):
(WebCore::ImageDataArray::isDetached const):
(WebCore::ImageDataArray::protectedArrayBufferView const): Deleted.
* Source/WebCore/html/ImageInputType.cpp:
(WebCore::ImageInputType::createInputRenderer):
(WebCore::ImageInputType::attach):
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::restoreFormControlState):
(WebCore::InputType::isFormDataAppendable const):
(WebCore::InputType::createInputRenderer):
(WebCore::InputType::blur):
(WebCore::InputType::removeShadowSubtree):
(WebCore::InputType::isMouseFocusable const):
(WebCore::InputType::accessKeyAction):
(WebCore::InputType::visibleValue const):
(WebCore::InputType::resultForDialogSubmit const):
(WebCore::InputType::createShadowSubtreeIfNeeded):
(WebCore::InputType::hasTouchEventHandler const):
* Source/WebCore/html/InputType.h:
(WebCore::InputType::element const):
(WebCore::InputType::protectedElement const): Deleted.
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::protectedElement const): Deleted.
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/html/MonthInputType.cpp:
(WebCore::MonthInputType::valueAsDate const):
* Source/WebCore/html/NumberInputType.cpp:
(WebCore::NumberInputType::setValue):
(WebCore::NumberInputType::valueAsDouble const):
(WebCore::NumberInputType::setValueAsDouble const):
(WebCore::NumberInputType::setValueAsDecimal const):
(WebCore::NumberInputType::typeMismatch const):
(WebCore::NumberInputType::decorationWidth const):
(WebCore::NumberInputType::handleBeforeTextInsertedEvent):
(WebCore::NumberInputType::localizeValue const):
(WebCore::NumberInputType::visibleValue const):
(WebCore::NumberInputType::convertFromVisibleValue const):
(WebCore::NumberInputType::hasBadInput const):
* Source/WebCore/html/RangeInputType.cpp:
(WebCore::RangeInputType::valueAsDouble const):
(WebCore::RangeInputType::setValueAsDecimal const):
(WebCore::RangeInputType::sliderTrackElement const):
(WebCore::RangeInputType::createInputRenderer):
* Source/WebCore/html/SearchInputType.cpp:
(WebCore::SearchInputType::menuStyle const):
(WebCore::SearchInputType::clientPaddingLeft const):
(WebCore::SearchInputType::clientPaddingRight const):
(WebCore::SearchInputType::fontSelector const):
(WebCore::SearchInputType::hostWindow const):
(WebCore::SearchInputType::popupDidHide):
(WebCore::SearchInputType::setTextFromItem):
(WebCore::SearchInputType::createInputRenderer):
(WebCore::SearchInputType::setValue):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::isKeyboardFocusable const):
(WebCore::TextFieldInputType::isMouseFocusable const):
(WebCore::TextFieldInputType::showPicker):
(WebCore::TextFieldInputType::handleKeydownEventForSpinButton):
(WebCore::TextFieldInputType::forwardEvent):
(WebCore::TextFieldInputType::handleBlurEvent):
(WebCore::TextFieldInputType::createInputRenderer):
(WebCore::TextFieldInputType::shouldHaveSpinButton const):
(WebCore::TextFieldInputType::shouldHaveCapsLockIndicator const):
(WebCore::TextFieldInputType::shouldSpinButtonRespondToMouseEvents const):
(WebCore::TextFieldInputType::didSelectDataListOption):
* Source/WebCore/html/URLInputType.cpp:
(WebCore::URLInputType::typeMismatch const):
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
(WebCore::CanvasRenderingContext::canvasBase const):
(WebCore::CanvasRenderingContext::protectedCanvasBase const): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext2D.cpp:
(WebCore::CanvasRenderingContext2D::toTextDirection const):
* Source/WebCore/html/canvas/CanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContextSource::setPlaceholderBuffer):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::validateBufferDataTarget):
(WebCore::WebGL2RenderingContext::validateAndCacheBufferBinding):
(WebCore::WebGL2RenderingContext::vertexAttribIPointer):
(WebCore::WebGL2RenderingContext::drawBuffers):
(WebCore::WebGL2RenderingContext::resumeTransformFeedback):
(WebCore::WebGL2RenderingContext::setIndexedBufferBinding):
(WebCore::WebGL2RenderingContext::getIndexedParameter):
(WebCore::WebGL2RenderingContext::uncacheDeletedBuffer):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLDrawBuffers.cpp:
(WebCore::WebGLDrawBuffers::drawBuffersWEBGL):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::surfaceBufferToImageBuffer):
(WebCore::WebGLRenderingContextBase::validateAndCacheBufferBinding):
(WebCore::WebGLRenderingContextBase::uncacheDeletedBuffer):
(WebCore::WebGLRenderingContextBase::deleteRenderbuffer):
(WebCore::WebGLRenderingContextBase::deleteTexture):
(WebCore::WebGLRenderingContextBase::disableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::validateVertexArrayObject):
(WebCore::WebGLRenderingContextBase::enableVertexAttribArray):
(WebCore::WebGLRenderingContextBase::getParameter):
(WebCore::WebGLRenderingContextBase::getVertexAttrib):
(WebCore::WebGLRenderingContextBase::vertexAttribPointer):
(WebCore::WebGLRenderingContextBase::scheduleTaskToDispatchContextLostEvent):
(WebCore::WebGLRenderingContextBase::maybeRestoreContextSoon):
(WebCore::WebGLRenderingContextBase::vertexAttribDivisor):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
(WebCore::WebGLRenderingContextBase::protectedBoundVertexArrayObject const): Deleted.
(WebCore::WebGLRenderingContextBase::protectedFramebufferBinding const): Deleted.
* Source/WebCore/html/canvas/WebGLSync.cpp:
(WebCore::WebGLSync::scheduleAllowCacheUpdate):
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::insert):
(WebCore::executeReparentTask):
(WebCore::executeTakeAllChildrenAndReparentTask):
(WebCore::HTMLConstructionSite::insertComment):
(WebCore::HTMLConstructionSite::insertHTMLHeadElement):
(WebCore::HTMLConstructionSite::insertHTMLBodyElement):
(WebCore::HTMLConstructionSite::insertHTMLFormElement):
(WebCore::HTMLConstructionSite::insertHTMLElement):
(WebCore::HTMLConstructionSite::insertHTMLElementOrFindCustomElementInterface):
(WebCore::HTMLConstructionSite::insertCustomElement):
(WebCore::HTMLConstructionSite::insertSelfClosingHTMLElement):
(WebCore::HTMLConstructionSite::insertScriptElement):
(WebCore::HTMLConstructionSite::insertForeignElement):
(WebCore::HTMLConstructionSite::reconstructTheActiveFormattingElements):
* Source/WebCore/html/parser/HTMLConstructionSite.h:
(WebCore::HTMLConstructionSite::currentNode const):
(WebCore::HTMLConstructionSiteTask::protectedNonNullParent const): Deleted.
(WebCore::HTMLConstructionSiteTask::protectedNonNullChild const): Deleted.
(WebCore::HTMLConstructionSiteTask::protectedNonNullNextChild const): Deleted.
(WebCore::HTMLConstructionSite::protectedCurrentNode const): Deleted.
(WebCore::HTMLConstructionSite::protectedOwnerDocumentForCurrentNode): Deleted.
* Source/WebCore/html/parser/HTMLElementStack.h:
(WebCore::HTMLElementStack::ElementRecord::element const):
(WebCore::HTMLElementStack::ElementRecord::protectedElement const): Deleted.
* Source/WebCore/html/parser/HTMLFormattingElementList.cpp:
(WebCore::HTMLFormattingElementList::ensureNoahsArkCondition):
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::createPreloadRequest):
(WebCore::TokenPreloadScanner::StartTagScanner::resourceType const):
(WebCore::TokenPreloadScanner::StartTagScanner::protectedDocument const): Deleted.
* Source/WebCore/html/parser/HTMLStackItem.h:
(WebCore::HTMLStackItem::element const):
(WebCore::HTMLStackItem::protectedElement const): Deleted.
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::HTMLTreeBuilder::callTheAdoptionAgency):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::RenderSliderContainer::layout):
(WebCore::SliderThumbElement::setPositionFromPoint):
* Source/WebCore/html/track/AudioTrack.cpp:
(WebCore::AudioTrack::setPrivate):
* Source/WebCore/html/track/DataCue.cpp:
(WebCore::DataCue::data const):
(WebCore::DataCue::cueContentsMatch const):
(WebCore::DataCue::value const):
* Source/WebCore/html/track/DataCue.h:
* Source/WebCore/html/track/InbandDataTextTrack.cpp:
(WebCore::InbandDataTextTrack::findIncompleteCue):
* Source/WebCore/html/track/TrackBase.h:
(WebCore::TrackBase::protectedLogger const): Deleted.
* Source/WebCore/html/track/VTTCue.cpp:
(WebCore::VTTCue::getCueAsHTML):
(WebCore::VTTCue::createCueRenderingTree):
* Source/WebCore/html/track/VTTCue.h:
(WebCore::VTTCue::protectedWebVTTNodeTree const): Deleted.
* Source/WebCore/html/track/VideoTrack.cpp:
(WebCore::VideoTrack::setPrivate):
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTTreeBuilder::currentType const):
(WebCore::WebVTTTreeBuilder::constructTreeFromToken):
(WebCore::WebVTTTreeBuilder::protectedCurrentNode const): Deleted.
* Source/WebCore/inspector/InspectorNodeFinder.cpp:
(WebCore::InspectorNodeFinder::searchUsingDOMTreeTraversal):
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::buildObjectForNode):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::bestMediaElementForRemoteControls):
* Source/WebCore/rendering/RenderSlider.cpp:
(WebCore::RenderSlider::inDragMode const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::simulateAudioInterruption):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):

Canonical link: <a href="https://commits.webkit.org/307021@main">https://commits.webkit.org/307021@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45af078c746d15b69e8bd6404033dc5009cef085

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143085 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6357 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151759 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/258b3d9a-d91f-4ded-9c13-a8f089b5e8ca) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144952 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16220 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15641 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110036 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06e24853-f615-4569-a9b0-80910c8ce28b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146034 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12485 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128033 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90946 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81eccc59-f745-460f-a05e-9164ed0a3643) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11965 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9666 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1758 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4554 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154072 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118052 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15388 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118393 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30329 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14329 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70915 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15229 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4324 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14963 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78948 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15174 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15025 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->