### PR TITLE
[GStreamer] Remove un-used GObect finalize methods

### DIFF
--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp
@@ -32,12 +32,20 @@
 using namespace WebCore;
 
 struct _GStreamerMockDeviceProviderPrivate {
+    ~_GStreamerMockDeviceProviderPrivate();
 };
 
 GST_DEBUG_CATEGORY_STATIC(webkitGstMockDeviceProviderDebug);
 #define GST_CAT_DEFAULT webkitGstMockDeviceProviderDebug
 
 WEBKIT_DEFINE_TYPE_WITH_CODE(GStreamerMockDeviceProvider, webkit_mock_device_provider, GST_TYPE_DEVICE_PROVIDER, GST_DEBUG_CATEGORY_INIT(webkitGstMockDeviceProviderDebug, "webkitmockdeviceprovider", 0, "Mock Device Provider"))
+
+static GStreamerMockDeviceProvider* s_provider = nullptr;
+
+_GStreamerMockDeviceProviderPrivate::~_GStreamerMockDeviceProviderPrivate()
+{
+    s_provider = nullptr;
+}
 
 static GList* webkitMockDeviceProviderProbe(GstDeviceProvider* provider)
 {
@@ -58,13 +66,6 @@ static GList* webkitMockDeviceProviderProbe(GstDeviceProvider* provider)
 
     devices = g_list_reverse(devices);
     return devices;
-}
-
-static GStreamerMockDeviceProvider* s_provider = nullptr;
-
-GStreamerMockDeviceProvider* webkitGstMockDeviceProviderSingleton()
-{
-    return s_provider;
 }
 
 void webkitGstMockDeviceProviderSwitchDefaultDevice(const CaptureDevice& oldDevice, const CaptureDevice& newDevice)
@@ -117,17 +118,10 @@ static void webkitMockDeviceProviderConstructed(GObject* object)
     s_provider = WEBKIT_MOCK_DEVICE_PROVIDER(object);
 }
 
-static void webkitMockDeviceProviderFinalize(GObject* object)
-{
-    s_provider = nullptr;
-    G_OBJECT_CLASS(webkit_mock_device_provider_parent_class)->finalize(object);
-}
-
 static void webkit_mock_device_provider_class_init(GStreamerMockDeviceProviderClass* klass)
 {
     auto gobjectClass = G_OBJECT_CLASS(klass);
     gobjectClass->constructed = webkitMockDeviceProviderConstructed;
-    gobjectClass->finalize = webkitMockDeviceProviderFinalize;
 
     auto providerClass = GST_DEVICE_PROVIDER_CLASS(klass);
     providerClass->probe = GST_DEBUG_FUNCPTR(webkitMockDeviceProviderProbe);


### PR DESCRIPTION
#### 8545149b699b82b5a822c6000e4852b54c56c585
<pre>
[GStreamer] Remove un-used GObect finalize methods
<a href="https://bugs.webkit.org/show_bug.cgi?id=307235">https://bugs.webkit.org/show_bug.cgi?id=307235</a>

Reviewed by Xabier Rodriguez-Calvar.

The `finalize` method overrides in GObject classes defined with the WEBKIT_DEFINE_TYPE macro are not
called, the one defined by that macro is called instead. Clean-up code should go in the private
struct destructor.

* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(_WebKitGLVideoSinkPrivate::~_WebKitGLVideoSinkPrivate):
(webkit_gl_video_sink_class_init):
(webKitGLVideoSinkFinalize): Deleted.
* Source/WebCore/platform/mediastream/gstreamer/GStreamerMockDeviceProvider.cpp:
(_GStreamerMockDeviceProviderPrivate::~_GStreamerMockDeviceProviderPrivate):
(webkit_mock_device_provider_class_init):
(webkitGstMockDeviceProviderSingleton): Deleted.
(webkitMockDeviceProviderFinalize): Deleted.

Canonical link: <a href="https://commits.webkit.org/307065@main">https://commits.webkit.org/307065@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec8257c0531ae3772edb41f87eb1febe63e94415

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151755 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96302 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144948 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16216 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110032 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12481 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90942 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11989 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9662 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1754 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121368 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154068 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15347 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5346 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118048 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15372 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118389 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30361 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14320 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70896 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15225 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4311 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14959 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78944 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15021 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->