### PR TITLE
[GStreamer][WebRTC][Rice] Make sure the agent is closed during finalization of the GstWebRTCICE

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -66,6 +66,13 @@ using WebKitGstRiceStream = struct _WebKitGstRiceStream {
 
 using StreamHashMap = HashMap<unsigned, std::unique_ptr<WebKitGstRiceStream>, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>>;
 
+static gboolean agentClosedTimeoutCallback(gpointer userData)
+{
+    auto agentTimeout = reinterpret_cast<bool*>(userData);
+    *agentTimeout = true;
+    return FALSE;
+};
+
 typedef struct _WebKitGstIceAgentPrivate {
     ~_WebKitGstIceAgentPrivate()
     {
@@ -77,6 +84,29 @@ typedef struct _WebKitGstIceAgentPrivate {
 
         for (const auto& [sessionId, stream] : streams)
             iceBackend->finalizeStream(stream->stream->stream_id);
+
+        auto mainContext = runLoop->mainContext();
+
+        bool agentTimeout = false;
+        auto timeoutSource = adoptGRef(g_timeout_source_new(2000));
+        g_source_set_callback(timeoutSource.get(), agentClosedTimeoutCallback, &agentTimeout, nullptr);
+        g_source_attach(timeoutSource.get(), mainContext);
+
+        auto now = WTF::MonotonicTime::now().secondsSinceEpoch();
+        rice_agent_close(agent.get(), now.nanoseconds());
+        g_main_context_wakeup(mainContext);
+
+        bool isClosed = agentIsClosed.load();
+        if (!isClosed) {
+            while (!isClosed && !agentTimeout) {
+                g_main_context_iteration(mainContext, TRUE);
+                isClosed = agentIsClosed.load();
+            }
+
+            if (agentTimeout)
+                GST_WARNING("The agent hasn't closed successfully.");
+        }
+        g_source_destroy(timeoutSource.get());
     }
 
     RefPtr<RiceBackendClient> backendClient;
@@ -632,6 +662,37 @@ void webkitGstWebRTCIceAgentClosed(WebKitGstIceAgent* agent)
 }
 
 #if GST_CHECK_VERSION(1, 28, 0)
+struct CloseData {
+    GThreadSafeWeakPtr<GstWebRTCICE> weakIce;
+    bool shouldWait { false };
+    bool agentIsClosed { false };
+};
+WEBKIT_DEFINE_ASYNC_DATA_STRUCT(CloseData);
+
+static gboolean closeAgent(gpointer userData)
+{
+    auto closeData = reinterpret_cast<CloseData*>(userData);
+    GRefPtr ice = closeData->weakIce.get();
+    if (!ice)
+        return G_SOURCE_REMOVE;
+
+    auto backend = WEBKIT_GST_WEBRTC_ICE_BACKEND(ice.get());
+    auto now = WTF::MonotonicTime::now().secondsSinceEpoch();
+    rice_agent_close(backend->priv->agent.get(), now.nanoseconds());
+    webkitGstWebRTCIceAgentWakeup(backend);
+
+    bool isClosed = backend->priv->agentIsClosed.load();
+    if (!closeData->shouldWait || isClosed)
+        return G_SOURCE_REMOVE;
+
+    while (!isClosed) {
+        g_main_context_iteration(backend->priv->runLoop->mainContext(), TRUE);
+        isClosed = backend->priv->agentIsClosed.load();
+    }
+
+    return G_SOURCE_REMOVE;
+}
+
 static void webkitGstWebRTCIceAgentClose(GstWebRTCICE* ice, GstPromise* promise)
 {
     auto backend = WEBKIT_GST_WEBRTC_ICE_BACKEND(ice);
@@ -642,18 +703,12 @@ static void webkitGstWebRTCIceAgentClose(GstWebRTCICE* ice, GstPromise* promise)
 
     bool shouldWait = promise == nullptr;
     backend->priv->closePromise = promise;
-    auto now = WTF::MonotonicTime::now().secondsSinceEpoch();
-    rice_agent_close(backend->priv->agent.get(), now.nanoseconds());
-    webkitGstWebRTCIceAgentWakeup(backend);
 
-    isClosed = backend->priv->agentIsClosed.load();
-    if (!shouldWait || isClosed)
-        return;
+    auto data = createCloseData();
+    data->weakIce.reset(ice);
+    data->shouldWait = shouldWait;
 
-    while (!isClosed) {
-        g_main_context_iteration(backend->priv->runLoop->mainContext(), FALSE);
-        isClosed = backend->priv->agentIsClosed.load();
-    }
+    g_main_context_invoke_full(backend->priv->runLoop->mainContext(), G_PRIORITY_DEFAULT, closeAgent, data, reinterpret_cast<GDestroyNotify>(destroyCloseData));
 }
 #endif
 


### PR DESCRIPTION
#### 05da513a30694275e7393e2865dddda991d7fc6f
<pre>
[GStreamer][WebRTC][Rice] Make sure the agent is closed during finalization of the GstWebRTCICE
<a href="https://bugs.webkit.org/show_bug.cgi?id=307236">https://bugs.webkit.org/show_bug.cgi?id=307236</a>

Reviewed by NOBODY (OOPS!).

Close the agent during the ICE shutdown and prevent a potential infinite loop using a 2 seconds
timeout.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(agentClosedTimeoutCallback):
(_WebKitGstIceAgentPrivate::~_WebKitGstIceAgentPrivate):
(closeAgent):
(webkitGstWebRTCIceAgentClose):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05da513a30694275e7393e2865dddda991d7fc6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143082 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15557 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96303 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15638 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110033 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79234 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90943 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11990 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9663 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1755 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121369 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154069 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15352 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5347 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118049 "Found 8 new test failures: fast/mediastream/RTCRtpSender-outlives-RTCPeerConnection.html http/tests/webrtc/filtering-ice-candidate-same-origin-frame.html http/tests/webrtc/filtering-ice-candidate-same-origin-frame2.html webrtc/closing-peerconnection.html webrtc/pc-detached-document.html webrtc/processIceTransportStateChange-gc.html webrtc/video-mute-vp8.html webrtc/vp9.html (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13149 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118390 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14317 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125539 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70901 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15226 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4312 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14960 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78945 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15171 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15022 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->