### PR TITLE
[masonry] Import grid-lanes WPT Tests Feb 7

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -5052,6 +5052,7 @@
         "web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix2-ref.html",
         "web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-005-ref.html",
         "web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-006-ref.html",
+        "web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport-ref.html",
         "web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/row-defined-height-ref.html",
         "web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/row-intrinsic-inline-container-size-ref.html",
         "web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/column-auto-placement-001-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport-expected.html
@@ -1,0 +1,15 @@
+<!doctype quirks><!-- Intentional quirks mode -->
+<style>
+html {
+  margin:3px 6px 9px 12px;
+  padding: 0px;
+  background-color: green;
+}
+body {
+  display: grid;
+  margin: 7px 11px 14px 23px;
+  padding: 0px;
+  background-color: yellow;
+}
+</style>
+<p>This is test text.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport-ref.html
@@ -1,0 +1,15 @@
+<!doctype quirks><!-- Intentional quirks mode -->
+<style>
+html {
+  margin:3px 6px 9px 12px;
+  padding: 0px;
+  background-color: green;
+}
+body {
+  display: grid;
+  margin: 7px 11px 14px 23px;
+  padding: 0px;
+  background-color: yellow;
+}
+</style>
+<p>This is test text.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport.html
@@ -1,0 +1,20 @@
+<!doctype quirks><!-- Intentional quirks mode -->
+<title>CSS Test: Grid Lanes body in quirks mode should fill viewport except for margins</title>
+<link rel="author" title="Celeste Pan" href="celestepan@microsoft.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-3">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-body-element-fills-the-html-element-quirk" title="The body element fills the html element quirk">
+<link rel="match" href="grid-lanes-quirks-fill-viewport-ref.html">
+<style>
+html {
+  margin:3px 6px 9px 12px;
+  padding: 0px;
+  background-color: green;
+}
+body {
+  display: grid-lanes;
+  margin: 7px 11px 14px 23px;
+  padding: 0px;
+  background-color: yellow;
+}
+</style>
+<p>This is test text.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/w3c-import.log
@@ -189,6 +189,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-007-ref-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-007-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-007.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/row-defined-height-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/row-defined-height-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/row-defined-height.html


### PR DESCRIPTION
#### e3aeb605da3137d282eb9d10a46444d7e7bacb7d
<pre>
[masonry] Import grid-lanes WPT Tests Feb 7
<a href="https://bugs.webkit.org/show_bug.cgi?id=307237">https://bugs.webkit.org/show_bug.cgi?id=307237</a>
<a href="https://rdar.apple.com/problem/169874255">rdar://problem/169874255</a>

Reviewed by Alan Baradlay.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/453d0bcb6add6880901cc40ff280b170f9d7fa97">https://github.com/web-platform-tests/wpt/commit/453d0bcb6add6880901cc40ff280b170f9d7fa97</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-quirks-fill-viewport.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/307029@main">https://commits.webkit.org/307029@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/48da8ec1e94101afdd2a1097fc5d00e3c5fd9191

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143083 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96304 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d289cf7-cf71-43da-a986-072b1d45bf54) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15639 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110034 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79233 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/023e326e-e0df-4d97-9700-d4303ee5f564) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90944 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11c0053a-179a-422b-a0e7-35788b514a63) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11963 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9664 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1756 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121370 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154070 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15389 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5355 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118050 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13150 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30332 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14318 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125546 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70908 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15227 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4313 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14961 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15172 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15023 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->