### PR TITLE
[JSC] `String#indexOf` should find one char without resolving rope

### DIFF
--- a/JSTests/microbenchmarks/rope-indexOf-one-char.js
+++ b/JSTests/microbenchmarks/rope-indexOf-one-char.js
@@ -1,0 +1,21 @@
+// Benchmark: String.prototype.indexOf with single char on a fresh rope each iteration.
+// This tests the target use case: (a + b + c).indexOf("x") where the rope is temporary.
+// The base string is pre-resolved so that (base + "z") creates a shallow depth-1 rope.
+
+let base = (-1).toLocaleString().padEnd(315241, "hello ");
+base.charCodeAt(0); // Force resolve so (base + suffix) creates a shallow rope
+
+function testFoundEarly(a, b) {
+    return (a + b).indexOf("h");
+}
+noInline(testFoundEarly);
+
+function testNotFound(a, b) {
+    return (a + b).indexOf("Q");
+}
+noInline(testNotFound);
+
+for (let i = 0; i < 1e2; i++) {
+    testFoundEarly(base, "z");
+    testNotFound(base, "z");
+}

--- a/JSTests/stress/rope-string-indexOf.js
+++ b/JSTests/stress/rope-string-indexOf.js
@@ -1,0 +1,138 @@
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message || "Assertion failed");
+}
+
+// Build a rope string that exceeds the 0x128 (296) length threshold.
+function makeLongRope() {
+    let a = "a".repeat(200);
+    let b = "b".repeat(200);
+    return a + b;
+}
+
+// Basic: rope indexOf with single character.
+function testBasicRopeIndexOf() {
+    let rope = makeLongRope();
+    assert(rope.indexOf("a") === 0, "first 'a' should be at 0");
+    assert(rope.indexOf("b") === 200, "first 'b' should be at 200");
+    assert(rope.indexOf("z") === -1, "'z' should not be found");
+}
+
+// startPosition argument.
+function testRopeIndexOfWithPosition() {
+    let rope = makeLongRope();
+    assert(rope.indexOf("a", 100) === 100, "'a' from 100 should be at 100");
+    assert(rope.indexOf("a", 200) === -1, "'a' from 200 should not be found");
+    assert(rope.indexOf("b", 300) === 300, "'b' from 300 should be at 300");
+    assert(rope.indexOf("b", 400) === -1, "'b' from 400 should not be found");
+}
+
+// Deep rope (multi-level concatenation).
+function testDeepRope() {
+    let s = "x".repeat(100);
+    for (let i = 0; i < 10; i++)
+        s = s + "y".repeat(30);
+    // s is "x"*100 + "y"*300 = 400 chars, exceeds threshold
+    assert(s.indexOf("x") === 0, "first 'x' at 0");
+    assert(s.indexOf("y") === 100, "first 'y' at 100");
+}
+
+// Edge: character at fiber boundary.
+function testFiberBoundary() {
+    let a = "a".repeat(150);
+    let b = "b" + "a".repeat(149);
+    let rope = a + b; // 300 chars, 'b' is at position 150
+    assert(rope.indexOf("b") === 150, "'b' at fiber boundary should be at 150");
+}
+
+// Three-fiber rope.
+function testThreeFiberRope() {
+    let a = "a".repeat(100);
+    let b = "b".repeat(100);
+    let c = "c".repeat(100);
+    let rope = a + b + c; // JSC may create a 3-fiber rope
+    assert(rope.indexOf("a") === 0);
+    assert(rope.indexOf("b") === 100);
+    assert(rope.indexOf("c") === 200);
+    assert(rope.indexOf("c", 250) === 250);
+    assert(rope.indexOf("z") === -1);
+}
+
+// Last character.
+function testLastChar() {
+    let a = "a".repeat(299);
+    let rope = a + "z"; // 300 chars
+    assert(rope.indexOf("z") === 299);
+}
+
+// Ensure short ropes still work (they take the normal path).
+function testShortRope() {
+    let rope = "hello" + " world";
+    assert(rope.indexOf("w") === 6);
+    assert(rope.indexOf("z") === -1);
+}
+
+// Substring rope as root: slice() creates a substring rope.
+function testSubstringRopeRoot() {
+    let base = "a".repeat(200) + "b".repeat(200);
+    // Force resolve so slice() creates a substring rope over a resolved base.
+    base.charCodeAt(0);
+    let sub = base.slice(100, 350); // 250 chars, substring rope
+    assert(sub.indexOf("a") === 0, "sub: first 'a' at 0");
+    assert(sub.indexOf("b") === 100, "sub: first 'b' at 100");
+    assert(sub.indexOf("z") === -1, "sub: 'z' not found");
+    assert(sub.indexOf("b", 150) === 150, "sub: 'b' from 150 at 150");
+}
+
+// Substring rope as fiber: concat a substring with another string.
+function testSubstringRopeFiber() {
+    let base = "x".repeat(400);
+    base.charCodeAt(0);
+    let sub = base.slice(0, 200); // substring rope, 200 chars of 'x'
+    let rope = sub + "y".repeat(200); // fiber0=substring rope, fiber1=resolved
+    assert(rope.indexOf("x") === 0, "fiber sub: first 'x' at 0");
+    assert(rope.indexOf("y") === 200, "fiber sub: first 'y' at 200");
+    assert(rope.indexOf("z") === -1, "fiber sub: 'z' not found");
+    assert(rope.indexOf("x", 199) === 199, "fiber sub: last 'x' at 199");
+    assert(rope.indexOf("x", 200) === -1, "fiber sub: no 'x' from 200");
+}
+
+// Nested rope with startPosition: ensure startPosition is not regressed
+// when tryFindOneChar bails out on a non-substring rope fiber.
+// Regression test for: https://github.com/WebKit/WebKit/pull/58116#discussion_r2786165212
+function makeNestedRope() {
+    // Build rope = (partA + partB) + partC
+    //   fiber0 = inner rope (partA + partB), 1000 chars, not resolved
+    //   fiber1 = partC, 200 chars, resolved
+    // 'z' is at position 50 inside partA.
+    // tryFindOneChar sees fiber0 is a non-substring rope and bails out.
+    // Bug: startPosition is set to offset (0), which is smaller than the
+    //      original startPosition (e.g. 100). The fallback then searches
+    //      from 0 and incorrectly finds 'z' at 50.
+    let partA = "a".repeat(50) + "z" + "a".repeat(449); // 500 chars, 'z' at index 50
+    let partB = "a".repeat(500);                          // 500 chars
+    let inner = partA + partB;                             // 1000 chars, rope
+    let partC = "b".repeat(200);                           // 200 chars
+    return inner + partC;                                  // 1200 chars, fiber0 = inner (rope)
+}
+function testNestedRopeStartPosition() {
+    // Each assertion uses a fresh rope because the first indexOf call
+    // resolves the rope, hiding the bug for subsequent calls.
+    assert(makeNestedRope().indexOf("z", 100) === -1, "nested rope: indexOf('z', 100) should be -1");
+    assert(makeNestedRope().indexOf("z", 51) === -1, "nested rope: indexOf('z', 51) should be -1");
+    assert(makeNestedRope().indexOf("z", 50) === 50, "nested rope: indexOf('z', 50) should be 50");
+    assert(makeNestedRope().indexOf("z") === 50, "nested rope: indexOf('z') should be 50");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testBasicRopeIndexOf();
+    testRopeIndexOfWithPosition();
+    testDeepRope();
+    testFiberBoundary();
+    testThreeFiberRope();
+    testLastChar();
+    testShortRope();
+    testSubstringRopeRoot();
+    testSubstringRopeFiber();
+    testNestedRopeStartPosition();
+}

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -130,6 +130,9 @@ public:
     static constexpr unsigned MaxLength = std::numeric_limits<int32_t>::max();
     static_assert(MaxLength == String::MaxLength);
 
+    // Minimum rope length for rope-walk optimizations (tryFindOneChar, tryReplaceOneChar).
+    static constexpr unsigned minLengthForRopeWalk = 0x128;
+
     static constexpr uintptr_t isRopeInPointer = 0x1;
 
     static constexpr unsigned maxLengthForOnStackResolve = 2048;
@@ -278,6 +281,7 @@ public:
     bool is8Bit() const;
 
     ALWAYS_INLINE JSString* tryReplaceOneChar(JSGlobalObject*, char16_t, JSString* replacement);
+    inline std::optional<size_t> tryFindOneChar(JSGlobalObject*, char16_t character, unsigned& startPosition) const;
 
     bool isSubstring() const;
 protected:

--- a/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
+++ b/Source/JavaScriptCore/runtime/StringPrototypeInlines.h
@@ -519,7 +519,7 @@ inline JSString* tryReplaceOneCharUsingString(JSGlobalObject* globalObject, JSSt
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     // FIXME: Substring should be supported. However, substring of substring is not allowed at the moment.
-    if (!string->isNonSubstringRope() || string->length() < 0x128)
+    if (!string->isNonSubstringRope() || string->length() < JSString::minLengthForRopeWalk)
         return nullptr;
 
     RETURN_IF_EXCEPTION(scope, nullptr);


### PR DESCRIPTION
#### 8d918b4794c471c9d35df47ddbcabd7e069077c3
<pre>
[JSC] `String#indexOf` should find one char without resolving rope
<a href="https://bugs.webkit.org/show_bug.cgi?id=307239">https://bugs.webkit.org/show_bug.cgi?id=307239</a>

Reviewed by Yusuke Suzuki.

This patch changes to make `String#indexOf` find one char without resolving rope.

In the execution of the JetStream3 benchmarks, there were 790 calls to String#indexOf for
single-character searches, 701 of which were on substring ropes with a depth of 0. This
patch allows for bypassing the resolving process for these calls.

                               TipOfTree                  Patched

rope-indexOf-one-char        5.1815+-0.1595     ^      1.2982+-0.0956        ^ definitely 3.9913x faster

Tests: JSTests/microbenchmarks/rope-indexOf-one-char.js
       JSTests/stress/rope-string-indexOf.js

* JSTests/microbenchmarks/rope-indexOf-one-char.js: Added.
(testFoundEarly):
(testNotFound):
* JSTests/stress/rope-string-indexOf.js: Added.
(assert):
(makeLongRope):
(testBasicRopeIndexOf):
(testNestedRopeStartPosition):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSString::tryFindOneChar const):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::stringIndexOfImpl):
* Source/JavaScriptCore/runtime/StringPrototypeInlines.h:
(JSC::tryReplaceOneCharUsingString):

Canonical link: <a href="https://commits.webkit.org/307324@main">https://commits.webkit.org/307324@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/288ab820bfd38d590c57b41ccc6698152807ac58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16077 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7696 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96832 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16754 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110430 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79469 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91348 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12355 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10076 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135584 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121794 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5579 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154573 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4402 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118431 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13582 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30536 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14731 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71538 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15745 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5376 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174882 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15480 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79517 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45128 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15692 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15544 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->