### PR TITLE
Remove various style adjustments for `appearance: base`

### DIFF
--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
@@ -1,8 +1,22 @@
 <!DOCTYPE html>
 <html>
+<head>
+    <style>
+        select {
+            all: unset; /* Remove all UA styles */
+            appearance: none;
+            background-color: green;
+            color: white;
+        }
+    </style>
+</head>
 <body>
-    <div style="color: orange">This text should be orange</div>
-    <div style="color: blue">This text should be blue</div>
-    <div style="color: blue">This text should be blue</div>
+    <div style="color: orange">This text should be orange (default)</div>
+    <div style="color: blue">This text should be blue (base-select on non-select)</div>
+    <div style="color: blue">This text should be blue (base)</div>
+
+    <select><option>This select should be green with white text. (base-select)</option></select>
+    <select><option>This select should be green with white text. (base)</option></select>
+    <select style="background-color: red;"><option>This select should be red with white text. (default)</option></select>
 </body>
 </html>

--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
@@ -9,9 +9,21 @@
         div {
             color: -internal-auto-base(orange, blue);
         }
+        select {
+            all: unset; /* Remove all UA styles */
+            background-color: -internal-auto-base(red, green);
+            color: white;
+        }
+        ::picker-icon {
+            display: none;
+        }
     </style>
-    <div>This text should be orange</div>
-    <div style="appearance: base-select">This text should be blue</div>
-    <div style="appearance: base">This text should be blue</div>
+    <div>This text should be orange (default)</div>
+    <div style="appearance: base-select">This text should be blue (base-select on non-select)</div>
+    <div style="appearance: base">This text should be blue (base)</div>
+
+    <select style="appearance: base-select"><option>This select should be green with white text. (base-select)</option></select>
+    <select style="appearance: base"><option>This select should be green with white text. (base)</option></select>
+    <select><option>This select should be red with white text. (default)</option></select>
 </body>
 </html>

--- a/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
+++ b/Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp
@@ -349,7 +349,7 @@ void RenderThemeAdwaita::adjustMenuListButtonStyle(RenderStyle& style, const Ele
 
 Style::PaddingBox RenderThemeAdwaita::popupInternalPaddingBox(const RenderStyle& style) const
 {
-    if (style.usedAppearance() == StyleAppearance::None)
+    if (style.usedAppearance() == StyleAppearance::None || style.usedAppearance() == StyleAppearance::Base)
         return { 0_css_px };
 
     auto zoomedArrowSize = menuListButtonArrowSize * style.usedZoom();

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -399,6 +399,7 @@ static inline bool canAdjustBorderRadiusForAppearance(StyleAppearance appearance
 #if ENABLE(APPLE_PAY)
     case StyleAppearance::ApplePayButton:
 #endif
+    case StyleAppearance::Base:
     case StyleAppearance::None:
     case StyleAppearance::SearchField:
         return false;

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -1108,12 +1108,6 @@ inline bool RenderStyle::hasAnimationsOrTransitions() const
     return hasAnimations() || hasTransitions();
 }
 
-// FIXME: Rename this function.
-inline bool RenderStyle::hasAppearance() const
-{
-    return appearance() != StyleAppearance::None && appearance() != StyleAppearance::Base;
-}
-
 #if HAVE(CORE_MATERIAL)
 inline bool RenderStyle::hasAppleVisualEffect() const
 {

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -455,7 +455,6 @@ public:
 
     inline bool hasAnimations() const;
     inline bool hasAnimationsOrTransitions() const;
-    inline bool hasAppearance() const;
     inline bool hasAspectRatio() const;
     inline bool hasAutoLengthContainIntrinsicSize() const;
     inline bool hasBackdropFilter() const;

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -805,7 +805,7 @@ void Adjuster::adjust(RenderStyle& style) const
 #endif
 
     // Let the theme also have a crack at adjusting the style.
-    if (style.hasAppearance())
+    if (style.appearance() != StyleAppearance::None && style.appearance() != StyleAppearance::Base)
         adjustThemeStyle(style, m_parentStyle);
 
     // This should be kept in sync with requiresRenderingConsolidationForViewTransition
@@ -1030,13 +1030,16 @@ void Adjuster::adjustAnimatedStyle(RenderStyle& style, OptionSet<AnimationImpact
 
 void Adjuster::adjustThemeStyle(RenderStyle& style, const RenderStyle& parentStyle) const
 {
-    ASSERT(style.hasAppearance());
+    ASSERT(style.appearance() != StyleAppearance::None && style.appearance() != StyleAppearance::Base);
     auto isOldWidthAuto = style.width().isAuto();
     auto isOldMinWidthAuto = style.minWidth().isAuto();
     auto isOldHeightAuto = style.height().isAuto();
     auto isOldMinHeightAuto = style.minHeight().isAuto();
 
     RenderTheme::singleton().adjustStyle(style, parentStyle, m_element.get());
+
+    if (style.usedAppearance() == StyleAppearance::None || style.usedAppearance() == StyleAppearance::Base)
+        return;
 
     if (style.usedContain().contains(Style::ContainValue::Size)) {
         if (!style.containIntrinsicWidth().isNone()) {


### PR DESCRIPTION
#### f725782c898df9c4feacac10ac08c74198052f66
<pre>
Remove various style adjustments for `appearance: base`
<a href="https://bugs.webkit.org/show_bug.cgi?id=307241">https://bugs.webkit.org/show_bug.cgi?id=307241</a>
<a href="https://rdar.apple.com/169879916">rdar://169879916</a>

Reviewed by Simon Fraser.

I found these while writing the test for PR #58103, the adjustments were causing the test to fail.

Make `appearance: base` / `appearance: base-select` behave as closely as possible to `appearance: none` WRT theme style adjustments.

* LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html:
* LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html:
* Source/WebCore/rendering/adwaita/RenderThemeAdwaita.cpp:
(WebCore::RenderThemeAdwaita::popupInternalPaddingBox const):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::canAdjustBorderRadiusForAppearance):
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
(WebCore::RenderStyle::hasAppearance const): Deleted.
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
(WebCore::Style::Adjuster::adjustThemeStyle const):

Canonical link: <a href="https://commits.webkit.org/307018@main">https://commits.webkit.org/307018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2000cf534f7bd8bc1fbc0f2aa0ca7af34e9af6a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143090 "Build is in progress. Recent messages:OS: Sequoia (15.5), Xcode: 16.4; Skipping applying patch since patch_id isn't provided; Checked out pull request; check-webkit-style") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15565 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151764 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d89b5ed-6452-44a9-b079-605e48f96307) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144957 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16225 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15646 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110043 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96311 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/425ed3c8-ea4f-4470-a549-ec46e6834637) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12490 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128046 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90953 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8dea1bd5-eccb-4beb-8c84-499e62c6d30f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11970 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9671 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1763 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4562 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154077 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15418 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118057 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13157 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118398 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14345 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125620 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70926 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22064 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15234 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4345 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78953 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15179 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15030 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->