### PR TITLE
[JSC] Remove JSBigInt::rightTrim and JSBigInt::tryRightTrim

### DIFF
--- a/Source/JavaScriptCore/runtime/JSBigInt.h
+++ b/Source/JavaScriptCore/runtime/JSBigInt.h
@@ -80,7 +80,8 @@ public:
     JS_EXPORT_PRIVATE static JSBigInt* createFrom(JSGlobalObject*, Int128 value);
     static JSBigInt* createFrom(JSGlobalObject*, bool value);
     static JSBigInt* createFrom(JSGlobalObject*, double value);
-    static JSBigInt* createFrom(JSGlobalObject*, VM&, bool sign, std::span<const Digit>);
+
+    JS_EXPORT_PRIVATE static JSBigInt* tryCreateFrom(JSGlobalObject*, VM&, bool sign, std::span<const Digit>);
 
     static JSBigInt* createFrom(JSGlobalObject*, VM&, int32_t value);
 
@@ -194,6 +195,8 @@ public:
     static ComparisonResult compareToDouble(double x, JSValue y) { return flip(compareToDouble(y, x)); }
 
 private:
+    static JSBigInt* tryCreateFromImpl(JSGlobalObject*, VM&, bool sign, std::span<const Digit>);
+
     ALWAYS_INLINE static ComparisonResult flip(ComparisonResult result)
     {
         switch (result) {
@@ -458,8 +461,6 @@ public:
 
     Digit digit(unsigned);
     void setDigit(unsigned, Digit); // Use only when initializing.
-    JS_EXPORT_PRIVATE JSBigInt* rightTrim(JSGlobalObject*);
-    JS_EXPORT_PRIVATE JSBigInt* tryRightTrim(VM&);
     std::span<const Digit> digits() const
     {
         return { dataStorage(), length() };
@@ -507,11 +508,9 @@ private:
         return { dataStorage(), length() };
     }
 
-    JSBigInt* rightTrim(JSGlobalObject*, VM&);
-
     JS_EXPORT_PRIVATE unsigned hashSlow();
 
-    static JSBigInt* createFromImpl(JSGlobalObject*, uint64_t value, bool sign);
+    static JSBigInt* tryCreateFromImpl(JSGlobalObject*, uint64_t value, bool sign);
 
     static constexpr int maxInt = 0x7FFFFFFF;
 


### PR DESCRIPTION
#### 304cf0713b9de42f2df2d5eb876d0658916a22d1
<pre>
[JSC] Remove JSBigInt::rightTrim and JSBigInt::tryRightTrim
<a href="https://bugs.webkit.org/show_bug.cgi?id=307243">https://bugs.webkit.org/show_bug.cgi?id=307243</a>
<a href="https://rdar.apple.com/169881775">rdar://169881775</a>

Reviewed by Sosuke Suzuki.

We would like to just use the span based constructor, and do not want to
use allocated JSBigInt as a temporary buffer. Now we use Vector before
construction in SerializedScriptValue too and remove rightTrim /
tryRightTrim functions completely.

* Source/JavaScriptCore/runtime/JSBigInt.cpp:
(JSC::JSBigInt::tryCreateFromImpl):
(JSC::JSBigInt::createFrom):
(JSC::JSBigInt::exponentiateImpl):
(JSC::JSBigInt::multiplyImpl):
(JSC::JSBigInt::divideImpl):
(JSC::JSBigInt::remainderImpl):
(JSC::JSBigInt::incImpl):
(JSC::JSBigInt::decImpl):
(JSC::JSBigInt::bitwiseAndImpl):
(JSC::JSBigInt::bitwiseOrImpl):
(JSC::JSBigInt::bitwiseXorImpl):
(JSC::JSBigInt::bitwiseNotImpl):
(JSC::JSBigInt::absoluteAdd):
(JSC::JSBigInt::absoluteSub):
(JSC::JSBigInt::leftShiftByAbsolute):
(JSC::JSBigInt::rightShiftByAbsolute):
(JSC::JSBigInt::parseInt):
(JSC::JSBigInt::truncateToNBits):
(JSC::JSBigInt::truncateAndSubFromPowerOfTwo):
(JSC::JSBigInt::tryCreateFrom):
(JSC::JSBigInt::createFromImpl): Deleted.
(JSC::JSBigInt::rightTrim): Deleted.
(JSC::JSBigInt::tryRightTrim): Deleted.
* Source/JavaScriptCore/runtime/JSBigInt.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readBigInt):

Canonical link: <a href="https://commits.webkit.org/307032@main">https://commits.webkit.org/307032@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/31163f25cd1ed1efe3a2fbd5c33f114b22854245

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6590 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151816 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96362 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef7d5373-21da-4265-98b5-1bc6b10aa605) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145008 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15697 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110083 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79247 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f08a4e43-711b-467f-82cd-0dc0d4880d6e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12516 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128101 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90994 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eda046d8-521d-4daf-b93f-fe05ad10dc16) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11999 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9712 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1814 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135140 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154128 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3953 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15557 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118099 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13200 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118439 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14362 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70998 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22073 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15285 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4425 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174438 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15019 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79004 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45046 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15230 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15081 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->