### PR TITLE
[JSC] Enable libpas JITHeap on Windows

### DIFF
--- a/Source/JavaScriptCore/jit/ExecutableMemoryHandle.h
+++ b/Source/JavaScriptCore/jit/ExecutableMemoryHandle.h
@@ -37,7 +37,7 @@
 #include <wtf/MetaAllocatorHandle.h>
 #endif
 
-#if BENABLE(LIBPAS) && (OS(DARWIN) || OS(LINUX))
+#if BENABLE(LIBPAS) && ENABLE(JIT)
 #define ENABLE_LIBPAS_JIT_HEAP 1
 #endif
 


### PR DESCRIPTION
#### 671fffdf2012a39407b7a641d834b92ac5342c91
<pre>
[JSC] Enable libpas JITHeap on Windows
<a href="https://bugs.webkit.org/show_bug.cgi?id=307245">https://bugs.webkit.org/show_bug.cgi?id=307245</a>
<a href="https://rdar.apple.com/169882927">rdar://169882927</a>

Reviewed by NOBODY (OOPS!).

Just enable libpas JITHeap on Windows too.

* Source/JavaScriptCore/jit/ExecutableMemoryHandle.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/671fffdf2012a39407b7a641d834b92ac5342c91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143107 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15582 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6448 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96328 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5bb96fdf-36f7-4abd-bb75-200ef64fe1a9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110054 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79243 "Exiting early after 60 failures. 60 tests run. 1 flakes 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c30e68f-cf64-4109-ab28-bf37cc040ccf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90964 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a05e586-a0e7-4af2-ab96-6f2a5190c838) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11979 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9688 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135106 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121393 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154094 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/3919 "Built successfully and passed tests") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5475 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118070 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13174 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118409 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70947 "Built successfully") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24481 "Failed to checkout and rebase branch from PR 58122") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14349 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4373 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174404 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15251 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78970 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45041 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14985 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15047 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->