### PR TITLE
Rename WebUITextIndicatorData to WebUITextIndicator.

### DIFF
--- a/Source/WebKitLegacy/ios/WebKit.iOS.exp
+++ b/Source/WebKitLegacy/ios/WebKit.iOS.exp
@@ -6,7 +6,7 @@
 .objc_class_name_WebPDFView
 .objc_class_name_WebPDFViewPlaceholder
 .objc_class_name_WebSelectionRect
-.objc_class_name_WebUITextIndicatorData
+.objc_class_name_WebUITextIndicator
 .objc_class_name_WebVisiblePosition
 _WebDatabaseOriginsDidChangeNotification
 _WebKitCreatePathWithShrinkWrappedRects

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -825,7 +825,7 @@ static bool isLockdownModeEnabled()
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
 
-@implementation WebUITextIndicatorData
+@implementation WebUITextIndicator
 
 @synthesize dataInteractionImage = _dataInteractionImage;
 @synthesize selectionRectInRootViewCoordinates = _selectionRectInRootViewCoordinates;
@@ -851,9 +851,9 @@ static bool isLockdownModeEnabled()
 
 @end
 
-@implementation WebUITextIndicatorData (WebUITextIndicatorInternal)
+@implementation WebUITextIndicator (WebUITextIndicatorInternal)
 
-- (WebUITextIndicatorData *)initWithImage:(CGImageRef)image textIndicator:(RefPtr<WebCore::TextIndicator>&&)indicator scale:(CGFloat)scale
+- (WebUITextIndicator *)initWithImage:(CGImageRef)image textIndicator:(RefPtr<WebCore::TextIndicator>&&)indicator scale:(CGFloat)scale
 {
     if (!(self = [super init]))
         return nil;
@@ -882,7 +882,7 @@ static bool isLockdownModeEnabled()
     return self;
 }
 
-- (WebUITextIndicatorData *)initWithImage:(CGImageRef)image scale:(CGFloat)scale
+- (WebUITextIndicator *)initWithImage:(CGImageRef)image scale:(CGFloat)scale
 {
     if (!(self = [super init]))
         return nil;
@@ -894,7 +894,7 @@ static bool isLockdownModeEnabled()
 
 @end
 #elif !PLATFORM(MAC)
-@implementation WebUITextIndicatorData
+@implementation WebUITextIndicator
 @end
 #endif
 
@@ -1913,9 +1913,9 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     RefPtr<WebCore::TextIndicator> textIndicator = dragImage.textIndicator();
 
     if (textIndicator)
-        _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image textIndicator:WTF::move(textIndicator) scale:_private->page->deviceScaleFactor()]);
+        _private->textIndicator = adoptNS([[WebUITextIndicator alloc] initWithImage:image textIndicator:WTF::move(textIndicator) scale:_private->page->deviceScaleFactor()]);
     else
-        _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image scale:_private->page->deviceScaleFactor()]);
+        _private->textIndicator = adoptNS([[WebUITextIndicator alloc] initWithImage:image scale:_private->page->deviceScaleFactor()]);
     _private->draggedLinkURL = dragItem.url.isEmpty() ? RetainPtr<NSURL>() : dragItem.url.createNSURL();
     _private->draggedLinkTitle = dragItem.title.isEmpty() ? nil : dragItem.title.createNSString().get();
     _private->dragPreviewFrameInRootViewCoordinates = dragItem.dragPreviewFrameInRootViewCoordinates;
@@ -1931,7 +1931,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     return { };
 }
 
-- (WebUITextIndicatorData *)_dataOperationTextIndicator
+- (WebUITextIndicator *)_dataOperationTextIndicator
 {
     return _private->dataOperationTextIndicator.get();
 }
@@ -1956,9 +1956,9 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     return _private->dragPreviewFrameInRootViewCoordinates;
 }
 
-- (WebUITextIndicatorData *)_getDataInteractionData
+- (WebUITextIndicator *)_getDataInteraction
 {
-    return _private->textIndicatorData.get();
+    return _private->textIndicator.get();
 }
 
 - (WebDragDestinationAction)dragDestinationActionMaskForSession:(id <UIDropSession>)session
@@ -2060,7 +2060,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         return;
     if (auto range = frame->selection().selection().toNormalizedRange()) {
         if (RefPtr textIndicator = WebCore::TextIndicator::createWithRange(*range, defaultEditDragTextIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, WebCore::FloatSize()))
-            _private->dataOperationTextIndicator = adoptNS([[WebUITextIndicatorData alloc] initWithImage:nil textIndicator:WTF::move(textIndicator) scale:page->deviceScaleFactor()]);
+            _private->dataOperationTextIndicator = adoptNS([[WebUITextIndicator alloc] initWithImage:nil textIndicator:WTF::move(textIndicator) scale:page->deviceScaleFactor()]);
     }
 }
 
@@ -2071,12 +2071,12 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     return NO;
 }
 
-- (WebUITextIndicatorData *)_getDataInteractionData
+- (WebUITextIndicator *)_getDataInteraction
 {
     return nil;
 }
 
-- (WebUITextIndicatorData *)_dataOperationTextIndicator
+- (WebUITextIndicator *)_dataOperationTextIndicator
 {
     return nil;
 }

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.h
@@ -59,7 +59,7 @@ class PlaybackSessionModelMediaElement;
 }
 
 @class UIImage;
-@class WebUITextIndicatorData;
+@class WebUITextIndicator;
 @class WebImmediateActionController;
 @class WebInspector;
 @class WebNodeHighlight;
@@ -250,8 +250,8 @@ class WebSelectionServiceController;
 #endif
     
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
-    RetainPtr<WebUITextIndicatorData> textIndicatorData;
-    RetainPtr<WebUITextIndicatorData> dataOperationTextIndicator;
+    RetainPtr<WebUITextIndicator> textIndicator;
+    RetainPtr<WebUITextIndicator> dataOperationTextIndicator;
     CGRect dragPreviewFrameInRootViewCoordinates;
     WebDragSourceAction dragSourceAction;
     RetainPtr<NSURL> draggedLinkURL;

--- a/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
@@ -129,9 +129,9 @@ OptionSet<WebCore::LayoutMilestone> coreLayoutMilestones(WebLayoutMilestones);
 WebLayoutMilestones kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone>);
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT) && defined(__cplusplus)
-@interface WebUITextIndicatorData (WebUITextIndicatorInternal)
-- (WebUITextIndicatorData *)initWithImage:(CGImageRef)image textIndicator:(RefPtr<WebCore::TextIndicator>&&)indicator scale:(CGFloat)scale;
-- (WebUITextIndicatorData *)initWithImage:(CGImageRef)image scale:(CGFloat)scale;
+@interface WebUITextIndicator (WebUITextIndicatorInternal)
+- (WebUITextIndicator *)initWithImage:(CGImageRef)image textIndicator:(RefPtr<WebCore::TextIndicator>&&)indicator scale:(CGFloat)scale;
+- (WebUITextIndicator *)initWithImage:(CGImageRef)image scale:(CGFloat)scale;
 @end
 #endif
 

--- a/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
@@ -146,7 +146,7 @@ typedef enum {
 } WebNotificationPermission;
 
 #if TARGET_OS_IPHONE
-@interface WebUITextIndicatorData : NSObject
+@interface WebUITextIndicator : NSObject
 @property (nonatomic, retain) UIImage *dataInteractionImage;
 @property (nonatomic, assign) CGRect selectionRectInRootViewCoordinates;
 @property (nonatomic, assign) CGRect textBoundingRectInRootViewCoordinates;
@@ -437,8 +437,8 @@ Could be worth adding to the API.
 
 #if TARGET_OS_IOS
 - (BOOL)_requestStartDataInteraction:(CGPoint)clientPosition globalPosition:(CGPoint)globalPosition;
-- (WebUITextIndicatorData *)_getDataInteractionData;
-@property (nonatomic, readonly, strong, getter=_dataOperationTextIndicator) WebUITextIndicatorData *dataOperationTextIndicator;
+- (WebUITextIndicator *)_getDataInteraction;
+@property (nonatomic, readonly, strong, getter=_dataOperationTextIndicator) WebUITextIndicator *dataOperationTextIndicator;
 @property (nonatomic, readonly) NSUInteger _dragSourceAction;
 @property (nonatomic, strong, readonly) NSString *_draggedLinkTitle;
 @property (nonatomic, strong, readonly) NSURL *_draggedLinkURL;


### PR DESCRIPTION
#### dc19cbbc32793ceb8bdeeae8744b9dda7fb673cc
<pre>
Rename WebUITextIndicatorData to WebUITextIndicator.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307246">https://bugs.webkit.org/show_bug.cgi?id=307246</a>
<a href="https://rdar.apple.com/169883008">rdar://169883008</a>

Reviewed by Abrar Rahman Protyasha.

With all of the work I am doing to remove
TextIndicatorData, I keep running into this
legacy class. Since it mirrors TextIndicator
more than TextIndicatorData and it is old, and it
is making my TextIndicatorData removal work
more difficult, I would like to rename this class.

* Source/WebKitLegacy/ios/WebKit.iOS.exp:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebUITextIndicator initWithImage:textIndicator:scale:]):
(-[WebUITextIndicator initWithImage:scale:]):
(-[WebView _startDrag:]):
(-[WebView _dataOperationTextIndicator]):
(-[WebView _getDataInteraction]):
(-[WebView _didConcludeEditDrag]):
(-[WebUITextIndicatorData dealloc]): Deleted.
(-[WebUITextIndicatorData initWithImage:textIndicator:scale:]): Deleted.
(-[WebUITextIndicatorData initWithImage:scale:]): Deleted.
(-[WebView _getDataInteractionData]): Deleted.
* Source/WebKitLegacy/mac/WebView/WebViewData.h:
* Source/WebKitLegacy/mac/WebView/WebViewInternal.h:
* Source/WebKitLegacy/mac/WebView/WebViewPrivate.h:

Canonical link: <a href="https://commits.webkit.org/307030@main">https://commits.webkit.org/307030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/649ea8e5f12f7f2aadc50259b3d5d5d17186a77a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6435 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151779 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ece5b0a-2895-4391-915e-5e01a103d16d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110050 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38ffdb17-3196-48e3-8ef3-28d151fa6309) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146053 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12501 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128057 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/90960 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3ec33ac-2440-4b34-a35d-fd7cf53a889e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/11978 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9682 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1777 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121392 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154091 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15411 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5444 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118067 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15426 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13168 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118406 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30333 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14330 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125640 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70944 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15248 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4361 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14982 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78967 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15193 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15044 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->