### PR TITLE
Sync `maxFrameRate` with RTCRtpEncodingParameters interface specification

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-maxFramerate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-maxFramerate-expected.txt
@@ -1,13 +1,9 @@
 
-FAIL addTransceiver() with sendEncoding.maxFramerate field set to less than 0 should reject with RangeError assert_throws_js: function "() => pc.addTransceiver('video', {
-    sendEncodings: [{
-      maxFramerate: -10
-    }]
-  })" did not throw
+PASS addTransceiver() with sendEncoding.maxFramerate field set to less than 0 should reject with RangeError
 PASS addTransceiver('audio') with sendEncoding.maxFramerate should succeed, but remove the maxFramerate, even if it is invalid
 FAIL setParameters with maxFramerate on an audio sender should succeed, but remove the maxFramerate assert_not_own_property: unexpected property "maxFramerate" is found on object
-FAIL setParameters with an invalid maxFramerate on an audio sender should succeed, but remove the maxFramerate assert_not_own_property: unexpected property "maxFramerate" is found on object
-FAIL setParameters() with encoding.maxFramerate field set to less than 0 should reject with RangeError assert_unreached: Should have rejected: undefined Reached unreachable code
+FAIL setParameters with an invalid maxFramerate on an audio sender should succeed, but remove the maxFramerate promise_test: Unhandled rejection with value: object "RangeError: Attempted to set RtpParameters max_framerate to an invalid value. max_framerate must be >= 0.0"
+PASS setParameters() with encoding.maxFramerate field set to less than 0 should reject with RangeError
 PASS setParameters() with maxFramerate 24->16 should succeed with RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate 24->16 should succeed without RTCRtpTransceiverInit
 PASS setParameters() with maxFramerate undefined->16 should succeed with RTCRtpTransceiverInit

--- a/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018 Apple Inc. All rights reserved.
+ * Copyright (C) 2018-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ struct RTCRtpEncodingParameters : RTCRtpCodingParameters {
 
     bool active { true };
     std::optional<unsigned long> maxBitrate;
-    std::optional<unsigned long> maxFramerate;
+    std::optional<double> maxFramerate;
     std::optional<double> scaleResolutionDownBy;
 
     RTCPriorityType priority { RTCPriorityType::Low };

--- a/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.idl
+++ b/Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.idl
@@ -1,5 +1,5 @@
 /*
-* Copyright (C) 2018 Apple Inc. All rights reserved.
+* Copyright (C) 2018-2026 Apple Inc. All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
 * modification, are permitted provided that the following conditions
@@ -34,8 +34,7 @@
 
     boolean active = true;
     unsigned long maxBitrate;
-    // FIXME: `maxFramerate` should be of type `double`.
-    unsigned long maxFramerate;
+    double maxFramerate;
     double scaleResolutionDownBy;
 
     RTCPriorityType priority = "low";

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp
@@ -88,7 +88,7 @@ ExceptionOr<GUniquePtr<GstStructure>> fromRTCEncodingParameters(const RTCRtpEnco
         gst_structure_set(rtcParameters.get(), "max-bitrate", G_TYPE_UINT, *parameters.maxBitrate, nullptr);
 
     if (parameters.maxFramerate)
-        gst_structure_set(rtcParameters.get(), "max-framerate", G_TYPE_UINT, *parameters.maxFramerate, nullptr);
+        gst_structure_set(rtcParameters.get(), "max-framerate", G_TYPE_DOUBLE, *parameters.maxFramerate, nullptr);
 
     if (parameters.scaleResolutionDownBy && kind == "video"_s)
         gst_structure_set(rtcParameters.get(), "scale-resolution-down-by", G_TYPE_DOUBLE, *parameters.scaleResolutionDownBy, nullptr);

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp
@@ -191,7 +191,7 @@ void GStreamerVideoRTPPacketizer::configure(const GstStructure* encodingParamete
     ASSERT(encodingParameters);
     GST_DEBUG_OBJECT(m_bin.get(), "Configuring with encoding parameters: %" GST_PTR_FORMAT, encodingParameters);
 
-    auto maxFrameRate = gstStructureGet<unsigned>(encodingParameters, "max-framerate"_s).value_or(0);
+    auto maxFrameRate = gstStructureGet<double>(encodingParameters, "max-framerate"_s).value_or(0);
     if (maxFrameRate) {
         if (!m_videoRate)
             GST_WARNING_OBJECT(m_bin.get(), "Unable to configure max-framerate");
@@ -201,7 +201,7 @@ void GStreamerVideoRTPPacketizer::configure(const GstStructure* encodingParamete
                 maxFrameRate = 2;
 
             int numerator, denominator;
-            gst_util_double_to_fraction(static_cast<double>(maxFrameRate), &numerator, &denominator);
+            gst_util_double_to_fraction(maxFrameRate, &numerator, &denominator);
 
             auto caps = adoptGRef(gst_caps_new_simple("video/x-raw", "framerate", GST_TYPE_FRACTION, numerator, denominator, nullptr));
             g_object_set(m_frameRateCapsFilter.get(), "caps", caps.get(), nullptr);


### PR DESCRIPTION
#### a1805f298e4930bc60fa92c06044e8778aa7b44c
<pre>
Sync `maxFrameRate` with RTCRtpEncodingParameters interface specification
<a href="https://bugs.webkit.org/show_bug.cgi?id=307249">https://bugs.webkit.org/show_bug.cgi?id=307249</a>
<a href="https://rdar.apple.com/169885744">rdar://169885744</a>

Reviewed by Philippe Normand.

This patch aligns WebKit with Gecko / Firefox, Blink / Chromium and
Web Specification [1]:

As per specification [1], the `maxFrameRate` should be `double` and
not `unsigned long`, this patch fixes it.

[1] <a href="https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters">https://w3c.github.io/webrtc-pc/#dom-rtcrtpencodingparameters</a>

* Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.h:
* Source/WebCore/Modules/mediastream/RTCRtpEncodingParameters.idl:
* Source/WebCore/Modules/mediastream/gstreamer/GStreamerWebRTCUtils.cpp:
(WebCore::fromRTCEncodingParameters): Change to G_TYPE_DOUBLE
* Source/WebCore/platform/mediastream/gstreamer/GStreamerVideoRTPPacketizer.cpp:
(WebCore::GStreamerVideoRTPPacketizer::configure const): Change to `double` and removed unneeded static_cast
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCRtpParameters-maxFramerate-expected.txt: Progressions

Canonical link: <a href="https://commits.webkit.org/307033@main">https://commits.webkit.org/307033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15c45dca2f92a47c392d885998f7877bac2a67b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151857 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bdc03df-0a4e-4c6b-9557-29bcce78de04) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145048 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110110 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e16f43f6-27d7-42ad-99a3-9e0c7cb761c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12547 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128130 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91021 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07122ad2-0aba-44d9-8483-9f5512fdc92a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12030 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9743 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1854 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154168 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15660 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118129 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15664 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13231 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118469 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/30335 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14395 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71051 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15325 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4455 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15059 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79044 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15270 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->