### PR TITLE
[iOS] REGRESSION (305399@main): Web process crashes when pasting DOM fragment with depth of ~100 elements in Mail compose

### DIFF
--- a/LayoutTests/editing/pasteboard/copy-paste-deep-dom-no-crash-expected.txt
+++ b/LayoutTests/editing/pasteboard/copy-paste-deep-dom-no-crash-expected.txt
@@ -1,0 +1,10 @@
+This test copies and pastes a deeply nested DOM structure inside a contenteditable container and verifies that the web process does not crash.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Did not crash
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/pasteboard/copy-paste-deep-dom-no-crash.html
+++ b/LayoutTests/editing/pasteboard/copy-paste-deep-dom-no-crash.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true editable=true ] -->
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <script>
+    jsTestIsAsync = true;
+
+    window.internals?.settings?.setUseDarkAppearance(true);
+
+    addEventListener("load", async () => {
+        description("This test copies and pastes a deeply nested DOM structure inside a contenteditable container and verifies that the web process does not crash.");
+
+        const container = document.getElementById("container");
+        let currentElement = container;
+
+        for (let depth = 0; depth < 500; depth++) {
+            const div = document.createElement("div");
+            div.textContent = `Depth ${depth}`;
+            currentElement.appendChild(div);
+            currentElement = div;
+        }
+
+        await UIHelper.ensurePresentationUpdate();
+
+        getSelection().selectAllChildren(container);
+        document.execCommand("Cut", true);
+        getSelection().collapse(container, 0);
+        document.execCommand("Paste", true);
+
+        container.style.display = "none";
+        testPassed("Did not crash");
+        finishJSTest();
+    });
+    </script>
+</head>
+<body>
+    <div id="container" contenteditable></div>
+</body>
+</html>

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -2034,7 +2034,8 @@ using ElementToStyleProperties = HashMap<Ref<StyledElement>, Vector<CSSPropertyI
         addStylesToRemove(*element);
 
     if (RefPtr container = dynamicDowncast<ContainerNode>(node)) {
-        for (Ref child : composedTreeChildren(*container)) {
+        static constexpr auto inlineCapacityToAvoidExceedingStackLimit = 0;
+        for (Ref child : composedTreeChildren<inlineCapacityToAvoidExceedingStackLimit>(*container)) {
             if (collectStylesToRemove(child, lastLeaf, backgroundLuminance, stylesToRemove) == IterationStatus::Done)
                 break;
         }

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1544,6 +1544,7 @@ bool TestController::resetStateToConsistentValues(const TestOptions& options, Re
     setNavigationGesturesEnabled(false);
     
     setIgnoresViewportScaleLimits(options.ignoresViewportScaleLimits());
+    m_mainWebView->setEditable(options.editable());
 
     m_openPanelFileURLs = nullptr;
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -358,9 +358,6 @@ void TestController::platformCreateWebView(WKPageConfigurationRef configuration,
     if (options.punchOutWhiteBackgroundsInDarkMode())
         m_mainWebView->setDrawsBackground(false);
 
-    if (options.editable())
-        m_mainWebView->setEditable(true);
-
     m_mainWebView->platformView().allowsLinkPreview = options.allowsLinkPreview();
     [m_mainWebView->platformView() _setShareSheetCompletesImmediatelyWithResolutionForTesting:YES];
 }


### PR DESCRIPTION
#### 81f0e08ab7b0d778be26b25bff178128d8639a68
<pre>
[iOS] REGRESSION (305399@main): Web process crashes when pasting DOM fragment with depth of ~100 elements in Mail compose
<a href="https://bugs.webkit.org/show_bug.cgi?id=307250">https://bugs.webkit.org/show_bug.cgi?id=307250</a>
<a href="https://rdar.apple.com/169722784">rdar://169722784</a>

Reviewed by Ryosuke Niwa and Richard Robinson.

After 305399@main (which adds a heuristic to keep text legible after pasting dark text into Mail
compose in dark mode), pasting very-deeply nested DOM content into Mail compose in dark mode may
cause a web content process crash, due to exceeding maximum stack memory limits.

This happens because the call to `composedTreeChildren` allocates ~1 KB of stack memory by default;
since this is called recursively, any attempt to paste content more than 100 elements deep will
exceed the 1 MB maximum stack size on iOS.

Address this by specifying an explicit inline capacity of 0.

Test: editing/pasteboard/copy-paste-deep-dom-no-crash.html

* LayoutTests/editing/pasteboard/copy-paste-deep-dom-no-crash-expected.txt: Added.
* LayoutTests/editing/pasteboard/copy-paste-deep-dom-no-crash.html: Added.

Note that this test only fails on a real iOS device or virtual machine, where the stack size limit
is 1 MB. On a macOS device, this isn&apos;t an issue even at max depth because we still fit comformably
in the 16 MB limit, with the default inline capacity.

* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
(WebCore::collectStylesToRemove):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetStateToConsistentValues):
* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):

Canonical link: <a href="https://commits.webkit.org/307017@main">https://commits.webkit.org/307017@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/093df643b22bbf722339f19eb4436a0a5ab63af7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143115 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15590 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6487 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151790 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33c0cde3-0a5f-474a-8a52-3ca3fe6ec1b7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/144982 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16250 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110061 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b8b05a25-c573-4481-b7a8-7b414fb141a8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12507 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128071 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/90972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb128252-1e03-4963-957d-f60cf6d18f27) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/11986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9694 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1788 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154102 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15430 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5494 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118078 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13180 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30326 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14337 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125694 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/70957 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15259 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4383 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/14993 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/78978 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15204 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15055 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->