### PR TITLE
Fix misc safer C++ smart pointer warnings in Source/WebKit

### DIFF
--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -46,6 +46,10 @@
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/Variant.h>
 
+#if USE(CG)
+#include <wtf/cf/CFTypeTraits.h>
+#endif
+
 #if USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColor.h>
@@ -54,6 +58,8 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #if USE(CG)
 typedef struct CGColor* CGColorRef;
+extern "C" CFTypeID CGColorGetTypeID();
+WTF_DECLARE_CF_TYPE_TRAIT(CGColor);
 #endif
 
 namespace WebCore {

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
@@ -73,7 +73,7 @@ void WebParentalControlsURLFilter::isURLAllowedImpl(const URL& mainDocumentURL, 
             return;
         }
 
-        auto filter = ensureWebContentFilter();
+        RetainPtr filter = ensureWebContentFilter();
 #if HAVE(WEBCONTENTRESTRICTIONS_TRANSITIVE_TRUST)
 #if __has_include(<WebKitAdditions/BEKAdditions.h>)
         MAYBE_EVALUATE_URL_WITH_TRANSITIVE_TRUST

--- a/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm
@@ -170,7 +170,7 @@ SOFT_LINK_CLASS(ContactsUI, CNContactPickerViewController)
     [_contactPickerViewController setDelegate:_contactPickerDelegate.get()];
     [_contactPickerViewController setPrompt:requestData.url.createNSString().get()];
 
-    auto presentationViewController = [_webView.get() _wk_viewControllerForFullScreenPresentation];
+    RetainPtr presentationViewController = [_webView.get() _wk_viewControllerForFullScreenPresentation];
 #if PLATFORM(VISION)
     if (RetainPtr webView = _webView.get())
         [webView _page]->dispatchWillPresentModalUI();

--- a/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
@@ -70,7 +70,7 @@ static UIActionIdentifier const WKPDFActionTwoPagesIdentifier = @"WKPDFActionPla
 - (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willDisplayMenuForConfiguration:(UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionAnimating>)animator
 {
     [super contextMenuInteraction:interaction willDisplayMenuForConfiguration:configuration animator:animator];
-    [_delegate pdfPageNumberIndicatorButtonWillDisplayMenu:self];
+    [protect(_delegate) pdfPageNumberIndicatorButtonWillDisplayMenu:self];
 }
 
 - (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willEndForConfiguration:(UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionAnimating>)animator
@@ -82,7 +82,7 @@ static UIActionIdentifier const WKPDFActionTwoPagesIdentifier = @"WKPDFActionPla
         if (!strongSelf)
             return;
 
-        [strongSelf->_delegate pdfPageNumberIndicatorButtonDidDismissMenu:strongSelf.get()];
+        [protect(strongSelf->_delegate) pdfPageNumberIndicatorButtonDidDismissMenu:strongSelf.get()];
     }];
 }
 
@@ -112,7 +112,7 @@ static UIActionIdentifier const WKPDFActionTwoPagesIdentifier = @"WKPDFActionPla
 
     BOOL shouldEnableUserInteraction = NO;
     if (RefPtr page = view->_page)
-        shouldEnableUserInteraction = page->preferences().twoUpPDFDisplayModeSupportEnabled();
+        shouldEnableUserInteraction = protect(page->preferences())->twoUpPDFDisplayModeSupportEnabled();
     self.userInteractionEnabled = shouldEnableUserInteraction;
 
 #if HAVE(UI_GLASS_EFFECT)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -283,11 +283,11 @@ ScrollingTreeScrollingNodeDelegateIOS::ScrollingTreeScrollingNodeDelegateIOS(Scr
 ScrollingTreeScrollingNodeDelegateIOS::~ScrollingTreeScrollingNodeDelegateIOS()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    if (UIScrollView *scrollView = (UIScrollView *)[protect(scrollLayer()) delegate]) {
+    if (RetainPtr scrollView = dynamic_objc_cast<UIScrollView>([protect(scrollLayer()) delegate])) {
         ASSERT([scrollView isKindOfClass:[UIScrollView class]]);
         // The scrollView may have been adopted by another node, so only clear the delegate if it's ours.
-        if (scrollView.delegate == m_scrollViewDelegate.get())
-            scrollView.delegate = nil;
+        if (scrollView.get().delegate == m_scrollViewDelegate.get())
+            scrollView.get().delegate = nil;
     }
     END_BLOCK_OBJC_EXCEPTIONS
 }
@@ -295,9 +295,9 @@ ScrollingTreeScrollingNodeDelegateIOS::~ScrollingTreeScrollingNodeDelegateIOS()
 void ScrollingTreeScrollingNodeDelegateIOS::resetScrollViewDelegate()
 {
     BEGIN_BLOCK_OBJC_EXCEPTIONS
-    if (UIScrollView *scrollView = (UIScrollView *)[protect(scrollLayer()) delegate]) {
+    if (RetainPtr scrollView = dynamic_objc_cast<UIScrollView>([protect(scrollLayer()) delegate])) {
         ASSERT([scrollView isKindOfClass:[UIScrollView class]]);
-        scrollView.delegate = nil;
+        scrollView.get().delegate = nil;
     }
     END_BLOCK_OBJC_EXCEPTIONS
 }

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -210,7 +210,7 @@ UITargetedDragPreview *DragDropInteractionState::finalDropPreview(UIDragItem *it
 
 void DragDropInteractionState::deliverDelayedDropPreview(UIView *contentView, UIView *previewContainer, RefPtr<WebCore::TextIndicator>&& textIndicator)
 {
-    auto textIndicatorImage = uiImageForImage(protect(textIndicator)->contentImage());
+    auto textIndicatorImage = uiImageForImage(protect(protect(textIndicator)->contentImage()));
     auto preview = createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, textIndicator->textBoundingRectInRootViewCoordinates(), textIndicator->textRectsInBoundingRectCoordinates(), cocoaColor(textIndicator->estimatedBackgroundColor()).get(), nil, AddPreviewViewToContainer::No);
     if (!preview)
         return;
@@ -298,7 +298,7 @@ RetainPtr<UITargetedDragPreview> DragDropInteractionState::createDragPreviewInte
         // If the context menu preview was created using the snapshot mechanism,
         // the drag preview should be created likewise, so that the size and position
         // of both previews match.
-        auto textIndicatorImage = uiImageForImage(protect(indicator)->contentImage());
+        auto textIndicatorImage = uiImageForImage(protect(protect(indicator)->contentImage()));
         return createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, indicator->textBoundingRectInRootViewCoordinates(), indicator->textRectsInBoundingRectCoordinates(), cocoaColor(indicator->estimatedBackgroundColor()).get(), nil, addPreviewViewToContainer).autorelease();
     }
 
@@ -307,7 +307,7 @@ RetainPtr<UITargetedDragPreview> DragDropInteractionState::createDragPreviewInte
         ASSERT(image);
         if (shouldUseVisiblePathToCreatePreviewForDragSource(source)) {
             auto path = source.visiblePath.value();
-            UIBezierPath *visiblePath = [UIBezierPath bezierPathWithCGPath:protect<CGPathRef>(path.platformPath()).get()];
+            RetainPtr visiblePath = [UIBezierPath bezierPathWithCGPath:protect<CGPathRef>(path.platformPath()).get()];
             return createTargetedDragPreview(image->get(), contentView, previewContainer, source.dragPreviewFrameInRootViewCoordinates, { }, nil, visiblePath, addPreviewViewToContainer).autorelease();
         }
         return createTargetedDragPreview(image->get(), contentView, previewContainer, source.dragPreviewFrameInRootViewCoordinates, { }, nil, nil, addPreviewViewToContainer).autorelease();
@@ -315,7 +315,7 @@ RetainPtr<UITargetedDragPreview> DragDropInteractionState::createDragPreviewInte
 
     if (shouldUseTextIndicatorToCreatePreviewForDragSource(source)) {
         RefPtr textIndicator = source.textIndicator;
-        RetainPtr textIndicatorImage = uiImageForImage(protect(textIndicator)->contentImage());
+        RetainPtr textIndicatorImage = uiImageForImage(protect(protect(textIndicator)->contentImage()));
         return createTargetedDragPreview(textIndicatorImage.get(), contentView, previewContainer, textIndicator->textBoundingRectInRootViewCoordinates(), textIndicator->textRectsInBoundingRectCoordinates(), cocoaColor(textIndicator->estimatedBackgroundColor()).get(), nil, addPreviewViewToContainer).autorelease();
     }
 

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -73,6 +73,7 @@
 #import "WebProcessProxy.h"
 #import "_WKDownloadInternal.h"
 #import <WebCore/AXObjectCache.h>
+#import <WebCore/Color.h>
 #import <WebCore/Cursor.h>
 #import <WebCore/DOMPasteAccess.h>
 #import <WebCore/DictionaryLookup.h>
@@ -360,7 +361,7 @@ void PageClientImpl::didCompleteSyntheticClick()
 void PageClientImpl::decidePolicyForGeolocationPermissionRequest(WebFrameProxy& frame, const FrameInfoData& frameInfo, Function<void(bool)>& completionHandler)
 {
     if (auto webView = this->webView()) {
-        auto* geolocationProvider = [protect(wrapper(webView->_page->configuration().processPool())) _geolocationProvider];
+        RetainPtr geolocationProvider = [protect(wrapper(webView->_page->configuration().processPool())) _geolocationProvider];
         [geolocationProvider decidePolicyForGeolocationRequestFromOrigin:FrameInfoData { frameInfo } completionHandler:std::exchange(completionHandler, nullptr) view:webView.get()];
     }
 }
@@ -1310,10 +1311,10 @@ WebCore::Color PageClientImpl::contentViewBackgroundColor()
 {
     WebCore::Color color;
     [[webView() traitCollection] performAsCurrentTraitCollection:[&, protectedThis = Ref { *this }]() {
-        color = WebCore::roundAndClampToSRGBALossy(protect([protectedThis->contentView() backgroundColor]).get().CGColor);
+        color = WebCore::roundAndClampToSRGBALossy(protect(protect([protectedThis->contentView() backgroundColor]).get().CGColor));
         if (color.isValid())
             return;
-        color = WebCore::roundAndClampToSRGBALossy(protect(UIColor.systemBackgroundColor).get().CGColor);
+        color = WebCore::roundAndClampToSRGBALossy(protect(protect(UIColor.systemBackgroundColor).get().CGColor));
     }];
 
     return color;

--- a/Source/WebKit/UIProcess/ios/WKActionSheet.mm
+++ b/Source/WebKit/UIProcess/ios/WKActionSheet.mm
@@ -107,7 +107,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (BOOL)presentSheetFromRect:(CGRect)presentationRect
 {
-    UIView *view = [protect(_sheetDelegate) hostViewForSheet];
+    RetainPtr<UIView> view = [protect(_sheetDelegate) hostViewForSheet];
     if (!view)
         return NO;
 
@@ -122,7 +122,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (_popoverPresentationControllerDelegateWhileRotating)
         presentationController.get().delegate = _popoverPresentationControllerDelegateWhileRotating.get();
 
-    _currentPresentingViewController = view._wk_viewControllerForFullScreenPresentation;
+    _currentPresentingViewController = view.get()._wk_viewControllerForFullScreenPresentation;
     [_currentPresentingViewController presentViewController:presentedViewController.get() animated:YES completion:nil];
 
     return YES;
@@ -160,11 +160,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     //    rotation, we take this opportunity to simplify the view controller hierarchy and simply re-present the content
     //    view controller, without re-presenting the alert controller.
 
-    UIView *view = [protect(_sheetDelegate) hostViewForSheet];
+    RetainPtr<UIView> view = [protect(_sheetDelegate) hostViewForSheet];
     if (!view)
         return;
 
-    auto presentingViewController = view._wk_viewControllerForFullScreenPresentation;
+    auto presentingViewController = view.get()._wk_viewControllerForFullScreenPresentation;
 
     // topPresentedViewController is either self (cases (a) and (b) above) or an action's view controller
     // (case (c) above).

--- a/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm
@@ -235,13 +235,13 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (![newTraitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection])
         return;
 
-    auto doneButtonAttributes = [NSMutableDictionary dictionaryWithObject:protect(WebKit::doneButtonFont()).get() forKey:NSFontAttributeName];
+    RetainPtr doneButtonAttributes = [NSMutableDictionary dictionaryWithObject:protect(WebKit::doneButtonFont()).get() forKey:NSFontAttributeName];
 
     UIColor *tintColor = nil;
 
     if (newTraitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) {
         tintColor = UIColor.whiteColor;
-        doneButtonAttributes[NSForegroundColorAttributeName] = tintColor;
+        doneButtonAttributes.get()[NSForegroundColorAttributeName] = tintColor;
     }
 
     self.tintColor = tintColor;

--- a/Source/WebKit/UIProcess/ios/forms/WKFormPopover.h
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormPopover.h
@@ -37,7 +37,7 @@
 - (void)dismissPopoverAnimated:(BOOL)animated;
 - (UIPopoverArrowDirection)popoverArrowDirections;
 
-@property (nonatomic, readonly) WKContentView *view;
+@property (nonatomic, readonly) WKContentView *view SUPPRESS_UNRETAINED_MEMBER;
 
 @property (nonatomic, assign) CGPoint presentationPoint;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN


### PR DESCRIPTION
#### ab35dc23af0ecbe0a909597f87c43727f15ac94e
<pre>
Fix misc safer C++ smart pointer warnings in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307252">https://bugs.webkit.org/show_bug.cgi?id=307252</a>

Reviewed by Geoffrey Garen.

Fixed various safer C++ warnings.

* Source/WebCore/platform/graphics/Color.h:
* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm:
(WebKit::WebParentalControlsURLFilter::isURLAllowedImpl):
* Source/WebKit/UIProcess/Cocoa/WKContactPicker.mm:
(-[WKContactPicker presentWithRequestData:completionHandler:]):
* Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicatorButton contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):
(-[WKPDFPageNumberIndicatorButton contextMenuInteraction:willEndForConfiguration:animator:]):
(-[WKPDFPageNumberIndicator initWithFrame:view:pageCount:]):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::~ScrollingTreeScrollingNodeDelegateIOS):
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::resetScrollViewDelegate):
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::deliverDelayedDropPreview):
(WebKit::DragDropInteractionState::createDragPreviewInternal const):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::decidePolicyForGeolocationPermissionRequest):
(WebKit::PageClientImpl::contentViewBackgroundColor):
* Source/WebKit/UIProcess/ios/WKActionSheet.mm:
(-[WKActionSheet presentSheetFromRect:]):
(-[WKActionSheet willRotate]):
* Source/WebKit/UIProcess/ios/forms/WKFormAccessoryView.mm:
(-[WKFormAccessoryView traitCollectionDidChange:]):
* Source/WebKit/UIProcess/ios/forms/WKFormPopover.h:

Canonical link: <a href="https://commits.webkit.org/307037@main">https://commits.webkit.org/307037@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e3fc4467cdbd493017ab1a3e90b3ac422f83638

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96408 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41ff031a-2191-4276-90fd-1b8f3477b103) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145054 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110116 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79267 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24a302ca-846d-4531-91c5-4bdf2e8a3cf3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12554 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128136 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91027 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/391bd384-4226-439c-9761-65550533f1b1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12037 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9749 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1860 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121456 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4633 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154174 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15667 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5620 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118135 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15671 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118475 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14401 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125820 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71066 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22075 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15331 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4461 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15065 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79050 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15276 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->