### PR TITLE
[Scroll Anchoring] Implement the anchor selection algorithm and scroll adjustment

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6346,8 +6346,34 @@ webkit.org/b/241104 fast/block/fill-available-with-no-specified-containing-block
 webkit.org/b/241104 fast/block/fill-available-with-absolute-position.html [ ImageOnlyFailure ]
 webkit.org/b/241104 fast/css/fill-available-with-percent-height-no-quirk.html [ ImageOnlyFailure ]
 
-# temporarily disable all scroll anchoring tests
-imported/w3c/web-platform-tests/css/css-scroll-anchoring [ Skip ]
+# scroll anchoring failures
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/ancestor-change-heuristic.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-inside-textarea.tentative.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/anchor-updates-after-explicit-scroll.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/clipped-scrollers-skipped.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/contenteditable-near-cursor.tentative.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/device-pixel-adjustment.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/heuristic-with-offset-update-from-scroll-event-listener.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/heuristic-with-offset-update.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/history-restore-anchors.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/infinite-scroll-event.tentative.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/multicol-fragmented-anchor.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-dynamic-scroller.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out-dynamic.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/opt-out.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-display-none-to-abspos-change.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic-in-nested-scroll-box.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heuristic.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html [ Pass Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/nested-overflow-subtree-layout-vertical.html [ ImageOnlyFailure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/nested-overflow-subtree-layout.html [ ImageOnlyFailure ]
+fast/repaint/absolute-position-changed.html [ Pass ImageOnlyFailure ]
+
+webkit.org/b/307272 editing/execCommand/insert-line-break-no-scroll.html [ Failure ]
+webkit.org/b/307272 fast/events/no-scroll-on-input-text-selection.html [ Failure ]
+webkit.org/b/307273 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-iframe.html [ ImageOnlyFailure ]
+
 # affected by scroll anchoring.
 http/tests/site-isolation/mouse-events/scrolled-mainframe.html [ Skip ]
 

--- a/LayoutTests/compositing/repaint/sticky-repaint-on-scroll.html
+++ b/LayoutTests/compositing/repaint/sticky-repaint-on-scroll.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/dom/Element/body-scrollLeft-basics-quirks.html
+++ b/LayoutTests/fast/dom/Element/body-scrollLeft-basics-quirks.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
     <head>
         <style>

--- a/LayoutTests/fast/dom/Element/body-scrollTop-basics-quirks.html
+++ b/LayoutTests/fast/dom/Element/body-scrollTop-basics-quirks.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
     <head>
         <style>

--- a/LayoutTests/fast/overflow/scroll-anchor-in-overflow-in-position-fixed.html
+++ b/LayoutTests/fast/overflow/scroll-anchor-in-overflow-in-position-fixed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/repaint/absolute-position-changed.html
+++ b/LayoutTests/fast/repaint/absolute-position-changed.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <link rel="stylesheet" href="resources/default.css">

--- a/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html
+++ b/LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ] -->
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true AsyncOverflowScrollingEnabled=true ] -->
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true AsyncOverflowScrollingEnabled=true CSSScrollAnchoringEnabled=false ] -->
 <!DOCTYPE html>
 <html>
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/LayoutTests/fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html
+++ b/LayoutTests/fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html>
-
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/visual-viewport/client-rects-relative-to-layout-viewport.html
+++ b/LayoutTests/fast/visual-viewport/client-rects-relative-to-layout-viewport.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html>
-
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/visual-viewport/nonzoomed-rects.html
+++ b/LayoutTests/fast/visual-viewport/nonzoomed-rects.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html>
-
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/visual-viewport/rtl-nonzoomed-rects.html
+++ b/LayoutTests/fast/visual-viewport/rtl-nonzoomed-rects.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html>
-
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html dir="rtl">
 <head>
     <script src="../../resources/js-test-pre.js"></script>

--- a/LayoutTests/fast/visual-viewport/rtl-zoomed-rects.html
+++ b/LayoutTests/fast/visual-viewport/rtl-zoomed-rects.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html>
-
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html dir="rtl">
 <head>
     <style>

--- a/LayoutTests/fast/visual-viewport/zoomed-rects.html
+++ b/LayoutTests/fast/visual-viewport/zoomed-rects.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html>
-
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/fast/visual-viewport/zoomed-scroll-into-view-fixed.html
+++ b/LayoutTests/fast/visual-viewport/zoomed-scroll-into-view-fixed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7606,6 +7606,18 @@ webanimations/frame-rate/animation-frame-rate-alignment-started-with-one-frame-s
 # webkit.org/b/277905 [ iOS ] fast/scrolling/ios/scroll-anchoring-momentum-scroll.html is a flaky text failure
 fast/scrolling/ios/scroll-anchoring-momentum-scroll.html [ Pass Failure ]
 
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/adjustments-in-scroll-event-handler.tentative.html [ Pass Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/after-scrollable-range-shrinkage-002.html [ Pass Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/contenteditable-insert-line-at-top.tentative.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/dirty-contents-reselect-anchor.tentative.html [ Pass Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/ignore-adjustments-while-scrolling-to-anchor.tentative.html [ Pass Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html [ Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-001.html [ Pass Failure ]
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-002.html [ Pass Failure ]
+
+# Requires user interaction.
+imported/w3c/web-platform-tests/css/css-scroll-anchoring/fullscreen-crash.html [ Skip ]
+
 # rdar://124971386 (css-box/margin-trim/computed-margin-values layout tests failing in recursive cases)
 imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-child-with-border.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html [ Pass Failure ]

--- a/LayoutTests/scrollingcoordinator/mac/latching/simple-page-rubberbands.html
+++ b/LayoutTests/scrollingcoordinator/mac/latching/simple-page-rubberbands.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <style>

--- a/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-tall-content.html
+++ b/LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-tall-content.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 <html>
 <head>
     <style>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -27,10 +27,9 @@
 #include "ScrollAnchoringController.h"
 
 #include "ContainerNodeInlines.h"
+#include "Document.h"
 #include "Editing.h"
-#include "ElementChildIteratorInlines.h"
-#include "ElementIterator.h"
-#include "HTMLHtmlElement.h"
+#include "FloatRect.h"
 #include "LegacyRenderSVGModelObject.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
@@ -45,7 +44,6 @@
 #include "RenderSVGModelObject.h"
 #include "RenderText.h"
 #include "RenderView.h"
-#include "TypedElementDescendantIteratorInlines.h"
 #include <wtf/SetForScope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/TextStream.h>
@@ -70,23 +68,23 @@ bool ScrollAnchoringController::shouldMaintainScrollAnchor() const
     if (!scrollerBox)
         return false;
 
-    // Maybe only check the block direction.
+    // FIXME: Writing modes: only check the block direction.
     if (!scrollerBox->hasScrollableOverflowX() && !scrollerBox->hasScrollableOverflowY())
         return false;
 
     if (scrollerBox->style().overflowAnchor() == OverflowAnchor::None)
         return false;
 
-    // FIXME: RTL: only check the block direction.
+    // FIXME: Writing modes: only check the block direction.
     if (!m_owningScrollableArea->scrollOffset().y())
         return false;
 
     return true;
 }
 
-LocalFrameView& ScrollAnchoringController::frameView()
+LocalFrameView& ScrollAnchoringController::frameView() const
 {
-    if (auto* renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(m_owningScrollableArea.get()))
+    if (CheckedPtr renderLayerScrollableArea = dynamicDowncast<RenderLayerScrollableArea>(m_owningScrollableArea.get()))
         return renderLayerScrollableArea->layer().renderer().view().frameView();
 
     return downcast<LocalFrameView>(downcast<ScrollView>(m_owningScrollableArea));
@@ -103,8 +101,29 @@ RenderBox* ScrollAnchoringController::scrollableAreaBox() const
     return nullptr;
 }
 
-void ScrollAnchoringController::clearAnchor(bool)
+void ScrollAnchoringController::clearAnchor(bool includeAncestors)
 {
+    if (m_isUpdatingScrollPositionForAnchoring)
+        return;
+
+    m_anchorObject = nullptr;
+    m_lastAnchorOffset = { };
+
+    if (includeAncestors) {
+        if (is<ScrollView>(m_owningScrollableArea))
+            return;
+
+        CheckedPtr scrollerBox = scrollableAreaBox();
+        if (!scrollerBox)
+            return;
+
+        for (CheckedPtr layer = scrollerBox->layer(); layer; layer = layer->parent()) {
+            if (CheckedPtr scrollableArea = layer->scrollableArea()) {
+                if (CheckedPtr controller = scrollableArea->scrollAnchoringController())
+                    controller->clearAnchor(false);
+            }
+        }
+    }
 }
 
 void ScrollAnchoringController::invalidate()
@@ -120,16 +139,299 @@ void ScrollAnchoringController::invalidate()
     }
 }
 
+static FloatRect candidateLocalRectForAnchoring(RenderObject& renderer)
+{
+    if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer)) {
+        if (box->hasNonVisibleOverflow())
+            return box->borderBoxRect();
+
+        return box->layoutOverflowRect();
+    }
+
+    if (CheckedPtr text = dynamicDowncast<RenderText>(renderer))
+        return text->linesBoundingBox();
+
+    if (CheckedPtr text = dynamicDowncast<RenderText>(renderer))
+        return text->linesBoundingBox();
+
+    if (is<LegacyRenderSVGModelObject>(renderer))
+        return renderer.decoratedBoundingBox();
+
+    if (is<RenderSVGModelObject>(renderer))
+        return renderer.decoratedBoundingBox();
+
+    return { };
+}
+
+auto ScrollAnchoringController::computeScrollerRelativeRects(RenderObject& candidate) const -> Rects
+{
+    // FIXME: This needs to handle writing modes and zooming.
+    CheckedPtr scrollerBox = scrollableAreaBox();
+    if (!scrollerBox)
+        return { };
+
+    auto localAnchoringRect = candidateLocalRectForAnchoring(candidate);
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "computeScrollerRelativeRects - candidate " << candidate << " localAnchoringRect " << localAnchoringRect);
+
+    if (scrollerBox->isRenderView()) {
+        RefPtr frameView = dynamicDowncast<LocalFrameView>(downcast<ScrollView>(m_owningScrollableArea.get()));
+        if (!frameView)
+            return { };
+
+        auto scrollViewport = frameView->layoutViewportRect();
+
+        RefPtr documentElement = frameView->frame().document() ? frameView->frame().document()->documentElement() : nullptr;
+        if (!documentElement)
+            return { };
+
+        CheckedPtr docRenderer = documentElement->renderBox();
+        if (!docRenderer)
+            return { };
+
+        scrollViewport.contract(docRenderer->scrollPaddingForViewportRect(scrollViewport));
+
+        // FIXME: Need to clamp negative layout overflow for clamp-negative-overflow.html.
+        return {
+            .boundsRelativeToScrolledContent = candidate.localToAbsoluteQuad(localAnchoringRect).boundingBox(),
+            .scrollerContentsVisibleRect = scrollViewport
+        };
+    }
+
+    auto scrollerRect = LayoutRect { m_owningScrollableArea->visibleContentRect() };
+    scrollerRect.contract(scrollerBox->scrollPaddingForViewportRect(scrollerRect));
+
+    // FIXME: Check for writing modes.
+    // FIXME: This really needs to compute bounds relative to the padding box.
+    auto boundsInScrollerContentCoordinates = candidate.localToContainerQuad(localAnchoringRect, scrollerBox.get()).boundingBox();
+    boundsInScrollerContentCoordinates.moveBy(m_owningScrollableArea->scrollPosition());
+
+    // Ignore layout overflow on the block and inline start edges, since these do not contribute to scrolling overflow.
+    // FIXME: writing modes.
+    if (boundsInScrollerContentCoordinates.x() < 0)
+        boundsInScrollerContentCoordinates.shiftXEdgeTo(0);
+
+    if (boundsInScrollerContentCoordinates.y() < 0)
+        boundsInScrollerContentCoordinates.shiftYEdgeTo(0);
+
+    return {
+        .boundsRelativeToScrolledContent = boundsInScrollerContentCoordinates,
+        .scrollerContentsVisibleRect = scrollerRect
+    };
+}
+
+FloatPoint ScrollAnchoringController::computeOffsetFromOwningScroller(RenderObject& candidate) const
+{
+    auto rects = computeScrollerRelativeRects(candidate);
+    return toFloatPoint(rects.boundsRelativeToScrolledContent.location() - rects.scrollerContentsVisibleRect.location());
+}
+
 void ScrollAnchoringController::notifyChildHadSuppressingStyleChange(RenderElement&)
 {
 }
 
-void ScrollAnchoringController::chooseAnchorElement(Document&)
+// https://drafts.csswg.org/css-scroll-anchoring/#anchor-priority-candidates
+bool ScrollAnchoringController::findPriorityCandidate(Document&)
 {
-    UNUSED_PARAM(m_isUpdatingScrollPositionForAnchoring);
-    UNUSED_PARAM(m_isQueuedForScrollPositionUpdate);
-    UNUSED_PARAM(m_anchoringSuppressedByStyleChange);
-    UNUSED_PARAM(m_shouldSuppressScrollPositionUpdate);
+    // FIXME: Implement, without triggering assertion via isEditableNode() for interleaved layouts.
+    return false;
+}
+
+static bool candidateMayMoveWithScroller(RenderObject& candidate, RenderBox& scrollerBox)
+{
+    CheckedPtr renderElement = dynamicDowncast<RenderElement>(candidate);
+    if (!renderElement)
+        return true;
+
+    if (renderElement->isStickilyPositioned() || renderElement->isFixedPositioned())
+        return false;
+
+    CheckedPtr scrollerBlock = dynamicDowncast<RenderBlock>(scrollerBox);
+    if (!scrollerBlock->isContainingBlockAncestorFor(candidate))
+        return false;
+
+    return true;
+}
+
+AnchorSearchStatus ScrollAnchoringController::examinePriorityCandidate(RenderObject& renderer) const
+{
+    CheckedPtr scrollerBox = scrollableAreaBox();
+
+    RenderObject* ancestor = &renderer;
+    while (ancestor && ancestor != scrollerBox.get()) {
+
+        if (ancestor->style().overflowAnchor() == OverflowAnchor::None)
+            return AnchorSearchStatus::Exclude;
+
+        if (!candidateMayMoveWithScroller(*ancestor, *scrollerBox))
+            return AnchorSearchStatus::Exclude;
+
+        ancestor = ancestor->parent();
+    }
+
+    if (!ancestor)
+        return AnchorSearchStatus::Exclude;
+
+    return examineAnchorCandidate(*ancestor);
+}
+
+// https://drafts.csswg.org/css-scroll-anchoring/#candidate-examination
+AnchorSearchStatus ScrollAnchoringController::examineAnchorCandidate(RenderObject& candidate) const
+{
+    CheckedPtr scrollerBox = scrollableAreaBox();
+
+    if (&candidate == scrollerBox.get())
+        return AnchorSearchStatus::Continue;
+
+    if (candidate.style().overflowAnchor() == OverflowAnchor::None)
+        return AnchorSearchStatus::Exclude;
+
+    if (candidate.isBR())
+        return AnchorSearchStatus::Exclude;
+
+    if (candidate.isAnonymous())
+        return AnchorSearchStatus::Continue;
+
+    if (!candidateMayMoveWithScroller(candidate, *scrollerBox))
+        return AnchorSearchStatus::Exclude;
+
+    bool isScrollableWithAnchor = [&]() {
+        CheckedPtr candidateBox = dynamicDowncast<RenderBox>(candidate);
+        if (candidateBox && candidateBox->canBeScrolledAndHasScrollableArea() && candidateBox->hasLayer()) {
+            if (CheckedPtr scrollableArea = downcast<RenderLayerModelObject>(candidate).layer()->scrollableArea()) {
+                CheckedPtr controller = scrollableArea->scrollAnchoringController();
+                if (controller && controller->shouldMaintainScrollAnchor())
+                    return true;
+            }
+        }
+        return false;
+    }();
+
+    auto shouldDescendIntoObjectWithEmptyLayoutOverflow = [](RenderObject& candidate) {
+        if (candidate.isInline())
+            return true;
+
+        if (CheckedPtr blockFlow = dynamicDowncast<RenderBlockFlow>(candidate))
+            return blockFlow->subtreeContainsFloats();
+
+        return false;
+    };
+
+    auto rects = computeScrollerRelativeRects(candidate);
+    if (rects.boundsRelativeToScrolledContent.isEmpty()) {
+        if (shouldDescendIntoObjectWithEmptyLayoutOverflow(candidate))
+            return AnchorSearchStatus::Continue;
+
+        return AnchorSearchStatus::Exclude;
+    }
+
+    if (rects.scrollerContentsVisibleRect.contains(rects.boundsRelativeToScrolledContent))
+        return AnchorSearchStatus::Choose;
+
+    // This takes scroll padding into account
+    auto intersectionRect = intersection(rects.boundsRelativeToScrolledContent, rects.scrollerContentsVisibleRect);
+    LOG_WITH_STREAM(ScrollAnchoring, stream << " bounds in scrolled content " << rects.boundsRelativeToScrolledContent << " scroller viewport " << rects.scrollerContentsVisibleRect << " intersectionRect " << intersectionRect);
+
+    if (intersectionRect.isEmpty())
+        return AnchorSearchStatus::Exclude;
+
+    return isScrollableWithAnchor ? AnchorSearchStatus::Choose : AnchorSearchStatus::Constrain;
+}
+
+#if !LOG_DISABLED
+static TextStream& operator<<(TextStream& ts, AnchorSearchStatus result)
+{
+    switch (result) {
+    case AnchorSearchStatus::Exclude:
+        ts << "Exclude"_s;
+        break;
+    case AnchorSearchStatus::Continue:
+        ts << "Continue"_s;
+        break;
+    case AnchorSearchStatus::Constrain:
+        ts << "Constrain"_s;
+        break;
+    case AnchorSearchStatus::Choose:
+        ts << "Choose"_s;
+        break;
+    }
+    return ts;
+}
+#endif
+
+// For each absolutely-positioned element A whose containing block is N...
+AnchorSearchStatus ScrollAnchoringController::findAnchorInOutOfFlowObjects(RenderObject& candidate)
+{
+    CheckedPtr block = dynamicDowncast<RenderBlock>(candidate);
+    if (!block)
+        return AnchorSearchStatus::Exclude;
+
+    auto* outOfFlowBoxes = block->outOfFlowBoxes();
+    if (!outOfFlowBoxes)
+        return AnchorSearchStatus::Exclude;
+
+    for (auto& outOfFlowBox : *outOfFlowBoxes) {
+        auto status = findAnchorRecursive(&outOfFlowBox);
+        if (isViableStatus(status))
+            return status;
+    }
+
+    return AnchorSearchStatus::Exclude;
+}
+
+AnchorSearchStatus ScrollAnchoringController::findAnchorRecursive(RenderObject* object)
+{
+    if (!object)
+        return AnchorSearchStatus::Exclude;
+
+    if (!object->everHadLayout())
+        return AnchorSearchStatus::Exclude;
+
+    auto status = examineAnchorCandidate(*object);
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " findAnchorRecursive() element: " << *object <<" examination result: " << status);
+
+    if (isViableStatus(status))
+        m_anchorObject = *object;
+
+    if (status == AnchorSearchStatus::Choose || status == AnchorSearchStatus::Exclude)
+        return status;
+
+    CheckedPtr renderElement = dynamicDowncast<RenderElement>(*object);
+    if (!renderElement)
+        return AnchorSearchStatus::Exclude;
+
+    for (CheckedPtr child = renderElement->firstChild(); child; child = child->nextSibling()) {
+        auto childStatus = findAnchorRecursive(child.get());
+        if (childStatus == AnchorSearchStatus::Choose)
+            return childStatus;
+
+        if (childStatus == AnchorSearchStatus::Constrain) {
+            // FIXME: Do something better in fragmented contexts?
+            return childStatus;
+        }
+    }
+
+    auto outOfFlowStatus = findAnchorInOutOfFlowObjects(*object);
+    if (isViableStatus(outOfFlowStatus))
+        return outOfFlowStatus;
+
+    return status;
+}
+
+// https://drafts.csswg.org/css-scroll-anchoring/#anchor-node-selection
+void ScrollAnchoringController::chooseAnchorElement(Document& document)
+{
+    bool foundPriorityObject = findPriorityCandidate(document);
+
+    if (!foundPriorityObject)
+        findAnchorRecursive(scrollableAreaBox());
+
+    if (!m_anchorObject) {
+        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " chooseAnchorElement() failed to find anchor");
+        return;
+    }
+
+    m_lastAnchorOffset = computeOffsetFromOwningScroller(*m_anchorObject);
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::chooseAnchorElement() found anchor: " << *m_anchorObject << " offset: " << m_lastAnchorOffset);
 }
 
 // https://drafts.csswg.org/css-scroll-anchoring/#suppression-triggers
@@ -140,10 +442,85 @@ bool ScrollAnchoringController::anchoringSuppressedByStyleChange() const
 
 void ScrollAnchoringController::updateBeforeLayout()
 {
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " on " << *scrollableAreaBox() << " updateBeforeLayout() - queued " << m_isQueuedForScrollPositionUpdate);
+
+    if (m_isQueuedForScrollPositionUpdate) {
+        m_anchoringSuppressedByStyleChange |= anchoringSuppressedByStyleChange();
+        return;
+    }
+
+    auto scrollOffset = m_owningScrollableArea->scrollOffset();
+    // FIXME: Writing modes.
+    if (!scrollOffset.y()) {
+        clearAnchor();
+        return;
+    }
+
+    if (!m_anchorObject) {
+        RefPtr document = frameView().frame().document();
+        if (!document)
+            return;
+
+        chooseAnchorElement(*document);
+        if (!m_anchorObject) {
+            LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " updateBeforeLayout() - did not find anchor");
+            return;
+        }
+    }
+
+    m_anchoringSuppressedByStyleChange = anchoringSuppressedByStyleChange();
+
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " updateBeforeLayout() - anchor " << *m_anchorObject << " offset " << m_lastAnchorOffset << " suppressedByStyleChange " << m_anchoringSuppressedByStyleChange);
+
+    frameView().queueScrollableAreaForScrollAnchoringUpdate(m_owningScrollableArea);
+    m_isQueuedForScrollPositionUpdate = true;
 }
 
+// https://drafts.csswg.org/css-scroll-anchoring/#scroll-adjustment
 void ScrollAnchoringController::adjustScrollPositionForAnchoring()
 {
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " adjustScrollPositionForAnchoring() - anchor " << m_anchorObject << " offset " << m_lastAnchorOffset << " suppressed  " << m_shouldSuppressScrollPositionUpdate);
+
+    auto suppressed = std::exchange(m_shouldSuppressScrollPositionUpdate, false);
+    if (suppressed)
+        return;
+
+    auto queued = std::exchange(m_isQueuedForScrollPositionUpdate, false);
+    if (!m_anchorObject || !queued)
+        return;
+
+    SetForScope midUpdatingScrollPositionForAnchorElement(m_isUpdatingScrollPositionForAnchoring, true);
+
+    auto currentOffset = computeOffsetFromOwningScroller(*m_anchorObject);
+
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::adjustScrollPositionForAnchoring() found anchor: " << *m_anchorObject << " offset: " << m_lastAnchorOffset << " suppressedByStyleChange " << m_anchoringSuppressedByStyleChange);
+    if (m_anchoringSuppressedByStyleChange) {
+        clearAnchor();
+        m_anchoringSuppressedByStyleChange = false;
+        return;
+    }
+
+    auto adjustment = currentOffset - m_lastAnchorOffset;
+    if (adjustment.isZero())
+        return;
+
+    // FIXME: Handle content-visibility.
+
+    auto currentPosition = m_owningScrollableArea->scrollPosition();
+    auto newScrollPosition = currentPosition + roundedIntSize(adjustment);
+    RELEASE_LOG(ScrollAnchoring, "ScrollAnchoringController::adjustScrollPositionForAnchoring() is main frame: %d, is main scroller: %d, adjusting from (%d, %d) to (%d, %d)",  frameView().frame().isMainFrame(), !m_owningScrollableArea->isRenderLayer(), currentPosition.x(), currentPosition.y(), newScrollPosition.x(), newScrollPosition.y());
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " adjustScrollPositionForAnchoring() for scroller element: " << ValueOrNull(scrollableAreaBox()) << " anchor: " << *m_anchorObject << "adjusting from " << currentPosition << " to " << newScrollPosition);
+
+    auto options = ScrollPositionChangeOptions::createProgrammatic();
+    options.originalScrollDelta = adjustment;
+
+    auto oldScrollType = m_owningScrollableArea->currentScrollType();
+    m_owningScrollableArea->setCurrentScrollType(ScrollType::Programmatic);
+
+    if (!m_owningScrollableArea->requestScrollToPosition(newScrollPosition, options))
+        m_owningScrollableArea->scrollToPositionWithoutAnimation(newScrollPosition);
+
+    m_owningScrollableArea->setCurrentScrollType(oldScrollType);
 }
 
 } // namespace WebCore


### PR DESCRIPTION
#### b9c702f9efb53ba85042d10c1070d72a6487676f
<pre>
[Scroll Anchoring] Implement the anchor selection algorithm and scroll adjustment
<a href="https://bugs.webkit.org/show_bug.cgi?id=307256">https://bugs.webkit.org/show_bug.cgi?id=307256</a>
<a href="https://rdar.apple.com/169893438">rdar://169893438</a>

Reviewed by Tim Nguyen.

Implement the anchor selection algorithm, and the scroll adjustment parts of
scroll anchoring[1], via render tree traversal (replacing the former
DOM traversal implementation that was removed).

There are a number of FIXME comments that will be addressed in future
commits, many around writing modes.

Unskip some of the scroll-anchoring tests that now pass. Several tests which
test scrolling are perturbed by scroll anchoring, so disable it in them.

[1] <a href="https://drafts.csswg.org/css-scroll-anchoring/">https://drafts.csswg.org/css-scroll-anchoring/</a>

* LayoutTests/TestExpectations:
* LayoutTests/compositing/repaint/sticky-repaint-on-scroll.html:
* LayoutTests/fast/dom/Element/body-scrollLeft-basics-quirks.html:
* LayoutTests/fast/dom/Element/body-scrollTop-basics-quirks.html:
* LayoutTests/fast/overflow/scroll-anchor-in-overflow-in-position-fixed.html: Despite the name, this test
is not about scroll anchoring; it&apos;s about scrolling to an `&lt;a&gt;`.
* LayoutTests/fast/repaint/absolute-position-changed.html:
* LayoutTests/fast/scrolling/ios/click-events-during-momentum-scroll-in-main-frame.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html:
* LayoutTests/fast/visual-viewport/client-coordinates-relative-to-layout-viewport.html:
* LayoutTests/fast/visual-viewport/client-rects-relative-to-layout-viewport.html:
* LayoutTests/fast/visual-viewport/nonzoomed-rects.html:
* LayoutTests/fast/visual-viewport/rtl-nonzoomed-rects.html:
* LayoutTests/fast/visual-viewport/rtl-zoomed-rects.html:
* LayoutTests/fast/visual-viewport/zoomed-rects.html:
* LayoutTests/fast/visual-viewport/zoomed-scroll-into-view-fixed.html:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/scrollingcoordinator/mac/latching/simple-page-rubberbands.html:
* LayoutTests/scrollingcoordinator/mac/rubberbanding-bounce-based-on-size-tall-content.html:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::shouldMaintainScrollAnchor const):
(WebCore::ScrollAnchoringController::frameView const):
(WebCore::ScrollAnchoringController::clearAnchor):
(WebCore::candidateLocalRectForAnchoring):
(WebCore::ScrollAnchoringController::computeScrollerRelativeRects const):
(WebCore::ScrollAnchoringController::computeOffsetFromOwningScroller const):
(WebCore::ScrollAnchoringController::findPriorityCandidate):
(WebCore::candidateMayMoveWithScroller):
(WebCore::ScrollAnchoringController::examinePriorityCandidate const):
(WebCore::ScrollAnchoringController::examineAnchorCandidate const):
(WebCore::operator&lt;&lt;):
(WebCore::ScrollAnchoringController::findAnchorInOutOfFlowObjects):
(WebCore::ScrollAnchoringController::findAnchorRecursive):
(WebCore::ScrollAnchoringController::chooseAnchorElement):
(WebCore::ScrollAnchoringController::updateBeforeLayout):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
(WebCore::ScrollAnchoringController::frameView): Deleted.
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
(WebCore::ScrollAnchoringController::isViableStatus):

Canonical link: <a href="https://commits.webkit.org/307039@main">https://commits.webkit.org/307039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff63aeedbdd933aa3d3d75ac5f80ebdb537723cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15683 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151884 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96429 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b524a0cd-8113-4a16-9eef-6b9cf9d5088c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145075 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16343 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110134 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79285 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c3535de-c94c-4e67-99bb-7f3a4cae60f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12576 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128157 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91045 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9de54eb-80db-4473-8c0c-e951f4a995e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12059 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9770 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1881 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154195 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15698 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118153 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15716 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118493 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30338 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14422 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125841 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71112 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15352 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4482 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15086 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79071 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15297 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15148 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->