### PR TITLE
experiment layout monospace

### DIFF
--- a/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h
+++ b/Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h
@@ -46,6 +46,8 @@ inline TextRun BoxModernPath::textRun(TextRunMode mode) const
     auto characterScanForCodePath = isText() && !renderText().canUseSimpleFontCodePath();
     auto textRun = TextRun { mode == TextRunMode::Editing ? originalText() : box().text().renderedContent(), logicalLeft(), expansion.horizontalExpansion, expansion.behavior, direction(), style.rtlOrdering() == Order::Visual, characterScanForCodePath };
     textRun.setTabSize(!style.collapseWhiteSpace(), Style::toPlatform(style.tabSize()));
+    if (isText())
+        textRun.setCanUseSimplifiedMeasuring(renderText().canUseSimplifiedTextMeasuring().value_or(false));
     return textRun;
 }
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -167,6 +167,18 @@ void FontCascade::update(RefPtr<FontSelector>&& fontSelector) const
 
 GlyphBuffer FontCascade::layoutText(CodePath codePathToUse, const TextRun& run, unsigned from, unsigned to, ForTextEmphasisOrNot forTextEmphasis) const
 {
+    if (codePathToUse != CodePath::Complex
+        && forTextEmphasis == ForTextEmphasisOrNot::NotForTextEmphasis
+        && run.canUseSimplifiedMeasuring()
+        && canTakeFixedPitchFastContentMeasuring()
+        && !primaryFont()->syntheticBoldOffset()
+        && !run.expansion()
+        && run.horizontalGlyphStretch() == 1
+        && !wordSpacing()
+        && !letterSpacing()) {
+        return layoutSimpleTextForFixedPitch(run, from, to);
+    }
+
     if (shouldUseComplexTextController(codePathToUse))
         return layoutComplexText(run, from, to, forTextEmphasis);
 
@@ -1453,6 +1465,39 @@ float FontCascade::floatEmphasisMarkHeight(const AtomString& mark) const
     if (RefPtr font = fontForEmphasisMark(mark))
         return font->fontMetrics().height();
     return { };
+}
+
+GlyphBuffer FontCascade::layoutSimpleTextForFixedPitch(const TextRun& run, unsigned from, unsigned to) const
+{
+    GlyphBuffer glyphBuffer;
+    Ref font = primaryFont();
+    auto advance = font->spaceWidth(Font::SyntheticBoldInclusion::Exclude);
+
+    auto addGlyphs = [&](auto characters) {
+        for (size_t i = 0; i < characters.size(); ++i) {
+            auto glyph = font->glyphForCharacter(characters[i]);
+            glyphBuffer.add(glyph, font.get(), advance, from + i);
+        }
+    };
+
+    auto subText = run.text().substring(from, to - from);
+    if (subText.is8Bit())
+        addGlyphs(subText.span8());
+    else
+        addGlyphs(subText.span16());
+
+    auto initialAdvance = font->applyTransforms(glyphBuffer, 0, from,
+        enableKerning(), requiresShaping(),
+        fontDescription().computedLocale(), run.text(), run.direction());
+    glyphBuffer.setInitialAdvance(initialAdvance);
+
+    if (from > 0)
+        glyphBuffer.expandInitialAdvance(from * advance);
+
+    if (run.rtl())
+        glyphBuffer.reverse(0, glyphBuffer.size());
+
+    return glyphBuffer;
 }
 
 GlyphBuffer FontCascade::layoutSimpleText(const TextRun& run, unsigned from, unsigned to, ForTextEmphasisOrNot forTextEmphasis) const

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -248,6 +248,7 @@ private:
 
     GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
     GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
+    GlyphBuffer layoutSimpleTextForFixedPitch(const TextRun&, unsigned from, unsigned to) const;
     void drawGlyphBuffer(GraphicsContext&, const GlyphBuffer&, FloatPoint&, CustomFontNotReadyAction) const;
     void drawEmphasisMarks(GraphicsContext&, const GlyphBuffer&, const AtomString&, const FloatPoint&) const;
     int offsetForPositionForSimpleText(const TextRun&, float position, bool includePartialGlyphs) const;

--- a/Source/WebCore/platform/graphics/TextRun.cpp
+++ b/Source/WebCore/platform/graphics/TextRun.cpp
@@ -42,7 +42,7 @@ struct ExpectedTextRunSize final : public CanMakeCheckedPtr<ExpectedTextRunSize>
     float float3;
     ExpansionBehavior expansionBehavior;
     TextSpacing::SpacingState spacingState;
-    unsigned bitfields : 5;
+    unsigned bitfields : 6;
 };
 
 static_assert(sizeof(TextRun) == sizeof(ExpectedTextRunSize), "TextRun should be small");

--- a/Source/WebCore/platform/graphics/TextRun.h
+++ b/Source/WebCore/platform/graphics/TextRun.h
@@ -59,6 +59,7 @@ public:
         , m_directionalOverride(directionalOverride)
         , m_characterScanForCodePath(characterScanForCodePath)
         , m_disableSpacing(false)
+        , m_canUseSimplifiedMeasuring(false)
     {
         ASSERT(!m_text.isNull());
     }
@@ -80,6 +81,7 @@ public:
         , m_directionalOverride(0)
         , m_characterScanForCodePath(0)
         , m_disableSpacing(0)
+        , m_canUseSimplifiedMeasuring(0)
     {
     }
 
@@ -95,6 +97,7 @@ public:
         , m_directionalOverride(0)
         , m_characterScanForCodePath(0)
         , m_disableSpacing(0)
+        , m_canUseSimplifiedMeasuring(0)
     {
     }
 
@@ -146,8 +149,10 @@ public:
     bool directionalOverride() const { return m_directionalOverride; }
     bool characterScanForCodePath() const { return m_characterScanForCodePath; }
     bool spacingDisabled() const { return m_disableSpacing; }
+    bool canUseSimplifiedMeasuring() const { return m_canUseSimplifiedMeasuring; }
 
     void disableSpacing() { m_disableSpacing = true; }
+    void setCanUseSimplifiedMeasuring(bool value) { m_canUseSimplifiedMeasuring = value; }
     void setDirection(TextDirection direction) { m_direction = static_cast<unsigned>(direction); }
     void setDirectionalOverride(bool override) { m_directionalOverride = override; }
     void setCharacterScanForCodePath(bool scan) { m_characterScanForCodePath = scan; }
@@ -182,6 +187,7 @@ private:
     unsigned m_directionalOverride : 1; // Was this direction set by an override character.
     unsigned m_characterScanForCodePath : 1;
     unsigned m_disableSpacing : 1;
+    unsigned m_canUseSimplifiedMeasuring : 1;
 };
 
 inline void TextRun::setTabSize(bool allow, const TabSize& size)

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -711,6 +711,10 @@ GlyphBufferAdvance Font::applyTransforms(GlyphBuffer& glyphBuffer, unsigned begi
     ASSERT(numberOfInputGlyphs || glyphBuffer.size() == beginningGlyphIndex);
     ASSERT(numberOfInputGlyphs || (!initialAdvance.width && !initialAdvance.height));
 
+    // auto outputGlyphCount = glyphBuffer.size() - beginningGlyphIndex;
+    // if (outputGlyphCount != numberOfInputGlyphs)
+    //     WTFLogAlways("[applyTransforms] GLYPH COUNT MUTATION: %u -> %u for font %s", numberOfInputGlyphs, outputGlyphCount, String(adoptCF(CTFontCopyPostScriptName(ctFont.get())).get()).utf8().data());
+
     for (unsigned i = 0; i < glyphBuffer.size() - beginningGlyphIndex; ++i)
         glyphBuffer.offsetsInString(beginningGlyphIndex)[i] += beginningStringIndex;
 


### PR DESCRIPTION
#### 15526612bd907aec5c89f3fbe52442f2352a4068
<pre>
experiment layout monospace
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/WebCore/layout/integration/inline/InlineIteratorBoxModernPathInlines.h:
(WebCore::InlineIterator::BoxModernPath::textRun const):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::layoutText const):
(WebCore::FontCascade::layoutSimpleTextForFixedPitch const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/TextRun.cpp:
* Source/WebCore/platform/graphics/TextRun.h:
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::applyTransforms const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/15526612bd907aec5c89f3fbe52442f2352a4068

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151830 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96376 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16290 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15711 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110093 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79251 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128106 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91004 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12009 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/first-line-line-height-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vertical-002.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vertical-004.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9721 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1828 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121425 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154142 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15602 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118111 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15598 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13209 "Found 3 new test failures: imported/w3c/web-platform-tests/css/css-pseudo/first-line-line-height-001.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vertical-002.html imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vertical-004.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118451 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14371 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71012 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15299 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4431 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15033 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79018 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15244 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15095 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->