### PR TITLE
inkOverflowForDecorations() should use its own return type

### DIFF
--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -1139,20 +1139,20 @@ void InlineDisplayContentBuilder::collectInkOverflowForTextDecorations(InlineDis
             return inkOverflowForDecorations(parentStyle, { displayBox.height(), textRunLogicalOffsetFromLineBottom });
         }();
 
-        if (!decorationOverflow.isEmpty()) {
+        if (!decorationOverflow.isZero()) {
             m_contentHasInkOverflow = true;
             auto inflatedInkOverflowRect = [&] {
                 auto inkOverflowRect = displayBox.inkOverflow();
                 switch (writingMode.blockDirection()) {
                 case FlowDirection::TopToBottom:
                 case FlowDirection::BottomToTop:
-                    inkOverflowRect.inflate(decorationOverflow.left, decorationOverflow.top, decorationOverflow.right, decorationOverflow.bottom);
+                    inkOverflowRect.inflate(decorationOverflow.left(), decorationOverflow.top(), decorationOverflow.right(), decorationOverflow.bottom());
                     break;
                 case FlowDirection::LeftToRight:
-                    inkOverflowRect.inflate(decorationOverflow.bottom, decorationOverflow.right, decorationOverflow.top, decorationOverflow.left);
+                    inkOverflowRect.inflate(decorationOverflow.bottom(), decorationOverflow.right(), decorationOverflow.top(), decorationOverflow.left());
                     break;
                 case FlowDirection::RightToLeft:
-                    inkOverflowRect.inflate(decorationOverflow.top, decorationOverflow.right, decorationOverflow.bottom, decorationOverflow.left);
+                    inkOverflowRect.inflate(decorationOverflow.top(), decorationOverflow.right(), decorationOverflow.bottom(), decorationOverflow.left());
                     break;
                 default:
                     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -51,35 +51,6 @@ class IntRect;
 class MixedFontGlyphPage;
 
 struct GlyphOverflow {
-    bool isEmpty() const
-    {
-        return !left && !right && !top && !bottom;
-    }
-
-    void extendTo(const GlyphOverflow& other)
-    {
-        left = std::max(left, other.left);
-        right = std::max(right, other.right);
-        top = std::max(top, other.top);
-        bottom = std::max(bottom, other.bottom);
-    }
-
-    void extendTop(float extendTo)
-    {
-        top = std::max(top, LayoutUnit(ceilf(extendTo)));
-    }
-
-    void extendBottom(float extendTo)
-    {
-        bottom = std::max(bottom, LayoutUnit(ceilf(extendTo)));
-    }
-
-    bool operator!=(const GlyphOverflow& other)
-    {
-        // FIXME: Probably should name this rather than making it the != operator since it ignores the value of computeBounds. webkit.org/b/307002
-        return left != other.left || right != other.right || top != other.top || bottom != other.bottom;
-    }
-
     // FIXME: May need clearer&safer storage and names. See webkit.org/b/307002
     LayoutUnit left;
     LayoutUnit right;

--- a/Source/WebCore/style/InlineTextBoxStyle.h
+++ b/Source/WebCore/style/InlineTextBoxStyle.h
@@ -30,7 +30,7 @@
 #include "RenderStyleConstants.h"
 
 namespace WebCore {
-    
+
 class RenderStyle;
 
 inline float wavyOffsetFromDecoration()
@@ -51,15 +51,25 @@ struct WavyStrokeParameters {
 };
 WavyStrokeParameters wavyStrokeParameters(float fontSize);
 
+struct InkOverflowForDecorations : RectEdges<LayoutUnit> {
+    void extendTop(float extendTo)
+    {
+        top() = std::max(top(), LayoutUnit(ceilf(extendTo)));
+    }
+
+    void extendBottom(float extendTo)
+    {
+        bottom() = std::max(bottom(), LayoutUnit(ceilf(extendTo)));
+    }
+};
 struct TextUnderlinePositionUnder {
     float textRunLogicalHeight { 0.f };
     // This offset value is the distance between the current text run's logical bottom and the lowest position of all the text runs
     // on line that belong to the same decorating box.
     float textRunOffsetFromBottomMost { 0.f };
 };
-GlyphOverflow inkOverflowForDecorations(const RenderStyle&);
-GlyphOverflow inkOverflowForDecorations(const RenderStyle&, TextUnderlinePositionUnder);
-GlyphOverflow inkOverflowForDecorations(const InlineIterator::LineBoxIterator&, const RenderText&, float textBoxLogicalTop, float textBoxLogicalBottom);
+InkOverflowForDecorations inkOverflowForDecorations(const RenderStyle&);
+InkOverflowForDecorations inkOverflowForDecorations(const RenderStyle&, TextUnderlinePositionUnder);
 bool isAlignedForUnder(const RenderStyle& decoratingBoxStyle);
 
 float underlineOffsetForTextBoxPainting(const InlineIterator::InlineBox&, const RenderStyle&);


### PR DESCRIPTION
#### 4af680358f82030d8ff29069f1a3d98d367a7b01
<pre>
inkOverflowForDecorations() should use its own return type
<a href="https://bugs.webkit.org/show_bug.cgi?id=307281">https://bugs.webkit.org/show_bug.cgi?id=307281</a>
<a href="https://rdar.apple.com/169927130">rdar://169927130</a>

Reviewed by Cameron McCormack.

inkOverflowForDecorations() was using GlyphOverflow as output, but it
doesn&apos;t share code paths with other users of GlyphOverflow going through
FontCascade::width(), and it doesn&apos;t need the `computeBounds` member.
Instead it now returns its own data type, based on RectEdge&lt;LayoutUnit&gt;,
with some helper member functions stolen from GlyphOverflow.

Also some unused code was removed.

* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::collectInkOverflowForTextDecorations):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::GlyphOverflow::isEmpty const): Deleted.
(WebCore::GlyphOverflow::extendTo): Deleted.
(WebCore::GlyphOverflow::extendTop): Deleted.
(WebCore::GlyphOverflow::extendBottom): Deleted.
(WebCore::GlyphOverflow::operator!=): Deleted.
* Source/WebCore/style/InlineTextBoxStyle.cpp:
(WebCore::computedUnderlineOffset):
(WebCore::computedInkOverflowForDecorations):
(WebCore::inkOverflowForDecorations):
(WebCore::enclosingRendererWithTextDecoration): Deleted.
(WebCore::textRunOffsetFromBottomMost): Deleted.
* Source/WebCore/style/InlineTextBoxStyle.h:
(WebCore::InkOverflowForDecorations::extendTop):
(WebCore::InkOverflowForDecorations::extendBottom):

Canonical link: <a href="https://commits.webkit.org/307046@main">https://commits.webkit.org/307046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efdc82f46d95219856b2136b5febaaf629158eee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15696 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6690 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151897 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96442 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8894585-ea40-46f7-a8a0-2e87e6dfb05d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145088 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110144 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79295 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c76a3b59-35aa-49e9-8990-67e96a42d3d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91055 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/817a81e8-cd09-4062-bbe6-e79ee23b2259) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12071 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9782 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1894 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121497 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154208 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5652 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118163 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13270 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118503 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30344 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14436 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125852 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71127 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15365 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4493 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15099 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79084 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15310 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15161 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->