### PR TITLE
Use Variant for XPathValue

### DIFF
--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -71,184 +71,184 @@ private:
 
 class FunLast final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunLast);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 public:
     FunLast() { setIsContextSizeSensitive(true); }
 };
 
 class FunPosition final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunPosition);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 public:
     FunPosition() { setIsContextPositionSensitive(true); }
 };
 
 class FunCount final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunCount);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 };
 
 class FunId final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunId);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::NodeSet; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::NodeSet; }
 };
 
 class FunLocalName final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunLocalName);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 public:
     FunLocalName() { setIsContextNodeSensitive(true); } // local-name() with no arguments uses context node. 
 };
 
 class FunNamespaceURI final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunNamespaceURI);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 public:
     FunNamespaceURI() { setIsContextNodeSensitive(true); } // namespace-uri() with no arguments uses context node. 
 };
 
 class FunName final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunName);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 public:
     FunName() { setIsContextNodeSensitive(true); } // name() with no arguments uses context node. 
 };
 
 class FunString final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunString);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 public:
     FunString() { setIsContextNodeSensitive(true); } // string() with no arguments uses context node. 
 };
 
 class FunConcat final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunConcat);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 };
 
 class FunStartsWith final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunStartsWith);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Boolean; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Boolean; }
 };
 
 class FunContains final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunContains);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Boolean; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Boolean; }
 };
 
 class FunSubstringBefore final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunSubstringBefore);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 };
 
 class FunSubstringAfter final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunSubstringAfter);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 };
 
 class FunSubstring final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunSubstring);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 };
 
 class FunStringLength final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunStringLength);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 public:
     FunStringLength() { setIsContextNodeSensitive(true); } // string-length() with no arguments uses context node. 
 };
 
 class FunNormalizeSpace final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunNormalizeSpace);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 public:
     FunNormalizeSpace() { setIsContextNodeSensitive(true); } // normalize-space() with no arguments uses context node. 
 };
 
 class FunTranslate final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunTranslate);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 };
 
 class FunBoolean final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunBoolean);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Boolean; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Boolean; }
 };
 
 class FunNot : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunNot);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Boolean; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Boolean; }
 };
 
 class FunTrue final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunTrue);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Boolean; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Boolean; }
 };
 
 class FunFalse final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunFalse);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Boolean; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Boolean; }
 };
 
 class FunLang final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunLang);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Boolean; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Boolean; }
 public:
     FunLang() { setIsContextNodeSensitive(true); } // lang() always works on context node. 
 };
 
 class FunNumber final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunNumber);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 public:
     FunNumber() { setIsContextNodeSensitive(true); } // number() with no arguments uses context node. 
 };
 
 class FunSum final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunSum);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 };
 
 class FunFloor final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunFloor);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 };
 
 class FunCeiling final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunCeiling);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 };
 
 class FunRound final : public Function {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(FunRound);
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 public:
     static double round(double);
 };

--- a/Source/WebCore/xml/XPathPath.h
+++ b/Source/WebCore/xml/XPathPath.h
@@ -29,8 +29,7 @@
 #include "XPathExpressionNode.h"
 #include <wtf/TZoneMalloc.h>
 
-namespace WebCore {
-namespace XPath {
+namespace WebCore::XPath {
 
 class Step;
 
@@ -40,8 +39,8 @@ public:
     Filter(std::unique_ptr<Expression>, Vector<std::unique_ptr<Expression>> predicates);
 
 private:
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::NodeSet; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::NodeSet; }
 
     std::unique_ptr<Expression> m_expression;
     Vector<std::unique_ptr<Expression>> m_predicates;
@@ -60,8 +59,8 @@ public:
     void prependStep(std::unique_ptr<Step>);
 
 private:
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::NodeSet; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::NodeSet; }
 
     Vector<std::unique_ptr<Step>> m_steps;
     bool m_isAbsolute;
@@ -73,12 +72,11 @@ public:
     Path(std::unique_ptr<Expression> filter, std::unique_ptr<LocationPath>);
 
 private:
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::NodeSet; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::NodeSet; }
 
     std::unique_ptr<Expression> m_filter;
     std::unique_ptr<LocationPath> m_path;
 };
 
-} // namespace XPath
-} // namespace WebCore
+} // namespace WebCore::XPath

--- a/Source/WebCore/xml/XPathPredicate.h
+++ b/Source/WebCore/xml/XPathPredicate.h
@@ -29,8 +29,7 @@
 #include "XPathExpressionNode.h"
 #include <wtf/TZoneMalloc.h>
 
-namespace WebCore {
-namespace XPath {
+namespace WebCore::XPath {
 
 class Number final : public Expression {
     WTF_MAKE_TZONE_ALLOCATED(Number);
@@ -38,8 +37,8 @@ public:
     explicit Number(double);
 
 private:
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 
     Value m_value;
 };
@@ -50,8 +49,8 @@ public:
     explicit StringExpression(String&&);
 
 private:
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::String; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::String; }
 
     Value m_value;
 };
@@ -62,8 +61,8 @@ public:
     explicit Negative(std::unique_ptr<Expression>);
 
 private:
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 };
 
 class NumericOp final : public Expression {
@@ -73,8 +72,8 @@ public:
     NumericOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
 
 private:
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::Number; }
 
     Opcode m_opcode;
 };
@@ -84,10 +83,10 @@ class EqTestOp final : public Expression {
 public:
     enum class Opcode : uint8_t { Eq, Ne, Gt, Lt, Ge, Le };
     EqTestOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
-    Value evaluate() const override;
+    Value evaluate() const final;
 
 private:
-    Value::Type resultType() const override { return Value::Type::Boolean; }
+    Value::Type resultType() const final { return Value::Type::Boolean; }
     bool compare(const Value&, const Value&) const;
 
     Opcode m_opcode;
@@ -100,9 +99,9 @@ public:
     LogicalOp(Opcode, std::unique_ptr<Expression> lhs, std::unique_ptr<Expression> rhs);
 
 private:
-    Value::Type resultType() const override { return Value::Type::Boolean; }
+    Value::Type resultType() const final { return Value::Type::Boolean; }
     bool shortCircuitOn() const;
-    Value evaluate() const override;
+    Value evaluate() const final;
 
     Opcode m_opcode;
 };
@@ -113,12 +112,11 @@ public:
     Union(std::unique_ptr<Expression>, std::unique_ptr<Expression>);
 
 private:
-    Value evaluate() const override;
-    Value::Type resultType() const override { return Value::Type::NodeSet; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { return Value::Type::NodeSet; }
 };
 
 bool evaluatePredicate(const Expression&);
 bool predicateIsContextPositionSensitive(const Expression&);
 
-} // namespace XPath
-} // namespace WebCore
+} // namespace WebCore::XPath

--- a/Source/WebCore/xml/XPathResult.cpp
+++ b/Source/WebCore/xml/XPathResult.cpp
@@ -36,25 +36,24 @@ namespace WebCore {
 XPathResult::XPathResult(Document& document, const XPath::Value& value)
     : m_value(value)
 {
-    switch (m_value.type()) {
-    case XPath::Value::Type::Boolean:
-        m_resultType = BOOLEAN_TYPE;
-        return;
-    case XPath::Value::Type::Number:
-        m_resultType = NUMBER_TYPE;
-        return;
-    case XPath::Value::Type::String:
-        m_resultType = STRING_TYPE;
-        return;
-    case XPath::Value::Type::NodeSet:
-        m_resultType = UNORDERED_NODE_ITERATOR_TYPE;
-        m_nodeSetPosition = 0;
-        m_nodeSet = m_value.toNodeSet();
-        m_document = document;
-        m_domTreeVersion = document.domTreeVersion();
-        return;
-    }
-    ASSERT_NOT_REACHED();
+    WTF::switchOn(m_value,
+        [&](bool) {
+            m_resultType = BOOLEAN_TYPE;
+        },
+        [&](double) {
+            m_resultType = NUMBER_TYPE;
+        },
+        [&](const String&) {
+            m_resultType = STRING_TYPE;
+        },
+        [&](const XPath::NodeSet& nodeSet) {
+            m_resultType = UNORDERED_NODE_ITERATOR_TYPE;
+            m_nodeSetPosition = 0;
+            m_nodeSet = nodeSet;
+            m_document = document;
+            m_domTreeVersion = document.domTreeVersion();
+        }
+    );
 }
 
 XPathResult::~XPathResult() = default;

--- a/Source/WebCore/xml/XPathValue.cpp
+++ b/Source/WebCore/xml/XPathValue.cpp
@@ -1,17 +1,17 @@
 /*
  * Copyright 2005 Frerich Raabe <raabe@kde.org>
- * Copyright (C) 2006-2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2006-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * 1. Redistributions of source code must retain the above copyright
  *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
  * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
@@ -39,100 +39,99 @@ namespace WebCore::XPath {
 
 const NodeSet& Value::toNodeSet() const
 {
-    if (!isNodeSet())
+    if (!isNodeSet()) {
         Expression::evaluationContext().hadTypeConversionError = true;
-
-    if (!m_data) {
         static NeverDestroyed<NodeSet> emptyNodeSet;
         return emptyNodeSet;
     }
 
-    return m_data->nodeSet;
-}    
+    return std::get<Ref<NodeSetHolder>>(m_value)->nodeSet;
+}
 
 NodeSet& Value::modifiableNodeSet()
 {
-    if (!isNodeSet())
+    if (!isNodeSet()) {
         Expression::evaluationContext().hadTypeConversionError = true;
+        m_value = NodeSetHolder::create(NodeSet { });
+    }
 
-    if (!m_data)
-        m_data = Data::create();
-
-    m_type = Type::NodeSet;
-    return m_data->nodeSet;
+    return std::get<Ref<NodeSetHolder>>(m_value)->nodeSet;
 }
 
 bool Value::toBoolean() const
 {
-    switch (m_type) {
-    case Type::NodeSet:
-        return !m_data->nodeSet.isEmpty();
-    case Type::Boolean:
-        return m_bool;
-    case Type::Number:
-        return m_number && !std::isnan(m_number);
-    case Type::String:
-        return !m_data->string.isEmpty();
-    }
-    ASSERT_NOT_REACHED();
-    return false;
+    return switchOn(
+        [](bool value) {
+            return value;
+        },
+        [](double value) {
+            return value && !std::isnan(value);
+        },
+        [](const String& string) {
+            return !string.isEmpty();
+        },
+        [](const NodeSet& nodeSet) {
+            return !nodeSet.isEmpty();
+        }
+    );
 }
 
 double Value::toNumber() const
 {
-    switch (m_type) {
-    case Type::NodeSet:
-        return Value(toString()).toNumber();
-    case Type::Number:
-        return m_number;
-    case Type::String: {
-        const String& str = m_data->string.simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
-
-        // String::toDouble() supports exponential notation, which is not allowed in XPath.
-        unsigned len = str.length();
-        for (unsigned i = 0; i < len; ++i) {
-            char16_t c = str[i];
-            if (!isASCIIDigit(c) && c != '.'  && c != '-')
-                return std::numeric_limits<double>::quiet_NaN();
-        }
-
-        bool canConvert;
-        double value = str.toDouble(&canConvert);
-        if (canConvert)
+    return switchOn(
+        [](bool value) -> double {
             return value;
-        return std::numeric_limits<double>::quiet_NaN();
-    }
-    case Type::Boolean:
-        return m_bool;
-    }
+        },
+        [](double value) {
+            return value;
+        },
+        [](const String& string) -> double {
+            auto simplified = string.simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
 
-    ASSERT_NOT_REACHED();
-    return 0.0;
+            // String::toDouble() supports exponential notation, which is not allowed in XPath.
+            unsigned len = simplified.length();
+            for (unsigned i = 0; i < len; ++i) {
+                char16_t c = simplified[i];
+                if (!isASCIIDigit(c) && c != '.' && c != '-')
+                    return std::numeric_limits<double>::quiet_NaN();
+            }
+
+            bool canConvert;
+            auto value = simplified.toDouble(&canConvert);
+            if (canConvert)
+                return value;
+            return std::numeric_limits<double>::quiet_NaN();
+        },
+        [this](const NodeSet&) {
+            return Value(toString()).toNumber();
+        }
+    );
 }
 
 String Value::toString() const
 {
-    switch (m_type) {
-    case Type::NodeSet:
-        if (m_data->nodeSet.isEmpty())
-            return emptyString();
-        return stringValue(Ref { *m_data->nodeSet.firstNode() });
-    case Type::String:
-        return m_data->string;
-    case Type::Number:
-        if (std::isnan(m_number))
-            return "NaN"_s;
-        if (!m_number)
-            return "0"_s;
-        if (std::isinf(m_number))
-            return std::signbit(m_number) ? "-Infinity"_s : "Infinity"_s;
-        return String::number(m_number);
-    case Type::Boolean:
-        return m_bool ? trueAtom() : falseAtom();
-    }
-
-    ASSERT_NOT_REACHED();
-    return String();
+    return switchOn(
+        [](bool value) -> String {
+            return value ? trueAtom() : falseAtom();
+        },
+        [](double value) -> String {
+            if (std::isnan(value))
+                return "NaN"_s;
+            if (!value)
+                return "0"_s;
+            if (std::isinf(value))
+                return std::signbit(value) ? "-Infinity"_s : "Infinity"_s;
+            return String::number(value);
+        },
+        [](const String& string) {
+            return string;
+        },
+        [](const NodeSet& nodeSet) -> String {
+            if (nodeSet.isEmpty())
+                return emptyString();
+            return stringValue(Ref { *nodeSet.firstNode() });
+        }
+    );
 }
 
 } // namespace WebCore::XPath

--- a/Source/WebCore/xml/XPathVariableReference.h
+++ b/Source/WebCore/xml/XPathVariableReference.h
@@ -29,19 +29,17 @@
 #include "XPathExpressionNode.h"
 #include <wtf/TZoneMalloc.h>
 
-namespace WebCore {
-namespace XPath {
+namespace WebCore::XPath {
 
 // Variable references are not used with XPathEvaluator.
-class VariableReference : public Expression {
+class VariableReference final : public Expression {
     WTF_MAKE_TZONE_ALLOCATED(VariableReference);
 public:
     explicit VariableReference(const String& name);
 private:
-    Value evaluate() const override;
-    Value::Type resultType() const override { ASSERT_NOT_REACHED(); return Value::Type::Number; }
+    Value evaluate() const final;
+    Value::Type resultType() const final { ASSERT_NOT_REACHED(); return Value::Type::Number; }
     String m_name;
 };
 
-} // namespace XPath
-} // namespace WebCore
+} // namespace WebCore::XPath


### PR DESCRIPTION
#### dcf32fb4c87d1cd82e74ae9dea41239195c30762
<pre>
Use Variant for XPathValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=307264">https://bugs.webkit.org/show_bug.cgi?id=307264</a>

Reviewed by Sam Weinig.

Reduce memory footprint and improve clarity.

Remove Value(const char*) as it is unused.

Also mark a fair number of methods as final.

Canonical link: <a href="https://commits.webkit.org/307163@main">https://commits.webkit.org/307163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eec70ab8ae9ee4edf04938d29fb7e0f1cda0866c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143574 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16055 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152239 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b04e2cb-0276-46e8-9d33-a97b25a99cf4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16732 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16143 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96810 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a388129c-abf8-40fe-b29f-e2051ab50b44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146537 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12853 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91322 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5759483a-d791-44aa-ad2f-320a52d68be5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10057 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2241 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154551 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16102 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6589 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118411 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16138 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13559 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118767 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14707 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71516 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22140 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15723 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5353 "Found 1 new test failure: http/tests/navigation/process-swap-on-client-side-redirect-private.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15458 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15670 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15522 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->