### PR TITLE
[JSC] Add ArithDiv(Int52Use, Int52Use) in DFG / FTL

### DIFF
--- a/JSTests/stress/int52-arith-div-logical-not.js
+++ b/JSTests/stress/int52-arith-div-logical-not.js
@@ -1,0 +1,127 @@
+// Test that LogicalNot does NOT incorrectly clear NodeBytecodeNeedsNaNOrInfinity
+// for ArithDiv. Division by zero produces ±Infinity, and !Infinity is false.
+// If the flag were incorrectly cleared, chillDiv would return 0 for zero-divisor,
+// and !0 would be true — a wrong result.
+
+// ===== Basic: !(int52 / 0) should be false (Infinity is truthy) =====
+
+function divInt52LogicalNotDivByZero(a, b) {
+    return !(a / b);
+}
+noInline(divInt52LogicalNotDivByZero);
+
+// Warm up with normal division first so the function gets JIT-compiled
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divInt52LogicalNotDivByZero(2147483648 * 6, 3);
+    if (result !== false)
+        throw "FAIL: divInt52LogicalNotDivByZero normal, got " + result + " expected false";
+}
+
+// Now test division by zero: x / 0 = Infinity, !Infinity = false
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divInt52LogicalNotDivByZero(2147483648, 0);
+    // !Infinity should be false. If the optimization incorrectly clears
+    // NeedsNaNOrInfinity, chillDiv returns 0, and !0 = true (WRONG).
+    if (result !== false)
+        throw "FAIL: divInt52LogicalNotDivByZero div-by-zero, got " + result + " expected false";
+}
+
+// ===== Mixed: alternate between normal and div-by-zero =====
+
+function divInt52LogicalNotMixed(a, b) {
+    return !(a / b);
+}
+noInline(divInt52LogicalNotMixed);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (i % 2 === 0) {
+        let result = divInt52LogicalNotMixed(2147483648 * 4, 2);
+        if (result !== false)
+            throw "FAIL: divInt52LogicalNotMixed normal, got " + result + " expected false";
+    } else {
+        // nonzero / 0 = Infinity, !Infinity = false
+        let result = divInt52LogicalNotMixed(2147483648, 0);
+        if (result !== false)
+            throw "FAIL: divInt52LogicalNotMixed div-by-zero, got " + result + " expected false";
+    }
+}
+
+// ===== Negative infinity: negative_int52 / 0 = -Infinity, !(-Infinity) = false =====
+
+function divInt52LogicalNotNegInf(a, b) {
+    return !(a / b);
+}
+noInline(divInt52LogicalNotNegInf);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (i % 2 === 0) {
+        let result = divInt52LogicalNotNegInf(-2147483648 * 6, 3);
+        if (result !== false)
+            throw "FAIL: divInt52LogicalNotNegInf normal, got " + result + " expected false";
+    } else {
+        let result = divInt52LogicalNotNegInf(-2147483648, 0);
+        if (result !== false)
+            throw "FAIL: divInt52LogicalNotNegInf neg-div-by-zero, got " + result + " expected false";
+    }
+}
+
+// ===== 0 / 0 = NaN, !NaN = true (this is the NaN case, should still work) =====
+
+function divInt52LogicalNotNaN(a, b) {
+    return !(a / b);
+}
+noInline(divInt52LogicalNotNaN);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (i % 3 === 0) {
+        // Normal case: result is nonzero, !nonzero = false
+        let result = divInt52LogicalNotNaN(2147483648 * 6, 3);
+        if (result !== false)
+            throw "FAIL: divInt52LogicalNotNaN normal, got " + result + " expected false";
+    } else if (i % 3 === 1) {
+        // Infinity case: nonzero / 0 = Infinity, !Infinity = false
+        let result = divInt52LogicalNotNaN(2147483648, 0);
+        if (result !== false)
+            throw "FAIL: divInt52LogicalNotNaN infinity, got " + result + " expected false";
+    } else {
+        // NaN case: 0 / 0 = NaN, !NaN = true
+        let result = divInt52LogicalNotNaN(0, 0);
+        if (result !== true)
+            throw "FAIL: divInt52LogicalNotNaN nan, got " + result + " expected true";
+    }
+}
+
+// ===== Exact division producing zero: !(0 / int52) = true for positive divisor =====
+
+function divInt52LogicalNotZeroResult(a, b) {
+    return !(a / b);
+}
+noInline(divInt52LogicalNotZeroResult);
+
+for (let i = 0; i < testLoopCount; i++) {
+    // 0 / positive = +0, !(+0) = true
+    let result = divInt52LogicalNotZeroResult(0, 2147483648);
+    if (result !== true)
+        throw "FAIL: divInt52LogicalNotZeroResult zero, got " + result + " expected true";
+}
+
+// ===== Verify ArithMod with LogicalNot still works (regression check) =====
+// Mod by zero produces NaN, !NaN = true. chillMod returns 0, !0 = true. Same result.
+
+function modInt52LogicalNotDivByZero(a, b) {
+    return !(a % b);
+}
+noInline(modInt52LogicalNotDivByZero);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (i % 2 === 0) {
+        let result = modInt52LogicalNotDivByZero(2147483648, 7);
+        if (result !== false)
+            throw "FAIL: modInt52LogicalNotDivByZero normal, got " + result + " expected false";
+    } else {
+        // x % 0 = NaN, !NaN = true. chillMod returns 0, !0 = true. Correct.
+        let result = modInt52LogicalNotDivByZero(2147483648, 0);
+        if (result !== true)
+            throw "FAIL: modInt52LogicalNotDivByZero mod-by-zero, got " + result + " expected true";
+    }
+}

--- a/JSTests/stress/int52-arith-div-with-overflow-unchecked.js
+++ b/JSTests/stress/int52-arith-div-with-overflow-unchecked.js
@@ -1,0 +1,179 @@
+// Test Int52 ArithDiv with Arith::Unchecked mode.
+// When the result of Int52 division feeds into bitwise operations (like | 0),
+// backward propagation clears NodeBytecodeNeedsNaNOrInfinity and NodeBytecodeNeedsNegZero,
+// enabling Arith::Unchecked mode which avoids OSR exits on division-by-zero,
+// non-exact division, and negative-zero results.
+
+// ===== Basic Int52 div with | 0 (Arith::Unchecked path) =====
+
+function divInt52BitOr(a, b) {
+    return (a / b) | 0;
+}
+noInline(divInt52BitOr);
+
+// Basic Int52 div with | 0 (exact division)
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divInt52BitOr(2147483648 * 6, 3);
+    let expected = (2147483648 * 6 / 3) | 0;
+    if (result !== expected)
+        throw "FAIL: divInt52BitOr basic, got " + result + " expected " + expected;
+}
+
+// Non-exact division: result is truncated by | 0
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divInt52BitOr(2147483649, 2);
+    let expected = (2147483649 / 2) | 0;
+    if (result !== expected)
+        throw "FAIL: divInt52BitOr non-exact, got " + result + " expected " + expected;
+}
+
+// Negative numerator
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divInt52BitOr(-4503599627370496, 4);
+    let expected = (-4503599627370496 / 4) | 0;
+    if (result !== expected)
+        throw "FAIL: divInt52BitOr negative numerator, got " + result + " expected " + expected;
+}
+
+// ===== Division by zero with | 0 (Arith::Unchecked, should NOT OSR exit) =====
+
+function divInt52DivByZeroBitOr(a, b) {
+    return (a / b) | 0;
+}
+noInline(divInt52DivByZeroBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    if (i % 2 === 0) {
+        let result = divInt52DivByZeroBitOr(2147483648 * 6, 3);
+        let expected = (2147483648 * 6 / 3) | 0;
+        if (result !== expected)
+            throw "FAIL: divInt52DivByZeroBitOr normal case, got " + result;
+    } else {
+        // x / 0 in JS produces Infinity (or -Infinity), Infinity | 0 = 0.
+        // With Arith::Unchecked, chillDiv returns 0 for zero denominator,
+        // then | 0 produces 0. Same result.
+        let result = divInt52DivByZeroBitOr(2147483648, 0);
+        if (result !== 0)
+            throw "FAIL: divInt52DivByZeroBitOr div-by-zero, got " + result + " expected 0";
+    }
+}
+
+// Pure division by zero case
+function divInt52AlwaysZeroDivisorBitOr(a) {
+    return (a / 0) | 0;
+}
+noInline(divInt52AlwaysZeroDivisorBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divInt52AlwaysZeroDivisorBitOr(2147483648 + i);
+    if (result !== 0)
+        throw "FAIL: divInt52AlwaysZeroDivisorBitOr, got " + result + " expected 0";
+}
+
+// ===== Negative zero with | 0 (Arith::Unchecked, -0 | 0 = 0) =====
+
+function divInt52NegZeroBitOr(a, b) {
+    return (a / b) | 0;
+}
+noInline(divInt52NegZeroBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    // 0 / -2^31 would be -0, but | 0 makes it +0 = 0.
+    let result = divInt52NegZeroBitOr(0, -2147483648);
+    if (result !== 0)
+        throw "FAIL: divInt52NegZeroBitOr, got " + result + " expected 0";
+}
+
+// ===== Int52 div with other bitwise operators (also Arith::Unchecked) =====
+
+function divInt52BitAnd(a, b) {
+    return (a / b) & 0x7FFFFFFF;
+}
+noInline(divInt52BitAnd);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divInt52BitAnd(4503599627370496, 4);
+    let expected = (4503599627370496 / 4) & 0x7FFFFFFF;
+    if (result !== expected)
+        throw "FAIL: divInt52BitAnd, got " + result + " expected " + expected;
+}
+
+function divInt52BitXor(a, b) {
+    return (a / b) ^ 0;
+}
+noInline(divInt52BitXor);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divInt52BitXor(2147483648 * 6, 3);
+    let expected = (2147483648 * 6 / 3) ^ 0;
+    if (result !== expected)
+        throw "FAIL: divInt52BitXor, got " + result + " expected " + expected;
+}
+
+function divInt52BitShift(a, b) {
+    return (a / b) >> 0;
+}
+noInline(divInt52BitShift);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divInt52BitShift(4503599627370496, 2097152);
+    let expected = (4503599627370496 / 2097152) >> 0;
+    if (result !== expected)
+        throw "FAIL: divInt52BitShift, got " + result + " expected " + expected;
+}
+
+// ===== Varying inputs to prevent constant folding =====
+
+function divInt52VaryingBitOr(a, b) {
+    return (a / b) | 0;
+}
+noInline(divInt52VaryingBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let a = (2147483648 + i) * 7;
+    let b = 7;
+    let result = divInt52VaryingBitOr(a, b);
+    let expected = (a / b) | 0;
+    if (result !== expected)
+        throw "FAIL: divInt52VaryingBitOr at i=" + i + ", got " + result + " expected " + expected;
+}
+
+// Varying inputs with occasional zero divisor
+function divInt52VaryingZeroBitOr(a, b) {
+    return (a / b) | 0;
+}
+noInline(divInt52VaryingZeroBitOr);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let a = 2147483648 + i;
+    // Every 1000th iteration, divisor is 0
+    let b = (i % 1000 === 0) ? 0 : 1;
+    let result = divInt52VaryingZeroBitOr(a, b);
+    let expected = (a / b) | 0;
+    if (result !== expected)
+        throw "FAIL: divInt52VaryingZeroBitOr at i=" + i + ", got " + result + " expected " + expected;
+}
+
+// ===== Stress test: many different Int52 values through Unchecked path =====
+
+function divInt52StressBitOr(a, b) {
+    return (a / b) | 0;
+}
+noInline(divInt52StressBitOr);
+
+let int52Values = [
+    2147483648, -2147483649, 4294967296, -4294967296,
+    1099511627776, -1099511627776, 4503599627370496, -4503599627370496,
+    2251799813685248, -2251799813685248, 8589934592, -8589934592
+];
+
+let divisors = [1, -1, 2, -2, 4, -4, 8, 2147483648];
+
+for (let i = 0; i < testLoopCount; i++) {
+    let a = int52Values[i % int52Values.length];
+    let b = divisors[i % divisors.length];
+    let result = divInt52StressBitOr(a, b);
+    let expected = (a / b) | 0;
+    if (result !== expected)
+        throw "FAIL: divInt52StressBitOr a=" + a + " b=" + b + ", got " + result + " expected " + expected;
+}

--- a/JSTests/stress/int52-arith-div.js
+++ b/JSTests/stress/int52-arith-div.js
@@ -1,0 +1,354 @@
+// Test Int52 division operation with comprehensive edge cases
+
+// ===== Basic Int52 division with exact results =====
+function divideInt52(a, b) {
+    return a / b;
+}
+noInline(divideInt52);
+
+// Int52 values (exceed Int32 max of 2147483647)
+let large = 2147483648 * 6;  // 2^31 * 6
+let expected = large / 3;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divideInt52(large, 3);
+    if (result !== expected)
+        throw "FAIL: int52 div basic case, got " + result + " expected " + expected;
+}
+
+// Larger Int52 values
+let larger = 4503599627370496;  // 2^52
+let largerExpected = larger / 4;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divideInt52(larger, 4);
+    if (result !== largerExpected)
+        throw "FAIL: int52 div large case, got " + result + " expected " + largerExpected;
+}
+
+// Negative Int52 numerator
+let negative = -2147483648 * 6;
+let negExpected = negative / 3;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divideInt52(negative, 3);
+    if (result !== negExpected)
+        throw "FAIL: int52 div negative numerator, got " + result + " expected " + negExpected;
+}
+
+// Test with negative divisor
+let negDivisorExpected = large / -3;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divideInt52(large, -3);
+    if (result !== negDivisorExpected)
+        throw "FAIL: int52 div negative divisor, got " + result + " expected " + negDivisorExpected;
+}
+
+// Test both negative
+let bothNegExpected = negative / -3;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divideInt52(negative, -3);
+    if (result !== bothNegExpected)
+        throw "FAIL: int52 div both negative, got " + result + " expected " + bothNegExpected;
+}
+
+// ===== AnyIntAsDouble cases =====
+function divideAnyIntAsDouble(a, b) {
+    return (a * 1.0) / (b * 1.0);
+}
+noInline(divideAnyIntAsDouble);
+
+let doubleInt52 = 2147483648.0 * 6;  // 2^31 * 6 as double
+let doubleExpected = doubleInt52 / 3;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divideAnyIntAsDouble(doubleInt52, 3);
+    if (result !== doubleExpected)
+        throw "FAIL: AnyIntAsDouble div case, got " + result + " expected " + doubleExpected;
+}
+
+// ===== Self-division (a / a == 1) =====
+function divideSelf(a) {
+    return a / a;
+}
+noInline(divideSelf);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divideSelf(2147483648);
+    if (result !== 1)
+        throw "FAIL: divideSelf(2^31), got " + result + " expected 1";
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divideSelf(-4503599627370496);
+    if (result !== 1)
+        throw "FAIL: divideSelf(-2^52), got " + result + " expected 1";
+}
+
+// ===== Division by 1 and -1 =====
+function divByOne(a) {
+    return a / 1;
+}
+noInline(divByOne);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divByOne(2147483648);
+    if (result !== 2147483648)
+        throw "FAIL: divByOne(2^31), got " + result + " expected 2147483648";
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divByOne(-4503599627370496);
+    if (result !== -4503599627370496)
+        throw "FAIL: divByOne(-2^52), got " + result + " expected -4503599627370496";
+}
+
+function divByNegOne(a) {
+    return a / -1;
+}
+noInline(divByNegOne);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divByNegOne(2147483648);
+    if (result !== -2147483648)
+        throw "FAIL: divByNegOne(2^31), got " + result + " expected -2147483648";
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divByNegOne(-4503599627370496);
+    if (result !== 4503599627370496)
+        throw "FAIL: divByNegOne(-2^52), got " + result + " expected 4503599627370496";
+}
+
+// ===== Division by powers of 2 =====
+function divByPowerOfTwo(a, b) {
+    return a / b;
+}
+noInline(divByPowerOfTwo);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divByPowerOfTwo(1099511627776, 1024);  // 2^40 / 2^10 = 2^30
+    if (result !== 1073741824)
+        throw "FAIL: divByPowerOfTwo 2^40/2^10, got " + result + " expected 1073741824";
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divByPowerOfTwo(4503599627370496, 2097152);  // 2^52 / 2^21 = 2^31
+    if (result !== 2147483648)
+        throw "FAIL: divByPowerOfTwo 2^52/2^21, got " + result + " expected 2147483648";
+}
+
+// ===== Negative zero edge cases =====
+// For division, -0 occurs when numerator == 0 and denominator < 0
+
+function checkNegativeZero(value, testName) {
+    if (value !== 0)
+        throw "FAIL: " + testName + " should be zero, got " + value;
+    if (1 / value !== -Infinity)
+        throw "FAIL: " + testName + " should be -0, got " + (1/value);
+}
+
+function checkPositiveZero(value, testName) {
+    if (value !== 0)
+        throw "FAIL: " + testName + " should be zero, got " + value;
+    if (1 / value !== Infinity)
+        throw "FAIL: " + testName + " should be +0, got " + (1/value);
+}
+
+// 0 / negative_int52 = -0
+function divNegZero1(a, b) {
+    return a / b;
+}
+noInline(divNegZero1);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divNegZero1(0, -2147483648);
+    checkNegativeZero(result, "divNegZero1: 0 / -2147483648");
+}
+
+function divNegZero2(a, b) {
+    return a / b;
+}
+noInline(divNegZero2);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divNegZero2(0, -4503599627370496);
+    checkNegativeZero(result, "divNegZero2: 0 / -4503599627370496");
+}
+
+// 0 / positive_int52 = +0
+function divPosZero1(a, b) {
+    return a / b;
+}
+noInline(divPosZero1);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divPosZero1(0, 2147483648);
+    checkPositiveZero(result, "divPosZero1: 0 / 2147483648");
+}
+
+// ===== Non-exact division (should fall back to double via OSR exit) =====
+function divNonExact(a, b) {
+    return a / b;
+}
+noInline(divNonExact);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divNonExact(2147483649, 2);  // Not exactly divisible
+    if (result !== 2147483649 / 2)
+        throw "FAIL: divNonExact, got " + result + " expected " + (2147483649 / 2);
+}
+
+// ===== Boundary values =====
+
+// MAX_INT52 / 1 = MAX_INT52
+function divMaxInt52(a, b) {
+    return a / b;
+}
+noInline(divMaxInt52);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divMaxInt52(2251799813685247, 1);  // MAX_INT52 (2^51-1)
+    if (result !== 2251799813685247)
+        throw "FAIL: divMaxInt52 / 1, got " + result + " expected 2251799813685247";
+}
+
+// MIN_INT52 / 1 = MIN_INT52
+function divMinInt52(a, b) {
+    return a / b;
+}
+noInline(divMinInt52);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divMinInt52(-2251799813685248, 1);  // MIN_INT52 (-2^51)
+    if (result !== -2251799813685248)
+        throw "FAIL: divMinInt52 / 1, got " + result + " expected -2251799813685248";
+}
+
+// MIN_INT52 / -1 = 2^51 (exceeds MAX_INT52, should OSR exit to double)
+function divMinInt52ByNegOne(a, b) {
+    return a / b;
+}
+noInline(divMinInt52ByNegOne);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divMinInt52ByNegOne(-2251799813685248, -1);
+    if (result !== 2251799813685248)
+        throw "FAIL: divMinInt52ByNegOne, got " + result + " expected 2251799813685248";
+}
+
+// ===== Large exact divisions =====
+function divLargeExact1(a, b) {
+    return a / b;
+}
+noInline(divLargeExact1);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divLargeExact1(1099511627776 * 3, 3);  // 2^40 * 3 / 3 = 2^40
+    if (result !== 1099511627776)
+        throw "FAIL: divLargeExact1, got " + result + " expected 1099511627776";
+}
+
+function divLargeExact2(a, b) {
+    return a / b;
+}
+noInline(divLargeExact2);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divLargeExact2(-4294967296 * 7, 7);  // -2^32 * 7 / 7 = -2^32
+    if (result !== -4294967296)
+        throw "FAIL: divLargeExact2, got " + result + " expected -4294967296";
+}
+
+// ===== Mixed positive/negative with exact results =====
+function divMixed1(a, b) {
+    return a / b;
+}
+noInline(divMixed1);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divMixed1(-8589934592, 4);  // -2^33 / 4 = -2^31
+    if (result !== -2147483648)
+        throw "FAIL: divMixed1, got " + result + " expected -2147483648";
+}
+
+function divMixed2(a, b) {
+    return a / b;
+}
+noInline(divMixed2);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divMixed2(8589934592, -4);  // 2^33 / -4 = -2^31
+    if (result !== -2147483648)
+        throw "FAIL: divMixed2, got " + result + " expected -2147483648";
+}
+
+// ===== Values just above Int32 range to ensure Int52 path is taken =====
+function divJustAboveInt32(a, b) {
+    return a / b;
+}
+noInline(divJustAboveInt32);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divJustAboveInt32(2147483648 * 2, 2);  // (2^31 * 2) / 2 = 2^31
+    if (result !== 2147483648)
+        throw "FAIL: divJustAboveInt32, got " + result + " expected 2147483648";
+}
+
+function divJustBelowInt32Min(a, b) {
+    return a / b;
+}
+noInline(divJustBelowInt32Min);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divJustBelowInt32Min(-2147483649 * 3, 3);  // -(2^31+1)*3 / 3 = -(2^31+1)
+    if (result !== -2147483649)
+        throw "FAIL: divJustBelowInt32Min, got " + result + " expected -2147483649";
+}
+
+// ===== Alternating values to stress JIT =====
+function divAlternating(a, b) {
+    return a / b;
+}
+noInline(divAlternating);
+
+for (let i = 0; i < testLoopCount; i++) {
+    let a_val = (i % 2 === 0) ? 1099511627776 * 5 : -1099511627776 * 5;  // ±2^40 * 5
+    let result = divAlternating(a_val, 5);
+    let expected = a_val / 5;
+    if (result !== expected)
+        throw "FAIL: divAlternating iteration " + i + ", got " + result + " expected " + expected;
+}
+
+// ===== Stress test with various exact divisions =====
+function divStress(a, b) {
+    return a / b;
+}
+noInline(divStress);
+
+let int52Values = [
+    2147483648, -2147483649, 4294967296, -4294967296,
+    1099511627776, -1099511627776, 2251799813685247, -2251799813685248,
+    8589934592, -8589934592
+];
+
+let exactDivisors = [1, -1, 2, -2, 4, -4, 8, -8];
+
+for (let i = 0; i < testLoopCount; i++) {
+    let a = int52Values[i % int52Values.length];
+    let b = exactDivisors[i % exactDivisors.length];
+    let result = divStress(a, b);
+    let expected = a / b;
+    if (result !== expected)
+        throw "FAIL: divStress a=" + a + " b=" + b + ", got " + result + " expected " + expected;
+}
+
+// ===== Computed Int52 division =====
+function divComputedInt52(x) {
+    let largeValue = x * 2147483648;  // Will be Int52-range
+    return largeValue / 2;
+}
+noInline(divComputedInt52);
+
+let computedExpected = (6 * 2147483648) / 2;
+for (let i = 0; i < testLoopCount; i++) {
+    let result = divComputedInt52(6);
+    if (result !== computedExpected)
+        throw "FAIL: computed Int52 div case, got " + result + " expected " + computedExpected;
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -380,12 +380,29 @@ bool AbstractInterpreter<AbstractStateType>::handleConstantDivOp(Node* node)
             if (isDivOperation) {
                 double doubleResult = left.asNumber() / right.asNumber();
 
-                if (isClobbering)
-                    didFoldClobberWorld();
-                if (op == ValueDiv)
-                    setConstant(node, jsNumber(doubleResult));
-                else
-                    setConstant(node, jsDoubleNumber(doubleResult));
+                if (node->child1().useKind() == Int52RepUse) {
+                    if (node->hasArithMode()) {
+                        if (!shouldCheckOverflow(node->arithMode())) {
+                            if (std::isnan(doubleResult) || std::isinf(doubleResult))
+                                doubleResult = 0;
+                            else
+                                doubleResult = trunc(doubleResult);
+                        } else if (!shouldCheckNegativeZero(node->arithMode()))
+                            doubleResult += 0; // Sanitizes zero.
+                    }
+                    if (tryConvertToInt52(doubleResult) != JSValue::notInt52) {
+                        if (isClobbering)
+                            didFoldClobberWorld();
+                        setConstant(node, jsNumber(doubleResult));
+                    }
+                } else {
+                    if (isClobbering)
+                        didFoldClobberWorld();
+                    if (op == ValueDiv)
+                        setConstant(node, jsNumber(doubleResult));
+                    else
+                        setConstant(node, jsDoubleNumber(doubleResult));
+                }
             } else {
                 double doubleResult = fmod(left.asNumber(), right.asNumber());
 
@@ -1325,7 +1342,6 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             setNonCellTypeForNode(node, SpecInt32Only);
             break;
         case Int52RepUse:
-            ASSERT(node->op() == ArithMod);
             setNonCellTypeForNode(node, SpecInt52Any);
             break;
         case DoubleRepUse:

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -529,6 +529,9 @@ private:
                 // We can clear this flag since Mod and Div never produces Infinity. It is only NaN.
                 flags &= ~NodeBytecodeNeedsNaNOrInfinity;
                 break;
+            // NOTE: We intentionally do NOT clear NodeBytecodeNeedsNaNOrInfinity for ArithDiv/ValueDiv.
+            // Division by zero produces ±Infinity (not NaN), and !Infinity is false, while chillDiv
+            // returns 0 for zero-divisor and !0 is true — a different result.
             default:
                 break;
             }

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -133,10 +133,15 @@ private:
             return;
         }
 
-        if ((node->op() == ArithMod || node->op() == ValueMod) && m_graph.modShouldSpeculateInt52(node)) {
+        if (m_graph.divShouldSpeculateInt52(node)) {
             fixEdge<Int52RepUse>(leftChild);
             fixEdge<Int52RepUse>(rightChild);
-            if (bytecodeCanIgnoreNaNAndInfinity(node->arithNodeFlags()) && bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
+
+            // We need to be careful about skipping overflow check because div / mod can generate non integer values
+            // from (Int52, Int52) inputs. For now, we always check non-zero divisor.
+            if (((node->op() == ArithDiv || node->op() == ValueDiv) && bytecodeCanTruncateInteger(node->arithNodeFlags()))
+                && bytecodeCanIgnoreNaNAndInfinity(node->arithNodeFlags())
+                && bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
                 node->setArithMode(Arith::Unchecked);
             else if (bytecodeCanIgnoreNegativeZero(node->arithNodeFlags()))
                 node->setArithMode(Arith::CheckOverflow);

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -418,7 +418,7 @@ public:
         return shouldSpeculateInt52ForAdd(left) && shouldSpeculateInt52ForAdd(right);
     }
 
-    bool modShouldSpeculateInt52(Node* node)
+    bool divShouldSpeculateInt52(Node* node)
     {
         // This is much more relaxed compared to addShouldSpeculateInt52.
         // The reason is double mod is so costly, so it is worth trying with much more aggressively compared to addShouldSpeculateInt52.

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -528,7 +528,7 @@ private:
                     && isFullNumberOrBooleanSpeculationExpectingDefined(right)) {
                     if (m_graph.binaryArithShouldSpeculateInt32(node, m_pass))
                         changed |= mergePrediction(SpecInt32Only);
-                    else if ((op == ValueMod || op == ArithMod) && m_graph.modShouldSpeculateInt52(node))
+                    else if (m_graph.divShouldSpeculateInt52(node))
                         changed |= mergePrediction(SpecInt52Any);
                     else
                         changed |= mergePrediction(SpecBytecodeDouble);
@@ -861,7 +861,7 @@ private:
             if (isFullNumberSpeculation(left)
                 && isFullNumberSpeculation(right)
                 && !m_graph.binaryArithShouldSpeculateInt32(node, m_pass)
-                && !((node->op() == ArithMod || node->op() == ValueMod) && m_graph.modShouldSpeculateInt52(node)))
+                && !m_graph.divShouldSpeculateInt52(node))
                 ballot = VoteDouble;
             else
                 ballot = VoteValue;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -6014,16 +6014,120 @@ void SpeculativeJIT::compileArithDiv(Node* node)
 #endif
         break;
     }
-        
+
+#if USE(JSVALUE64)
+    case Int52RepUse: {
+        SpeculateStrictInt52Operand op1(this, node->child1());
+        SpeculateStrictInt52Operand op2(this, node->child2());
+
+        GPRReg op1GPR = op1.gpr();
+        GPRReg op2GPR = op2.gpr();
+
+#if CPU(X86_64)
+        GPRTemporary eax(this, X86Registers::eax);
+        GPRTemporary edx(this, X86Registers::edx);
+
+        GPRReg op1SaveGPR;
+        if (op1GPR == X86Registers::eax || op1GPR == X86Registers::edx) {
+            op1SaveGPR = allocate();
+            move(op1GPR, op1SaveGPR);
+        } else
+            op1SaveGPR = op1GPR;
+
+        GPRReg op2TempGPR = InvalidGPRReg;
+        if (op2GPR == X86Registers::eax || op2GPR == X86Registers::edx) {
+            op2TempGPR = allocate();
+            move(op2GPR, op2TempGPR);
+            op2GPR = op2TempGPR;
+        }
+
+        JumpList doneCases;
+
+        if (shouldCheckOverflow(node->arithMode()))
+            speculationCheck(Int52Overflow, JSValueRegs(), nullptr, branchTest64(Zero, op2GPR));
+        else {
+            Jump notZero = branchTest64(NonZero, op2GPR);
+            move(TrustedImm64(0), X86Registers::eax);
+            doneCases.append(jump());
+
+            notZero.link(this);
+        }
+
+        if (shouldCheckNegativeZero(node->arithMode())) {
+            Jump numeratorNonZero = branchTest64(NonZero, op1SaveGPR);
+            speculationCheck(NegativeZero, JSValueRegs(), nullptr, branch64(LessThan, op2GPR, TrustedImm64(0)));
+            numeratorNonZero.link(this);
+        }
+
+        move(op1GPR, X86Registers::eax);
+        x86ConvertToQuadWord64();
+        x86Div64(op2GPR);
+
+        if (shouldCheckOverflow(node->arithMode()))
+            speculationCheck(Int52Overflow, JSValueRegs(), nullptr, branchTest64(NonZero, X86Registers::edx));
+
+        doneCases.link(this);
+
+        if (op1SaveGPR != op1GPR)
+            unlock(op1SaveGPR);
+        if (op2TempGPR != InvalidGPRReg)
+            unlock(op2TempGPR);
+
+        strictInt52Result(X86Registers::eax, node);
+#elif CPU(ARM64)
+        GPRTemporary quotient(this);
+        GPRTemporary multiplyAnswer(this);
+
+        GPRReg quotientGPR = quotient.gpr();
+        GPRReg multiplyAnswerGPR = multiplyAnswer.gpr();
+
+        JumpList doneCases;
+
+        if (shouldCheckOverflow(node->arithMode()))
+            speculationCheck(Int52Overflow, JSValueRegs(), nullptr, branchTest64(Zero, op2GPR));
+        else {
+            Jump notZero = branchTest64(NonZero, op2GPR);
+            move(TrustedImm64(0), quotientGPR);
+            doneCases.append(jump());
+
+            notZero.link(this);
+        }
+
+        if (shouldCheckNegativeZero(node->arithMode())) {
+            Jump numeratorNonZero = branchTest64(NonZero, op1GPR);
+            speculationCheck(NegativeZero, JSValueRegs(), nullptr, branch64(LessThan, op2GPR, TrustedImm64(0)));
+            numeratorNonZero.link(this);
+        }
+
+        div64(op1GPR, op2GPR, quotientGPR);
+
+        // Check that the division was exact: quotient * denominator must equal numerator.
+        // No need to check for multiplication overflow: both operands are Int52, and
+        // |quotient| <= |numerator| (integer division can't increase magnitude), so
+        // |quotient * denominator| <= |numerator| which fits in Int52, let alone int64.
+        if (shouldCheckOverflow(node->arithMode())) {
+            mul64(quotientGPR, op2GPR, multiplyAnswerGPR);
+            speculationCheck(Int52Overflow, JSValueRegs(), nullptr, branch64(NotEqual, multiplyAnswerGPR, op1GPR));
+        }
+
+        doneCases.link(this);
+        strictInt52Result(quotientGPR, node);
+#else
+        RELEASE_ASSERT_NOT_REACHED();
+#endif
+        break;
+    }
+#endif // USE(JSVALUE64)
+
     case DoubleRepUse: {
         SpeculateDoubleOperand op1(this, node->child1());
         SpeculateDoubleOperand op2(this, node->child2());
         FPRTemporary result(this, op1);
-        
+
         FPRReg reg1 = op1.fpr();
         FPRReg reg2 = op2.fpr();
         divDouble(reg1, reg2, result.fpr());
-        
+
         doubleResult(result.fpr(), node);
         break;
     }

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -3217,6 +3217,39 @@ private:
             break;
         }
 
+        case Int52RepUse: {
+            LValue numerator = lowStrictInt52(m_node->child1());
+            LValue denominator = lowStrictInt52(m_node->child2());
+
+            if (shouldCheckNegativeZero(m_node->arithMode())) {
+                LBasicBlock zeroNumerator = m_out.newBlock();
+                LBasicBlock numeratorContinuation = m_out.newBlock();
+
+                m_out.branch(
+                    m_out.isZero64(numerator),
+                    rarely(zeroNumerator), usually(numeratorContinuation));
+
+                LBasicBlock innerLastNext = m_out.appendTo(zeroNumerator, numeratorContinuation);
+
+                speculate(
+                    NegativeZero, noValue(), nullptr, m_out.lessThan(denominator, m_out.int64Zero));
+
+                m_out.jump(numeratorContinuation);
+
+                m_out.appendTo(numeratorContinuation, innerLastNext);
+            }
+
+            if (shouldCheckOverflow(m_node->arithMode())) {
+                speculate(Int52Overflow, noValue(), nullptr, m_out.isZero64(denominator));
+                LValue result = m_out.div(numerator, denominator);
+                speculate(Int52Overflow, noValue(), nullptr, m_out.notEqual(m_out.mul(result, denominator), numerator));
+                setStrictInt52(result);
+            } else
+                setStrictInt52(m_out.chillDiv(numerator, denominator));
+
+            break;
+        }
+
         case DoubleRepUse: {
             setDouble(m_out.doubleDiv(
                 lowDouble(m_node->child1()), lowDouble(m_node->child2())));


### PR DESCRIPTION
#### 582cb0306b7c19a8a9ebd3846629d36280685858
<pre>
[JSC] Add ArithDiv(Int52Use, Int52Use) in DFG / FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=307266">https://bugs.webkit.org/show_bug.cgi?id=307266</a>
<a href="https://rdar.apple.com/169906979">rdar://169906979</a>

Reviewed by Sosuke Suzuki.

This patch adds ArithDiv(Int52Use, Int52Use) support in DFG / FTL.
Basically this is exactly similar to ArithDiv(Int32Use, Int32Use). But
one difference is that, because both are Int52, not Int64, we don&apos;t need
to consider about -INT64_MIN like overflow.

Tests: JSTests/stress/int52-arith-div-logical-not.js
       JSTests/stress/int52-arith-div-with-overflow-unchecked.js
       JSTests/stress/int52-arith-div.js

* JSTests/stress/int52-arith-div-logical-not.js: Added.
(divInt52LogicalNotDivByZero):
(divInt52LogicalNotMixed):
(divInt52LogicalNotNegInf):
(divInt52LogicalNotNaN):
(i.else):
(divInt52LogicalNotZeroResult):
(modInt52LogicalNotDivByZero):
* JSTests/stress/int52-arith-div-with-overflow-unchecked.js: Added.
(divInt52BitOr):
(divInt52DivByZeroBitOr):
(divInt52AlwaysZeroDivisorBitOr):
(divInt52NegZeroBitOr):
(divInt52BitAnd):
(divInt52BitXor):
(divInt52BitShift):
(divInt52VaryingBitOr):
(divInt52VaryingZeroBitOr):
(divInt52StressBitOr):
* JSTests/stress/int52-arith-div.js: Added.
(divideInt52):
(divideAnyIntAsDouble):
(divideSelf):
(divByOne):
(divByNegOne):
(divByPowerOfTwo):
(checkNegativeZero):
(checkPositiveZero):
(divNegZero1):
(divNegZero2):
(divPosZero1):
(divNonExact):
(divMaxInt52):
(divMinInt52):
(divMinInt52ByNegOne):
(divLargeExact1):
(divLargeExact2):
(divMixed1):
(divMixed2):
(divJustAboveInt32):
(divJustBelowInt32Min):
(divAlternating):
(divStress):
(divComputedInt52):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::handleConstantDivOp):
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupArithDiv):
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArithDiv):

Canonical link: <a href="https://commits.webkit.org/307061@main">https://commits.webkit.org/307061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7d5cb81f32f5a6548250b128ed2d555e01b2ba1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151907 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96452 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee27a300-ddc2-4852-a502-a8d8a34c57c6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16366 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110153 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79304 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12e79d59-a6d0-4763-9d2d-4b7d0f97c38e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12594 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91064 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4547311-6f9f-4477-9bdc-8f4b27ca2254) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12077 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9791 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1904 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135230 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121504 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154218 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4043 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5662 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118172 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13279 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118512 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14446 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125862 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71137 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22083 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15375 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4503 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174528 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79095 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45065 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15320 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15171 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->