### PR TITLE
Remove LegacyNativeDictionaryRequiredInterfaceNullability in WebCore/testing

### DIFF
--- a/Source/WebCore/testing/FakeXRBoundsPoint.idl
+++ b/Source/WebCore/testing/FakeXRBoundsPoint.idl
@@ -26,7 +26,7 @@
 [
     Conditional=WEBXR,
     EnabledBySetting=WebXREnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRBoundsPoint {
-    double x; double z;
+    double x = 0;
+    double z = 0;
 };

--- a/Source/WebCore/testing/FakeXRButtonStateInit.idl
+++ b/Source/WebCore/testing/FakeXRButtonStateInit.idl
@@ -45,7 +45,6 @@
 [
     EnabledBySetting=WebXREnabled,
     Conditional=WEBXR,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRButtonStateInit {
     required FakeXRButtonType buttonType;
     required boolean pressed;

--- a/Source/WebCore/testing/FakeXRInputSourceInit.h
+++ b/Source/WebCore/testing/FakeXRInputSourceInit.h
@@ -48,7 +48,7 @@ struct FakeXRInputSourceInit {
     bool selectionStarted { false };
     bool selectionClicked { false };
     Vector<FakeXRButtonStateInit> supportedButtons;
-    FakeXRRigidTransformInit gripOrigin;
+    std::optional<FakeXRRigidTransformInit> gripOrigin;
 #if ENABLE(WEBXR_HANDS)
     Vector<FakeXRJointStateInit> handJoints;
 #endif

--- a/Source/WebCore/testing/FakeXRInputSourceInit.idl
+++ b/Source/WebCore/testing/FakeXRInputSourceInit.idl
@@ -26,7 +26,6 @@
 [
     Conditional=WEBXR,
     EnabledBySetting=WebXREnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRInputSourceInit {
     required XRHandedness handedness;
     required XRTargetRayMode targetRayMode;
@@ -39,10 +38,10 @@
     // Initial button state for any buttons beyond the primary that are supported.
     // If empty, only the primary button is supported.
     // Note that if any FakeXRButtonType is repeated the behavior is undefined.
-    sequence<FakeXRButtonStateInit> supportedButtons;
+    sequence<FakeXRButtonStateInit> supportedButtons = [];
     // If not set the controller is assumed to not be tracked.
     FakeXRRigidTransformInit gripOrigin;
     // Optional hand input. For now we don't care about the actual
     // data. We're just creating the object for testing.
-    [Conditional=WEBXR_HANDS] sequence<FakeXRJointStateInit> handJoints;
+    [Conditional=WEBXR_HANDS] sequence<FakeXRJointStateInit> handJoints = [];
 };

--- a/Source/WebCore/testing/FakeXRJointStateInit.h
+++ b/Source/WebCore/testing/FakeXRJointStateInit.h
@@ -32,7 +32,7 @@
 namespace WebCore {
 
 struct FakeXRJointStateInit {
-    FakeXRRigidTransformInit pose;
+    std::optional<FakeXRRigidTransformInit> pose;
     float radius;
 };
 

--- a/Source/WebCore/testing/FakeXRJointStateInit.idl
+++ b/Source/WebCore/testing/FakeXRJointStateInit.idl
@@ -27,7 +27,6 @@
 [
     EnabledBySetting=WebXREnabled&WebXRHandInputModuleEnabled,
     Conditional=WEBXR_HANDS,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRJointStateInit {
     FakeXRRigidTransformInit pose;
     float radius = 0.0;

--- a/Source/WebCore/testing/FakeXRViewInit.idl
+++ b/Source/WebCore/testing/FakeXRViewInit.idl
@@ -28,7 +28,6 @@
 [
     Conditional=WEBXR,
     EnabledBySetting=WebXREnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRDeviceResolution {
     required long width;
     required long height;
@@ -38,7 +37,6 @@
 [
     EnabledBySetting=WebXREnabled,
     Conditional=WEBXR,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRFieldOfViewInit {
     required float upDegrees;
     required float downDegrees;
@@ -50,7 +48,6 @@
 [
     EnabledBySetting=WebXREnabled,
     Conditional=WEBXR,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRViewInit {
     required XREye eye;
     // https://immersive-web.github.io/webxr/#view-projection-matrix

--- a/Source/WebCore/testing/FakeXRWorldInit.idl
+++ b/Source/WebCore/testing/FakeXRWorldInit.idl
@@ -35,7 +35,6 @@
 [
     Conditional=WEBXR_HIT_TEST,
     EnabledBySetting=WebXRHitTestModuleEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRTriangleInit {
     required sequence<DOMPointInit> vertices;
 };
@@ -43,7 +42,6 @@
 [
     Conditional=WEBXR_HIT_TEST,
     EnabledBySetting=WebXRHitTestModuleEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRRegionInit {
     required sequence<FakeXRTriangleInit> faces;
     required FakeXRRegionType type;
@@ -52,7 +50,6 @@
 [
     Conditional=WEBXR_HIT_TEST,
     EnabledBySetting=WebXRHitTestModuleEnabled,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRWorldInit {
     required sequence<FakeXRRegionInit> hitTestRegions;
 };

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -7371,6 +7371,37 @@ auto Internals::getCookies() const -> Vector<CookieData>
     });
 }
 
+static Internals::WebDriverCookieData createWebDriverCookieData(Cookie cookie)
+{
+    Internals::WebDriverCookieData data;
+    data.name = cookie.name;
+    data.value = cookie.value;
+    data.path = cookie.path;
+    data.domain = cookie.domain;
+    data.secure = cookie.secure;
+    data.httpOnly = cookie.httpOnly;
+    data.expiry = cookie.expires ? std::make_optional(*cookie.expires / 1000) : std::nullopt;
+
+    // Due to how CFNetwork handles host-only cookies, we may need to prepend a '.' to the domain when
+    // setting a cookie (see CookieStore::set). So we must strip this '.' when returning the cookie.
+    if (data.domain.startsWith('.'))
+        data.domain = data.domain.substring(1, data.domain.length() - 1);
+
+    switch (cookie.sameSite) {
+    case Cookie::SameSitePolicy::Strict:
+        data.sameSite = "Strict"_s;
+        break;
+    case Cookie::SameSitePolicy::Lax:
+        data.sameSite = "Lax"_s;
+        break;
+    case Cookie::SameSitePolicy::None:
+        data.sameSite = "None"_s;
+        break;
+    }
+
+    return data;
+}
+
 auto Internals::webDriverGetCookies(Document& document) const -> Vector<WebDriverCookieData>
 {
     auto* page = document.page();
@@ -7380,7 +7411,7 @@ auto Internals::webDriverGetCookies(Document& document) const -> Vector<WebDrive
     Vector<Cookie> cookies;
     page->cookieJar().getRawCookies(document, document.cookieURL(), cookies);
     return WTF::map(cookies, [](auto& cookie) {
-        return WebDriverCookieData { cookie };
+        return createWebDriverCookieData(cookie);
     });
 }
 
@@ -7463,21 +7494,15 @@ String Internals::highlightPseudoElementColor(const AtomString& highlightName, E
 
     return serializationForCSS(resolvedStyle->style->color());
 }
-    
-Internals::TextIndicatorInfo::TextIndicatorInfo() = default;
-
-Internals::TextIndicatorInfo::TextIndicatorInfo(const WebCore::TextIndicatorData& data)
-    : textBoundingRectInRootViewCoordinates(DOMRect::create(data.textBoundingRectInRootViewCoordinates))
-    , textRectsInBoundingRectCoordinates(DOMRectList::create(data.textRectsInBoundingRectCoordinates))
-{
-}
-    
-Internals::TextIndicatorInfo::~TextIndicatorInfo() = default;
 
 Internals::TextIndicatorInfo Internals::textIndicatorForRange(const Range& range, TextIndicatorOptions options)
 {
     auto indicator = TextIndicator::createWithRange(makeSimpleRange(range), options.coreOptions(), TextIndicatorPresentationTransition::None);
-    return indicator->data();
+    auto data = indicator->data();
+    return {
+        DOMRect::create(data.textBoundingRectInRootViewCoordinates),
+        DOMRectList::create(data.textRectsInBoundingRectCoordinates)
+    };
 }
 
 void Internals::addPrefetchLoadEventListener(HTMLLinkElement& link, RefPtr<EventListener>&& listener)

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1415,8 +1415,8 @@ public:
     void setCookie(CookieData&&);
     Vector<CookieData> getCookies() const;
 
-    // This attempts to implement https://w3c.github.io/webdriver/#cookies but that specification
-    // is not the clearest.
+    // In combination with createWebDriverCookieData() this attempts to implement
+    // https://w3c.github.io/webdriver/#cookies but that specification is not the clearest.
     struct WebDriverCookieData {
         String name;
         String value;
@@ -1426,36 +1426,6 @@ public:
         bool httpOnly { false };
         std::optional<double> expiry { std::nullopt }; // Cookie's expires field in seconds.
         String sameSite { "None"_s };
-
-        WebDriverCookieData(Cookie cookie)
-            : name(cookie.name)
-            , value(cookie.value)
-            , path(cookie.path)
-            , domain(cookie.domain)
-            , secure(cookie.secure)
-            , httpOnly(cookie.httpOnly)
-            , expiry(cookie.expires ? std::make_optional(*cookie.expires / 1000) : std::nullopt)
-        {
-            // Due to how CFNetwork handles host-only cookies, we may need to prepend a '.' to the domain when
-            // setting a cookie (see CookieStore::set). So we must strip this '.' when returning the cookie.
-            if (domain.startsWith('.'))
-                domain = domain.substring(1, domain.length() - 1);
-
-            switch (cookie.sameSite) {
-            case Cookie::SameSitePolicy::Strict:
-                sameSite = "Strict"_s;
-                break;
-            case Cookie::SameSitePolicy::Lax:
-                sameSite = "Lax"_s;
-                break;
-            case Cookie::SameSitePolicy::None:
-                sameSite = "None"_s;
-                break;
-            }
-        }
-
-        WebDriverCookieData()
-        { }
     };
 
     Vector<WebDriverCookieData> webDriverGetCookies(Document&) const;
@@ -1474,10 +1444,6 @@ public:
     struct TextIndicatorInfo {
         RefPtr<DOMRectReadOnly> textBoundingRectInRootViewCoordinates;
         RefPtr<DOMRectList> textRectsInBoundingRectCoordinates;
-        
-        TextIndicatorInfo();
-        TextIndicatorInfo(const WebCore::TextIndicatorData&);
-        ~TextIndicatorInfo();
     };
         
     struct TextIndicatorOptions {

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -361,7 +361,6 @@ enum AV1ConfigurationRange {
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
     JSGenerateToNativeObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary WebDriverCookieData {
     DOMString name;
     DOMString value;
@@ -376,7 +375,6 @@ enum AV1ConfigurationRange {
 [
     ExportMacro=WEBCORE_TESTSUPPORT_EXPORT,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary TextIndicatorInfo {
     DOMRectReadOnly textBoundingRectInRootViewCoordinates;
     DOMRectList textRectsInBoundingRectCoordinates;

--- a/Source/WebCore/testing/MockPaymentAddress.h
+++ b/Source/WebCore/testing/MockPaymentAddress.h
@@ -28,11 +28,93 @@
 #if ENABLE(APPLE_PAY)
 
 #include "ApplePayPaymentContact.h"
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
-struct MockPaymentAddress : LocalizedApplePayPaymentContact {
+struct MockPaymentAddress {
+    String phoneNumber;
+    String emailAddress;
+    String givenName;
+    String familyName;
+    String phoneticGivenName;
+    String phoneticFamilyName;
+    std::optional<Vector<String>> addressLines;
+    String subLocality;
+    String locality;
+    String postalCode;
+    String subAdministrativeArea;
+    String administrativeArea;
+    String country;
+    String countryCode;
+    String localizedName;
+    String localizedPhoneticName;
 };
+
+inline MockPaymentAddress toMockPaymentAddress(const LocalizedApplePayPaymentContact& contact)
+{
+    return {
+        contact.phoneNumber,
+        contact.emailAddress,
+        contact.givenName,
+        contact.familyName,
+        contact.phoneticGivenName,
+        contact.phoneticFamilyName,
+        contact.addressLines,
+        contact.subLocality,
+        contact.locality,
+        contact.postalCode,
+        contact.subAdministrativeArea,
+        contact.administrativeArea,
+        contact.country,
+        contact.countryCode,
+        contact.localizedName,
+        contact.localizedPhoneticName
+    };
+}
+
+inline ApplePayPaymentContact toApplePayPaymentContact(const MockPaymentAddress& address)
+{
+    return {
+        .phoneNumber = address.phoneNumber,
+        .emailAddress = address.emailAddress,
+        .givenName = address.givenName,
+        .familyName = address.familyName,
+        .phoneticGivenName = address.phoneticGivenName,
+        .phoneticFamilyName = address.phoneticFamilyName,
+        .addressLines = address.addressLines,
+        .subLocality = address.subLocality,
+        .locality = address.locality,
+        .postalCode = address.postalCode,
+        .subAdministrativeArea = address.subAdministrativeArea,
+        .administrativeArea = address.administrativeArea,
+        .country = address.country,
+        .countryCode = address.countryCode
+    };
+}
+
+inline LocalizedApplePayPaymentContact toLocalizedApplePayPaymentContact(const MockPaymentAddress& address)
+{
+    LocalizedApplePayPaymentContact contact;
+    contact.phoneNumber = address.phoneNumber;
+    contact.emailAddress = address.emailAddress;
+    contact.givenName = address.givenName;
+    contact.familyName = address.familyName;
+    contact.phoneticGivenName = address.phoneticGivenName;
+    contact.phoneticFamilyName = address.phoneticFamilyName;
+    contact.addressLines = address.addressLines;
+    contact.subLocality = address.subLocality;
+    contact.locality = address.locality;
+    contact.postalCode = address.postalCode;
+    contact.subAdministrativeArea = address.subAdministrativeArea;
+    contact.administrativeArea = address.administrativeArea;
+    contact.country = address.country;
+    contact.countryCode = address.countryCode;
+    contact.localizedName = address.localizedName;
+    contact.localizedPhoneticName = address.localizedPhoneticName;
+    return contact;
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/testing/MockPaymentAddress.idl
+++ b/Source/WebCore/testing/MockPaymentAddress.idl
@@ -25,15 +25,21 @@
 
 [
     Conditional=APPLE_PAY,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MockPaymentAddress {
-    DOMString countryCode;
-    FrozenArray<DOMString> addressLines;
-    DOMString administrativeArea;
-    DOMString locality;
-    DOMString subLocality;
-    DOMString postalCode;
-    DOMString localizedName;
     DOMString phoneNumber;
     DOMString emailAddress;
+    DOMString givenName;
+    DOMString familyName;
+    DOMString phoneticGivenName;
+    DOMString phoneticFamilyName;
+    FrozenArray<DOMString> addressLines;
+    DOMString subLocality;
+    DOMString locality;
+    DOMString postalCode;
+    DOMString subAdministrativeArea;
+    DOMString administrativeArea;
+    DOMString country;
+    DOMString countryCode;
+    DOMString localizedName;
+    DOMString localizedPhoneticName;
 };

--- a/Source/WebCore/testing/MockPaymentContactFields.h
+++ b/Source/WebCore/testing/MockPaymentContactFields.h
@@ -31,13 +31,24 @@
 
 namespace WebCore {
 
-struct MockPaymentContactFields : public ApplePaySessionPaymentRequest::ContactFields {
-    MockPaymentContactFields() = default;
-    MockPaymentContactFields(const ApplePaySessionPaymentRequest::ContactFields& contactFields)
-        : ApplePaySessionPaymentRequest::ContactFields { contactFields }
-    {
-    }
+struct MockPaymentContactFields {
+    bool postalAddress { false };
+    bool phone { false };
+    bool email { false };
+    bool name { false };
+    bool phoneticName { false };
 };
+
+inline MockPaymentContactFields toMockPaymentContactFields(const ApplePaySessionPaymentRequestContactFields& fields)
+{
+    return {
+        fields.postalAddress,
+        fields.phone,
+        fields.email,
+        fields.name,
+        fields.phoneticName
+    };
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/testing/MockPaymentContactFields.idl
+++ b/Source/WebCore/testing/MockPaymentContactFields.idl
@@ -26,7 +26,6 @@
 [
     Conditional=APPLE_PAY,
     JSGenerateToJSObject,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary MockPaymentContactFields {
     boolean postalAddress = false;
     boolean phone = false;

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -119,11 +119,11 @@ void MockPaymentCoordinator::dispatchIfShowing(Function<void()>&& function)
 bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const ApplePaySessionPaymentRequest& request)
 {
     if (request.shippingContact().pkContact().get())
-        m_shippingAddress = request.shippingContact().toLocalizedApplePayPaymentContact(request.version());
+        m_shippingAddress = toMockPaymentAddress(request.shippingContact().toLocalizedApplePayPaymentContact(request.version()));
     m_supportedCountries = request.supportedCountries();
     m_shippingMethods = request.shippingMethods();
-    m_requiredBillingContactFields = request.requiredBillingContactFields();
-    m_requiredShippingContactFields = request.requiredShippingContactFields();
+    m_requiredBillingContactFields = toMockPaymentContactFields(request.requiredBillingContactFields());
+    m_requiredShippingContactFields = toMockPaymentContactFields(request.requiredShippingContactFields());
 #if ENABLE(APPLE_PAY_INSTALLMENTS)
     if (auto& configuration = request.installmentConfiguration().applePayInstallmentConfiguration())
         m_installmentConfiguration = *configuration;
@@ -179,7 +179,7 @@ void MockPaymentCoordinator::completeMerchantValidation(const PaymentMerchantSes
         return;
 
     dispatchIfShowing([page = WTF::move(page), shippingAddress = m_shippingAddress]() mutable {
-        protect(page->paymentCoordinator())->didSelectShippingContact(MockPaymentContact { WTF::move(shippingAddress) });
+        protect(page->paymentCoordinator())->didSelectShippingContact(MockPaymentContact { toLocalizedApplePayPaymentContact(shippingAddress) });
     });
 }
 
@@ -346,9 +346,9 @@ void MockPaymentCoordinator::acceptPayment()
 
     dispatchIfShowing([page = WTF::move(page), shippingAddress = m_shippingAddress]() mutable {
         ApplePayPayment payment;
-        payment.shippingContact = shippingAddress;
+        payment.shippingContact = toApplePayPaymentContact(shippingAddress);
         LocalizedApplePayPayment localizedPayment;
-        localizedPayment.shippingContact = shippingAddress;
+        localizedPayment.shippingContact = toLocalizedApplePayPaymentContact(shippingAddress);
         protect(page->paymentCoordinator())->didAuthorizePayment(MockPayment { WTF::move(payment), WTF::move(localizedPayment) });
     });
 }

--- a/Source/WebCore/testing/MockPaymentCoordinator.h
+++ b/Source/WebCore/testing/MockPaymentCoordinator.h
@@ -159,7 +159,7 @@ private:
     uint64_t m_hideCount { 0 };
     bool m_canMakePayments { true };
     bool m_canMakePaymentsWithActiveCard { true };
-    LocalizedApplePayPaymentContact m_shippingAddress;
+    MockPaymentAddress m_shippingAddress;
     ApplePayLineItem m_total;
     Vector<ApplePayLineItem> m_lineItems;
     Vector<MockPaymentError> m_errors;

--- a/Source/WebCore/testing/WebFakeXRInputController.cpp
+++ b/Source/WebCore/testing/WebFakeXRInputController.cpp
@@ -61,7 +61,8 @@ WebFakeXRInputController::WebFakeXRInputController(PlatformXR::InputSourceHandle
     , m_simulateSelect(init.selectionClicked)
 {
     setPointerOrigin(init.pointerOrigin, false);
-    setGripOrigin(init.gripOrigin, false);
+    if (init.gripOrigin)
+        setGripOrigin(*init.gripOrigin, false);
     setSupportedButtons(init.supportedButtons);
 #if ENABLE(WEBXR_HANDS)
     updateHandJoints(init.handJoints);
@@ -200,7 +201,11 @@ void WebFakeXRInputController::updateHandJoints(const Vector<FakeXRJointStateIni
 
     HandJointsVector updatedJoints;
     for (auto handJoint : handJoints) {
-        auto transform = WebFakeXRDevice::parseRigidTransform(handJoint.pose);
+        if (!handJoint.pose) {
+            updatedJoints.append(std::nullopt);
+            continue;
+        }
+        auto transform = WebFakeXRDevice::parseRigidTransform(*handJoint.pose);
         if (transform.hasException()) {
             updatedJoints.append(std::nullopt);
             continue;

--- a/Source/WebCore/testing/WebXRTest.cpp
+++ b/Source/WebCore/testing/WebXRTest.cpp
@@ -70,12 +70,8 @@ void WebXRTest::simulateDeviceConnection(ScriptExecutionContext& context, const 
 
         device->setViews(init.views);
 
-        PlatformXR::Device::FeatureList supportedFeatures;
-        if (init.supportedFeatures)
-            supportedFeatures = parseFeatures(init.supportedFeatures.value(), context);
-        PlatformXR::Device::FeatureList enabledFeatures;
-        if (init.enabledFeatures)
-            enabledFeatures = parseFeatures(init.enabledFeatures.value(), context);
+        auto supportedFeatures = parseFeatures(init.supportedFeatures, context);
+        auto enabledFeatures = parseFeatures(init.enabledFeatures, context);
 
         if (init.boundsCoordinates) {
             if (init.boundsCoordinates->size() < 3) {

--- a/Source/WebCore/testing/WebXRTest.h
+++ b/Source/WebCore/testing/WebXRTest.h
@@ -48,8 +48,8 @@ public:
         std::optional<Vector<XRSessionMode>> supportedModes;
         Vector<FakeXRViewInit> views;
 
-        std::optional<Vector<JSC::JSValue>> supportedFeatures;
-        std::optional<Vector<JSC::JSValue>> enabledFeatures;
+        Vector<JSC::JSValue> supportedFeatures;
+        Vector<JSC::JSValue> enabledFeatures;
 
         std::optional<Vector<FakeXRBoundsPoint>> boundsCoordinates;
 

--- a/Source/WebCore/testing/WebXRTest.idl
+++ b/Source/WebCore/testing/WebXRTest.idl
@@ -46,10 +46,9 @@
 [
     EnabledBySetting=WebXREnabled,
     Conditional=WEBXR,
-    LegacyNativeDictionaryRequiredInterfaceNullability,
 ] dictionary FakeXRDeviceInit {
     // Deprecated - use `supportedModes` instead.
-    boolean supportsImmersive;
+    boolean supportsImmersive = false;
     // Sequence of modes that should be supported by this device.
     sequence<XRSessionMode> supportedModes;
     required sequence<FakeXRViewInit> views;
@@ -61,11 +60,11 @@
     // If not specified/empty, the device supports no features.
     // NOTE: This is meant to emulate hardware support, not whether a feature is
     // currently available (e.g. bounds not being tracked per below)
-    sequence<any> supportedFeatures;
-    
+    sequence<any> supportedFeatures = [];
+
     // The list of features that are automatically enabled and do
     // not need further explicit consent.
-    sequence<any> enabledFeatures;
+    sequence<any> enabledFeatures = [];
 
     // The bounds coordinates. If empty, no bounded reference space is currently tracked.
     // If not, must have at least three elements.


### PR DESCRIPTION
#### 59167068c06ad5243107905fc3ee0dc273c5bdb8
<pre>
Remove LegacyNativeDictionaryRequiredInterfaceNullability in WebCore/testing
<a href="https://bugs.webkit.org/show_bug.cgi?id=307271">https://bugs.webkit.org/show_bug.cgi?id=307271</a>

Reviewed by Ryosuke Niwa and Abrar Rahman Protyasha.

This required some fairly involved changes for MockPayment classes as
they now need dedicated structs.

Canonical link: <a href="https://commits.webkit.org/311285@main">https://commits.webkit.org/311285@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e1cca8aaba2bad860251b8c34a8b8d585dae0c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/156560 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23078 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/165383 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/110640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/158431 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/29899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121263 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/110640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/159518 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/23487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/140595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101930 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/22543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/20728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13154 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/132222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/18425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/167865 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11986 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129378 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/29497 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24806 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/129488 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/29420 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87222 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23834 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24307 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17021 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29128 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93093 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/28654 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/28883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/28779 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->