### PR TITLE
Add C++17 [[nodiscard]] to WTF::Variant functions

### DIFF
--- a/Source/WTF/wtf/Variant.h
+++ b/Source/WTF/wtf/Variant.h
@@ -928,7 +928,7 @@ namespace mpark {
 
   class bad_variant_access : public std::exception {
     public:
-    virtual const char *what() const noexcept override { return "bad_variant_access"; }
+    [[nodiscard]] virtual const char *what() const noexcept override { return "bad_variant_access"; }
   };
 
   [[noreturn]] inline void throw_bad_variant_access() {
@@ -2443,11 +2443,11 @@ namespace mpark {
       return impl_.template emplace<I>(il, lib::forward<Args>(args)...);
     }
 
-    inline constexpr bool valueless_by_exception() const noexcept {
+    [[nodiscard]] inline constexpr bool valueless_by_exception() const noexcept {
       return impl_.valueless_by_exception();
     }
 
-    inline constexpr std::size_t index() const noexcept {
+    [[nodiscard]] inline constexpr std::size_t index() const noexcept {
       return impl_.index();
     }
 
@@ -2473,12 +2473,12 @@ namespace mpark {
   };
 
   template <std::size_t I, typename... Ts>
-  inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept {
+  [[nodiscard]] inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept {
     return v.index() == I;
   }
 
   template <typename T, typename... Ts>
-  inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept {
+  [[nodiscard]] inline constexpr bool holds_alternative(const variant<Ts...> &v) noexcept {
     return holds_alternative<detail::find_index_checked<T, Ts...>::value>(v);
   }
 
@@ -2500,46 +2500,46 @@ namespace mpark {
   }  // namespace detail
 
   template <std::size_t I, typename... Ts>
-  inline constexpr variant_alternative_t<I, variant<Ts...>> &get(
+  [[nodiscard]] inline constexpr variant_alternative_t<I, variant<Ts...>> &get(
       variant<Ts...> &v) {
     return detail::generic_get<I>(v);
   }
 
   template <std::size_t I, typename... Ts>
-  inline constexpr variant_alternative_t<I, variant<Ts...>> &&get(
+  [[nodiscard]] inline constexpr variant_alternative_t<I, variant<Ts...>> &&get(
       variant<Ts...> &&v) {
     return detail::generic_get<I>(lib::move(v));
   }
 
   template <std::size_t I, typename... Ts>
-  inline constexpr const variant_alternative_t<I, variant<Ts...>> &get(
+  [[nodiscard]] inline constexpr const variant_alternative_t<I, variant<Ts...>> &get(
       const variant<Ts...> &v) {
     return detail::generic_get<I>(v);
   }
 
   template <std::size_t I, typename... Ts>
-  inline constexpr const variant_alternative_t<I, variant<Ts...>> &&get(
+  [[nodiscard]] inline constexpr const variant_alternative_t<I, variant<Ts...>> &&get(
       const variant<Ts...> &&v) {
     return detail::generic_get<I>(lib::move(v));
   }
 
   template <typename T, typename... Ts>
-  inline constexpr T &get(variant<Ts...> &v) {
+  [[nodiscard]] inline constexpr T &get(variant<Ts...> &v) {
     return mpark::get<detail::find_index_checked<T, Ts...>::value>(v);
   }
 
   template <typename T, typename... Ts>
-  inline constexpr T &&get(variant<Ts...> &&v) {
+  [[nodiscard]] inline constexpr T &&get(variant<Ts...> &&v) {
     return mpark::get<detail::find_index_checked<T, Ts...>::value>(lib::move(v));
   }
 
   template <typename T, typename... Ts>
-  inline constexpr const T &get(const variant<Ts...> &v) {
+  [[nodiscard]] inline constexpr const T &get(const variant<Ts...> &v) {
     return mpark::get<detail::find_index_checked<T, Ts...>::value>(v);
   }
 
   template <typename T, typename... Ts>
-  inline constexpr const T &&get(const variant<Ts...> &&v) {
+  [[nodiscard]] inline constexpr const T &&get(const variant<Ts...> &&v) {
     return mpark::get<detail::find_index_checked<T, Ts...>::value>(lib::move(v));
   }
 
@@ -2554,26 +2554,26 @@ namespace mpark {
   }  // namespace detail
 
   template <std::size_t I, typename... Ts>
-  inline constexpr lib::add_pointer_t<variant_alternative_t<I, variant<Ts...>>>
+  [[nodiscard]] inline constexpr lib::add_pointer_t<variant_alternative_t<I, variant<Ts...>>>
   get_if(variant<Ts...> *v) noexcept {
     return detail::generic_get_if<I>(v);
   }
 
   template <std::size_t I, typename... Ts>
-  inline constexpr lib::add_pointer_t<
+  [[nodiscard]] inline constexpr lib::add_pointer_t<
       const variant_alternative_t<I, variant<Ts...>>>
   get_if(const variant<Ts...> *v) noexcept {
     return detail::generic_get_if<I>(v);
   }
 
   template <typename T, typename... Ts>
-  inline constexpr lib::add_pointer_t<T>
+  [[nodiscard]] inline constexpr lib::add_pointer_t<T>
   get_if(variant<Ts...> *v) noexcept {
     return mpark::get_if<detail::find_index_checked<T, Ts...>::value>(v);
   }
 
   template <typename T, typename... Ts>
-  inline constexpr lib::add_pointer_t<const T>
+  [[nodiscard]] inline constexpr lib::add_pointer_t<const T>
   get_if(const variant<Ts...> *v) noexcept {
     return mpark::get_if<detail::find_index_checked<T, Ts...>::value>(v);
   }
@@ -2834,7 +2834,7 @@ namespace std {
     using argument_type = mpark::variant<Ts...>;
     using result_type = std::size_t;
 
-    inline result_type operator()(const argument_type &v) const {
+    [[nodiscard]] inline result_type operator()(const argument_type &v) const {
       using mpark::detail::visitation::variant;
       std::size_t result =
           v.valueless_by_exception()
@@ -2878,7 +2878,7 @@ namespace std {
     using argument_type = mpark::monostate;
     using result_type = std::size_t;
 
-    inline result_type operator()(const argument_type &) const noexcept {
+    [[nodiscard]] inline result_type operator()(const argument_type &) const noexcept {
       return 66740831;  // return a fundamentally attractive random value.
     }
   };
@@ -2889,21 +2889,21 @@ namespace std {
 
 namespace std {
 
-template<class T, class... Types> constexpr bool holds_alternative(const mpark::variant<Types...>& v) noexcept { return mpark::holds_alternative<T>(v); }
+template<class T, class... Types> [[nodiscard]] constexpr bool holds_alternative(const mpark::variant<Types...>& v) noexcept { return mpark::holds_alternative<T>(v); }
 
-template<size_t I, class... Types> constexpr mpark::variant_alternative_t<I, mpark::variant<Types...>>& get(mpark::variant<Types...>& v) { return mpark::get<I>(v); }
-template<size_t I, class... Types> constexpr mpark::variant_alternative_t<I, mpark::variant<Types...>>&& get(mpark::variant<Types...>&& v) { return mpark::get<I>(std::forward<mpark::variant<Types...>>(v)); }
-template<size_t I, class... Types> constexpr const mpark::variant_alternative_t<I, mpark::variant<Types...>>& get( const mpark::variant<Types...>& v ) { return mpark::get<I>(v); }
-template<size_t I, class... Types> constexpr const mpark::variant_alternative_t<I, mpark::variant<Types...>>&& get( const mpark::variant<Types...>&& v ) { return mpark::get<I>(std::forward<mpark::variant<Types...>>(v)); }
-template<class T, class... Types> constexpr T& get(mpark::variant<Types...>& v) { return mpark::get<T>(v); }
-template<class T, class... Types> constexpr T&& get(mpark::variant<Types...>&& v)  { return mpark::get<T>(std::forward<mpark::variant<Types...>>(v)); }
-template<class T, class... Types> constexpr const T& get(const mpark::variant<Types...>& v) { return mpark::get<T>(v); }
-template<class T, class... Types> constexpr const T&& get(const mpark::variant<Types...>&& v) { return mpark::get<T>(std::forward<mpark::variant<Types...>>(v)); }
+template<size_t I, class... Types> [[nodiscard]] constexpr mpark::variant_alternative_t<I, mpark::variant<Types...>>& get(mpark::variant<Types...>& v) { return mpark::get<I>(v); }
+template<size_t I, class... Types> [[nodiscard]] constexpr mpark::variant_alternative_t<I, mpark::variant<Types...>>&& get(mpark::variant<Types...>&& v) { return mpark::get<I>(std::forward<mpark::variant<Types...>>(v)); }
+template<size_t I, class... Types> [[nodiscard]] constexpr const mpark::variant_alternative_t<I, mpark::variant<Types...>>& get( const mpark::variant<Types...>& v ) { return mpark::get<I>(v); }
+template<size_t I, class... Types> [[nodiscard]] constexpr const mpark::variant_alternative_t<I, mpark::variant<Types...>>&& get( const mpark::variant<Types...>&& v ) { return mpark::get<I>(std::forward<mpark::variant<Types...>>(v)); }
+template<class T, class... Types> [[nodiscard]] constexpr T& get(mpark::variant<Types...>& v) { return mpark::get<T>(v); }
+template<class T, class... Types> [[nodiscard]] constexpr T&& get(mpark::variant<Types...>&& v)  { return mpark::get<T>(std::forward<mpark::variant<Types...>>(v)); }
+template<class T, class... Types> [[nodiscard]] constexpr const T& get(const mpark::variant<Types...>& v) { return mpark::get<T>(v); }
+template<class T, class... Types> [[nodiscard]] constexpr const T&& get(const mpark::variant<Types...>&& v) { return mpark::get<T>(std::forward<mpark::variant<Types...>>(v)); }
 
-template<size_t I, class... Types> constexpr add_pointer_t<mpark::variant_alternative_t<I, mpark::variant<Types...>>> get_if( mpark::variant<Types...>* v ) noexcept { return mpark::get_if<I>(v); }
-template<size_t I, class... Types> constexpr add_pointer_t<const mpark::variant_alternative_t<I, mpark::variant<Types...>>> get_if(const mpark::variant<Types...>* v ) noexcept { return mpark::get_if<I>(v); }
-template<class T, class... Types> constexpr add_pointer_t<T> get_if(mpark::variant<Types...>* v ) noexcept { return mpark::get_if<T>(v); }
-template<class T, class... Types> constexpr add_pointer_t<const T> get_if(const mpark::variant<Types...>* v) noexcept { return mpark::get_if<T>(v); }
+template<size_t I, class... Types> [[nodiscard]] constexpr add_pointer_t<mpark::variant_alternative_t<I, mpark::variant<Types...>>> get_if( mpark::variant<Types...>* v ) noexcept { return mpark::get_if<I>(v); }
+template<size_t I, class... Types> [[nodiscard]] constexpr add_pointer_t<const mpark::variant_alternative_t<I, mpark::variant<Types...>>> get_if(const mpark::variant<Types...>* v ) noexcept { return mpark::get_if<I>(v); }
+template<class T, class... Types> [[nodiscard]] constexpr add_pointer_t<T> get_if(mpark::variant<Types...>* v ) noexcept { return mpark::get_if<T>(v); }
+template<class T, class... Types> [[nodiscard]] constexpr add_pointer_t<const T> get_if(const mpark::variant<Types...>* v) noexcept { return mpark::get_if<T>(v); }
 
 }
 


### PR DESCRIPTION
#### 76f61457be347eefc0c0ae1c42d5fb6816b2b683
<pre>
Add C++17 [[nodiscard]] to WTF::Variant functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=307279">https://bugs.webkit.org/show_bug.cgi?id=307279</a>
<a href="https://rdar.apple.com/169926855">rdar://169926855</a>

Reviewed by Darin Adler.

libc++ marks std::variant&apos;s functions as [[nodiscard]].
Apply the same to WTF::Variant to warn against discarding return values.

LLVM/libc++ docs: <a href="https://libcxx.llvm.org/CodingGuidelines.html#apply-nodiscard-where-relevant">https://libcxx.llvm.org/CodingGuidelines.html#apply-nodiscard-where-relevant</a>

* Source/WTF/wtf/Variant.h:
(mpark::get):
(std::get):

Canonical link: <a href="https://commits.webkit.org/308474@main">https://commits.webkit.org/308474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a4637e49af62176e648bf26c72d0551012f3d2f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143218 "19 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96439 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15774 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110145 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79485 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146167 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12584 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128169 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91056 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12067 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9783 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135217 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4666 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154205 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4030 "Built successfully and passed tests") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5653 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118164 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13271 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118504 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31255 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15727 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125853 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71124 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14439 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4494 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174515 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15362 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79081 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45063 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15096 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->