### PR TITLE
[Scroll anchoring] overflow:hidden areas need to participate in scroll anchoring

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6367,7 +6367,6 @@ imported/w3c/web-platform-tests/css/css-scroll-anchoring/position-change-heurist
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/shadow-dom-subscroller.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/start-edge-in-block-layout-direction.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/nested-overflow-subtree-layout-vertical.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scroll-anchoring/nested-overflow-subtree-layout.html [ ImageOnlyFailure ]
 fast/repaint/absolute-position-changed.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/307272 editing/execCommand/insert-line-break-no-scroll.html [ Failure ]

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4714,6 +4714,20 @@ void LocalFrameView::performPostLayoutTasks()
         m_frame->eventHandler().scheduleMouseEventTargetUpdateAfterLayout();
 }
 
+void LocalFrameView::addScrollableAreaForScrollAnchoring(ScrollableArea& scrollableArea)
+{
+    if (!m_anchoringScrollableAreas)
+        m_anchoringScrollableAreas = makeUnique<ScrollableAreaSet>();
+
+    m_anchoringScrollableAreas->add(scrollableArea);
+}
+
+void LocalFrameView::removeScrollableAreaForScrollAnchoring(ScrollableArea& scrollableArea)
+{
+    if (m_anchoringScrollableAreas)
+        m_anchoringScrollableAreas->remove(scrollableArea);
+}
+
 void LocalFrameView::dequeueScrollableAreaForScrollAnchoringUpdate(ScrollableArea& scrollableArea)
 {
     m_scrollableAreasWithScrollAnchoringControllersNeedingUpdate.remove(scrollableArea);
@@ -4727,10 +4741,10 @@ void LocalFrameView::queueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&
 void LocalFrameView::clearScrollAnchorsInScrollableAreas()
 {
     clearScrollAnchor();
-    if (!m_scrollableAreas)
+    if (!m_anchoringScrollableAreas)
         return;
 
-    for (auto& scrollableArea : *m_scrollableAreas)
+    for (auto& scrollableArea : *m_anchoringScrollableAreas)
         scrollableArea.clearScrollAnchor();
 }
 
@@ -4739,11 +4753,10 @@ void LocalFrameView::updateScrollAnchoringBeforeLayoutForScrollableAreas()
     if (CheckedPtr controller = scrollAnchoringController())
         controller->updateBeforeLayout();
 
-    if (!m_scrollableAreas)
+    if (!m_anchoringScrollableAreas)
         return;
 
-    // Maybe just store scrollable areas that need anchoring
-    for (auto& scrollableArea : *m_scrollableAreas) {
+    for (auto& scrollableArea : *m_anchoringScrollableAreas) {
         if (CheckedPtr controller = scrollableArea.scrollAnchoringController())
             controller->updateBeforeLayout();
     }

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -736,6 +736,11 @@ public:
     ScrollbarWidth scrollbarWidthStyle() const final;
     std::optional<ScrollbarColor> scrollbarColorStyle() const final;
 
+    // overflow:hidden scrollable areas can participate in anchoring, so they need their own set.
+    void addScrollableAreaForScrollAnchoring(ScrollableArea&);
+    void removeScrollableAreaForScrollAnchoring(ScrollableArea&);
+    const ScrollableAreaSet* scrollableAreasForScrollAnchoring() const { return m_anchoringScrollableAreas.get(); }
+
     void dequeueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);
     void queueScrollableAreaForScrollAnchoringUpdate(ScrollableArea&);
     void clearScrollAnchorsInScrollableAreas();
@@ -1064,6 +1069,7 @@ private:
 
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreas;
     std::unique_ptr<ScrollableAreaSet> m_scrollableAreasForAnimatedScroll;
+    std::unique_ptr<ScrollableAreaSet> m_anchoringScrollableAreas;
     std::unique_ptr<SingleThreadWeakHashSet<RenderLayerModelObject>> m_viewportConstrainedObjects;
     mutable std::optional<bool> m_hasAnchorPositionedViewportConstrainedObjects;
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -61,6 +61,9 @@ public:
 
     bool shouldMaintainScrollAnchor() const;
 
+    void scrollPositionDidChange();
+    void scrollerDidLayout();
+
     void clearAnchor(bool includeAncestors = false);
     void updateBeforeLayout();
     void adjustScrollPositionForAnchoring();
@@ -99,6 +102,7 @@ private:
     void invalidate();
     void chooseAnchorElement(Document&);
     bool anchoringSuppressedByStyleChange() const;
+    void updateScrollableAreaRegistration();
 
     CheckedRef<ScrollableArea> m_owningScrollableArea;
     SingleThreadWeakPtr<RenderObject> m_anchorObject;

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -261,8 +261,8 @@ void ScrollableArea::scrollPositionChanged(const ScrollPosition& position)
     if (scrollPosition() != oldPosition) {
         scrollbarsController().notifyContentAreaScrolled(scrollPosition() - oldPosition);
 
-        LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollableArea::scrollPositionChanged() from " << oldPosition << " to " << scrollPosition() << " - clearing scroll anchor");
-        clearScrollAnchor();
+        if (CheckedPtr controller = scrollAnchoringController())
+            controller->scrollPositionDidChange();
 
         updateAnchorPositionedAfterScroll();
     }

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1290,7 +1290,7 @@ void RenderLayerScrollableArea::updateScrollbarsAfterStyleChange(const RenderSty
 
 void RenderLayerScrollableArea::updateScrollbarsAfterLayout()
 {
-    RenderBox* box = m_layer.renderBox();
+    CheckedPtr box = m_layer.renderBox();
     ASSERT(box);
 
     // List box parts handle the scrollbars by themselves so we have nothing to do.
@@ -1357,6 +1357,9 @@ void RenderLayerScrollableArea::updateScrollbarsAfterLayout()
     };
 
     updateScrollableAreaSet(hasScrollableOverflow());
+
+    if (CheckedPtr scrollAnchoringController = this->scrollAnchoringController())
+        scrollAnchoringController->scrollerDidLayout();
 }
 
 void RenderLayerScrollableArea::updateScrollbarSteps()


### PR DESCRIPTION
#### 695f7498cde009612482f820ae52d9aa70a819e1
<pre>
[Scroll anchoring] overflow:hidden areas need to participate in scroll anchoring
<a href="https://bugs.webkit.org/show_bug.cgi?id=307283">https://bugs.webkit.org/show_bug.cgi?id=307283</a>
<a href="https://rdar.apple.com/169928637">rdar://169928637</a>

Reviewed by Tim Nguyen.

`overflow:hidden` elements need to participate in scroll anchoring, but they are
not tracked in the scrollable area set that LocalFrameView uses. So keep a separate
set of ScrollableAreas for those that need to do scroll anchoring. We only need to
track those for which `shouldMaintainScrollAnchor()` returns true, which means only
those that have scrolled away from 0.

* LayoutTests/TestExpectations: nested-overflow-subtree-layout.html now passes.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::addScrollableAreaForScrollAnchoring):
(WebCore::LocalFrameView::removeScrollableAreaForScrollAnchoring):
(WebCore::LocalFrameView::clearScrollAnchorsInScrollableAreas):
(WebCore::LocalFrameView::updateScrollAnchoringBeforeLayoutForScrollableAreas):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::shouldMaintainScrollAnchor const):
(WebCore::ScrollAnchoringController::scrollPositionDidChange):
(WebCore::ScrollAnchoringController::scrollerDidLayout):
(WebCore::ScrollAnchoringController::updateScrollableAreaRegistration):
(WebCore::ScrollAnchoringController::updateBeforeLayout):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollableArea::scrollPositionChanged):
* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterLayout):

Canonical link: <a href="https://commits.webkit.org/307045@main">https://commits.webkit.org/307045@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/497a0f9c5cee97c74decedbcc24beb01bf8526f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15698 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151899 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96444 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b18d14f-49e6-47a2-b24d-7511a77931e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110147 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79297 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47a8070e-f5c4-4535-9d99-365fdc505854) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146172 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12589 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128171 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91058 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c821f0e2-4517-495b-b11d-a614d8ab7510) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12072 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9785 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1896 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154210 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15730 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118166 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15763 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13273 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118506 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30343 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14441 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125855 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71129 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15367 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4496 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15101 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79086 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15312 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15163 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->