### PR TITLE
AX: Setting null on an ElementInternals ARIA reflection property should fully clear any previous value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-aria-element-reflection-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-aria-element-reflection-expected.txt
@@ -12,7 +12,7 @@ Labelled by from IDL attribute
 PASS Getting previously-unset ARIA element reflection properties on ElementInternals should return null.
 PASS Getting ARIA element reflection properties on ElementInternals should return the value that was set.
 PASS Setting ARIA element reflection properties to an empty array should work as expected.
-FAIL Setting ARIA element reflection properties on ElementInternals to null should delete any previous value, and not crash assert_equals: expected null but got []
+PASS Setting ARIA element reflection properties on ElementInternals to null should delete any previous value, and not crash
 PASS Setting ariaLabelledByElements on ElementInternals should change the accessible name of the custom element
 PASS Setting aria-labelledby or ariaLabelledByElements on the custom element should supersede the value of ariaLabelledByElements on ElementInternals
 PASS Caching invariant different attributes.

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5968,9 +5968,11 @@ bool AXObjectCache::addRelation(Element& origin, const QualifiedName& attribute)
     auto& value = origin.attributeWithoutSynchronization(attribute);
     if (value.isNull()) {
         if (CheckedPtr defaultARIA = origin.customElementDefaultARIAIfExists()) {
-            for (auto& target : defaultARIA->elementsForAttribute(origin, attribute)) {
-                if (addRelation(origin, target, relation))
-                    addedRelation = true;
+            if (std::optional elements = defaultARIA->elementsForAttribute(origin, attribute)) {
+                for (auto& target : *elements) {
+                    if (addRelation(origin, target, relation))
+                        addedRelation = true;
+                }
             }
         }
         return addedRelation;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -4117,8 +4117,10 @@ Vector<Ref<Element>> AccessibilityObject::elementsFromAttribute(const QualifiedN
     if (auto elementsFromAttribute = element->elementsArrayForAttributeInternal(attribute))
         return elementsFromAttribute.value();
 
-    if (auto* defaultARIA = element->customElementDefaultARIAIfExists())
-        return defaultARIA->elementsForAttribute(*element, attribute);
+    if (auto* defaultARIA = element->customElementDefaultARIAIfExists()) {
+        if (std::optional elements = defaultARIA->elementsForAttribute(*element, attribute))
+            return *elements;
+    }
 
     return { };
 }

--- a/Source/WebCore/dom/CustomElementDefaultARIA.h
+++ b/Source/WebCore/dom/CustomElementDefaultARIA.h
@@ -50,7 +50,7 @@ public:
     void setValueForAttribute(const QualifiedName&, const AtomString&);
     RefPtr<Element> elementForAttribute(const Element& thisElement, const QualifiedName&) const;
     void setElementForAttribute(const QualifiedName&, Element*);
-    Vector<Ref<Element>> elementsForAttribute(const Element& thisElement, const QualifiedName&) const;
+    std::optional<Vector<Ref<Element>>> elementsForAttribute(const Element& thisElement, const QualifiedName&) const;
     void setElementsForAttribute(const QualifiedName&, std::optional<Vector<Ref<Element>>>&&);
 
 private:


### PR DESCRIPTION
#### b0a6dd388232482df1f9c2ff58e57652ebc49f13
<pre>
AX: Setting null on an ElementInternals ARIA reflection property should fully clear any previous value
<a href="https://bugs.webkit.org/show_bug.cgi?id=307286">https://bugs.webkit.org/show_bug.cgi?id=307286</a>
<a href="https://rdar.apple.com/169929531">rdar://169929531</a>

Reviewed by Anne van Kesteren.

When ARIA element reflection array properties (ariaControlsElements, ariaDescribedByElements, etc.)
on ElementInternals were set to null, subsequently getting them returned an empty array instead of
null. This was because setElementsForAttribute stored an empty vector in the map when null was
passed, rather than removing the entry entirely.

* LayoutTests/imported/w3c/web-platform-tests/custom-elements/element-internals-aria-element-reflection-expected.txt:
Mark testcase as passing.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::addRelation):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::elementsFromAttribute const):
* Source/WebCore/dom/CustomElementDefaultARIA.cpp:
(WebCore::CustomElementDefaultARIA::elementsForAttribute const):
(WebCore::CustomElementDefaultARIA::setElementsForAttribute):
* Source/WebCore/dom/CustomElementDefaultARIA.h:

Canonical link: <a href="https://commits.webkit.org/307437@main">https://commits.webkit.org/307437@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e2c7cdee3cf4443ade304fd485aec44b8af5747

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144291 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8526 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152961 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97530 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cce6ed23-e604-4ded-aa5e-e01f7310989f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146166 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17452 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110954 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79693 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147254 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129622 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91872 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10537 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/407 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122286 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6286 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155273 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16822 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7340 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118968 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14116 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119326 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30609 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15192 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127498 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72243 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16444 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5921 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16389 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16244 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->