### PR TITLE
[JSC][WASM][Debugger] Fix debugger races with idle and active VMs in stop-the-world

### DIFF
--- a/Source/JavaScriptCore/runtime/VMManager.h
+++ b/Source/JavaScriptCore/runtime/VMManager.h
@@ -323,7 +323,6 @@ private:
     void decrementActiveVMs(VM&) WTF_REQUIRES_LOCK(m_worldLock);
 
     void dispatchStopHandler(VM&);
-    void handleStopViaDispatch(VM&);
 
     JS_EXPORT_PRIVATE static bool isValidVMSlow(VM*);
     JS_EXPORT_PRIVATE VM* findMatchingVMImpl(const ScopedLambda<TestCallback>&);

--- a/Source/JavaScriptCore/runtime/VMTraps.h
+++ b/Source/JavaScriptCore/runtime/VMTraps.h
@@ -332,6 +332,9 @@ private:
     // to increment their m_numberOfActiveVMs.
     bool m_hasBeenCountedAsActive { false };
 
+    // Prevents dispatching multiple idle stop handlers for a single stop cycle.
+    Atomic<bool> m_hasDispatchedIdleStopHandler { false };
+
     Box<Lock> m_trapSignalingLock;
     Box<Condition> m_condition;
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmDebugServerUtilities.h
@@ -207,7 +207,6 @@ struct DebugState {
 
     void setStopped() { state = State::Stopped; }
     bool isStopped() const { return state == State::Stopped; }
-    void setRunning() { state = State::Running; }
     bool isRunning() const { return state == State::Running; }
 
     bool hasStepIntoEvent() { return stepIntoEvent.hasAny(); }

--- a/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
+++ b/Source/JavaScriptCore/wasm/debugger/WasmExecutionHandler.h
@@ -146,8 +146,6 @@ private:
     void sendErrorReply(ProtocolError);
 
     void selectDebuggeeIfNeeded(VM& fallbackVM) WTF_REQUIRES_LOCK(m_lock);
-    void markVMStates(VM* debuggee) WTF_REQUIRES_LOCK(m_lock);
-    void clearOtherVMStopData(VM* debuggee) WTF_REQUIRES_LOCK(m_lock);
 
     bool requiresStopConfirmation() const WTF_REQUIRES_LOCK(m_lock)
     {

--- a/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.h
+++ b/Source/JavaScriptCore/wasm/debugger/tests/ExecutionHandlerTestSupport.h
@@ -56,7 +56,7 @@ using JSC::Wasm::ExecutionHandler;
 using TestScripts::TestScript;
 
 constexpr bool verboseLogging = false;
-constexpr double defaultTimeoutSeconds = 5.0;
+constexpr double defaultTimeoutSeconds = 10.0;
 
 extern std::atomic<unsigned> replyCount;
 


### PR DESCRIPTION
#### 629632da96e15c297e5260d60f185ba93ff649c3
<pre>
[JSC][WASM][Debugger] Fix debugger races with idle and active VMs in stop-the-world
<a href="https://bugs.webkit.org/show_bug.cgi?id=307288">https://bugs.webkit.org/show_bug.cgi?id=307288</a>
<a href="https://rdar.apple.com/169930077">rdar://169930077</a>

Reviewed by Mark Lam.

Fix multiple race conditions in VMManager&apos;s stop-the-world mechanism that
caused the WASM debugger to fail when handling idle VMs (not executing code)
and active VMs (executing code) concurrently. Investigation revealed three
interconnected issues that needed fixing together.

The Story:

We started investigating flaky WASM debugger behavior where interrupting
idle VMs would sometimes fail or cause assertion failures. Tracing through
the code revealed a cascade of architectural issues:

Issue 1: VM Debug State Management Race
========================================

The WasmExecutionHandler&apos;s debugger callback (wasmDebuggerOnStop) runs on
the LAST VM that stops. The old code called markVMStates() in this callback,
which iterated through ALL VMs and marked them as stopped. However, this
created a race condition with idle VMs:

- Active VMs (executing code) stop immediately when they check traps
- Idle VMs (not executing code) stop via RunLoop dispatch callbacks
- The dispatch task might not have been triggered/executed yet when the
  debugger callback runs
- But markVMStates() marks the idle VM as &quot;stopped&quot; even though its
  dispatch callback hasn&apos;t run yet and it hasn&apos;t actually stopped
- This creates inconsistent state where the debugger thinks a VM is stopped
  but the VM is still running/idle

Example race sequence:
T1 (Main): VMManager::requestStopAll() sets traps and dispatches stop handlers
T2 (Active VM): Checks traps immediately and calls notifyVMStop()
T3 (Active VM): Enters debugger callback as last active VM
T3 (Active VM): Callback calls markVMStates() -&gt; marks idle VM as &quot;stopped&quot;
T4 (Idle VM): Dispatch callback hasn&apos;t run yet -&gt; still processing RunLoop events
Result: State inconsistency - debugger thinks idle VM stopped, but it hasn&apos;t

Fix: Move debug state management into VMManager::notifyVMStop() where EACH
VM sets its own state (setStopped) when it ACTUALLY stops, not having one VM
mark all other VMs from the callback. Each VM clears its state (clearStop)
when it exits notifyVMStop(). This ensures state transitions are synchronized
with the actual stop coordination.

Issue 2: RunLoop Dispatch Complexity
====================================

For idle VMs (not executing, not checking traps), we use RunLoop dispatch
to deliver stop requests. The old implementation (handleStopViaDispatch)
manually orchestrated the entire stop sequence:
- Test-and-clear the trap flag
- Manually increment active VM count
- Call notifyVMStop
- Manually decrement active VM count

This was error-prone and duplicated logic from VM entry services.

Fix: Simplify to just use VMEntryScope which naturally triggers the normal
VM entry path, letting entry services and notifyVMStop handle everything
correctly.

Issue 3: Active VM Counting Race
=================================

While fixing Issue 2, we discovered a fundamental race in active VM counting.
Entry services check the NeedStopTheWorld flag without holding m_worldLock
(VM.cpp:1698-1699):

  if (hasEntryScopeServiceRequest(ConcurrentEntryScopeService::NeedStopTheWorld)) [[unlikely]]
      VMManager::singleton().notifyVMActivation(*this);

The hasEntryScopeServiceRequest() uses atomic operations without holding any lock.
Between the unlocked flag check and lock acquisition in notifyVMActivation(), the
world can resume to RunAll mode, causing m_hasBeenCountedAsActive flag corruption:

Race sequence:
T1 (VM thread): EntryScope check NeedStopTheWorld flag (atomic, no lock) - flag SET
T2 (Debugger): World resumes to RunAll mode
T2 (Debugger): Clears NeedStopTheWorld flag and all m_hasBeenCountedAsActive flags
T1 (VM thread): (delayed) Acquires lock and calls notifyVMActivation()
T1 (VM thread): notifyVMActivation() calls incrementActiveVMs() which corrupts
                m_numberOfActiveVMs (increments from invalidNumberOfActiveVMs sentinel)
                and sets m_hasBeenCountedAsActive=true
T1 (VM thread): notifyVMActivation() sees RunAll mode, so needsStopping=false
T1 (VM thread): Does NOT call notifyVMStop() - just returns
T1 (VM thread): VM continues executing with m_hasBeenCountedAsActive erroneously true
T2 (Debugger): Later, new requestStopAll() from RunAll mode resets m_numberOfActiveVMs=0
               but does NOT clear the m_hasBeenCountedAsActive flags
T2 (Debugger): requestStopAll() iterates VMs and calls incrementActiveVMs() for entered VMs
T2 (Debugger): incrementActiveVMs() sees flag=true and skips incrementing (guard prevents
               double-count, but flag shouldn&apos;t be true here)
T1 (VM thread): Trap handler fires and calls notifyVMStop()
T1 (VM thread): VM is in notifyVMStop() but was never counted (skipped above)
Result: Assertion failure numberOfStoppedVMs &gt; numberOfActiveVMs

Fix: Replace eager active VM counting (at construction/activation points)
with defensive counting at the actual stop point (notifyVMStop). This makes
counting idempotent and race-safe:
- If entry services succeeded: VM already counted, defensive increment is no-op
- If entry services raced: defensive increment catches the missed count
- Add RunAll mode guard in incrementActiveVMs() to prevent counter corruption

The defensive counting approach is sound because notifyVMStop() is only
called when worldMode is Stopping/Stopped/RunOne, never RunAll, so the
counter is always valid when we increment.

Implementation:

VMManager.cpp/h:
* Moved VM debug state management (setStopped/clearStop) into notifyVMStop()
  so each VM sets its own state when it actually stops, not having one VM
  mark all others from the debugger callback
* Added defensive incrementActiveVMs() at the start of notifyVMStop() to
  handle race conditions where entry services miss the count
* Added RunAll mode skip in incrementActiveVMs() - counter is invalid in
  RunAll mode (set to sentinel value invalidNumberOfActiveVMs)
* Added RunAll mode assertion in decrementActiveVMs() - verify that
  m_hasBeenCountedAsActive flag is never true in RunAll mode
* Removed incrementActiveVMs() from notifyVMConstruction() and
  notifyVMActivation() - defensive counting handles both cases now
* Simplified dispatchStopHandler() by removing handleStopViaDispatch() and
  using VMEntryScope directly, which naturally triggers the stop mechanism
* Removed handleStopViaDispatch() function - no longer needed
* Added m_hasDispatchedStopHandler atomic flag to prevent duplicate RunLoop
  task dispatches for idle VMs during a single stop cycle

WasmExecutionHandler.cpp/h:
* Removed manual VM debug state management from stopCode() - VMManager now
  handles this per-VM in notifyVMStop()
* Removed markVMStates() and clearOtherVMStopData() functions - no longer
  needed since each VM manages its own state in notifyVMStop()
* Added defensive isStopped() checks when enumerating VMs in
  selectDebuggeeIfNeeded(), findVM(), and collectAllStoppedThreads() -
  not all VMs may be stopped during iteration (especially idle VMs whose
  dispatch callbacks may not have run yet)
* Removed redundant stopped check in interrupt() - VMManager handles this

VMTraps.h:
* Added atomic m_hasDispatchedStopHandler flag to prevent duplicate
  dispatches to the same VM during a single stop cycle

WasmDebugServerUtilities.h:
* Removed setRunning() method - VMManager now manages all state transitions

Test Improvements:

ExecutionHandlerIdleStopTest.cpp:
* Added testIdleVMWithActiveVM() to test 2 idle + 3 active VMs scenario,
  specifically stressing RunLoop dispatch mechanism for idle VMs that don&apos;t
  check traps - this test would have caught Issue 1
* Improved error reporting by using CHECK instead of warnings
* Added explicit world resume before cleanup to release waiting VMs

ExecutionHandlerTest.cpp:
* Enhanced validateStop() and resume() to verify ALL VMs are in expected state,
  not just the debuggee VM - catches state management bugs like Issue 1
* Improved synchronization using getReplyCount() for deterministic waits
* Updated setupScriptAndWaitForVMs() to wait for VMs to be fully entered and
  actively running before tests start - eliminates VM lifecycle races
* Added final cleanup check to ensure all VMs are destroyed after tests
* Better error detection with CHECK failures instead of warnings

Canonical link: <a href="https://commits.webkit.org/307138@main">https://commits.webkit.org/307138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6de3ff255400a3cb675a9936ec25aca7b181db42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143431 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152096 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16000 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110301 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17efc81b-8a89-41f1-b774-50247a0bf27b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146394 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128929 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91213 "Found 1 new API test failure: TestWTF:WTF.DragonBox (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edb7bb0a-7453-4322-8aa3-fb355af483a8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12258 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9972 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2098 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135419 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121689 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5434 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154408 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4237 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15959 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6470 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118321 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15995 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13461 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118665 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30419 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14622 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126633 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71373 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15580 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5258 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174717 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15315 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79294 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45104 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15379 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->