### PR TITLE
[AutoFill Debugging] Add an option to include offscreen password fields

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
@@ -1,0 +1,35 @@
+-- texttree
+
+root,scrollPosition=(0,0),contentSize=[…]
+    section
+        article
+            'Article Title'
+            'January 1, 2024'
+            'This is some article content with highlighted text.'
+        form,autocomplete='on',name='signup'
+            'Sign up for our newsletter'
+            input,'text',placeholder='Username',name='username',minlength=3,maxlength=20,required
+            input,'password',placeholder='Password',name='password',minlength=3,maxlength=20,required,secure
+            input,'text',placeholder='Email',pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$',name='email',required
+            input,'text',placeholder='Zip Code',pattern='[0-9]{5}',name='zipcode',minlength=5,maxlength=5
+
+-- html
+
+<body>
+    <section>
+        <article>
+            Article Title
+            January 1, 2024
+            This is some article content with highlighted text.
+        </article>
+        <form autocomplete='on' name='signup'>
+            Sign up for our newsletter
+            <input type='text' placeholder='Username' name='username' minlength=3 maxlength=20 required>
+            <input type='password' placeholder='Password' name='password' minlength=3 maxlength=20 required>
+            <input type='text' placeholder='Email' pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$' name='email' required>
+            <input type='text' placeholder='Zip Code' pattern='[0-9]{5}' name='zipcode' minlength=5 maxlength=5>
+        </form>
+    </section>
+</body>
+
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html
@@ -1,0 +1,114 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<style>
+.text-representation {
+    white-space: pre-wrap;
+}
+
+.form-container {
+    border: solid 1px tomato;
+    padding: 1em;
+    margin: 1em;
+    display: inline-block;
+}
+
+.tall {
+    width: 1px;
+    height: 150vh;
+}
+
+form {
+    width: 390px;
+    height: 350px;
+    border-radius: 1em;
+    border: 1px solid black;
+    padding: 1em;
+}
+
+h4 {
+    margin: auto;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<main role="main">
+    <section id="section2" aria-label="Content with Roles">
+        <article role="article">
+            <header>
+                <h3>Article Title</h3>
+                <time datetime="2024-01-01">January 1, 2024</time>
+            </header>
+            <p>This is some article content with <mark>highlighted text</mark>.</p>
+        </article>
+        <div class="tall"></div>
+        <form name="signup" autocomplete="on">
+            <h4>Sign up for our newsletter</h4>
+            <div class="form-container">
+                <input name="username" placeholder="Username" minlength="3" maxlength="20" required />
+                <input name="password" placeholder="Password" minlength="3" maxlength="20" type="password" required />
+            </div>
+            <br>
+            <div class="form-container">
+                <input name="email" placeholder="Email" pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$" required />
+                <input name="zipcode" placeholder="Zip Code" pattern="[0-9]{5}" minlength="5" maxlength="5" />
+            </div>
+        </form>
+        <select>
+            <option value="one">Number 1</option>
+            <option value="two">Number 2</option>
+            <option selected value="three">Number 3</option>
+        </select>
+        <select multiple>
+            <option selected value="banana">Banana</option>
+            <option selected value="pear">Pear</option>
+            <option value="apple">Apple</option>
+        </select>
+    </section>
+</main>
+<footer role="contentinfo">
+    <p>Footer content with <span role="img" aria-label="copyright symbol">©</span> 2024</p>
+</footer>
+<div role="dialog" aria-hidden="true" style="display: none;">
+    <p>This dialog is hidden and should not be extracted.</p>
+</div>
+<script>
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const results = [];
+    for (let outputFormat of ["texttree", "html"]) {
+        const heading = document.createElement("h1");
+        heading.textContent = `-- ${outputFormat}`;
+
+        const container = document.createElement("pre");
+        container.classList.add("text-representation");
+        let textContent = await UIHelper.requestDebugText({
+            normalize: true,
+            includeRects: false,
+            includeURLs: false,
+            includeOffscreenPasswordFields: true,
+            clipToBounds: true,
+            outputFormat,
+        });
+
+        container.textContent = textContent;
+        results.push(heading);
+        results.push(container);
+        results.push(document.createElement("br"));
+    }
+
+    document.body.replaceChildren(...results);
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -104,6 +104,7 @@ struct Request {
     bool includeEventListeners { false };
     bool includeAccessibilityAttributes { false };
     bool includeTextInAutoFilledControls { false };
+    bool includeOffscreenPasswordFields { false };
 #if ENABLE(DATA_DETECTION)
     OptionSet<DataDetectorType> dataDetectorTypes;
 #endif

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6894,6 +6894,7 @@ header: <WebCore/TextExtractionTypes.h>
     bool includeEventListeners;
     bool includeAccessibilityAttributes;
     bool includeTextInAutoFilledControls;
+    bool includeOffscreenPasswordFields;
 #if ENABLE(DATA_DETECTION)
     OptionSet<WebCore::DataDetectorType> dataDetectorTypes;
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7325,6 +7325,7 @@ static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtract
             .includeEventListeners = !!configuration.includeEventListeners,
             .includeAccessibilityAttributes = !!configuration.includeAccessibilityAttributes,
             .includeTextInAutoFilledControls = !!configuration.includeTextInAutoFilledControls,
+            .includeOffscreenPasswordFields = !!configuration.includeOffscreenPasswordFields,
 #if ENABLE(DATA_DETECTION)
             .dataDetectorTypes = coreDataDetectorTypes(configuration.dataDetectorTypes),
 #endif

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -131,6 +131,12 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
 @property (nonatomic) BOOL includeTextInAutoFilledControls;
 
 /*!
+ Include context around password fields, including those outside of `targetRect`.
+ The default value is `false`.
+ */
+@property (nonatomic) BOOL includeOffscreenPasswordFields;
+
+/*!
  Max number of words to include per paragraph; remaining text is truncated with an ellipsis (…).
  The default value is `NSUIntegerMax`.
  */

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -52,6 +52,7 @@ dictionary TextExtractionTestOptions {
     boolean includeEventListeners = false;
     boolean includeAccessibilityAttributes = false;
     boolean includeTextInAutoFilledControls = false;
+    boolean includeOffscreenPasswordFields = false;
     boolean mergeParagraphs = false;
     boolean skipNearlyTransparentContent = false;
     DOMString outputFormat;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -67,6 +67,7 @@ struct TextExtractionTestOptions {
     bool includeEventListeners { false };
     bool includeAccessibilityAttributes { false };
     bool includeTextInAutoFilledControls { false };
+    bool includeOffscreenPasswordFields { false };
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
     JSRetainPtr<JSStringRef> outputFormat;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -78,6 +78,7 @@ TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSV
     options.includeEventListeners = booleanProperty(context, (JSObjectRef)argument, "includeEventListeners", false);
     options.includeAccessibilityAttributes = booleanProperty(context, (JSObjectRef)argument, "includeAccessibilityAttributes", false);
     options.includeTextInAutoFilledControls = booleanProperty(context, (JSObjectRef)argument, "includeTextInAutoFilledControls", false);
+    options.includeOffscreenPasswordFields = booleanProperty(context, (JSObjectRef)argument, "includeOffscreenPasswordFields", false);
     options.wordLimit = static_cast<unsigned>(numericProperty(context, (JSObjectRef)argument, "wordLimit"));
     options.mergeParagraphs = booleanProperty(context, (JSObjectRef)argument, "mergeParagraphs", false);
     options.skipNearlyTransparentContent = booleanProperty(context, (JSObjectRef)argument, "skipNearlyTransparentContent", false);

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -392,6 +392,7 @@ RetainPtr<_WKTextExtractionConfiguration> createTextExtractionConfiguration(WKWe
     [configuration setIncludeEventListeners:options && options->includeEventListeners];
     [configuration setIncludeAccessibilityAttributes:options && options->includeAccessibilityAttributes];
     [configuration setIncludeTextInAutoFilledControls:options && options->includeTextInAutoFilledControls];
+    [configuration setIncludeOffscreenPasswordFields:options && options->includeOffscreenPasswordFields];
 
     auto outputFormat = [&] -> std::optional<_WKTextExtractionOutputFormat> {
         if (!options)


### PR DESCRIPTION
#### e08a4a0ebf2a2816e0c68686e7235bec313f7628
<pre>
[AutoFill Debugging] Add an option to include offscreen password fields
<a href="https://bugs.webkit.org/show_bug.cgi?id=307297">https://bugs.webkit.org/show_bug.cgi?id=307297</a>
<a href="https://rdar.apple.com/169930774">rdar://169930774</a>

Reviewed by Megan Gardner and Abrar Rahman Protyasha.

Add a new flag to include text around password fields, even if the password fields lie outside of
the target collection rect. See below for more details.

Test: fast/text-extraction/debug-text-extraction-form-controls-2.html

* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html: Added.

Add a layout test to exercise the new flag.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::findLargeContainerAboveNode):
(WebCore::TextExtraction::findContainerNodeForDataDetectorResults):
(WebCore::TextExtraction::extractItem):

Implement support for this new behavior. If the flag is set and there is a target collection rect
specified (note: the absence of a target collection rect means we won&apos;t check for viewport
intersection in the first place), we scan the extraction root subtree for all inputs of type
`password`, and then use the same render tree ancestor heuristic as data detectors to find a &quot;large&quot;
ancestor for each node.

While recursively traversing the DOM, keep track of the number of parent nodes that are in this set,
via `inAdditionalContainerToCollectCount`. As long as `inAdditionalContainerToCollectCount` is
nonzero, we then ignore the viewport intersection check and include context from the container
regardless.

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _requestTextExtractionInternal:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:

Add the new property.

* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::createTextExtractionConfiguration):

Add test support for this new property.

Canonical link: <a href="https://commits.webkit.org/307093@main">https://commits.webkit.org/307093@main</a>
</pre>
