### PR TITLE
Adjust fuzziness for tests in wpt /svg/pservers/reftests

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7768,12 +7768,8 @@ imported/w3c/web-platform-tests/svg/painting/color-interpolation-001.svg [ Pass 
 
 # web-platform-tests/svg/pservers failures
 imported/w3c/web-platform-tests/svg/pservers/scripted/pattern-transform-clear.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-none-1.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-currentcolor-1.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/gradient-transform-03.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/pservers/reftests/pattern-transform-03.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/pservers/reftests/radialgradient-fully-overlapping.svg [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/pservers/reftests/stop-color-currentcolor-dynamic-001.svg [ ImageOnlyFailure ]
 
 # re-import css/css-align WPT failure
 webkit.org/b/271692 imported/w3c/web-platform-tests/css/css-align/blocks/align-content-block-break-overflow-020.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-currentcolor-1.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-currentcolor-1.svg
@@ -1,5 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
-  <h:link rel="match" href="reference/green-100x100.svg"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="match" href="reference/green-100x100.svg"/>
+  <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5000"/>
   <linearGradient id="lg">
     <stop stop-color="#008000"/>
   </linearGradient>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-none-1.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-none-1.svg
@@ -1,5 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
-  <h:link rel="match" href="reference/green-100x100.svg"/>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
+  <html:link rel="match" href="reference/green-100x100.svg"/>
+  <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-5000"/>
   <linearGradient id="lg">
     <stop stop-color="#008000"/>
   </linearGradient>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/radialgradient-fully-overlapping.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/radialgradient-fully-overlapping.svg
@@ -1,9 +1,10 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml">
   <title>Radial gradient with overlapping start and end circles</title>
   <metadata>
-    <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#RadialGradientNotes"/>
-    <h:link rel="match" href="reference/green-100x100.svg"/>
-    <h:meta name="assert" content="If the start circle fully overlaps with the end circle, the gradient should be drawn."/>
+    <html:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#RadialGradientNotes"/>
+    <html:link rel="match" href="reference/green-100x100.svg"/>
+    <html:meta name="assert" content="If the start circle fully overlaps with the end circle, the gradient should be drawn."/>
+    <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-4500"/>
   </metadata>
 
   <rect width="100" height="100" fill="red"/>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/stop-color-currentcolor-dynamic-001.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/stop-color-currentcolor-dynamic-001.svg
@@ -1,8 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml"
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml"
      style="color: red">
   <title>stop-color: Dynamically changing 'color' for a gradient with a stop with 'currentcolor'</title>
-  <h:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty"/>
-  <h:link rel="match" href="reference/green-100x100.svg"/>
+  <html:link rel="help" href="https://svgwg.org/svg2-draft/pservers.html#StopColorProperty"/>
+  <html:link rel="match" href="reference/green-100x100.svg"/>
+  <html:meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2500"/>
   <linearGradient id="g">
     <stop stop-color="currentcolor"/>
   </linearGradient>


### PR DESCRIPTION
#### 54e001adea8886ac6fc0cec8d8e3ec2d2a4d7b64
<pre>
Adjust fuzziness for tests in wpt /svg/pservers/reftests
<a href="https://bugs.webkit.org/show_bug.cgi?id=307299">https://bugs.webkit.org/show_bug.cgi?id=307299</a>
<a href="https://rdar.apple.com/169933712">rdar://169933712</a>

Reviewed by Tim Nguyen.

This series of tests are failing only because Safari is adding noise to
gradients against fingerprinting. Each of these reftests show otherwise
a green square and are passing. This adds fuzziness to the tests.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-currentcolor-1.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/fill-fallback-none-1.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/radialgradient-fully-overlapping.svg:
* LayoutTests/imported/w3c/web-platform-tests/svg/pservers/reftests/stop-color-currentcolor-dynamic-001.svg:

Canonical link: <a href="https://commits.webkit.org/307315@main">https://commits.webkit.org/307315@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/337dbab6c58651039c18a69fcab39c05b04d7ea6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16043 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152227 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96798 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/864d8487-187c-411c-bfa3-5fdf30ab0d89) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16131 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110392 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79454 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5b812a6-247b-429d-8c26-e69a2a4cd1a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12840 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129003 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91311 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/454d1344-1884-4a04-9eed-5cac5f13e7c3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12329 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10046 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121765 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154539 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6567 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118400 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16126 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118756 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14692 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71504 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22219 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15711 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5334 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15446 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15658 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->