### PR TITLE
Start adopting NODELETE annotation on non-inline trivial getters

### DIFF
--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -225,7 +225,7 @@ public:
     SuperBinding superBinding() const { return static_cast<SuperBinding>(m_superBinding); }
     JSParserScriptMode scriptMode() const { return static_cast<JSParserScriptMode>(m_scriptMode); }
 
-    const JSInstructionStream& instructions() const;
+    const JSInstructionStream& NODELETE instructions() const;
     const JSInstruction* instructionAt(BytecodeIndex index) const { return instructions().at(index).ptr(); }
     unsigned bytecodeOffset(const JSInstruction* instruction)
     {

--- a/Source/WebCore/Modules/async-clipboard/Clipboard.h
+++ b/Source/WebCore/Modules/async-clipboard/Clipboard.h
@@ -50,7 +50,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const final;
 
     LocalFrame* frame() const;
-    Navigator* navigator();
+    Navigator* NODELETE navigator();
 
     using RefCounted::ref;
     using RefCounted::deref;

--- a/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
+++ b/Source/WebCore/Modules/async-clipboard/ClipboardItem.h
@@ -67,8 +67,8 @@ public:
     void collectDataForWriting(Clipboard& destination, CompletionHandler<void(std::optional<PasteboardCustomData>)>&&);
 
     PresentationStyle presentationStyle() const { return m_presentationStyle; };
-    Navigator* navigator();
-    Clipboard* clipboard();
+    Navigator* NODELETE navigator();
+    Clipboard* NODELETE clipboard();
 
 private:
     ClipboardItem(Vector<KeyValuePair<String, Ref<DOMPromise>>>&&, const Options&);

--- a/Source/WebCore/Modules/contact-picker/ContactsManager.h
+++ b/Source/WebCore/Modules/contact-picker/ContactsManager.h
@@ -48,7 +48,7 @@ public:
     ~ContactsManager();
 
     LocalFrame* frame() const;
-    Navigator* navigator();
+    Navigator* NODELETE navigator();
 
     void getProperties(Ref<DeferredPromise>&&);
     void select(const Vector<ContactProperty>&, const ContactsSelectOptions&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -82,7 +82,7 @@ public:
     void setError(GeolocationError&);
     bool shouldBlockGeolocationRequests();
 
-    Navigator* navigator();
+    Navigator* NODELETE navigator();
     WEBCORE_EXPORT LocalFrame* frame() const;
 
 private:

--- a/Source/WebCore/Modules/geolocation/GeolocationController.h
+++ b/Source/WebCore/Modules/geolocation/GeolocationController.h
@@ -61,7 +61,7 @@ public:
 
     std::optional<GeolocationPositionData> lastPosition();
 
-    GeolocationClient& client();
+    GeolocationClient& NODELETE client();
 
     WEBCORE_EXPORT static ASCIILiteral supplementName();
     static GeolocationController* from(Page* page) { return downcast<GeolocationController>(Supplement<Page>::from(page, supplementName())); }

--- a/Source/WebCore/Modules/indexeddb/server/MemoryCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryCursor.h
@@ -48,7 +48,7 @@ public:
     virtual void iterate(const IDBKeyData&, const IDBKeyData& primaryKey, uint32_t count, IDBGetResult&) = 0;
 
     IDBCursorInfo info() const { return m_info; }
-    MemoryBackingStoreTransaction* transaction() const;
+    MemoryBackingStoreTransaction* NODELETE transaction() const;
 
 protected:
     MemoryCursor(const IDBCursorInfo&, MemoryBackingStoreTransaction&);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryIndex.h
@@ -83,7 +83,7 @@ public:
     MemoryIndexCursor* maybeOpenCursor(const IDBCursorInfo&, MemoryBackingStoreTransaction&);
     IndexValueStore* valueStore() { return m_records.get(); }
 
-    MemoryObjectStore* objectStore();
+    MemoryObjectStore* NODELETE objectStore();
 
     void cursorDidBecomeClean(MemoryIndexCursor&);
     void cursorDidBecomeDirty(MemoryIndexCursor&);

--- a/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h
@@ -66,7 +66,7 @@ public:
     void writeTransactionStarted(MemoryBackingStoreTransaction&);
     void writeTransactionFinished(MemoryBackingStoreTransaction&);
     void transactionAborted(MemoryBackingStoreTransaction&);
-    MemoryBackingStoreTransaction* writeTransaction();
+    MemoryBackingStoreTransaction* NODELETE writeTransaction();
 
     IDBError addIndex(MemoryBackingStoreTransaction&, const IDBIndexInfo&);
     void revertAddIndex(MemoryBackingStoreTransaction&, IDBIndexIdentifier);

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h
@@ -60,7 +60,7 @@ public:
     ~SQLiteIDBCursor();
 
     const IDBResourceIdentifier& identifier() const { return m_cursorIdentifier; }
-    SQLiteIDBTransaction* transaction() const;
+    SQLiteIDBTransaction* NODELETE transaction() const;
 
     IDBObjectStoreIdentifier objectStoreID() const { return m_objectStoreID; }
     int64_t currentRecordRowID() const;

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -84,8 +84,8 @@ public:
 
     WEBCORE_EXPORT void openDatabaseConnection(IDBConnectionToClient&, const IDBOpenRequestData&);
 
-    const IDBDatabaseInfo& info() const;
-    UniqueIDBDatabaseManager* manager();
+    const IDBDatabaseInfo& NODELETE info() const;
+    UniqueIDBDatabaseManager* NODELETE manager();
     const IDBDatabaseIdentifier& identifier() const { return m_identifier; }
 
     enum class SpaceCheckResult : uint8_t {

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h
@@ -54,7 +54,7 @@ public:
     const IDBResourceIdentifier& openRequestIdentifier() { return m_openRequestIdentifier; }
     UniqueIDBDatabase* database() { return m_database.get(); }
     CheckedPtr<UniqueIDBDatabase> checkedDatabase();
-    UniqueIDBDatabaseManager* manager();
+    UniqueIDBDatabaseManager* NODELETE manager();
     IDBConnectionToClient& connectionToClient() { return m_connectionToClient; }
     Ref<IDBConnectionToClient> protectedConnectionToClient();
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -62,7 +62,7 @@ public:
 
     WEBCORE_EXPORT ~UniqueIDBDatabaseTransaction();
 
-    UniqueIDBDatabaseConnection* databaseConnection() const;
+    UniqueIDBDatabaseConnection* NODELETE databaseConnection() const;
     UniqueIDBDatabase* database() const;
     CheckedPtr<UniqueIDBDatabase> checkedDatabase() const;
     const IDBTransactionInfo& info() const { return m_transactionInfo; }

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
@@ -101,15 +101,15 @@ public:
     const IDBError& error() const { return m_error; }
     IDBDatabaseConnectionIdentifier databaseConnectionIdentifier() const { return *m_databaseConnectionIdentifier; }
 
-    const IDBDatabaseInfo& databaseInfo() const;
-    const IDBTransactionInfo& transactionInfo() const;
+    const IDBDatabaseInfo& NODELETE databaseInfo() const;
+    const IDBTransactionInfo& NODELETE transactionInfo() const;
 
     const IDBKeyData* resultKey() const { return m_resultKey.get(); }
     uint64_t resultInteger() const { return m_resultInteger; }
 
-    WEBCORE_EXPORT const IDBGetResult& getResult() const;
-    WEBCORE_EXPORT IDBGetResult& getResultRef();
-    WEBCORE_EXPORT const IDBGetAllResult& getAllResult() const;
+    WEBCORE_EXPORT const IDBGetResult& NODELETE getResult() const;
+    WEBCORE_EXPORT IDBGetResult& NODELETE getResultRef();
+    WEBCORE_EXPORT const IDBGetAllResult& NODELETE getAllResult() const;
 
     WEBCORE_EXPORT IDBResultData();
 

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h
@@ -45,7 +45,7 @@ public:
     static Ref<RTCPeerConnectionIceEvent> create(const AtomString& type, Init&&);
     static Ref<RTCPeerConnectionIceEvent> create(CanBubble, IsCancelable, RefPtr<RTCIceCandidate>&&, String&& serverURL);
 
-    RTCIceCandidate* candidate() const;
+    RTCIceCandidate* NODELETE candidate() const;
     const String& url() const { return m_url; }
 
 private:

--- a/Source/WebCore/Modules/permissions/Permissions.h
+++ b/Source/WebCore/Modules/permissions/Permissions.h
@@ -56,7 +56,7 @@ public:
     static Ref<Permissions> create(NavigatorBase&);
     ~Permissions();
 
-    NavigatorBase* navigator();
+    NavigatorBase* NODELETE navigator();
     void query(JSC::Strong<JSC::JSObject>, DOMPromiseDeferred<IDLInterface<PermissionStatus>>&&);
     WEBCORE_EXPORT static std::optional<PermissionQuerySource> sourceFromContext(const ScriptExecutionContext&);
     WEBCORE_EXPORT static std::optional<PermissionName> toPermissionName(const String&);

--- a/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
+++ b/Source/WebCore/Modules/remoteplayback/RemotePlayback.h
@@ -79,7 +79,7 @@ public:
     void invalidate();
 
     WebCoreOpaqueRoot opaqueRootConcurrently() const;
-    Node* ownerNode() const;
+    Node* NODELETE ownerNode() const;
 
 private:
     explicit RemotePlayback(HTMLMediaElement&);

--- a/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
+++ b/Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h
@@ -62,7 +62,7 @@ public:
     const String& lang() const { return m_platformUtterance->lang(); }
     void setLang(const String& lang) { m_platformUtterance->setLang(lang); }
 
-    SpeechSynthesisVoice* voice() const;
+    SpeechSynthesisVoice* NODELETE voice() const;
     void setVoice(SpeechSynthesisVoice*);
 
     float volume() const { return m_platformUtterance->volume(); }

--- a/Source/WebCore/Modules/streams/ReadableStream.h
+++ b/Source/WebCore/Modules/streams/ReadableStream.h
@@ -111,14 +111,14 @@ public:
     InternalReadableStream* internalReadableStream() { return m_internalReadableStream.get(); }
 
     void setDefaultReader(ReadableStreamDefaultReader*);
-    ReadableStreamDefaultReader* defaultReader();
+    ReadableStreamDefaultReader* NODELETE defaultReader();
 
     bool hasByteStreamController() { return !!m_controller; }
     ReadableByteStreamController* controller() { return m_controller.get(); }
     RefPtr<ReadableByteStreamController> protectedController() { return m_controller.get(); }
 
     void setByobReader(ReadableStreamBYOBReader*);
-    ReadableStreamBYOBReader* byobReader();
+    ReadableStreamBYOBReader* NODELETE byobReader();
     void fulfillReadIntoRequest(JSDOMGlobalObject&, RefPtr<JSC::ArrayBufferView>&&, bool done);
 
     void fulfillReadRequest(JSDOMGlobalObject&, RefPtr<JSC::ArrayBufferView>&&, bool done);

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h
@@ -42,7 +42,7 @@ class ReadableStreamBYOBRequest : public RefCounted<ReadableStreamBYOBRequest> {
 public:
     static Ref<ReadableStreamBYOBRequest> create();
 
-    JSC::ArrayBufferView* view() const;
+    JSC::ArrayBufferView* NODELETE view() const;
     ExceptionOr<void> respond(JSDOMGlobalObject&, size_t);
     ExceptionOr<void> respondWithNewView(JSDOMGlobalObject&, JSC::ArrayBufferView&);
 

--- a/Source/WebCore/Modules/webaudio/AudioWorklet.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorklet.h
@@ -45,7 +45,7 @@ public:
     static Ref<AudioWorklet> create(BaseAudioContext&);
 
     AudioWorkletMessagingProxy* proxy() const;
-    BaseAudioContext* audioContext() const;
+    BaseAudioContext* NODELETE audioContext() const;
 
     void createProcessor(const String& name, TransferredMessagePort, Ref<SerializedScriptValue>&&, AudioWorkletNode&);
 

--- a/Source/WebCore/Modules/webauthn/AuthenticatorResponse.h
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorResponse.h
@@ -57,7 +57,7 @@ public:
     WEBCORE_EXPORT void setExtensions(AuthenticationExtensionsClientOutputs&&);
     WEBCORE_EXPORT AuthenticationExtensionsClientOutputs extensions() const;
     WEBCORE_EXPORT void setClientDataJSON(Ref<ArrayBuffer>&&);
-    ArrayBuffer* clientDataJSON() const;
+    ArrayBuffer* NODELETE clientDataJSON() const;
     WEBCORE_EXPORT AuthenticatorAttachment attachment() const;
 
 protected:

--- a/Source/WebCore/Modules/webdatabase/SQLStatement.h
+++ b/Source/WebCore/Modules/webdatabase/SQLStatement.h
@@ -60,8 +60,8 @@ public:
     void setDatabaseDeletedError();
     void setVersionMismatchedError();
 
-    SQLError* sqlError() const;
-    SQLResultSet* sqlResultSet() const;
+    SQLError* NODELETE sqlError() const;
+    SQLResultSet* NODELETE sqlResultSet() const;
 
 private:
     void setFailureDueToQuota();

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h
@@ -49,7 +49,7 @@ class ThreadableWebSocketChannelClientWrapper : public ThreadSafeRefCountedAndCa
 public:
     static Ref<ThreadableWebSocketChannelClientWrapper> create(ScriptExecutionContext&, WebSocketChannelClient&);
 
-    WorkerThreadableWebSocketChannel::Peer* peer() const;
+    WorkerThreadableWebSocketChannel::Peer* NODELETE peer() const;
     void didCreateWebSocketChannel(Ref<WorkerThreadableWebSocketChannel::Peer>&&);
     void clearPeer();
 

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStream.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStream.h
@@ -46,7 +46,7 @@ public:
     ~WebTransportSendStream();
 
     void getStats(ScriptExecutionContext&, Ref<DeferredPromise>&&);
-    WebTransportSendGroup* sendGroup();
+    WebTransportSendGroup* NODELETE sendGroup();
     ExceptionOr<void> setSendGroup(WebTransportSendGroup*);
     std::optional<int64_t> sendOrder() { return m_sendOrder; }
     void setSendOrder(std::optional<int64_t> order) { m_sendOrder = order; }

--- a/Source/WebCore/Modules/webxr/WebXRInputSource.h
+++ b/Source/WebCore/Modules/webxr/WebXRInputSource.h
@@ -84,7 +84,7 @@ public:
     void pollEvents(Vector<Ref<XRInputSourceEvent>>&);
 
     // For GC reachablitiy.
-    WebXRSession* session();
+    WebXRSession* NODELETE session();
 
 private:
     WebXRInputSource(Document&, WebXRSession&, double timestamp, const InputSource&);

--- a/Source/WebCore/Modules/webxr/WebXRRay.h
+++ b/Source/WebCore/Modules/webxr/WebXRRay.h
@@ -50,7 +50,7 @@ public:
     ~WebXRRay();
     const DOMPointReadOnly& origin();
     const DOMPointReadOnly& direction();
-    const Float32Array& matrix();
+    const Float32Array& NODELETE matrix();
 
 private:
     WebXRRay(Ref<DOMPointReadOnly>&& origin, Ref<DOMPointReadOnly>&& direction);

--- a/Source/WebCore/Modules/webxr/WebXRRigidTransform.h
+++ b/Source/WebCore/Modules/webxr/WebXRRigidTransform.h
@@ -50,8 +50,8 @@ public:
 
     const DOMPointReadOnly& position() const;
     const DOMPointReadOnly& orientation() const;
-    const Float32Array& matrix();
-    const WebXRRigidTransform& inverse();
+    const Float32Array& NODELETE matrix();
+    const WebXRRigidTransform& NODELETE inverse();
     const TransformationMatrix& rawTransform() const;
 
     JSValueInWrappedObject& cachedMatrix() { return m_cachedMatrix; }

--- a/Source/WebCore/Modules/webxr/WebXRSession.h
+++ b/Source/WebCore/Modules/webxr/WebXRSession.h
@@ -83,7 +83,7 @@ public:
     XREnvironmentBlendMode environmentBlendMode() const;
     XRInteractionMode interactionMode() const;
     XRVisibilityState visibilityState() const;
-    const WebXRRenderState& renderState() const;
+    const WebXRRenderState& NODELETE renderState() const;
     const WebXRInputSourceArray& inputSources() const { return m_inputSources; }
     RefPtr<PlatformXR::Device> device() const { return m_device; }
 

--- a/Source/WebCore/Modules/webxr/WebXRSystem.h
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.h
@@ -85,7 +85,7 @@ public:
     WEBCORE_EXPORT void registerSimulatedXRDeviceForTesting(PlatformXR::Device&);
     WEBCORE_EXPORT void unregisterSimulatedXRDeviceForTesting(PlatformXR::Device&);
 
-    Navigator* navigator();
+    Navigator* NODELETE navigator();
 
 protected:
     // EventTarget

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.h
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.h
@@ -55,7 +55,7 @@ public:
     bool ignoreDepthValues() const;
     std::optional<float> fixedFoveation() const;
     void setFixedFoveation(std::optional<float>);
-    WebXRRigidTransform* deltaPose() const;
+    WebXRRigidTransform* NODELETE deltaPose() const;
     void setDeltaPose(WebXRRigidTransform*);
 
     // WebXRLayer

--- a/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.h
+++ b/Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.h
@@ -48,7 +48,7 @@ public:
     virtual ~XRReferenceSpaceEvent();
 
     const WebXRReferenceSpace& referenceSpace() const;
-    WebXRRigidTransform* transform() const;
+    WebXRRigidTransform* NODELETE transform() const;
 
 private:
     XRReferenceSpaceEvent(const AtomString&, Init&&, IsTrusted);

--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -38,7 +38,6 @@ animation/StyleOriginatedAnimation.cpp
 animation/StyleOriginatedAnimationEvent.cpp
 animation/ViewTimeline.cpp
 animation/WebAnimation.cpp
-animation/WebAnimationUtilities.cpp
 bindings/js/DOMPromiseProxy.h
 bindings/js/JSCanvasRenderingContext2DCustom.cpp
 bindings/js/JSCustomElementInterface.cpp
@@ -353,7 +352,6 @@ page/cocoa/PageCocoa.mm
 [ iOS ] page/ios/ContentChangeObserver.cpp
 [ iOS ] page/ios/EventHandlerIOS.mm
 [ iOS ] page/ios/FrameIOS.mm
-[ Mac ] page/mac/EventHandlerMac.mm
 [ Mac ] page/mac/ServicesOverlayController.mm
 page/scrolling/AsyncScrollingCoordinator.cpp
 page/scrolling/ScrollAnchoringController.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -85,7 +85,6 @@ animation/StyleOriginatedAnimation.cpp
 animation/StyleOriginatedAnimationEvent.cpp
 animation/ViewTimeline.cpp
 animation/WebAnimation.cpp
-animation/WebAnimationUtilities.cpp
 bindings/js/CachedModuleScriptLoader.cpp
 bindings/js/CommonVM.cpp
 bindings/js/DOMPromiseProxy.h
@@ -441,7 +440,6 @@ inspector/agents/page/PageNetworkAgent.cpp
 inspector/agents/page/PageRuntimeAgent.cpp
 inspector/agents/worker/ServiceWorkerAgent.cpp
 inspector/agents/worker/WorkerRuntimeAgent.cpp
-layout/integration/LayoutIntegrationBoxGeometryUpdater.cpp
 layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
 layout/integration/inline/LayoutIntegrationLineLayout.cpp
 loader/ApplicationManifestLoader.cpp
@@ -633,7 +631,6 @@ rendering/MarkedText.cpp
 rendering/MotionPath.cpp
 rendering/RenderAttachment.cpp
 rendering/RenderBlock.cpp
-rendering/RenderBlockFlow.cpp
 rendering/RenderBox.cpp
 rendering/RenderBoxModelObject.cpp
 rendering/RenderButton.cpp

--- a/Source/WebCore/bindings/js/JSDOMWindowBase.h
+++ b/Source/WebCore/bindings/js/JSDOMWindowBase.h
@@ -60,7 +60,7 @@ public:
     ~JSDOMWindowBase();
     void updateDocument();
 
-    DOMWindow& wrapped() const;
+    DOMWindow& NODELETE wrapped() const;
     Document* scriptExecutionContext() const;
 
     // Called just before removing this window from the JSWindowProxy.
@@ -89,7 +89,7 @@ public:
     static void fireFrameClearedWatchpointsForWindow(LocalDOMWindow*);
 
     void setCurrentEvent(Event*);
-    Event* currentEvent() const;
+    Event* NODELETE currentEvent() const;
 
 protected:
     JSDOMWindowBase(JSC::VM&, JSC::Structure*, RefPtr<DOMWindow>&&, JSWindowProxy*);

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h
@@ -46,7 +46,7 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     WorkerGlobalScope& wrapped() const { return *m_wrapped; }
-    ScriptExecutionContext* scriptExecutionContext() const;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {

--- a/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
+++ b/Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h
@@ -47,7 +47,7 @@ public:
     DECLARE_VISIT_CHILDREN;
 
     WorkletGlobalScope& wrapped() const { return *m_wrapped; }
-    ScriptExecutionContext* scriptExecutionContext() const;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const;
 
     static JSC::Structure* createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSValue prototype)
     {

--- a/Source/WebCore/contentextensions/ContentExtension.h
+++ b/Source/WebCore/contentextensions/ContentExtension.h
@@ -47,7 +47,7 @@ public:
     const String& identifier() const { return m_identifier; }
     const URL& extensionBaseURL() const { return m_extensionBaseURL; }
     const CompiledContentExtension& compiledExtension() const { return m_compiledExtension.get(); }
-    StyleSheetContents* globalDisplayNoneStyleSheet();
+    StyleSheetContents* NODELETE globalDisplayNoneStyleSheet();
     const DFABytecodeInterpreter::Actions& topURLActions(const URL& topURL) const;
     const DFABytecodeInterpreter::Actions& frameURLActions(const URL& frameURL) const;
     const Vector<uint64_t>& universalActions() const { return m_universalActions; }

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -138,7 +138,7 @@ public:
     // We don't guarantee that the FontFace wrapper will be the same every time you ask for it.
     Ref<FontFace> wrapper(ScriptExecutionContext*);
     void setWrapper(FontFace&);
-    FontFace* existingWrapper();
+    FontFace* NODELETE existingWrapper();
 
     struct FontLoadTiming {
         Seconds blockPeriod;

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -47,7 +47,7 @@ public:
     bool isEmpty() const { return m_fontFaceName.isEmpty(); }
     const AtomString& fontFaceName() const { return m_fontFaceName; }
 
-    SVGFontFaceElement* svgFontFaceElement() const;
+    SVGFontFaceElement* NODELETE svgFontFaceElement() const;
     void setSVGFontFaceElement(SVGFontFaceElement&);
 
     String customCSSText(const CSS::SerializationContext&) const;

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -89,7 +89,7 @@ public:
 
     ScriptExecutionContext* scriptExecutionContext() const { return m_context.get(); }
 
-    FontFaceSet* fontFaceSetIfExists();
+    FontFaceSet* NODELETE fontFaceSetIfExists();
     FontFaceSet& fontFaceSet();
     CSSFontFaceSet& cssFontFaceSet() { return m_cssFontFaceSet; }
 

--- a/Source/WebCore/css/CSSStyleProperties.h
+++ b/Source/WebCore/css/CSSStyleProperties.h
@@ -146,7 +146,7 @@ private:
 
     CSSStyleSheet* parentStyleSheet() const final;
 
-    CSSRule* parentRule() const final;
+    CSSRule* NODELETE parentRule() const final;
 
     [[nodiscard]] bool willMutate() final;
     void didMutate(MutationType) final;

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -72,7 +72,7 @@ public:
     virtual ~CSSStyleSheet();
 
     CSSStyleSheet* parentStyleSheet() const final;
-    Node* ownerNode() const final;
+    Node* NODELETE ownerNode() const final;
     MediaList* media() const final;
     String href() const final;
     String title() const final { return !m_title.isEmpty() ? m_title : String(); }
@@ -94,14 +94,14 @@ public:
 
     bool wasMutated() const { return m_wasMutated; }
     bool wasConstructedByJS() const { return m_wasConstructedByJS; }
-    Document* constructorDocument() const;
+    Document* NODELETE constructorDocument() const;
 
     // For CSSRuleList.
     unsigned length() const;
     CSSRule* item(unsigned index);
 
     void clearOwnerNode() final;
-    WEBCORE_EXPORT CSSImportRule* ownerRule() const final;
+    WEBCORE_EXPORT CSSImportRule* NODELETE ownerRule() const final;
     URL baseURL() const final;
     bool isLoading() const final;
 
@@ -114,7 +114,7 @@ public:
     Document* ownerDocument() const;
     CSSStyleSheet& rootStyleSheet();
     const CSSStyleSheet& rootStyleSheet() const;
-    Style::Scope* styleScope();
+    Style::Scope* NODELETE styleScope();
 
     const MQ::MediaQueryList& mediaQueries() const { return m_mediaQueries; }
     void setMediaQueries(MQ::MediaQueryList&&);

--- a/Source/WebCore/css/MediaList.h
+++ b/Source/WebCore/css/MediaList.h
@@ -59,8 +59,8 @@ public:
     WEBCORE_EXPORT String mediaText() const;
     WEBCORE_EXPORT void setMediaText(const String&);
 
-    CSSRule* parentRule() const;
-    CSSStyleSheet* parentStyleSheet() const;
+    CSSRule* NODELETE parentRule() const;
+    CSSStyleSheet* NODELETE parentStyleSheet() const;
     void detachFromParent();
 
     const MQ::MediaQueryList& mediaQueries() const;

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -54,7 +54,7 @@ protected:
     PropertySetCSSDescriptors(MutableStyleProperties&, CSSRule&);
 
     CSSStyleSheet* parentStyleSheet() const final;
-    CSSRule* parentRule() const final;
+    CSSRule* NODELETE parentRule() const final;
     // FIXME: To implement.
     CSSRuleList* cssRules() const override { return nullptr; }
     unsigned length() const final;

--- a/Source/WebCore/css/typedom/CSSStyleImageValue.h
+++ b/Source/WebCore/css/typedom/CSSStyleImageValue.h
@@ -48,7 +48,7 @@ public:
 
     CachedImage* image() { return m_cssValue->cachedImage(); }
     bool isLoadedFromOpaqueSource() const { return m_cssValue->isLoadedFromOpaqueSource(); }
-    Document* document() const;
+    Document* NODELETE document() const;
     
     CSSStyleValueType styleValueType() const final { return CSSStyleValueType::CSSStyleImageValue; }
     

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -893,7 +893,7 @@ public:
     const URL& baseURLOverride() const { return m_baseURLOverride; }
     const URL& baseElementURL() const { return m_baseElementURL; }
     const AtomString& baseTarget() const { return m_baseTarget; }
-    HTMLBaseElement* firstBaseElement() const;
+    HTMLBaseElement* NODELETE firstBaseElement() const;
     void processBaseElement();
 
     // https://wicg.github.io/nav-speculation/speculation-rules.html#consider-speculation
@@ -1147,10 +1147,10 @@ public:
 
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
     ContentChangeObserver* contentChangeObserverIfExists() { return m_contentChangeObserver.get(); }
-    WEBCORE_EXPORT ContentChangeObserver& contentChangeObserver();
+    WEBCORE_EXPORT ContentChangeObserver& NODELETE contentChangeObserver();
 
     DOMTimerHoldingTank* domTimerHoldingTankIfExists() { return m_domTimerHoldingTank.get(); }
-    DOMTimerHoldingTank& domTimerHoldingTank();
+    DOMTimerHoldingTank& NODELETE domTimerHoldingTank();
 #endif
     void processViewport(const String& features, ViewportArguments::Type origin);
     WEBCORE_EXPORT bool isViewportDocument() const;
@@ -1479,8 +1479,8 @@ public:
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     DocumentImmersive* immersiveIfExists() { return m_immersive.get(); }
     const DocumentImmersive* immersiveIfExists() const { return m_immersive.get(); }
-    WEBCORE_EXPORT DocumentImmersive& immersive();
-    WEBCORE_EXPORT const DocumentImmersive& immersive() const;
+    WEBCORE_EXPORT DocumentImmersive& NODELETE immersive();
+    WEBCORE_EXPORT const DocumentImmersive& NODELETE immersive() const;
 #endif
 
 #if ENABLE(POINTER_LOCK)
@@ -1507,10 +1507,10 @@ public:
 #endif
 
 #if ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
-    DeviceMotionController& deviceMotionController() const;
+    DeviceMotionController& NODELETE deviceMotionController() const;
     WEBCORE_EXPORT void simulateDeviceMotionChange(double xAcceleration, double yAcceleration, double zAcceleration, double xAccelerationIncludingGravity, double yAccelerationIncludingGravity, double zAccelerationIncludingGravity, double xRotationRate, double yRotationRate, double zRotationRate);
 
-    DeviceOrientationController& deviceOrientationController() const;
+    DeviceOrientationController& NODELETE deviceOrientationController() const;
     WEBCORE_EXPORT void simulateDeviceOrientationChange(double alpha, double beta, double gamma);
 #endif
 
@@ -1777,7 +1777,7 @@ public:
 
     using StartViewTransitionCallbackOptions = Variant<RefPtr<JSViewTransitionUpdateCallback>, StartViewTransitionOptions>;
     RefPtr<ViewTransition> startViewTransition(StartViewTransitionCallbackOptions&&);
-    ViewTransition* activeViewTransition() const;
+    ViewTransition* NODELETE activeViewTransition() const;
     bool activeViewTransitionCapturedDocumentElement() const;
     void setActiveViewTransition(RefPtr<ViewTransition>&&);
 
@@ -2054,7 +2054,7 @@ public:
     WEBCORE_EXPORT FrameMemoryMonitor& frameMemoryMonitor();
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    ResourceMonitor* resourceMonitorIfExists();
+    ResourceMonitor* NODELETE resourceMonitorIfExists();
     ResourceMonitor& resourceMonitor();
     ResourceMonitor* parentResourceMonitorIfExists();
 
@@ -2116,7 +2116,7 @@ private:
     ScriptModuleLoader& ensureModuleLoader();
     WEBCORE_EXPORT DocumentFullscreen& ensureFullscreen();
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
-    WEBCORE_EXPORT DocumentImmersive& ensureImmersive();
+    WEBCORE_EXPORT DocumentImmersive& NODELETE ensureImmersive();
 #endif
     inline DocumentFontLoader& fontLoader();
     DocumentFontLoader& ensureFontLoader();

--- a/Source/WebCore/dom/DocumentImmersive.h
+++ b/Source/WebCore/dom/DocumentImmersive.h
@@ -48,7 +48,7 @@ public:
 
     // Document+Immersive.idl methods.
     static bool immersiveEnabled(Document&);
-    static Element* immersiveElement(Document&);
+    static Element* NODELETE immersiveElement(Document&);
     static void exitImmersive(Document&, Ref<DeferredPromise>&&);
 
     // Helpers.

--- a/Source/WebCore/dom/InputEvent.h
+++ b/Source/WebCore/dom/InputEvent.h
@@ -56,7 +56,7 @@ public:
 
     const String& inputType() const { return m_inputType; }
     const String& data() const { return m_data; }
-    DataTransfer* dataTransfer() const;
+    DataTransfer* NODELETE dataTransfer() const;
     const Vector<Ref<StaticRange>>& getTargetRanges() { return m_targetRanges; }
     bool isInputMethodComposing() const { return m_isInputMethodComposing; }
 

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -86,10 +86,10 @@ public:
     virtual CrossOriginOpenerPolicy crossOriginOpenerPolicy() const { return m_crossOriginOpenerPolicy; }
     void setCrossOriginOpenerPolicy(const CrossOriginOpenerPolicy& crossOriginOpenerPolicy) { m_crossOriginOpenerPolicy = crossOriginOpenerPolicy; }
 
-    const IntegrityPolicy* integrityPolicy() const;
+    const IntegrityPolicy* NODELETE integrityPolicy() const;
     void setIntegrityPolicy(std::unique_ptr<IntegrityPolicy>&&);
 
-    const IntegrityPolicy* integrityPolicyReportOnly() const;
+    const IntegrityPolicy* NODELETE integrityPolicyReportOnly() const;
     void setIntegrityPolicyReportOnly(std::unique_ptr<IntegrityPolicy>&&);
 
     virtual ReferrerPolicy referrerPolicy() const { return m_referrerPolicy; }

--- a/Source/WebCore/dom/TemplateContentDocumentFragment.h
+++ b/Source/WebCore/dom/TemplateContentDocumentFragment.h
@@ -42,7 +42,7 @@ public:
         return adoptRef(*new TemplateContentDocumentFragment(document, host));
     }
 
-    const HTMLTemplateElement* host() const;
+    const HTMLTemplateElement* NODELETE host() const;
     void clearHost();
 
 private:

--- a/Source/WebCore/editing/Editor.h
+++ b/Source/WebCore/editing/Editor.h
@@ -666,7 +666,7 @@ public:
     WritingSuggestionData* writingSuggestionData() const { return m_writingSuggestionData.get(); }
     bool isInsertingTextForWritingSuggestion() const { return m_isInsertingTextForWritingSuggestion; }
 
-    RenderInline* writingSuggestionRenderer() const;
+    RenderInline* NODELETE writingSuggestionRenderer() const;
     void setWritingSuggestionRenderer(RenderInline&);
 
     WEBCORE_EXPORT void closeTyping();

--- a/Source/WebCore/history/CachedFrame.h
+++ b/Source/WebCore/history/CachedFrame.h
@@ -84,7 +84,7 @@ public:
     void destroy();
 
     WEBCORE_EXPORT void setCachedFramePlatformData(std::unique_ptr<CachedFramePlatformData>);
-    WEBCORE_EXPORT CachedFramePlatformData* cachedFramePlatformData();
+    WEBCORE_EXPORT CachedFramePlatformData* NODELETE cachedFramePlatformData();
 
     HasInsecureContent hasInsecureContent() const;
     UsedLegacyTLS usedLegacyTLS() const;

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -110,7 +110,7 @@ public:
     std::optional<FrameIdentifier> frameID() const { return m_frameID; }
     bool isTargetItem() const { return m_isTargetItem; }
     
-    WEBCORE_EXPORT FormData* formData();
+    WEBCORE_EXPORT FormData* NODELETE formData();
     WEBCORE_EXPORT String formContentType() const;
     
     bool lastVisitWasFailure() const { return m_lastVisitWasFailure; }

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -85,7 +85,7 @@ private:
     bool receiveDroppedFiles(const DragData&) final;
 #endif
 
-    Icon* icon() const final;
+    Icon* NODELETE icon() const final;
     void createShadowSubtree() final;
     void disabledStateChanged() final;
     void attributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -52,7 +52,7 @@ public:
     static URL archiveResourceURL(const String&);
 
     WEBCORE_EXPORT URL blobURL() const;
-    WEBCORE_EXPORT File* file() const;
+    WEBCORE_EXPORT File* NODELETE file() const;
 
     enum class UpdateDisplayAttributes : bool { No, Yes };
     void setFile(RefPtr<File>&&, UpdateDisplayAttributes = UpdateDisplayAttributes::No);
@@ -95,7 +95,7 @@ public:
 
     bool isWideLayout() const { return m_implementation == Implementation::WideLayout; }
     HTMLElement* wideLayoutShadowContainer() const { return m_containerElement.get(); }
-    HTMLElement* wideLayoutImageElement() const;
+    HTMLElement* NODELETE wideLayoutImageElement() const;
     WEBCORE_EXPORT static String shadowUserAgentStyleSheetText();
 
     enum class HighlightState : uint8_t {

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -124,7 +124,7 @@ public:
     void setImageMenuEnabled(bool value) { m_isImageMenuEnabled = value; }
 #endif
 
-    HTMLPictureElement* pictureElement() const;
+    HTMLPictureElement* NODELETE pictureElement() const;
     void setPictureElement(HTMLPictureElement*);
 
 #if USE(SYSTEM_PREVIEW)
@@ -242,11 +242,11 @@ private:
     bool childShouldCreateRenderer(const Node&) const override;
 #endif
 
-    HTMLSourceElement* sourceElement() const;
+    HTMLSourceElement* NODELETE sourceElement() const;
     void setSourceElement(HTMLSourceElement*);
 
     IntersectionObserverData& ensureIntersectionObserverData() final;
-    IntersectionObserverData* intersectionObserverDataIfExists() const final;
+    IntersectionObserverData* NODELETE intersectionObserverDataIfExists() const final;
 
     const std::unique_ptr<HTMLImageLoader> m_imageLoader;
     std::unique_ptr<IntersectionObserverData> m_intersectionObserverData;

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -251,7 +251,7 @@ public:
 
 // DOM API
 // error state
-    WEBCORE_EXPORT MediaError* error() const;
+    WEBCORE_EXPORT MediaError* NODELETE error() const;
 
     const URL& currentSrc() const { return m_currentSrc; }
 
@@ -353,7 +353,7 @@ public:
 #endif
 
 #if ENABLE(ENCRYPTED_MEDIA)
-    MediaKeys* mediaKeys() const;
+    MediaKeys* NODELETE mediaKeys() const;
 
     void setMediaKeys(MediaKeys*, Ref<DeferredPromise>&&);
 #endif
@@ -548,7 +548,7 @@ public:
     bool isPlaying() const final { return m_playing; }
 
 #if ENABLE(WEB_AUDIO)
-    MediaElementAudioSourceNode* audioSourceNode();
+    MediaElementAudioSourceNode* NODELETE audioSourceNode();
     void setAudioSourceNode(MediaElementAudioSourceNode*);
 
     AudioSourceProvider* audioSourceProvider();
@@ -560,7 +560,7 @@ public:
     const String& mediaGroup() const;
     void setMediaGroup(const String&);
 
-    MediaController* controller() const;
+    MediaController* NODELETE controller() const;
     void setController(RefPtr<MediaController>&&);
 
     MediaController* controllerForBindings() const { return controller(); }
@@ -616,7 +616,7 @@ public:
     void isVisibleInViewportChanged();
     void updateRateChangeRestrictions();
 
-    WEBCORE_EXPORT const MediaResourceLoader* lastMediaResourceLoaderForTesting() const;
+    WEBCORE_EXPORT const MediaResourceLoader* NODELETE lastMediaResourceLoaderForTesting() const;
 
 #if ENABLE(MEDIA_STREAM)
     void mediaStreamCaptureStarted();

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -46,7 +46,7 @@ public:
 
     DocumentFragment& fragmentForInsertion() const;
     DocumentFragment& content() const;
-    DocumentFragment* contentIfAvailable() const;
+    DocumentFragment* NODELETE contentIfAvailable() const;
 
     const AtomString& shadowRootMode() const;
 

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -125,7 +125,7 @@ public:
 
     ~ImageBitmap();
 
-    ImageBuffer* buffer() const;
+    ImageBuffer* NODELETE buffer() const;
 
     RefPtr<ImageBuffer> takeImageBuffer();
 

--- a/Source/WebCore/html/ImageDocument.h
+++ b/Source/WebCore/html/ImageDocument.h
@@ -45,7 +45,7 @@ public:
         return document;
     }
 
-    WEBCORE_EXPORT HTMLImageElement* imageElement() const;
+    WEBCORE_EXPORT HTMLImageElement* NODELETE imageElement() const;
 
     void updateDuringParsing();
     void finishedParsing();

--- a/Source/WebCore/html/SearchInputType.h
+++ b/Source/WebCore/html/SearchInputType.h
@@ -92,8 +92,8 @@ private:
     bool needsContainer() const final;
     void createShadowSubtree() final;
     void removeShadowSubtree() final;
-    HTMLElement* resultsButtonElement() const final;
-    HTMLElement* cancelButtonElement() const final;
+    HTMLElement* NODELETE resultsButtonElement() const final;
+    HTMLElement* NODELETE cancelButtonElement() const final;
     ShouldCallBaseEventHandler handleKeydownEvent(KeyboardEvent&) final;
     void didSetValueByUserEdit() final;
     bool sizeShouldIncludeDecoration(int defaultSize, int& preferredSize) const final;

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -61,12 +61,12 @@ protected:
     void handleKeydownEventForSpinButton(KeyboardEvent&);
     void handleClickEvent(MouseEvent&) final;
 
-    HTMLElement* containerElement() const final;
-    HTMLElement* innerBlockElement() const final;
+    HTMLElement* NODELETE containerElement() const final;
+    HTMLElement* NODELETE innerBlockElement() const final;
     RefPtr<TextControlInnerTextElement> innerTextElement() const final;
-    HTMLElement* innerSpinButtonElement() const final;
-    HTMLElement* autoFillButtonElement() const final;
-    HTMLElement* dataListButtonElement() const final;
+    HTMLElement* NODELETE innerSpinButtonElement() const final;
+    HTMLElement* NODELETE autoFillButtonElement() const final;
+    HTMLElement* NODELETE dataListButtonElement() const final;
 
     virtual bool needsContainer() const;
     void createShadowSubtree() override;
@@ -94,7 +94,7 @@ private:
     RenderPtr<RenderElement> createInputRenderer(RenderStyle&&) override;
     bool shouldUseInputMethod() const override;
     bool shouldRespectListAttribute() override;
-    HTMLElement* placeholderElement() const final;
+    HTMLElement* NODELETE placeholderElement() const final;
     void updatePlaceholderText() final;
     bool appendFormData(DOMFormData&) const final;
     void subtreeHasChanged() final;

--- a/Source/WebCore/html/UserActivation.h
+++ b/Source/WebCore/html/UserActivation.h
@@ -40,7 +40,7 @@ public:
     static Ref<UserActivation> create(Navigator&);
     ~UserActivation();
 
-    Navigator* navigator();
+    Navigator* NODELETE navigator();
 
     bool hasBeenActive() const;
     bool isActive() const;

--- a/Source/WebCore/html/parser/HTMLElementStack.h
+++ b/Source/WebCore/html/parser/HTMLElementStack.h
@@ -137,10 +137,10 @@ public:
     bool secondElementIsHTMLBodyElement() const;
     bool hasTemplateInHTMLScope() const;
     Element& htmlElement() const;
-    Element& headElement() const;
-    Element& bodyElement() const;
+    Element& NODELETE headElement() const;
+    Element& NODELETE bodyElement() const;
 
-    ContainerNode& rootNode() const;
+    ContainerNode& NODELETE rootNode() const;
 
 #if ENABLE(TREE_DEBUGGING)
     void show();

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -52,7 +52,7 @@ class TextTrackCueBox : public HTMLElement {
 public:
     static Ref<TextTrackCueBox> create(Document&, TextTrackCue&);
 
-    TextTrackCue* getCue() const;
+    TextTrackCue* NODELETE getCue() const;
     virtual void applyCSSProperties() { }
 
 protected:
@@ -78,7 +78,7 @@ public:
 
     void didMoveToNewDocument(Document&);
 
-    TextTrack* track() const;
+    TextTrack* NODELETE track() const;
     RefPtr<TextTrack> protectedTrack() const;
     void setTrack(TextTrack*);
 

--- a/Source/WebCore/html/track/TrackBase.h
+++ b/Source/WebCore/html/track/TrackBase.h
@@ -71,13 +71,13 @@ public:
     virtual int uniqueId() const { return m_uniqueId; }
 
 #if ENABLE(MEDIA_SOURCE)
-    SourceBuffer* sourceBuffer() const;
+    SourceBuffer* NODELETE sourceBuffer() const;
     void setSourceBuffer(SourceBuffer*);
 #endif
 
     void setTrackList(TrackListBase&);
     void clearTrackList();
-    TrackListBase* trackList() const;
+    TrackListBase* NODELETE trackList() const;
     WebCoreOpaqueRoot opaqueRoot();
 
     virtual bool enabled() const = 0;

--- a/Source/WebCore/inspector/InspectorOverlay.h
+++ b/Source/WebCore/inspector/InspectorOverlay.h
@@ -205,7 +205,7 @@ public:
 
     void setShowRulers(bool);
 
-    Node* highlightedNode() const;
+    Node* NODELETE highlightedNode() const;
     unsigned gridOverlayCount() const { return m_activeGridOverlays.size(); }
     unsigned flexOverlayCount() const { return m_activeFlexOverlays.size(); }
 

--- a/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.h
+++ b/Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.h
@@ -45,7 +45,7 @@ private:
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     bool setEmulatedConditionsInternal(std::optional<int>&& bytesPerSecondLimit);
 #endif
-    ScriptExecutionContext* scriptExecutionContext(Inspector::Protocol::ErrorString&, const Inspector::Protocol::Network::FrameId&);
+    ScriptExecutionContext* NODELETE scriptExecutionContext(Inspector::Protocol::ErrorString&, const Inspector::Protocol::Network::FrameId&);
     void addConsoleMessage(std::unique_ptr<Inspector::ConsoleMessage>&&);
     bool shouldForceBufferingNetworkResourceData() const { return true; }
 

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h
@@ -72,7 +72,7 @@ private:
 
     Layout::LayoutState& layoutState() { return *m_layoutState; }
     const Layout::LayoutState& layoutState() const { return *m_layoutState; }
-    const Layout::ElementBox& rootLayoutBox() const;
+    const Layout::ElementBox& NODELETE rootLayoutBox() const;
     const RenderBlock& rootRenderer() const;
     inline WritingMode writingMode() const;
 

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -111,7 +111,7 @@ class CachedRawResource;
         SecurityOrigin& securityOrigin() const;
         const ContentSecurityPolicy& contentSecurityPolicy() const;
         CheckedRef<const ContentSecurityPolicy> checkedContentSecurityPolicy() const;
-        const CrossOriginEmbedderPolicy& crossOriginEmbedderPolicy() const;
+        const CrossOriginEmbedderPolicy& NODELETE crossOriginEmbedderPolicy() const;
 
         Document& document() { return *m_document; }
 

--- a/Source/WebCore/loader/cache/CachedResourceHandle.h
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.h
@@ -35,7 +35,7 @@ class CachedResourceHandleBase {
 public:
     WEBCORE_EXPORT ~CachedResourceHandleBase();
 
-    WEBCORE_EXPORT CachedResource* get() const;
+    WEBCORE_EXPORT CachedResource* NODELETE get() const;
     
     bool operator!() const { return !m_resource; }
     operator bool() const { return !!m_resource; }

--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -60,7 +60,7 @@ class AutoscrollController final : public CanMakeCheckedPtr<AutoscrollController
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(AutoscrollController);
 public:
     AutoscrollController();
-    RenderBox* autoscrollRenderer() const;
+    RenderBox* NODELETE autoscrollRenderer() const;
     bool autoscrollInProgress() const;
     bool panScrollInProgress() const;
     void startAutoscrollForSelection(RenderObject*);

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -46,7 +46,7 @@ public:
     WEBCORE_EXPORT AtomString uniqueName() const;
     WEBCORE_EXPORT void setSpecifiedName(const AtomString&);
     WEBCORE_EXPORT void clearName();
-    WEBCORE_EXPORT Frame* parent() const;
+    WEBCORE_EXPORT Frame* NODELETE parent() const;
 
     Frame* nextSibling() const { return m_nextSibling.get(); }
     Frame* previousSibling() const { return m_previousSibling.get(); }

--- a/Source/WebCore/page/LocalDOMWindowProperty.h
+++ b/Source/WebCore/page/LocalDOMWindowProperty.h
@@ -36,7 +36,7 @@ class LocalDOMWindowProperty {
 public:
     WEBCORE_EXPORT LocalFrame* frame() const;
     RefPtr<LocalFrame> protectedFrame() const;
-    LocalDOMWindow* window() const;
+    LocalDOMWindow* NODELETE window() const;
     RefPtr<LocalDOMWindow> protectedWindow() const { return window(); }
 
 protected:

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -114,7 +114,7 @@ public:
     std::optional<TextBoxTrim> textBoxTrim() const { return m_textBoxTrim; }
     void setTextBoxTrim(std::optional<TextBoxTrim> textBoxTrim) { m_textBoxTrim = textBoxTrim; }
 
-    RenderElement* subtreeLayoutRoot() const;
+    RenderElement* NODELETE subtreeLayoutRoot() const;
     void clearSubtreeLayoutRoot() { m_subtreeLayoutRoot.clear(); }
     void convertSubtreeLayoutToFullLayout();
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1009,7 +1009,7 @@ public:
     WEBCORE_EXPORT Ref<UserContentProvider> protectedUserContentProviderForFrame();
     WEBCORE_EXPORT void setUserContentProviderForWebKitLegacy(Ref<UserContentProvider>&&);
 
-    ScreenOrientationManager* screenOrientationManager() const;
+    ScreenOrientationManager* NODELETE screenOrientationManager() const;
 
     VisitedLinkStore& visitedLinkStore();
     Ref<VisitedLinkStore> protectedVisitedLinkStore();
@@ -1091,7 +1091,7 @@ public:
     void setAllowsPlaybackControlsForAutoplayingAudio(bool allowsPlaybackControlsForAutoplayingAudio) { m_allowsPlaybackControlsForAutoplayingAudio = allowsPlaybackControlsForAutoplayingAudio; }
 
     IDBClient::IDBConnectionToServer& idbConnection();
-    WEBCORE_EXPORT IDBClient::IDBConnectionToServer* optionalIDBConnection();
+    WEBCORE_EXPORT IDBClient::IDBConnectionToServer* NODELETE optionalIDBConnection();
     WEBCORE_EXPORT void clearIDBConnection();
 
     void setShowAllPlugins(bool showAll) { m_showAllPlugins = showAll; }
@@ -1224,7 +1224,7 @@ public:
     WEBCORE_EXPORT void clearAccessibilityIsolatedTree();
 #endif
 #if USE(ATSPI)
-    AccessibilityRootAtspi* accessibilityRootObject() const;
+    AccessibilityRootAtspi* NODELETE accessibilityRootObject() const;
     void setAccessibilityRootObject(AccessibilityRootAtspi*);
 #endif
 
@@ -1364,7 +1364,7 @@ public:
     WEBCORE_EXPORT RefPtr<HTMLMediaElement> bestMediaElementForRemoteControls(PlatformMediaSessionPlaybackControlsPurpose, Document*);
 
     WEBCORE_EXPORT RefPtr<MediaSessionManagerInterface> mediaSessionManager();
-    WEBCORE_EXPORT MediaSessionManagerInterface* mediaSessionManagerIfExists() const;
+    WEBCORE_EXPORT MediaSessionManagerInterface* NODELETE mediaSessionManagerIfExists() const;
     WEBCORE_EXPORT static RefPtr<MediaSessionManagerInterface> mediaSessionManagerForPageIdentifier(PageIdentifier);
 
 #if ENABLE(MODEL_ELEMENT)
@@ -1457,7 +1457,7 @@ private:
 
     RenderingUpdateScheduler& renderingUpdateScheduler();
     CheckedRef<RenderingUpdateScheduler> checkedRenderingUpdateScheduler();
-    RenderingUpdateScheduler* existingRenderingUpdateScheduler();
+    RenderingUpdateScheduler* NODELETE existingRenderingUpdateScheduler();
 
     WheelEventTestMonitor& ensureWheelEventTestMonitor();
     Ref<WheelEventTestMonitor> ensureProtectedWheelEventTestMonitor();

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -84,7 +84,7 @@ public:
     PageOverlayID pageOverlayID() const { return m_pageOverlayID; }
 
     void setPage(Page*);
-    WEBCORE_EXPORT Page* page() const;
+    WEBCORE_EXPORT Page* NODELETE page() const;
     WEBCORE_EXPORT void setNeedsDisplay(const IntRect& dirtyRect);
     WEBCORE_EXPORT void setNeedsDisplay();
 

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -84,10 +84,10 @@ public:
 private:
     void createRootLayersIfNeeded();
 
-    WEBCORE_EXPORT GraphicsLayer* documentOverlayRootLayer() const;
+    WEBCORE_EXPORT GraphicsLayer* NODELETE documentOverlayRootLayer() const;
     RefPtr<GraphicsLayer> protectedDocumentOverlayRootLayer() const;
 
-    WEBCORE_EXPORT GraphicsLayer* viewOverlayRootLayer() const;
+    WEBCORE_EXPORT GraphicsLayer* NODELETE viewOverlayRootLayer() const;
     RefPtr<GraphicsLayer> protectedViewOverlayRootLayer() const;
 
     void installedPageOverlaysChanged();

--- a/Source/WebCore/page/PointerLockController.h
+++ b/Source/WebCore/page/PointerLockController.h
@@ -71,7 +71,7 @@ public:
     void documentDetached(Document&);
     bool isLocked() const;
     WEBCORE_EXPORT bool lockPending() const;
-    WEBCORE_EXPORT Element* element() const;
+    WEBCORE_EXPORT Element* NODELETE element() const;
 
     WEBCORE_EXPORT void didAcquirePointerLock();
     WEBCORE_EXPORT void didNotAcquirePointerLock();

--- a/Source/WebCore/page/UndoItem.h
+++ b/Source/WebCore/page/UndoItem.h
@@ -54,10 +54,10 @@ public:
     bool isValid() const { return !!m_undoManager; }
     void invalidate();
 
-    Document* document() const;
+    Document* NODELETE document() const;
     RefPtr<Document> protectedDocument() const;
 
-    UndoManager* undoManager() const;
+    UndoManager* NODELETE undoManager() const;
     void setUndoManager(UndoManager*);
 
     const String& label() const { return m_label; }

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -245,7 +245,7 @@ protected:
 
     virtual void willCommitTree(FrameIdentifier) { }
 
-    WEBCORE_EXPORT Page* page() const;
+    WEBCORE_EXPORT Page* NODELETE page() const;
     WEBCORE_EXPORT RefPtr<Page> protectedPage() const;
 
 private:

--- a/Source/WebCore/platform/ScreenOrientationManager.h
+++ b/Source/WebCore/platform/ScreenOrientationManager.h
@@ -54,7 +54,7 @@ public:
     virtual void removeObserver(ScreenOrientationManagerObserver&) = 0;
 
     void setLockPromise(ScreenOrientation&, Ref<DeferredPromise>&&);
-    ScreenOrientation* lockRequester() const;
+    ScreenOrientation* NODELETE lockRequester() const;
     RefPtr<DeferredPromise> takeLockPromise();
 
 protected:

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -142,7 +142,7 @@ public:
 
     WEBCORE_EXPORT void removeFromParent();
     WEBCORE_EXPORT virtual void setParent(ScrollView* view);
-    WEBCORE_EXPORT ScrollView* parent() const;
+    WEBCORE_EXPORT ScrollView* NODELETE parent() const;
     WEBCORE_EXPORT RefPtr<ScrollView> protectedParent() const;
     FrameView* root() const;
 

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h
@@ -46,7 +46,7 @@ public:
 
     WEBCORE_EXPORT std::optional<WTF::UUID> identifier() const;
 
-    MediaDeviceRoute* route() const;
+    MediaDeviceRoute* NODELETE route() const;
 
 private:
     MediaPlaybackTargetWirelessPlayback(RefPtr<MediaDeviceRoute>&&, bool hasActiveRoute);

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -747,8 +747,8 @@ public:
     void remoteEngineFailedToLoad();
     SecurityOriginData documentSecurityOrigin() const;
 
-    const MediaPlayerPrivateInterface* playerPrivate() const;
-    MediaPlayerPrivateInterface* playerPrivate();
+    const MediaPlayerPrivateInterface* NODELETE playerPrivate() const;
+    MediaPlayerPrivateInterface* NODELETE playerPrivate();
     RefPtr<MediaPlayerPrivateInterface> protectedPlayerPrivate();
 
     DynamicRangeMode preferredDynamicRangeMode() const { return m_preferredDynamicRangeMode; }
@@ -814,7 +814,7 @@ public:
 #endif
 
     void setMessageClientForTesting(WeakPtr<MessageClientForTesting>);
-    MessageClientForTesting* messageClientForTesting() const;
+    MessageClientForTesting* NODELETE messageClientForTesting() const;
 
     void elementIdChanged(const String&) const;
 

--- a/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
+++ b/Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h
@@ -105,7 +105,7 @@ public:
     
     RenderingMode renderingMode() const final;
 
-    cairo_t* cr() const;
+    cairo_t* NODELETE cr() const;
     Vector<float>& layers();
     void pushImageMask(cairo_surface_t*, const FloatRect&);
 

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h
@@ -43,7 +43,7 @@ public:
 
     static std::unique_ptr<ImageBufferCGBitmapBackend> create(const Parameters&, const ImageBufferCreationContext&);
     bool canMapBackingStore() const final;
-    GraphicsContext& context() final;
+    GraphicsContext& NODELETE context() final;
 
 private:
     ImageBufferCGBitmapBackend(const Parameters&, std::span<uint8_t> data, RetainPtr<CGDataProviderRef>&&, std::unique_ptr<GraphicsContextCG>&&);

--- a/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h
+++ b/Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h
@@ -49,7 +49,7 @@ private:
 
     bool canMapBackingStore() const { return false; }
     unsigned bytesPerRow() const final { return 0; }
-    GraphicsContext& context() final;
+    GraphicsContext& NODELETE context() final;
 
     RefPtr<NativeImage> copyNativeImage() final { return createNativeImageReference(); }
     RefPtr<NativeImage> createNativeImageReference() final { return nullptr; }

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h
@@ -194,7 +194,7 @@ private:
     void collectDamageSelfChildrenReplicaFilterAndMask(TextureMapperPaintOptions&, Damage&);
     void collectDamageSelfChildrenFilterAndMask(TextureMapperPaintOptions&, Damage&);
     void collectDamageFromLayerAboutToBeRemoved(TextureMapperLayer&);
-    ALWAYS_INLINE Damage& ensureDamageInLayerCoordinateSpace();
+    ALWAYS_INLINE Damage& NODELETE ensureDamageInLayerCoordinateSpace();
     inline void damageWholeLayer();
     void damageWholeLayerIncludingItsRectFromPreviousFrame();
 #endif

--- a/Source/WebCore/platform/mac/DataDetectorHighlight.h
+++ b/Source/WebCore/platform/mac/DataDetectorHighlight.h
@@ -74,7 +74,7 @@ public:
 
     DDHighlightRef highlight() const { return m_highlight.get(); }
     RetainPtr<DDHighlightRef> protectedHighlight() const { return m_highlight; }
-    const SimpleRange& range() const;
+    const SimpleRange& NODELETE range() const;
     GraphicsLayer& layer() const { return m_graphicsLayer.get(); }
 
     enum class Type : uint8_t {

--- a/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
+++ b/Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h
@@ -81,7 +81,7 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper.
-    const Logger& logger() const final;
+    const Logger& NODELETE logger() const final;
     ASCIILiteral logClassName() const final { return "IncomingAudioMediaStreamTrackRendererUnit"_s; }
     WTFLogChannel& logChannel() const final;
     uint64_t logIdentifier() const final;

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.h
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.h
@@ -70,7 +70,7 @@ protected:
     void incrementReadItemCount() { ++m_readItemCount; }
     uint64_t lengthOfItemBeingRead() const { return m_itemLengthList[m_readItemCount]; }
     WEBCORE_EXPORT void clearAsyncStream();
-    WEBCORE_EXPORT BlobData* blobData() const;
+    WEBCORE_EXPORT BlobData* NODELETE blobData() const;
     FileStream* syncStream() const;
     AsyncFileStream* asyncStream() const;
     Vector<uint8_t>& buffer() { return m_buffer; }

--- a/Source/WebCore/platform/text/LocaleICU.h
+++ b/Source/WebCore/platform/text/LocaleICU.h
@@ -55,7 +55,7 @@ public:
     String shortTimeFormat() override;
     String dateTimeFormatWithSeconds() override;
     String dateTimeFormatWithoutSeconds() override;
-    const Vector<String>& monthLabels() override;
+    const Vector<String>& NODELETE monthLabels() override;
     const Vector<String>& shortMonthLabels() override;
     const Vector<String>& standAloneMonthLabels() override;
     const Vector<String>& shortStandAloneMonthLabels() override;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -94,7 +94,7 @@ public:
     void setGrowthLimitCap(std::optional<LayoutUnit>);
     std::optional<LayoutUnit> growthLimitCap() const { return m_growthLimitCap; }
 
-    const Style::GridTrackSize& cachedTrackSize() const;
+    const Style::GridTrackSize& NODELETE cachedTrackSize() const;
     void setCachedTrackSize(const Style::GridTrackSize&);
 
 private:

--- a/Source/WebCore/rendering/RenderHighlight.h
+++ b/Source/WebCore/rendering/RenderHighlight.h
@@ -68,7 +68,7 @@ private:
 class RenderRangeIterator {
 public:
     RenderRangeIterator(RenderObject* start);
-    RenderObject* current() const;
+    RenderObject* NODELETE current() const;
     RenderObject* next();
 
 private:

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -180,7 +180,7 @@ public:
 
     WEBCORE_EXPORT ~RenderLayer();
 
-    WEBCORE_EXPORT RenderLayerScrollableArea* scrollableArea() const;
+    WEBCORE_EXPORT RenderLayerScrollableArea* NODELETE scrollableArea() const;
     WEBCORE_EXPORT CheckedPtr<RenderLayerScrollableArea> checkedScrollableArea() const;
     WEBCORE_EXPORT RenderLayerScrollableArea* ensureLayerScrollableArea();
 

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -70,7 +70,7 @@ public:
     bool isImage() const final;
 
     LayoutUnit lineLogicalOffsetForListItem() const { return m_lineLogicalOffsetForListItem; }
-    const RenderListItem* listItem() const;
+    const RenderListItem* NODELETE listItem() const;
 
     std::pair<float, float> layoutBounds() const { return m_layoutBounds; }
 

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -104,9 +104,9 @@ public:
         m_columnPos[index] = position;
     }
 
-    RenderTableSection* header() const;
-    RenderTableSection* footer() const;
-    RenderTableSection* firstBody() const;
+    RenderTableSection* NODELETE header() const;
+    RenderTableSection* NODELETE footer() const;
+    RenderTableSection* NODELETE firstBody() const;
 
     // This function returns 0 if the table has no section.
     RenderTableSection* topSection() const;

--- a/Source/WebCore/style/AnchorPositionEvaluator.h
+++ b/Source/WebCore/style/AnchorPositionEvaluator.h
@@ -69,7 +69,7 @@ struct AnchorScrollSnapshot {
 class AnchorScrollAdjuster {
 public:
     AnchorScrollAdjuster(RenderBox& anchored, const RenderBoxModelObject& defaultAnchor);
-    RenderBox* anchored() const;
+    RenderBox* NODELETE anchored() const;
 
     inline bool isEmpty() const;
     bool mayNeedAdjustment() const { return m_needsXAdjustment | m_needsYAdjustment; }

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -112,8 +112,8 @@ public:
     std::unique_ptr<RenderStyle> styleForPage(int pageIndex);
     std::unique_ptr<RenderStyle> defaultStyleForElement(const Element*);
 
-    Document& document();
-    const Document& document() const;
+    Document& NODELETE document();
+    const Document& NODELETE document() const;
     const Settings& settings() const;
 
     ScopeType scopeType() const { return m_scopeType; }
@@ -154,7 +154,7 @@ public:
     void addKeyframeStyle(Ref<StyleRuleKeyframes>&&);
     Vector<Ref<StyleRuleKeyframe>> keyframeRulesForName(const AtomString&, const TimingFunction*) const;
 
-    const CustomFunctionRegistry* customFunctionRegistry() const;
+    const CustomFunctionRegistry* NODELETE customFunctionRegistry() const;
     CustomFunctionRegistry& ensureCustomFunctionRegistry();
 
     RefPtr<StyleRuleViewTransition> viewTransitionRule() const;

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -230,7 +230,7 @@ private:
     void pendingUpdateTimerFired();
     void clearPendingUpdate();
 
-    TreeScope& treeScope();
+    TreeScope& NODELETE treeScope();
 
     using MediaQueryViewportState = std::tuple<IntSize, float, bool>;
     static MediaQueryViewportState mediaQueryViewportStateForDocument(const Document&);

--- a/Source/WebCore/style/StyleScopeRuleSets.h
+++ b/Source/WebCore/style/StyleScopeRuleSets.h
@@ -66,7 +66,7 @@ public:
 
     bool isAuthorStyleDefined() const { return m_isAuthorStyleDefined; }
     RuleSet* userAgentMediaQueryStyle() const;
-    RuleSet* dynamicViewTransitionsStyle() const;
+    RuleSet* NODELETE dynamicViewTransitionsStyle() const;
     RuleSet& authorStyle() const { return *m_authorStyle; }
     RuleSet* userStyle() const;
     RuleSet* styleForDeclarationOrigin(DeclarationOrigin);

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyBase.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyBase.h
@@ -47,7 +47,7 @@ public:
     // Manage the relationship with the owner.
     bool isAttached() const { return !!m_contextElement; }
     void detach() { m_contextElement = nullptr; }
-    SVGElement* contextElement() const;
+    SVGElement* NODELETE contextElement() const;
 
     virtual String baseValAsString() const { return emptyString(); }
     virtual String animValAsString() const { return emptyString(); }

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -873,7 +873,7 @@ public:
     void hideCaptionDisplaySettingsPreviewForMediaElement(HTMLMediaElement&);
 
     void setMockCaptionDisplaySettingsClientCallback(RefPtr<MockCaptionDisplaySettingsClientCallback>&&);
-    MockCaptionDisplaySettingsClientCallback* mockCaptionDisplaySettingsClientCallback() const;
+    MockCaptionDisplaySettingsClientCallback* NODELETE mockCaptionDisplaySettingsClientCallback() const;
     RefPtr<MediaControlsHost> controlsHostForMediaElement(HTMLMediaElement&);
 #endif
 
@@ -1702,7 +1702,7 @@ public:
     void testAsyncIterator(JSDOMGlobalObject&, JSC::JSValue, IteratorResultPromise&&);
 
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
-    MockMediaDeviceRouteController& mockMediaDeviceRouteController();
+    MockMediaDeviceRouteController& NODELETE mockMediaDeviceRouteController();
 #endif
 
 private:

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -107,7 +107,7 @@ public:
     WorkerStorageConnection& storageConnection();
     static void postFileSystemStorageTask(Function<void()>&&);
     WorkerFileSystemStorageConnection& getFileSystemStorageConnection(Ref<FileSystemStorageConnection>&&);
-    WEBCORE_EXPORT WorkerFileSystemStorageConnection* fileSystemStorageConnection();
+    WEBCORE_EXPORT WorkerFileSystemStorageConnection* NODELETE fileSystemStorageConnection();
     CacheStorageConnection& cacheStorageConnection();
     MessagePortChannelProvider& messagePortChannelProvider();
 
@@ -144,7 +144,7 @@ public:
     SecurityOrigin& topOrigin() const final { return m_topOrigin.get(); }
 
     Crypto& crypto();
-    Performance& performance() const;
+    Performance& NODELETE performance() const;
     ReportingScope& reportingScope() const { return m_reportingScope.get(); }
 
     void prepareForDestruction() override;

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.h
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.h
@@ -69,9 +69,9 @@ public:
 
     ServiceWorkerRegistrationIdentifier identifier() const { return m_registrationData.identifier; }
 
-    ServiceWorker* installing();
-    ServiceWorker* waiting();
-    ServiceWorker* active();
+    ServiceWorker* NODELETE installing();
+    ServiceWorker* NODELETE waiting();
+    ServiceWorker* NODELETE active();
 
     bool isActive() const final { return !!m_activeWorker; }
 

--- a/Source/WebCore/workers/service/server/SWServerToContextConnection.h
+++ b/Source/WebCore/workers/service/server/SWServerToContextConnection.h
@@ -59,7 +59,7 @@ class SWServerToContextConnection: public RefCountedAndCanMakeWeakPtr<SWServerTo
 public:
     WEBCORE_EXPORT virtual ~SWServerToContextConnection();
 
-    WEBCORE_EXPORT SWServer* server() const;
+    WEBCORE_EXPORT SWServer* NODELETE server() const;
 
     // This flag gets set when the service worker process is no longer clean (because it has loaded several eTLD+1s).
     bool shouldTerminateWhenPossible() const { return m_shouldTerminateWhenPossible; }

--- a/Source/WebCore/workers/service/server/SWServerWorker.h
+++ b/Source/WebCore/workers/service/server/SWServerWorker.h
@@ -134,7 +134,7 @@ public:
     WEBCORE_EXPORT std::optional<RouterSource> getRouterSource(const FetchOptions&, const ResourceRequest&) const;
     WEBCORE_EXPORT RouterSource defaultRouterSource() const;
 
-    WEBCORE_EXPORT SWServerRegistration* registration() const;
+    WEBCORE_EXPORT SWServerRegistration* NODELETE registration() const;
 
     void setHasTimedOutAnyFetchTasks() { m_hasTimedOutAnyFetchTasks = true; }
     bool hasTimedOutAnyFetchTasks() const { return m_hasTimedOutAnyFetchTasks; }

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -328,7 +328,7 @@ private:
 #endif
 
 #if PLATFORM(IOS_FAMILY)
-    RemoteMediaSessionHelperProxy& mediaSessionHelperProxy();
+    RemoteMediaSessionHelperProxy& NODELETE mediaSessionHelperProxy();
     void ensureMediaSessionHelper();
 #endif
 

--- a/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
+++ b/Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h
@@ -92,7 +92,7 @@ public:
 
     ModelProcessModelPlayerManagerProxy& modelProcessModelPlayerManagerProxy() { return m_modelProcessModelPlayerManagerProxy.get(); }
 
-    Logger& logger();
+    Logger& NODELETE logger();
 
     const WebCore::ProcessIdentity& webProcessIdentity() const { return m_webProcessIdentity; }
 

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h
@@ -49,7 +49,7 @@ class DynamicContentScalingBifurcatedImageBuffer : public WebCore::ImageBuffer {
 public:
     DynamicContentScalingBifurcatedImageBuffer(WebCore::ImageBufferParameters, const WebCore::ImageBufferBackend::Info&, const WebCore::ImageBufferCreationContext&, std::unique_ptr<WebCore::ImageBufferBackend>&& = nullptr, WebCore::RenderingResourceIdentifier = WebCore::RenderingResourceIdentifier::generate());
 
-    WebCore::GraphicsContext& context() const final;
+    WebCore::GraphicsContext& NODELETE context() const final;
 
 protected:
     std::optional<WebCore::DynamicContentScalingDisplayList> dynamicContentScalingDisplayList() final;

--- a/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h
@@ -45,7 +45,7 @@ public:
     DynamicContentScalingImageBufferBackend(const Parameters&, const WebCore::ImageBufferCreationContext&, WebCore::RenderingMode);
     ~DynamicContentScalingImageBufferBackend();
 
-    WebCore::GraphicsContext& context() final;
+    WebCore::GraphicsContext& NODELETE context() final;
     std::optional<ImageBufferBackendHandle> createBackendHandle(WebCore::SharedMemory::Protection = WebCore::SharedMemory::Protection::ReadWrite) const final;
 
     void releaseGraphicsContext() final;

--- a/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/gtk/PageClientImpl.h
@@ -124,7 +124,7 @@ private:
 
     // Auxiliary Client Creation
 #if ENABLE(FULLSCREEN_API)
-    WebFullScreenManagerProxyClient& fullScreenManagerProxyClient() final;
+    WebFullScreenManagerProxyClient& NODELETE fullScreenManagerProxyClient() final;
     void setFullScreenClientForTesting(std::unique_ptr<WebFullScreenManagerProxyClient>&&) final;
 #endif
 

--- a/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
+++ b/Source/WebKit/UIProcess/API/wpe/PageClientImpl.h
@@ -166,7 +166,7 @@ private:
     void didRestoreScrollPosition() override;
 
 #if ENABLE(FULLSCREEN_API)
-    WebFullScreenManagerProxyClient& fullScreenManagerProxyClient() final;
+    WebFullScreenManagerProxyClient& NODELETE fullScreenManagerProxyClient() final;
     void setFullScreenClientForTesting(std::unique_ptr<WebFullScreenManagerProxyClient>&&) final;
 
     void closeFullScreenManager() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h
@@ -69,7 +69,7 @@ public:
     RetainPtr<CALayer> protectedLayerForID(std::optional<WebCore::PlatformLayerIdentifier>) const;
     CALayer *rootLayer() const;
 
-    RemoteLayerTreeDrawingAreaProxy& drawingArea() const;
+    RemoteLayerTreeDrawingAreaProxy& NODELETE drawingArea() const;
 
     // Returns true if the root layer changed.
     bool updateLayerTree(const IPC::Connection&, const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&, float indicatorScaleFactor  = 1);

--- a/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
+++ b/Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h
@@ -40,7 +40,7 @@ public:
 protected:
     explicit FidoAuthenticator(Ref<CtapDriver>&&);
 
-    CtapDriver& driver() const;
+    CtapDriver& NODELETE driver() const;
     Ref<CtapDriver> releaseDriver();
 
     String transportForDebugging() const;

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -762,7 +762,7 @@ private:
 #endif
 
 #if ENABLE(MODEL_PROCESS)
-    ModelProcessProxy& ensureModelProcess();
+    ModelProcessProxy& NODELETE ensureModelProcess();
     void updateModelProcessAssertion();
     void terminateAllWebContentProcessesWithModelPlayers();
 #endif

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -254,7 +254,7 @@ private:
     void requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin) override;
 
 #if ENABLE(FULLSCREEN_API)
-    WebFullScreenManagerProxyClient& fullScreenManagerProxyClient() final;
+    WebFullScreenManagerProxyClient& NODELETE fullScreenManagerProxyClient() final;
 
     // WebFullScreenManagerProxyClient
     void closeFullScreenManager() override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -214,7 +214,7 @@ private:
     void removeAllPDFHUDs() override;
 
 #if ENABLE(FULLSCREEN_API)
-    WebFullScreenManagerProxyClient& fullScreenManagerProxyClient() final;
+    WebFullScreenManagerProxyClient& NODELETE fullScreenManagerProxyClient() final;
 #endif
 
 #if ENABLE(FULLSCREEN_API)

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
@@ -42,7 +42,7 @@ public:
     static Ref<WebIDBConnectionToServer> create(PAL::SessionID);
     virtual ~WebIDBConnectionToServer();
 
-    WebCore::IDBClient::IDBConnectionToServer& coreConnectionToServer();
+    WebCore::IDBClient::IDBConnectionToServer& NODELETE coreConnectionToServer();
     std::optional<WebCore::IDBConnectionIdentifier> identifier() const final;
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h
@@ -105,7 +105,7 @@ public:
     void prepareToDisplay(const WebCore::Region& dirtyRegion, bool supportsPartialRepaint, bool hasEmptyDirtyRegion, bool drawingRequiresClearedPixels);
 #endif
 
-    WebCore::GraphicsContext& context();
+    WebCore::GraphicsContext& NODELETE context();
     bool hasContext() const { return !!m_context; }
 
     RemoteGraphicsContextIdentifier contextIdentifier() const { return m_contextIdentifier; }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
@@ -141,7 +141,7 @@ private:
 
     // CoordinatedPlatformLayer::Client
 #if USE(CAIRO)
-    WebCore::Cairo::PaintingEngine& paintingEngine() override;
+    WebCore::Cairo::PaintingEngine& NODELETE paintingEngine() override;
 #elif USE(SKIA)
     WebCore::SkiaPaintingEngine& paintingEngine() const override { return *m_skiaPaintingEngine.get(); }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1962,7 +1962,7 @@ public:
 #endif
 
 #if ENABLE(WEBXR)
-    PlatformXRSystemProxy& xrSystemProxy();
+    PlatformXRSystemProxy& NODELETE xrSystemProxy();
 #endif
 
     void prepareToRunModalJavaScriptDialog();

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -1,8 +1,10 @@
 Storage/InProcessIDBServer.cpp
 Storage/StorageSyncManager.cpp
-Storage/WebDatabaseProvider.cpp
 WebCoreSupport/SocketStreamHandleImpl.cpp
 WebCoreSupport/WebSocketChannel.cpp
+[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
+[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
+[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
 mac/DOM/DOM.mm
 mac/DOM/DOMAbstractView.mm
 mac/DOM/DOMAttr.mm
@@ -78,6 +80,7 @@ mac/DOM/DOMRange.mm
 mac/DOM/DOMStyleSheet.mm
 mac/DOM/DOMText.mm
 mac/DOM/DOMTreeWalker.mm
+[ iOS ] mac/DOM/DOMUIKitExtensions.mm
 mac/DOM/DOMXPathExpression.mm
 mac/DOM/DOMXPathResult.mm
 mac/DOM/WebDOMOperations.mm
@@ -107,7 +110,3 @@ mac/WebView/WebScriptDebugger.mm
 mac/WebView/WebTextIterator.mm
 [ Mac ] mac/WebView/WebVideoFullscreenController.mm
 mac/WebView/WebView.mm
-[ iOS ] ios/WebCoreSupport/WebFrameIOS.mm
-[ iOS ] ios/WebCoreSupport/WebVisiblePosition.mm
-[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
-[ iOS ] mac/DOM/DOMUIKitExtensions.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -3,7 +3,6 @@ Storage/StorageAreaImpl.cpp
 Storage/StorageAreaSync.cpp
 Storage/StorageNamespaceImpl.cpp
 Storage/StorageThread.cpp
-Storage/WebDatabaseProvider.cpp
 Storage/WebStorageNamespaceProvider.cpp
 WebCoreSupport/PageStorageSessionProvider.h
 WebCoreSupport/PingHandle.h

--- a/Source/WebKitLegacy/Storage/InProcessIDBServer.h
+++ b/Source/WebKitLegacy/Storage/InProcessIDBServer.h
@@ -64,8 +64,8 @@ public:
 
     virtual ~InProcessIDBServer();
 
-    WebCore::IDBClient::IDBConnectionToServer& connectionToServer() const;
-    WebCore::IDBServer::IDBConnectionToClient& connectionToClient() const;
+    WebCore::IDBClient::IDBConnectionToServer& NODELETE connectionToServer() const;
+    WebCore::IDBServer::IDBConnectionToClient& NODELETE connectionToClient() const;
     WebCore::IDBServer::IDBServer& server() { return *m_server; }
 
     void ref() const final { ThreadSafeRefCounted::ref(); }


### PR DESCRIPTION
#### d3c3b11e603b6fa78354fe9cb51550030e27dbb5
<pre>
Start adopting NODELETE annotation on non-inline trivial getters
<a href="https://bugs.webkit.org/show_bug.cgi?id=307301">https://bugs.webkit.org/show_bug.cgi?id=307301</a>

Reviewed by Ryosuke Niwa.

* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
* Source/WebCore/Modules/async-clipboard/Clipboard.h:
* Source/WebCore/Modules/async-clipboard/ClipboardItem.h:
* Source/WebCore/Modules/contact-picker/ContactsManager.h:
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/Modules/geolocation/GeolocationController.h:
* Source/WebCore/Modules/indexeddb/server/MemoryCursor.h:
* Source/WebCore/Modules/indexeddb/server/MemoryIndex.h:
* Source/WebCore/Modules/indexeddb/server/MemoryObjectStore.h:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseConnection.h:
* Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
* Source/WebCore/Modules/indexeddb/shared/IDBResultData.h:
* Source/WebCore/Modules/mediastream/RTCPeerConnectionIceEvent.h:
* Source/WebCore/Modules/permissions/Permissions.h:
* Source/WebCore/Modules/remoteplayback/RemotePlayback.h:
* Source/WebCore/Modules/speech/SpeechSynthesisUtterance.h:
* Source/WebCore/Modules/streams/ReadableStream.h:
* Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h:
* Source/WebCore/Modules/webaudio/AudioWorklet.h:
* Source/WebCore/Modules/webauthn/AuthenticatorResponse.h:
* Source/WebCore/Modules/webdatabase/SQLStatement.h:
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannelClientWrapper.h:
* Source/WebCore/Modules/webtransport/WebTransportSendStream.h:
* Source/WebCore/Modules/webxr/WebXRInputSource.h:
* Source/WebCore/Modules/webxr/WebXRRay.h:
* Source/WebCore/Modules/webxr/WebXRRigidTransform.h:
* Source/WebCore/Modules/webxr/WebXRSession.h:
* Source/WebCore/Modules/webxr/WebXRSystem.h:
* Source/WebCore/Modules/webxr/XRProjectionLayer.h:
* Source/WebCore/Modules/webxr/XRReferenceSpaceEvent.h:
* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/bindings/js/JSDOMWindowBase.h:
* Source/WebCore/bindings/js/JSWorkerGlobalScopeBase.h:
* Source/WebCore/bindings/js/JSWorkletGlobalScopeBase.h:
* Source/WebCore/contentextensions/ContentExtension.h:
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/CSSStyleProperties.h:
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/MediaList.h:
* Source/WebCore/css/PropertySetCSSDescriptors.h:
* Source/WebCore/css/typedom/CSSStyleImageValue.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentImmersive.h:
* Source/WebCore/dom/InputEvent.h:
* Source/WebCore/dom/SecurityContext.h:
* Source/WebCore/dom/TemplateContentDocumentFragment.h:
* Source/WebCore/editing/Editor.h:
* Source/WebCore/history/CachedFrame.h:
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLTemplateElement.h:
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/html/ImageDocument.h:
* Source/WebCore/html/SearchInputType.h:
* Source/WebCore/html/TextFieldInputType.h:
* Source/WebCore/html/UserActivation.h:
* Source/WebCore/html/parser/HTMLElementStack.h:
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TrackBase.h:
* Source/WebCore/inspector/InspectorOverlay.h:
* Source/WebCore/inspector/agents/worker/WorkerNetworkAgent.h:
* Source/WebCore/layout/integration/LayoutIntegrationBoxGeometryUpdater.h:
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/loader/cache/CachedResourceHandle.h:
* Source/WebCore/page/AutoscrollController.h:
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/LocalDOMWindowProperty.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/page/PointerLockController.h:
* Source/WebCore/page/UndoItem.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/platform/ScreenOrientationManager.h:
* Source/WebCore/platform/Widget.h:
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.h:
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/cairo/GraphicsContextCairo.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGBitmapBackend.h:
* Source/WebCore/platform/graphics/cg/ImageBufferCGPDFDocumentBackend.h:
* Source/WebCore/platform/graphics/texmap/TextureMapperLayer.h:
* Source/WebCore/platform/mac/DataDetectorHighlight.h:
* Source/WebCore/platform/mediastream/cocoa/IncomingAudioMediaStreamTrackRendererUnit.h:
* Source/WebCore/platform/network/BlobResourceHandleBase.h:
* Source/WebCore/platform/text/LocaleICU.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/RenderHighlight.h:
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/style/AnchorPositionEvaluator.h:
* Source/WebCore/style/StyleResolver.h:
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/StyleScopeRuleSets.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyBase.h:
* Source/WebCore/testing/Internals.h:
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/service/ServiceWorkerRegistration.h:
* Source/WebCore/workers/service/server/SWServerToContextConnection.h:
* Source/WebCore/workers/service/server/SWServerWorker.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/ModelProcess/ModelConnectionToWebProcess.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingBifurcatedImageBuffer.h:
* Source/WebKit/Shared/RemoteLayerTree/DynamicContentScalingImageBufferBackend.h:
* Source/WebKit/UIProcess/API/gtk/PageClientImpl.h:
* Source/WebKit/UIProcess/API/wpe/PageClientImpl.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeHost.h:
* Source/WebKit/UIProcess/WebAuthentication/fido/FidoAuthenticator.h:
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferSetProxy.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKitLegacy/Storage/InProcessIDBServer.h:

Canonical link: <a href="https://commits.webkit.org/307108@main">https://commits.webkit.org/307108@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3d9e64f006dbb6b888e3f1ae90e1d95b805ad6d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7320 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152012 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96583 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3597e865-50ad-4354-b9f0-bf4881f8d623) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145203 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15892 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110241 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79382 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b52cfc9f-59d9-48dd-bed0-5ea1c58f6c0b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146285 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12698 "Failed to checkout and rebase branch from PR 58163") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91150 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12170 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9888 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2010 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135335 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121598 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154323 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4148 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15855 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6296 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118260 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15892 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13376 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118601 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30401 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14538 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71250 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15480 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5161 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174633 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79200 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45088 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15425 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15276 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->