### PR TITLE
AX: Images with alt="" but valid ARIA accname should not be ignored

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt
@@ -55,8 +55,8 @@ PASS el-aside-in-section-title
 PASS el-footer-ancestorbody
 PASS el-header-ancestorbody
 FAIL el-img-no-name assert_equals: <img data-testname="el-img-no-name" data-expectedrole="image" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="> expected "image" but got "none"
-FAIL el-img-empty-alt-aria-label assert_equals: <img data-testname="el-img-empty-alt-aria-label" data-expectedrole="image" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt="" aria-label="x"> expected "image" but got "none"
-FAIL el-img-empty-alt-aria-labelledby assert_equals: <img data-testname="el-img-empty-alt-aria-labelledby" data-expectedrole="image" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt="" aria-labelledby="labelledby"> expected "image" but got "none"
+PASS el-img-empty-alt-aria-label
+PASS el-img-empty-alt-aria-labelledby
 PASS el-section
 PASS el-section-aria-labelledby
 PASS el-section-title

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -127,6 +127,7 @@
 #include "SVGImage.h"
 #include "SVGSVGElement.h"
 #include "ShadowRootMode.h"
+#include "SpaceSplitString.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "Text.h"
 #include "TextControlInnerElements.h"
@@ -1369,17 +1370,37 @@ bool AccessibilityRenderObject::computeIsIgnored() const
         else
             altTextInclusion = objectInclusionFromAltText(altTextFromAttributeOrStyle());
 
-        if (altTextInclusion == AccessibilityObjectInclusion::IgnoreObject)
-            return true;
         if (altTextInclusion == AccessibilityObjectInclusion::IncludeObject)
             return false;
 
         // webkit.org/b/173870 - If an image has other alternative text, don't ignore it if alt text is empty.
-        // This means we should process title and aria-label first.
+        // Per HTML-AAM, aria-label and valid aria-labelledby (referencing elements with non-empty text) take
+        // precedence over alt="", so check for valid ARIA accname before ignoring the image due to empty alt text.
 
-        // If an image has an accname, accessibility should be lenient and allow it to appear in the hierarchy (according to WAI-ARIA).
-        if (hasAccNameAttribute())
+        // Check if image has aria-label with non-empty content.
+        String ariaLabel = getAttribute(aria_labelAttr);
+        if (!ariaLabel.isEmpty() && !ariaLabel.containsOnly<isASCIIWhitespace>())
             return false;
+
+        // Check if image has aria-labelledby that references existing element(s) with text content.
+        const AtomString& ariaLabelledBy = getAttribute(aria_labelledbyAttr);
+        if (!ariaLabelledBy.isEmpty()) {
+            SpaceSplitString ids(ariaLabelledBy, SpaceSplitString::ShouldFoldCase::No);
+            if (RefPtr document = this->document()) {
+                for (auto& id : ids) {
+                    if (RefPtr element = document->getElementById(id)) {
+                        String elementText = element->textContent();
+                        if (!elementText.isEmpty() && !elementText.containsOnly<isASCIIWhitespace>())
+                            return false;
+                    }
+                }
+            }
+        }
+
+        if (altTextInclusion == AccessibilityObjectInclusion::IgnoreObject) {
+            // If the image is decorative (i.e. alt="") and has no valid ARIA accname, it should be ignored.
+            return true;
+        }
 
         if (image) {
             // check for one-dimensional image


### PR DESCRIPTION
#### 788a2e6a51d03744a8f081f7696defdae5dfb188
<pre>
AX: Images with alt=&quot;&quot; but valid ARIA accname should not be ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=307302">https://bugs.webkit.org/show_bug.cgi?id=307302</a>
<a href="https://rdar.apple.com/169934468">rdar://169934468</a>

Reviewed by NOBODY (OOPS!).

Per HTML-AAM (<a href="https://w3c.github.io/html-aam/#el-img-empty-alt)">https://w3c.github.io/html-aam/#el-img-empty-alt)</a>,
aria-label and valid aria-labelledby (referencing elements with
non-empty text) take precedence over alt=&quot;&quot;, so images should not
be ignored due to empty alt text when they have a valid ARIA accessible name.

This commit updates computeIsIgnored() to check for valid aria-label and
aria-labelledby before deciding to ignore an image due to empty alt.
The aria-labelledby validation ensures referenced elements exist and
have non-empty text content.

* LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt:
Mark testcase as PASS.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::computeIsIgnored const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/788a2e6a51d03744a8f081f7696defdae5dfb188

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143243 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15718 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96464 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc4f4429-8164-43b7-accc-5622f7804538) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145110 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16378 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15799 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110162 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79312 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a7343d4-8bba-4491-b88f-39ed0803ab91) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146192 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12609 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91072 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8373e611-f900-48d3-998c-871bee91522d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12092 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9805 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1916 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121521 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154230 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15762 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118181 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13293 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118521 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14462 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/125897 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71152 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15387 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4538 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15121 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79107 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15332 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15183 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->