### PR TITLE
AX: hasAccNameAttribute doesn't validate aria-labelledby ID references, causing incorrect role computation

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt
@@ -55,8 +55,8 @@ PASS el-aside-in-section-title
 PASS el-footer-ancestorbody
 PASS el-header-ancestorbody
 FAIL el-img-no-name assert_equals: <img data-testname="el-img-no-name" data-expectedrole="image" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="> expected "image" but got "none"
-FAIL el-img-empty-alt-aria-label assert_equals: <img data-testname="el-img-empty-alt-aria-label" data-expectedrole="image" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt="" aria-label="x"> expected "image" but got "none"
-FAIL el-img-empty-alt-aria-labelledby assert_equals: <img data-testname="el-img-empty-alt-aria-labelledby" data-expectedrole="image" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==" alt="" aria-labelledby="labelledby"> expected "image" but got "none"
+PASS el-img-empty-alt-aria-label
+PASS el-img-empty-alt-aria-labelledby
 PASS el-section
 PASS el-section-aria-labelledby
 PASS el-section-title
@@ -68,11 +68,11 @@ PASS el-aside-in-nav
 PASS el-aside-in-section
 PASS el-aside-in-section-aria-label-empty
 PASS el-aside-in-section-aria-label-whitespace
-FAIL el-aside-in-section-aria-labelledby-non-existing assert_false: Computed Role: "complementary" does not match any of the acceptable role strings in ["generic", "", "none"]: <aside data-testname="el-aside-in-section-aria-labelledby-non-existing" class="ex-generic" aria-labelledby="non-existing">x</aside> expected false got true
-FAIL el-aside-in-section-aria-labelledby-empty assert_false: Computed Role: "complementary" does not match any of the acceptable role strings in ["generic", "", "none"]: <aside data-testname="el-aside-in-section-aria-labelledby-empty" class="ex-generic" aria-labelledby="empty">x</aside> expected false got true
-FAIL el-aside-in-section-aria-labelledby-whitespace assert_false: Computed Role: "complementary" does not match any of the acceptable role strings in ["generic", "", "none"]: <aside data-testname="el-aside-in-section-aria-labelledby-whitespace" class="ex-generic" aria-labelledby="space">x</aside> expected false got true
+PASS el-aside-in-section-aria-labelledby-non-existing
+PASS el-aside-in-section-aria-labelledby-empty
+PASS el-aside-in-section-aria-labelledby-whitespace
 PASS el-aside-in-section-title-empty
-FAIL el-aside-in-section-title-whitespace assert_false: Computed Role: "complementary" does not match any of the acceptable role strings in ["generic", "", "none"]: <aside data-testname="el-aside-in-section-title-whitespace" class="ex-generic" title=" ">x</aside> expected false got true
+PASS el-aside-in-section-title-whitespace
 PASS el-img-empty-alt-aria-label-empty
 PASS el-img-empty-alt-aria-label-whitespace
 PASS el-img-empty-alt-aria-labelledby-non-existing
@@ -84,9 +84,9 @@ PASS el-img-empty-alt-title-whitespace
 PASS el-section-no-name
 PASS el-section-aria-label-empty
 PASS el-section-aria-label-whitespace
-FAIL el-section-aria-labelledby-non-existing assert_false: Computed Role: "region" does not match any of the acceptable role strings in ["generic", "", "none"]: <section data-testname="el-section-aria-labelledby-non-existing" class="ex-generic" aria-labelledby="non-existing">x</section> expected false got true
-FAIL el-section-aria-labelledby-empty assert_false: Computed Role: "region" does not match any of the acceptable role strings in ["generic", "", "none"]: <section data-testname="el-section-aria-labelledby-empty" class="ex-generic" aria-labelledby="empty">x</section> expected false got true
-FAIL el-section-aria-labelledby-whitespace assert_false: Computed Role: "region" does not match any of the acceptable role strings in ["generic", "", "none"]: <section data-testname="el-section-aria-labelledby-whitespace" class="ex-generic" aria-labelledby="space">x</section> expected false got true
+PASS el-section-aria-labelledby-non-existing
+PASS el-section-aria-labelledby-empty
+PASS el-section-aria-labelledby-whitespace
 PASS el-section-title-empty
-FAIL el-section-title-whitespace assert_false: Computed Role: "region" does not match any of the acceptable role strings in ["generic", "", "none"]: <section data-testname="el-section-title-whitespace" class="ex-generic" title=" ">x</section> expected false got true
+PASS el-section-title-whitespace
 

--- a/Source/WebCore/accessibility/AXUtilities.h
+++ b/Source/WebCore/accessibility/AXUtilities.h
@@ -63,6 +63,9 @@ RenderImage* toSimpleImage(RenderObject&);
 // Returns true if the element has an attribute that will result in an accname being computed.
 // https://www.w3.org/TR/accname-1.2/
 bool hasAccNameAttribute(Element&);
+// Like hasAccNameAttribute, but only checks ARIA attributes (aria-label, aria-labelledby,
+// aria-describedby, aria-description), not the HTML title attribute.
+bool hasARIAAccNameAttribute(Element&);
 
 bool isNodeFocused(Node&);
 


### PR DESCRIPTION
#### b0b7fd4bdd3a70858657ed0441c3dc8b598c3660
<pre>
AX: hasAccNameAttribute doesn&apos;t validate aria-labelledby ID references, causing incorrect role computation
<a href="https://bugs.webkit.org/show_bug.cgi?id=307306">https://bugs.webkit.org/show_bug.cgi?id=307306</a>
<a href="https://rdar.apple.com/169935334">rdar://169935334</a>

Reviewed by Joshua Hoffman.

This commit updates hasAccNameAttribute() to validate that aria-labelledby and
aria-describedby actually reference existing elements with non-empty
text content. Previously, the function would return true for any
non-empty aria-labelledby value, even if it referenced non-existing
IDs, empty elements, or elements with only whitespace.

This ensures that elements like &lt;section&gt; and &lt;aside&gt; (which require
an accessible name to be exposed as landmarks) don&apos;t incorrectly get
landmark roles when aria-labelledby references invalid or empty
content. Also validates that title attributes with only whitespace
are not considered valid accessible names.

* LayoutTests/imported/w3c/web-platform-tests/html-aam/roles-contextual-expected.txt:
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::hasAccNameAttribute):

Canonical link: <a href="https://commits.webkit.org/308183@main">https://commits.webkit.org/308183@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58959b20254e73d4511da53a111cf1b321f9f33a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155302 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3d7e065-c797-4c81-83b5-04be3c95a36e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148513 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19216 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112988 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15228 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131756 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93734 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4fc5cffc-2157-4b07-9d67-350f19ab804c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14478 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12246 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2746 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124057 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9619 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157630 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/773 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11053 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120995 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121207 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31053 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131371 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74926 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16833 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8280 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18733 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82480 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18463 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18613 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18522 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->