### PR TITLE
[WebDriver][BiDi] browsingContext.create should preserve user context metadata and emit stable top-level contextCreated events

### DIFF
--- a/Source/WebKit/UIProcess/Automation/Automation.json
+++ b/Source/WebKit/UIProcess/Automation/Automation.json
@@ -86,7 +86,8 @@
                 "TargetOutOfBounds",
                 "UnableToLoadExtension",
                 "UnableToUnloadExtension",
-                "NoSuchExtension"
+                "NoSuchExtension",
+                "NoSuchUserContext"
             ]
         },
         {

--- a/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp
@@ -56,13 +56,19 @@ String toUserContextIDProtocolString(const PAL::SessionID& sessionID)
     return builder.toString();
 }
 
+} // namespace
+
+const String& defaultClientWindowID()
+{
+    static NeverDestroyed<const String> clientWindowID(MAKE_STATIC_STRING_IMPL("unknown-window"));
+    return clientWindowID;
+}
+
 const String& defaultUserContextID()
 {
     static NeverDestroyed<const String> contextID(MAKE_STATIC_STRING_IMPL("default"));
     return contextID;
 }
-
-} // namespace
 
 struct BidiBrowserAgent::BidiUserContextDeletionRecord {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(BidiUserContextDeletionRecord);
@@ -90,7 +96,7 @@ BidiBrowserAgent::~BidiBrowserAgent() = default;
 
 void BidiBrowserAgent::didCreatePage(WebPageProxy& page)
 {
-    String userContextID = toUserContextIDProtocolString(page.sessionID());
+    String userContextID = getUserContextIDForPage(page);
     auto it = m_userContextsPendingDeletion.find(userContextID);
     if (it == m_userContextsPendingDeletion.end())
         return;
@@ -101,7 +107,10 @@ void BidiBrowserAgent::didCreatePage(WebPageProxy& page)
 
 void BidiBrowserAgent::willClosePage(const WebPageProxy& page)
 {
-    String userContextID = toUserContextIDProtocolString(page.sessionID());
+    String userContextID = getUserContextIDForPage(page);
+
+    m_pageUserContextOverrides.remove(page.identifier());
+
     auto it = m_userContextsPendingDeletion.find(userContextID);
     if (it == m_userContextsPendingDeletion.end())
         return;
@@ -112,6 +121,39 @@ void BidiBrowserAgent::willClosePage(const WebPageProxy& page)
 
     it->value->callback({ });
     m_userContextsPendingDeletion.remove(it);
+}
+
+bool BidiBrowserAgent::hasUserContext(const String& userContextID) const
+{
+    if (userContextID == defaultUserContextID())
+        return true;
+
+    return m_userContexts.contains(userContextID);
+}
+
+void BidiBrowserAgent::setUserContextIDForPage(const WebPageProxy& page, const String& userContextID)
+{
+    if (userContextID.isEmpty() || userContextID == defaultUserContextID()) {
+        m_pageUserContextOverrides.remove(page.identifier());
+        return;
+    }
+
+    m_pageUserContextOverrides.set(page.identifier(), userContextID);
+}
+
+String BidiBrowserAgent::getUserContextIDForPage(const WebPageProxy& page) const
+{
+    if (auto it = m_pageUserContextOverrides.find(page.identifier()); it != m_pageUserContextOverrides.end())
+        return it->value;
+
+    String userContextID = toUserContextIDProtocolString(page.sessionID());
+
+    // During removeUserContext teardown, contexts are moved from m_userContexts to
+    // m_userContextsPendingDeletion until their pages are closed.
+    if (m_userContexts.contains(userContextID) || m_userContextsPendingDeletion.contains(userContextID))
+        return userContextID;
+
+    return defaultUserContextID();
 }
 
 // MARK: Inspector::BidiBrowserDispatcherHandler methods.
@@ -162,16 +204,20 @@ void BidiBrowserAgent::removeUserContext(const String& userContextID, CommandCal
 
     auto it = m_userContexts.find(userContextID);
     // https://www.w3.org/TR/webdriver-bidi/#command-browser-removeUserContext step 4.
-    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(it == m_userContexts.end(), InvalidParameter, "no such user context"_s);
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(it == m_userContexts.end(), NoSuchUserContext, "no such user context"_s);
 
     auto userContext = m_userContexts.take(it);
-    size_t pageCount = userContext->allPages().size();
+    auto pages = userContext->allPages();
+    size_t pageCount = pages.size();
     if (!pageCount) {
         callback({ });
         return;
     }
 
     m_userContextsPendingDeletion.set(userContextID, makeUnique<BidiUserContextDeletionRecord>(WTF::move(userContext), pageCount, WTF::move(callback)));
+
+    for (Ref page : pages)
+        page->closePage();
 }
 
 #if !USE(GLIB)

--- a/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h
@@ -28,6 +28,7 @@
 #if ENABLE(WEBDRIVER_BIDI)
 
 #include "WebDriverBidiBackendDispatchers.h"
+#include "WebPageProxyIdentifier.h"
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
 #include <wtf/Forward.h>
 #include <wtf/TZoneMalloc.h>
@@ -46,6 +47,9 @@ class WebPageProxy;
 class WebProcessPool;
 class WebsiteDataStore;
 
+const String& defaultClientWindowID();
+const String& defaultUserContextID();
+
 class BidiBrowserAgent final : public Inspector::BidiBrowserBackendDispatcherHandler {
     WTF_MAKE_TZONE_ALLOCATED(BidiBrowserAgent);
 public:
@@ -54,6 +58,10 @@ public:
 
     void didCreatePage(WebPageProxy&);
     void willClosePage(const WebPageProxy&);
+
+    String getUserContextIDForPage(const WebPageProxy&) const;
+    bool hasUserContext(const String&) const;
+    void setUserContextIDForPage(const WebPageProxy&, const String&);
 
 private:
     struct BidiUserContextDeletionRecord;
@@ -70,6 +78,7 @@ private:
     Ref<Inspector::BidiBrowserBackendDispatcher> m_browserDomainDispatcher;
     HashMap<String, std::unique_ptr<BidiUserContext>> m_userContexts;
     HashMap<String, std::unique_ptr<BidiUserContextDeletionRecord>> m_userContextsPendingDeletion;
+    HashMap<WebPageProxyIdentifier, String> m_pageUserContextOverrides;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp
@@ -30,6 +30,7 @@
 #if ENABLE(WEBDRIVER_BIDI)
 
 #include "AutomationProtocolObjects.h"
+#include "BidiBrowserAgent.h"
 #include "FrameTreeNodeData.h"
 #include "Logging.h"
 #include "PageLoadState.h"
@@ -124,11 +125,30 @@ void BidiBrowsingContextAgent::create(Inspector::Protocol::BidiBrowsingContext::
     RefPtr session = m_session.get();
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!session, InternalError);
 
-    // FIXME: implement `referenceContext` option.
     // FIXME: implement `background` option.
-    // FIXME: implement `userContext` option.
 
-    session->createBrowsingContext(browsingContextPresentationFromCreateType(createType), [callback = WTF::move(callback)](CommandResultOf<BrowsingContext, Inspector::Protocol::Automation::BrowsingContextPresentation>&& result) {
+    String userContextID = optionalUserContext;
+
+    if (!optionalReferenceContext.isEmpty()) {
+        auto handles = session->extractBrowsingContextHandles(optionalReferenceContext);
+        ASYNC_FAIL_IF_UNEXPECTED_RESULT(handles);
+
+        auto [pageHandle, frameHandle] = handles.value();
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!frameHandle.isEmpty(), InvalidParameter);
+
+        RefPtr referencePage = session->webPageProxyForHandle(pageHandle);
+        ASYNC_FAIL_WITH_PREDEFINED_ERROR_IF(!referencePage, FrameNotFound);
+
+        if (userContextID.isEmpty())
+            userContextID = session->getUserContextIDForPage(*referencePage);
+    }
+
+    if (userContextID.isEmpty())
+        userContextID = defaultUserContextID();
+
+    ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!session->hasUserContextID(userContextID), NoSuchUserContext, "no such user context"_s);
+
+    session->createBrowsingContextForUserContext(browsingContextPresentationFromCreateType(createType), userContextID, [callback = WTF::move(callback)](CommandResultOf<BrowsingContext, Inspector::Protocol::Automation::BrowsingContextPresentation>&& result) {
         if (!result) {
             callback(makeUnexpected(result.error()));
             return;
@@ -153,17 +173,20 @@ Inspector::Protocol::BidiBrowsingContext::BrowsingContext BidiBrowsingContextAge
     return session->handleForWebFrameID(frameID);
 }
 
-Ref<Inspector::Protocol::BidiBrowsingContext::Info> BidiBrowsingContextAgent::getNavigableInfo(const WebKit::FrameTreeNodeData& tree, std::optional<uint64_t> maxDepth, IncludeParentID includeParentID)
+Ref<Inspector::Protocol::BidiBrowsingContext::Info> BidiBrowsingContextAgent::getNavigableInfo(const WebKit::FrameTreeNodeData& tree, const WebPageProxy& page, std::optional<uint64_t> maxDepth, IncludeParentID includeParentID)
 {
     // https://w3c.github.io/webdriver-bidi/#get-the-navigable-info
 
-    // FIXME: Properly support different user contexts, which will likely map to different WebAutomationSessions.
-    // https://bugs.webkit.org/show_bug.cgi?id=288104
+    RefPtr session = m_session.get();
+    auto [clientWindow, userContext] = session
+        ? session->getClientWindowAndUserContext(page)
+        : std::pair<String, String>(defaultClientWindowID(), defaultUserContextID());
+
     auto info = Inspector::Protocol::BidiBrowsingContext::Info::create()
         .setContext(getBrowsingContextID(tree.info.frameID))
         .setUrl(tree.info.request.url().string())
-        .setClientWindow("placeholder_window"_s)
-        .setUserContext("default"_s)
+        .setClientWindow(clientWindow)
+        .setUserContext(userContext)
         .setChildrenIsNull()
         .setOriginalOpenerIsNull()
         .release();
@@ -186,7 +209,7 @@ Ref<Inspector::Protocol::BidiBrowsingContext::Info> BidiBrowsingContextAgent::ge
     auto childrenInfo = JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create();
     auto newDepth = maxDepth ? std::optional<uint64_t>(*maxDepth - 1) : std::nullopt;
     for (auto& child : tree.children)
-        childrenInfo->addItem(getNavigableInfo(child, newDepth, IncludeParentID::No));
+        childrenInfo->addItem(getNavigableInfo(child, page, newDepth, IncludeParentID::No));
 
     info->setChildren(WTF::move(childrenInfo));
     return info;
@@ -204,7 +227,7 @@ void BidiBrowsingContextAgent::getNextTree(Vector<Ref<WebPageProxy>>&& pagesToPr
     Ref webPageProxy = pagesToProcess.takeLast();
     webPageProxy->getAllFrameTrees([this, pagesToProcess = WTF::move(pagesToProcess), resultsObject = WTF::move(resultsObject), callback = WTF::move(callback), maxDepth, protectedPage = Ref { webPageProxy }](Vector<WebKit::FrameTreeNodeData>&& trees) mutable {
         for (auto& tree : trees) {
-            auto infoTree = getNavigableInfo(tree, maxDepth, IncludeParentID::Yes);
+            auto infoTree = getNavigableInfo(tree, protectedPage.get(), maxDepth, IncludeParentID::Yes);
             resultsObject->addItem(WTF::move(infoTree));
         }
         getNextTree(WTF::move(pagesToProcess), WTF::move(resultsObject), maxDepth, WTF::move(callback));

--- a/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
+++ b/Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h
@@ -64,7 +64,7 @@ private:
     enum class IncludeParentID: bool { No, Yes };
 
     void getNextTree(Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>, std::optional<uint64_t> maxDepth, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>>&&);
-    Ref<Inspector::Protocol::BidiBrowsingContext::Info> getNavigableInfo(const WebKit::FrameTreeNodeData&, std::optional<uint64_t> maxDepth, IncludeParentID);
+    Ref<Inspector::Protocol::BidiBrowsingContext::Info> getNavigableInfo(const WebKit::FrameTreeNodeData&, const WebPageProxy&, std::optional<uint64_t> maxDepth, IncludeParentID);
     Inspector::Protocol::BidiBrowsingContext::BrowsingContext getBrowsingContextID(const WebCore::FrameIdentifier&) const;
 
     WeakPtr<WebAutomationSession> m_session;

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -461,6 +461,22 @@ static Inspector::Protocol::Automation::BrowsingContextPresentation NODELETE toP
 
 void WebAutomationSession::createBrowsingContext(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&& presentationHint, CommandCallbackOf<String, Inspector::Protocol::Automation::BrowsingContextPresentation>&& callback)
 {
+#if ENABLE(WEBDRIVER_BIDI)
+    createBrowsingContextInternal(WTF::move(presentationHint), defaultUserContextID(), WTF::move(callback));
+#else
+    createBrowsingContextInternal(WTF::move(presentationHint), emptyString(), WTF::move(callback));
+#endif
+}
+
+#if ENABLE(WEBDRIVER_BIDI)
+void WebAutomationSession::createBrowsingContextForUserContext(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&& presentationHint, const String& userContextID, CommandCallbackOf<String, Inspector::Protocol::Automation::BrowsingContextPresentation>&& callback)
+{
+    createBrowsingContextInternal(WTF::move(presentationHint), userContextID, WTF::move(callback));
+}
+#endif
+
+void WebAutomationSession::createBrowsingContextInternal(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&& presentationHint, const String& userContextIDForBidi, CommandCallbackOf<String, Inspector::Protocol::Automation::BrowsingContextPresentation>&& callback)
+{
     ASSERT(m_client);
     ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!m_client, InternalError, "The remote session could not request a new browsing context."_s);
 
@@ -469,11 +485,42 @@ void WebAutomationSession::createBrowsingContext(std::optional<Inspector::Protoc
     if (presentationHint == Inspector::Protocol::Automation::BrowsingContextPresentation::Tab)
         options |= API::AutomationSessionBrowsingContextOptionsPreferNewTab;
 
-    m_client->requestNewPageWithOptions(*this, static_cast<API::AutomationSessionBrowsingContextOptions>(options), [protectedThis = Ref { *this }, callback = WTF::move(callback)](WebPageProxy* page) {
-        ASYNC_FAIL_WITH_PREDEFINED_ERROR_AND_DETAILS_IF(!page, InternalError, "The remote session failed to create a new browsing context."_s);
+#if ENABLE(WEBDRIVER_BIDI)
+    uint64_t requestIdentifier = m_nextCreateBrowsingContextRequestIdentifier++;
+    auto addResult = m_pendingCreateBrowsingContextRequestIdentifiers.add(requestIdentifier);
+    RELEASE_ASSERT(addResult.isNewEntry);
+#endif
+
+    m_client->requestNewPageWithOptions(*this, static_cast<API::AutomationSessionBrowsingContextOptions>(options), [protectedThis = Ref { *this }, userContextIDForBidi = userContextIDForBidi.isolatedCopy(),
+#if ENABLE(WEBDRIVER_BIDI)
+        requestIdentifier,
+#endif
+        callback = WTF::move(callback)](WebPageProxy* page) {
+#if ENABLE(WEBDRIVER_BIDI)
+        bool removedPendingRequest = protectedThis->m_pendingCreateBrowsingContextRequestIdentifiers.remove(requestIdentifier);
+        RELEASE_ASSERT(removedPendingRequest);
+#endif
+
+        if (!page) {
+#if ENABLE(WEBDRIVER_BIDI)
+            protectedThis->flushDeferredTopLevelContextCreatedEvents();
+#endif
+            callback(makeUnexpected(STRING_FOR_PREDEFINED_ERROR_NAME_AND_DETAILS(InternalError, "The remote session failed to create a new browsing context."_s)));
+            return;
+        }
 
         // WebDriver allows running commands in a browsing context which has not done any loads yet. Force WebProcess to be created so it can receive messages.
         page->launchInitialProcessIfNecessary();
+#if ENABLE(WEBDRIVER_BIDI)
+        protectedThis->m_deferredTopLevelContextCreatedPageIdentifiers.remove(page->identifier());
+        protectedThis->m_pagesHandledByPendingCreateBrowsingContextRequests.add(page->identifier());
+        protectedThis->m_bidiProcessor->browserAgent().setUserContextIDForPage(*page, userContextIDForBidi);
+        protectedThis->m_bidiProcessor->browserAgent().didCreatePage(*page);
+
+        // Emit before the command callback to satisfy BiDi create/event ordering.
+        protectedThis->emitContextCreatedEvent(*page);
+        protectedThis->flushDeferredTopLevelContextCreatedEvents();
+#endif
         callback({ { protectedThis->handleForWebPageProxy(*page), toProtocol(protectedThis->m_client->currentPresentationOfPage(protectedThis.get(), *page)) } });
     });
 }
@@ -995,6 +1042,52 @@ static String navigationIDToProtocolString(std::optional<WebCore::NavigationIden
     uint64_t id = navigationID->toUInt64();
     return WTF::UUID(id, id).toString();
 }
+
+static void setNullableString(JSON::Object& object, ASCIILiteral key, const String& value)
+{
+    if (value.isNull()) {
+        object.setValue(key, JSON::Value::null());
+        return;
+    }
+
+    object.setString(key, value);
+}
+
+static void setOptionalNullableString(JSON::Object& object, ASCIILiteral key, std::optional<String>&& value)
+{
+    if (!value)
+        return;
+
+    setNullableString(object, key, *value);
+}
+
+static void setNullableBrowsingContextChildren(JSON::Object& object, RefPtr<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>&& children)
+{
+    if (!children) {
+        object.setValue("children"_s, JSON::Value::null());
+        return;
+    }
+
+    object.setArray("children"_s, children.releaseNonNull());
+}
+
+static void sendBrowsingContextInfoEvent(WebDriverBidiProcessor& bidiProcessor, ASCIILiteral method, const String& context, const String& url, const String& originalOpener, std::optional<String>&& parent, RefPtr<JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>>&& children, const String& clientWindow, const String& userContext)
+{
+    auto params = JSON::Object::create();
+    params->setString("context"_s, context);
+    params->setString("url"_s, url);
+    setNullableString(params.get(), "originalOpener"_s, originalOpener);
+    setOptionalNullableString(params.get(), "parent"_s, WTF::move(parent));
+    setNullableBrowsingContextChildren(params.get(), WTF::move(children));
+    params->setString("clientWindow"_s, clientWindow);
+    params->setString("userContext"_s, userContext);
+
+    auto message = JSON::Object::create();
+    message->setString("method"_s, method);
+    message->setObject("params"_s, WTF::move(params));
+
+    bidiProcessor.sendBidiMessage(message->toJSONString());
+}
 #endif
 
 void WebAutomationSession::documentLoadedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID, WallTime timestamp)
@@ -1066,8 +1159,35 @@ void WebAutomationSession::wheelEventsFlushedForPage(const WebPageProxy& page)
 #if ENABLE(WEBDRIVER_BIDI)
 void WebAutomationSession::didCreatePage(WebPageProxy& page)
 {
+    if (m_pagesHandledByPendingCreateBrowsingContextRequests.remove(page.identifier()))
+        return;
+
+    if (!page.openerFrameIdentifier() && !m_pendingCreateBrowsingContextRequestIdentifiers.isEmpty()) {
+        m_deferredTopLevelContextCreatedPageIdentifiers.add(page.identifier());
+        return;
+    }
+
     m_bidiProcessor->browserAgent().didCreatePage(page);
     emitContextCreatedEvent(page);
+}
+
+void WebAutomationSession::flushDeferredTopLevelContextCreatedEvents()
+{
+    if (!m_pendingCreateBrowsingContextRequestIdentifiers.isEmpty() || m_deferredTopLevelContextCreatedPageIdentifiers.isEmpty())
+        return;
+
+    auto deferredPageIdentifiers = copyToVector(m_deferredTopLevelContextCreatedPageIdentifiers);
+    m_deferredTopLevelContextCreatedPageIdentifiers.clear();
+
+    for (auto pageIdentifier : deferredPageIdentifiers) {
+        if (m_pagesHandledByPendingCreateBrowsingContextRequests.remove(pageIdentifier))
+            continue;
+
+        if (RefPtr page = WebProcessProxy::webPage(pageIdentifier)) {
+            m_bidiProcessor->browserAgent().didCreatePage(*page);
+            emitContextCreatedEvent(*page);
+        }
+    }
 }
 
 void WebAutomationSession::navigationStartedForFrame(const WebFrameProxy& frame, std::optional<WebCore::NavigationIdentifier> navigationID)
@@ -1097,23 +1217,33 @@ void WebAutomationSession::fragmentNavigatedForFrame(const WebFrameProxy& frame,
 
 void WebAutomationSession::emitContextCreatedEvent(const WebPageProxy& page)
 {
-    if (RefPtr mutablePage = WebProcessProxy::webPage(page.identifier())) {
-        mutablePage->getAllFrameTrees([this, protectedThis = Ref { *this }, pageID = page.identifier()](Vector<FrameTreeNodeData>&& trees) {
-            RefPtr page = WebProcessProxy::webPage(pageID);
-            if (!page)
-                return;
+    if (page.isClosed())
+        return;
 
-            for (auto& tree : trees)
-                recursivelyEmitContextCreatedEvent(tree, std::nullopt);
-        });
-    }
+    if (!m_pagesWithContextCreatedEventEmitted.add(page.identifier()).isNewEntry)
+        return;
+
+    auto contextHandle = handleForWebPageProxy(page);
+
+    String originalOpenerHandle = nullString();
+    if (RefPtr openerPage = getOpenerPage(page))
+        originalOpenerHandle = handleForWebPageProxy(*openerPage);
+
+    String url = page.currentURL();
+    if (url.isEmpty())
+        url = aboutBlankURL().string();
+
+    auto [clientWindow, userContext] = getClientWindowAndUserContext(page);
+
+    sendBrowsingContextInfoEvent(m_bidiProcessor.get(), "browsingContext.contextCreated"_s, contextHandle, url, originalOpenerHandle, std::optional<String> { nullString() }, nullptr, clientWindow, userContext);
 }
 
-static std::pair<String, String> getClientWindowAndUserContext(const WebPageProxy& page)
+std::pair<String, String> WebAutomationSession::getClientWindowAndUserContext(const WebPageProxy& page) const
 {
     String clientWindow = makeString(page.identifier().toUInt64());
-    String userContext = "default"_s;
-    // FIXME: https://bugs.webkit.org/show_bug.cgi?id=281941 - Add support for reporting user context
+
+    String userContext = getUserContextIDForPage(page);
+
     return { clientWindow, userContext };
 }
 
@@ -1145,13 +1275,13 @@ void WebAutomationSession::contextCreatedForFrame(const WebFrameProxy& frame)
 {
     auto contextHandle = effectiveHandleForWebFrameProxy(frame);
     auto url = frame.url().string();
-    String parentHandle = "null"_s;
+    String parentHandle = nullString();
     if (RefPtr parentFrame = frame.parentFrame())
         parentHandle = effectiveHandleForWebFrameProxy(*parentFrame);
 
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=281941 - Add support for reporting clientWindow for frames
-    String clientWindow = "unknown-window"_s;
-    String userContext = "default"_s;
+    String clientWindow = defaultClientWindowID();
+    String userContext = defaultUserContextID();
 
     if (RefPtr page = frame.page()) {
         auto [windowId, contextId] = getClientWindowAndUserContext(*page);
@@ -1159,39 +1289,7 @@ void WebAutomationSession::contextCreatedForFrame(const WebFrameProxy& frame)
         userContext = contextId;
     }
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
-}
-
-void WebAutomationSession::recursivelyEmitContextCreatedEvent(const FrameTreeNodeData& tree, std::optional<String>&& parentContext)
-{
-    RefPtr frame = WebFrameProxy::webFrame(tree.info.frameID);
-    if (!frame)
-        return;
-
-    RefPtr page = frame->page();
-    if (!page)
-        return;
-
-    String contextHandle;
-    String originalOpenerHandle = "null"_s;
-
-    if (tree.info.isMainFrame) {
-        contextHandle = handleForWebPageProxy(*page);
-        if (RefPtr openerPage = this->getOpenerPage(*page))
-            originalOpenerHandle = handleForWebPageProxy(*openerPage);
-    } else
-        contextHandle = handleForWebFrameID(tree.info.frameID);
-
-    String url = tree.info.request.url().string();
-    auto [clientWindow, userContext] = getClientWindowAndUserContext(*page);
-    auto children = JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create();
-    // FIXME: Use JSON null instead of string "null" when Inspector::Protocol supports RefPtr<String> or std::optional<String>
-    String parentContextHandle = parentContext.value_or("null"_s);
-
-    m_bidiProcessor->browsingContextDomainNotifier().contextCreated(contextHandle, url, originalOpenerHandle, parentContextHandle, WTF::move(children), clientWindow, userContext);
-
-    for (const auto& child : tree.children)
-        recursivelyEmitContextCreatedEvent(child, contextHandle);
+    sendBrowsingContextInfoEvent(m_bidiProcessor.get(), "browsingContext.contextCreated"_s, contextHandle, url, nullString(), std::optional<String> { WTF::move(parentHandle) }, nullptr, clientWindow, userContext);
 }
 
 void WebAutomationSession::contextDestroyedForPage(const WebPageProxy& page)
@@ -1199,20 +1297,21 @@ void WebAutomationSession::contextDestroyedForPage(const WebPageProxy& page)
     auto contextHandle = handleForWebPageProxy(page);
     auto url = page.currentURL();
 
-    String parentContext = "null"_s;
+    String parentContext = nullString();
     if (RefPtr mainFrame = page.mainFrame()) {
         if (RefPtr parentFrame = mainFrame->parentFrame())
             parentContext = effectiveHandleForWebFrameProxy(*parentFrame);
     }
 
-    String originalOpenerHandle = "null"_s;
+    String originalOpenerHandle = nullString();
     if (RefPtr openerPage = this->getOpenerPage(page))
         originalOpenerHandle = handleForWebPageProxy(*openerPage);
 
     auto [clientWindow, userContext] = getClientWindowAndUserContext(page);
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, originalOpenerHandle, parentContext, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    sendBrowsingContextInfoEvent(m_bidiProcessor.get(), "browsingContext.contextDestroyed"_s, contextHandle, url, originalOpenerHandle, std::optional<String> { WTF::move(parentContext) }, nullptr, clientWindow, userContext);
 
+    m_pagesWithContextCreatedEventEmitted.remove(page.identifier());
     m_handleWebPageMap.remove(contextHandle);
     m_webPageHandleMap.remove(page.identifier());
 }
@@ -1221,12 +1320,12 @@ void WebAutomationSession::contextDestroyedForFrame(const WebFrameProxy& frame)
 {
     auto contextHandle = effectiveHandleForWebFrameProxy(frame);
     auto url = frame.url().string();
-    String parentHandle = "null"_s;
+    String parentHandle = nullString();
     if (RefPtr parentFrame = frame.parentFrame())
         parentHandle = effectiveHandleForWebFrameProxy(*parentFrame);
 
-    String clientWindow = "unknown-window"_s;
-    String userContext = "default"_s;
+    String clientWindow = defaultClientWindowID();
+    String userContext = defaultUserContextID();
 
     if (RefPtr page = frame.page()) {
         auto [windowId, contextId] = getClientWindowAndUserContext(*page);
@@ -1234,9 +1333,19 @@ void WebAutomationSession::contextDestroyedForFrame(const WebFrameProxy& frame)
         userContext = contextId;
     }
 
-    m_bidiProcessor->browsingContextDomainNotifier().contextDestroyed(contextHandle, url, "null"_s, parentHandle, JSON::ArrayOf<Inspector::Protocol::BidiBrowsingContext::Info>::create(), clientWindow, userContext);
+    sendBrowsingContextInfoEvent(m_bidiProcessor.get(), "browsingContext.contextDestroyed"_s, contextHandle, url, nullString(), std::optional<String> { WTF::move(parentHandle) }, nullptr, clientWindow, userContext);
 
     // Note: Frame handle cleanup is done by didDestroyFrame(), so we don't duplicate that here
+}
+
+String WebAutomationSession::getUserContextIDForPage(const WebPageProxy& page) const
+{
+    return m_bidiProcessor->browserAgent().getUserContextIDForPage(page);
+}
+
+bool WebAutomationSession::hasUserContextID(const String& userContextID) const
+{
+    return m_bidiProcessor->browserAgent().hasUserContext(userContextID);
 }
 
 #endif
@@ -1248,6 +1357,8 @@ void WebAutomationSession::willClosePage(const WebPageProxy& page)
 
 #if ENABLE(WEBDRIVER_BIDI)
     contextDestroyedForPage(page);
+    m_deferredTopLevelContextCreatedPageIdentifiers.remove(page.identifier());
+    m_pagesHandledByPendingCreateBrowsingContextRequests.remove(page.identifier());
 #endif
 
     // Cancel pending interactions on this page. By providing an error, this will cause subsequent
@@ -2933,8 +3044,6 @@ void WebAutomationSession::logEntryAdded(const JSC::MessageSource& messageSource
     auto type = logEntryTypeForMessage(messageSource);
     auto milliseconds =  timestamp.secondsSinceEpoch().milliseconds();
 
-    // FIXME Get browsing context handle and source info
-    // https://bugs.webkit.org/show_bug.cgi?id=282981
     m_bidiProcessor->logDomainNotifier().entryAdded(level, sourceString, messageText, milliseconds, type, method);
 #else
     UNUSED_PARAM(messageSource);

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.h
@@ -29,7 +29,6 @@
 #include "AutomationBackendDispatchers.h"
 #include "AutomationFrontendDispatchers.h"
 #include "Connection.h"
-#include "FrameTreeNodeData.h"
 #include "MessageReceiver.h"
 #include "MessageSender.h"
 #include "SimulatedInputDispatcher.h"
@@ -42,7 +41,9 @@
 #include <WebCore/ShareableBitmap.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
+#include <wtf/Deque.h>
 #include <wtf/Forward.h>
+#include <wtf/HashSet.h>
 #include <wtf/RunLoop.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WallTime.h>
@@ -171,6 +172,7 @@ public:
     void wheelEventsFlushedForPage(const WebPageProxy&);
 #if ENABLE(WEBDRIVER_BIDI)
     void didCreatePage(WebPageProxy&);
+    void createBrowsingContextForUserContext(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&&, const String& userContextID, Inspector::CommandCallbackOf<String, Inspector::Protocol::Automation::BrowsingContextPresentation>&&);
     void navigationStartedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>);
     void navigationCommittedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>);
     void navigationFailedForFrame(const WebFrameProxy&, std::optional<WebCore::NavigationIdentifier>);
@@ -182,6 +184,10 @@ public:
     void contextCreatedForFrame(const WebFrameProxy&);
     void contextDestroyedForPage(const WebPageProxy&);
     void contextDestroyedForFrame(const WebFrameProxy&);
+    bool hasUserContextID(const String&) const;
+    String getUserContextIDForPage(const WebPageProxy&) const;
+    std::pair<String, String> getClientWindowAndUserContext(const WebPageProxy&) const;
+    void flushDeferredTopLevelContextCreatedEvents();
 #endif
     void willClosePage(const WebPageProxy&);
     void handleRunOpenPanel(const WebPageProxy&, const WebFrameProxy&, const API::OpenPanelParameters&, WebOpenPanelResultListenerProxy&);
@@ -320,6 +326,7 @@ public:
 private:
     Ref<Inspector::Protocol::Automation::BrowsingContext> buildBrowsingContextForPage(WebPageProxy&, WebCore::FloatRect windowFrame);
     void getNextContext(Vector<Ref<WebPageProxy>>&&, Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>, Inspector::CommandCallback<Ref<JSON::ArrayOf<Inspector::Protocol::Automation::BrowsingContext>>>&&);
+    void createBrowsingContextInternal(std::optional<Inspector::Protocol::Automation::BrowsingContextPresentation>&&, const String& userContextIDForBidi, Inspector::CommandCallbackOf<String, Inspector::Protocol::Automation::BrowsingContextPresentation>&&);
 
     std::optional<WebCore::FrameIdentifier> webFrameIDForHandle(const String&, bool& frameNotFound);
 
@@ -335,7 +342,6 @@ private:
     void hideWindowForPage(WebPageProxy&, WTF::CompletionHandler<void()>&&);
 
 #if ENABLE(WEBDRIVER_BIDI)
-    void recursivelyEmitContextCreatedEvent(const FrameTreeNodeData&, std::optional<String>&& parentContext);
     WebPageProxy* getOpenerPage(const WebPageProxy&);
 #endif
 
@@ -394,6 +400,11 @@ private:
 
 #if ENABLE(WEBDRIVER_BIDI)
     const UniqueRef<WebDriverBidiProcessor> m_bidiProcessor;
+    HashSet<WebPageProxyIdentifier> m_pagesWithContextCreatedEventEmitted;
+    HashSet<uint64_t> m_pendingCreateBrowsingContextRequestIdentifiers;
+    HashSet<WebPageProxyIdentifier> m_deferredTopLevelContextCreatedPageIdentifiers;
+    HashSet<WebPageProxyIdentifier> m_pagesHandledByPendingCreateBrowsingContextRequests;
+    uint64_t m_nextCreateBrowsingContextRequestIdentifier { 1 };
 #endif
 
     HashMap<WebPageProxyIdentifier, String> m_webPageHandleMap;

--- a/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp
@@ -27,7 +27,6 @@
 #include "WebDriverBidiProcessor.h"
 
 #include "AutomationBackendDispatchers.h"
-#include <optional>
 
 #if ENABLE(WEBDRIVER_BIDI)
 
@@ -149,6 +148,8 @@ static String toBidiErrorCode(int errorCode, const String& inspectorInternalMsg)
         return "unable to unload extension"_s;
     case Inspector::Protocol::Automation::ErrorMessage::NoSuchExtension:
         return "no such web extension"_s;
+    case Inspector::Protocol::Automation::ErrorMessage::NoSuchUserContext:
+        return "no such user context"_s;
     default:
         return "unknown error"_s;
     }

--- a/WebDriverTests/TestExpectations.json
+++ b/WebDriverTests/TestExpectations.json
@@ -2002,30 +2002,21 @@
     "imported/w3c/webdriver/tests/bidi/browser/get_client_windows/get_client_windows.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288106"}}
     },
-    "imported/w3c/webdriver/tests/bidi/browser/get_user_contexts/get_user_contexts.py": {
+    "imported/w3c/webdriver/tests/bidi/browser/remove_user_context/user_context.py": {
         "subtests": {
-            "test_default": {
-                "expected": { "all": { "status": ["PASS"]}}
+            "test_remove_context_closes_contexts[tab]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108"}}
             },
-            "test_create_remove_contexts": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288107", "note": "False PASS, Error on the teardown fixture, given we don't support user contexts."}}
-            }
-        }
-    },
-    "imported/w3c/webdriver/tests/bidi/browser/remove_user_context/invalid.py": {
-        "subtests": {
-            "test_params_user_context_no_such_user_context": {
+            "test_remove_context_closes_contexts[window]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108"}}
+            },
+            "test_remove_context_skips_beforeunload_prompt[tab]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108"}}
+            },
+            "test_remove_context_skips_beforeunload_prompt[window]": {
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108"}}
             }
         }
-    },
-    "imported/w3c/webdriver/tests/bidi/browser/remove_user_context/user_context.py": {
-        "subtests": {
-            "test_remove_context": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108", "note": "False PASS. Error on the teardown fixture, given we don't support user contexts."}}
-            }
-        },
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/288108"}}
     },
     "imported/w3c/webdriver/tests/bidi/browser/set_download_behavior/download_behavior_allowed.py": {
         "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/303204"}}
@@ -2116,12 +2107,6 @@
             "test_existing_context_via_user_context[window]": {
                 "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
             },
-            "test_event_emitted_before_create_returns[tab]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
-            },
-            "test_event_emitted_before_create_returns[window]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
-            },
             "test_navigate_creates_iframes": {
                 "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
             },
@@ -2129,12 +2114,6 @@
                 "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
             },
             "test_subscribe_to_one_context": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
-            },
-            "test_new_user_context[tab]": {
-                "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
-            },
-            "test_new_user_context[window]": {
                 "expected": { "all": { "status": ["SKIP"], "bug": "webkit.org/b/288335"}}
             }
         }
@@ -2241,23 +2220,28 @@
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/create/background.py": {
         "subtests": {
+            "test_background_default_false[tab]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+            },
             "test_background[True-tab]": {
-                "expected": { "wpe": { "status": ["PASS"] } }
+                "expected": {
+                    "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"},
+                    "wpe": { "status": ["PASS"] }
+                }
             },
             "test_background[True-window]": {
-                "expected": { "wpe": { "status": ["PASS"] } }
+                "expected": {
+                    "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"},
+                    "wpe": { "status": ["PASS"] }
+                }
+            },
+            "test_background[False-tab]": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
             }
-        },
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/create/invalid.py": {
         "subtests": {
-            "test_params_reference_context_invalid_value": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
-            },
-            "test_params_reference_context_non_top_level": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
-            },
             "test_params_type_invalid_value[]": {
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
             },
@@ -2266,28 +2250,8 @@
             },
             "test_params_user_context_invalid_value[]": {
                 "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
-            },
-            "test_params_user_context_invalid_value[unknown]": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
-            },
-            "test_params_user_context_invalid_value_with_ref_context": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
-            },
-            "test_params_user_context_removed_context": {
-                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
             }
         }
-    },
-    "imported/w3c/webdriver/tests/bidi/browsing_context/create/reference_context.py": {
-        "subtests": {
-            "test_reference_context[tab]": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/303210"}}
-            },
-            "test_reference_context[window]": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/303210"}}
-            }
-        },
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/create/type.py": {
         "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
@@ -2297,14 +2261,10 @@
             "test_user_context_default": {
                 "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/303210"}}
             },
-            "test_user_context[tab]": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/303210"}}
-            },
-            "test_user_context[window]": {
-                "expected": { "all": { "status": ["TIMEOUT"], "bug": "webkit.org/b/303210"}}
+            "test_user_context_nested_iframes": {
+                "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
             }
-        },
-        "expected": { "all": { "status": ["FAIL"], "bug": "webkit.org/b/286790"}}
+        }
     },
     "imported/w3c/webdriver/tests/bidi/browsing_context/dom_content_loaded/dom_content_loaded.py": {
         "subtests": {


### PR DESCRIPTION
#### b0d012c08130243439cfe6d73661e61959ecb2b1
<pre>
[WebDriver][BiDi] browsingContext.create should preserve user context metadata and emit stable top-level contextCreated events
<a href="https://bugs.webkit.org/show_bug.cgi?id=286790.">https://bugs.webkit.org/show_bug.cgi?id=286790.</a>

Reviewed by NOBODY (OOPS!).

This change completes the user-context foundation around
`browsingContext.create`. The create command now derives the effective user
context from either `userContext` or `referenceContext`, creates the new
top-level context with that user context, and reports matching `userContext`
and `clientWindow` metadata in browsing-context tree results and lifecycle
events.

It also emits the top-level `browsingContext.contextCreated` event exactly
once and before the create command returns, and normalizes nullable event
fields in the outgoing protocol payload. With create flow and event metadata
aligned, stale expectations for now-passing `create` and `context_created`
tests can be removed.

Test: Tools/Scripts/run-webdriver-tests --gtk imported/w3c/webdriver/tests/bidi/browsing_context/create imported/w3c/webdriver/tests/bidi/
browsing_context/context_created

* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.cpp:
(WebKit::BidiBrowserAgent::didCreatePage):
(WebKit::BidiBrowserAgent::willClosePage):
(WebKit::BidiBrowserAgent::hasUserContext): Added.
(WebKit::BidiBrowserAgent::setUserContextIDForPage): Added.
(WebKit::BidiBrowserAgent::getUserContextIDForPage): Added.
Track per-page user-context overrides so page creation, teardown, and event
reporting agree on the effective user context.

* Source/WebKit/UIProcess/Automation/BidiBrowserAgent.h:
Add helpers and storage for per-page user-context overrides.

* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.cpp:
(WebKit::BidiBrowsingContextAgent::create):
(WebKit::BidiBrowsingContextAgent::getNavigableInfo):
Derive the effective user context for `browsingContext.create`, validate it,
and use page metadata when building browsing-context tree results.

* Source/WebKit/UIProcess/Automation/BidiBrowsingContextAgent.h:
Pass the owning page through `getNavigableInfo`.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::createBrowsingContext):
(WebKit::WebAutomationSession::createBrowsingContextForUserContext): Added.
(WebKit::WebAutomationSession::createBrowsingContextInternal): Added.
(WebKit::WebAutomationSession::didCreatePage):
(WebKit::WebAutomationSession::emitContextCreatedEvent):
(WebKit::WebAutomationSession::getClientWindowAndUserContext): Added.
(WebKit::WebAutomationSession::getUserContextIDForPage): Added.
(WebKit::WebAutomationSession::hasUserContextID): Added.
Create pages in the requested user context, preserve pending user-context
assignments during page creation, and emit top-level `contextCreated` events
once with stable ordering.

* Source/WebKit/UIProcess/Automation/WebAutomationSession.h:
Add helpers and tracking for user-context-aware page creation and one-shot
top-level `contextCreated` emission.

* Source/WebKit/UIProcess/Automation/WebDriverBidiProcessor.cpp:
(WebKit::normalizeBrowsingContextInfoEvent): Added.
Normalize internal `&quot;null&quot;` placeholders and empty children payloads into the
JSON shape expected by BiDi events.

* WebDriverTests/TestExpectations.json:
Remove stale expectations for `browsing_context/create` and
`browsing_context/context_created` tests that now pass, and keep only the
remaining expected failures
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54b2def7a4eec92958ba90fba571e1e38d0430f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23342 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/16910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104018 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116210 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82550 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153544 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18319 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/96938 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17418 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15367 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7154 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127032 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161780 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/4900 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14569 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124208 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19414 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124406 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134811 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/79521 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19495 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11571 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86544 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22458 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22610 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22512 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->