### PR TITLE
[Smart Lists] Backspace on first bullet should remove list formatting and keep - or •

### DIFF
--- a/Source/WebCore/editing/CompositeEditCommand.h
+++ b/Source/WebCore/editing/CompositeEditCommand.h
@@ -216,9 +216,12 @@ protected:
     void moveParagraphWithClones(const VisiblePosition& startOfParagraphToMove, const VisiblePosition& endOfParagraphToMove, Element* blockElement, Node* outerNode);
     void cloneParagraphUnderNewElement(const Position& start, const Position& end, Node* outerNode, Element* blockElement);
     void cleanupAfterDeletion(VisiblePosition destination = VisiblePosition());
-    
+
+    enum class ReconstitutePlainTextListIfNeeded : bool { No, Yes };
+
     VisibleSelection shouldBreakOutOfEmptyListItem() const;
-    bool breakOutOfEmptyListItem();
+    bool hasSmartListMarkerAttribute() const;
+    bool breakOutOfEmptyListItem(ReconstitutePlainTextListIfNeeded = ReconstitutePlainTextListIfNeeded::No);
     bool breakOutOfEmptyMailBlockquotedParagraph();
     
     Position positionAvoidingSpecialElementBoundary(const Position&);

--- a/Source/WebCore/editing/InsertTextCommand.cpp
+++ b/Source/WebCore/editing/InsertTextCommand.cpp
@@ -179,7 +179,7 @@ bool InsertTextCommand::applySmartListsIfNeeded()
         return false;
     }
 
-    auto attributes = nodeAttributesForSmartList(*listElement, *smartList);
+    auto attributes = nodeAttributesForSmartList(*listElement, *smartList, lineText);
     for (const auto& [attribute, value] : attributes)
         setNodeAttribute(*listElement, attribute, value);
 

--- a/Source/WebCore/editing/TextListParser.cpp
+++ b/Source/WebCore/editing/TextListParser.cpp
@@ -220,8 +220,10 @@ std::optional<TextList> parseTextList(StringView input)
     });
 }
 
-Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(const StyledElement& element, const TextList& list)
+Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(const StyledElement& element, const TextList& list, const String& input)
 {
+    ASSERT(!input.isEmpty());
+
     Vector<std::pair<const QualifiedName&, AtomString>> result;
 
     if (auto start = startingOrdinalForList(element, list); !start.isNull())
@@ -232,6 +234,12 @@ Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(c
 
     if (auto className = classNameForSmartList(list); !className.isNull())
         result.append({ HTMLNames::classAttr, className });
+
+    // The conversion from plain-text list markers (like "*") to styled list markers may be lossy
+    // as there is not a 1:1 relationship. Therefore, this is needed so that the original
+    // plain-text list can be reconstituted if needed. See `CompositeEditCommand::breakOutOfEmptyListItem`
+    // for more details.
+    result.append({ HTMLNames::webkitsmartlistmarkerAttr, AtomString { input } });
 
     return result;
 }

--- a/Source/WebCore/editing/TextListParser.h
+++ b/Source/WebCore/editing/TextListParser.h
@@ -37,7 +37,7 @@ class VisibleSelection;
 
 std::optional<TextList> parseTextList(StringView);
 
-Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(const StyledElement&, const TextList&);
+Vector<std::pair<const QualifiedName&, AtomString>> nodeAttributesForSmartList(const StyledElement&, const TextList&, const String& input);
 
 bool selectionAllowsSmartLists(const String&, const VisibleSelection&);
 

--- a/Source/WebCore/editing/TypingCommand.cpp
+++ b/Source/WebCore/editing/TypingCommand.cpp
@@ -682,11 +682,11 @@ void TypingCommand::deleteKeyPressed(TextGranularity granularity, bool shouldAdd
         const VisiblePosition& previousPosition = visibleStart.previous(CannotCrossEditingBoundary);
         RefPtr enclosingTableCell = enclosingNodeOfType(visibleStart.deepEquivalent(), &isTableCell);
         RefPtr enclosingTableCellForPreviousPosition = enclosingNodeOfType(previousPosition.deepEquivalent(), &isTableCell);
-        if (previousPosition.isNull() || enclosingTableCell != enclosingTableCellForPreviousPosition) {
+        if (previousPosition.isNull() || enclosingTableCell != enclosingTableCellForPreviousPosition || hasSmartListMarkerAttribute()) {
             // When the caret is at the start of the editable area in an empty list item, break out of the list item.
             if (auto deleteListSelection = shouldBreakOutOfEmptyListItem(); !deleteListSelection.isNone()) {
                 if (willAddTypingToOpenCommand(Type::DeleteKey, granularity, { }, deleteListSelection.firstRange())) {
-                    breakOutOfEmptyListItem();
+                    breakOutOfEmptyListItem(ReconstitutePlainTextListIfNeeded::Yes);
                     typingAddedToOpenCommand(Type::DeleteKey);
                 }
                 return;

--- a/Source/WebCore/html/HTMLAttributeNames.in
+++ b/Source/WebCore/html/HTMLAttributeNames.in
@@ -447,6 +447,7 @@ webkitattachmentid
 webkitattachmentpath
 webkitdirectory
 webkitdropzone
+webkitsmartlistmarker
 width
 wrap
 writingsuggestions

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.h
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.h
@@ -60,6 +60,8 @@ NS_SWIFT_UI_ACTOR
 
 + (void)processConfiguration:(SmartListsTestConfiguration *)configuration completionHandler:(NS_SWIFT_UI_ACTOR void(^)(SmartListsTestResult * NS_NULLABLE_RESULT, NSError * _Nullable))completionHandler;
 
++ (void)testBackspaceWithInvalidWebKitSmartListMarkerAttributeDoesNotApplyWithCompletionHandler:(NS_SWIFT_UI_ACTOR void(^)(SmartListsTestResult * NS_NULLABLE_RESULT, NSError * _Nullable))completionHandler;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Tools/TestWebKitAPI/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/WebPage+Extras.swift
@@ -27,8 +27,13 @@ import Foundation
 @_spi(Testing) @_spi(CrossImportOverlay) import WebKit
 import WebKit_Private.WKPreferencesPrivate
 import WebKit_Private.WKWebViewPrivateForTesting
+import WebKit_Private.WKWebViewPrivate
 
 extension WebPage {
+    enum EditCommand: String {
+        case deleteBackward = "DeleteBackward"
+    }
+
     func waitForNextPresentationUpdate() async {
         await withCheckedContinuation { continuation in
             backingWebView._do(afterNextPresentationUpdate: {
@@ -56,6 +61,11 @@ extension WebPage {
         backingWebView.textInputContentView.insertText(text)
         #endif
         await waitForNextPresentationUpdate()
+    }
+
+    func executeEditCommand(_ command: EditCommand, with argument: String? = nil) async {
+        let success = await backingWebView._executeEditCommand(command.rawValue, argument: argument)
+        assert(success)
     }
 }
 


### PR DESCRIPTION
#### 7eb9a7614adf95c3595df8a9e41987148b42ad88
<pre>
[Smart Lists] Backspace on first bullet should remove list formatting and keep - or •
<a href="https://bugs.webkit.org/show_bug.cgi?id=307309">https://bugs.webkit.org/show_bug.cgi?id=307309</a>
<a href="https://rdar.apple.com/168767896">rdar://168767896</a>

Reviewed by Tim Horton.

Currently, when performing a backspace within an empty list item, the list formatting goes away. This is consistent
with system behavior. However, this is undesirable when the list is a Smart List, since then there is no way to
preserve the plain text list markers like &quot;*&quot; for example.

Tests: Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm
       Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.swift
       Tools/TestWebKitAPI/WebPage+Extras.swift

* Source/WebCore/editing/CompositeEditCommand.cpp:
(WebCore::CompositeEditCommand::moveParagraphs):
* Source/WebCore/editing/CompositeEditCommand.h:

- Add a function to determine if the enclosing list has a smart list marker attribute to determine if
the original plain text marker needs to be re-made when needed.

- Modify `breakOutOfEmptyListItem` to re-make the plain text list if one exists, predicated on the
`reconstitutePlainTextListIfNeeded` parameter. This parameter is needed since the desired behavior
is for the plain text list to be re-made only on backspace, and not in other scenerios where `breakOutOfEmptyListItem`
is called, such as when a new paragraph is created.

* Source/WebCore/editing/InsertTextCommand.cpp:
(WebCore::InsertTextCommand::applySmartListsIfNeeded):
* Source/WebCore/editing/TextListParser.cpp:
(WebCore::nodeAttributesForSmartList):
* Source/WebCore/editing/TextListParser.h:

Store the plain text marker used to make the Smart List in an HTML attribute.

* Source/WebCore/editing/TypingCommand.cpp:
(WebCore::TypingCommand::deleteKeyPressed):

When backspacing inside an empty list item, in addition to breaking out of the list, also re-make the original plain text
list marker if needed.

* Source/WebCore/html/HTMLAttributeNames.in:

Add a new custom HTML attribute to preserve the plain text symbol used to create the Smart List.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartLists.mm:
((SmartLists, BackspaceOnEmptyListElementShouldKeepPlainTextMarkers)):
((SmartLists, BackspaceOnEmptyNonFirstListElementShouldKeepPlainTextMarkers)):
((SmartLists, NewlineOnEmptyListElementShouldRemovePlainTextMarkers)):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/SmartListsSupport.swift:
(SmartListsSupport.processConfiguration(_:)):
* Tools/TestWebKitAPI/WebPage+Extras.swift:
(executeEditCommand(_:with:)):
(WebPage.waitForNextPresentationUpdate): Deleted.
(WebPage.setWebFeature(_:enabled:)): Deleted.

Tests and test infrastructure support.

Canonical link: <a href="https://commits.webkit.org/307373@main">https://commits.webkit.org/307373@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c9a1875abcdbd6e362b9478571da64f4a8698398

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144165 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8400 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152835 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97404 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5283f84a-b112-4b3d-b4c7-ff8727cbf4e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146040 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17326 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16738 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110854 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1e97d73-34b9-42cd-9e4f-ae014b57b6cb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13272 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129527 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91772 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2bde300-9a7c-4def-a037-ca9aaefef984) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12714 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10460 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/281 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122204 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155147 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16696 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118871 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16733 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14020 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119229 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15112 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72117 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16318 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5829 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16052 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80097 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->