### PR TITLE
AX: Add AXTreeID type for type-safe tree identification

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -2078,13 +2078,10 @@ Color defaultColor()
     return color.get();
 }
 
-bool performCustomActionPress(std::optional<AXID> treeID, AXID targetID)
+bool performCustomActionPress(AXTreeID treeID, AXID targetID)
 {
-    if (!treeID)
-        return false;
-
     return retrieveValueFromMainThreadWithTimeoutAndDefault([treeID, targetID] () -> bool {
-        if (WeakPtr<AXObjectCache> cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(*treeID)) {
+        if (WeakPtr<AXObjectCache> cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(treeID)) {
             if (RefPtr object = cache->objectForID(targetID))
                 return object->press();
         }

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -478,7 +478,7 @@ public:
     String debugDescription(OptionSet<AXDebugStringOption> options) const { return debugDescriptionInternal(false, { options }); }
 
     inline AXID objectID() const { return m_id; }
-    virtual std::optional<AXID> treeID() const = 0;
+    virtual std::optional<AXTreeID> treeID() const = 0;
     virtual ProcessID processID() const = 0;
 
     // When the corresponding WebCore object that this accessible object
@@ -1817,7 +1817,7 @@ Color defaultColor();
 
 // Performs a press action on the target object identified by treeID and targetID.
 // Handles the tree lookup and main thread execution. Returns true if the press succeeded.
-bool performCustomActionPress(std::optional<AXID> treeID, AXID targetID);
+bool performCustomActionPress(AXTreeID, AXID targetID);
 
 // Intended to work with size-types (like IntSize) or rect-types (like LayoutRect).
 template <typename SizeOrRectType>

--- a/Source/WebCore/accessibility/AXID.h
+++ b/Source/WebCore/accessibility/AXID.h
@@ -32,4 +32,7 @@ namespace WebCore {
 enum class AXIDType { };
 using AXID = ObjectIdentifier<AXIDType>;
 
+enum class AXTreeIDType { };
+using AXTreeID = ObjectIdentifier<AXTreeIDType>;
+
 } // namespace WebCore

--- a/Source/WebCore/accessibility/AXTextMarker.cpp
+++ b/Source/WebCore/accessibility/AXTextMarker.cpp
@@ -319,7 +319,7 @@ AXTextMarkerRange::AXTextMarkerRange(AXTextMarker&& start, AXTextMarker&& end)
     m_end = reverse ? WTF::move(start) : WTF::move(end);
 }
 
-AXTextMarkerRange::AXTextMarkerRange(std::optional<AXID> treeID, std::optional<AXID> objectID, unsigned start, unsigned end)
+AXTextMarkerRange::AXTextMarkerRange(std::optional<AXTreeID> treeID, std::optional<AXID> objectID, unsigned start, unsigned end)
 {
     if (start > end)
         std::swap(start, end);

--- a/Source/WebCore/accessibility/AXTextMarker.h
+++ b/Source/WebCore/accessibility/AXTextMarker.h
@@ -178,7 +178,7 @@ struct TextMarkerData {
         zeroBytes(*this);
     }
 
-    TextMarkerData(std::optional<AXID> axTreeID, std::optional<AXID> axObjectID,
+    TextMarkerData(std::optional<AXTreeID> axTreeID, std::optional<AXID> axObjectID,
         unsigned offsetParam = 0,
         Position::AnchorType anchorTypeParam = Position::PositionIsOffsetInAnchor,
         Affinity affinityParam = Affinity::Downstream,
@@ -201,9 +201,9 @@ struct TextMarkerData {
 
     friend bool operator==(const TextMarkerData&, const TextMarkerData&) = default;
 
-    std::optional<AXID> axTreeID() const
+    std::optional<AXTreeID> axTreeID() const
     {
-        return treeID ? std::optional { ObjectIdentifier<AXIDType>(treeID) } : std::nullopt;
+        return treeID ? std::optional { ObjectIdentifier<AXTreeIDType>(treeID) } : std::nullopt;
     }
 
     std::optional<AXID> axObjectID() const
@@ -236,7 +236,7 @@ public:
 #if PLATFORM(COCOA)
     AXTextMarker(PlatformTextMarkerData);
 #endif
-    AXTextMarker(std::optional<AXID> treeID, std::optional<AXID> objectID, unsigned offset, TextMarkerOrigin origin = TextMarkerOrigin::Unknown)
+    AXTextMarker(std::optional<AXTreeID> treeID, std::optional<AXID> objectID, unsigned offset, TextMarkerOrigin origin = TextMarkerOrigin::Unknown)
         : m_data({ treeID, objectID, offset, Position::PositionIsOffsetInAnchor, Affinity::Downstream, 0, offset, false, origin })
     { }
     AXTextMarker(const AXCoreObject& object, unsigned offset, TextMarkerOrigin origin = TextMarkerOrigin::Unknown)
@@ -257,7 +257,7 @@ public:
     operator PlatformTextMarkerData() const { return platformData().autorelease(); }
 #endif
 
-    std::optional<AXID> treeID() const { return m_data.axTreeID(); }
+    std::optional<AXTreeID> treeID() const { return m_data.axTreeID(); }
     std::optional<AXID> objectID() const { return m_data.axObjectID(); }
     unsigned offset() const { return m_data.offset; }
     bool isNull() const { return !treeID() || !objectID(); }
@@ -387,8 +387,8 @@ public:
 #if PLATFORM(MAC)
     AXTextMarkerRange(AXTextMarkerRangeRef);
 #endif
-    AXTextMarkerRange(std::optional<AXID> treeID, std::optional<AXID> objectID, const CharacterRange&);
-    AXTextMarkerRange(std::optional<AXID> treeID, std::optional<AXID> objectID, unsigned offset, unsigned length);
+    AXTextMarkerRange(std::optional<AXTreeID>, std::optional<AXID>, const CharacterRange&);
+    AXTextMarkerRange(std::optional<AXTreeID>, std::optional<AXID>, unsigned offset, unsigned length);
     AXTextMarkerRange() = default;
 
     operator bool() const { return m_start && m_end; }
@@ -435,7 +435,7 @@ private:
     AXTextMarker m_end;
 };
 
-inline AXTextMarkerRange::AXTextMarkerRange(std::optional<AXID> treeID, std::optional<AXID> objectID, const CharacterRange& range)
+inline AXTextMarkerRange::AXTextMarkerRange(std::optional<AXTreeID> treeID, std::optional<AXID> objectID, const CharacterRange& range)
     : AXTextMarkerRange(treeID, objectID, range.location, range.location + range.length)
 { }
 

--- a/Source/WebCore/accessibility/AXTreeStore.h
+++ b/Source/WebCore/accessibility/AXTreeStore.h
@@ -53,7 +53,7 @@ using AXTreeWeakPtr = Variant<WeakPtr<AXObjectCache>
 #endif
 >;
 
-AXTreePtr axTreeForID(AXID);
+AXTreePtr axTreeForID(std::optional<AXTreeID>);
 WEBCORE_EXPORT AXTreePtr findAXTree(Function<bool(AXTreePtr)>&&);
 
 template<typename T>
@@ -64,42 +64,41 @@ class AXTreeStore {
     WTF_MAKE_NONCOPYABLE(AXTreeStore);
     friend WEBCORE_EXPORT AXTreePtr findAXTree(Function<bool(AXTreePtr)>&&);
 public:
-    AXID treeID() const { return m_id; }
-    inline static WeakPtr<AXObjectCache> axObjectCacheForID(std::optional<AXID>);
-    inline static WeakPtr<AXObjectCache> axObjectCacheForID(AXID);
+    AXTreeID treeID() const { return m_id; }
+    inline static WeakPtr<AXObjectCache> axObjectCacheForID(std::optional<AXTreeID>);
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    static RefPtr<AXIsolatedTree> isolatedTreeForID(std::optional<AXID>);
+    static RefPtr<AXIsolatedTree> isolatedTreeForID(std::optional<AXTreeID>);
     static void applyPendingChangesForAllIsolatedTrees();
 #endif
 
 protected:
-    AXTreeStore(AXID axID = generateNewID())
-        : m_id(axID)
+    AXTreeStore(AXTreeID treeID = generateNewID())
+        : m_id(treeID)
     { }
 
-    inline static void set(AXID, const AXTreeWeakPtr&);
-    inline static void add(AXID, const AXTreeWeakPtr&);
-    inline static void remove(AXID);
-    inline static bool contains(AXID);
+    inline static void set(AXTreeID, const AXTreeWeakPtr&);
+    inline static void add(AXTreeID, const AXTreeWeakPtr&);
+    inline static void remove(AXTreeID);
+    inline static bool contains(AXTreeID);
 
-    inline static AXID generateNewID();
-    const AXID m_id;
+    inline static AXTreeID generateNewID();
+    const AXTreeID m_id;
     static Lock s_storeLock;
 private:
-    inline static HashMap<AXID, WeakPtr<AXObjectCache>>& liveTreeMap();
+    inline static HashMap<AXTreeID, WeakPtr<AXObjectCache>>& liveTreeMap();
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    inline static HashMap<AXID, ThreadSafeWeakPtr<AXIsolatedTree>>& isolatedTreeMap() WTF_REQUIRES_LOCK(s_storeLock);
+    inline static HashMap<AXTreeID, ThreadSafeWeakPtr<AXIsolatedTree>>& isolatedTreeMap() WTF_REQUIRES_LOCK(s_storeLock);
 #endif
 };
 
 template<typename T>
-inline AXID AXTreeStore<T>::generateNewID()
+inline AXTreeID AXTreeStore<T>::generateNewID()
 {
     AX_ASSERT(isMainThread());
 
-    std::optional<AXID> axID;
+    std::optional<AXTreeID> axID;
     do {
-        axID = AXID::generate();
+        axID = AXTreeID::generate();
     } while (liveTreeMap().contains(*axID));
     return *axID;
 }

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -74,7 +74,7 @@ class AccessibilityObject : public AXCoreObject {
 public:
     virtual ~AccessibilityObject();
 
-    std::optional<AXID> treeID() const final;
+    std::optional<AXTreeID> treeID() const final;
     String debugDescriptionInternal(bool, std::optional<OptionSet<AXDebugStringOption>> = std::nullopt) const final;
     virtual String extraDebugInfo() const { return emptyString(); }
 

--- a/Source/WebCore/accessibility/AccessibilityObjectInlines.h
+++ b/Source/WebCore/accessibility/AccessibilityObjectInlines.h
@@ -298,7 +298,7 @@ inline void AccessibilityObject::initializeAncestorFlags(const OptionSet<AXAnces
     m_ancestorFlags.add(flags);
 }
 
-inline std::optional<AXID> AccessibilityObject::treeID() const
+inline std::optional<AXTreeID> AccessibilityObject::treeID() const
 {
     auto* cache = axObjectCache();
     return cache ? std::optional { cache->treeID() } : std::nullopt;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -57,7 +57,7 @@ public:
     ~AXIsolatedObject();
 
     // FIXME: tree()->treeID() is never optional, so this shouldn't return an optional either.
-    std::optional<AXID> treeID() const final { return tree()->treeID(); }
+    std::optional<AXTreeID> treeID() const final { return tree()->treeID(); }
     String debugDescriptionInternal(bool, std::optional<OptionSet<AXDebugStringOption>> = std::nullopt) const final;
 
     void updateFromData(IsolatedObjectData&&);

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -511,7 +511,7 @@ public:
     WEBCORE_EXPORT void applyPendingChanges();
     void applyPendingChangesUnlessQueuedForDestruction();
 
-    constexpr AXID treeID() const { return m_id; }
+    constexpr AXTreeID treeID() const { return m_id; }
     constexpr ProcessID processID() const { return m_processID; }
     void setPageActivityState(OptionSet<ActivityState>);
     OptionSet<ActivityState> pageActivityState() const;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.h
@@ -51,7 +51,7 @@ class VisiblePosition;
 struct CustomActionData {
     String name;
     AXID targetID;
-    std::optional<AXID> treeID;
+    AXTreeID treeID;
 };
 
 // NSAttributedString support.

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperBase.mm
@@ -789,7 +789,8 @@ std::optional<SimpleRange> makeDOMRange(Document* document, NSRange range)
         if (actionName.isEmpty())
             continue;
 
-        result.append({ WTF::move(actionName), actionElement->objectID(), backingObject->treeID() });
+        if (std::optional treeID = backingObject->treeID())
+            result.append({ WTF::move(actionName), actionElement->objectID(), *treeID });
     }
 
     return result;

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -67,6 +67,7 @@ header: <wtf/JSONValues.h>
 header: <wtf/ObjectIdentifier.h>
 template: class WebKit::WebURLSchemeHandler
 template: enum class WebCore::AXIDType
+template: enum class WebCore::AXTreeIDType
 template: struct WebCore::BackgroundFetchRecordIdentifierType
 template: struct WebCore::NodeIdentifierType
 template: struct WebCore::JSHandleIdentifierType


### PR DESCRIPTION
#### d498a35a268343ed3473b6b510f397a509c22daa
<pre>
AX: Add AXTreeID type for type-safe tree identification
<a href="https://bugs.webkit.org/show_bug.cgi?id=307311">https://bugs.webkit.org/show_bug.cgi?id=307311</a>
<a href="https://rdar.apple.com/169944533">rdar://169944533</a>

Reviewed by Joshua Hoffman.

Previously, tree IDs and object IDs both used the AXID type, which meant
the compiler couldn&apos;t catch mistakes where an objectID was passed to a
function expecting a treeID.

This patch introduces a separate AXTreeID type (using ObjectIdentifier
with a distinct tag type) to provide compile-time safety when working
with tree identifiers.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXID.h:
* Source/WebCore/accessibility/AXTextMarker.cpp:
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
* Source/WebCore/accessibility/AXTextMarker.h:
(WebCore::TextMarkerData::TextMarkerData):
(WebCore::TextMarkerData::axTreeID const):
(WebCore::AXTextMarker::AXTextMarker):
(WebCore::AXTextMarker::treeID const):
(WebCore::AXTextMarkerRange::AXTextMarkerRange):
* Source/WebCore/accessibility/AXTreeStore.h:
(WebCore::AXTreeStore::treeID const):
(WebCore::AXTreeStore::AXTreeStore):
(WebCore::AXTreeStore&lt;T&gt;::generateNewID):
* Source/WebCore/accessibility/AXTreeStoreInlines.h:
(WebCore::AXTreeStore&lt;T&gt;::set):
(WebCore::AXTreeStore&lt;T&gt;::add):
(WebCore::AXTreeStore&lt;T&gt;::remove):
(WebCore::AXTreeStore&lt;T&gt;::contains):
(WebCore::AXTreeStore&lt;T&gt;::axObjectCacheForID):
(WebCore::AXTreeStore&lt;T&gt;::isolatedTreeForID):
(WebCore::AXTreeStore&lt;T&gt;::liveTreeMap):
(WebCore::AXTreeStore&lt;T&gt;::isolatedTreeMap):
(WebCore::axTreeForID):
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityObjectInlines.h:
(WebCore::AccessibilityObject::treeID const):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::treeID const):

Canonical link: <a href="https://commits.webkit.org/307610@main">https://commits.webkit.org/307610@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/368a544a12c8009ec237e075fd7b044fd9edf7c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144849 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9250 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98484 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f5950ae-450e-4c33-9381-f3e6a3eefaf7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146724 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17422 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111374 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79825 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd749f38-a4c1-4761-a6d1-43dd40f61a3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130077 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92269 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17a3af38-8b7c-4dff-b00a-4c6bd072e0f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13110 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10863 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/965 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122625 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155832 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17380 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7909 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119377 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119705 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30710 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15509 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128079 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72943 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17002 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6377 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16738 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80781 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16947 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16802 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->