### PR TITLE
REGRESSION (304761@main): Unable to select text and scroll while dragging

### DIFF
--- a/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
+++ b/Source/WebCore/platform/mac/PlatformEventFactoryMac.mm
@@ -153,8 +153,6 @@ MouseButton mouseButtonForEvent(NSEvent *event)
         return buttonFromButtonNumber(event);
     case NSEventTypeMouseEntered:
     case NSEventTypeMouseExited:
-    case NSEventTypeMouseMoved:
-        return MouseButton::None;
     case NSEventTypePressure:
         return currentMouseButton();
     default:

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h
@@ -929,6 +929,7 @@ typedef NS_OPTIONS(NSUInteger, _WKWebViewDataType) {
 
 - (void)_simulateMouseMove:(NSEvent *)event WK_API_AVAILABLE(macos(13.0));
 - (void)_simulateMouseEnter:(NSEvent *)event WK_API_AVAILABLE(macos(15.0));
+- (void)_simulateMouseExit:(NSEvent *)event WK_API_AVAILABLE(macos(WK_MAC_TBA));
 
 - (void)_setFont:(NSFont *)font sender:(id)sender WK_API_AVAILABLE(macos(13.3));
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -2127,6 +2127,11 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _impl->mouseEntered(event);
 }
 
+- (void)_simulateMouseExit:(NSEvent *)event
+{
+    _impl->mouseExited(event);
+}
+
 - (void)_setFont:(NSFont *)font sender:(id)sender
 {
     _impl->setFontForWebView(font, sender);


### PR DESCRIPTION
#### 4be0e16798850bcc12eac7486bdcaf87c8fa6856
<pre>
REGRESSION (304761@main): Unable to select text and scroll while dragging
<a href="https://bugs.webkit.org/show_bug.cgi?id=307312">https://bugs.webkit.org/show_bug.cgi?id=307312</a>
<a href="https://rdar.apple.com/169571126">rdar://169571126</a>

Reviewed by Richard Robinson.

In 304761@main, `mouseButtonForEvent(NSEvent *event)` was changed to return
`MouseButton::None` for `NSEventTypeMouseEntered` and `NSEventTypeMouseExited`.
As a result, a left click drag which leaves the window will cause an exit event
to be created, for which we incorrectly identify the mouse button as
`MouseButton::None` during processing, and thus behave as if the mouse was
released. Fix this by simply restoring the previous return values for
`NSEventTypeMouseEntered` and `NSEventTypeMouseExited`.

Test: Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm

* Source/WebCore/platform/mac/PlatformEventFactoryMac.mm:
(WebCore::mouseButtonForEvent):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivate.h:
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _simulateMouseExit:]):
* Tools/TestWebKitAPI/Tests/mac/MouseEventTests.mm:
(TestWebKitAPI::TEST(MouseEventTests, AutoscrollOnMouseDragBelowWindow)):

Canonical link: <a href="https://commits.webkit.org/307090@main">https://commits.webkit.org/307090@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/25f64e3c31870d5d84b8d55f30aa3cdc13d6cd58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143275 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15750 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/6954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96496 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72b122ac-fe4a-4b28-8750-23524200aff0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145142 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110190 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79331 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c299907-8c60-42d2-afcf-796390b1ec2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91100 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3973c622-5c6c-41bc-a491-bbfb9ce963c6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12118 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9832 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1948 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121549 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/4914 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154262 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15794 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/5906 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118208 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118548 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30389 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14485 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126106 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71189 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15419 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/4741 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15153 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79139 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15364 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15215 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->