### PR TITLE
[WebGL] Prevent READ_FRAMEBUFFER operations from corrupting DRAW_FRAMEBUFFER state

### DIFF
--- a/LayoutTests/webgl/draw-framebuffer-state-sync-on-bind-expected.txt
+++ b/LayoutTests/webgl/draw-framebuffer-state-sync-on-bind-expected.txt
@@ -1,0 +1,34 @@
+Test that draw buffer state is properly synced when framebuffer is bound to DRAW after modifications while bound to READ.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 19 PASS, 0 FAIL
+
+
+Test 1: Detach while bound to READ_FRAMEBUFFER, then rebind to DRAW_FRAMEBUFFER
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.COLOR_ATTACHMENT0
+PASS gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER) is gl.FRAMEBUFFER_COMPLETE
+PASS getError was expected value: NO_ERROR : setup should succeed
+PASS getError was expected value: NO_ERROR : detach while bound to READ should succeed
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.COLOR_ATTACHMENT0
+PASS gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER) is gl.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT
+
+Test 2: Attach while bound to READ_FRAMEBUFFER, then rebind to DRAW_FRAMEBUFFER
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.COLOR_ATTACHMENT0
+PASS gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER) is gl.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT
+PASS getError was expected value: NO_ERROR : attach while bound to READ should succeed
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.COLOR_ATTACHMENT0
+PASS gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER) is gl.FRAMEBUFFER_COMPLETE
+
+Test 3: Multiple draw buffers with partial detachment while bound to READ
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.COLOR_ATTACHMENT0
+PASS gl.getParameter(gl.DRAW_BUFFER1) is gl.COLOR_ATTACHMENT1
+PASS gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER) is gl.FRAMEBUFFER_COMPLETE
+PASS getError was expected value: NO_ERROR : partial detach while bound to READ should succeed
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.COLOR_ATTACHMENT0
+PASS gl.getParameter(gl.DRAW_BUFFER1) is gl.COLOR_ATTACHMENT1
+PASS gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER) is gl.FRAMEBUFFER_COMPLETE
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/draw-framebuffer-state-sync-on-bind.html
+++ b/LayoutTests/webgl/draw-framebuffer-state-sync-on-bind.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body onload="test()">
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="2" height="2"></canvas>
+<script>
+"use strict";
+description("Test that draw buffer state is properly synced when framebuffer is bound to DRAW after modifications while bound to READ.");
+
+var wtu = WebGLTestUtils;
+var gl;
+
+function test()
+{
+    var canvas = document.getElementById("canvas");
+    gl = wtu.create3DContext(canvas, undefined, 2);
+
+    if (!gl) {
+        testFailed("WebGL2 context does not exist");
+        finishTest();
+        return;
+    }
+
+    testDetachWhileBoundToRead();
+    testAttachWhileBoundToRead();
+    testMultipleDrawBuffers();
+
+    finishTest();
+}
+
+// Test 1: Detach texture while bound to READ, then rebind to DRAW
+function testDetachWhileBoundToRead()
+{
+    debug("");
+    debug("Test 1: Detach while bound to READ_FRAMEBUFFER, then rebind to DRAW_FRAMEBUFFER");
+
+    var fb = gl.createFramebuffer();
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+    // Bind to DRAW, configure draw buffers, attach texture
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);
+    gl.drawBuffers([gl.COLOR_ATTACHMENT0]);
+    gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+    // Verify initial state
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.COLOR_ATTACHMENT0");
+    shouldBe("gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "setup should succeed");
+
+    // Switch to READ only
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fb);
+
+    // Detach texture while bound to READ only
+    gl.framebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, null, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "detach while bound to READ should succeed");
+
+    // Bind back to DRAW - draw buffer state should be synced
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);
+
+    // getParameter returns user-set values, not internal filtered state
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.COLOR_ATTACHMENT0");
+
+    // Framebuffer has no attachments, so it's incomplete
+    shouldBe("gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER)", "gl.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT");
+
+    // Cleanup
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(texture);
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);
+}
+
+// Test 2: Attach texture while bound to READ, then rebind to DRAW
+function testAttachWhileBoundToRead()
+{
+    debug("");
+    debug("Test 2: Attach while bound to READ_FRAMEBUFFER, then rebind to DRAW_FRAMEBUFFER");
+
+    var fb = gl.createFramebuffer();
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+    // Bind to DRAW, configure draw buffers (but don't attach yet)
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);
+    gl.drawBuffers([gl.COLOR_ATTACHMENT0]);
+
+    // getParameter returns user-set values
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.COLOR_ATTACHMENT0");
+
+    // Framebuffer is incomplete - no attachment yet
+    shouldBe("gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER)", "gl.FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT");
+
+    // Switch to READ only
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fb);
+
+    // Attach texture while bound to READ only
+    gl.framebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "attach while bound to READ should succeed");
+
+    // Bind back to DRAW - draw buffer state should be synced
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);
+
+    // Draw buffer should now be COLOR_ATTACHMENT0 (attachment exists)
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.COLOR_ATTACHMENT0");
+
+    // Framebuffer should be complete
+    shouldBe("gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+
+    // Cleanup
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(texture);
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);
+}
+
+// Test 3: Multiple draw buffers with partial detachment
+function testMultipleDrawBuffers()
+{
+    debug("");
+    debug("Test 3: Multiple draw buffers with partial detachment while bound to READ");
+
+    var fb = gl.createFramebuffer();
+    var texture0 = gl.createTexture();
+    var texture1 = gl.createTexture();
+
+    gl.bindTexture(gl.TEXTURE_2D, texture0);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.bindTexture(gl.TEXTURE_2D, texture1);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 1, 1, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+
+    // Bind to DRAW, configure both draw buffers, attach both textures
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);
+    gl.drawBuffers([gl.COLOR_ATTACHMENT0, gl.COLOR_ATTACHMENT1]);
+    gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture0, 0);
+    gl.framebufferTexture2D(gl.DRAW_FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.TEXTURE_2D, texture1, 0);
+
+    // Verify initial state
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.COLOR_ATTACHMENT0");
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER1)", "gl.COLOR_ATTACHMENT1");
+    shouldBe("gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+
+    // Switch to READ only
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, fb);
+
+    // Detach texture1 from COLOR_ATTACHMENT1 while bound to READ
+    gl.framebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT1, gl.TEXTURE_2D, null, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "partial detach while bound to READ should succeed");
+
+    // Bind back to DRAW - draw buffer state should be synced
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, fb);
+
+    // getParameter returns user-set values
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.COLOR_ATTACHMENT0");
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER1)", "gl.COLOR_ATTACHMENT1");
+
+    // Framebuffer should be complete (internal state filters out detached COLOR_ATTACHMENT1)
+    shouldBe("gl.checkFramebufferStatus(gl.DRAW_FRAMEBUFFER)", "gl.FRAMEBUFFER_COMPLETE");
+
+    // Cleanup
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(texture0);
+    gl.deleteTexture(texture1);
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, null);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/webgl/read-framebuffer-attachment-preserves-draw-state-expected.txt
+++ b/LayoutTests/webgl/read-framebuffer-attachment-preserves-draw-state-expected.txt
@@ -1,0 +1,17 @@
+Test that modifying READ_FRAMEBUFFER does not affect DRAW_FRAMEBUFFER state.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 8 PASS, 0 FAIL
+
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.BACK
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.NONE
+PASS gl.getParameter(gl.DRAW_FRAMEBUFFER_BINDING) is null
+PASS getError was expected value: NO_ERROR : framebufferTexture2D should succeed
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.NONE
+PASS getError was expected value: NO_ERROR : drawArrays should succeed
+PASS gl.getParameter(gl.DRAW_BUFFER0) is gl.NONE
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/read-framebuffer-attachment-preserves-draw-state.html
+++ b/LayoutTests/webgl/read-framebuffer-attachment-preserves-draw-state.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body onload="test()">
+<div id="description"></div>
+<div id="console"></div>
+<canvas id="canvas" width="2" height="2"></canvas>
+<script>
+"use strict";
+description("Test that modifying READ_FRAMEBUFFER does not affect DRAW_FRAMEBUFFER state.");
+
+var wtu = WebGLTestUtils;
+var gl;
+
+function test()
+{
+    var canvas = document.getElementById("canvas");
+    gl = wtu.create3DContext(canvas, undefined, 2);
+
+    if (!gl) {
+        testFailed("WebGL2 context does not exist");
+        finishTest();
+        return;
+    }
+
+    var vertexShaderSource = `#version 300 es
+        layout(location=0) in highp vec4 a_position;
+        void main() { gl_Position = a_position; }`;
+
+    var fragmentShaderSource = `#version 300 es
+        precision highp float;
+        out ivec4 outColor0;
+        void main() { outColor0.a = 1; }`;
+
+    var program = wtu.setupProgram(gl, [vertexShaderSource, fragmentShaderSource]);
+    if (!program) {
+        testFailed("Failed to create program");
+        finishTest();
+        return;
+    }
+
+    // Verify initial state
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.BACK");
+
+    // Create framebuffer and set its draw buffers to COLOR_ATTACHMENT0
+    var framebuffer = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, framebuffer);
+    gl.drawBuffers([gl.COLOR_ATTACHMENT0]); // Set explicit draw buffer state
+    gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
+
+    // Set default framebuffer draw buffer to NONE
+    gl.drawBuffers([gl.NONE]);
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.NONE");
+
+    // Bind framebuffer to READ_FRAMEBUFFER only
+    gl.bindFramebuffer(gl.READ_FRAMEBUFFER, framebuffer);
+    shouldBe("gl.getParameter(gl.DRAW_FRAMEBUFFER_BINDING)", "null");
+
+    // Attach texture to READ_FRAMEBUFFER (should NOT corrupt DRAW_FRAMEBUFFER state)
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.framebufferTexture2D(gl.READ_FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "framebufferTexture2D should succeed");
+
+    // Verify draw buffer state was not corrupted
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.NONE");
+
+    // Draw should succeed
+    gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawArrays should succeed");
+
+    // Verify draw buffer state is still preserved
+    shouldBe("gl.getParameter(gl.DRAW_BUFFER0)", "gl.NONE");
+
+    finishTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.h
@@ -87,6 +87,9 @@ public:
     // Wrapper for drawBuffersEXT/drawBuffersARB to work around a driver bug.
     void drawBuffers(const Vector<GCGLenum>& bufs);
 
+    // Apply m_filteredDrawBuffers to GL state if pending sync is needed.
+    void applyFilteredDrawBuffers();
+
     GCGLenum getDrawBuffer(GCGLenum);
 
     void addMembersToOpaqueRoots(const AbstractLocker&, JSC::AbstractSlotVisitor&);
@@ -120,8 +123,8 @@ private:
     // Check if the framebuffer is currently bound to the given target.
     bool isBound(GCGLenum target) const;
 
-    // Check if a new drawBuffers call should be issued. This is called when we add or remove an attachment.
-    void drawBuffersIfNecessary(bool force);
+    // Update m_filteredDrawBuffers based on current attachments. Returns true if changed.
+    bool updateFilteredDrawBuffers(bool force);
 
     void setAttachmentInternal(GCGLenum attachment, AttachmentEntry);
     // If a given attachment point for the currently bound framebuffer is not
@@ -137,6 +140,7 @@ private:
     bool m_hasEverBeenBound { false };
     Vector<GCGLenum> m_drawBuffers;
     Vector<GCGLenum> m_filteredDrawBuffers;
+    bool m_drawBufferStatePendingSync { false };
 #if ENABLE(WEBXR)
     const bool m_isOpaque;
     bool m_insideWebXRRAF { false };

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5365,6 +5365,10 @@ void WebGLRenderingContextBase::setFramebuffer(const AbstractLocker&, GCGLenum t
         m_framebufferBinding = buffer;
     auto fbo = buffer ? buffer->object() : m_defaultFramebuffer->object();
     graphicsContextGL()->bindFramebuffer(target, fbo);
+
+    // Apply deferred draw buffer state when binding for drawing.
+    if (buffer && (target == GraphicsContextGL::FRAMEBUFFER || target == GraphicsContextGL::DRAW_FRAMEBUFFER))
+        buffer->applyFilteredDrawBuffers();
 }
 
 bool WebGLRenderingContextBase::supportsDrawBuffers()


### PR DESCRIPTION
#### 45661a5258636ca7d70e1c088943c84228965e03
<pre>
[WebGL] Prevent READ_FRAMEBUFFER operations from corrupting DRAW_FRAMEBUFFER state
<a href="https://bugs.webkit.org/show_bug.cgi?id=307316">https://bugs.webkit.org/show_bug.cgi?id=307316</a>
<a href="https://rdar.apple.com/169621664">rdar://169621664</a>

Reviewed by Kimmo Kinnunen.

Calling framebufferTexture2D() on READ_FRAMEBUFFER was unexpectedly modifying
DRAW_FRAMEBUFFER state. The issue was that drawBuffersIfNecessary() unconditionally
called glDrawBuffers(), which always targets DRAW_FRAMEBUFFER - so modifying one
framebuffer&apos;s attachments would corrupt whatever was bound to DRAW_FRAMEBUFFER.

Fix by deferring the glDrawBuffers() call: when attachments change while bound to
READ_FRAMEBUFFER, record that sync is pending and apply it when the framebuffer is
later bound for drawing. The fix handles both WebGL 2.0 (separate READ/DRAW bindings)
and WebGL 1.0 with the WEBGL_draw_buffers extension (single FRAMEBUFFER binding).

Tests: webgl/draw-framebuffer-state-sync-on-bind.html
       webgl/read-framebuffer-attachment-preserves-draw-state.html

* LayoutTests/webgl/draw-framebuffer-state-sync-on-bind-expected.txt: Added.
* LayoutTests/webgl/draw-framebuffer-state-sync-on-bind.html: Added.
* LayoutTests/webgl/read-framebuffer-attachment-preserves-draw-state-expected.txt: Added.
* LayoutTests/webgl/read-framebuffer-attachment-preserves-draw-state.html: Added.
* Source/WebCore/html/canvas/WebGLFramebuffer.cpp:
(WebCore::WebGLFramebuffer::isBoundForDrawing const):
(WebCore::WebGLFramebuffer::applyFilteredDrawBuffers):
(WebCore::WebGLFramebuffer::syncDrawBuffersState):
(WebCore::WebGLFramebuffer::drawBuffersIfNecessary):
* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::setFramebuffer):

Canonical link: <a href="https://commits.webkit.org/307223@main">https://commits.webkit.org/307223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2395ab909e5a390aadf7829b38f654cdd8382900

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7906 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152396 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44a0991c-2b8e-4d52-b100-d412f28fc9d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145603 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16886 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16297 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110538 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/865a11d6-e846-4b7b-88d3-9e1969f85c18) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146691 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91456 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fda3aac3-0a05-4c38-b557-04ecabe9ee79) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10174 "Passed tests") | [  ~~🛠 wpe-libwebrtc~~](https://ews-build.webkit.org/#/builders/172/builds/2398 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121903 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154708 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16257 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118543 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13692 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118901 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30473 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14842 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71670 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15878 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5493 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15612 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15824 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15676 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->