### PR TITLE
[YARR] Support JIT for forward reference

### DIFF
--- a/JSTests/stress/regexp-forward-reference.js
+++ b/JSTests/stress/regexp-forward-reference.js
@@ -1,0 +1,214 @@
+// Test forward references in regular expressions.
+// Forward references refer to capture groups that appear later in the pattern.
+// Per ES spec (22.2.2.7.2 BackreferenceMatcher step 1.7), when the referenced
+// capture is undefined (not yet captured), the backreference matches the empty
+// string. This tests the Yarr JIT implementation of forward references.
+
+function testExec(re, str, expected, description) {
+    let match = re.exec(str);
+
+    if (expected === null) {
+        if (match !== null)
+            throw new Error(`${description}: expected no match, but got ${JSON.stringify(match)}`);
+        return;
+    }
+
+    if (match === null)
+        throw new Error(`${description}: expected ${JSON.stringify(expected)}, but got no match`);
+
+    if (match[0] !== expected[0])
+        throw new Error(`${description}: expected match[0]="${expected[0]}", got "${match[0]}"`);
+
+    for (let i = 1; i < expected.length; i++) {
+        if (match[i] !== expected[i])
+            throw new Error(`${description}: expected match[${i}]="${expected[i]}", got "${match[i]}"`);
+    }
+}
+
+function testTest(re, str, expected, description) {
+    let result = re.test(str);
+    if (result !== expected)
+        throw new Error(`${description}: ${re}.test("${str}") = ${result}, expected ${expected}`);
+}
+
+// ==== Basic numbered forward references ====
+
+testTest(/\1(a)/, "a", true, "basic numbered forward ref");
+testTest(/\1(a)/, "b", false, "basic numbered forward ref no match");
+testExec(/\1(a)/, "a", ["a", "a"], "basic numbered forward ref exec");
+
+testTest(/\1(.)/, "x", true, "forward ref dot");
+testExec(/\1(.)/, "x", ["x", "x"], "forward ref dot exec");
+
+// Forward ref matches empty, so only the group content needs to match
+testExec(/\1(ab)/, "ab", ["ab", "ab"], "forward ref multi-char group");
+testTest(/\1(ab)/, "xab", true, "forward ref multi-char group with prefix");
+
+// ==== Basic named forward references ====
+
+testTest(/\k<a>(?<a>x)/, "x", true, "basic named forward ref");
+testTest(/\k<a>(?<a>x)/, "y", false, "basic named forward ref no match");
+testExec(/\k<a>(?<a>x)/, "x", ["x", "x"], "basic named forward ref exec");
+
+testExec(/\k<grp>(?<grp>hello)/, "hello", ["hello", "hello"], "named forward ref word");
+testTest(/\k<grp>(?<grp>hello)/, "world", false, "named forward ref word no match");
+
+// ==== Forward reference then back reference ====
+// \k<a> is a forward ref (empty match), (?<a>x) captures "x", \k<a> is now a back ref matching "x"
+
+testExec(/\k<a>(?<a>x)\k<a>/, "xx", ["xx", "x"], "forward ref then back ref");
+testTest(/\k<a>(?<a>x)\k<a>/, "xy", false, "forward ref then back ref no match");
+testTest(/\k<a>(?<a>x)\k<a>/, "x", false, "forward ref then back ref too short");
+
+testExec(/\1(abc)\1/, "abcabc", ["abcabc", "abc"], "numbered forward then back ref");
+testTest(/\1(abc)\1/, "abcdef", false, "numbered forward then back ref no match");
+
+// ==== Multiple forward references ====
+
+testExec(/\1\2(a)(b)/, "ab", ["ab", "a", "b"], "two forward refs");
+testExec(/\1\2(a)(b)\1\2/, "abab", ["abab", "a", "b"], "two forward refs then back refs");
+testTest(/\1\2(a)(b)\1\2/, "abba", false, "two forward refs then back refs no match");
+
+testExec(/\k<x>\k<y>(?<x>A)(?<y>B)\k<x>\k<y>/, "ABAB",
+    ["ABAB", "A", "B"], "two named forward refs then back refs");
+
+// ==== Forward reference with quantifiers on the group ====
+
+testExec(/\1([a-z]+)/, "hello", ["hello", "hello"], "forward ref with + group");
+testExec(/\1([a-z]*)/, "hello", ["hello", "hello"], "forward ref with * group");
+testExec(/\1([a-z]?)/, "h", ["h", "h"], "forward ref with ? group");
+testExec(/\1([a-z]?)/, "", ["", ""], "forward ref with ? group empty");
+
+// ==== Forward reference with quantifiers on the reference ====
+
+testExec(/\1*(a)/, "a", ["a", "a"], "forward ref with * quantifier");
+testExec(/\1+(a)/, "a", ["a", "a"], "forward ref with + quantifier");
+testExec(/\1?(a)/, "a", ["a", "a"], "forward ref with ? quantifier");
+testExec(/\1{0,3}(a)/, "a", ["a", "a"], "forward ref with {0,3} quantifier");
+
+// ==== Forward reference in alternation ====
+
+testExec(/\1(a)|b/, "a", ["a", "a"], "forward ref in alternation left");
+testExec(/\1(a)|b/, "b", ["b", undefined], "forward ref in alternation right");
+testExec(/c|\1(a)/, "a", ["a", "a"], "forward ref in alternation right side");
+
+// ==== Forward reference with anchors ====
+
+testExec(/^\1(abc)$/, "abc", ["abc", "abc"], "forward ref with anchors");
+testTest(/^\1(abc)$/, "xabc", false, "forward ref with anchors no match");
+testTest(/^\1(abc)$/, "abcx", false, "forward ref with anchors no match 2");
+
+// ==== Forward reference with character classes ====
+
+testExec(/\1([aeiou])/, "e", ["e", "e"], "forward ref with char class");
+testExec(/\1([0-9]{3})/, "123", ["123", "123"], "forward ref with digit range");
+testExec(/\1([^abc])/, "x", ["x", "x"], "forward ref with negated class");
+
+// ==== Forward reference with case insensitive flag ====
+
+testTest(/\k<a>(?<a>x)\k<a>/i, "xX", true, "forward ref case insensitive");
+testTest(/\k<a>(?<a>x)\k<a>/i, "xx", true, "forward ref case insensitive same case");
+testExec(/\1(A)\1/i, "AaA".toLowerCase(), ["aa", "a"], "numbered forward ref case insensitive");
+testTest(/\1(A)\1/i, "Aa", true, "numbered forward ref case insensitive mixed");
+
+// ==== Forward reference with unicode flag ====
+
+testTest(/\1(.)/u, "a", true, "forward ref unicode mode");
+testExec(/\k<a>(?<a>.)/u, "\u{1F600}", ["\u{1F600}", "\u{1F600}"], "forward ref unicode emoji");
+testExec(/\1(.)\1/u, "\u{1F600}\u{1F600}", ["\u{1F600}\u{1F600}", "\u{1F600}"],
+    "forward then back ref unicode emoji");
+
+// ==== Forward reference with dotAll flag ====
+
+testExec(/\1(.)/s, "\n", ["\n", "\n"], "forward ref dotAll newline");
+testExec(/\1(.)\1/s, "\n\n", ["\n\n", "\n"], "forward then back ref dotAll");
+
+// ==== Forward reference with multiline flag ====
+
+testTest(/^\1(a)/m, "a", true, "forward ref multiline");
+testTest(/^\1(a)$/m, "\na", true, "forward ref multiline second line");
+
+// ==== Forward reference in lookahead ====
+
+testTest(/(?=\1(a))a/, "a", true, "forward ref in positive lookahead");
+testTest(/(?!\1(b))a/, "a", true, "forward ref in negative lookahead");
+
+// ==== Nested groups with forward reference ====
+
+testExec(/\1((ab))/, "ab", ["ab", "ab", "ab"], "forward ref to nested group");
+testExec(/\2(a(b))/, "ab", ["ab", "ab", "b"], "forward ref to inner nested group");
+
+// ==== Forward reference with non-capturing groups ====
+
+testExec(/\1(?:x)(a)/, "xa", ["xa", "a"], "forward ref with non-capturing group");
+testExec(/(?:\1(a))/, "a", ["a", "a"], "forward ref inside non-capturing group");
+
+// ==== Complex patterns ====
+
+// Pattern: forward ref, literal, capture, back ref
+testExec(/\k<z>X(?<z>z*)X\k<z>/, "XzzXzz", ["XzzXzz", "zz"],
+    "forward ref + literal + capture + back ref");
+testTest(/\k<z>X(?<z>z*)X\k<z>/, "XzzXz", false,
+    "forward ref + literal + capture + back ref no match");
+
+// Multiple forward references to different groups, then back references
+testExec(/\k<a>\k<b>(?<a>[A-Z]+)(?<b>[0-9]+)\k<a>\k<b>/, "ABC123ABC123",
+    ["ABC123ABC123", "ABC", "123"],
+    "multiple named forward refs then back refs complex");
+
+// Forward reference in a repeated group
+// Note: captures inside quantified groups are reset to undefined at each iteration
+// (ES spec 22.2.2.5.1 RepeatMatcher step 1.6), so \1 matches empty on both iterations.
+testExec(/(?:\1(a)){2}/, "aa", ["aa", "a"], "forward ref in repeated group");
+
+// ==== Interaction with optional groups ====
+
+// Forward ref to optional group that does match
+testExec(/\1(a)?b/, "ab", ["ab", "a"], "forward ref to optional group that matches");
+// Forward ref to optional group that doesn't match
+testExec(/\1(a)?b/, "b", ["b", undefined], "forward ref to optional group unmatched");
+
+// ==== Stress: ensure JIT handles forward refs correctly under repeated execution ====
+
+for (let i = 0; i < testLoopCount; i++) {
+    let r1 = /\k<a>(?<a>x)/.test("x");
+    if (!r1)
+        throw new Error("JIT stress test 1 failed at iteration " + i);
+
+    let r2 = /\1(a)\1/.test("aa");
+    if (!r2)
+        throw new Error("JIT stress test 2 failed at iteration " + i);
+
+    let r3 = /\k<a>(?<a>.)X\k<a>/.test("aXa");
+    if (!r3)
+        throw new Error("JIT stress test 3 failed at iteration " + i);
+
+    let r4 = /\k<a>(?<a>.)X\k<a>/.test("aXb");
+    if (r4)
+        throw new Error("JIT stress test 4 (should not match) failed at iteration " + i);
+}
+
+// ==== Stress: forward reference with String.prototype.match/replace/split ====
+
+let m = "hello".match(/\1([a-z]+)/);
+if (m[0] !== "hello" || m[1] !== "hello")
+    throw new Error("String.prototype.match with forward ref failed");
+
+let r = "abc".replace(/\1(b)/, "X");
+if (r !== "aXc")
+    throw new Error("String.prototype.replace with forward ref failed: " + r);
+
+let s = "aXbXc".split(/\1(X)/);
+if (s[0] !== "a" || s[1] !== "X" || s[2] !== "b" || s[3] !== "X" || s[4] !== "c")
+    throw new Error("String.prototype.split with forward ref failed: " + JSON.stringify(s));
+
+// ==== Stress: forward reference with global/sticky flags ====
+
+let gre = /\1(a)/g;
+let gmatches = "aaa".match(gre);
+if (gmatches.length !== 3 || gmatches[0] !== "a" || gmatches[1] !== "a" || gmatches[2] !== "a")
+    throw new Error("global flag with forward ref failed: " + JSON.stringify(gmatches));
+
+let yre = /\1(a)/y;
+if (!yre.test("a"))
+    throw new Error("sticky flag with forward ref failed");

--- a/Source/JavaScriptCore/yarr/YarrJIT.h
+++ b/Source/JavaScriptCore/yarr/YarrJIT.h
@@ -59,7 +59,6 @@ class YarrCodeBlock;
 enum class JITFailureReason : uint8_t {
     DecodeSurrogatePair,
     BackReference,
-    ForwardReference,
     Lookbehind,
     VariableCountedParenthesisWithNonZeroMinimum,
     ParenthesizedSubpattern,


### PR DESCRIPTION
#### e5ff20e030ca65db18005f6c7f8237a26d1fe22b
<pre>
[YARR] Support JIT for forward reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=307317">https://bugs.webkit.org/show_bug.cgi?id=307317</a>

Reviewed by Yusuke Suzuki.

This patch changes YARR JIT to support forward reference JIT.

According to the spec[1], forward refernce always matches the empty string.

[1]: <a href="https://tc39.es/ecma262/#sec-backreference-matcher">https://tc39.es/ecma262/#sec-backreference-matcher</a>

* JSTests/stress/regexp-forward-reference.js: Added.
(testExec):
(testExec.1):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
(JSC::Yarr::dumpCompileFailure):
* Source/JavaScriptCore/yarr/YarrJIT.h:

Canonical link: <a href="https://commits.webkit.org/307322@main">https://commits.webkit.org/307322@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff15df6bb95578943e17a3ef93b019191ab34853

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143883 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97122 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16452 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110647 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79571 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146846 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13070 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129279 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91565 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12534 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10266 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135871 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121997 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154863 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4689 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16412 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6957 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118655 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16447 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13801 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119009 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30535 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14924 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71825 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16033 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5592 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175169 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15767 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79820 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45178 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15979 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15832 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->