### PR TITLE
[SaferCPP] Use ObjectIdentifier for hit test source ids

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -844,8 +844,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Modules/webxr/XRCanvasConfiguration.h
     Modules/webxr/XRGPUProjectionLayerInit.h
-    Modules/webxr/XRLayerBacking.h
     Modules/webxr/XRHitTestTrackableType.h
+    Modules/webxr/XRLayerBacking.h
 
     Scripts/generate-log-declarations.py
 
@@ -3104,6 +3104,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/video-codecs/VideoCodecType.h
 
     platform/xr/PlatformXR.h
+    platform/xr/XRHitTestSourceIdentifier.h
 
     plugins/PluginData.h
     plugins/PluginInfoProvider.h

--- a/Source/WebCore/platform/xr/PlatformXR.h
+++ b/Source/WebCore/platform/xr/PlatformXR.h
@@ -49,6 +49,7 @@
 #endif
 
 #if ENABLE(WEBXR_HIT_TEST)
+#include "XRHitTestSourceIdentifier.h"
 #include <WebCore/ExceptionOr.h>
 #endif
 
@@ -110,8 +111,10 @@ enum class VisibilityState : uint8_t {
 using LayerHandle = int;
 
 #if ENABLE(WEBXR)
-using HitTestSource = unsigned;
-using TransientInputHitTestSource = unsigned;
+#if ENABLE(WEBXR_HIT_TEST)
+using HitTestSource = WebCore::XRHitTestSourceIdentifier;
+using TransientInputHitTestSource = WebCore::XRHitTestSourceIdentifier;
+#endif
 using InputSourceHandle = int;
 
 // https://immersive-web.github.io/webxr/#enumdef-xrhandedness

--- a/Source/WebCore/platform/xr/XRHitTestSourceIdentifier.h
+++ b/Source/WebCore/platform/xr/XRHitTestSourceIdentifier.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2026 Igalia, S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/ObjectIdentifier.h>
+
+#if ENABLE(WEBXR_HIT_TEST)
+
+namespace WebCore {
+
+struct XRHitTestSourceIdentifierType;
+using XRHitTestSourceIdentifier = ObjectIdentifier<XRHitTestSourceIdentifierType>;
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_HIT_TEST)

--- a/Source/WebCore/testing/WebFakeXRDevice.cpp
+++ b/Source/WebCore/testing/WebFakeXRDevice.cpp
@@ -26,11 +26,11 @@
 
 #include "config.h"
 #include "WebFakeXRDevice.h"
+#include "PlatformXR.h"
 
 #if ENABLE(WEBXR)
 
 #include "DOMPointReadOnly.h"
-#include "GraphicsContextGL.h"
 #include "JSDOMPromiseDeferred.h"
 #include "WebFakeXRInputController.h"
 #include <wtf/CompletionHandler.h>
@@ -315,10 +315,10 @@ void SimulatedXRDevice::deleteLayer(PlatformXR::LayerHandle handle)
 #if ENABLE(WEBXR_HIT_TEST)
 void SimulatedXRDevice::requestHitTestSource(const PlatformXR::HitTestOptions& options, CompletionHandler<void(WebCore::ExceptionOr<PlatformXR::HitTestSource>)>&& completionHandler)
 {
-    auto addResult = m_hitTestSources.add(m_nextHitTestSource, makeUniqueRef<PlatformXR::HitTestOptions>(options));
+    auto sourceId = PlatformXR::HitTestSource::generate();
+    auto addResult = m_hitTestSources.add(sourceId, makeUniqueRef<PlatformXR::HitTestOptions>(options));
     ASSERT_UNUSED(addResult.isNewEntry, addResult);
-    completionHandler(m_nextHitTestSource);
-    m_nextHitTestSource++;
+    completionHandler(WTF::move(sourceId));
 }
 
 void SimulatedXRDevice::deleteHitTestSource(PlatformXR::HitTestSource source)
@@ -329,10 +329,10 @@ void SimulatedXRDevice::deleteHitTestSource(PlatformXR::HitTestSource source)
 
 void SimulatedXRDevice::requestTransientInputHitTestSource(const PlatformXR::TransientInputHitTestOptions& options, CompletionHandler<void(WebCore::ExceptionOr<PlatformXR::TransientInputHitTestSource>)>&& completionHandler)
 {
-    auto addResult = m_transientInputHitTestSources.add(m_nextTransientInputHitTestSource, makeUniqueRef<PlatformXR::TransientInputHitTestOptions>(options));
+    auto sourceId = PlatformXR::TransientInputHitTestSource::generate();
+    auto addResult = m_transientInputHitTestSources.add(sourceId, makeUniqueRef<PlatformXR::TransientInputHitTestOptions>(options));
     ASSERT_UNUSED(addResult.isNewEntry, addResult);
-    completionHandler(m_nextTransientInputHitTestSource);
-    m_nextTransientInputHitTestSource++;
+    completionHandler(WTF::move(sourceId));
 }
 
 void SimulatedXRDevice::deleteTransientInputHitTestSource(PlatformXR::TransientInputHitTestSource source)

--- a/Source/WebCore/testing/WebFakeXRDevice.h
+++ b/Source/WebCore/testing/WebFakeXRDevice.h
@@ -125,8 +125,6 @@ private:
     HashMap<PlatformXR::LayerHandle, WebCore::IntSize> m_layers;
     uint32_t m_layerIndex { 0 };
 #if ENABLE(WEBXR_HIT_TEST)
-    PlatformXR::HitTestSource m_nextHitTestSource { 1 };
-    PlatformXR::TransientInputHitTestSource m_nextTransientInputHitTestSource { 1 };
     HashMap<PlatformXR::HitTestSource, UniqueRef<PlatformXR::HitTestOptions>> m_hitTestSources;
     HashMap<PlatformXR::TransientInputHitTestSource, UniqueRef<PlatformXR::TransientInputHitTestOptions>> m_transientInputHitTestSources;
     FakeXRWorldInit m_world;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -484,6 +484,7 @@ def serialized_identifiers():
         'WebCore::WebTransportSendGroupIdentifier',
         'WebCore::WebTransportStreamIdentifier',
         'WebCore::WindowIdentifier',
+        'WebCore::XRHitTestSourceIdentifier',
         'WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier',
         'WebKit::AuthenticationChallengeIdentifier',
         'WebKit::WebModelIdentifier',

--- a/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
+++ b/Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp
@@ -531,6 +531,7 @@ Vector<ASCIILiteral> serializedIdentifiers()
         "WebCore::WebTransportSendGroupIdentifier"_s,
         "WebCore::WebTransportStreamIdentifier"_s,
         "WebCore::WindowIdentifier"_s,
+        "WebCore::XRHitTestSourceIdentifier"_s,
         "WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifier"_s,
         "WebKit::AuthenticationChallengeIdentifier"_s,
         "WebKit::WebModelIdentifier"_s,

--- a/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WTFArgumentCoders.serialization.in
@@ -86,6 +86,9 @@ template: enum class WebCore::TextManipulationItemIdentifierType
 template: enum class WebCore::TextManipulationTokenIdentifierType
 template: struct WebCore::WindowIdentifierType
 template: enum class WebCore::WorkletGlobalScopeIdentifierType
+#if ENABLE(WEBXR_HIT_TEST)
+template: struct WebCore::XRHitTestSourceIdentifierType
+#endif
 template: struct WebKit::AudioMediaStreamTrackRendererInternalUnitIdentifierType
 template: struct WebKit::ContentWorldIdentifierType
 template: enum class WebKit::ImageAnalysisRequestIdentifierType

--- a/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
+++ b/Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp
@@ -65,8 +65,6 @@ struct OpenXRCoordinator::RenderState {
     XrFrameState frameState;
     bool passthroughFullyObscured { false };
 #if ENABLE(WEBXR_HIT_TEST)
-    PlatformXR::HitTestSource nextHitTestSource { 1 };
-    PlatformXR::TransientInputHitTestSource nextTransientInputHitTestSource { 1 };
     HashMap<PlatformXR::HitTestSource, UniqueRef<PlatformXR::HitTestOptions>> hitTestSources;
     HashMap<PlatformXR::TransientInputHitTestSource, UniqueRef<PlatformXR::TransientInputHitTestOptions>> transientInputHitTestSources;
     std::unique_ptr<OpenXRHitTestManager> hitTestManager;
@@ -411,12 +409,12 @@ void OpenXRCoordinator::requestHitTestSource(WebPageProxy& page, const PlatformX
                     });
                     return;
                 }
-                auto addResult = renderState->hitTestSources.add(renderState->nextHitTestSource, WTF::move(options));
+                auto sourceId = PlatformXR::HitTestSource::generate();
+                auto addResult = renderState->hitTestSources.add(sourceId, WTF::move(options));
                 ASSERT_UNUSED(addResult.isNewEntry, addResult);
-                callOnMainRunLoop([source = renderState->nextHitTestSource, completionHandler = WTF::move(completionHandler)] mutable {
-                    completionHandler(source);
+                callOnMainRunLoop([sourceId = WTF::move(sourceId), completionHandler = WTF::move(completionHandler)] mutable {
+                    completionHandler(WTF::move(sourceId));
                 });
-                renderState->nextHitTestSource++;
             });
         });
 }
@@ -474,12 +472,12 @@ void OpenXRCoordinator::requestTransientInputHitTestSource(WebPageProxy& page, c
                     });
                     return;
                 }
-                auto addResult = renderState->transientInputHitTestSources.add(renderState->nextTransientInputHitTestSource, WTF::move(options));
+                auto sourceId = PlatformXR::TransientInputHitTestSource::generate();
+                auto addResult = renderState->transientInputHitTestSources.add(sourceId, WTF::move(options));
                 ASSERT_UNUSED(addResult.isNewEntry, addResult);
-                callOnMainRunLoop([source = renderState->nextTransientInputHitTestSource, completionHandler = WTF::move(completionHandler)] mutable {
-                    completionHandler(source);
+                callOnMainRunLoop([sourceId = WTF::move(sourceId), completionHandler = WTF::move(completionHandler)] mutable {
+                    completionHandler(WTF::move(sourceId));
                 });
-                renderState->nextTransientInputHitTestSource++;
             });
         });
 }


### PR DESCRIPTION
#### 196fcc85b39ee2362c6c7492fabbb1b9d4983509
<pre>
[SaferCPP] Use ObjectIdentifier for hit test source ids
<a href="https://bugs.webkit.org/show_bug.cgi?id=307322">https://bugs.webkit.org/show_bug.cgi?id=307322</a>

Reviewed by Fujii Hironori.

As per the SaferCPP guidelines we should use object identifiers instead
of uints for ids. Using weakly-typed identifiers such as uint64_t leads
to confusion between identifier types and bugs.

No new tests as this does not affect funcionality.

* Source/WebCore/Headers.cmake:
* Source/WebCore/platform/xr/PlatformXR.h:
* Source/WebCore/platform/xr/XRHitTestSourceIdentifier.h: Added.
* Source/WebCore/testing/WebFakeXRDevice.cpp:
(WebCore::SimulatedXRDevice::requestHitTestSource):
(WebCore::SimulatedXRDevice::requestTransientInputHitTestSource):
* Source/WebCore/testing/WebFakeXRDevice.h:
* Source/WebKit/Scripts/webkit/messages.py:
(serialized_identifiers):
* Source/WebKit/Scripts/webkit/tests/MessageArgumentDescriptions.cpp:
(IPC::serializedIdentifiers):
* Source/WebKit/Shared/WTFArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/XR/openxr/PlatformXROpenXR.cpp:
(WebKit::OpenXRCoordinator::requestHitTestSource):
(WebKit::OpenXRCoordinator::requestTransientInputHitTestSource):

Canonical link: <a href="https://commits.webkit.org/307341@main">https://commits.webkit.org/307341@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67cfe152bdb39a97067bd40a2eb825a99f48131a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143593 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7693 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96829 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145468 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16751 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110421 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79468 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146556 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91340 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/142919 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12353 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10068 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5560 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154570 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118426 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13574 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118782 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30546 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14725 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126767 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71535 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15742 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5361 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79514 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15541 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->