### PR TITLE
Give position-area a more accurate scrollable rect and apply to all scrollers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-001.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-001.tentative-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL Initial scroll position assert_equals: e3 width expected 350 but got 100
-FAIL Scroll to 40,60 assert_equals: e3 width expected 350 but got 100
-FAIL Redisplay at 40,60 assert_equals: e3 width expected 350 but got 100
+PASS Initial scroll position
+PASS Scroll to 40,60
+PASS Redisplay at 40,60
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative-expected.txt
@@ -1,6 +1,6 @@
 
 
-PASS Initial scroll position
-PASS Scroll to 40,60
-PASS Redisplay at 40,60
+FAIL Initial scroll position assert_equals: e7 height expected 350 but got 100
+FAIL Scroll to 40,60 assert_equals: e7 height expected 350 but got 100
+FAIL Redisplay at 40,60 assert_equals: e7 height expected 350 but got 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scrollable-containing-block-position-area-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scrollable-containing-block-position-area-expected.txt
@@ -1,14 +1,6 @@
 
-FAIL .target 1 assert_equals:
-<div class="target" style="position-area: top;" data-offset-x="0" data-offset-y="0" data-expected-width="200" data-expected-height="70"></div>
-width expected 200 but got 120
-FAIL .target 2 assert_equals:
-<div class="target" style="position-area: right;" data-offset-x="120" data-offset-y="0" data-expected-width="80" data-expected-height="200"></div>
-width expected 80 but got 0
-FAIL .target 3 assert_equals:
-<div class="target" style="position-area: bottom;" data-offset-x="0" data-offset-y="120" data-expected-width="200" data-expected-height="80"></div>
-width expected 200 but got 120
-FAIL .target 4 assert_equals:
-<div class="target" style="position-area: left;" data-offset-x="0" data-offset-y="0" data-expected-width="70" data-expected-height="200"></div>
-height expected 200 but got 120
+PASS .target 1
+PASS .target 2
+PASS .target 3
+PASS .target 4
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scrollable-containing-block-validity-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scrollable-containing-block-validity-expected.txt
@@ -4,5 +4,7 @@ FAIL .target 2 assert_equals:
 <div class="target" style="position-anchor: --a;" data-expected-width="200" data-expected-height="200"></div>
 width expected 200 but got 100
 PASS .target 3
-PASS .target 4
+FAIL .target 4 assert_equals:
+<div class="target" style="position-area: top;" data-expected-width="100" data-expected-height="100"></div>
+width expected 100 but got 200
 

--- a/Source/WebCore/platform/graphics/LayoutRect.h
+++ b/Source/WebCore/platform/graphics/LayoutRect.h
@@ -34,6 +34,7 @@
 #include <WebCore/FloatRect.h>
 #include <WebCore/IntRect.h>
 #include <WebCore/LayoutPoint.h>
+#include <WebCore/LayoutRange.h>
 #include <wtf/ArgumentCoder.h>
 #include <wtf/Forward.h>
 
@@ -73,6 +74,8 @@ public:
     LayoutUnit maxY() const { return y() + height(); }
     LayoutUnit width() const { return m_size.width(); }
     LayoutUnit height() const { return m_size.height(); }
+    LayoutRange xRange() const { return { x(), width() }; }
+    LayoutRange yRange() const { return { y(), height() }; }
 
     template<typename T> void setX(T x) { m_location.setX(x); }
     template<typename T> void setY(T y) { m_location.setY(y); }


### PR DESCRIPTION
#### acd646641dc3157d4422138e1903c37729f9482c
<pre>
Give position-area a more accurate scrollable rect and apply to all scrollers
<a href="https://bugs.webkit.org/show_bug.cgi?id=291864">https://bugs.webkit.org/show_bug.cgi?id=291864</a>
<a href="https://rdar.apple.com/149717067">rdar://149717067</a>

Reviewed by Alan Baradlay.

Replaces the hacky core of PositionedLayoutConstraints::expandToScrollableArea()
with a call to the new RenderBox::scrollablePaddingAreaOverflowRect() method,
which returns the true scrollable content area bounds.

* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-001.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-003.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scrollable-containing-block-position-area-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-anchor-position/scrollable-containing-block-validity-expected.txt:

Update test expectations.

* Source/WebCore/platform/graphics/LayoutRect.h:
(WebCore::LayoutRect::xRange const):
(WebCore::LayoutRect::yRange const):

Add helper methods.

* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::expandToScrollableArea const):

Update to use the scrollable containing block for position-area != none.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::getScrollableContainingBlockRange):
(WebCore::RenderBox::containingBlockRangeForPositioned const):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::gridAreaRangeForOutOfFlow const):

Update to return the scrollable containing block for position-area != none.

Canonical link: <a href="https://commits.webkit.org/307593@main">https://commits.webkit.org/307593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aedca943b08373ca50b1ff077a593e9686fa22b3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144813 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9211 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153484 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98448 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ac2a6df-6676-4cfd-9057-4c4dbc5f109e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146688 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17975 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17386 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111349 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79809 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d914936a-5fd0-455e-b740-5e92aa4ec600) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147776 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92244 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d1407d48-389f-417b-bda3-c0504185e9bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13087 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10841 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/929 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122602 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6798 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155796 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17344 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7886 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119353 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14483 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119681 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30701 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15489 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128056 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72905 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16966 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6354 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80745 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16911 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16766 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->