### PR TITLE
Reduce use of protected functions in Source/WebKit

### DIFF
--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -48,11 +48,6 @@
 
 @end
 
-static Ref<WebKit::WebPageProxy> protectedPage(WKObservablePageState *state)
-{
-    return *state->_page;
-}
-
 @implementation WKObservablePageState
 
 - (id)initWithPage:(RefPtr<WebKit::WebPageProxy>&&)page
@@ -63,7 +58,7 @@ static Ref<WebKit::WebPageProxy> protectedPage(WKObservablePageState *state)
     _page = WTF::move(page);
     Ref observer = WebKit::PageLoadStateObserver::create(self, @"URL");
     _observer = observer.get();
-    protect(protectedPage(self)->pageLoadState())->addObserver(observer.get());
+    protect(protect(*_page)->pageLoadState())->addObserver(observer.get());
 
     return self;
 }
@@ -81,42 +76,42 @@ static Ref<WebKit::WebPageProxy> protectedPage(WKObservablePageState *state)
 
 - (BOOL)isLoading
 {
-    return protect(protectedPage(self)->pageLoadState())->isLoading();
+    return protect(protect(*_page)->pageLoadState())->isLoading();
 }
 
 - (NSString *)title
 {
-    return protect(protectedPage(self)->pageLoadState())->title().createNSString().autorelease();
+    return protect(protect(*_page)->pageLoadState())->title().createNSString().autorelease();
 }
 
 - (NSURL *)URL
 {
-    return [NSURL _web_URLWithWTFString:protect(protectedPage(self)->pageLoadState())->activeURL()];
+    return [NSURL _web_URLWithWTFString:protect(protect(*_page)->pageLoadState())->activeURL()];
 }
 
 - (BOOL)hasOnlySecureContent
 {
-    return protect(protectedPage(self)->pageLoadState())->hasOnlySecureContent();
+    return protect(protect(*_page)->pageLoadState())->hasOnlySecureContent();
 }
 
 - (BOOL)_webProcessIsResponsive
 {
-    return protect(protectedPage(self)->legacyMainFrameProcess())->isResponsive();
+    return protect(protect(*_page)->legacyMainFrameProcess())->isResponsive();
 }
 
 - (double)estimatedProgress
 {
-    return protectedPage(self)->estimatedProgress();
+    return protect(*_page)->estimatedProgress();
 }
 
 - (NSURL *)unreachableURL
 {
-    return [NSURL _web_URLWithWTFString:protectedPage(self)->pageLoadState().unreachableURL()];
+    return [NSURL _web_URLWithWTFString:protect(*_page)->pageLoadState().unreachableURL()];
 }
 
 - (SecTrustRef)serverTrust
 {
-    return protectedPage(self)->pageLoadState().certificateInfo().trust().get();
+    return protect(*_page)->pageLoadState().certificateInfo().trust().get();
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm
@@ -38,17 +38,12 @@
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
-static Ref<API::FrameInfo> protectedFrameInfo(WKFrameInfo *frameInfo)
-{
-    return *frameInfo->_frameInfo;
-}
-
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKFrameInfo.class, self))
         return;
 
-    SUPPRESS_UNCOUNTED_ARG protectedFrameInfo(self)->~FrameInfo();
+    SUPPRESS_UNCOUNTED_ARG protect(*_frameInfo)->~FrameInfo();
 
     [super dealloc];
 }
@@ -78,7 +73,7 @@ static Ref<API::FrameInfo> protectedFrameInfo(WKFrameInfo *frameInfo)
 
 - (WKWebView *)webView
 {
-    RefPtr page = protectedFrameInfo(self)->page();
+    RefPtr page = protect(*_frameInfo)->page();
     return page ? page->cocoaView().autorelease() : nil;
 }
 
@@ -100,12 +95,12 @@ static Ref<API::FrameInfo> protectedFrameInfo(WKFrameInfo *frameInfo)
 
 - (_WKFrameHandle *)_handle
 {
-    return wrapper(protectedFrameInfo(self)->handle()).autorelease();
+    return wrapper(protect(*_frameInfo)->handle()).autorelease();
 }
 
 - (_WKFrameHandle *)_parentFrameHandle
 {
-    return wrapper(protectedFrameInfo(self)->parentFrameHandle()).autorelease();
+    return wrapper(protect(*_frameInfo)->parentFrameHandle()).autorelease();
 }
 
 - (NSUUID *)_documentIdentifier
@@ -138,7 +133,7 @@ static Ref<API::FrameInfo> protectedFrameInfo(WKFrameInfo *frameInfo)
 
 - (NSString *)_title
 {
-    return protectedFrameInfo(self)->title().createNSString().autorelease();
+    return protect(*_frameInfo)->title().createNSString().autorelease();
 }
 
 - (BOOL)_isScrollable

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -37,11 +37,6 @@
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/RetainPtr.h>
 
-static Ref<WebKit::WebPreferences> protectedPreferences(WKPreferences *preferences)
-{
-    return *preferences->_preferences;
-}
-
 @implementation WKPreferences
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
@@ -111,96 +106,96 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    return [wrapper(protectedPreferences(self)->copy()) retain];
+    return [wrapper(protect(*_preferences)->copy()) retain];
 }
 
 - (CGFloat)minimumFontSize
 {
-    return protectedPreferences(self)->minimumFontSize();
+    return protect(*_preferences)->minimumFontSize();
 }
 
 - (void)setMinimumFontSize:(CGFloat)minimumFontSize
 {
-    protectedPreferences(self)->setMinimumFontSize(minimumFontSize);
+    protect(*_preferences)->setMinimumFontSize(minimumFontSize);
 }
 
 - (void)setFraudulentWebsiteWarningEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setSafeBrowsingEnabled(enabled);
+    protect(*_preferences)->setSafeBrowsingEnabled(enabled);
 }
 
 - (BOOL)isFraudulentWebsiteWarningEnabled
 {
-    return protectedPreferences(self)->safeBrowsingEnabled();
+    return protect(*_preferences)->safeBrowsingEnabled();
 }
 
 - (BOOL)javaScriptCanOpenWindowsAutomatically
 {
-    return protectedPreferences(self)->javaScriptCanOpenWindowsAutomatically();
+    return protect(*_preferences)->javaScriptCanOpenWindowsAutomatically();
 }
 
 - (void)setJavaScriptCanOpenWindowsAutomatically:(BOOL)javaScriptCanOpenWindowsAutomatically
 {
-    protectedPreferences(self)->setJavaScriptCanOpenWindowsAutomatically(javaScriptCanOpenWindowsAutomatically);
+    protect(*_preferences)->setJavaScriptCanOpenWindowsAutomatically(javaScriptCanOpenWindowsAutomatically);
 }
 
 - (void)setShouldPrintBackgrounds:(BOOL)enabled
 {
-    protectedPreferences(self)->setShouldPrintBackgrounds(enabled);
+    protect(*_preferences)->setShouldPrintBackgrounds(enabled);
 }
 
 - (BOOL)shouldPrintBackgrounds
 {
-    return protectedPreferences(self)->shouldPrintBackgrounds();
+    return protect(*_preferences)->shouldPrintBackgrounds();
 }
 
 - (BOOL)isTextInteractionEnabled
 {
-    return protectedPreferences(self)->textInteractionEnabled();
+    return protect(*_preferences)->textInteractionEnabled();
 }
 
 - (void)setTextInteractionEnabled:(BOOL)textInteractionEnabled
 {
-    protectedPreferences(self)->setTextInteractionEnabled(textInteractionEnabled);
+    protect(*_preferences)->setTextInteractionEnabled(textInteractionEnabled);
 }
 
 - (BOOL)isSiteSpecificQuirksModeEnabled
 {
-    return protectedPreferences(self)->needsSiteSpecificQuirks();
+    return protect(*_preferences)->needsSiteSpecificQuirks();
 }
 
 - (void)setSiteSpecificQuirksModeEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setNeedsSiteSpecificQuirks(enabled);
+    protect(*_preferences)->setNeedsSiteSpecificQuirks(enabled);
 }
 
 - (BOOL)isElementFullscreenEnabled
 {
-    return protectedPreferences(self)->fullScreenEnabled();
+    return protect(*_preferences)->fullScreenEnabled();
 }
 
 - (void)setElementFullscreenEnabled:(BOOL)elementFullscreenEnabled
 {
-    protectedPreferences(self)->setFullScreenEnabled(elementFullscreenEnabled);
+    protect(*_preferences)->setFullScreenEnabled(elementFullscreenEnabled);
 }
 
 - (void)setInactiveSchedulingPolicy:(WKInactiveSchedulingPolicy)policy
 {
     switch (policy) {
     case WKInactiveSchedulingPolicySuspend:
-        protectedPreferences(self)->setShouldTakeNearSuspendedAssertions(false);
-        protectedPreferences(self)->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
-        protectedPreferences(self)->setShouldDropNearSuspendedAssertionAfterDelay(WebKit::defaultShouldDropNearSuspendedAssertionAfterDelay());
+        protect(*_preferences)->setShouldTakeNearSuspendedAssertions(false);
+        protect(*_preferences)->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
+        protect(*_preferences)->setShouldDropNearSuspendedAssertionAfterDelay(WebKit::defaultShouldDropNearSuspendedAssertionAfterDelay());
         break;
     case WKInactiveSchedulingPolicyThrottle:
-        protectedPreferences(self)->setShouldTakeNearSuspendedAssertions(true);
-        protectedPreferences(self)->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
-        protectedPreferences(self)->setShouldDropNearSuspendedAssertionAfterDelay(false);
+        protect(*_preferences)->setShouldTakeNearSuspendedAssertions(true);
+        protect(*_preferences)->setBackgroundWebContentRunningBoardThrottlingEnabled(true);
+        protect(*_preferences)->setShouldDropNearSuspendedAssertionAfterDelay(false);
         break;
     case WKInactiveSchedulingPolicyNone:
-        protectedPreferences(self)->setShouldTakeNearSuspendedAssertions(true);
-        protectedPreferences(self)->setBackgroundWebContentRunningBoardThrottlingEnabled(false);
-        protectedPreferences(self)->setShouldDropNearSuspendedAssertionAfterDelay(false);
+        protect(*_preferences)->setShouldTakeNearSuspendedAssertions(true);
+        protect(*_preferences)->setBackgroundWebContentRunningBoardThrottlingEnabled(false);
+        protect(*_preferences)->setShouldDropNearSuspendedAssertionAfterDelay(false);
         break;
     default:
         ASSERT_NOT_REACHED();
@@ -209,27 +204,27 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (WKInactiveSchedulingPolicy)inactiveSchedulingPolicy
 {
-    return protectedPreferences(self)->backgroundWebContentRunningBoardThrottlingEnabled() ? (protectedPreferences(self)->shouldTakeNearSuspendedAssertions() ? WKInactiveSchedulingPolicyThrottle : WKInactiveSchedulingPolicySuspend) : WKInactiveSchedulingPolicyNone;
+    return protect(*_preferences)->backgroundWebContentRunningBoardThrottlingEnabled() ? (protect(*_preferences)->shouldTakeNearSuspendedAssertions() ? WKInactiveSchedulingPolicyThrottle : WKInactiveSchedulingPolicySuspend) : WKInactiveSchedulingPolicyNone;
 }
 
 - (BOOL)tabFocusesLinks
 {
-    return protectedPreferences(self)->tabsToLinks();
+    return protect(*_preferences)->tabsToLinks();
 }
 
 - (void)setTabFocusesLinks:(BOOL)tabFocusesLinks
 {
-    protectedPreferences(self)->setTabsToLinks(tabFocusesLinks);
+    protect(*_preferences)->setTabsToLinks(tabFocusesLinks);
 }
 
 - (BOOL)_useSystemAppearance
 {
-    return protectedPreferences(self)->useSystemAppearance();
+    return protect(*_preferences)->useSystemAppearance();
 }
 
 - (void)_setUseSystemAppearance:(BOOL)useSystemAppearance
 {
-    protectedPreferences(self)->setUseSystemAppearance(useSystemAppearance);
+    protect(*_preferences)->setUseSystemAppearance(useSystemAppearance);
 }
 
 #pragma mark WKObject protocol implementation
@@ -243,7 +238,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)setIsLookToScrollEnabled:(BOOL)enabled
 {
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    protectedPreferences(self)->setOverlayRegionsEnabled(enabled);
+    protect(*_preferences)->setOverlayRegionsEnabled(enabled);
 #else
     UNUSED_PARAM(enabled);
 #endif
@@ -252,7 +247,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (BOOL)isLookToScrollEnabled
 {
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    return protectedPreferences(self)->overlayRegionsEnabled();
+    return protect(*_preferences)->overlayRegionsEnabled();
 #else
     return NO;
 #endif
@@ -265,12 +260,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (BOOL)_telephoneNumberDetectionIsEnabled
 {
-    return protectedPreferences(self)->telephoneNumberParsingEnabled();
+    return protect(*_preferences)->telephoneNumberParsingEnabled();
 }
 
 - (void)_setTelephoneNumberDetectionIsEnabled:(BOOL)telephoneNumberDetectionIsEnabled
 {
-    protectedPreferences(self)->setTelephoneNumberParsingEnabled(telephoneNumberDetectionIsEnabled);
+    protect(*_preferences)->setTelephoneNumberParsingEnabled(telephoneNumberDetectionIsEnabled);
 }
 
 static WebCore::StorageBlockingPolicy toStorageBlockingPolicy(_WKStorageBlockingPolicy policy)
@@ -305,272 +300,272 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 
 - (_WKStorageBlockingPolicy)_storageBlockingPolicy
 {
-    return toAPI(static_cast<WebCore::StorageBlockingPolicy>(protectedPreferences(self)->storageBlockingPolicy()));
+    return toAPI(static_cast<WebCore::StorageBlockingPolicy>(protect(*_preferences)->storageBlockingPolicy()));
 }
 
 - (void)_setStorageBlockingPolicy:(_WKStorageBlockingPolicy)policy
 {
-    protectedPreferences(self)->setStorageBlockingPolicy(static_cast<uint32_t>(toStorageBlockingPolicy(policy)));
+    protect(*_preferences)->setStorageBlockingPolicy(static_cast<uint32_t>(toStorageBlockingPolicy(policy)));
 }
 
 - (BOOL)_fullScreenEnabled
 {
-    return protectedPreferences(self)->fullScreenEnabled();
+    return protect(*_preferences)->fullScreenEnabled();
 }
 
 - (void)_setFullScreenEnabled:(BOOL)fullScreenEnabled
 {
-    protectedPreferences(self)->setFullScreenEnabled(fullScreenEnabled);
+    protect(*_preferences)->setFullScreenEnabled(fullScreenEnabled);
 }
 
 - (BOOL)_allowsPictureInPictureMediaPlayback
 {
-    return protectedPreferences(self)->allowsPictureInPictureMediaPlayback();
+    return protect(*_preferences)->allowsPictureInPictureMediaPlayback();
 }
 
 - (void)_setAllowsPictureInPictureMediaPlayback:(BOOL)allowed
 {
-    protectedPreferences(self)->setAllowsPictureInPictureMediaPlayback(allowed);
+    protect(*_preferences)->setAllowsPictureInPictureMediaPlayback(allowed);
 }
 
 - (BOOL)_compositingBordersVisible
 {
-    return protectedPreferences(self)->compositingBordersVisible();
+    return protect(*_preferences)->compositingBordersVisible();
 }
 
 - (void)_setCompositingBordersVisible:(BOOL)compositingBordersVisible
 {
-    protectedPreferences(self)->setCompositingBordersVisible(compositingBordersVisible);
+    protect(*_preferences)->setCompositingBordersVisible(compositingBordersVisible);
 }
 
 - (BOOL)_compositingRepaintCountersVisible
 {
-    return protectedPreferences(self)->compositingRepaintCountersVisible();
+    return protect(*_preferences)->compositingRepaintCountersVisible();
 }
 
 - (void)_setCompositingRepaintCountersVisible:(BOOL)repaintCountersVisible
 {
-    protectedPreferences(self)->setCompositingRepaintCountersVisible(repaintCountersVisible);
+    protect(*_preferences)->setCompositingRepaintCountersVisible(repaintCountersVisible);
 }
 
 - (BOOL)_tiledScrollingIndicatorVisible
 {
-    return protectedPreferences(self)->tiledScrollingIndicatorVisible();
+    return protect(*_preferences)->tiledScrollingIndicatorVisible();
 }
 
 - (void)_setTiledScrollingIndicatorVisible:(BOOL)tiledScrollingIndicatorVisible
 {
-    protectedPreferences(self)->setTiledScrollingIndicatorVisible(tiledScrollingIndicatorVisible);
+    protect(*_preferences)->setTiledScrollingIndicatorVisible(tiledScrollingIndicatorVisible);
 }
 
 - (BOOL)_resourceUsageOverlayVisible
 {
-    return protectedPreferences(self)->resourceUsageOverlayVisible();
+    return protect(*_preferences)->resourceUsageOverlayVisible();
 }
 
 - (void)_setResourceUsageOverlayVisible:(BOOL)resourceUsageOverlayVisible
 {
-    protectedPreferences(self)->setResourceUsageOverlayVisible(resourceUsageOverlayVisible);
+    protect(*_preferences)->setResourceUsageOverlayVisible(resourceUsageOverlayVisible);
 }
 
 - (_WKDebugOverlayRegions)_visibleDebugOverlayRegions
 {
-    return protectedPreferences(self)->visibleDebugOverlayRegions();
+    return protect(*_preferences)->visibleDebugOverlayRegions();
 }
 
 - (void)_setVisibleDebugOverlayRegions:(_WKDebugOverlayRegions)regionFlags
 {
-    protectedPreferences(self)->setVisibleDebugOverlayRegions(regionFlags);
+    protect(*_preferences)->setVisibleDebugOverlayRegions(regionFlags);
 }
 
 - (BOOL)_legacyLineLayoutVisualCoverageEnabled
 {
-    return protectedPreferences(self)->legacyLineLayoutVisualCoverageEnabled();
+    return protect(*_preferences)->legacyLineLayoutVisualCoverageEnabled();
 }
 
 - (void)_setLegacyLineLayoutVisualCoverageEnabled:(BOOL)legacyLineLayoutVisualCoverageEnabled
 {
-    protectedPreferences(self)->setLegacyLineLayoutVisualCoverageEnabled(legacyLineLayoutVisualCoverageEnabled);
+    protect(*_preferences)->setLegacyLineLayoutVisualCoverageEnabled(legacyLineLayoutVisualCoverageEnabled);
 }
 
 - (BOOL)_contentChangeObserverEnabled
 {
-    return protectedPreferences(self)->contentChangeObserverEnabled();
+    return protect(*_preferences)->contentChangeObserverEnabled();
 }
 
 - (void)_setContentChangeObserverEnabled:(BOOL)contentChangeObserverEnabled
 {
-    protectedPreferences(self)->setContentChangeObserverEnabled(contentChangeObserverEnabled);
+    protect(*_preferences)->setContentChangeObserverEnabled(contentChangeObserverEnabled);
 }
 
 - (BOOL)_acceleratedDrawingEnabled
 {
-    return protectedPreferences(self)->acceleratedDrawingEnabled();
+    return protect(*_preferences)->acceleratedDrawingEnabled();
 }
 
 - (void)_setAcceleratedDrawingEnabled:(BOOL)acceleratedDrawingEnabled
 {
-    protectedPreferences(self)->setAcceleratedDrawingEnabled(acceleratedDrawingEnabled);
+    protect(*_preferences)->setAcceleratedDrawingEnabled(acceleratedDrawingEnabled);
 }
 
 - (BOOL)_largeImageAsyncDecodingEnabled
 {
-    return protectedPreferences(self)->largeImageAsyncDecodingEnabled();
+    return protect(*_preferences)->largeImageAsyncDecodingEnabled();
 }
 
 - (void)_setLargeImageAsyncDecodingEnabled:(BOOL)_largeImageAsyncDecodingEnabled
 {
-    protectedPreferences(self)->setLargeImageAsyncDecodingEnabled(_largeImageAsyncDecodingEnabled);
+    protect(*_preferences)->setLargeImageAsyncDecodingEnabled(_largeImageAsyncDecodingEnabled);
 }
 
 - (BOOL)_needsInAppBrowserPrivacyQuirks
 {
-    return protectedPreferences(self)->needsInAppBrowserPrivacyQuirks();
+    return protect(*_preferences)->needsInAppBrowserPrivacyQuirks();
 }
 
 - (void)_setNeedsInAppBrowserPrivacyQuirks:(BOOL)enabled
 {
-    protectedPreferences(self)->setNeedsInAppBrowserPrivacyQuirks(enabled);
+    protect(*_preferences)->setNeedsInAppBrowserPrivacyQuirks(enabled);
 }
 
 - (BOOL)_animatedImageAsyncDecodingEnabled
 {
-    return protectedPreferences(self)->animatedImageAsyncDecodingEnabled();
+    return protect(*_preferences)->animatedImageAsyncDecodingEnabled();
 }
 
 - (void)_setAnimatedImageAsyncDecodingEnabled:(BOOL)_animatedImageAsyncDecodingEnabled
 {
-    protectedPreferences(self)->setAnimatedImageAsyncDecodingEnabled(_animatedImageAsyncDecodingEnabled);
+    protect(*_preferences)->setAnimatedImageAsyncDecodingEnabled(_animatedImageAsyncDecodingEnabled);
 }
 
 - (BOOL)_textAutosizingEnabled
 {
-    return protectedPreferences(self)->textAutosizingEnabled();
+    return protect(*_preferences)->textAutosizingEnabled();
 }
 
 - (void)_setTextAutosizingEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setTextAutosizingEnabled(enabled);
+    protect(*_preferences)->setTextAutosizingEnabled(enabled);
 }
 
 - (BOOL)_developerExtrasEnabled
 {
-    return protectedPreferences(self)->developerExtrasEnabled();
+    return protect(*_preferences)->developerExtrasEnabled();
 }
 
 - (void)_setDeveloperExtrasEnabled:(BOOL)developerExtrasEnabled
 {
-    protectedPreferences(self)->setDeveloperExtrasEnabled(developerExtrasEnabled);
+    protect(*_preferences)->setDeveloperExtrasEnabled(developerExtrasEnabled);
 }
 
 - (BOOL)_logsPageMessagesToSystemConsoleEnabled
 {
-    return protectedPreferences(self)->logsPageMessagesToSystemConsoleEnabled();
+    return protect(*_preferences)->logsPageMessagesToSystemConsoleEnabled();
 }
 
 - (void)_setLogsPageMessagesToSystemConsoleEnabled:(BOOL)logsPageMessagesToSystemConsoleEnabled
 {
-    protectedPreferences(self)->setLogsPageMessagesToSystemConsoleEnabled(logsPageMessagesToSystemConsoleEnabled);
+    protect(*_preferences)->setLogsPageMessagesToSystemConsoleEnabled(logsPageMessagesToSystemConsoleEnabled);
 }
 
 - (BOOL)_hiddenPageDOMTimerThrottlingEnabled
 {
-    return protectedPreferences(self)->hiddenPageDOMTimerThrottlingEnabled();
+    return protect(*_preferences)->hiddenPageDOMTimerThrottlingEnabled();
 }
 
 - (void)_setHiddenPageDOMTimerThrottlingEnabled:(BOOL)hiddenPageDOMTimerThrottlingEnabled
 {
-    protectedPreferences(self)->setHiddenPageDOMTimerThrottlingEnabled(hiddenPageDOMTimerThrottlingEnabled);
+    protect(*_preferences)->setHiddenPageDOMTimerThrottlingEnabled(hiddenPageDOMTimerThrottlingEnabled);
 }
 
 - (BOOL)_hiddenPageDOMTimerThrottlingAutoIncreases
 {
-    return protectedPreferences(self)->hiddenPageDOMTimerThrottlingAutoIncreases();
+    return protect(*_preferences)->hiddenPageDOMTimerThrottlingAutoIncreases();
 }
 
 - (void)_setHiddenPageDOMTimerThrottlingAutoIncreases:(BOOL)hiddenPageDOMTimerThrottlingAutoIncreases
 {
-    protectedPreferences(self)->setHiddenPageDOMTimerThrottlingAutoIncreases(hiddenPageDOMTimerThrottlingAutoIncreases);
+    protect(*_preferences)->setHiddenPageDOMTimerThrottlingAutoIncreases(hiddenPageDOMTimerThrottlingAutoIncreases);
 }
 
 - (BOOL)_pageVisibilityBasedProcessSuppressionEnabled
 {
-    return protectedPreferences(self)->pageVisibilityBasedProcessSuppressionEnabled();
+    return protect(*_preferences)->pageVisibilityBasedProcessSuppressionEnabled();
 }
 
 - (void)_setPageVisibilityBasedProcessSuppressionEnabled:(BOOL)pageVisibilityBasedProcessSuppressionEnabled
 {
-    protectedPreferences(self)->setPageVisibilityBasedProcessSuppressionEnabled(pageVisibilityBasedProcessSuppressionEnabled);
+    protect(*_preferences)->setPageVisibilityBasedProcessSuppressionEnabled(pageVisibilityBasedProcessSuppressionEnabled);
 }
 
 - (BOOL)_allowFileAccessFromFileURLs
 {
-    return protectedPreferences(self)->allowFileAccessFromFileURLs();
+    return protect(*_preferences)->allowFileAccessFromFileURLs();
 }
 
 - (void)_setAllowFileAccessFromFileURLs:(BOOL)allowFileAccessFromFileURLs
 {
-    protectedPreferences(self)->setAllowFileAccessFromFileURLs(allowFileAccessFromFileURLs);
+    protect(*_preferences)->setAllowFileAccessFromFileURLs(allowFileAccessFromFileURLs);
 }
 
 - (_WKJavaScriptRuntimeFlags)_javaScriptRuntimeFlags
 {
-    return protectedPreferences(self)->javaScriptRuntimeFlags();
+    return protect(*_preferences)->javaScriptRuntimeFlags();
 }
 
 - (void)_setJavaScriptRuntimeFlags:(_WKJavaScriptRuntimeFlags)javaScriptRuntimeFlags
 {
-    protectedPreferences(self)->setJavaScriptRuntimeFlags(javaScriptRuntimeFlags);
+    protect(*_preferences)->setJavaScriptRuntimeFlags(javaScriptRuntimeFlags);
 }
 
 - (BOOL)_isStandalone
 {
-    return protectedPreferences(self)->standalone();
+    return protect(*_preferences)->standalone();
 }
 
 - (void)_setStandalone:(BOOL)standalone
 {
-    protectedPreferences(self)->setStandalone(standalone);
+    protect(*_preferences)->setStandalone(standalone);
 }
 
 - (BOOL)_diagnosticLoggingEnabled
 {
-    return protectedPreferences(self)->diagnosticLoggingEnabled();
+    return protect(*_preferences)->diagnosticLoggingEnabled();
 }
 
 - (void)_setDiagnosticLoggingEnabled:(BOOL)diagnosticLoggingEnabled
 {
-    protectedPreferences(self)->setDiagnosticLoggingEnabled(diagnosticLoggingEnabled);
+    protect(*_preferences)->setDiagnosticLoggingEnabled(diagnosticLoggingEnabled);
 }
 
 - (NSUInteger)_defaultFontSize
 {
-    return protectedPreferences(self)->defaultFontSize();
+    return protect(*_preferences)->defaultFontSize();
 }
 
 - (void)_setDefaultFontSize:(NSUInteger)defaultFontSize
 {
-    protectedPreferences(self)->setDefaultFontSize(defaultFontSize);
+    protect(*_preferences)->setDefaultFontSize(defaultFontSize);
 }
 
 - (NSUInteger)_defaultFixedPitchFontSize
 {
-    return protectedPreferences(self)->defaultFixedFontSize();
+    return protect(*_preferences)->defaultFixedFontSize();
 }
 
 - (void)_setDefaultFixedPitchFontSize:(NSUInteger)defaultFixedPitchFontSize
 {
-    protectedPreferences(self)->setDefaultFixedFontSize(defaultFixedPitchFontSize);
+    protect(*_preferences)->setDefaultFixedFontSize(defaultFixedPitchFontSize);
 }
 
 - (NSString *)_fixedPitchFontFamily
 {
-    return protectedPreferences(self)->fixedFontFamily().createNSString().autorelease();
+    return protect(*_preferences)->fixedFontFamily().createNSString().autorelease();
 }
 
 - (void)_setFixedPitchFontFamily:(NSString *)fixedPitchFontFamily
 {
-    protectedPreferences(self)->setFixedFontFamily(fixedPitchFontFamily);
+    protect(*_preferences)->setFixedFontFamily(fixedPitchFontFamily);
 }
 
 + (NSArray<_WKFeature *> *)_features
@@ -587,12 +582,12 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 
 - (BOOL)_isEnabledForInternalDebugFeature:(_WKFeature *)feature
 {
-    return protectedPreferences(self)->isFeatureEnabled(Ref { *feature->_wrappedFeature });
+    return protect(*_preferences)->isFeatureEnabled(Ref { *feature->_wrappedFeature });
 }
 
 - (void)_setEnabled:(BOOL)value forInternalDebugFeature:(_WKFeature *)feature
 {
-    protectedPreferences(self)->setFeatureEnabled(Ref { *feature->_wrappedFeature }, value);
+    protect(*_preferences)->setFeatureEnabled(Ref { *feature->_wrappedFeature }, value);
 }
 
 + (NSArray<_WKExperimentalFeature *> *)_experimentalFeatures
@@ -603,12 +598,12 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 
 - (BOOL)_isEnabledForFeature:(_WKFeature *)feature
 {
-    return protectedPreferences(self)->isFeatureEnabled(Ref { *feature->_wrappedFeature });
+    return protect(*_preferences)->isFeatureEnabled(Ref { *feature->_wrappedFeature });
 }
 
 - (void)_setEnabled:(BOOL)value forFeature:(_WKFeature *)feature
 {
-    protectedPreferences(self)->setFeatureEnabled(Ref { *feature->_wrappedFeature }, value);
+    protect(*_preferences)->setFeatureEnabled(Ref { *feature->_wrappedFeature }, value);
 }
 
 - (BOOL)_isEnabledForExperimentalFeature:(_WKFeature *)feature
@@ -623,18 +618,18 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 
 - (void)_disableRichJavaScriptFeatures
 {
-    protectedPreferences(self)->disableRichJavaScriptFeatures();
+    protect(*_preferences)->disableRichJavaScriptFeatures();
 }
 
 - (void)_disableMediaPlaybackRelatedFeatures
 {
-    protectedPreferences(self)->disableMediaPlaybackRelatedFeatures();
+    protect(*_preferences)->disableMediaPlaybackRelatedFeatures();
 }
 
 - (BOOL)_applePayCapabilityDisclosureAllowed
 {
 #if ENABLE(APPLE_PAY)
-    return protectedPreferences(self)->applePayCapabilityDisclosureAllowed();
+    return protect(*_preferences)->applePayCapabilityDisclosureAllowed();
 #else
     return NO;
 #endif
@@ -643,163 +638,163 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 - (void)_setApplePayCapabilityDisclosureAllowed:(BOOL)applePayCapabilityDisclosureAllowed
 {
 #if ENABLE(APPLE_PAY)
-    protectedPreferences(self)->setApplePayCapabilityDisclosureAllowed(applePayCapabilityDisclosureAllowed);
+    protect(*_preferences)->setApplePayCapabilityDisclosureAllowed(applePayCapabilityDisclosureAllowed);
 #endif
 }
 
 - (BOOL)_shouldSuppressKeyboardInputDuringProvisionalNavigation
 {
-    return protectedPreferences(self)->shouldSuppressTextInputFromEditingDuringProvisionalNavigation();
+    return protect(*_preferences)->shouldSuppressTextInputFromEditingDuringProvisionalNavigation();
 }
 
 - (void)_setShouldSuppressKeyboardInputDuringProvisionalNavigation:(BOOL)shouldSuppress
 {
-    protectedPreferences(self)->setShouldSuppressTextInputFromEditingDuringProvisionalNavigation(shouldSuppress);
+    protect(*_preferences)->setShouldSuppressTextInputFromEditingDuringProvisionalNavigation(shouldSuppress);
 }
 
 - (BOOL)_loadsImagesAutomatically
 {
-    return protectedPreferences(self)->loadsImagesAutomatically();
+    return protect(*_preferences)->loadsImagesAutomatically();
 }
 
 - (void)_setLoadsImagesAutomatically:(BOOL)loadsImagesAutomatically
 {
-    protectedPreferences(self)->setLoadsImagesAutomatically(loadsImagesAutomatically);
+    protect(*_preferences)->setLoadsImagesAutomatically(loadsImagesAutomatically);
 }
 
 - (BOOL)_peerConnectionEnabled
 {
-    return protectedPreferences(self)->peerConnectionEnabled();
+    return protect(*_preferences)->peerConnectionEnabled();
 }
 
 - (void)_setPeerConnectionEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setPeerConnectionEnabled(enabled);
+    protect(*_preferences)->setPeerConnectionEnabled(enabled);
 }
 
 - (BOOL)_mediaDevicesEnabled
 {
-    return protectedPreferences(self)->mediaDevicesEnabled();
+    return protect(*_preferences)->mediaDevicesEnabled();
 }
 
 - (void)_setMediaDevicesEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setMediaDevicesEnabled(enabled);
+    protect(*_preferences)->setMediaDevicesEnabled(enabled);
 }
 
 - (BOOL)_getUserMediaRequiresFocus
 {
-    return protectedPreferences(self)->getUserMediaRequiresFocus();
+    return protect(*_preferences)->getUserMediaRequiresFocus();
 }
 
 - (void)_setGetUserMediaRequiresFocus:(BOOL)enabled
 {
-    protectedPreferences(self)->setGetUserMediaRequiresFocus(enabled);
+    protect(*_preferences)->setGetUserMediaRequiresFocus(enabled);
 }
 
 - (BOOL)_screenCaptureEnabled
 {
-    return protectedPreferences(self)->screenCaptureEnabled();
+    return protect(*_preferences)->screenCaptureEnabled();
 }
 
 - (void)_setScreenCaptureEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setScreenCaptureEnabled(enabled);
+    protect(*_preferences)->setScreenCaptureEnabled(enabled);
 }
 
 - (BOOL)_mockCaptureDevicesEnabled
 {
-    return protectedPreferences(self)->mockCaptureDevicesEnabled();
+    return protect(*_preferences)->mockCaptureDevicesEnabled();
 }
 
 - (void)_setMockCaptureDevicesEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setMockCaptureDevicesEnabled(enabled);
+    protect(*_preferences)->setMockCaptureDevicesEnabled(enabled);
 }
 
 - (BOOL)_mockCaptureDevicesPromptEnabled
 {
-    return protectedPreferences(self)->mockCaptureDevicesPromptEnabled();
+    return protect(*_preferences)->mockCaptureDevicesPromptEnabled();
 }
 
 - (void)_setMockCaptureDevicesPromptEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setMockCaptureDevicesPromptEnabled(enabled);
+    protect(*_preferences)->setMockCaptureDevicesPromptEnabled(enabled);
 }
 
 - (BOOL)_mediaCaptureRequiresSecureConnection
 {
-    return protectedPreferences(self)->mediaCaptureRequiresSecureConnection();
+    return protect(*_preferences)->mediaCaptureRequiresSecureConnection();
 }
 
 - (void)_setMediaCaptureRequiresSecureConnection:(BOOL)requiresSecureConnection
 {
-    protectedPreferences(self)->setMediaCaptureRequiresSecureConnection(requiresSecureConnection);
+    protect(*_preferences)->setMediaCaptureRequiresSecureConnection(requiresSecureConnection);
 }
 
 - (double)_inactiveMediaCaptureStreamRepromptIntervalInMinutes
 {
-    return protectedPreferences(self)->inactiveMediaCaptureStreamRepromptIntervalInMinutes();
+    return protect(*_preferences)->inactiveMediaCaptureStreamRepromptIntervalInMinutes();
 }
 
 - (void)_setInactiveMediaCaptureStreamRepromptIntervalInMinutes:(double)interval
 {
-    protectedPreferences(self)->setInactiveMediaCaptureStreamRepromptIntervalInMinutes(interval);
+    protect(*_preferences)->setInactiveMediaCaptureStreamRepromptIntervalInMinutes(interval);
 }
 
 - (double)_inactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes
 {
-    return protectedPreferences(self)->inactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes();
+    return protect(*_preferences)->inactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes();
 }
 
 - (void)_setInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes:(double)interval
 {
-    protectedPreferences(self)->setInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes(interval);
+    protect(*_preferences)->setInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes(interval);
 }
 
 - (BOOL)_interruptAudioOnPageVisibilityChangeEnabled
 {
-    return protectedPreferences(self)->interruptAudioOnPageVisibilityChangeEnabled();
+    return protect(*_preferences)->interruptAudioOnPageVisibilityChangeEnabled();
 }
 
 - (void)_setInterruptAudioOnPageVisibilityChangeEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setInterruptAudioOnPageVisibilityChangeEnabled(enabled);
+    protect(*_preferences)->setInterruptAudioOnPageVisibilityChangeEnabled(enabled);
 }
 
 - (BOOL)_enumeratingAllNetworkInterfacesEnabled
 {
-    return protectedPreferences(self)->enumeratingAllNetworkInterfacesEnabled();
+    return protect(*_preferences)->enumeratingAllNetworkInterfacesEnabled();
 }
 
 - (void)_setEnumeratingAllNetworkInterfacesEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setEnumeratingAllNetworkInterfacesEnabled(enabled);
+    protect(*_preferences)->setEnumeratingAllNetworkInterfacesEnabled(enabled);
 }
 
 - (BOOL)_iceCandidateFilteringEnabled
 {
-    return protectedPreferences(self)->iceCandidateFilteringEnabled();
+    return protect(*_preferences)->iceCandidateFilteringEnabled();
 }
 
 - (void)_setICECandidateFilteringEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setICECandidateFilteringEnabled(enabled);
+    protect(*_preferences)->setICECandidateFilteringEnabled(enabled);
 }
 
 - (void)_setJavaScriptCanAccessClipboard:(BOOL)javaScriptCanAccessClipboard
 {
-    protectedPreferences(self)->setJavaScriptCanAccessClipboard(javaScriptCanAccessClipboard);
+    protect(*_preferences)->setJavaScriptCanAccessClipboard(javaScriptCanAccessClipboard);
 }
 
 - (BOOL)_shouldAllowUserInstalledFonts
 {
-    return protectedPreferences(self)->shouldAllowUserInstalledFonts();
+    return protect(*_preferences)->shouldAllowUserInstalledFonts();
 }
 
 - (void)_setShouldAllowUserInstalledFonts:(BOOL)_shouldAllowUserInstalledFonts
 {
-    protectedPreferences(self)->setShouldAllowUserInstalledFonts(_shouldAllowUserInstalledFonts);
+    protect(*_preferences)->setShouldAllowUserInstalledFonts(_shouldAllowUserInstalledFonts);
 }
 
 static _WKEditableLinkBehavior toAPI(WebCore::EditableLinkBehavior behavior)
@@ -842,253 +837,253 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (_WKEditableLinkBehavior)_editableLinkBehavior
 {
-    return toAPI(static_cast<WebCore::EditableLinkBehavior>(protectedPreferences(self)->editableLinkBehavior()));
+    return toAPI(static_cast<WebCore::EditableLinkBehavior>(protect(*_preferences)->editableLinkBehavior()));
 }
 
 - (void)_setEditableLinkBehavior:(_WKEditableLinkBehavior)editableLinkBehavior
 {
-    protectedPreferences(self)->setEditableLinkBehavior(static_cast<uint32_t>(toEditableLinkBehavior(editableLinkBehavior)));
+    protect(*_preferences)->setEditableLinkBehavior(static_cast<uint32_t>(toEditableLinkBehavior(editableLinkBehavior)));
 }
 
 - (void)_setAVFoundationEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setAVFoundationEnabled(enabled);
+    protect(*_preferences)->setAVFoundationEnabled(enabled);
 }
 
 - (BOOL)_avFoundationEnabled
 {
-    return protectedPreferences(self)->isAVFoundationEnabled();
+    return protect(*_preferences)->isAVFoundationEnabled();
 }
 
 - (void)_setTextExtractionEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setTextExtractionEnabled(enabled);
+    protect(*_preferences)->setTextExtractionEnabled(enabled);
 }
 
 - (BOOL)_textExtractionEnabled
 {
-    return protectedPreferences(self)->textExtractionEnabled();
+    return protect(*_preferences)->textExtractionEnabled();
 }
 
 - (void)_setColorFilterEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setColorFilterEnabled(enabled);
+    protect(*_preferences)->setColorFilterEnabled(enabled);
 }
 
 - (BOOL)_colorFilterEnabled
 {
-    return protectedPreferences(self)->colorFilterEnabled();
+    return protect(*_preferences)->colorFilterEnabled();
 }
 
 - (void)_setPunchOutWhiteBackgroundsInDarkMode:(BOOL)punches
 {
-    protectedPreferences(self)->setPunchOutWhiteBackgroundsInDarkMode(punches);
+    protect(*_preferences)->setPunchOutWhiteBackgroundsInDarkMode(punches);
 }
 
 - (BOOL)_punchOutWhiteBackgroundsInDarkMode
 {
-    return protectedPreferences(self)->punchOutWhiteBackgroundsInDarkMode();
+    return protect(*_preferences)->punchOutWhiteBackgroundsInDarkMode();
 }
 
 - (void)_setLowPowerVideoAudioBufferSizeEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setLowPowerVideoAudioBufferSizeEnabled(enabled);
+    protect(*_preferences)->setLowPowerVideoAudioBufferSizeEnabled(enabled);
 }
 
 - (BOOL)_lowPowerVideoAudioBufferSizeEnabled
 {
-    return protectedPreferences(self)->lowPowerVideoAudioBufferSizeEnabled();
+    return protect(*_preferences)->lowPowerVideoAudioBufferSizeEnabled();
 }
 
 - (void)_setShouldIgnoreMetaViewport:(BOOL)ignoreMetaViewport
 {
-    return protectedPreferences(self)->setShouldIgnoreMetaViewport(ignoreMetaViewport);
+    return protect(*_preferences)->setShouldIgnoreMetaViewport(ignoreMetaViewport);
 }
 
 - (BOOL)_shouldIgnoreMetaViewport
 {
-    return protectedPreferences(self)->shouldIgnoreMetaViewport();
+    return protect(*_preferences)->shouldIgnoreMetaViewport();
 }
 
 - (void)_setNeedsSiteSpecificQuirks:(BOOL)enabled
 {
-    protectedPreferences(self)->setNeedsSiteSpecificQuirks(enabled);
+    protect(*_preferences)->setNeedsSiteSpecificQuirks(enabled);
 }
 
 - (BOOL)_needsSiteSpecificQuirks
 {
-    return protectedPreferences(self)->needsSiteSpecificQuirks();
+    return protect(*_preferences)->needsSiteSpecificQuirks();
 }
 
 - (void)_setItpDebugModeEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setItpDebugModeEnabled(enabled);
+    protect(*_preferences)->setItpDebugModeEnabled(enabled);
 }
 
 - (BOOL)_itpDebugModeEnabled
 {
-    return protectedPreferences(self)->itpDebugModeEnabled();
+    return protect(*_preferences)->itpDebugModeEnabled();
 }
 
 - (void)_setMediaSourceEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setMediaSourceEnabled(enabled);
+    protect(*_preferences)->setMediaSourceEnabled(enabled);
 }
 
 - (BOOL)_mediaSourceEnabled
 {
-    return protectedPreferences(self)->mediaSourceEnabled();
+    return protect(*_preferences)->mediaSourceEnabled();
 }
 
 - (void)_setManagedMediaSourceEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setManagedMediaSourceEnabled(enabled);
+    protect(*_preferences)->setManagedMediaSourceEnabled(enabled);
 }
 
 - (BOOL)_managedMediaSourceEnabled
 {
-    return protectedPreferences(self)->managedMediaSourceEnabled();
+    return protect(*_preferences)->managedMediaSourceEnabled();
 }
 
 - (void)_setManagedMediaSourceLowThreshold:(double)threshold
 {
-    protectedPreferences(self)->setManagedMediaSourceLowThreshold(threshold);
+    protect(*_preferences)->setManagedMediaSourceLowThreshold(threshold);
 }
 
 - (double)_managedMediaSourceLowThreshold
 {
-    return protectedPreferences(self)->managedMediaSourceLowThreshold();
+    return protect(*_preferences)->managedMediaSourceLowThreshold();
 }
 
 - (void)_setManagedMediaSourceHighThreshold:(double)threshold
 {
-    protectedPreferences(self)->setManagedMediaSourceHighThreshold(threshold);
+    protect(*_preferences)->setManagedMediaSourceHighThreshold(threshold);
 }
 
 - (double)_managedMediaSourceHighThreshold
 {
-    return protectedPreferences(self)->managedMediaSourceHighThreshold();
+    return protect(*_preferences)->managedMediaSourceHighThreshold();
 }
 
 - (BOOL)_secureContextChecksEnabled
 {
-    return protectedPreferences(self)->secureContextChecksEnabled();
+    return protect(*_preferences)->secureContextChecksEnabled();
 }
 
 - (void)_setSecureContextChecksEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setSecureContextChecksEnabled(enabled);
+    protect(*_preferences)->setSecureContextChecksEnabled(enabled);
 }
 
 - (void)_setWebAudioEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setWebAudioEnabled(enabled);
+    protect(*_preferences)->setWebAudioEnabled(enabled);
 }
 
 - (BOOL)_webAudioEnabled
 {
-    return protectedPreferences(self)->webAudioEnabled();
+    return protect(*_preferences)->webAudioEnabled();
 }
 
 - (void)_setAcceleratedCompositingEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setAcceleratedCompositingEnabled(enabled);
+    protect(*_preferences)->setAcceleratedCompositingEnabled(enabled);
 }
 
 - (BOOL)_acceleratedCompositingEnabled
 {
-    return protectedPreferences(self)->acceleratedCompositingEnabled();
+    return protect(*_preferences)->acceleratedCompositingEnabled();
 }
 
 - (BOOL)_remotePlaybackEnabled
 {
-    return protectedPreferences(self)->remotePlaybackEnabled();
+    return protect(*_preferences)->remotePlaybackEnabled();
 }
 
 - (void)_setRemotePlaybackEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setRemotePlaybackEnabled(enabled);
+    protect(*_preferences)->setRemotePlaybackEnabled(enabled);
 }
 
 - (BOOL)_serviceWorkerEntitlementDisabledForTesting
 {
-    return protectedPreferences(self)->serviceWorkerEntitlementDisabledForTesting();
+    return protect(*_preferences)->serviceWorkerEntitlementDisabledForTesting();
 }
 
 - (void)_setServiceWorkerEntitlementDisabledForTesting:(BOOL)disable
 {
-    protectedPreferences(self)->setServiceWorkerEntitlementDisabledForTesting(disable);
+    protect(*_preferences)->setServiceWorkerEntitlementDisabledForTesting(disable);
 }
 
 #if PLATFORM(MAC)
 - (void)_setCanvasUsesAcceleratedDrawing:(BOOL)enabled
 {
-    protectedPreferences(self)->setCanvasUsesAcceleratedDrawing(enabled);
+    protect(*_preferences)->setCanvasUsesAcceleratedDrawing(enabled);
 }
 
 - (BOOL)_canvasUsesAcceleratedDrawing
 {
-    return protectedPreferences(self)->canvasUsesAcceleratedDrawing();
+    return protect(*_preferences)->canvasUsesAcceleratedDrawing();
 }
 
 - (void)_setDefaultTextEncodingName:(NSString *)name
 {
-    protectedPreferences(self)->setDefaultTextEncodingName(name);
+    protect(*_preferences)->setDefaultTextEncodingName(name);
 }
 
 - (NSString *)_defaultTextEncodingName
 {
-    return protectedPreferences(self)->defaultTextEncodingName().createNSString().autorelease();
+    return protect(*_preferences)->defaultTextEncodingName().createNSString().autorelease();
 }
 
 - (void)_setAuthorAndUserStylesEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setAuthorAndUserStylesEnabled(enabled);
+    protect(*_preferences)->setAuthorAndUserStylesEnabled(enabled);
 }
 
 - (BOOL)_authorAndUserStylesEnabled
 {
-    return protectedPreferences(self)->authorAndUserStylesEnabled();
+    return protect(*_preferences)->authorAndUserStylesEnabled();
 }
 
 - (void)_setDOMTimersThrottlingEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setDOMTimersThrottlingEnabled(enabled);
+    protect(*_preferences)->setDOMTimersThrottlingEnabled(enabled);
 }
 
 - (BOOL)_domTimersThrottlingEnabled
 {
-    return protectedPreferences(self)->domTimersThrottlingEnabled();
+    return protect(*_preferences)->domTimersThrottlingEnabled();
 }
 
 - (void)_setWebArchiveDebugModeEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setWebArchiveDebugModeEnabled(enabled);
+    protect(*_preferences)->setWebArchiveDebugModeEnabled(enabled);
 }
 
 - (BOOL)_webArchiveDebugModeEnabled
 {
-    return protectedPreferences(self)->webArchiveDebugModeEnabled();
+    return protect(*_preferences)->webArchiveDebugModeEnabled();
 }
 
 - (void)_setLocalFileContentSniffingEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setLocalFileContentSniffingEnabled(enabled);
+    protect(*_preferences)->setLocalFileContentSniffingEnabled(enabled);
 }
 
 - (BOOL)_localFileContentSniffingEnabled
 {
-    return protectedPreferences(self)->localFileContentSniffingEnabled();
+    return protect(*_preferences)->localFileContentSniffingEnabled();
 }
 
 - (void)_setUsesPageCache:(BOOL)enabled
 {
-    protectedPreferences(self)->setUsesBackForwardCache(enabled);
+    protect(*_preferences)->setUsesBackForwardCache(enabled);
 }
 
 - (BOOL)_usesPageCache
 {
-    return protectedPreferences(self)->usesBackForwardCache();
+    return protect(*_preferences)->usesBackForwardCache();
 }
 
 - (void)_setShouldPrintBackgrounds:(BOOL)enabled
@@ -1103,292 +1098,292 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (void)_setWebSecurityEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setWebSecurityEnabled(enabled);
+    protect(*_preferences)->setWebSecurityEnabled(enabled);
 }
 
 - (BOOL)_webSecurityEnabled
 {
-    return protectedPreferences(self)->webSecurityEnabled();
+    return protect(*_preferences)->webSecurityEnabled();
 }
 
 - (void)_setUniversalAccessFromFileURLsAllowed:(BOOL)enabled
 {
-    protectedPreferences(self)->setAllowUniversalAccessFromFileURLs(enabled);
+    protect(*_preferences)->setAllowUniversalAccessFromFileURLs(enabled);
 }
 
 - (BOOL)_universalAccessFromFileURLsAllowed
 {
-    return protectedPreferences(self)->allowUniversalAccessFromFileURLs();
+    return protect(*_preferences)->allowUniversalAccessFromFileURLs();
 }
 
 - (void)_setTopNavigationToDataURLsAllowed:(BOOL)enabled
 {
-    protectedPreferences(self)->setAllowTopNavigationToDataURLs(enabled);
+    protect(*_preferences)->setAllowTopNavigationToDataURLs(enabled);
 }
 
 - (BOOL)_topNavigationToDataURLsAllowed
 {
-    return protectedPreferences(self)->allowTopNavigationToDataURLs();
+    return protect(*_preferences)->allowTopNavigationToDataURLs();
 }
 
 - (void)_setSuppressesIncrementalRendering:(BOOL)enabled
 {
-    protectedPreferences(self)->setSuppressesIncrementalRendering(enabled);
+    protect(*_preferences)->setSuppressesIncrementalRendering(enabled);
 }
 
 - (BOOL)_suppressesIncrementalRendering
 {
-    return protectedPreferences(self)->suppressesIncrementalRendering();
+    return protect(*_preferences)->suppressesIncrementalRendering();
 }
 
 - (void)_setCookieEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setCookieEnabled(enabled);
+    protect(*_preferences)->setCookieEnabled(enabled);
 }
 
 - (BOOL)_cookieEnabled
 {
-    return protectedPreferences(self)->cookieEnabled();
+    return protect(*_preferences)->cookieEnabled();
 }
 
 - (void)_setViewGestureDebuggingEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setViewGestureDebuggingEnabled(enabled);
+    protect(*_preferences)->setViewGestureDebuggingEnabled(enabled);
 }
 
 - (BOOL)_viewGestureDebuggingEnabled
 {
-    return protectedPreferences(self)->viewGestureDebuggingEnabled();
+    return protect(*_preferences)->viewGestureDebuggingEnabled();
 }
 
 - (void)_setStandardFontFamily:(NSString *)family
 {
-    protectedPreferences(self)->setStandardFontFamily(family);
+    protect(*_preferences)->setStandardFontFamily(family);
 }
 
 - (NSString *)_standardFontFamily
 {
-    return protectedPreferences(self)->standardFontFamily().createNSString().autorelease();
+    return protect(*_preferences)->standardFontFamily().createNSString().autorelease();
 }
 
 - (void)_setBackspaceKeyNavigationEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setBackspaceKeyNavigationEnabled(enabled);
+    protect(*_preferences)->setBackspaceKeyNavigationEnabled(enabled);
 }
 
 - (BOOL)_backspaceKeyNavigationEnabled
 {
-    return protectedPreferences(self)->backspaceKeyNavigationEnabled();
+    return protect(*_preferences)->backspaceKeyNavigationEnabled();
 }
 
 - (void)_setWebGLEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setWebGLEnabled(enabled);
+    protect(*_preferences)->setWebGLEnabled(enabled);
 }
 
 - (BOOL)_webGLEnabled
 {
-    return protectedPreferences(self)->webGLEnabled();
+    return protect(*_preferences)->webGLEnabled();
 }
 
 - (void)_setAllowsInlineMediaPlayback:(BOOL)enabled
 {
-    protectedPreferences(self)->setAllowsInlineMediaPlayback(enabled);
+    protect(*_preferences)->setAllowsInlineMediaPlayback(enabled);
 }
 
 - (BOOL)_allowsInlineMediaPlayback
 {
-    return protectedPreferences(self)->allowsInlineMediaPlayback();
+    return protect(*_preferences)->allowsInlineMediaPlayback();
 }
 
 - (void)_setApplePayEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setApplePayEnabled(enabled);
+    protect(*_preferences)->setApplePayEnabled(enabled);
 }
 
 - (BOOL)_applePayEnabled
 {
-    return protectedPreferences(self)->applePayEnabled();
+    return protect(*_preferences)->applePayEnabled();
 }
 
 - (void)_setInlineMediaPlaybackRequiresPlaysInlineAttribute:(BOOL)enabled
 {
-    protectedPreferences(self)->setInlineMediaPlaybackRequiresPlaysInlineAttribute(enabled);
+    protect(*_preferences)->setInlineMediaPlaybackRequiresPlaysInlineAttribute(enabled);
 }
 
 - (BOOL)_inlineMediaPlaybackRequiresPlaysInlineAttribute
 {
-    return protectedPreferences(self)->inlineMediaPlaybackRequiresPlaysInlineAttribute();
+    return protect(*_preferences)->inlineMediaPlaybackRequiresPlaysInlineAttribute();
 }
 
 - (void)_setInvisibleMediaAutoplayNotPermitted:(BOOL)enabled
 {
-    protectedPreferences(self)->setInvisibleAutoplayNotPermitted(enabled);
+    protect(*_preferences)->setInvisibleAutoplayNotPermitted(enabled);
 }
 
 - (BOOL)_invisibleMediaAutoplayNotPermitted
 {
-    return protectedPreferences(self)->invisibleAutoplayNotPermitted();
+    return protect(*_preferences)->invisibleAutoplayNotPermitted();
 }
 
 - (void)_setLegacyEncryptedMediaAPIEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setLegacyEncryptedMediaAPIEnabled(enabled);
+    protect(*_preferences)->setLegacyEncryptedMediaAPIEnabled(enabled);
 }
 
 - (BOOL)_legacyEncryptedMediaAPIEnabled
 {
-    return protectedPreferences(self)->legacyEncryptedMediaAPIEnabled();
+    return protect(*_preferences)->legacyEncryptedMediaAPIEnabled();
 }
 
 - (void)_setMainContentUserGestureOverrideEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setMainContentUserGestureOverrideEnabled(enabled);
+    protect(*_preferences)->setMainContentUserGestureOverrideEnabled(enabled);
 }
 
 - (BOOL)_mainContentUserGestureOverrideEnabled
 {
-    return protectedPreferences(self)->mainContentUserGestureOverrideEnabled();
+    return protect(*_preferences)->mainContentUserGestureOverrideEnabled();
 }
 
 - (void)_setNeedsStorageAccessFromFileURLsQuirk:(BOOL)enabled
 {
-    protectedPreferences(self)->setNeedsStorageAccessFromFileURLsQuirk(enabled);
+    protect(*_preferences)->setNeedsStorageAccessFromFileURLsQuirk(enabled);
 }
 
 - (BOOL)_needsStorageAccessFromFileURLsQuirk
 {
-    return protectedPreferences(self)->needsStorageAccessFromFileURLsQuirk();
+    return protect(*_preferences)->needsStorageAccessFromFileURLsQuirk();
 }
 
 - (void)_setPDFPluginEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setPDFPluginEnabled(enabled);
+    protect(*_preferences)->setPDFPluginEnabled(enabled);
 }
 
 - (BOOL)_pdfPluginEnabled
 {
-    return protectedPreferences(self)->pdfPluginEnabled();
+    return protect(*_preferences)->pdfPluginEnabled();
 }
 
 - (void)_setRequiresUserGestureForAudioPlayback:(BOOL)enabled
 {
-    protectedPreferences(self)->setRequiresUserGestureForAudioPlayback(enabled);
+    protect(*_preferences)->setRequiresUserGestureForAudioPlayback(enabled);
 }
 
 - (BOOL)_requiresUserGestureForAudioPlayback
 {
-    return protectedPreferences(self)->requiresUserGestureForAudioPlayback();
+    return protect(*_preferences)->requiresUserGestureForAudioPlayback();
 }
 
 - (void)_setRequiresUserGestureForVideoPlayback:(BOOL)enabled
 {
-    protectedPreferences(self)->setRequiresUserGestureForVideoPlayback(enabled);
+    protect(*_preferences)->setRequiresUserGestureForVideoPlayback(enabled);
 }
 
 - (BOOL)_requiresUserGestureForVideoPlayback
 {
-    return protectedPreferences(self)->requiresUserGestureForVideoPlayback();
+    return protect(*_preferences)->requiresUserGestureForVideoPlayback();
 }
 
 - (void)_setServiceControlsEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setServiceControlsEnabled(enabled);
+    protect(*_preferences)->setServiceControlsEnabled(enabled);
 }
 
 - (BOOL)_serviceControlsEnabled
 {
-    return protectedPreferences(self)->serviceControlsEnabled();
+    return protect(*_preferences)->serviceControlsEnabled();
 }
 
 - (void)_setShowsToolTipOverTruncatedText:(BOOL)enabled
 {
-    protectedPreferences(self)->setShowsToolTipOverTruncatedText(enabled);
+    protect(*_preferences)->setShowsToolTipOverTruncatedText(enabled);
 }
 
 - (BOOL)_showsToolTipOverTruncatedText
 {
-    return protectedPreferences(self)->showsToolTipOverTruncatedText();
+    return protect(*_preferences)->showsToolTipOverTruncatedText();
 }
 
 - (void)_setTextAreasAreResizable:(BOOL)enabled
 {
-    protectedPreferences(self)->setTextAreasAreResizable(enabled);
+    protect(*_preferences)->setTextAreasAreResizable(enabled);
 }
 
 - (BOOL)_textAreasAreResizable
 {
-    return protectedPreferences(self)->textAreasAreResizable();
+    return protect(*_preferences)->textAreasAreResizable();
 }
 
 - (void)_setUseGiantTiles:(BOOL)enabled
 {
-    protectedPreferences(self)->setUseGiantTiles(enabled);
+    protect(*_preferences)->setUseGiantTiles(enabled);
 }
 
 - (BOOL)_useGiantTiles
 {
-    return protectedPreferences(self)->useGiantTiles();
+    return protect(*_preferences)->useGiantTiles();
 }
 
 - (void)_setWantsBalancedSetDefersLoadingBehavior:(BOOL)enabled
 {
-    protectedPreferences(self)->setWantsBalancedSetDefersLoadingBehavior(enabled);
+    protect(*_preferences)->setWantsBalancedSetDefersLoadingBehavior(enabled);
 }
 
 - (BOOL)_wantsBalancedSetDefersLoadingBehavior
 {
-    return protectedPreferences(self)->wantsBalancedSetDefersLoadingBehavior();
+    return protect(*_preferences)->wantsBalancedSetDefersLoadingBehavior();
 }
 
 - (void)_setAggressiveTileRetentionEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setAggressiveTileRetentionEnabled(enabled);
+    protect(*_preferences)->setAggressiveTileRetentionEnabled(enabled);
 }
 
 - (BOOL)_aggressiveTileRetentionEnabled
 {
-    return protectedPreferences(self)->aggressiveTileRetentionEnabled();
+    return protect(*_preferences)->aggressiveTileRetentionEnabled();
 }
 
 - (void)_setAppNapEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setPageVisibilityBasedProcessSuppressionEnabled(enabled);
+    protect(*_preferences)->setPageVisibilityBasedProcessSuppressionEnabled(enabled);
 }
 
 - (BOOL)_appNapEnabled
 {
-    return protectedPreferences(self)->pageVisibilityBasedProcessSuppressionEnabled();
+    return protect(*_preferences)->pageVisibilityBasedProcessSuppressionEnabled();
 }
 
 #endif // PLATFORM(MAC)
 
 - (BOOL)_javaScriptCanAccessClipboard
 {
-    return protectedPreferences(self)->javaScriptCanAccessClipboard();
+    return protect(*_preferences)->javaScriptCanAccessClipboard();
 }
 
 - (void)_setDOMPasteAllowed:(BOOL)domPasteAllowed
 {
-    protectedPreferences(self)->setDOMPasteAllowed(domPasteAllowed);
+    protect(*_preferences)->setDOMPasteAllowed(domPasteAllowed);
 }
 
 - (BOOL)_domPasteAllowed
 {
-    return protectedPreferences(self)->domPasteAllowed();
+    return protect(*_preferences)->domPasteAllowed();
 }
 
 - (void)_setShouldEnableTextAutosizingBoost:(BOOL)shouldEnableTextAutosizingBoost
 {
 #if ENABLE(TEXT_AUTOSIZING)
-    protectedPreferences(self)->setShouldEnableTextAutosizingBoost(shouldEnableTextAutosizingBoost);
+    protect(*_preferences)->setShouldEnableTextAutosizingBoost(shouldEnableTextAutosizingBoost);
 #endif
 }
 
 - (BOOL)_shouldEnableTextAutosizingBoost
 {
 #if ENABLE(TEXT_AUTOSIZING)
-    return protectedPreferences(self)->shouldEnableTextAutosizingBoost();
+    return protect(*_preferences)->shouldEnableTextAutosizingBoost();
 #else
     return NO;
 #endif
@@ -1396,35 +1391,35 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (BOOL)_isSafeBrowsingEnabled
 {
-    return protectedPreferences(self)->safeBrowsingEnabled();
+    return protect(*_preferences)->safeBrowsingEnabled();
 }
 
 - (void)_setSafeBrowsingEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setSafeBrowsingEnabled(enabled);
+    protect(*_preferences)->setSafeBrowsingEnabled(enabled);
 }
 
 - (void)_setVideoQualityIncludesDisplayCompositingEnabled:(BOOL)videoQualityIncludesDisplayCompositingEnabled
 {
-    protectedPreferences(self)->setVideoQualityIncludesDisplayCompositingEnabled(videoQualityIncludesDisplayCompositingEnabled);
+    protect(*_preferences)->setVideoQualityIncludesDisplayCompositingEnabled(videoQualityIncludesDisplayCompositingEnabled);
 }
 
 - (BOOL)_videoQualityIncludesDisplayCompositingEnabled
 {
-    return protectedPreferences(self)->videoQualityIncludesDisplayCompositingEnabled();
+    return protect(*_preferences)->videoQualityIncludesDisplayCompositingEnabled();
 }
 
 - (void)_setDeviceOrientationEventEnabled:(BOOL)enabled
 {
 #if ENABLE(DEVICE_ORIENTATION)
-    protectedPreferences(self)->setDeviceOrientationEventEnabled(enabled);
+    protect(*_preferences)->setDeviceOrientationEventEnabled(enabled);
 #endif
 }
 
 - (BOOL)_deviceOrientationEventEnabled
 {
 #if ENABLE(DEVICE_ORIENTATION)
-    return protectedPreferences(self)->deviceOrientationEventEnabled();
+    return protect(*_preferences)->deviceOrientationEventEnabled();
 #else
     return false;
 #endif
@@ -1433,14 +1428,14 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 - (void)_setAccessibilityIsolatedTreeEnabled:(BOOL)accessibilityIsolatedTreeEnabled
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    protectedPreferences(self)->setIsAccessibilityIsolatedTreeEnabled(accessibilityIsolatedTreeEnabled);
+    protect(*_preferences)->setIsAccessibilityIsolatedTreeEnabled(accessibilityIsolatedTreeEnabled);
 #endif
 }
 
 - (BOOL)_accessibilityIsolatedTreeEnabled
 {
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-    return protectedPreferences(self)->isAccessibilityIsolatedTreeEnabled();
+    return protect(*_preferences)->isAccessibilityIsolatedTreeEnabled();
 #else
     return false;
 #endif
@@ -1448,58 +1443,58 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (BOOL)_speechRecognitionEnabled
 {
-    return protectedPreferences(self)->speechRecognitionEnabled();
+    return protect(*_preferences)->speechRecognitionEnabled();
 }
 
 - (void)_setSpeechRecognitionEnabled:(BOOL)speechRecognitionEnabled
 {
-    protectedPreferences(self)->setSpeechRecognitionEnabled(speechRecognitionEnabled);
+    protect(*_preferences)->setSpeechRecognitionEnabled(speechRecognitionEnabled);
 }
 
 - (BOOL)_privateClickMeasurementEnabled
 {
-    return protectedPreferences(self)->privateClickMeasurementEnabled();
+    return protect(*_preferences)->privateClickMeasurementEnabled();
 }
 
 - (void)_setPrivateClickMeasurementEnabled:(BOOL)privateClickMeasurementEnabled
 {
-    protectedPreferences(self)->setPrivateClickMeasurementEnabled(privateClickMeasurementEnabled);
+    protect(*_preferences)->setPrivateClickMeasurementEnabled(privateClickMeasurementEnabled);
 }
 
 - (BOOL)_privateClickMeasurementDebugModeEnabled
 {
-    return protectedPreferences(self)->privateClickMeasurementDebugModeEnabled();
+    return protect(*_preferences)->privateClickMeasurementDebugModeEnabled();
 }
 
 - (void)_setPrivateClickMeasurementDebugModeEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setPrivateClickMeasurementDebugModeEnabled(enabled);
+    protect(*_preferences)->setPrivateClickMeasurementDebugModeEnabled(enabled);
 }
 
 - (_WKPitchCorrectionAlgorithm)_pitchCorrectionAlgorithm
 {
-    return static_cast<_WKPitchCorrectionAlgorithm>(protectedPreferences(self)->pitchCorrectionAlgorithm());
+    return static_cast<_WKPitchCorrectionAlgorithm>(protect(*_preferences)->pitchCorrectionAlgorithm());
 }
 
 - (void)_setPitchCorrectionAlgorithm:(_WKPitchCorrectionAlgorithm)pitchCorrectionAlgorithm
 {
-    protectedPreferences(self)->setPitchCorrectionAlgorithm(pitchCorrectionAlgorithm);
+    protect(*_preferences)->setPitchCorrectionAlgorithm(pitchCorrectionAlgorithm);
 }
 
 - (BOOL)_mediaSessionEnabled
 {
-    return protectedPreferences(self)->mediaSessionEnabled();
+    return protect(*_preferences)->mediaSessionEnabled();
 }
 
 - (void)_setMediaSessionEnabled:(BOOL)mediaSessionEnabled
 {
-    protectedPreferences(self)->setMediaSessionEnabled(mediaSessionEnabled);
+    protect(*_preferences)->setMediaSessionEnabled(mediaSessionEnabled);
 }
 
 - (BOOL)_isExtensibleSSOEnabled
 {
 #if HAVE(APP_SSO)
-    return protectedPreferences(self)->isExtensibleSSOEnabled();
+    return protect(*_preferences)->isExtensibleSSOEnabled();
 #else
     return false;
 #endif
@@ -1508,194 +1503,194 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 - (void)_setExtensibleSSOEnabled:(BOOL)extensibleSSOEnabled
 {
 #if HAVE(APP_SSO)
-    protectedPreferences(self)->setExtensibleSSOEnabled(extensibleSSOEnabled);
+    protect(*_preferences)->setExtensibleSSOEnabled(extensibleSSOEnabled);
 #endif
 }
 
 - (BOOL)_requiresPageVisibilityToPlayAudio
 {
-    return protectedPreferences(self)->requiresPageVisibilityToPlayAudio();
+    return protect(*_preferences)->requiresPageVisibilityToPlayAudio();
 }
 
 - (void)_setRequiresPageVisibilityToPlayAudio:(BOOL)requiresVisibility
 {
-    protectedPreferences(self)->setRequiresPageVisibilityToPlayAudio(requiresVisibility);
+    protect(*_preferences)->setRequiresPageVisibilityToPlayAudio(requiresVisibility);
 }
 
 - (BOOL)_fileSystemAccessEnabled
 {
-    return protectedPreferences(self)->fileSystemEnabled();
+    return protect(*_preferences)->fileSystemEnabled();
 }
 
 - (void)_setFileSystemAccessEnabled:(BOOL)fileSystemAccessEnabled
 {
-    protectedPreferences(self)->setFileSystemEnabled(fileSystemAccessEnabled);
+    protect(*_preferences)->setFileSystemEnabled(fileSystemAccessEnabled);
 }
 
 - (BOOL)_storageAPIEnabled
 {
-    return protectedPreferences(self)->storageAPIEnabled();
+    return protect(*_preferences)->storageAPIEnabled();
 }
 
 - (void)_setStorageAPIEnabled:(BOOL)storageAPIEnabled
 {
-    protectedPreferences(self)->setStorageAPIEnabled(storageAPIEnabled);
+    protect(*_preferences)->setStorageAPIEnabled(storageAPIEnabled);
 }
 
 - (BOOL)_accessHandleEnabled
 {
-    return protectedPreferences(self)->accessHandleEnabled();
+    return protect(*_preferences)->accessHandleEnabled();
 }
 
 - (void)_setAccessHandleEnabled:(BOOL)accessHandleEnabled
 {
-    protectedPreferences(self)->setAccessHandleEnabled(accessHandleEnabled);
+    protect(*_preferences)->setAccessHandleEnabled(accessHandleEnabled);
 }
 
 - (void)_setNotificationsEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setNotificationsEnabled(enabled);
+    protect(*_preferences)->setNotificationsEnabled(enabled);
 }
 
 - (BOOL)_notificationsEnabled
 {
-    return protectedPreferences(self)->notificationsEnabled();
+    return protect(*_preferences)->notificationsEnabled();
 }
 
 - (void)_setNotificationEventEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setNotificationEventEnabled(enabled);
+    protect(*_preferences)->setNotificationEventEnabled(enabled);
 }
 
 - (BOOL)_notificationEventEnabled
 {
-    return protectedPreferences(self)->notificationEventEnabled();
+    return protect(*_preferences)->notificationEventEnabled();
 }
 
 - (BOOL)_pushAPIEnabled
 {
-    return protectedPreferences(self)->pushAPIEnabled();
+    return protect(*_preferences)->pushAPIEnabled();
 }
 
 - (void)_setPushAPIEnabled:(BOOL)pushAPIEnabled
 {
-    protectedPreferences(self)->setPushAPIEnabled(pushAPIEnabled);
+    protect(*_preferences)->setPushAPIEnabled(pushAPIEnabled);
 }
 
 - (void)_setModelDocumentEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setModelDocumentEnabled(enabled);
+    protect(*_preferences)->setModelDocumentEnabled(enabled);
 }
 
 - (BOOL)_modelDocumentEnabled
 {
-    return protectedPreferences(self)->modelDocumentEnabled();
+    return protect(*_preferences)->modelDocumentEnabled();
 }
 
 - (void)_setRequiresFullscreenToLockScreenOrientation:(BOOL)enabled
 {
-    protectedPreferences(self)->setFullscreenRequirementForScreenOrientationLockingEnabled(enabled);
+    protect(*_preferences)->setFullscreenRequirementForScreenOrientationLockingEnabled(enabled);
 }
 
 - (BOOL)_requiresFullscreenToLockScreenOrientation
 {
-    return protectedPreferences(self)->fullscreenRequirementForScreenOrientationLockingEnabled();
+    return protect(*_preferences)->fullscreenRequirementForScreenOrientationLockingEnabled();
 }
 
 - (void)_setInteractionRegionMinimumCornerRadius:(double)radius
 {
-    protectedPreferences(self)->setInteractionRegionMinimumCornerRadius(radius);
+    protect(*_preferences)->setInteractionRegionMinimumCornerRadius(radius);
 }
 
 - (double)_interactionRegionMinimumCornerRadius
 {
-    return protectedPreferences(self)->interactionRegionMinimumCornerRadius();
+    return protect(*_preferences)->interactionRegionMinimumCornerRadius();
 }
 
 - (void)_setInteractionRegionInlinePadding:(double)padding
 {
-    protectedPreferences(self)->setInteractionRegionInlinePadding(padding);
+    protect(*_preferences)->setInteractionRegionInlinePadding(padding);
 }
 
 - (double)_interactionRegionInlinePadding
 {
-    return protectedPreferences(self)->interactionRegionInlinePadding();
+    return protect(*_preferences)->interactionRegionInlinePadding();
 }
 
 - (void)_setMediaPreferredFullscreenWidth:(double)width
 {
-    protectedPreferences(self)->setMediaPreferredFullscreenWidth(width);
+    protect(*_preferences)->setMediaPreferredFullscreenWidth(width);
 }
 
 - (double)_mediaPreferredFullscreenWidth
 {
-    return protectedPreferences(self)->mediaPreferredFullscreenWidth();
+    return protect(*_preferences)->mediaPreferredFullscreenWidth();
 }
 
 - (void)_setAppBadgeEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setAppBadgeEnabled(enabled);
+    protect(*_preferences)->setAppBadgeEnabled(enabled);
 }
 
 - (BOOL)_appBadgeEnabled
 {
-    return protectedPreferences(self)->appBadgeEnabled();
+    return protect(*_preferences)->appBadgeEnabled();
 }
 
 - (void)_setVerifyWindowOpenUserGestureFromUIProcess:(BOOL)enabled
 {
-    protectedPreferences(self)->setVerifyWindowOpenUserGestureFromUIProcess(enabled);
+    protect(*_preferences)->setVerifyWindowOpenUserGestureFromUIProcess(enabled);
 }
 
 - (BOOL)_verifyWindowOpenUserGestureFromUIProcess
 {
-    return protectedPreferences(self)->verifyWindowOpenUserGestureFromUIProcess();
+    return protect(*_preferences)->verifyWindowOpenUserGestureFromUIProcess();
 }
 
 - (BOOL)_mediaCapabilityGrantsEnabled
 {
-    return protectedPreferences(self)->mediaCapabilityGrantsEnabled();
+    return protect(*_preferences)->mediaCapabilityGrantsEnabled();
 }
 
 - (void)_setMediaCapabilityGrantsEnabled:(BOOL)mediaCapabilityGrantsEnabled
 {
-    protectedPreferences(self)->setMediaCapabilityGrantsEnabled(mediaCapabilityGrantsEnabled);
+    protect(*_preferences)->setMediaCapabilityGrantsEnabled(mediaCapabilityGrantsEnabled);
 }
 
 - (void)_setAllowPrivacySensitiveOperationsInNonPersistentDataStores:(BOOL)allowPrivacySensitiveOperationsInNonPersistentDataStores
 {
-    protectedPreferences(self)->setAllowPrivacySensitiveOperationsInNonPersistentDataStores(allowPrivacySensitiveOperationsInNonPersistentDataStores);
+    protect(*_preferences)->setAllowPrivacySensitiveOperationsInNonPersistentDataStores(allowPrivacySensitiveOperationsInNonPersistentDataStores);
 }
 
 - (BOOL)_allowPrivacySensitiveOperationsInNonPersistentDataStores
 {
-    return protectedPreferences(self)->allowPrivacySensitiveOperationsInNonPersistentDataStores();
+    return protect(*_preferences)->allowPrivacySensitiveOperationsInNonPersistentDataStores();
 }
 
 - (void)_setVideoFullscreenRequiresElementFullscreen:(BOOL)videoFullscreenRequiresElementFullscreen
 {
-    protectedPreferences(self)->setVideoFullscreenRequiresElementFullscreen(videoFullscreenRequiresElementFullscreen);
+    protect(*_preferences)->setVideoFullscreenRequiresElementFullscreen(videoFullscreenRequiresElementFullscreen);
 }
 
 - (BOOL)_videoFullscreenRequiresElementFullscreen
 {
-    return protectedPreferences(self)->videoFullscreenRequiresElementFullscreen();
+    return protect(*_preferences)->videoFullscreenRequiresElementFullscreen();
 }
 
 - (void)_setCSSTransformStyleSeparatedEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setCSSTransformStyleSeparatedEnabled(enabled);
+    protect(*_preferences)->setCSSTransformStyleSeparatedEnabled(enabled);
 }
 
 - (BOOL)_cssTransformStyleSeparatedEnabled
 {
-    return protectedPreferences(self)->cssTransformStyleSeparatedEnabled();
+    return protect(*_preferences)->cssTransformStyleSeparatedEnabled();
 }
 
 - (void)_setOverlayRegionsEnabled:(BOOL)enabled
 {
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    protectedPreferences(self)->setOverlayRegionsEnabled(enabled);
+    protect(*_preferences)->setOverlayRegionsEnabled(enabled);
 #else
     UNUSED_PARAM(enabled);
 #endif
@@ -1704,7 +1699,7 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 - (BOOL)_overlayRegionsEnabled
 {
 #if ENABLE(OVERLAY_REGIONS_IN_EVENT_REGION)
-    return protectedPreferences(self)->overlayRegionsEnabled();
+    return protect(*_preferences)->overlayRegionsEnabled();
 #else
     return NO;
 #endif
@@ -1712,55 +1707,55 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (void)_setModelElementEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setModelElementEnabled(enabled);
+    protect(*_preferences)->setModelElementEnabled(enabled);
 }
 
 - (BOOL)_modelProcessEnabled
 {
-    return protectedPreferences(self)->modelProcessEnabled();
+    return protect(*_preferences)->modelProcessEnabled();
 }
 
 - (void)_setModelProcessEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setModelProcessEnabled(enabled);
+    protect(*_preferences)->setModelProcessEnabled(enabled);
 }
 
 - (BOOL)_modelElementEnabled
 {
-    return protectedPreferences(self)->modelElementEnabled();
+    return protect(*_preferences)->modelElementEnabled();
 }
 
 - (void)_setModelNoPortalAttributeEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setModelNoPortalAttributeEnabled(enabled);
+    protect(*_preferences)->setModelNoPortalAttributeEnabled(enabled);
 }
 
 - (BOOL)_modelNoPortalAttributeEnabled
 {
-    return protectedPreferences(self)->modelNoPortalAttributeEnabled();
+    return protect(*_preferences)->modelNoPortalAttributeEnabled();
 }
 
 - (void)_setUpdateSceneGeometryEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setUpdateSceneGeometryEnabled(enabled);
+    protect(*_preferences)->setUpdateSceneGeometryEnabled(enabled);
 }
 
 - (BOOL)_updateSceneGeometryEnabled
 {
-    return protectedPreferences(self)->updateSceneGeometryEnabled();
+    return protect(*_preferences)->updateSceneGeometryEnabled();
 }
 
 - (void)_setRequiresPageVisibilityForVideoToBeNowPlayingForTesting:(BOOL)enabled
 {
 #if ENABLE(REQUIRES_PAGE_VISIBILITY_FOR_NOW_PLAYING)
-    protectedPreferences(self)->setRequiresPageVisibilityForVideoToBeNowPlaying(enabled);
+    protect(*_preferences)->setRequiresPageVisibilityForVideoToBeNowPlaying(enabled);
 #endif
 }
 
 - (BOOL)_requiresPageVisibilityForVideoToBeNowPlayingForTesting
 {
 #if ENABLE(REQUIRES_PAGE_VISIBILITY_FOR_NOW_PLAYING)
-    return protectedPreferences(self)->requiresPageVisibilityForVideoToBeNowPlaying();
+    return protect(*_preferences)->requiresPageVisibilityForVideoToBeNowPlaying();
 #else
     return NO;
 #endif
@@ -1768,12 +1763,12 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (BOOL)_siteIsolationEnabled
 {
-    return protectedPreferences(self)->siteIsolationEnabled();
+    return protect(*_preferences)->siteIsolationEnabled();
 }
 
 - (void)_setSiteIsolationEnabled:(BOOL)enabled
 {
-    protectedPreferences(self)->setSiteIsolationEnabled(enabled);
+    protect(*_preferences)->setSiteIsolationEnabled(enabled);
 }
 
 @end
@@ -1806,12 +1801,12 @@ static WebCore::EditableLinkBehavior toEditableLinkBehavior(_WKEditableLinkBehav
 
 - (BOOL)javaScriptEnabled
 {
-    return protectedPreferences(self)->javaScriptEnabled();
+    return protect(*_preferences)->javaScriptEnabled();
 }
 
 - (void)setJavaScriptEnabled:(BOOL)javaScriptEnabled
 {
-    protectedPreferences(self)->setJavaScriptEnabled(javaScriptEnabled);
+    protect(*_preferences)->setJavaScriptEnabled(javaScriptEnabled);
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -69,13 +69,6 @@
 #import "WKGeolocationProviderIOS.h"
 #endif
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-static Ref<WebKit::WebProcessPool> protectedProcessPool(WKProcessPool *processPool)
-{
-    return *processPool->_processPool;
-}
-ALLOW_DEPRECATED_DECLARATIONS_END
-
 @interface _WKProcessInfo()
 - (instancetype)initWithTaskInfo:(const WebKit::AuxiliaryProcessProxy::TaskInfo&)info;
 @end
@@ -232,22 +225,22 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_registerURLSchemeAsCanDisplayOnlyIfCanRequest:(NSString *)scheme
 {
-    protectedProcessPool(self)->registerURLSchemeAsCanDisplayOnlyIfCanRequest(scheme);
+    protect(*_processPool)->registerURLSchemeAsCanDisplayOnlyIfCanRequest(scheme);
 }
 
 - (void)_registerURLSchemeAsSecure:(NSString *)scheme
 {
-    protectedProcessPool(self)->registerURLSchemeAsSecure(scheme);
+    protect(*_processPool)->registerURLSchemeAsSecure(scheme);
 }
 
 - (void)_registerURLSchemeAsBypassingContentSecurityPolicy:(NSString *)scheme
 {
-    protectedProcessPool(self)->registerURLSchemeAsBypassingContentSecurityPolicy(scheme);
+    protect(*_processPool)->registerURLSchemeAsBypassingContentSecurityPolicy(scheme);
 }
 
 - (void)_setDomainRelaxationForbiddenForURLScheme:(NSString *)scheme
 {
-    protectedProcessPool(self)->setDomainRelaxationForbiddenForURLScheme(scheme);
+    protect(*_processPool)->setDomainRelaxationForbiddenForURLScheme(scheme);
 }
 
 - (void)_setCanHandleHTTPSServerTrustEvaluation:(BOOL)value
@@ -256,7 +249,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id)_objectForBundleParameter:(NSString *)parameter
 {
-    return [protect(protectedProcessPool(self)->bundleParameters()) objectForKey:parameter];
+    return [protect(protect(*_processPool)->bundleParameters()) objectForKey:parameter];
 }
 
 - (void)_setObject:(id <NSCopying, NSSecureCoding>)object forBundleParameter:(NSString *)parameter
@@ -321,7 +314,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (void)_setDownloadDelegate:(id <_WKDownloadDelegate>)downloadDelegate
 {
     _downloadDelegate = downloadDelegate;
-    protectedProcessPool(self)->setLegacyDownloadClient(adoptRef(*new WebKit::LegacyDownloadClient(downloadDelegate)));
+    protect(*_processPool)->setLegacyDownloadClient(adoptRef(*new WebKit::LegacyDownloadClient(downloadDelegate)));
 }
 
 - (id <_WKAutomationDelegate>)_automationDelegate
@@ -332,23 +325,23 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (void)_setAutomationDelegate:(id <_WKAutomationDelegate>)automationDelegate
 {
     _automationDelegate = automationDelegate;
-    protectedProcessPool(self)->setAutomationClient(makeUnique<WebKit::AutomationClient>(self, automationDelegate));
+    protect(*_processPool)->setAutomationClient(makeUnique<WebKit::AutomationClient>(self, automationDelegate));
 }
 
 - (void)_warmInitialProcess
 {
-    protectedProcessPool(self)->prewarmProcess();
+    protect(*_processPool)->prewarmProcess();
 }
 
 - (void)_automationCapabilitiesDidChange
 {
-    protectedProcessPool(self)->updateAutomationCapabilities();
+    protect(*_processPool)->updateAutomationCapabilities();
 }
 
 - (void)_setAutomationSession:(_WKAutomationSession *)automationSession
 {
     _automationSession = automationSession;
-    protectedProcessPool(self)->setAutomationSession(automationSession ? automationSession->_session.get() : nullptr);
+    protect(*_processPool)->setAutomationSession(automationSession ? automationSession->_session.get() : nullptr);
 }
 
 - (NSURL *)_javaScriptConfigurationDirectory
@@ -372,17 +365,17 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     for (NSString *extension in nsExtensions)
         extensions.add(extension);
 
-    protectedProcessPool(self)->addSupportedPlugin(domain, name, WTF::move(mimeTypes), WTF::move(extensions));
+    protect(*_processPool)->addSupportedPlugin(domain, name, WTF::move(mimeTypes), WTF::move(extensions));
 }
 
 - (void)_clearSupportedPlugins
 {
-    protectedProcessPool(self)->clearSupportedPlugins();
+    protect(*_processPool)->clearSupportedPlugins();
 }
 
 - (void)_terminateServiceWorkers
 {
-    protectedProcessPool(self)->terminateServiceWorkers();
+    protect(*_processPool)->terminateServiceWorkers();
 }
 
 - (void)_setUseSeparateServiceWorkerProcess:(BOOL)useSeparateServiceWorkerProcess
@@ -393,14 +386,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (NSSet<NSNumber *> *)_prewarmedProcessIdentifiersForTesting
 {
     auto result = adoptNS([[NSMutableSet alloc] init]);
-    for (auto pid : protectedProcessPool(self)->prewarmedProcessIdentifiers())
+    for (auto pid : protect(*_processPool)->prewarmedProcessIdentifiers())
         [result addObject:@(pid)];
     return result.autorelease();
 }
 
 - (void)_countWebPagesInAllProcessesForTesting:(void(^)(unsigned))completionHandler
 {
-    protectedProcessPool(self)->countWebPagesInAllProcessesForTesting([completionHandler = makeBlockPtr(completionHandler)] (unsigned result) {
+    protect(*_processPool)->countWebPagesInAllProcessesForTesting([completionHandler = makeBlockPtr(completionHandler)] (unsigned result) {
         completionHandler(result);
     });
 }
@@ -492,7 +485,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     auto result = _processPool->processes().size();
     if (_processPool->useSeparateServiceWorkerProcess())
-        result -= protectedProcessPool(self)->serviceWorkerProxiesCount();
+        result -= protect(*_processPool)->serviceWorkerProxiesCount();
     return result;
 }
 
@@ -522,12 +515,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (size_t)_serviceWorkerProcessCount
 {
-    return protectedProcessPool(self)->serviceWorkerProxiesCount();
+    return protect(*_processPool)->serviceWorkerProxiesCount();
 }
 
 - (void)_isJITDisabledInAllRemoteWorkerProcesses:(void(^)(BOOL))completionHandler
 {
-    protectedProcessPool(self)->isJITDisabledInAllRemoteWorkerProcesses([completionHandler = makeBlockPtr(completionHandler)] (bool result) {
+    protect(*_processPool)->isJITDisabledInAllRemoteWorkerProcesses([completionHandler = makeBlockPtr(completionHandler)] (bool result) {
         completionHandler(result);
     });
 }
@@ -610,7 +603,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_setCookieStoragePartitioningEnabled:(BOOL)enabled
 {
-    protectedProcessPool(self)->setCookieStoragePartitioningEnabled(enabled);
+    protect(*_processPool)->setCookieStoragePartitioningEnabled(enabled);
 }
 
 #if PLATFORM(IOS_FAMILY)
@@ -630,19 +623,19 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_getActivePagesOriginsInWebProcessForTesting:(pid_t)pid completionHandler:(void(^)(NSArray<NSString *> *))completionHandler
 {
-    protectedProcessPool(self)->activePagesOriginsInWebProcessForTesting(pid, [completionHandler = makeBlockPtr(completionHandler)] (Vector<String>&& activePagesOrigins) {
+    protect(*_processPool)->activePagesOriginsInWebProcessForTesting(pid, [completionHandler = makeBlockPtr(completionHandler)] (Vector<String>&& activePagesOrigins) {
         completionHandler(createNSArray(activePagesOrigins).get());
     });
 }
 
 - (void)_clearPermanentCredentialsForProtectionSpace:(NSURLProtectionSpace *)protectionSpace
 {
-    protectedProcessPool(self)->clearPermanentCredentialsForProtectionSpace(WebCore::ProtectionSpace(protectionSpace));
+    protect(*_processPool)->clearPermanentCredentialsForProtectionSpace(WebCore::ProtectionSpace(protectionSpace));
 }
 
 - (void)_seedResourceLoadStatisticsForTestingWithFirstParty:(NSURL *)firstPartyURL thirdParty:(NSURL *)thirdPartyURL shouldScheduleNotification:(BOOL)shouldScheduleNotification completionHandler:(void(^)(void))completionHandler
 {
-    protectedProcessPool(self)->seedResourceLoadStatisticsForTesting(WebCore::RegistrableDomain { firstPartyURL }, WebCore::RegistrableDomain { thirdPartyURL }, shouldScheduleNotification, [completionHandler = makeBlockPtr(completionHandler)] () {
+    protect(*_processPool)->seedResourceLoadStatisticsForTesting(WebCore::RegistrableDomain { firstPartyURL }, WebCore::RegistrableDomain { thirdPartyURL }, shouldScheduleNotification, [completionHandler = makeBlockPtr(completionHandler)] () {
         completionHandler();
     });
 }
@@ -654,37 +647,37 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)_garbageCollectJavaScriptObjectsForTesting
 {
-    protectedProcessPool(self)->garbageCollectJavaScriptObjects();
+    protect(*_processPool)->garbageCollectJavaScriptObjects();
 }
 
 - (size_t)_numberOfConnectedGamepadsForTesting
 {
-    return protectedProcessPool(self)->numberOfConnectedGamepadsForTesting(WebKit::WebProcessPool::GamepadType::All);
+    return protect(*_processPool)->numberOfConnectedGamepadsForTesting(WebKit::WebProcessPool::GamepadType::All);
 }
 
 - (size_t)_numberOfConnectedHIDGamepadsForTesting
 {
-    return protectedProcessPool(self)->numberOfConnectedGamepadsForTesting(WebKit::WebProcessPool::GamepadType::HID);
+    return protect(*_processPool)->numberOfConnectedGamepadsForTesting(WebKit::WebProcessPool::GamepadType::HID);
 }
 
 - (size_t)_numberOfConnectedGameControllerFrameworkGamepadsForTesting
 {
-    return protectedProcessPool(self)->numberOfConnectedGamepadsForTesting(WebKit::WebProcessPool::GamepadType::GameControllerFramework);
+    return protect(*_processPool)->numberOfConnectedGamepadsForTesting(WebKit::WebProcessPool::GamepadType::GameControllerFramework);
 }
 
 - (void)_setUsesOnlyHIDGamepadProviderForTesting:(BOOL)usesHIDProvider
 {
-    protectedProcessPool(self)->setUsesOnlyHIDGamepadProviderForTesting(usesHIDProvider);
+    protect(*_processPool)->setUsesOnlyHIDGamepadProviderForTesting(usesHIDProvider);
 }
 
 - (void)_terminateAllWebContentProcesses
 {
-    protectedProcessPool(self)->terminateAllWebContentProcesses(WebKit::ProcessTerminationReason::RequestedByClient);
+    protect(*_processPool)->terminateAllWebContentProcesses(WebKit::ProcessTerminationReason::RequestedByClient);
 }
 
 - (WKNotificationManagerRef)_notificationManagerForTesting
 {
-    return WebKit::toAPI(protect(protectedProcessPool(self)->supplement<WebKit::WebNotificationManagerProxy>()).get());
+    return WebKit::toAPI(protect(protect(*_processPool)->supplement<WebKit::WebNotificationManagerProxy>()).get());
 }
 
 + (_WKProcessInfo *)_gpuProcessInfo
@@ -728,7 +721,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 #if PLATFORM(MAC)
 - (void)_registerAdditionalFonts:(NSArray<NSString *> *)fontNames
 {
-    protectedProcessPool(self)->registerAdditionalFonts(fontNames);
+    protect(*_processPool)->registerAdditionalFonts(fontNames);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm
@@ -51,11 +51,6 @@
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/TZoneMallocInlines.h>
 
-static Ref<WebKit::WebUserContentControllerProxy> protectedUserContentControllerProxy(WKUserContentController *controller)
-{
-    return *controller->_userContentControllerProxy;
-}
-
 @implementation WKUserContentController
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
@@ -104,32 +99,32 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)addUserScript:(WKUserScript *)userScript
 {
-    protectedUserContentControllerProxy(self)->addUserScript(Ref { *userScript->_userScript }, WebKit::InjectUserScriptImmediately::No);
+    protect(*_userContentControllerProxy)->addUserScript(Ref { *userScript->_userScript }, WebKit::InjectUserScriptImmediately::No);
 }
 
 - (void)removeAllUserScripts
 {
-    protectedUserContentControllerProxy(self)->removeAllUserScripts();
+    protect(*_userContentControllerProxy)->removeAllUserScripts();
 }
 
 - (void)addContentRuleList:(WKContentRuleList *)contentRuleList
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    protectedUserContentControllerProxy(self)->addContentRuleList(Ref { *contentRuleList->_contentRuleList });
+    protect(*_userContentControllerProxy)->addContentRuleList(Ref { *contentRuleList->_contentRuleList });
 #endif
 }
 
 - (void)removeContentRuleList:(WKContentRuleList *)contentRuleList
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    protectedUserContentControllerProxy(self)->removeContentRuleList(Ref { *contentRuleList->_contentRuleList }->name());
+    protect(*_userContentControllerProxy)->removeContentRuleList(Ref { *contentRuleList->_contentRuleList }->name());
 #endif
 }
 
 - (void)removeAllContentRuleLists
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    protectedUserContentControllerProxy(self)->removeAllContentRuleLists();
+    protect(*_userContentControllerProxy)->removeAllContentRuleLists();
 #endif
 }
 
@@ -193,7 +188,7 @@ private:
 
 - (void)_addScriptMessageHandler:(WebKit::WebScriptMessageHandler&)scriptMessageHandler
 {
-    if (!protectedUserContentControllerProxy(self)->addUserScriptMessageHandler(scriptMessageHandler))
+    if (!protect(*_userContentControllerProxy)->addUserScriptMessageHandler(scriptMessageHandler))
         [NSException raise:NSInvalidArgumentException format:@"Attempt to add script message handler with name '%@' when one already exists.", scriptMessageHandler.name().createNSString().get()];
 }
 
@@ -217,22 +212,22 @@ private:
 
 - (void)removeScriptMessageHandlerForName:(NSString *)name
 {
-    protectedUserContentControllerProxy(self)->removeUserMessageHandlerForName(name, API::ContentWorld::pageContentWorldSingleton());
+    protect(*_userContentControllerProxy)->removeUserMessageHandlerForName(name, API::ContentWorld::pageContentWorldSingleton());
 }
 
 - (void)removeScriptMessageHandlerForName:(NSString *)name contentWorld:(WKContentWorld *)contentWorld
 {
-    protectedUserContentControllerProxy(self)->removeUserMessageHandlerForName(name, Ref { *contentWorld->_contentWorld });
+    protect(*_userContentControllerProxy)->removeUserMessageHandlerForName(name, Ref { *contentWorld->_contentWorld });
 }
 
 - (void)removeAllScriptMessageHandlersFromContentWorld:(WKContentWorld *)contentWorld
 {
-    protectedUserContentControllerProxy(self)->removeAllUserMessageHandlers(Ref { *contentWorld->_contentWorld });
+    protect(*_userContentControllerProxy)->removeAllUserMessageHandlers(Ref { *contentWorld->_contentWorld });
 }
 
 - (void)removeAllScriptMessageHandlers
 {
-    protectedUserContentControllerProxy(self)->removeAllUserMessageHandlers();
+    protect(*_userContentControllerProxy)->removeAllUserMessageHandlers();
 }
 
 #pragma mark WKObject protocol implementation
@@ -248,17 +243,17 @@ private:
 
 - (void)_removeUserScript:(WKUserScript *)userScript
 {
-    protectedUserContentControllerProxy(self)->removeUserScript(Ref { *userScript->_userScript });
+    protect(*_userContentControllerProxy)->removeUserScript(Ref { *userScript->_userScript });
 }
 
 - (void)_removeAllUserScriptsAssociatedWithContentWorld:(WKContentWorld *)contentWorld
 {
-    protectedUserContentControllerProxy(self)->removeAllUserScripts(Ref { *contentWorld->_contentWorld });
+    protect(*_userContentControllerProxy)->removeAllUserScripts(Ref { *contentWorld->_contentWorld });
 }
 
 - (void)_addUserScriptImmediately:(WKUserScript *)userScript
 {
-    protectedUserContentControllerProxy(self)->addUserScript(Ref { *userScript->_userScript }, WebKit::InjectUserScriptImmediately::Yes);
+    protect(*_userContentControllerProxy)->addUserScript(Ref { *userScript->_userScript }, WebKit::InjectUserScriptImmediately::Yes);
 }
 
 #pragma clang diagnostic push
@@ -267,28 +262,28 @@ private:
 #pragma clang diagnostic pop
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    protectedUserContentControllerProxy(self)->addContentRuleList(Ref { *userContentFilter->_contentRuleList->_contentRuleList });
+    protect(*_userContentControllerProxy)->addContentRuleList(Ref { *userContentFilter->_contentRuleList->_contentRuleList });
 #endif
 }
 
 - (void)_addContentRuleList:(WKContentRuleList *)contentRuleList extensionBaseURL:(NSURL *)extensionBaseURL
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    protectedUserContentControllerProxy(self)->addContentRuleList(Ref { *contentRuleList->_contentRuleList }, extensionBaseURL);
+    protect(*_userContentControllerProxy)->addContentRuleList(Ref { *contentRuleList->_contentRuleList }, extensionBaseURL);
 #endif
 }
 
 - (void)_removeUserContentFilter:(NSString *)userContentFilterName
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    protectedUserContentControllerProxy(self)->removeContentRuleList(userContentFilterName);
+    protect(*_userContentControllerProxy)->removeContentRuleList(userContentFilterName);
 #endif
 }
 
 - (void)_removeAllUserContentFilters
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    protectedUserContentControllerProxy(self)->removeAllContentRuleLists();
+    protect(*_userContentControllerProxy)->removeAllContentRuleLists();
 #endif
 }
 
@@ -299,39 +294,39 @@ private:
 
 - (void)_addUserStyleSheet:(_WKUserStyleSheet *)userStyleSheet
 {
-    protectedUserContentControllerProxy(self)->addUserStyleSheet(Ref { *userStyleSheet->_userStyleSheet });
+    protect(*_userContentControllerProxy)->addUserStyleSheet(Ref { *userStyleSheet->_userStyleSheet });
 }
 
 - (void)_removeUserStyleSheet:(_WKUserStyleSheet *)userStyleSheet
 {
-    protectedUserContentControllerProxy(self)->removeUserStyleSheet(Ref { *userStyleSheet->_userStyleSheet });
+    protect(*_userContentControllerProxy)->removeUserStyleSheet(Ref { *userStyleSheet->_userStyleSheet });
 }
 
 - (void)_removeAllUserStyleSheets
 {
-    protectedUserContentControllerProxy(self)->removeAllUserStyleSheets();
+    protect(*_userContentControllerProxy)->removeAllUserStyleSheets();
 }
 
 - (void)_removeAllUserStyleSheetsAssociatedWithContentWorld:(WKContentWorld *)contentWorld
 {
-    protectedUserContentControllerProxy(self)->removeAllUserStyleSheets(Ref { *contentWorld->_contentWorld });
+    protect(*_userContentControllerProxy)->removeAllUserStyleSheets(Ref { *contentWorld->_contentWorld });
 }
 
 - (void)_addBuffer:(_WKJSBuffer *)buffer contentWorld:(WKContentWorld *)world name:(NSString *)name
 {
-    protectedUserContentControllerProxy(self)->addJSBuffer(Ref { *buffer->_buffer }, Ref { *world->_contentWorld }, name);
+    protect(*_userContentControllerProxy)->addJSBuffer(Ref { *buffer->_buffer }, Ref { *world->_contentWorld }, name);
 }
 
 - (void)_removeBufferWithName:(NSString *)name contentWorld:(WKContentWorld *)world
 {
-    protectedUserContentControllerProxy(self)->removeJSBuffer(Ref { *world->_contentWorld }, name);
+    protect(*_userContentControllerProxy)->removeJSBuffer(Ref { *world->_contentWorld }, name);
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 - (void)_addScriptMessageHandler:(id <WKScriptMessageHandler>)scriptMessageHandler name:(NSString *)name userContentWorld:(_WKUserContentWorld *)userContentWorld
 {
     auto handler = WebKit::WebScriptMessageHandler::create(makeUnique<ScriptMessageHandlerDelegate>(self, scriptMessageHandler, name), name, Ref { *userContentWorld->_contentWorld->_contentWorld });
-    if (!protectedUserContentControllerProxy(self)->addUserScriptMessageHandler(handler.get()))
+    if (!protect(*_userContentControllerProxy)->addUserScriptMessageHandler(handler.get()))
         [NSException raise:NSInvalidArgumentException format:@"Attempt to add script message handler with name '%@' when one already exists.", name];
 }
 
@@ -342,12 +337,12 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 
 - (void)_removeScriptMessageHandlerForName:(NSString *)name userContentWorld:(_WKUserContentWorld *)userContentWorld
 {
-    protectedUserContentControllerProxy(self)->removeUserMessageHandlerForName(name, Ref { *userContentWorld->_contentWorld->_contentWorld });
+    protect(*_userContentControllerProxy)->removeUserMessageHandlerForName(name, Ref { *userContentWorld->_contentWorld->_contentWorld });
 }
 
 - (void)_removeAllScriptMessageHandlersAssociatedWithUserContentWorld:(_WKUserContentWorld *)userContentWorld
 {
-    protectedUserContentControllerProxy(self)->removeAllUserMessageHandlers(Ref { *userContentWorld->_contentWorld->_contentWorld });
+    protect(*_userContentControllerProxy)->removeAllUserMessageHandlers(Ref { *userContentWorld->_contentWorld->_contentWorld });
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm
@@ -164,11 +164,6 @@ static WebCore::ModalContainerObservationPolicy coreModalContainerObservationPol
 
 } // namespace WebKit
 
-static Ref<API::WebsitePolicies> protectedWebsitePolicies(WKWebpagePreferences *preferences)
-{
-    return *preferences->_websitePolicies;
-}
-
 @implementation WKWebpagePreferences
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
@@ -201,7 +196,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (void)_setContentBlockersEnabled:(BOOL)contentBlockersEnabled
 {
     auto defaultEnablement = contentBlockersEnabled ? WebCore::ContentExtensionDefaultEnablement::Enabled : WebCore::ContentExtensionDefaultEnablement::Disabled;
-    protectedWebsitePolicies(self)->setContentExtensionEnablement({ defaultEnablement, { } });
+    protect(*_websitePolicies)->setContentExtensionEnablement({ defaultEnablement, { } });
 }
 
 - (BOOL)_contentBlockersEnabled
@@ -219,7 +214,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
         exceptions.add(identifier);
 
     auto defaultEnablement = enabled ? WebCore::ContentExtensionDefaultEnablement::Enabled : WebCore::ContentExtensionDefaultEnablement::Disabled;
-    protectedWebsitePolicies(self)->setContentExtensionEnablement({ defaultEnablement, WTF::move(exceptions) });
+    protect(*_websitePolicies)->setContentExtensionEnablement({ defaultEnablement, WTF::move(exceptions) });
 }
 
 - (void)_setActiveContentRuleListActionPatterns:(NSDictionary<NSString *, NSSet<NSString *> *> *)patterns
@@ -232,7 +227,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
             vector.append(pattern);
         map.add(key, WTF::move(vector));
     }];
-    protectedWebsitePolicies(self)->setActiveContentRuleListActionPatterns(WTF::move(map));
+    protect(*_websitePolicies)->setActiveContentRuleListActionPatterns(WTF::move(map));
 }
 
 - (NSDictionary<NSString *, NSSet<NSString *> *> *)_activeContentRuleListActionPatterns
@@ -406,7 +401,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
         RetainPtr<_WKCustomHeaderFields> element = fields[i];
         return downcast<API::CustomHeaderFields>([element _apiObject]).coreFields();
     });
-    protectedWebsitePolicies(self)->setCustomHeaderFields(WTF::move(vector));
+    protect(*_websitePolicies)->setCustomHeaderFields(WTF::move(vector));
 }
 
 - (WKWebsiteDataStore *)_websiteDataStore
@@ -416,7 +411,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (void)_setWebsiteDataStore:(WKWebsiteDataStore *)websiteDataStore
 {
-    protectedWebsitePolicies(self)->setWebsiteDataStore(websiteDataStore->_websiteDataStore.get());
+    protect(*_websitePolicies)->setWebsiteDataStore(websiteDataStore->_websiteDataStore.get());
 }
 
 - (WKUserContentController *)_userContentController
@@ -426,7 +421,7 @@ static _WKWebsiteDeviceOrientationAndMotionAccessPolicy toWKWebsiteDeviceOrienta
 
 - (void)_setUserContentController:(WKUserContentController *)userContentController
 {
-    protectedWebsitePolicies(self)->setUserContentController(userContentController ? userContentController->_userContentControllerProxy.get() : nullptr);
+    protect(*_websitePolicies)->setUserContentController(userContentController ? userContentController->_userContentControllerProxy.get() : nullptr);
 }
 
 - (void)_setCustomUserAgent:(NSString *)customUserAgent
@@ -544,7 +539,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (BOOL)_captivePortalModeEnabled
 {
-    return protectedWebsitePolicies(self)->lockdownModeEnabled();
+    return protect(*_websitePolicies)->lockdownModeEnabled();
 }
 
 - (void)_setAllowPrivacyProxy:(BOOL)allow
@@ -621,7 +616,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 - (BOOL)isLockdownModeEnabled
 {
 #if ENABLE(LOCKDOWN_MODE_API)
-    return protectedWebsitePolicies(self)->lockdownModeEnabled();
+    return protect(*_websitePolicies)->lockdownModeEnabled();
 #else
     return NO;
 #endif
@@ -767,7 +762,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         }
         result.append(WTF::move(selectorsForElement));
     }
-    protectedWebsitePolicies(self)->setVisibilityAdjustmentSelectors(WTF::move(result));
+    protect(*_websitePolicies)->setVisibilityAdjustmentSelectors(WTF::move(result));
 }
 
 - (NSArray<NSArray<NSSet<NSString *> *> *> *)_visibilityAdjustmentSelectorsIncludingShadowHosts
@@ -831,12 +826,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)setAlternateRequest:(NSURLRequest *)request
 {
-    protectedWebsitePolicies(self)->setAlternateRequest(request);
+    protect(*_websitePolicies)->setAlternateRequest(request);
 }
 
 - (NSURLRequest *)alternateRequest
 {
-    return protectedWebsitePolicies(self)->alternateRequest().protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).autorelease();
+    return protect(*_websitePolicies)->alternateRequest().protectedNSURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody).autorelease();
 }
 
 - (NSURLRequest *)_alternateRequest

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm
@@ -40,11 +40,6 @@
     AlignedStorage<WebKit::InjectedBundleNodeHandle> _nodeHandle;
 }
 
-static Ref<WebKit::InjectedBundleNodeHandle> protectedNodeHandle(WKWebProcessPlugInNodeHandle *handle)
-{
-    return *handle->_nodeHandle;
-}
-
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebProcessPlugInNodeHandle.class, self))
@@ -62,7 +57,7 @@ static Ref<WebKit::InjectedBundleNodeHandle> protectedNodeHandle(WKWebProcessPlu
 
 - (WKWebProcessPlugInFrame *)htmlIFrameElementContentFrame
 {
-    return WebKit::wrapper(protectedNodeHandle(self)->htmlIFrameElementContentFrame()).autorelease();
+    return WebKit::wrapper(protect(*_nodeHandle)->htmlIFrameElementContentFrame()).autorelease();
 }
 
 - (CocoaImage *)renderedImageWithOptions:(WKSnapshotOptions)options
@@ -76,7 +71,7 @@ static Ref<WebKit::InjectedBundleNodeHandle> protectedNodeHandle(WKWebProcessPlu
     if (width)
         optionalWidth = width.floatValue;
 
-    auto image = protectedNodeHandle(self)->renderedImage(WebKit::toSnapshotOptions(options), options & kWKSnapshotOptionsExcludeOverflow, optionalWidth);
+    auto image = protect(*_nodeHandle)->renderedImage(WebKit::toSnapshotOptions(options), options & kWKSnapshotOptionsExcludeOverflow, optionalWidth);
     if (!image)
         return nil;
 
@@ -93,42 +88,42 @@ static Ref<WebKit::InjectedBundleNodeHandle> protectedNodeHandle(WKWebProcessPlu
 
 - (CGRect)elementBounds
 {
-    return protectedNodeHandle(self)->elementBounds();
+    return protect(*_nodeHandle)->elementBounds();
 }
 
 - (BOOL)HTMLInputElementIsAutoFilled
 {
-    return protectedNodeHandle(self)->isHTMLInputElementAutoFilled();
+    return protect(*_nodeHandle)->isHTMLInputElementAutoFilled();
 }
 
 - (BOOL)HTMLInputElementIsAutoFilledAndViewable
 {
-    return protectedNodeHandle(self)->isHTMLInputElementAutoFilledAndViewable();
+    return protect(*_nodeHandle)->isHTMLInputElementAutoFilledAndViewable();
 }
 
 - (BOOL)HTMLInputElementIsAutoFilledAndObscured
 {
-    return protectedNodeHandle(self)->isHTMLInputElementAutoFilledAndObscured();
+    return protect(*_nodeHandle)->isHTMLInputElementAutoFilledAndObscured();
 }
 
 - (void)setHTMLInputElementIsAutoFilled:(BOOL)isAutoFilled
 {
-    protectedNodeHandle(self)->setHTMLInputElementAutoFilled(isAutoFilled);
+    protect(*_nodeHandle)->setHTMLInputElementAutoFilled(isAutoFilled);
 }
 
 - (void)setHTMLInputElementIsAutoFilledAndViewable:(BOOL)isAutoFilledAndViewable
 {
-    protectedNodeHandle(self)->setHTMLInputElementAutoFilledAndViewable(isAutoFilledAndViewable);
+    protect(*_nodeHandle)->setHTMLInputElementAutoFilledAndViewable(isAutoFilledAndViewable);
 }
 
 - (void)setHTMLInputElementIsAutoFilledAndObscured:(BOOL)isAutoFilledAndObscured
 {
-    protectedNodeHandle(self)->setHTMLInputElementAutoFilledAndObscured(isAutoFilledAndObscured);
+    protect(*_nodeHandle)->setHTMLInputElementAutoFilledAndObscured(isAutoFilledAndObscured);
 }
 
 - (BOOL)isHTMLInputElementAutoFillButtonEnabled
 {
-    return protectedNodeHandle(self)->isHTMLInputElementAutoFillButtonEnabled();
+    return protect(*_nodeHandle)->isHTMLInputElementAutoFillButtonEnabled();
 }
 
 static WebCore::AutoFillButtonType toAutoFillButtonType(_WKAutoFillButtonType autoFillButtonType)
@@ -174,52 +169,52 @@ static _WKAutoFillButtonType toWKAutoFillButtonType(WebCore::AutoFillButtonType 
 
 - (void)setHTMLInputElementAutoFillButtonEnabledWithButtonType:(_WKAutoFillButtonType)autoFillButtonType
 {
-    protectedNodeHandle(self)->setHTMLInputElementAutoFillButtonEnabled(toAutoFillButtonType(autoFillButtonType));
+    protect(*_nodeHandle)->setHTMLInputElementAutoFillButtonEnabled(toAutoFillButtonType(autoFillButtonType));
 }
 
 - (_WKAutoFillButtonType)htmlInputElementAutoFillButtonType
 {
-    return toWKAutoFillButtonType(protectedNodeHandle(self)->htmlInputElementAutoFillButtonType());
+    return toWKAutoFillButtonType(protect(*_nodeHandle)->htmlInputElementAutoFillButtonType());
 }
 
 - (_WKAutoFillButtonType)htmlInputElementLastAutoFillButtonType
 {
-    return toWKAutoFillButtonType(protectedNodeHandle(self)->htmlInputElementLastAutoFillButtonType());
+    return toWKAutoFillButtonType(protect(*_nodeHandle)->htmlInputElementLastAutoFillButtonType());
 }
 
 - (BOOL)HTMLInputElementIsUserEdited
 {
-    return protectedNodeHandle(self)->htmlInputElementLastChangeWasUserEdit();
+    return protect(*_nodeHandle)->htmlInputElementLastChangeWasUserEdit();
 }
 
 - (BOOL)HTMLTextAreaElementIsUserEdited
 {
-    return protectedNodeHandle(self)->htmlTextAreaElementLastChangeWasUserEdit();
+    return protect(*_nodeHandle)->htmlTextAreaElementLastChangeWasUserEdit();
 }
 
 - (BOOL)isSelectElement
 {
-    return protectedNodeHandle(self)->isSelectElement();
+    return protect(*_nodeHandle)->isSelectElement();
 }
 
 - (BOOL)isSelectableTextNode
 {
-    return protectedNodeHandle(self)->isSelectableTextNode();
+    return protect(*_nodeHandle)->isSelectableTextNode();
 }
 
 - (BOOL)isTextField
 {
-    return protectedNodeHandle(self)->isTextField();
+    return protect(*_nodeHandle)->isTextField();
 }
 
 - (WKWebProcessPlugInNodeHandle *)HTMLTableCellElementCellAbove
 {
-    return WebKit::wrapper(protectedNodeHandle(self)->htmlTableCellElementCellAbove()).autorelease();
+    return WebKit::wrapper(protect(*_nodeHandle)->htmlTableCellElementCellAbove()).autorelease();
 }
 
 - (WKWebProcessPlugInFrame *)frame
 {
-    return WebKit::wrapper(protectedNodeHandle(self)->document()->documentFrame()).autorelease();
+    return WebKit::wrapper(protect(*_nodeHandle)->document()->documentFrame()).autorelease();
 }
 
 - (WebKit::InjectedBundleNodeHandle&)_nodeHandle

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm
@@ -38,11 +38,6 @@
     AlignedStorage<WebKit::InjectedBundleRangeHandle> _rangeHandle;
 }
 
-static Ref<WebKit::InjectedBundleRangeHandle> protectedRangeHandle(WKWebProcessPlugInRangeHandle *handle)
-{
-    return *handle->_rangeHandle;
-}
-
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebProcessPlugInRangeHandle.class, self))
@@ -60,12 +55,12 @@ static Ref<WebKit::InjectedBundleRangeHandle> protectedRangeHandle(WKWebProcessP
 
 - (WKWebProcessPlugInFrame *)frame
 {
-    return wrapper(protectedRangeHandle(self)->document()->documentFrame()).autorelease();
+    return wrapper(protect(*_rangeHandle)->document()->documentFrame()).autorelease();
 }
 
 - (NSString *)text
 {
-    return protectedRangeHandle(self)->text().createNSString().autorelease();
+    return protect(*_rangeHandle)->text().createNSString().autorelease();
 }
 
 #if TARGET_OS_IPHONE

--- a/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm
@@ -33,11 +33,6 @@
     AlignedStorage<WebKit::InjectedBundleScriptWorld> _world;
 }
 
-static Ref<WebKit::InjectedBundleScriptWorld> protectedWorld(WKWebProcessPlugInScriptWorld *world)
-{
-    return *world->_world;
-}
-
 + (WKWebProcessPlugInScriptWorld *)world
 {
     return WebKit::wrapper(WebKit::InjectedBundleScriptWorld::create(WebKit::ContentWorldIdentifier::generate())).autorelease();
@@ -58,27 +53,27 @@ static Ref<WebKit::InjectedBundleScriptWorld> protectedWorld(WKWebProcessPlugInS
 
 - (void)clearWrappers
 {
-    protectedWorld(self)->clearWrappers();
+    protect(*_world)->clearWrappers();
 }
 
 - (void)makeAllShadowRootsOpen
 {
-    protectedWorld(self)->makeAllShadowRootsOpen();
+    protect(*_world)->makeAllShadowRootsOpen();
 }
 
 - (void)exposeClosedShadowRootsForExtensions
 {
-    protectedWorld(self)->exposeClosedShadowRootsForExtensions();
+    protect(*_world)->exposeClosedShadowRootsForExtensions();
 }
 
 - (void)disableOverrideBuiltinsBehavior
 {
-    protectedWorld(self)->disableOverrideBuiltinsBehavior();
+    protect(*_world)->disableOverrideBuiltinsBehavior();
 }
 
 - (void)allowJSHandleCreation
 {
-    protectedWorld(self)->setAllowJSHandleCreation();
+    protect(*_world)->setAllowJSHandleCreation();
 }
 
 - (NSString *)name

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm
@@ -51,17 +51,12 @@
 
 @end
 
-static Ref<WebCore::Document> protectedImpl(WKDOMDocument *document)
-{
-    return downcast<WebCore::Document>(*document->_impl);
-}
-
 @implementation WKDOMDocument
 
 - (WKDOMElement *)createElement:(NSString *)tagName
 {
     // FIXME: Do something about the exception.
-    auto result = protectedImpl(self)->createElementForBindings(tagName);
+    auto result = protect(downcast<WebCore::Document>(*_impl))->createElementForBindings(tagName);
     if (result.hasException())
         return nil;
     return WebKit::toWKDOMElement(result.releaseReturnValue().ptr());
@@ -69,27 +64,27 @@ static Ref<WebCore::Document> protectedImpl(WKDOMDocument *document)
 
 - (WKDOMText *)createTextNode:(NSString *)data
 {
-    return WebKit::toWKDOMText(protectedImpl(self)->createTextNode(data).ptr());
+    return WebKit::toWKDOMText(protect(downcast<WebCore::Document>(*_impl))->createTextNode(data).ptr());
 }
 
 - (WKDOMElement *)body
 {
-    return WebKit::toWKDOMElement(protect(protectedImpl(self)->bodyOrFrameset()).get());
+    return WebKit::toWKDOMElement(protect(protect(downcast<WebCore::Document>(*_impl))->bodyOrFrameset()).get());
 }
 
 - (WKDOMNode *)createDocumentFragmentWithMarkupString:(NSString *)markupString baseURL:(NSURL *)baseURL
 {
-    return WebKit::toWKDOMNode(createFragmentFromMarkup(protectedImpl(self), markupString, baseURL.absoluteString).ptr());
+    return WebKit::toWKDOMNode(createFragmentFromMarkup(protect(downcast<WebCore::Document>(*_impl)), markupString, baseURL.absoluteString).ptr());
 }
 
 - (WKDOMNode *)createDocumentFragmentWithText:(NSString *)text
 {
-    return WebKit::toWKDOMNode(createFragmentFromText(makeRangeSelectingNodeContents(protectedImpl(self)), text).ptr());
+    return WebKit::toWKDOMNode(createFragmentFromText(makeRangeSelectingNodeContents(protect(downcast<WebCore::Document>(*_impl))), text).ptr());
 }
 
 - (id)parserYieldToken
 {
-    return adoptNS([[WKDOMDocumentParserYieldToken alloc] initWithDocument:protectedImpl(self)]).autorelease();
+    return adoptNS([[WKDOMDocumentParserYieldToken alloc] initWithDocument:protect(downcast<WebCore::Document>(*_impl))]).autorelease();
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm
@@ -30,31 +30,26 @@
 #import <WebCore/Element.h>
 #import <WebCore/ExceptionOr.h>
 
-static Ref<WebCore::Element> protectedImpl(WKDOMElement *element)
-{
-    return downcast<WebCore::Element>(*element->_impl);
-}
-
 @implementation WKDOMElement
 
 - (BOOL)hasAttribute:(NSString *)attribute
 {
-    return protectedImpl(self)->hasAttribute(attribute);
+    return protect(downcast<WebCore::Element>(*_impl))->hasAttribute(attribute);
 }
 
 - (NSString *)getAttribute:(NSString *)attribute
 {
-    return protectedImpl(self)->getAttribute(attribute).createNSString().autorelease();
+    return protect(downcast<WebCore::Element>(*_impl))->getAttribute(attribute).createNSString().autorelease();
 }
 
 - (void)setAttribute:(NSString *)name value:(NSString *)value
 {
-    protectedImpl(self)->setAttribute(name, AtomString { value });
+    protect(downcast<WebCore::Element>(*_impl))->setAttribute(name, AtomString { value });
 }
 
 - (NSString *)tagName
 {
-    return protectedImpl(self)->tagName().createNSString().autorelease();
+    return protect(downcast<WebCore::Element>(*_impl))->tagName().createNSString().autorelease();
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm
@@ -36,11 +36,6 @@
 #import <wtf/MainThread.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-static Ref<WebCore::Node> protectedImpl(WKDOMNode *node)
-{
-    return *node->_impl;
-}
-
 @implementation WKDOMNode
 
 - (id)_initWithImpl:(WebCore::Node*)impl
@@ -69,7 +64,7 @@ static Ref<WebCore::Node> protectedImpl(WKDOMNode *node)
     if (!node)
         return;
 
-    protectedImpl(self)->insertBefore(*WebKit::toProtectedWebCoreNode(node).get(), WebKit::toProtectedWebCoreNode(refNode).get());
+    protect(*_impl)->insertBefore(*WebKit::toProtectedWebCoreNode(node).get(), WebKit::toProtectedWebCoreNode(refNode).get());
 }
 
 - (void)appendChild:(WKDOMNode *)node
@@ -77,7 +72,7 @@ static Ref<WebCore::Node> protectedImpl(WKDOMNode *node)
     if (!node)
         return;
 
-    protectedImpl(self)->appendChild(*WebKit::toProtectedWebCoreNode(node).get());
+    protect(*_impl)->appendChild(*WebKit::toProtectedWebCoreNode(node).get());
 }
 
 - (void)removeChild:(WKDOMNode *)node
@@ -85,37 +80,37 @@ static Ref<WebCore::Node> protectedImpl(WKDOMNode *node)
     if (!node)
         return;
 
-    protectedImpl(self)->removeChild(*WebKit::toProtectedWebCoreNode(node).get());
+    protect(*_impl)->removeChild(*WebKit::toProtectedWebCoreNode(node).get());
 }
 
 - (WKDOMDocument *)document
 {
-    return WebKit::toWKDOMDocument(protect(protectedImpl(self)->document()).ptr());
+    return WebKit::toWKDOMDocument(protect(protect(*_impl)->document()).ptr());
 }
 
 - (WKDOMNode *)parentNode
 {
-    return WebKit::toWKDOMNode(protect(protectedImpl(self)->parentNode()).get());
+    return WebKit::toWKDOMNode(protect(protect(*_impl)->parentNode()).get());
 }
 
 - (WKDOMNode *)firstChild
 {
-    return WebKit::toWKDOMNode(protect(protectedImpl(self)->firstChild()).get());
+    return WebKit::toWKDOMNode(protect(protect(*_impl)->firstChild()).get());
 }
 
 - (WKDOMNode *)lastChild
 {
-    return WebKit::toWKDOMNode(protect(protectedImpl(self)->lastChild()).get());
+    return WebKit::toWKDOMNode(protect(protect(*_impl)->lastChild()).get());
 }
 
 - (WKDOMNode *)previousSibling
 {
-    return WebKit::toWKDOMNode(protect(protectedImpl(self)->previousSibling()).get());
+    return WebKit::toWKDOMNode(protect(protect(*_impl)->previousSibling()).get());
 }
 
 - (WKDOMNode *)nextSibling
 {
-    return WebKit::toWKDOMNode(protect(protectedImpl(self)->nextSibling()).get());
+    return WebKit::toWKDOMNode(protect(protect(*_impl)->nextSibling()).get());
 }
 
 - (NSArray *)textRects
@@ -133,7 +128,7 @@ static Ref<WebCore::Node> protectedImpl(WKDOMNode *node)
 
 - (WKBundleNodeHandleRef)_copyBundleNodeHandleRef
 {
-    return toAPILeakingRef(WebKit::InjectedBundleNodeHandle::getOrCreate(protectedImpl(self).ptr()));
+    return toAPILeakingRef(WebKit::InjectedBundleNodeHandle::getOrCreate(protect(*_impl).ptr()));
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm
@@ -36,11 +36,6 @@
 #import <wtf/MainThread.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-static Ref<WebCore::Range> protectedImpl(WKDOMRange *range)
-{
-    return *range->_impl;
-}
-
 @implementation WKDOMRange
 
 - (id)_initWithImpl:(WebCore::Range*)impl
@@ -72,77 +67,77 @@ static Ref<WebCore::Range> protectedImpl(WKDOMRange *range)
 {
     if (!node)
         return;
-    protectedImpl(self)->setStart(*WebKit::toWebCoreNode(node), offset);
+    protect(*_impl)->setStart(*WebKit::toWebCoreNode(node), offset);
 }
 
 - (void)setEnd:(WKDOMNode *)node offset:(int)offset
 {
     if (!node)
         return;
-    protectedImpl(self)->setEnd(*WebKit::toWebCoreNode(node), offset);
+    protect(*_impl)->setEnd(*WebKit::toWebCoreNode(node), offset);
 }
 
 - (void)collapse:(BOOL)toStart
 {
-    protectedImpl(self)->collapse(toStart);
+    protect(*_impl)->collapse(toStart);
 }
 
 - (void)selectNode:(WKDOMNode *)node
 {
     if (!node)
         return;
-    protectedImpl(self)->selectNode(*WebKit::toProtectedWebCoreNode(node));
+    protect(*_impl)->selectNode(*WebKit::toProtectedWebCoreNode(node));
 }
 
 - (void)selectNodeContents:(WKDOMNode *)node
 {
     if (!node)
         return;
-    protectedImpl(self)->selectNodeContents(*WebKit::toProtectedWebCoreNode(node));
+    protect(*_impl)->selectNodeContents(*WebKit::toProtectedWebCoreNode(node));
 }
 
 - (WKDOMNode *)startContainer
 {
-    return WebKit::toWKDOMNode(protect(protectedImpl(self)->startContainer()).ptr());
+    return WebKit::toWKDOMNode(protect(protect(*_impl)->startContainer()).ptr());
 }
 
 - (NSInteger)startOffset
 {
-    return protectedImpl(self)->startOffset();
+    return protect(*_impl)->startOffset();
 }
 
 - (WKDOMNode *)endContainer
 {
-    return WebKit::toWKDOMNode(protect(protectedImpl(self)->endContainer()).ptr());
+    return WebKit::toWKDOMNode(protect(protect(*_impl)->endContainer()).ptr());
 }
 
 - (NSInteger)endOffset
 {
-    return protectedImpl(self)->endOffset();
+    return protect(*_impl)->endOffset();
 }
 
 - (NSString *)text
 {
-    auto range = makeSimpleRange(protectedImpl(self));
+    auto range = makeSimpleRange(protect(*_impl));
     protect(range.start.document())->updateLayout();
     return plainText(range).createNSString().autorelease();
 }
 
 - (BOOL)isCollapsed
 {
-    return protectedImpl(self)->collapsed();
+    return protect(*_impl)->collapsed();
 }
 
 - (NSArray *)textRects
 {
-    auto range = makeSimpleRange(protectedImpl(self));
+    auto range = makeSimpleRange(protect(*_impl));
     protect(range.start.document())->updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     return createNSArray(WebCore::RenderObject::absoluteTextRects(range)).autorelease();
 }
 
 - (WKDOMRange *)rangeByExpandingToWordBoundaryByCharacters:(NSUInteger)characters inDirection:(WKDOMRangeDirection)direction
 {
-    auto range = makeSimpleRange(protectedImpl(self));
+    auto range = makeSimpleRange(protect(*_impl));
     auto newRange = rangeExpandedByCharactersInDirectionAtWordBoundary(makeDeprecatedLegacyPosition(direction == WKDOMRangeDirectionForward ? range.end : range.start), characters, direction == WKDOMRangeDirectionForward ? WebCore::SelectionDirection::Forward : WebCore::SelectionDirection::Backward);
     return adoptNS([[WKDOMRange alloc] _initWithImpl:createLiveRange(newRange).get()]).autorelease();
 }
@@ -153,7 +148,7 @@ static Ref<WebCore::Range> protectedImpl(WKDOMRange *range)
 
 - (WKBundleRangeHandleRef)_copyBundleRangeHandleRef
 {
-    auto rangeHandle = WebKit::InjectedBundleRangeHandle::getOrCreate(protectedImpl(self).ptr());
+    auto rangeHandle = WebKit::InjectedBundleRangeHandle::getOrCreate(protect(*_impl).ptr());
     return toAPILeakingRef(WTF::move(rangeHandle));
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMText.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMText.mm
@@ -29,21 +29,16 @@
 #import "WKDOMInternals.h"
 #import <WebCore/Text.h>
 
-static Ref<WebCore::Text> protectedImpl(WKDOMText *text)
-{
-    return downcast<WebCore::Text>(*text->_impl);
-}
-
 @implementation WKDOMText
 
 - (NSString *)data
 {
-    return protectedImpl(self)->data().createNSString().autorelease();
+    return protect(downcast<WebCore::Text>(*_impl))->data().createNSString().autorelease();
 }
 
 - (void)setData:(NSString *)data
 {
-    protectedImpl(self)->setData(data);
+    protect(downcast<WebCore::Text>(*_impl))->setData(data);
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
@@ -42,11 +42,6 @@
     RetainPtr<id <WKWebProcessPlugIn>> _principalClassInstance;
 }
 
-static Ref<WebKit::InjectedBundle> protectedBundle(WKWebProcessPlugInController *controller)
-{
-    return *controller->_bundle;
-}
-
 - (void)dealloc
 {
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKWebProcessPlugInController.class, self))
@@ -93,12 +88,12 @@ static void setUpBundleClient(WKWebProcessPlugInController *plugInController, We
     ASSERT(!_principalClassInstance);
     _principalClassInstance = principalClassInstance;
 
-    setUpBundleClient(self, protectedBundle(self));
+    setUpBundleClient(self, protect(*_bundle));
 }
 
 - (id)parameters
 {
-    return protectedBundle(self)->bundleParameters();
+    return protect(*_bundle)->bundleParameters();
 }
 
 static Ref<API::Array> createWKArray(NSArray *array)
@@ -118,7 +113,7 @@ static Ref<API::Array> createWKArray(NSArray *array)
 - (void)extendClassesForParameterCoder:(NSArray *)classes
 {
     auto classList = createWKArray(classes);
-    protectedBundle(self)->extendClassesForParameterCoder(classList.get());
+    protect(*_bundle)->extendClassesForParameterCoder(classList.get());
 }
 
 #pragma mark WKObject protocol implementation
@@ -134,7 +129,7 @@ static Ref<API::Array> createWKArray(NSArray *array)
 
 - (WKBundleRef)_bundleRef
 {
-    return toAPI(protectedBundle(self).ptr());
+    return toAPI(protect(*_bundle).ptr());
 }
 
 @end

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -83,11 +83,6 @@
     RetainPtr<_WKRemoteObjectRegistry> _remoteObjectRegistry;
 }
 
-static Ref<WebKit::WebPage> protectedPage(WKWebProcessPlugInBrowserContextController *controller)
-{
-    return *controller->_page;
-}
-
 static void didStartProvisionalLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userDataRef, const void *clientInfo)
 {
     auto pluginContextController = (__bridge WKWebProcessPlugInBrowserContextController *)clientInfo;
@@ -405,7 +400,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
 - (WKDOMDocument *)mainFrameDocument
 {
-    RefPtr webCoreMainFrame = dynamicDowncast<WebCore::LocalFrame>(protectedPage(self)->mainFrame());
+    RefPtr webCoreMainFrame = dynamicDowncast<WebCore::LocalFrame>(protect(*_page)->mainFrame());
     if (!webCoreMainFrame)
         return nil;
 
@@ -414,7 +409,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
 - (WKDOMRange *)selectedRange
 {
-    auto range = protectedPage(self)->currentSelectionAsRange();
+    auto range = protect(*_page)->currentSelectionAsRange();
     if (!range)
         return nil;
 
@@ -439,7 +434,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
 - (WKBundlePageRef)_bundlePageRef
 {
-    return toAPI(protectedPage(self).ptr());
+    return toAPI(protect(*_page).ptr());
 }
 
 - (WKBrowsingContextHandle *)handle
@@ -579,9 +574,9 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
     };
 
     if (formDelegate)
-        protectedPage(self)->setInjectedBundleFormClient(makeUnique<FormClient>(self));
+        protect(*_page)->setInjectedBundleFormClient(makeUnique<FormClient>(self));
     else
-        protectedPage(self)->setInjectedBundleFormClient(nullptr);
+        protect(*_page)->setInjectedBundleFormClient(nullptr);
 }
 
 - (id <WKWebProcessPlugInEditingDelegate>)_editingDelegate
@@ -722,9 +717,9 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
     };
 
     if (editingDelegate)
-        protectedPage(self)->setInjectedBundleEditorClient(makeUnique<Client>(self));
+        protect(*_page)->setInjectedBundleEditorClient(makeUnique<Client>(self));
     else
-        protectedPage(self)->setInjectedBundleEditorClient(nullptr);
+        protect(*_page)->setInjectedBundleEditorClient(nullptr);
 }
 
 - (BOOL)_defersLoading
@@ -738,7 +733,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
 
 - (BOOL)_usesNonPersistentWebsiteDataStore
 {
-    return protectedPage(self)->usesEphemeralSession();
+    return protect(*_page)->usesEphemeralSession();
 }
 
 - (NSString *)_groupIdentifier


### PR DESCRIPTION
#### d57f4cb961573a2ccc407770cb3c550c534c64c0
<pre>
Reduce use of protected functions in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307326">https://bugs.webkit.org/show_bug.cgi?id=307326</a>

Reviewed by Anne van Kesteren.

* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(-[WKObservablePageState initWithPage:]):
(-[WKObservablePageState isLoading]):
(-[WKObservablePageState title]):
(-[WKObservablePageState URL]):
(-[WKObservablePageState hasOnlySecureContent]):
(-[WKObservablePageState _webProcessIsResponsive]):
(-[WKObservablePageState estimatedProgress]):
(-[WKObservablePageState unreachableURL]):
(-[WKObservablePageState serverTrust]):
(protectedPage): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKFrameInfo.mm:
(-[WKFrameInfo dealloc]):
(-[WKFrameInfo webView]):
(-[WKFrameInfo _handle]):
(-[WKFrameInfo _parentFrameHandle]):
(-[WKFrameInfo _title]):
(protectedFrameInfo): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences copyWithZone:]):
(-[WKPreferences minimumFontSize]):
(-[WKPreferences setMinimumFontSize:]):
(-[WKPreferences setFraudulentWebsiteWarningEnabled:]):
(-[WKPreferences isFraudulentWebsiteWarningEnabled]):
(-[WKPreferences javaScriptCanOpenWindowsAutomatically]):
(-[WKPreferences setJavaScriptCanOpenWindowsAutomatically:]):
(-[WKPreferences setShouldPrintBackgrounds:]):
(-[WKPreferences shouldPrintBackgrounds]):
(-[WKPreferences isTextInteractionEnabled]):
(-[WKPreferences setTextInteractionEnabled:]):
(-[WKPreferences isSiteSpecificQuirksModeEnabled]):
(-[WKPreferences setSiteSpecificQuirksModeEnabled:]):
(-[WKPreferences isElementFullscreenEnabled]):
(-[WKPreferences setElementFullscreenEnabled:]):
(-[WKPreferences setInactiveSchedulingPolicy:]):
(-[WKPreferences inactiveSchedulingPolicy]):
(-[WKPreferences tabFocusesLinks]):
(-[WKPreferences setTabFocusesLinks:]):
(-[WKPreferences _useSystemAppearance]):
(-[WKPreferences _setUseSystemAppearance:]):
(-[WKPreferences setIsLookToScrollEnabled:]):
(-[WKPreferences isLookToScrollEnabled]):
(-[WKPreferences _telephoneNumberDetectionIsEnabled]):
(-[WKPreferences _setTelephoneNumberDetectionIsEnabled:]):
(-[WKPreferences _storageBlockingPolicy]):
(-[WKPreferences _setStorageBlockingPolicy:]):
(-[WKPreferences _fullScreenEnabled]):
(-[WKPreferences _setFullScreenEnabled:]):
(-[WKPreferences _allowsPictureInPictureMediaPlayback]):
(-[WKPreferences _setAllowsPictureInPictureMediaPlayback:]):
(-[WKPreferences _compositingBordersVisible]):
(-[WKPreferences _setCompositingBordersVisible:]):
(-[WKPreferences _compositingRepaintCountersVisible]):
(-[WKPreferences _setCompositingRepaintCountersVisible:]):
(-[WKPreferences _tiledScrollingIndicatorVisible]):
(-[WKPreferences _setTiledScrollingIndicatorVisible:]):
(-[WKPreferences _resourceUsageOverlayVisible]):
(-[WKPreferences _setResourceUsageOverlayVisible:]):
(-[WKPreferences _visibleDebugOverlayRegions]):
(-[WKPreferences _setVisibleDebugOverlayRegions:]):
(-[WKPreferences _legacyLineLayoutVisualCoverageEnabled]):
(-[WKPreferences _setLegacyLineLayoutVisualCoverageEnabled:]):
(-[WKPreferences _contentChangeObserverEnabled]):
(-[WKPreferences _setContentChangeObserverEnabled:]):
(-[WKPreferences _acceleratedDrawingEnabled]):
(-[WKPreferences _setAcceleratedDrawingEnabled:]):
(-[WKPreferences _largeImageAsyncDecodingEnabled]):
(-[WKPreferences _setLargeImageAsyncDecodingEnabled:]):
(-[WKPreferences _needsInAppBrowserPrivacyQuirks]):
(-[WKPreferences _setNeedsInAppBrowserPrivacyQuirks:]):
(-[WKPreferences _animatedImageAsyncDecodingEnabled]):
(-[WKPreferences _setAnimatedImageAsyncDecodingEnabled:]):
(-[WKPreferences _textAutosizingEnabled]):
(-[WKPreferences _setTextAutosizingEnabled:]):
(-[WKPreferences _developerExtrasEnabled]):
(-[WKPreferences _setDeveloperExtrasEnabled:]):
(-[WKPreferences _logsPageMessagesToSystemConsoleEnabled]):
(-[WKPreferences _setLogsPageMessagesToSystemConsoleEnabled:]):
(-[WKPreferences _hiddenPageDOMTimerThrottlingEnabled]):
(-[WKPreferences _setHiddenPageDOMTimerThrottlingEnabled:]):
(-[WKPreferences _hiddenPageDOMTimerThrottlingAutoIncreases]):
(-[WKPreferences _setHiddenPageDOMTimerThrottlingAutoIncreases:]):
(-[WKPreferences _pageVisibilityBasedProcessSuppressionEnabled]):
(-[WKPreferences _setPageVisibilityBasedProcessSuppressionEnabled:]):
(-[WKPreferences _allowFileAccessFromFileURLs]):
(-[WKPreferences _setAllowFileAccessFromFileURLs:]):
(-[WKPreferences _javaScriptRuntimeFlags]):
(-[WKPreferences _setJavaScriptRuntimeFlags:]):
(-[WKPreferences _isStandalone]):
(-[WKPreferences _setStandalone:]):
(-[WKPreferences _diagnosticLoggingEnabled]):
(-[WKPreferences _setDiagnosticLoggingEnabled:]):
(-[WKPreferences _defaultFontSize]):
(-[WKPreferences _setDefaultFontSize:]):
(-[WKPreferences _defaultFixedPitchFontSize]):
(-[WKPreferences _setDefaultFixedPitchFontSize:]):
(-[WKPreferences _fixedPitchFontFamily]):
(-[WKPreferences _setFixedPitchFontFamily:]):
(-[WKPreferences _isEnabledForInternalDebugFeature:]):
(-[WKPreferences _setEnabled:forInternalDebugFeature:]):
(-[WKPreferences _isEnabledForFeature:]):
(-[WKPreferences _setEnabled:forFeature:]):
(-[WKPreferences _disableRichJavaScriptFeatures]):
(-[WKPreferences _disableMediaPlaybackRelatedFeatures]):
(-[WKPreferences _applePayCapabilityDisclosureAllowed]):
(-[WKPreferences _setApplePayCapabilityDisclosureAllowed:]):
(-[WKPreferences _shouldSuppressKeyboardInputDuringProvisionalNavigation]):
(-[WKPreferences _setShouldSuppressKeyboardInputDuringProvisionalNavigation:]):
(-[WKPreferences _loadsImagesAutomatically]):
(-[WKPreferences _setLoadsImagesAutomatically:]):
(-[WKPreferences _peerConnectionEnabled]):
(-[WKPreferences _setPeerConnectionEnabled:]):
(-[WKPreferences _mediaDevicesEnabled]):
(-[WKPreferences _setMediaDevicesEnabled:]):
(-[WKPreferences _getUserMediaRequiresFocus]):
(-[WKPreferences _setGetUserMediaRequiresFocus:]):
(-[WKPreferences _screenCaptureEnabled]):
(-[WKPreferences _setScreenCaptureEnabled:]):
(-[WKPreferences _mockCaptureDevicesEnabled]):
(-[WKPreferences _setMockCaptureDevicesEnabled:]):
(-[WKPreferences _mockCaptureDevicesPromptEnabled]):
(-[WKPreferences _setMockCaptureDevicesPromptEnabled:]):
(-[WKPreferences _mediaCaptureRequiresSecureConnection]):
(-[WKPreferences _setMediaCaptureRequiresSecureConnection:]):
(-[WKPreferences _inactiveMediaCaptureStreamRepromptIntervalInMinutes]):
(-[WKPreferences _setInactiveMediaCaptureStreamRepromptIntervalInMinutes:]):
(-[WKPreferences _inactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes]):
(-[WKPreferences _setInactiveMediaCaptureStreamRepromptWithoutUserGestureIntervalInMinutes:]):
(-[WKPreferences _interruptAudioOnPageVisibilityChangeEnabled]):
(-[WKPreferences _setInterruptAudioOnPageVisibilityChangeEnabled:]):
(-[WKPreferences _enumeratingAllNetworkInterfacesEnabled]):
(-[WKPreferences _setEnumeratingAllNetworkInterfacesEnabled:]):
(-[WKPreferences _iceCandidateFilteringEnabled]):
(-[WKPreferences _setICECandidateFilteringEnabled:]):
(-[WKPreferences _setJavaScriptCanAccessClipboard:]):
(-[WKPreferences _shouldAllowUserInstalledFonts]):
(-[WKPreferences _setShouldAllowUserInstalledFonts:]):
(-[WKPreferences _editableLinkBehavior]):
(-[WKPreferences _setEditableLinkBehavior:]):
(-[WKPreferences _setAVFoundationEnabled:]):
(-[WKPreferences _avFoundationEnabled]):
(-[WKPreferences _setTextExtractionEnabled:]):
(-[WKPreferences _textExtractionEnabled]):
(-[WKPreferences _setColorFilterEnabled:]):
(-[WKPreferences _colorFilterEnabled]):
(-[WKPreferences _setPunchOutWhiteBackgroundsInDarkMode:]):
(-[WKPreferences _punchOutWhiteBackgroundsInDarkMode]):
(-[WKPreferences _setLowPowerVideoAudioBufferSizeEnabled:]):
(-[WKPreferences _lowPowerVideoAudioBufferSizeEnabled]):
(-[WKPreferences _setShouldIgnoreMetaViewport:]):
(-[WKPreferences _shouldIgnoreMetaViewport]):
(-[WKPreferences _setNeedsSiteSpecificQuirks:]):
(-[WKPreferences _needsSiteSpecificQuirks]):
(-[WKPreferences _setItpDebugModeEnabled:]):
(-[WKPreferences _itpDebugModeEnabled]):
(-[WKPreferences _setMediaSourceEnabled:]):
(-[WKPreferences _mediaSourceEnabled]):
(-[WKPreferences _setManagedMediaSourceEnabled:]):
(-[WKPreferences _managedMediaSourceEnabled]):
(-[WKPreferences _setManagedMediaSourceLowThreshold:]):
(-[WKPreferences _managedMediaSourceLowThreshold]):
(-[WKPreferences _setManagedMediaSourceHighThreshold:]):
(-[WKPreferences _managedMediaSourceHighThreshold]):
(-[WKPreferences _secureContextChecksEnabled]):
(-[WKPreferences _setSecureContextChecksEnabled:]):
(-[WKPreferences _setWebAudioEnabled:]):
(-[WKPreferences _webAudioEnabled]):
(-[WKPreferences _setAcceleratedCompositingEnabled:]):
(-[WKPreferences _acceleratedCompositingEnabled]):
(-[WKPreferences _remotePlaybackEnabled]):
(-[WKPreferences _setRemotePlaybackEnabled:]):
(-[WKPreferences _serviceWorkerEntitlementDisabledForTesting]):
(-[WKPreferences _setServiceWorkerEntitlementDisabledForTesting:]):
(-[WKPreferences _setCanvasUsesAcceleratedDrawing:]):
(-[WKPreferences _canvasUsesAcceleratedDrawing]):
(-[WKPreferences _setDefaultTextEncodingName:]):
(-[WKPreferences _defaultTextEncodingName]):
(-[WKPreferences _setAuthorAndUserStylesEnabled:]):
(-[WKPreferences _authorAndUserStylesEnabled]):
(-[WKPreferences _setDOMTimersThrottlingEnabled:]):
(-[WKPreferences _domTimersThrottlingEnabled]):
(-[WKPreferences _setWebArchiveDebugModeEnabled:]):
(-[WKPreferences _webArchiveDebugModeEnabled]):
(-[WKPreferences _setLocalFileContentSniffingEnabled:]):
(-[WKPreferences _localFileContentSniffingEnabled]):
(-[WKPreferences _setUsesPageCache:]):
(-[WKPreferences _usesPageCache]):
(-[WKPreferences _setWebSecurityEnabled:]):
(-[WKPreferences _webSecurityEnabled]):
(-[WKPreferences _setUniversalAccessFromFileURLsAllowed:]):
(-[WKPreferences _universalAccessFromFileURLsAllowed]):
(-[WKPreferences _setTopNavigationToDataURLsAllowed:]):
(-[WKPreferences _topNavigationToDataURLsAllowed]):
(-[WKPreferences _setSuppressesIncrementalRendering:]):
(-[WKPreferences _suppressesIncrementalRendering]):
(-[WKPreferences _setCookieEnabled:]):
(-[WKPreferences _cookieEnabled]):
(-[WKPreferences _setViewGestureDebuggingEnabled:]):
(-[WKPreferences _viewGestureDebuggingEnabled]):
(-[WKPreferences _setStandardFontFamily:]):
(-[WKPreferences _standardFontFamily]):
(-[WKPreferences _setBackspaceKeyNavigationEnabled:]):
(-[WKPreferences _backspaceKeyNavigationEnabled]):
(-[WKPreferences _setWebGLEnabled:]):
(-[WKPreferences _webGLEnabled]):
(-[WKPreferences _setAllowsInlineMediaPlayback:]):
(-[WKPreferences _allowsInlineMediaPlayback]):
(-[WKPreferences _setApplePayEnabled:]):
(-[WKPreferences _applePayEnabled]):
(-[WKPreferences _setInlineMediaPlaybackRequiresPlaysInlineAttribute:]):
(-[WKPreferences _inlineMediaPlaybackRequiresPlaysInlineAttribute]):
(-[WKPreferences _setInvisibleMediaAutoplayNotPermitted:]):
(-[WKPreferences _invisibleMediaAutoplayNotPermitted]):
(-[WKPreferences _setLegacyEncryptedMediaAPIEnabled:]):
(-[WKPreferences _legacyEncryptedMediaAPIEnabled]):
(-[WKPreferences _setMainContentUserGestureOverrideEnabled:]):
(-[WKPreferences _mainContentUserGestureOverrideEnabled]):
(-[WKPreferences _setNeedsStorageAccessFromFileURLsQuirk:]):
(-[WKPreferences _needsStorageAccessFromFileURLsQuirk]):
(-[WKPreferences _setPDFPluginEnabled:]):
(-[WKPreferences _pdfPluginEnabled]):
(-[WKPreferences _setRequiresUserGestureForAudioPlayback:]):
(-[WKPreferences _requiresUserGestureForAudioPlayback]):
(-[WKPreferences _setRequiresUserGestureForVideoPlayback:]):
(-[WKPreferences _requiresUserGestureForVideoPlayback]):
(-[WKPreferences _setServiceControlsEnabled:]):
(-[WKPreferences _serviceControlsEnabled]):
(-[WKPreferences _setShowsToolTipOverTruncatedText:]):
(-[WKPreferences _showsToolTipOverTruncatedText]):
(-[WKPreferences _setTextAreasAreResizable:]):
(-[WKPreferences _textAreasAreResizable]):
(-[WKPreferences _setUseGiantTiles:]):
(-[WKPreferences _useGiantTiles]):
(-[WKPreferences _setWantsBalancedSetDefersLoadingBehavior:]):
(-[WKPreferences _wantsBalancedSetDefersLoadingBehavior]):
(-[WKPreferences _setAggressiveTileRetentionEnabled:]):
(-[WKPreferences _aggressiveTileRetentionEnabled]):
(-[WKPreferences _setAppNapEnabled:]):
(-[WKPreferences _appNapEnabled]):
(-[WKPreferences _javaScriptCanAccessClipboard]):
(-[WKPreferences _setDOMPasteAllowed:]):
(-[WKPreferences _domPasteAllowed]):
(-[WKPreferences _setShouldEnableTextAutosizingBoost:]):
(-[WKPreferences _shouldEnableTextAutosizingBoost]):
(-[WKPreferences _isSafeBrowsingEnabled]):
(-[WKPreferences _setSafeBrowsingEnabled:]):
(-[WKPreferences _setVideoQualityIncludesDisplayCompositingEnabled:]):
(-[WKPreferences _videoQualityIncludesDisplayCompositingEnabled]):
(-[WKPreferences _setDeviceOrientationEventEnabled:]):
(-[WKPreferences _deviceOrientationEventEnabled]):
(-[WKPreferences _setAccessibilityIsolatedTreeEnabled:]):
(-[WKPreferences _accessibilityIsolatedTreeEnabled]):
(-[WKPreferences _speechRecognitionEnabled]):
(-[WKPreferences _setSpeechRecognitionEnabled:]):
(-[WKPreferences _privateClickMeasurementEnabled]):
(-[WKPreferences _setPrivateClickMeasurementEnabled:]):
(-[WKPreferences _privateClickMeasurementDebugModeEnabled]):
(-[WKPreferences _setPrivateClickMeasurementDebugModeEnabled:]):
(-[WKPreferences _pitchCorrectionAlgorithm]):
(-[WKPreferences _setPitchCorrectionAlgorithm:]):
(-[WKPreferences _mediaSessionEnabled]):
(-[WKPreferences _setMediaSessionEnabled:]):
(-[WKPreferences _isExtensibleSSOEnabled]):
(-[WKPreferences _setExtensibleSSOEnabled:]):
(-[WKPreferences _requiresPageVisibilityToPlayAudio]):
(-[WKPreferences _setRequiresPageVisibilityToPlayAudio:]):
(-[WKPreferences _fileSystemAccessEnabled]):
(-[WKPreferences _setFileSystemAccessEnabled:]):
(-[WKPreferences _storageAPIEnabled]):
(-[WKPreferences _setStorageAPIEnabled:]):
(-[WKPreferences _accessHandleEnabled]):
(-[WKPreferences _setAccessHandleEnabled:]):
(-[WKPreferences _setNotificationsEnabled:]):
(-[WKPreferences _notificationsEnabled]):
(-[WKPreferences _setNotificationEventEnabled:]):
(-[WKPreferences _notificationEventEnabled]):
(-[WKPreferences _pushAPIEnabled]):
(-[WKPreferences _setPushAPIEnabled:]):
(-[WKPreferences _setModelDocumentEnabled:]):
(-[WKPreferences _modelDocumentEnabled]):
(-[WKPreferences _setRequiresFullscreenToLockScreenOrientation:]):
(-[WKPreferences _requiresFullscreenToLockScreenOrientation]):
(-[WKPreferences _setInteractionRegionMinimumCornerRadius:]):
(-[WKPreferences _interactionRegionMinimumCornerRadius]):
(-[WKPreferences _setInteractionRegionInlinePadding:]):
(-[WKPreferences _interactionRegionInlinePadding]):
(-[WKPreferences _setMediaPreferredFullscreenWidth:]):
(-[WKPreferences _mediaPreferredFullscreenWidth]):
(-[WKPreferences _setAppBadgeEnabled:]):
(-[WKPreferences _appBadgeEnabled]):
(-[WKPreferences _setVerifyWindowOpenUserGestureFromUIProcess:]):
(-[WKPreferences _verifyWindowOpenUserGestureFromUIProcess]):
(-[WKPreferences _mediaCapabilityGrantsEnabled]):
(-[WKPreferences _setMediaCapabilityGrantsEnabled:]):
(-[WKPreferences _setAllowPrivacySensitiveOperationsInNonPersistentDataStores:]):
(-[WKPreferences _allowPrivacySensitiveOperationsInNonPersistentDataStores]):
(-[WKPreferences _setVideoFullscreenRequiresElementFullscreen:]):
(-[WKPreferences _videoFullscreenRequiresElementFullscreen]):
(-[WKPreferences _setCSSTransformStyleSeparatedEnabled:]):
(-[WKPreferences _cssTransformStyleSeparatedEnabled]):
(-[WKPreferences _setOverlayRegionsEnabled:]):
(-[WKPreferences _overlayRegionsEnabled]):
(-[WKPreferences _setModelElementEnabled:]):
(-[WKPreferences _modelProcessEnabled]):
(-[WKPreferences _setModelProcessEnabled:]):
(-[WKPreferences _modelElementEnabled]):
(-[WKPreferences _setModelNoPortalAttributeEnabled:]):
(-[WKPreferences _modelNoPortalAttributeEnabled]):
(-[WKPreferences _setUpdateSceneGeometryEnabled:]):
(-[WKPreferences _updateSceneGeometryEnabled]):
(-[WKPreferences _setRequiresPageVisibilityForVideoToBeNowPlayingForTesting:]):
(-[WKPreferences _requiresPageVisibilityForVideoToBeNowPlayingForTesting]):
(-[WKPreferences _siteIsolationEnabled]):
(-[WKPreferences _setSiteIsolationEnabled:]):
(-[WKPreferences javaScriptEnabled]):
(-[WKPreferences setJavaScriptEnabled:]):
(protectedPreferences): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool _registerURLSchemeAsCanDisplayOnlyIfCanRequest:]):
(-[WKProcessPool _registerURLSchemeAsSecure:]):
(-[WKProcessPool _registerURLSchemeAsBypassingContentSecurityPolicy:]):
(-[WKProcessPool _setDomainRelaxationForbiddenForURLScheme:]):
(-[WKProcessPool _objectForBundleParameter:]):
(-[WKProcessPool _setDownloadDelegate:]):
(-[WKProcessPool _setAutomationDelegate:]):
(-[WKProcessPool _warmInitialProcess]):
(-[WKProcessPool _automationCapabilitiesDidChange]):
(-[WKProcessPool _setAutomationSession:]):
(-[WKProcessPool _addSupportedPlugin:named:withMimeTypes:withExtensions:]):
(-[WKProcessPool _clearSupportedPlugins]):
(-[WKProcessPool _terminateServiceWorkers]):
(-[WKProcessPool _prewarmedProcessIdentifiersForTesting]):
(-[WKProcessPool _countWebPagesInAllProcessesForTesting:]):
(-[WKProcessPool _webPageContentProcessCount]):
(-[WKProcessPool _serviceWorkerProcessCount]):
(-[WKProcessPool _isJITDisabledInAllRemoteWorkerProcesses:]):
(-[WKProcessPool _setCookieStoragePartitioningEnabled:]):
(-[WKProcessPool _getActivePagesOriginsInWebProcessForTesting:completionHandler:]):
(-[WKProcessPool _clearPermanentCredentialsForProtectionSpace:]):
(-[WKProcessPool _seedResourceLoadStatisticsForTestingWithFirstParty:thirdParty:shouldScheduleNotification:completionHandler:]):
(-[WKProcessPool _garbageCollectJavaScriptObjectsForTesting]):
(-[WKProcessPool _numberOfConnectedGamepadsForTesting]):
(-[WKProcessPool _numberOfConnectedHIDGamepadsForTesting]):
(-[WKProcessPool _numberOfConnectedGameControllerFrameworkGamepadsForTesting]):
(-[WKProcessPool _setUsesOnlyHIDGamepadProviderForTesting:]):
(-[WKProcessPool _terminateAllWebContentProcesses]):
(-[WKProcessPool _notificationManagerForTesting]):
(-[WKProcessPool _registerAdditionalFonts:]):
(protectedProcessPool): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKURLSchemeTask.mm:
(-[WKURLSchemeTaskImpl request]):
(-[WKURLSchemeTaskImpl _requestOnlyIfCached]):
(-[WKURLSchemeTaskImpl _willPerformRedirection:newRequest:completionHandler:]):
(-[WKURLSchemeTaskImpl didReceiveResponse:]):
(-[WKURLSchemeTaskImpl didReceiveData:]):
(-[WKURLSchemeTaskImpl didFinish]):
(-[WKURLSchemeTaskImpl didFailWithError:]):
(-[WKURLSchemeTaskImpl _didPerformRedirection:newRequest:]):
(protectedURLSchemeTask): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKUserContentController.mm:
(-[WKUserContentController addUserScript:]):
(-[WKUserContentController removeAllUserScripts]):
(-[WKUserContentController addContentRuleList:]):
(-[WKUserContentController removeContentRuleList:]):
(-[WKUserContentController removeAllContentRuleLists]):
(-[WKUserContentController _addScriptMessageHandler:]):
(-[WKUserContentController removeScriptMessageHandlerForName:]):
(-[WKUserContentController removeScriptMessageHandlerForName:contentWorld:]):
(-[WKUserContentController removeAllScriptMessageHandlersFromContentWorld:]):
(-[WKUserContentController removeAllScriptMessageHandlers]):
(-[WKUserContentController _removeUserScript:]):
(-[WKUserContentController _removeAllUserScriptsAssociatedWithContentWorld:]):
(-[WKUserContentController _addUserScriptImmediately:]):
(-[WKUserContentController _addUserContentFilter:]):
(-[WKUserContentController _addContentRuleList:extensionBaseURL:]):
(-[WKUserContentController _removeUserContentFilter:]):
(-[WKUserContentController _removeAllUserContentFilters]):
(-[WKUserContentController _addUserStyleSheet:]):
(-[WKUserContentController _removeUserStyleSheet:]):
(-[WKUserContentController _removeAllUserStyleSheets]):
(-[WKUserContentController _removeAllUserStyleSheetsAssociatedWithContentWorld:]):
(-[WKUserContentController _addBuffer:contentWorld:name:]):
(-[WKUserContentController _removeBufferWithName:contentWorld:]):
(-[WKUserContentController _addScriptMessageHandler:name:userContentWorld:]):
(-[WKUserContentController _removeScriptMessageHandlerForName:userContentWorld:]):
(-[WKUserContentController _removeAllScriptMessageHandlersAssociatedWithUserContentWorld:]):
(protectedUserContentControllerProxy): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebpagePreferences.mm:
(-[WKWebpagePreferences _setContentBlockersEnabled:]):
(-[WKWebpagePreferences _setContentRuleListsEnabled:exceptions:]):
(-[WKWebpagePreferences _setActiveContentRuleListActionPatterns:]):
(-[WKWebpagePreferences _setCustomHeaderFields:]):
(-[WKWebpagePreferences _setWebsiteDataStore:]):
(-[WKWebpagePreferences _setUserContentController:]):
(-[WKWebpagePreferences _captivePortalModeEnabled]):
(-[WKWebpagePreferences isLockdownModeEnabled]):
(-[WKWebpagePreferences _setVisibilityAdjustmentSelectorsIncludingShadowHosts:]):
(-[WKWebpagePreferences setAlternateRequest:]):
(-[WKWebpagePreferences alternateRequest]):
(protectedWebsitePolicies): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
(-[WKWebsiteDataStore httpCookieStore]):
(-[WKWebsiteDataStore removeDataOfTypes:modifiedSince:completionHandler:]):
(-[WKWebsiteDataStore removeDataOfTypes:forDataRecords:completionHandler:]):
(-[WKWebsiteDataStore setProxyConfigurations:]):
(-[WKWebsiteDataStore fetchDataOfTypes:completionHandler:]):
(-[WKWebsiteDataStore restoreData:completionHandler:]):
(-[WKWebsiteDataStore _initWithConfiguration:]):
(-[WKWebsiteDataStore _fetchDataRecordsOfTypes:withOptions:completionHandler:]):
(-[WKWebsiteDataStore _resourceLoadStatisticsEnabled]):
(-[WKWebsiteDataStore _setResourceLoadStatisticsEnabled:]):
(-[WKWebsiteDataStore _resourceLoadStatisticsDebugMode]):
(-[WKWebsiteDataStore _setResourceLoadStatisticsDebugMode:]):
(-[WKWebsiteDataStore _setPrivateClickMeasurementDebugModeEnabled:]):
(-[WKWebsiteDataStore _setStorageSiteValidationEnabled:]):
(-[WKWebsiteDataStore _setPersistedSites:]):
(-[WKWebsiteDataStore _setResourceLoadStatisticsTestingCallback:]):
(-[WKWebsiteDataStore _setStorageAccessPromptQuirkForTesting:withSubFrameDomains:withTriggerPages:completionHandler:]):
(-[WKWebsiteDataStore _grantStorageAccessForTesting:withSubFrameDomains:completionHandler:]):
(-[WKWebsiteDataStore _setResourceLoadStatisticsTimeAdvanceForTesting:completionHandler:]):
(-[WKWebsiteDataStore _scheduleCookieBlockingUpdate:]):
(-[WKWebsiteDataStore _logUserInteraction:completionHandler:]):
(-[WKWebsiteDataStore _setPrevalentDomain:completionHandler:]):
(-[WKWebsiteDataStore _getIsPrevalentDomain:completionHandler:]):
(-[WKWebsiteDataStore _clearPrevalentDomain:completionHandler:]):
(-[WKWebsiteDataStore _clearResourceLoadStatistics:]):
(-[WKWebsiteDataStore _closeDatabases:]):
(-[WKWebsiteDataStore _getResourceLoadStatisticsDataSummary:]):
(-[WKWebsiteDataStore _isRelationshipOnlyInDatabaseOnce:thirdParty:completionHandler:]):
(-[WKWebsiteDataStore _isRegisteredAsSubresourceUnderFirstParty:thirdParty:completionHandler:]):
(-[WKWebsiteDataStore _statisticsDatabaseHasAllTables:]):
(-[WKWebsiteDataStore _processStatisticsAndDataRecords:]):
(-[WKWebsiteDataStore _setThirdPartyCookieBlockingMode:onlyOnSitesWithoutUserInteraction:completionHandler:]):
(-[WKWebsiteDataStore _renameOrigin:to:forDataOfTypes:completionHandler:]):
(-[WKWebsiteDataStore _networkProcessHasEntitlementForTesting:]):
(-[WKWebsiteDataStore _setUserAgentStringQuirkForTesting:withUserAgent:completionHandler:]):
(-[WKWebsiteDataStore _setPrivateTokenIPCForTesting:]):
(-[WKWebsiteDataStore set_delegate:]):
(-[WKWebsiteDataStore _trustServerForLocalPCMTesting:]):
(-[WKWebsiteDataStore _setPrivateClickMeasurementDebugModeEnabledForTesting:]):
(-[WKWebsiteDataStore _terminateNetworkProcess]):
(-[WKWebsiteDataStore _sendNetworkProcessPrepareToSuspend:]):
(-[WKWebsiteDataStore _sendNetworkProcessWillSuspendImminently]):
(-[WKWebsiteDataStore _sendNetworkProcessDidResume]):
(-[WKWebsiteDataStore _synthesizeAppIsBackground:]):
(-[WKWebsiteDataStore _networkProcessIdentifier]):
(-[WKWebsiteDataStore _countNonDefaultSessionSets:]):
(-[WKWebsiteDataStore _hasServiceWorkerBackgroundActivityForTesting]):
(-[WKWebsiteDataStore _getPendingPushMessage:]):
(-[WKWebsiteDataStore _getPendingPushMessages:]):
(-[WKWebsiteDataStore _processPushMessage:completionHandler:]):
(-[WKWebsiteDataStore _processWebCorePersistentNotificationClick:completionHandler:]):
(-[WKWebsiteDataStore _processWebCorePersistentNotificationClose:completionHandler:]):
(-[WKWebsiteDataStore _getAllBackgroundFetchIdentifiers:]):
(-[WKWebsiteDataStore _getBackgroundFetchState:completionHandler:]):
(-[WKWebsiteDataStore _abortBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _pauseBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _resumeBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _clickBackgroundFetch:completionHandler:]):
(-[WKWebsiteDataStore _storeServiceWorkerRegistrations:]):
(-[WKWebsiteDataStore _scopeURL:hasPushSubscriptionForTesting:]):
(-[WKWebsiteDataStore _originDirectoryForTesting:topOrigin:type:completionHandler:]):
(-[WKWebsiteDataStore _setCompletionHandlerForRemovalFromNetworkProcess:]):
(-[WKWebsiteDataStore _setRestrictedOpenerTypeForTesting:forDomain:]):
(-[WKWebsiteDataStore _getAppBadgeForTesting:]):
(-[WKWebsiteDataStore _runningOrTerminatingServiceWorkerCountForTesting:]):
(-[WKWebsiteDataStore _isStorageSuspendedForTesting:]):
(-[WKWebsiteDataStore _thirdPartyCookieBlockingModeForTesting]):
(protectedWebsiteDataStore): Deleted.
* Source/WebKit/UIProcess/mac/WKPrintingView.mm:
(-[WKPrintingView _delayedResumeAutodisplayTimerFired]):
(-[WKPrintingView knowsPageRange:]):
(-[WKPrintingView _drawPreview:]):
(-[WKPrintingView rectForPage:]):
(protectedWebFrame): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInFrame.mm:
(-[WKWebProcessPlugInFrame jsContextForWorld:]):
(-[WKWebProcessPlugInFrame jsContextForServiceWorkerWorld:]):
(-[WKWebProcessPlugInFrame hitTest:]):
(-[WKWebProcessPlugInFrame hitTest:options:]):
(-[WKWebProcessPlugInFrame jsCSSStyleDeclarationForCSSStyleDeclarationHandle:inWorld:]):
(-[WKWebProcessPlugInFrame jsNodeForNodeHandle:inWorld:]):
(-[WKWebProcessPlugInFrame jsRangeForRangeHandle:inWorld:]):
(-[WKWebProcessPlugInFrame URL]):
(-[WKWebProcessPlugInFrame childFrames]):
(-[WKWebProcessPlugInFrame containsAnyFormElements]):
(-[WKWebProcessPlugInFrame isMainFrame]):
(-[WKWebProcessPlugInFrame _securityOrigin]):
(-[WKWebProcessPlugInFrame appleTouchIconURLs]):
(-[WKWebProcessPlugInFrame faviconURLs]):
(-[WKWebProcessPlugInFrame _parentFrame]):
(-[WKWebProcessPlugInFrame _certificateChain]):
(-[WKWebProcessPlugInFrame _serverTrust]):
(-[WKWebProcessPlugInFrame _provisionalURL]):
(protectedFrame): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInNodeHandle.mm:
(-[WKWebProcessPlugInNodeHandle htmlIFrameElementContentFrame]):
(-[WKWebProcessPlugInNodeHandle renderedImageWithOptions:width:]):
(-[WKWebProcessPlugInNodeHandle elementBounds]):
(-[WKWebProcessPlugInNodeHandle HTMLInputElementIsAutoFilled]):
(-[WKWebProcessPlugInNodeHandle HTMLInputElementIsAutoFilledAndViewable]):
(-[WKWebProcessPlugInNodeHandle HTMLInputElementIsAutoFilledAndObscured]):
(-[WKWebProcessPlugInNodeHandle setHTMLInputElementIsAutoFilled:]):
(-[WKWebProcessPlugInNodeHandle setHTMLInputElementIsAutoFilledAndViewable:]):
(-[WKWebProcessPlugInNodeHandle setHTMLInputElementIsAutoFilledAndObscured:]):
(-[WKWebProcessPlugInNodeHandle isHTMLInputElementAutoFillButtonEnabled]):
(-[WKWebProcessPlugInNodeHandle setHTMLInputElementAutoFillButtonEnabledWithButtonType:]):
(-[WKWebProcessPlugInNodeHandle htmlInputElementAutoFillButtonType]):
(-[WKWebProcessPlugInNodeHandle htmlInputElementLastAutoFillButtonType]):
(-[WKWebProcessPlugInNodeHandle HTMLInputElementIsUserEdited]):
(-[WKWebProcessPlugInNodeHandle HTMLTextAreaElementIsUserEdited]):
(-[WKWebProcessPlugInNodeHandle isSelectElement]):
(-[WKWebProcessPlugInNodeHandle isSelectableTextNode]):
(-[WKWebProcessPlugInNodeHandle isTextField]):
(-[WKWebProcessPlugInNodeHandle HTMLTableCellElementCellAbove]):
(-[WKWebProcessPlugInNodeHandle frame]):
(protectedNodeHandle): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInRangeHandle.mm:
(-[WKWebProcessPlugInRangeHandle frame]):
(-[WKWebProcessPlugInRangeHandle text]):
(protectedRangeHandle): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/Cocoa/WKWebProcessPlugInScriptWorld.mm:
(-[WKWebProcessPlugInScriptWorld clearWrappers]):
(-[WKWebProcessPlugInScriptWorld makeAllShadowRootsOpen]):
(-[WKWebProcessPlugInScriptWorld exposeClosedShadowRootsForExtensions]):
(-[WKWebProcessPlugInScriptWorld disableOverrideBuiltinsBehavior]):
(-[WKWebProcessPlugInScriptWorld allowJSHandleCreation]):
(protectedWorld): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMDocument.mm:
(-[WKDOMDocument createElement:]):
(-[WKDOMDocument createTextNode:]):
(-[WKDOMDocument body]):
(-[WKDOMDocument createDocumentFragmentWithMarkupString:baseURL:]):
(-[WKDOMDocument createDocumentFragmentWithText:]):
(-[WKDOMDocument parserYieldToken]):
(protectedImpl): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMElement.mm:
(-[WKDOMElement hasAttribute:]):
(-[WKDOMElement getAttribute:]):
(-[WKDOMElement setAttribute:value:]):
(-[WKDOMElement tagName]):
(protectedImpl): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMNode.mm:
(-[WKDOMNode insertNode:before:]):
(-[WKDOMNode appendChild:]):
(-[WKDOMNode removeChild:]):
(-[WKDOMNode document]):
(-[WKDOMNode parentNode]):
(-[WKDOMNode firstChild]):
(-[WKDOMNode lastChild]):
(-[WKDOMNode previousSibling]):
(-[WKDOMNode nextSibling]):
(-[WKDOMNode _copyBundleNodeHandleRef]):
(protectedImpl): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMRange.mm:
(-[WKDOMRange setStart:offset:]):
(-[WKDOMRange setEnd:offset:]):
(-[WKDOMRange collapse:]):
(-[WKDOMRange selectNode:]):
(-[WKDOMRange selectNodeContents:]):
(-[WKDOMRange startContainer]):
(-[WKDOMRange startOffset]):
(-[WKDOMRange endContainer]):
(-[WKDOMRange endOffset]):
(-[WKDOMRange text]):
(-[WKDOMRange isCollapsed]):
(-[WKDOMRange textRects]):
(-[WKDOMRange rangeByExpandingToWordBoundaryByCharacters:inDirection:]):
(-[WKDOMRange _copyBundleRangeHandleRef]):
(protectedImpl): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKDOMText.mm:
(-[WKDOMText data]):
(-[WKDOMText setData:]):
(protectedImpl): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm:
(-[WKWebProcessPlugInController _setPrincipalClassInstance:]):
(-[WKWebProcessPlugInController parameters]):
(-[WKWebProcessPlugInController extendClassesForParameterCoder:]):
(-[WKWebProcessPlugInController _bundleRef]):
(protectedBundle): Deleted.
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(-[WKWebProcessPlugInBrowserContextController mainFrameDocument]):
(-[WKWebProcessPlugInBrowserContextController selectedRange]):
(-[WKWebProcessPlugInBrowserContextController _bundlePageRef]):
(-[WKWebProcessPlugInBrowserContextController _setFormDelegate:]):
(-[WKWebProcessPlugInBrowserContextController _setEditingDelegate:]):
(-[WKWebProcessPlugInBrowserContextController _usesNonPersistentWebsiteDataStore]):
(protectedPage): Deleted.

Canonical link: <a href="https://commits.webkit.org/307109@main">https://commits.webkit.org/307109@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/453d019e92902106744c9fd7fe9658e9471cde86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143322 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7223 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/151998 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96543 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29af2fe1-3666-490e-b75f-99918363c6b8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16457 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110227 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79356 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e9b2682-f0e9-4583-81e6-3074aefd22e4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146271 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12668 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91136 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0fbce101-09af-48d9-8c3c-76dbf38c97d2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12156 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9871 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/1996 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121582 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154309 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15841 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6149 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15878 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118587 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30402 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14519 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126353 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71236 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15466 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5010 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15200 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79186 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15411 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15262 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->