### PR TITLE
Treat empty string keyframes‘ name as invalid

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -2289,6 +2289,7 @@
         "web-platform-tests/css/css-animations/jump-start-animation-before-phase-ref.html",
         "web-platform-tests/css/css-animations/nested-scale-animations-ref.html",
         "web-platform-tests/css/css-animations/parent-after-change-style-pseudo-element-flicker-ref.html",
+        "web-platform-tests/css/css-animations/parsing/animation-name-edge-cases-ref.html",
         "web-platform-tests/css/css-animations/svg-transform-animation-ref.html",
         "web-platform-tests/css/css-animations/transform-animation-under-large-scale-ref.html",
         "web-platform-tests/css/css-animations/translation-animation-on-important-property-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-edge-cases-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-edge-cases-expected.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<style>
+ .test {
+    width: 300px;
+    height: 25px;
+    margin-top: 10px;
+    background-color: green;
+  }
+
+</style>
+
+<h3>The following should have a green background:</h3>
+
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-edge-cases-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-edge-cases-ref.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<style>
+ .test {
+    width: 300px;
+    height: 25px;
+    margin-top: 10px;
+    background-color: green;
+  }
+
+</style>
+
+<h3>The following should have a green background:</h3>
+
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>
+<div class="test"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-edge-cases.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-edge-cases.html
@@ -1,0 +1,75 @@
+<!doctype html>
+<html>
+<head>
+<title>Setting 'animation-duration' to an infinite value should not hang</title>
+<link rel="author" title="yisibl(一丝)" href="https://github.com/yisibl"/>
+<link rel="author" title="Javier Fernandez" href="jfernandez@igalia.com">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#typedef-keyframes-name">
+<link rel="match" href="animation-name-edge-cases-ref.html">
+<meta name="assert" content="@keyframes name accepts CSS Wide Keywords as strings, but rejects an empty string.">
+<style>
+  @keyframes "" {
+    to { background: red }
+  }
+  @keyframes default {
+    to { background: red }
+  }
+  @keyframes "default" {
+    to { background: green }
+  }
+  @keyframes "string" {
+    to { background: green }
+  }
+  @keyframes "none" {
+    to { background: green }
+  }
+  @keyframes "inherit" {
+    to { background: green }
+  }
+  @keyframes "initial" {
+    to { background: green }
+  }
+  @keyframes "revert" {
+    to { background: green }
+  }
+  @keyframes "revert-layer" {
+    to { background: green }
+  }
+  @keyframes "revert-rule" {
+    to { background: green }
+  }
+  @keyframes "unset" {
+    to { background: green }
+  }
+
+  .test {
+    width: 300px;
+    height: 25px;
+    margin-top: 10px;
+    background-color: red;
+    animation: 0s both;
+  }
+
+  .test-invalid {
+    background-color: green;
+  }
+</style>
+</head>
+<body>
+<h3>The following should have a green background:</h3>
+
+<div class="test" style="animation-name: 'default';"></div>
+<div class="test" style="animation-name: 'none';"></div>
+<div class="test" style="animation-name: 'inherit';"></div>
+<div class="test" style="animation-name: 'initial';"></div>
+<div class="test" style="animation-name: 'revert';"></div>
+<div class="test" style="animation-name: 'revert-layer';"></div>
+<div class="test" style="animation-name: 'revert-rule';"></div>
+
+<!-- Invalid values -->
+<div class="test test-invalid" style="animation-name: default;"></div>
+<div class="test test-invalid" style="animation-name: '';"></div>
+<div class="test" style="animation-name: 'string'; animation-name: '';"></div>
+<div class="test" style="animation-name: 'none'; animation-name: ;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/keyframes-name-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/keyframes-name-invalid-expected.txt
@@ -18,4 +18,5 @@ PASS invalid: @keyframes one, unset { }
 PASS invalid: @keyframes default, two { }
 PASS invalid: @keyframes revert, three { }
 PASS invalid: @keyframes revert-layer, four { }
+PASS invalid: @keyframes "" { }
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/keyframes-name-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/keyframes-name-invalid.html
@@ -41,6 +41,8 @@
         test_keyframes_name_invalid('revert-layer, four');
         // TODO: https://bugs.chromium.org/p/chromium/issues/detail?id=1342609
         // test_keyframes_name_invalid('--foo');
+
+        test_keyframes_name_invalid('""');
     </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/w3c-import.log
@@ -36,6 +36,9 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-iteration-count-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-iteration-count-valid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-computed.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-edge-cases-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-edge-cases-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-edge-cases.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-invalid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-name-valid.html
 /LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/animation-play-state-computed.html

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -1003,6 +1003,9 @@ RefPtr<StyleRuleKeyframes> CSSParser::consumeKeyframesRule(CSSParserTokenRange p
 
     auto name = nameToken.value().toAtomString();
 
+    if (name.isEmpty())
+        return nullptr; // Parse error: empty string consider invalid.
+
     if (RefPtr observerWrapper = m_observerWrapper.get()) {
         observerWrapper->observer().startRuleHeader(StyleRuleType::Keyframes, observerWrapper->startOffset(rangeCopy));
         observerWrapper->observer().endRuleHeader(observerWrapper->endOffset(prelude));

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp
@@ -129,6 +129,10 @@ RefPtr<CSSValue> consumeKeyframesName(CSSParserTokenRange& range, CSS::PropertyP
 
     if (range.peek().type() == StringToken) {
         auto& token = range.consumeIncludingWhitespace();
+
+        if (token.value().isEmpty())
+            return nullptr;
+
         auto valueId = cssValueKeywordID(token.value());
         if (isValidCustomIdentifier(valueId) && valueId != CSSValueNone)
             return CSSPrimitiveValue::createCustomIdent(token.value().toString());


### PR DESCRIPTION
#### 3a1f35fcdd0a04a7bafbeba903e10bfe404dbf05
<pre>
Treat empty string keyframes‘ name as invalid
<a href="https://bugs.webkit.org/show_bug.cgi?id=307325">https://bugs.webkit.org/show_bug.cgi?id=307325</a>

Reviewed by Tim Nguyen.

This PR rejects &quot;&quot; at parsing time in favor of spec[1] changes.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/7762">https://github.com/w3c/csswg-drafts/issues/7762</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/keyframes-name-invalid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/keyframes-name-invalid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-animations/parsing/w3c-import.log:
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::CSSParser::consumeKeyframesRule):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Animations.cpp:
(WebCore::CSSPropertyParserHelpers::consumeKeyframesName):

Canonical link: <a href="https://commits.webkit.org/307207@main">https://commits.webkit.org/307207@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e18618f31a525fe8fb4b737f5e520f6e2339cce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143587 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16068 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7686 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152253 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96823 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145462 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16745 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16156 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110418 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79465 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146550 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91337 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12350 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10066 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2254 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154564 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118423 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16151 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118779 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30463 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14720 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126775 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71529 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15736 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5368 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15471 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79508 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15683 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15535 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->