### PR TITLE
FocusController assert can be hit with slot without fallback

### DIFF
--- a/LayoutTests/fast/shadow-dom/focus-empty-slot-crash-expected.txt
+++ b/LayoutTests/fast/shadow-dom/focus-empty-slot-crash-expected.txt
@@ -1,0 +1,3 @@
+This test passes if it doesn't crash/assert.
+
+

--- a/LayoutTests/fast/shadow-dom/focus-empty-slot-crash.html
+++ b/LayoutTests/fast/shadow-dom/focus-empty-slot-crash.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<title>Focus navigation with empty shadow slot shouldn't crash</title>
+<p>This test passes if it doesn't crash/assert.</p>
+<script>
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+customElements.define('custom-empty', class extends HTMLElement {
+    constructor() {
+        super();
+        const shadow = this.attachShadow({mode: 'open'});
+        const slot = document.createElement('slot');
+        shadow.appendChild(slot);
+    }
+});
+</script>
+
+<audio onloadstart="custom1.focus()" src=""></audio>
+<iframe id="iframe"></iframe>
+<div id="wrapper">
+    <custom-empty id="custom1" tabindex="0"></custom-empty>
+</div>
+<script>
+window.addEventListener("load", _ => iframe.appendChild(wrapper));
+</script>
+
+<input id="input1" type="text">
+<custom-empty id="custom2" tabindex="0"></custom-empty>
+<script>
+input1.focus();
+window.onload = () => document.adoptNode(custom2);
+</script>

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -959,7 +959,8 @@ Element* FocusController::previousFocusableElementOrScopeOwner(const FocusNaviga
     RefPtr<Node> last = nullptr;
     for (RefPtr node = scope.lastNodeInScope(); node; node = scope.lastChildInScope(*node))
         last = node;
-    ASSERT(last);
+    if (!last)
+        return nullptr;
 
     // First try to find the last node in the scope that comes before start and has the same tabindex as start.
     // If start is null, find the last node in the scope with a tabindex of 0.


### PR DESCRIPTION
#### 75eb619a7c945b9fc099501bf997fc89aa671234
<pre>
FocusController assert can be hit with slot without fallback
<a href="https://bugs.webkit.org/show_bug.cgi?id=307073">https://bugs.webkit.org/show_bug.cgi?id=307073</a>
<a href="https://rdar.apple.com/169714010">rdar://169714010</a>

Reviewed by NOBODY (OOPS!).

With assistance from Claude we understand that this loop in
previousFocusableElementOrScopeOwner

    for (RefPtr node = scope.lastNodeInScope(); node; node = scope.lastChildInScope(*node))
        last = node;

tries to find the last node in a focus navigation scope, but
scope.lastNodeInScope() can return nullptr, causing the loop to never
execute and leaving last as nullptr.

This can happen with a slot with no fallback content
(m_slotElement-&gt;lastChild() returns null). It can also happen when a
slot has no assigned nodes or a popover with an invoker but no
children.

This was originally discovered through
imported/w3c/web-platform-tests/focus/focus-element-crash.html but can
also be reproduced without &lt;select&gt; element (with a user agent shadow
root) as the added test shows.

Returning null matches the behavior of the forward-direction function
nextFocusableElementOrScopeOwner.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/75eb619a7c945b9fc099501bf997fc89aa671234

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152057 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96627 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e60e523-6105-4fc6-9152-f54a303cb1ea) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145265 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15950 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110274 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79398 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2960c4fb-e2d1-403f-82dd-88e0bab72c80) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146351 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128902 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91186 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/260fb6fa-9314-46e3-82b9-9735395814f6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12226 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9948 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2058 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121658 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/5401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154369 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/15920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6437 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118296 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15956 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118637 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14598 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126600 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71334 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15541 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5232 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15276 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79254 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15488 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/15340 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->