### PR TITLE
CanvasBase owns a ImageBuffer that belongs to the CanvasRenderingContext

### DIFF
--- a/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d

--- a/LayoutTests/fast/webgpu/draw-null-buffer-to-canvas-expected.txt
+++ b/LayoutTests/fast/webgpu/draw-null-buffer-to-canvas-expected.txt
@@ -1,2 +1,1 @@
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 This test passes if it does not crash.

--- a/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 67108864).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d

--- a/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt
@@ -1,5 +1,4 @@
 CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
-CONSOLE MESSAGE: Canvas area exceeds the maximum limit (width * height > 268435456).
 Testing height: 100 type: none
 Got exception: "InvalidStateError: The object is in an invalid state."
 Testing height: 100 type: 2d

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -388,7 +388,6 @@ html/canvas/CanvasRenderingContext2DBase.cpp
 html/canvas/CanvasStyle.cpp
 html/canvas/EXTDisjointTimerQuery.cpp
 html/canvas/GPUCanvasContextCocoa.mm
-html/canvas/ImageBitmapRenderingContext.cpp
 html/canvas/OffscreenCanvasRenderingContext2D.cpp
 html/canvas/PlaceholderRenderingContext.cpp
 html/canvas/WebGL2RenderingContext.cpp

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8658,7 +8658,7 @@ std::optional<RenderingContext> Document::getCSSCanvasContext(const String& type
     RefPtr element = getCSSCanvasElement(name);
     if (!element)
         return std::nullopt;
-    element->setCSSCanvasContextSize({ width, height });
+    element->setSizeForControllingContext({ width, height });
     auto context = element->getContext(type);
     if (!context)
         return std::nullopt;

--- a/Source/WebCore/html/CustomPaintCanvas.cpp
+++ b/Source/WebCore/html/CustomPaintCanvas.cpp
@@ -53,9 +53,6 @@ CustomPaintCanvas::CustomPaintCanvas(ScriptExecutionContext& context, unsigned w
 CustomPaintCanvas::~CustomPaintCanvas()
 {
     notifyObserversCanvasDestroyed();
-
-    m_context = nullptr; // Ensure this goes away before the ImageBuffer.
-    setImageBuffer(nullptr);
 }
 
 RefPtr<PaintRenderingContext2D> CustomPaintCanvas::getContext()

--- a/Source/WebCore/html/CustomPaintCanvas.h
+++ b/Source/WebCore/html/CustomPaintCanvas.h
@@ -59,6 +59,7 @@ public:
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
 
     void didDraw(const std::optional<FloatRect>&, ShouldApplyPostProcessingToDirtyRect) final { }
+    void setSizeForControllingContext(IntSize) { };
 
     Image* copiedImage() const final;
     void clearCopiedImage() const final;

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -76,7 +76,6 @@ public:
 
     WEBCORE_EXPORT ExceptionOr<void> setWidth(unsigned);
     WEBCORE_EXPORT ExceptionOr<void> setHeight(unsigned);
-    void setCSSCanvasContextSize(const IntSize& newSize);
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
     ExceptionOr<std::optional<RenderingContext>> getContext(JSC::JSGlobalObject&, const String& contextId, FixedVector<JSC::Strong<JSC::Unknown>>&& arguments);
@@ -130,10 +129,6 @@ public:
 
     SecurityOrigin* securityOrigin() const final;
 
-    // FIXME(https://bugs.webkit.org/show_bug.cgi?id=275100): Only some canvas rendering contexts need an ImageBuffer.
-    // It would be better to have the contexts own the buffers.
-    void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) final;
-
     bool needsPreparationForDisplay();
     void prepareForDisplay();
     void dynamicRangeLimitDidChange(PlatformDynamicRangeLimit);
@@ -152,6 +147,8 @@ public:
     void deref() const final { HTMLElement::deref(); }
 
     using HTMLElement::scriptExecutionContext;
+
+    void setSizeForControllingContext(IntSize) final;
 
 private:
     HTMLCanvasElement(const QualifiedName&, Document&);
@@ -174,8 +171,6 @@ private:
     bool canStartSelection() const final;
 
     void didUpdateSizeProperties();
-
-    void createImageBuffer() const final;
 
     bool usesContentsAsLayerContents() const;
 

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -127,8 +127,7 @@ public:
 
     void setWidth(unsigned);
     void setHeight(unsigned);
-
-    void setImageBufferAndMarkDirty(RefPtr<ImageBuffer>&&) final;
+    void setSizeForControllingContext(IntSize) final;
 
     CanvasRenderingContext* renderingContext() const final { return m_context.get(); }
 
@@ -166,8 +165,7 @@ private:
     void refEventTarget() final { RefCounted::ref(); }
     void derefEventTarget() final { RefCounted::deref(); }
 
-    void didUpdateSizeProperties();
-    void createImageBuffer() const final;
+    void didUpdateSizeProperties(bool sizeChanged);
 
     void scheduleCommitToPlaceholderCanvas();
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.cpp
@@ -94,17 +94,6 @@ void CanvasRenderingContext::deref() const
     m_canvas->deref();
 }
 
-RefPtr<ImageBuffer> CanvasRenderingContext::surfaceBufferToImageBuffer(SurfaceBuffer)
-{
-    // This will be removed once all contexts store their own buffers.
-    return canvasBase().buffer();
-}
-
-bool CanvasRenderingContext::isSurfaceBufferTransparentBlack(SurfaceBuffer) const
-{
-    return false;
-}
-
 bool CanvasRenderingContext::delegatesDisplay() const
 {
 #if USE(SKIA)
@@ -225,15 +214,8 @@ void CanvasRenderingContext::checkOrigin(const CSSStyleImageValue&)
     m_canvas->setOriginTainted();
 }
 
-void CanvasRenderingContext::updateMemoryCostOnAllocation(bool hasNewBuffer)
+void CanvasRenderingContext::updateMemoryCost(size_t newMemoryCost) const
 {
-    // FIXME: once the ImageBuffer is moved to 2D context, all different context
-    // types calculate the memory use in their own way.
-    size_t newMemoryCost = 0;
-    if (hasNewBuffer) {
-        if (RefPtr buffer = canvasBase().buffer())
-            newMemoryCost = buffer->memoryCost();
-    }
     size_t oldMemoryCost = m_memoryCost.load(std::memory_order_relaxed);
     m_memoryCost.store(newMemoryCost, std::memory_order_relaxed);
     if (newMemoryCost) {

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -79,6 +79,10 @@ public:
 
     virtual void clearAccumulatedDirtyRect() { }
 
+    // Called when the canvas size properties are assigned.
+    // The canvas will already have the new size.
+    virtual void didUpdateCanvasSizeProperties(bool sizeChanged) = 0;
+
     // Canvas 2DContext drawing buffer is the same as display buffer.
     // WebGL, WebGPU draws to drawing buffer. The draw buffer is then swapped to
     // display buffer during preparation and compositor composites the display buffer.
@@ -90,8 +94,8 @@ public:
     };
 
     // Draws the source buffer to the canvasBase().buffer().
-    virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer);
-    virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const;
+    virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) = 0;
+    virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const = 0;
     bool delegatesDisplay() const;
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
     virtual void setContentsToLayer(GraphicsLayer&);
@@ -128,7 +132,7 @@ public:
     void setIsInPreparationForDisplayOrFlush(bool flag) { m_isInPreparationForDisplayOrFlush = flag; }
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }
 
-    void updateMemoryCostOnAllocation(bool hasNewBuffer);
+    void updateMemoryCost(size_t newMemoryCost) const;
     size_t memoryCost() const;
 #if ENABLE(RESOURCE_USAGE)
     size_t externalMemoryCost() const;

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -41,7 +41,6 @@ public:
     void deref() const final { CanvasRenderingContext::deref(); }
     USING_CAN_MAKE_WEAKPTR(CanvasRenderingContext);
 
-    virtual void reshape() = 0;
 protected:
     explicit GPUBasedCanvasRenderingContext(CanvasBase&, CanvasRenderingContext::Type);
 

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.h
@@ -58,10 +58,11 @@ public:
     void prepareForDisplay() override;
     PixelFormat pixelFormat() const override;
     bool isOpaque() const override;
-    void reshape() override;
-
+    void didUpdateCanvasSizeProperties(bool) override;
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) override;
+    bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return false; }
+
     // GPUCanvasContext methods:
     CanvasType canvas() override;
     ExceptionOr<void> configure(GPUCanvasConfiguration&&) override;
@@ -94,6 +95,7 @@ private:
     void updateScreenHeadroom(float, bool suppressEDR);
     void updateScreenHeadroomFromScreenProperties();
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
+    void updateMemoryCost() const;
 
     struct Configuration {
         Ref<GPUDevice> device;
@@ -123,6 +125,7 @@ private:
     bool m_suppressEDR { false };
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
     bool m_compositingResultsNeedsUpdating { false };
+    RefPtr<ImageBuffer> m_readDisplayBuffer;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
+++ b/Source/WebCore/html/canvas/ImageBitmapRenderingContext.h
@@ -56,13 +56,16 @@ public:
     ExceptionOr<void> transferFromImageBitmap(RefPtr<ImageBitmap>);
     bool hasAlpha() { return m_settings.alpha; }
 
+    RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return !m_buffer; }
+    void didUpdateCanvasSizeProperties(bool) final { }
+
 private:
     ImageBitmapRenderingContext(CanvasBase&, ImageBitmapRenderingContextSettings&&);
 
     RefPtr<ImageBuffer> transferToImageBuffer() final;
 
-    void setBlank();
-
+    RefPtr<ImageBuffer> m_buffer;
     ImageBitmapRenderingContextSettings m_settings;
 };
 

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp
@@ -130,9 +130,9 @@ void OffscreenCanvasRenderingContext2D::setFont(const String& newFont)
 
 RefPtr<ImageBuffer> OffscreenCanvasRenderingContext2D::transferToImageBuffer()
 {
-    if (!canvasBase().hasCreatedImageBuffer())
-        return canvasBase().allocateImageBuffer();
-    RefPtr buffer = canvasBase().buffer();
+    if (!hasCreatedImageBuffer())
+        return allocateImageBuffer();
+    RefPtr buffer = this->buffer();
     if (!buffer)
         return nullptr;
     // As the canvas context state is stored in GraphicsContext, which is owned

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.h
@@ -44,12 +44,14 @@ public:
 
     virtual ~PaintRenderingContext2D();
 
-    GraphicsContext* ensureDrawingContext() const;
-    GraphicsContext* existingDrawingContext() const final;
-    AffineTransform baseTransform() const final;
+    GraphicsContext* drawingContext() const;
+    AffineTransform baseTransform() const;
 
     CustomPaintCanvas& canvas() const;
     void replayDisplayList(GraphicsContext& target) const;
+
+protected:
+    void didUpdateCanvasSizeProperties(bool) final;
 
 private:
     PaintRenderingContext2D(CustomPaintCanvas&);

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -72,6 +72,10 @@ public:
 
     PlaceholderRenderingContextSource& source() const { return m_source; }
 
+    RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final;
+    void didUpdateCanvasSizeProperties(bool) final;
+
 private:
     PlaceholderRenderingContext(HTMLCanvasElement&);
     void setContentsToLayer(GraphicsLayer&) final;
@@ -79,6 +83,7 @@ private:
     bool isOpaque() const final { return m_opaque; }
 
     const Ref<PlaceholderRenderingContextSource> m_source;
+    RefPtr<ImageBuffer> m_buffer;
     bool m_opaque { false };
 };
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -437,9 +437,10 @@ public:
 
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() override;
 
-    void reshape() override;
+    void didUpdateCanvasSizeProperties(bool) override;
 
     RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) final;
+    bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const final { return false; }
 
     RefPtr<ByteArrayPixelBuffer> drawingBufferToPixelBuffer();
 #if ENABLE(MEDIA_STREAM) || ENABLE(WEB_CODECS)
@@ -596,6 +597,7 @@ protected:
     virtual void uncacheDeletedBuffer(const AbstractLocker&, WebGLBuffer*);
     bool needsPreparationForDisplay() const final { return true; }
     void updateActiveOrdinal();
+    void updateMemoryCost() const;
 
     struct ContextLostState {
         ContextLostState(LostContextMode mode)
@@ -715,7 +717,8 @@ protected:
     int m_numGLErrorsToConsoleAllowed;
 
     bool m_compositingResultsNeedUpdating { false };
-    std::optional<SurfaceBuffer> m_canvasBufferContents;
+    RefPtr<ImageBuffer> m_readDrawingBuffer;
+    RefPtr<ImageBuffer> m_readDisplayBuffer;
 
     // Enabled extension objects.
     // FIXME: Move some of these to WebGLRenderingContext, the ones not needed for WebGL2

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -1118,7 +1118,7 @@ void InspectorInstrumentation::didChangeCanvasSizeImpl(InstrumentingAgents& inst
         canvasAgent->didChangeCanvasSize(context);
 }
 
-void InspectorInstrumentation::didChangeCanvasMemoryImpl(InstrumentingAgents& instrumentingAgents, CanvasRenderingContext& context)
+void InspectorInstrumentation::didChangeCanvasMemoryImpl(InstrumentingAgents& instrumentingAgents, const CanvasRenderingContext& context)
 {
     if (auto* canvasAgent = instrumentingAgents.enabledCanvasAgent())
         canvasAgent->didChangeCanvasMemory(context);

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -316,7 +316,7 @@ public:
     static void didChangeCSSCanvasClientNodes(CanvasBase&);
     static void didCreateCanvasRenderingContext(CanvasRenderingContext&);
     static void didChangeCanvasSize(CanvasRenderingContext&);
-    static void didChangeCanvasMemory(CanvasRenderingContext&);
+    static void didChangeCanvasMemory(const CanvasRenderingContext&);
     static void didFinishRecordingCanvasFrame(CanvasRenderingContext&, bool forceDispatch = false);
 #if ENABLE(WEBGL)
     static void didEnableExtension(WebGLRenderingContextBase&, const String&);
@@ -521,7 +521,7 @@ private:
     static void didChangeCSSCanvasClientNodesImpl(InstrumentingAgents&, CanvasBase&);
     static void didCreateCanvasRenderingContextImpl(InstrumentingAgents&, CanvasRenderingContext&);
     static void didChangeCanvasSizeImpl(InstrumentingAgents&, CanvasRenderingContext&);
-    static void didChangeCanvasMemoryImpl(InstrumentingAgents&, CanvasRenderingContext&);
+    static void didChangeCanvasMemoryImpl(InstrumentingAgents&, const CanvasRenderingContext&);
     static void didFinishRecordingCanvasFrameImpl(InstrumentingAgents&, CanvasRenderingContext&, bool forceDispatch = false);
 #if ENABLE(WEBGL)
     static void didEnableExtensionImpl(InstrumentingAgents&, WebGLRenderingContextBase&, const String&);
@@ -1444,7 +1444,7 @@ inline void InspectorInstrumentation::didChangeCanvasSize(CanvasRenderingContext
         didChangeCanvasSizeImpl(*agents, context);
 }
 
-inline void InspectorInstrumentation::didChangeCanvasMemory(CanvasRenderingContext& context)
+inline void InspectorInstrumentation::didChangeCanvasMemory(const CanvasRenderingContext& context)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (RefPtr agents = instrumentingAgents(context.canvasBase().scriptExecutionContext()))

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp
@@ -366,7 +366,7 @@ void InspectorCanvasAgent::didChangeCanvasSize(CanvasRenderingContext& context)
     m_frontendDispatcher->canvasSizeChanged(inspectorCanvas->identifier(), size.width(), size.height());
 }
 
-void InspectorCanvasAgent::didChangeCanvasMemory(CanvasRenderingContext& context)
+void InspectorCanvasAgent::didChangeCanvasMemory(const CanvasRenderingContext& context)
 {
     RefPtr<InspectorCanvas> inspectorCanvas;
 
@@ -707,7 +707,7 @@ RefPtr<InspectorCanvas> InspectorCanvasAgent::assertInspectorCanvas(Inspector::P
     return inspectorCanvas;
 }
 
-RefPtr<InspectorCanvas> InspectorCanvasAgent::findInspectorCanvas(CanvasRenderingContext& context)
+RefPtr<InspectorCanvas> InspectorCanvasAgent::findInspectorCanvas(const CanvasRenderingContext& context)
 {
     for (auto& inspectorCanvas : m_identifierToInspectorCanvas.values()) {
         if (&inspectorCanvas->canvasContext() == &context)

--- a/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorCanvasAgent.h
@@ -97,7 +97,7 @@ public:
     // InspectorInstrumentation
     void didCreateCanvasRenderingContext(CanvasRenderingContext&);
     void didChangeCanvasSize(CanvasRenderingContext&);
-    void didChangeCanvasMemory(CanvasRenderingContext&);
+    void didChangeCanvasMemory(const CanvasRenderingContext&);
     void didFinishRecordingCanvasFrame(CanvasRenderingContext&, bool forceDispatch = false);
     void consoleStartRecordingCanvas(CanvasRenderingContext&, JSC::JSGlobalObject&, JSC::JSObject* options);
     void consoleStopRecordingCanvas(CanvasRenderingContext&);
@@ -112,7 +112,7 @@ public:
     void recordAction(CanvasRenderingContext&, String&&, InspectorCanvasProcessedArguments&& = { });
 
     RefPtr<InspectorCanvas> assertInspectorCanvas(Inspector::Protocol::ErrorString&, const String& canvasId);
-    RefPtr<InspectorCanvas> findInspectorCanvas(CanvasRenderingContext&);
+    RefPtr<InspectorCanvas> findInspectorCanvas(const CanvasRenderingContext&);
 
 protected:
     InspectorCanvasAgent(WebAgentContext&);

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -621,7 +621,7 @@ void RenderLayerBacking::createPrimaryGraphicsLayer()
 #if USE(CA)
     if (!compositor().acceleratedDrawingEnabled() && renderer().isRenderHTMLCanvas()) {
         const RefPtr canvas = downcast<HTMLCanvasElement>(renderer().element());
-        if (canvas->shouldAccelerate(canvas->size()))
+        if (canvas->shouldAccelerate())
             m_graphicsLayer->setAcceleratesDrawing(true);
     }
 #endif    


### PR DESCRIPTION
#### 39eb51251d8f207ebf556e5c1662a99d55960c71
<pre>
CanvasBase owns a ImageBuffer that belongs to the CanvasRenderingContext
<a href="https://bugs.webkit.org/show_bug.cgi?id=275100">https://bugs.webkit.org/show_bug.cgi?id=275100</a>
<a href="https://rdar.apple.com/129208981">rdar://129208981</a>

Reviewed by Simon Fraser.

Before, CanvasBase would own a ImageBuffer that was historically the
2d context drawing backing store. This ImageBuffer was then repurposed for
bitmaprenderer, webgl, webgpu backing store to paint all these contexts
to page (i.e layer) contents. This coden organization is not good,
because this dictates that the content will exist in an ImageBuffer.
This needs an extra draw to bitmap to be used. This in turn results
in loss of performance and memory for all context types, and loss
of correctness for bitmaprenderer.

Fix by moving the ImageBuffer backing store to
CanvasRenderingContext2DBase. Fix by introducing the paint buffer
backing store specific to each rendering context. In subsequent commits,
each of the context type may hold and assign the paint buffer backing
store in efficient manner suitable for each context type.  Also in
subsequent commits, the paint storage will be held in NativeImages,
avoiding the need to use ImageBuffer for context types that do not
originate their images from ImageBuffer.

* LayoutTests/platform/ios/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt:
* LayoutTests/platform/mac-wk2/fast/canvas/offscreen-giant-transfer-to-imagebitmap-expected.txt:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::getCSSCanvasContext):
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::CanvasBase::~CanvasBase):
(WebCore::CanvasBase::makeRenderingResultsAvailable):
(WebCore::CanvasBase::setSize):
(WebCore::CanvasBase::shouldAccelerate const):
(WebCore::CanvasBase::validateArea const):
(WebCore::CanvasBase::buffer const): Deleted.
(WebCore::CanvasBase::setImageBuffer const): Deleted.
(WebCore::CanvasBase::allocateImageBuffer const): Deleted.
* Source/WebCore/html/CanvasBase.h:
(WebCore::CanvasBase::setImageBufferAndMarkDirty): Deleted.
(WebCore::CanvasBase::setHasCreatedImageBuffer): Deleted.
(WebCore::CanvasBase::hasCreatedImageBuffer const): Deleted.
(WebCore::CanvasBase::createImageBuffer const): Deleted.
* Source/WebCore/html/CustomPaintCanvas.cpp:
(WebCore::CustomPaintCanvas::~CustomPaintCanvas):
* Source/WebCore/html/CustomPaintCanvas.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::~HTMLCanvasElement):
(WebCore::HTMLCanvasElement::attributeChanged):
(WebCore::HTMLCanvasElement::setSizeForControllingContext):
(WebCore::HTMLCanvasElement::didUpdateSizeProperties):
(WebCore::HTMLCanvasElement::setCSSCanvasContextSize): Deleted.
(WebCore::HTMLCanvasElement::createImageBuffer const): Deleted.
(WebCore::HTMLCanvasElement::setImageBufferAndMarkDirty): Deleted.
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::OffscreenCanvas::~OffscreenCanvas):
(WebCore::OffscreenCanvas::setWidth):
(WebCore::OffscreenCanvas::setHeight):
(WebCore::OffscreenCanvas::setSizeForControllingContext):
(WebCore::OffscreenCanvas::didUpdateSizeProperties):
(WebCore::OffscreenCanvas::transferToImageBitmap):
(WebCore::OffscreenCanvas::createImageBuffer const): Deleted.
(WebCore::OffscreenCanvas::setImageBufferAndMarkDirty): Deleted.
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.cpp:
(WebCore::CanvasRenderingContext::updateMemoryCost const):
(WebCore::CanvasRenderingContext::surfaceBufferToImageBuffer): Deleted.
(WebCore::CanvasRenderingContext::isSurfaceBufferTransparentBlack const): Deleted.
(WebCore::CanvasRenderingContext::updateMemoryCostOnAllocation): Deleted.
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::~CanvasRenderingContext2DBase):
(WebCore::CanvasRenderingContext2DBase::surfaceBufferToImageBuffer):
(WebCore::CanvasRenderingContext2DBase::isSurfaceBufferTransparentBlack const):
(WebCore::CanvasRenderingContext2DBase::layerContentsDisplayDelegate):
(WebCore::CanvasRenderingContext2DBase::flushDeferredOperations):
(WebCore::CanvasRenderingContext2DBase::reset):
(WebCore::CanvasRenderingContext2DBase::didUpdateCanvasSizeProperties):
(WebCore::CanvasRenderingContext2DBase::drawingContext const):
(WebCore::CanvasRenderingContext2DBase::existingDrawingContext const):
(WebCore::CanvasRenderingContext2DBase::baseTransform const):
(WebCore::CanvasRenderingContext2DBase::prepareForDisplay):
(WebCore::CanvasRenderingContext2DBase::putImageData):
(WebCore::CanvasRenderingContext2DBase::getEffectiveRenderingModeForTesting):
(WebCore::CanvasRenderingContext2DBase::buffer const):
(WebCore::CanvasRenderingContext2DBase::allocateImageBuffer const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
(WebCore::CanvasRenderingContext2DBase::hasCreatedImageBuffer const):
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::GPUCanvasContextCocoa::didUpdateCanvasSizeProperties):
(WebCore::GPUCanvasContextCocoa::surfaceBufferToImageBuffer):
(WebCore::GPUCanvasContextCocoa::unconfigure):
(WebCore::GPUCanvasContextCocoa::prepareForDisplay):
(WebCore::GPUCanvasContextCocoa::markContextChangedAndNotifyCanvasObservers):
(WebCore::GPUCanvasContextCocoa::updateMemoryCost const):
(WebCore::GPUCanvasContextCocoa::reshape): Deleted.
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.cpp:
(WebCore::ImageBitmapRenderingContext::transferFromImageBitmap):
(WebCore::ImageBitmapRenderingContext::transferToImageBuffer):
(WebCore::ImageBitmapRenderingContext::surfaceBufferToImageBuffer):
(WebCore::ImageBitmapRenderingContext::setBlank): Deleted.
* Source/WebCore/html/canvas/ImageBitmapRenderingContext.h:
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.cpp:
(WebCore::OffscreenCanvasRenderingContext2D::transferToImageBuffer):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.cpp:
(WebCore::PlaceholderRenderingContext::setContentsToLayer):
(WebCore::PlaceholderRenderingContext::setPlaceholderBuffer):
(WebCore::PlaceholderRenderingContext::pixelFormat const):
(WebCore::PlaceholderRenderingContext::surfaceBufferToImageBuffer):
(WebCore::PlaceholderRenderingContext::isSurfaceBufferTransparentBlack const):
(WebCore::PlaceholderRenderingContext::didUpdateCanvasSizeProperties):
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::initializeNewContext):
(WebCore::WebGLRenderingContextBase::initializeContextState):
(WebCore::WebGLRenderingContextBase::markContextChangedAndNotifyCanvasObserver):
(WebCore::createImageBufferForWebGLContextReads):
(WebCore::WebGLRenderingContextBase::surfaceBufferToImageBuffer):
(WebCore::WebGLRenderingContextBase::transferToImageBuffer):
(WebCore::WebGLRenderingContextBase::didUpdateCanvasSizeProperties):
(WebCore::WebGLRenderingContextBase::prepareForDisplay):
(WebCore::WebGLRenderingContextBase::updateMemoryCost const):
(WebCore::WebGLRenderingContextBase::reshape): Deleted.
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didChangeCanvasMemoryImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didChangeCanvasMemory):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.cpp:
(WebCore::InspectorCanvasAgent::didChangeCanvasMemory):
(WebCore::InspectorCanvasAgent::findInspectorCanvas):
* Source/WebCore/inspector/agents/InspectorCanvasAgent.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::createPrimaryGraphicsLayer):

Canonical link: <a href="https://commits.webkit.org/307450@main">https://commits.webkit.org/307450@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b50ba25b064e57655b4dbd6767d924cdf7558f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144449 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8688 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153119 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17610 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17022 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111076 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0dff357-0037-4d87-b2da-d5af35257754) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147412 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13460 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91989 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10617 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/565 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6416 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155431 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119076 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17018 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14221 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119437 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30618 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15273 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127629 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16602 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6038 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16338 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16547 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16402 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->