### PR TITLE
Reduce use of protected functions in Source/WebCore/page

### DIFF
--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -495,7 +495,7 @@ ExceptionOr<Ref<ApplePaySession>> ApplePaySession::create(Document& document, un
     if (!document.page())
         return Exception { ExceptionCode::InvalidAccessError, "Frame is detached"_s };
 
-    auto convertedPaymentRequest = convertAndValidate(document, version, WTF::move(paymentRequest), protect(document.page())->protectedPaymentCoordinator().get());
+    auto convertedPaymentRequest = convertAndValidate(document, version, WTF::move(paymentRequest), protect(protect(document.page())->paymentCoordinator()).get());
     if (convertedPaymentRequest.hasException())
         return convertedPaymentRequest.releaseException();
 
@@ -527,7 +527,7 @@ ExceptionOr<bool> ApplePaySession::supportsVersion(Document& document, unsigned 
     if (!page)
         return Exception { ExceptionCode::InvalidAccessError };
 
-    return page->protectedPaymentCoordinator()->supportsVersion(document, version);
+    return protect(page->paymentCoordinator())->supportsVersion(document, version);
 }
 
 static bool shouldDiscloseApplePayCapability(Document& document)
@@ -549,7 +549,7 @@ ExceptionOr<bool> ApplePaySession::canMakePayments(Document& document)
     if (!page)
         return Exception { ExceptionCode::InvalidAccessError };
 
-    return page->protectedPaymentCoordinator()->canMakePayments();
+    return protect(page->paymentCoordinator())->canMakePayments();
 }
 
 ExceptionOr<void> ApplePaySession::canMakePaymentsWithActiveCard(Document& document, const String& merchantIdentifier, Ref<DeferredPromise>&& passedPromise)
@@ -564,7 +564,7 @@ ExceptionOr<void> ApplePaySession::canMakePaymentsWithActiveCard(Document& docum
         if (!page)
             return Exception { ExceptionCode::InvalidAccessError };
 
-        bool canMakePayments = page->protectedPaymentCoordinator()->canMakePayments();
+        bool canMakePayments = protect(page->paymentCoordinator())->canMakePayments();
 
         RunLoop::mainSingleton().dispatch([promise, canMakePayments]() mutable {
             promise->resolve<IDLBoolean>(canMakePayments);
@@ -576,7 +576,7 @@ ExceptionOr<void> ApplePaySession::canMakePaymentsWithActiveCard(Document& docum
     if (!page)
         return Exception { ExceptionCode::InvalidAccessError };
 
-    page->protectedPaymentCoordinator()->canMakePaymentsWithActiveCard(document, merchantIdentifier, [promise](bool canMakePayments) mutable {
+    protect(page->paymentCoordinator())->canMakePaymentsWithActiveCard(document, merchantIdentifier, [promise](bool canMakePayments) mutable {
         promise->resolve<IDLBoolean>(canMakePayments);
     });
     return { };
@@ -596,7 +596,7 @@ ExceptionOr<void> ApplePaySession::openPaymentSetup(Document& document, const St
         return Exception { ExceptionCode::InvalidAccessError };
 
     RefPtr<DeferredPromise> promise(WTF::move(passedPromise));
-    page->protectedPaymentCoordinator()->openPaymentSetup(document, merchantIdentifier, [promise](bool result) mutable {
+    protect(page->paymentCoordinator())->openPaymentSetup(document, merchantIdentifier, [promise](bool result) mutable {
         promise->resolve<IDLBoolean>(result);
     });
 

--- a/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySetup.cpp
@@ -78,7 +78,7 @@ void ApplePaySetup::getSetupFeatures(Document& document, SetupFeaturesPromise&& 
 
     m_setupFeaturesPromise = WTF::move(promise);
 
-    page->protectedPaymentCoordinator()->getSetupFeatures(m_configuration, document.url(), [pendingActivity = makePendingActivity(*this)](Vector<Ref<ApplePaySetupFeature>>&& setupFeatures) {
+    protect(page->paymentCoordinator())->getSetupFeatures(m_configuration, document.url(), [pendingActivity = makePendingActivity(*this)](Vector<Ref<ApplePaySetupFeature>>&& setupFeatures) {
         if (pendingActivity->object().m_setupFeaturesPromise)
             std::exchange(pendingActivity->object().m_setupFeaturesPromise, std::nullopt)->resolve(WTF::move(setupFeatures));
     });
@@ -110,7 +110,7 @@ void ApplePaySetup::begin(Document& document, Vector<Ref<ApplePaySetupFeature>>&
 
     m_beginPromise = WTF::move(promise);
 
-    page->protectedPaymentCoordinator()->beginApplePaySetup(m_configuration, page->mainFrameURL(), WTF::move(features), [pendingActivity = makePendingActivity(*this)](bool result) {
+    protect(page->paymentCoordinator())->beginApplePaySetup(m_configuration, page->mainFrameURL(), WTF::move(features), [pendingActivity = makePendingActivity(*this)](bool result) {
         if (pendingActivity->object().m_beginPromise)
             std::exchange(pendingActivity->object().m_beginPromise, std::nullopt)->resolve(result);
     });
@@ -138,7 +138,7 @@ void ApplePaySetup::stop()
         std::exchange(m_beginPromise, std::nullopt)->reject(Exception { ExceptionCode::AbortError });
 
     if (RefPtr page = downcast<Document>(*scriptExecutionContext()).page())
-        page->protectedPaymentCoordinator()->endApplePaySetup();
+        protect(page->paymentCoordinator())->endApplePaySetup();
 }
 
 void ApplePaySetup::suspend(ReasonForSuspension)

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -596,7 +596,7 @@ void CookieStore::stop()
     if (host.isEmpty())
         return;
 
-    page->protectedCookieJar()->removeChangeListener(host, *this);
+    protect(page->cookieJar())->removeChangeListener(host, *this);
 #endif
     m_hasChangeEventListener = false;
 }

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -215,7 +215,7 @@ AudioTimestamp AudioContext::getOutputTimestamp()
     DOMHighResTimeStamp performanceTime = 0.0;
     RefPtr document = this->document();
     if (document && document->window())
-        performanceTime = std::max(document->window()->protectedPerformance()->relativeTimeFromTimeOriginInReducedResolution(position.timestamp), 0.0);
+        performanceTime = std::max(protect(document->window()->performance())->relativeTimeFromTimeOriginInReducedResolution(position.timestamp), 0.0);
 
     return { position.position.seconds(), performanceTime };
 }

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -129,7 +129,7 @@ void BroadcastChannel::MainThreadBridge::registerChannel()
 {
     ensureOnMainThread([this, protectedThis = Ref { *this }, contextIdentifier = m_broadcastChannel->scriptExecutionContext()->identifier()](auto* page) mutable {
         if (page)
-            page->protectedBroadcastChannelRegistry()->registerChannel(m_origin, m_name, identifier());
+            protect(page->broadcastChannelRegistry())->registerChannel(m_origin, m_name, identifier());
         channelToContextIdentifier().add(identifier(), contextIdentifier);
     });
 }
@@ -138,7 +138,7 @@ void BroadcastChannel::MainThreadBridge::unregisterChannel()
 {
     ensureOnMainThread([this, protectedThis = Ref { *this }](auto* page) {
         if (page)
-            page->protectedBroadcastChannelRegistry()->unregisterChannel(m_origin, m_name, identifier());
+            protect(page->broadcastChannelRegistry())->unregisterChannel(m_origin, m_name, identifier());
         channelToContextIdentifier().remove(identifier());
     });
 }
@@ -150,7 +150,7 @@ void BroadcastChannel::MainThreadBridge::postMessage(Ref<SerializedScriptValue>&
             return;
 
         auto blobHandles = message->blobHandles();
-        page->protectedBroadcastChannelRegistry()->postMessage(m_origin, m_name, identifier(), WTF::move(message), [blobHandles = WTF::move(blobHandles)] {
+        protect(page->broadcastChannelRegistry())->postMessage(m_origin, m_name, identifier(), WTF::move(message), [blobHandles = WTF::move(blobHandles)] {
             // Keeps Blob data inside messageData alive until the message has been delivered.
         });
     });

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3541,7 +3541,7 @@ void Document::attachToCachedFrame(CachedFrameBase& cachedFrame)
     ASSERT(cachedFrame.view());
     ASSERT(m_backForwardCacheState == Document::InBackForwardCache);
     if (CheckedPtr localFrameView = dynamicDowncast<LocalFrameView>(cachedFrame.view()))
-        observeFrame(localFrameView->protectedFrame().ptr());
+        observeFrame(protect(localFrameView->frame()).ptr());
 }
 
 void Document::detachFromCachedFrame(CachedFrameBase& cachedFrame)
@@ -4085,7 +4085,7 @@ ExceptionOr<void> Document::open(Document* entryDocument)
             }
         }
 
-        bool isNavigating = frame->loader().policyChecker().delegateIsDecidingNavigationPolicy() || frame->loader().state() == FrameState::Provisional || frame->protectedNavigationScheduler()->hasQueuedNavigation();
+        bool isNavigating = frame->loader().policyChecker().delegateIsDecidingNavigationPolicy() || frame->loader().state() == FrameState::Provisional || protect(frame->navigationScheduler())->hasQueuedNavigation();
         if (frame->loader().policyChecker().delegateIsDecidingNavigationPolicy())
             frame->loader().policyChecker().stopCheck();
         // Null-checking m_frame again as `policyChecker().stopCheck()` may have cleared it.
@@ -4278,7 +4278,7 @@ void Document::explicitClose()
 void Document::implicitClose()
 {
     RELEASE_ASSERT(!m_inStyleRecalc);
-    bool wasLocationChangePending = frame() && frame()->protectedNavigationScheduler()->locationChangePending();
+    bool wasLocationChangePending = frame() && protect(frame()->navigationScheduler())->locationChangePending();
     bool doload = !parsing() && m_parser && !m_processingLoadEvent && !wasLocationChangePending;
 
     if (!doload)
@@ -11320,7 +11320,7 @@ void Document::navigateFromServiceWorker(const URL& url, CompletionHandler<void(
             callback(ScheduleLocationChangeResult::Stopped);
             return;
         }
-        frame->protectedNavigationScheduler()->scheduleLocationChange(*weakThis, weakThis->securityOrigin(), url, frame->loader().outgoingReferrer(), LockHistory::Yes, LockBackForwardList::No, NavigationHistoryBehavior::Auto, [callback = WTF::move(callback)](auto result) mutable {
+        protect(frame->navigationScheduler())->scheduleLocationChange(*weakThis, weakThis->securityOrigin(), url, frame->loader().outgoingReferrer(), LockHistory::Yes, LockBackForwardList::No, NavigationHistoryBehavior::Auto, [callback = WTF::move(callback)](auto result) mutable {
             callback(result);
         });
     });

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -652,7 +652,7 @@ void DocumentFullscreen::didExitFullscreen(CompletionHandler<void(ExceptionOr<vo
     INFO_LOG(LOGIDENTIFIER);
 
     if (RefPtr frame = document().frame())
-        finishExitFullscreen(frame->protectedMainFrame(), ExitMode::Resize);
+        finishExitFullscreen(protect(frame->mainFrame()), ExitMode::Resize);
 
     if (RefPtr exitedFullscreenElement = fullscreenOrPendingElement())
         exitedFullscreenElement->didStopBeingFullscreenElement();

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -128,7 +128,7 @@ void CachedFrameBase::restore()
         // Reconstruct the FrameTree. And open the child CachedFrames in their respective FrameLoaders.
         for (auto& childFrame : m_childFrames) {
             ASSERT(childFrame->view()->frame().page());
-            frame->tree().appendChild(protect(childFrame->view())->protectedFrame());
+            frame->tree().appendChild(protect(protect(childFrame->view())->frame()));
             childFrame->open();
             if (localFrame)
                 RELEASE_ASSERT_WITH_SECURITY_IMPLICATION(m_document == localFrame->document());
@@ -237,7 +237,7 @@ void CachedFrame::open()
     ASSERT(m_document || is<RemoteFrameView>(m_view.get()));
 
     if (RefPtr localFrameView = dynamicDowncast<LocalFrameView>(m_view.get()))
-        localFrameView->protectedFrame()->loader().open(*this);
+        protect(localFrameView->frame())->loader().open(*this);
 }
 
 void CachedFrame::clear()

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -63,7 +63,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(CachedPage);
 CachedPage::CachedPage(Page& page)
     : m_page(page)
     , m_expirationTime(MonotonicTime::now() + page.settings().backForwardCacheExpirationInterval())
-    , m_cachedMainFrame(makeUnique<CachedFrame>(page.protectedMainFrame()))
+    , m_cachedMainFrame(makeUnique<CachedFrame>(protect(page.mainFrame())))
     , m_loadedSubresourceDomains([&] {
         RefPtr localFrame = page.localMainFrame();
         return localFrame ? localFrame->loader().client().loadedSubresourceDomains() : Vector<RegistrableDomain>();

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -799,7 +799,7 @@ void HTMLVideoElement::serviceRequestVideoFrameCallbacks(ReducedResolutionSecond
     if (!videoFrameMetadata || !document().window())
         return;
 
-    processVideoFrameMetadataTimestamps(*videoFrameMetadata, document().window()->protectedPerformance());
+    processVideoFrameMetadataTimestamps(*videoFrameMetadata, protect(document().window()->performance()));
 
     Ref protectedThis { *this };
 

--- a/Source/WebCore/html/parser/HTMLDocumentParser.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.cpp
@@ -290,7 +290,7 @@ bool HTMLDocumentParser::pumpTokenizerLoop(SynchronousMode mode, bool parsingFra
         // how the parser has always handled stopping when the page assigns window.location. What should
         // happen instead is that assigning window.location causes the parser to stop parsing cleanly.
         // The problem is we're not prepared to do that at every point where we run JavaScript.
-        if (!parsingFragment && document()->frame() && document()->protectedFrame()->protectedNavigationScheduler()->locationChangePending()) [[unlikely]]
+        if (!parsingFragment && document()->frame() && protect(protect(document()->frame())->navigationScheduler())->locationChangePending()) [[unlikely]]
             return false;
 
         if (mode == SynchronousMode::AllowYield && parserScheduler->shouldYieldBeforeToken(session)) [[unlikely]]

--- a/Source/WebCore/inspector/CommandLineAPIHost.cpp
+++ b/Source/WebCore/inspector/CommandLineAPIHost.cpp
@@ -91,7 +91,7 @@ static InstrumentingAgents* instrumentingAgentsForGlobalObject(JSC::JSGlobalObje
 
     if (executionContext->isDocument()) {
         if (RefPtr frame = downcast<Document>(executionContext)->frame())
-            return &frame->protectedInspectorController()->instrumentingAgents();
+            return &protect(frame->inspectorController())->instrumentingAgents();
     } else if (executionContext->isWorkerGlobalScope())
         return &downcast<WorkerGlobalScope>(executionContext)->inspectorController().instrumentingAgents();
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -134,7 +134,7 @@ private:
             bool dispatched = false;
             if (m_dispatchTarget == InspectorFrontendClientLocal::DispatchBackendTarget::MainFrame) {
                 if (RefPtr localMainFrame = protect(controller->inspectedPage())->localMainFrame()) {
-                    localMainFrame->protectedInspectorController()->dispatchMessageFromFrontend(m_messages.takeFirst());
+                    protect(localMainFrame->inspectorController())->dispatchMessageFromFrontend(m_messages.takeFirst());
                     dispatched = true;
                 }
             }
@@ -281,7 +281,7 @@ RefPtr<PageInspectorController> InspectorFrontendClientLocal::protectedInspected
 
 void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 {
-    unsigned totalHeight = protect(frontendPage())->protectedMainFrame()->protectedVirtualView()->visibleHeight() + protect(protectedInspectedPageController()->inspectedPage())->protectedMainFrame()->protectedVirtualView()->visibleHeight();
+    unsigned totalHeight = protect(protect(frontendPage())->mainFrame())->protectedVirtualView()->visibleHeight() + protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->protectedVirtualView()->visibleHeight();
     unsigned attachedHeight = constrainedAttachedWindowHeight(height, totalHeight);
     m_settings->setProperty(inspectorAttachedHeightSetting, String::number(attachedHeight));
     setAttachedWindowHeight(attachedHeight);
@@ -289,7 +289,7 @@ void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 
 void InspectorFrontendClientLocal::changeAttachedWindowWidth(unsigned width)
 {
-    unsigned totalWidth = protect(frontendPage())->protectedMainFrame()->protectedVirtualView()->visibleWidth() + protect(protectedInspectedPageController()->inspectedPage())->protectedMainFrame()->protectedVirtualView()->visibleWidth();
+    unsigned totalWidth = protect(protect(frontendPage())->mainFrame())->protectedVirtualView()->visibleWidth() + protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->protectedVirtualView()->visibleWidth();
     unsigned attachedWidth = constrainedAttachedWindowWidth(width, totalWidth);
     setAttachedWindowWidth(attachedWidth);
 }
@@ -359,7 +359,7 @@ void InspectorFrontendClientLocal::setAttachedWindow(DockSide dockSide)
 
 void InspectorFrontendClientLocal::restoreAttachedWindowHeight()
 {
-    unsigned inspectedPageHeight = protect(protectedInspectedPageController()->inspectedPage())->protectedMainFrame()->protectedVirtualView()->visibleHeight();
+    unsigned inspectedPageHeight = protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->protectedVirtualView()->visibleHeight();
     String value = m_settings->getProperty(inspectorAttachedHeightSetting);
     unsigned preferredHeight = value.isEmpty() ? defaultAttachedHeight : parseIntegerAllowingTrailingJunk<unsigned>(value).value_or(0);
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -456,7 +456,7 @@ void DocumentLoader::notifyFinished(CachedResource& resource, const NetworkLoadM
 
     if (RefPtr document = this->document()) {
         if (RefPtr window = document->window())
-            window->protectedPerformance()->documentLoadFinished(*metrics);
+            protect(window->performance())->documentLoadFinished(*metrics);
     }
 
     ASSERT_UNUSED(resource, m_mainResource == &resource);
@@ -915,7 +915,7 @@ void DocumentLoader::responseReceived(const CachedResource& resource, const Reso
             auto firstPartyDomain = RegistrableDomain(response.url());
             if (auto loginDomains = NetworkStorageSession::subResourceDomainsInNeedOfStorageAccessForFirstParty(firstPartyDomain)) {
                 if (!Quirks::hasStorageAccessForAllLoginDomains(*loginDomains, firstPartyDomain)) {
-                    frame->protectedNavigationScheduler()->scheduleRedirect(document, 0, microsoftTeamsRedirectURL(), IsMetaRefresh::No);
+                    protect(frame->navigationScheduler())->scheduleRedirect(document, 0, microsoftTeamsRedirectURL(), IsMetaRefresh::No);
                     completionHandler();
                     return;
                 }
@@ -1352,7 +1352,7 @@ void DocumentLoader::commitData(const SharedBuffer& data)
                     || source == ResourceResponse::Source::MemoryCacheAfterValidation;
                 if (RefPtr frameLoader = this->frameLoader())
                     finalMetrics.fromPrefetch = frameLoader->documentPrefetcher().wasPrefetched(url());
-                window->protectedPerformance()->addNavigationTiming(*this, document, *m_mainResource, timing(), finalMetrics);
+                protect(window->performance())->addNavigationTiming(*this, document, *m_mainResource, timing(), finalMetrics);
             }
         }
 

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -692,7 +692,7 @@ void DocumentThreadableLoader::loadRequest(ResourceRequest&& request, SecurityCh
         finishedTimingForWorkerLoad(resourceTiming);
     else {
         if (RefPtr window = document().window())
-            window->protectedPerformance()->addResourceTiming(WTF::move(resourceTiming));
+            protect(window->performance())->addResourceTiming(WTF::move(resourceTiming));
     }
 
     didFinishLoading(identifier, { });

--- a/Source/WebCore/loader/ResourceTimingInformation.cpp
+++ b/Source/WebCore/loader/ResourceTimingInformation.cpp
@@ -76,7 +76,7 @@ void ResourceTimingInformation::addResourceTiming(CachedResource& resource, Docu
 
     resourceTiming.overrideInitiatorType(info.type);
 
-    initiatorWindow->protectedPerformance()->addResourceTiming(WTF::move(resourceTiming));
+    protect(initiatorWindow->performance())->addResourceTiming(WTF::move(resourceTiming));
 
     info.added = Added;
 }

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -284,7 +284,7 @@ LocalFrame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerEl
                 page->willChangeLocationInCompletelyLoadedSubframe();
         }
 
-        frame->protectedNavigationScheduler()->scheduleLocationChange(initiatingDocument, protect(initiatingDocument->securityOrigin()), upgradedRequestURL, m_frame->loader().outgoingReferrer(), lockHistory, lockBackForwardList, NavigationHistoryBehavior::Auto, WTF::move(stopDelayingLoadEvent));
+        protect(frame->navigationScheduler())->scheduleLocationChange(initiatingDocument, protect(initiatingDocument->securityOrigin()), upgradedRequestURL, m_frame->loader().outgoingReferrer(), lockHistory, lockBackForwardList, NavigationHistoryBehavior::Auto, WTF::move(stopDelayingLoadEvent));
     } else
         frame = loadSubframe(ownerElement, upgradedRequestURL, frameName, m_frame->loader().outgoingReferrerURL());
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -327,7 +327,7 @@ CachedResourceHandle<CachedCSSStyleSheet> CachedResourceLoader::requestUserCSSSt
 
     request.removeFragmentIdentifierIfNeeded();
 
-    CachedResourceHandle userSheet = new CachedCSSStyleSheet(WTF::move(request), page.sessionID(), page.protectedCookieJar().ptr());
+    CachedResourceHandle userSheet = new CachedCSSStyleSheet(WTF::move(request), page.sessionID(), protect(page.cookieJar()).ptr());
 
     if (userSheet->allowsCaching())
         memoryCache->add(*userSheet);
@@ -1149,7 +1149,7 @@ ResourceErrorOr<CachedResourceHandle<CachedResource>> CachedResourceLoader::requ
             if (results.shouldBlock()) {
                 CACHEDRESOURCELOADER_RELEASE_LOG_WITH_FRAME("requestResource: Resource blocked by content blocker", frame.get());
                 if (type == CachedResource::Type::MainResource) {
-                    auto resource = createResource(type, WTF::move(request), page->sessionID(), page->protectedCookieJar().ptr(), page->settings(), document.get());
+                    auto resource = createResource(type, WTF::move(request), page->sessionID(), protect(page->cookieJar()).ptr(), page->settings(), document.get());
                     ASSERT(resource);
                     resource->error(CachedResource::Status::LoadError);
                     resource->setResourceError(ResourceError(ContentExtensions::WebKitContentBlockerDomain, 0, resourceRequest.url(), WEB_UI_STRING("The URL was blocked by a content blocker", "WebKitErrorBlockedByContentBlocker description")));

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -600,10 +600,10 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         protect(frame->editor())->capitalizeWord();
         break;
     case ContextMenuItemTagConvertToTraditionalChinese:
-        frame->protectedEditor()->convertToTraditionalChinese();
+        protect(frame->editor())->convertToTraditionalChinese();
         break;
     case ContextMenuItemTagConvertToSimplifiedChinese:
-        frame->protectedEditor()->convertToSimplifiedChinese();
+        protect(frame->editor())->convertToSimplifiedChinese();
         break;
 #endif
 #if PLATFORM(COCOA)

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -119,7 +119,7 @@ private:
 
 bool MouseWheelRegionOverlay::updateRegion()
 {
-    RefPtr page = m_page.get();
+    RefPtr page = m_page;
     if (!page)
         return false;
 #if ENABLE(WHEEL_EVENT_REGIONS)
@@ -174,7 +174,7 @@ private:
 
 bool NonFastScrollableRegionOverlay::updateRegion()
 {
-    RefPtr page = m_page.get();
+    RefPtr page = m_page;
     if (!page)
         return false;
     bool regionChanged = false;
@@ -327,7 +327,7 @@ static Vector<Path> pathsForRect(const FloatRect& rect, float borderRadius)
 
 std::optional<std::pair<RenderLayer&, GraphicsLayer&>> InteractionRegionOverlay::activeLayer() const
 {
-    RefPtr page = m_page.get();
+    RefPtr page = m_page;
     if (!page)
         return std::nullopt;
     constexpr OptionSet<HitTestRequest::Type> hitType {
@@ -368,7 +368,7 @@ std::optional<std::pair<RenderLayer&, GraphicsLayer&>> InteractionRegionOverlay:
 std::optional<InteractionRegion> InteractionRegionOverlay::activeRegion() const
 {
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
-    RefPtr page = m_page.get();
+    RefPtr page = m_page;
     if (!page)
         return std::nullopt;
     auto layerPair = activeLayer();
@@ -463,7 +463,7 @@ static void drawCheckbox(const String& text, GraphicsContext& context, const Fon
 
 FloatRect InteractionRegionOverlay::rectForSettingAtIndex(unsigned index) const
 {
-    RefPtr mainFrameView = RefPtr { m_page.get() }->protectedMainFrame()->virtualView();
+    RefPtr mainFrameView = protect(protect(m_page)->mainFrame())->virtualView();
     if (!mainFrameView)
         return FloatRect();
     auto viewSize = mainFrameView->layoutSize();
@@ -564,14 +564,14 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
                 AffineTransform transform;
 
                 transform.translate(rectInLayerCoordinates.location());
-                if (RefPtr page = m_page.get())
+                if (RefPtr page = m_page)
                     transform.scale(page->pageScaleFactor());
 
                 existingClip.transform(transform);
                 clipPaths.append(existingClip);
             } else {
                 auto scaleFactor = 1.f;
-                if (RefPtr page = m_page.get())
+                if (RefPtr page = m_page)
                     scaleFactor = page->pageScaleFactor();
 
                 if (region->useContinuousCorners) {
@@ -639,7 +639,7 @@ void InteractionRegionOverlay::drawRect(PageOverlay&, GraphicsContext& context, 
 
 bool InteractionRegionOverlay::mouseEvent(PageOverlay& overlay, const PlatformMouseEvent& event)
 {
-    RefPtr page = m_page.get();
+    RefPtr page = m_page;
     if (!page)
         return false;
     RefPtr localMainFrame = page->localMainFrame();
@@ -705,7 +705,7 @@ private:
 
 void EnhancedSecurityOverlay::drawRect(PageOverlay&, GraphicsContext& context, const IntRect& dirtyRect)
 {
-    RefPtr page = m_page.get();
+    RefPtr page = m_page;
     if (!page)
         return;
 
@@ -751,7 +751,7 @@ RegionOverlay::RegionOverlay(Page& page, Color regionColor)
 
 RegionOverlay::~RegionOverlay()
 {
-    RefPtr page = m_page.get();
+    RefPtr page = m_page;
     if (!page)
         return;
     if (RefPtr overlay = m_overlay)

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -539,7 +539,7 @@ void FocusController::setFocusedInternal(bool focused)
     }
 
     if (!focusedFrame())
-        setFocusedFrame(m_page->protectedMainFrame().ptr());
+        setFocusedFrame(protect(m_page->mainFrame()).ptr());
 
     RefPtr focusedFrame = focusedLocalFrame();
     if (focusedFrame && focusedFrame->view()) {

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -139,7 +139,7 @@ Frame::Frame(Page& page, FrameIdentifier frameID, FrameType frameType, HTMLFrame
 Frame::~Frame()
 {
     protect(windowProxy())->detachFromFrame();
-    protectedNavigationScheduler()->cancel();
+    protect(navigationScheduler())->cancel();
 
 #if ASSERT_ENABLED
     FrameLifetimeVerifier::singleton().frameDestroyed(*this);
@@ -195,19 +195,9 @@ void Frame::takeWindowProxyAndOpenerFrom(Frame& frame)
     frame.m_openedFrames.clear();
 }
 
-Ref<WindowProxy> Frame::protectedWindowProxy() const
-{
-    return m_windowProxy;
-}
-
 RefPtr<DOMWindow> Frame::protectedWindow() const
 {
     return window();
-}
-
-Ref<NavigationScheduler> Frame::protectedNavigationScheduler() const
-{
-    return m_navigationScheduler.get();
 }
 
 std::optional<uint64_t> Frame::indexInFrameTreeSiblings() const
@@ -366,7 +356,7 @@ void Frame::updateFrameTreeSyncData(Ref<FrameTreeSyncData>&& data)
 
 void Frame::updateFrameTreeSyncData(const FrameTreeSyncSerializationData& data)
 {
-    protectedFrameTreeSyncData()->update(data);
+    protect(frameTreeSyncData())->update(data);
 }
 
 bool Frame::frameCanCreatePaymentSession() const
@@ -394,11 +384,6 @@ SecurityOrigin& Frame::topOrigin() const
         return page->mainFrameOrigin();
 
     return SecurityOrigin::opaqueOrigin();
-}
-
-Ref<SecurityOrigin> Frame::protectedTopOrigin() const
-{
-    return topOrigin();
 }
 
 float Frame::frameScaleFactor() const

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -75,7 +75,6 @@ public:
 
     WindowProxy& windowProxy() { return m_windowProxy; }
     const WindowProxy& windowProxy() const { return m_windowProxy; }
-    Ref<WindowProxy> protectedWindowProxy() const;
 
     DOMWindow* window() const { return virtualWindow(); }
     RefPtr<DOMWindow> protectedWindow() const;
@@ -83,16 +82,13 @@ public:
     WEBCORE_EXPORT std::optional<uint64_t> indexInFrameTreeSiblings() const;
     WEBCORE_EXPORT Vector<uint64_t> pathToFrame() const;
     FrameIdentifier frameID() const { return m_frameID; }
-    SecurityOrigin& topOrigin() const;
-    WEBCORE_EXPORT Ref<SecurityOrigin> protectedTopOrigin() const;
+    WEBCORE_EXPORT SecurityOrigin& topOrigin() const;
     inline Page* page() const; // Defined in DocumentPage.h.
     inline RefPtr<Page> protectedPage() const; // Defined in DocumentPage.h.
     inline std::optional<PageIdentifier> pageID() const; // Defined in DocumentPage.h.
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() { return *m_mainFrame; }
     const Frame& mainFrame() const { return *m_mainFrame; }
-    Ref<Frame> protectedMainFrame() { return mainFrame(); }
-    Ref<const Frame> protectedMainFrame() const { return mainFrame(); }
     bool isMainFrame() const { return this == m_mainFrame.get(); }
     WEBCORE_EXPORT void disownOpener(NotifyUIProcess = NotifyUIProcess::No);
     WEBCORE_EXPORT void updateOpener(Frame&, NotifyUIProcess = NotifyUIProcess::Yes);
@@ -114,7 +110,6 @@ public:
 
     WEBCORE_EXPORT void disconnectOwnerElement();
     NavigationScheduler& navigationScheduler() const { return m_navigationScheduler.get(); }
-    Ref<NavigationScheduler> protectedNavigationScheduler() const;
     WEBCORE_EXPORT void takeWindowProxyAndOpenerFrom(Frame&);
 
     virtual void frameDetached() = 0;
@@ -156,7 +151,6 @@ public:
 
     virtual bool frameCanCreatePaymentSession() const;
     FrameTreeSyncData& frameTreeSyncData() const { return m_frameTreeSyncData.get(); }
-    Ref<FrameTreeSyncData> protectedFrameTreeSyncData() const { return m_frameTreeSyncData.get(); }
     WEBCORE_EXPORT virtual SecurityOrigin* frameDocumentSecurityOrigin() const = 0;
     WEBCORE_EXPORT virtual std::optional<DocumentSecurityPolicy> frameDocumentSecurityPolicy() const = 0;
     WEBCORE_EXPORT virtual String frameURLProtocol() const = 0;

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -563,11 +563,6 @@ Frame& FrameTree::top() const
     return m_thisFrame->mainFrame();
 }
 
-Ref<Frame> FrameTree::protectedTop() const
-{
-    return top();
-}
-
 unsigned FrameTree::depth() const
 {
     unsigned depth = 0;
@@ -676,7 +671,7 @@ void showFrameTree(const WebCore::Frame* frame)
         return;
     }
 
-    printFrames(frame->tree().protectedTop(), frame, 0);
+    printFrames(protect(frame->tree().top()), frame, 0);
 }
 
 #endif

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -83,7 +83,6 @@ public:
     WEBCORE_EXPORT unsigned childCount() const;
     unsigned descendantCount() const;
     WEBCORE_EXPORT Frame& top() const;
-    Ref<Frame> protectedTop() const;
     unsigned depth() const;
 
     WEBCORE_EXPORT RefPtr<Frame> scopedChild(unsigned index) const;

--- a/Source/WebCore/page/FrameView.cpp
+++ b/Source/WebCore/page/FrameView.cpp
@@ -163,7 +163,7 @@ bool FrameView::forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const
 
 IntRect FrameView::scrollableAreaBoundingBox(bool*) const
 {
-    RefPtr ownerRenderer = protectedFrame()->ownerRenderer();
+    RefPtr ownerRenderer = protect(frame())->ownerRenderer();
     if (!ownerRenderer)
         return frameRect();
 
@@ -330,7 +330,7 @@ IntPoint FrameView::convertToContainingView(IntPoint localPoint) const
     if (RefPtr parentScrollView = parent()) {
         if (RefPtr parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
-            RefPtr renderer = protectedFrame()->ownerRenderer();
+            RefPtr renderer = protect(frame())->ownerRenderer();
             if (!renderer)
                 return localPoint;
 
@@ -348,7 +348,7 @@ FloatPoint FrameView::convertToContainingView(FloatPoint localPoint) const
     if (RefPtr parentScrollView = parent()) {
         if (RefPtr parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
-            RefPtr renderer = protectedFrame()->ownerRenderer();
+            RefPtr renderer = protect(frame())->ownerRenderer();
             if (!renderer)
                 return localPoint;
 
@@ -361,17 +361,12 @@ FloatPoint FrameView::convertToContainingView(FloatPoint localPoint) const
     return localPoint;
 }
 
-Ref<Frame> FrameView::protectedFrame() const
-{
-    return frame();
-}
-
 IntRect FrameView::convertToContainingView(const IntRect& localRect) const
 {
     if (RefPtr parentScrollView = parent()) {
         if (RefPtr parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
-            RefPtr renderer = protectedFrame()->ownerRenderer();
+            RefPtr renderer = protect(frame())->ownerRenderer();
             if (!renderer)
                 return localRect;
 
@@ -389,7 +384,7 @@ FloatRect FrameView::convertToContainingView(const FloatRect& localRect) const
     if (RefPtr parentScrollView = parent()) {
         if (RefPtr parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
-            RefPtr renderer = protectedFrame()->ownerRenderer();
+            RefPtr renderer = protect(frame())->ownerRenderer();
             if (!renderer)
                 return localRect;
 
@@ -409,7 +404,7 @@ IntPoint FrameView::convertFromContainingView(IntPoint parentPoint) const
     if (RefPtr parentScrollView = parent()) {
         if (RefPtr parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
-            RefPtr renderer = protectedFrame()->ownerRenderer();
+            RefPtr renderer = protect(frame())->ownerRenderer();
             if (!renderer)
                 return parentPoint;
 
@@ -427,7 +422,7 @@ FloatPoint FrameView::convertFromContainingView(FloatPoint parentPoint) const
     if (RefPtr parentScrollView = parent()) {
         if (RefPtr parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
-            RefPtr renderer = protectedFrame()->ownerRenderer();
+            RefPtr renderer = protect(frame())->ownerRenderer();
             if (!renderer)
                 return parentPoint;
 
@@ -445,7 +440,7 @@ DoublePoint FrameView::convertFromContainingView(DoublePoint parentPoint) const
     if (RefPtr parentScrollView = parent()) {
         if (RefPtr parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
-            RefPtr renderer = protectedFrame()->ownerRenderer();
+            RefPtr renderer = protect(frame())->ownerRenderer();
             if (!renderer)
                 return parentPoint;
 
@@ -464,7 +459,7 @@ IntRect FrameView::convertFromContainingView(const IntRect& parentRect) const
     if (RefPtr parentScrollView = parent()) {
         if (RefPtr parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
-            RefPtr renderer = protectedFrame()->ownerRenderer();
+            RefPtr renderer = protect(frame())->ownerRenderer();
             if (!renderer)
                 return parentRect;
 
@@ -482,7 +477,7 @@ FloatRect FrameView::convertFromContainingView(const FloatRect& parentRect) cons
     if (RefPtr parentScrollView = parent()) {
         if (RefPtr parentView = dynamicDowncast<FrameView>(*parentScrollView)) {
             // Get our renderer in the parent view
-            RefPtr renderer = protectedFrame()->ownerRenderer();
+            RefPtr renderer = protect(frame())->ownerRenderer();
             if (!renderer)
                 return parentRect;
 

--- a/Source/WebCore/page/FrameView.h
+++ b/Source/WebCore/page/FrameView.h
@@ -42,7 +42,6 @@ public:
     virtual Type viewType() const = 0;
     virtual void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) = 0;
     virtual Frame& frame() const = 0;
-    Ref<Frame> protectedFrame() const;
 
     WEBCORE_EXPORT int headerHeight() const final;
     WEBCORE_EXPORT int footerHeight() const final;

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -175,7 +175,7 @@ ExceptionOr<void> History::go(int distance)
     if (!isDocumentFullyActive(frame.get()))
         return documentNotFullyActive();
 
-    frame->protectedNavigationScheduler()->scheduleHistoryNavigation(distance);
+    protect(frame->navigationScheduler())->scheduleHistoryNavigation(distance);
     return { };
 }
 
@@ -192,7 +192,7 @@ ExceptionOr<void> History::go(Document& document, int distance)
     if (document.canNavigate(frame.get()) != CanNavigateState::Able)
         return { };
 
-    frame->protectedNavigationScheduler()->scheduleHistoryNavigation(distance);
+    protect(frame->navigationScheduler())->scheduleHistoryNavigation(distance);
     return { };
 }
 

--- a/Source/WebCore/page/LargestContentfulPaintData.cpp
+++ b/Source/WebCore/page/LargestContentfulPaintData.cpp
@@ -196,7 +196,7 @@ void LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry(Eleme
 
     if (image) {
         pendingEntry->setURLString(image->url().string());
-        auto loadTimestamp = window->protectedPerformance()->relativeTimeFromTimeOriginInReducedResolution(loadTime);
+        auto loadTimestamp = protect(window->performance())->relativeTimeFromTimeOriginInReducedResolution(loadTime);
         pendingEntry->setLoadTime(loadTimestamp);
     }
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -810,11 +810,6 @@ Performance& LocalDOMWindow::performance() const
     return *m_performance;
 }
 
-Ref<Performance> LocalDOMWindow::protectedPerformance() const
-{
-    return performance();
-}
-
 ReducedResolutionSeconds LocalDOMWindow::nowTimestamp() const
 {
     return performance().nowInReducedResolutionSeconds();
@@ -2818,7 +2813,7 @@ void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& comple
     // We want a new history item if we are processing a user gesture.
     LockHistory lockHistory = (locking != SetLocationLocking::LockHistoryBasedOnGestureState || !UserGestureIndicator::processingUserGesture()) ? LockHistory::Yes : LockHistory::No;
     LockBackForwardList lockBackForwardList = (locking != SetLocationLocking::LockHistoryBasedOnGestureState) ? LockBackForwardList::Yes : LockBackForwardList::No;
-    frame->protectedNavigationScheduler()->scheduleLocationChange(*activeDocument, protect(activeDocument->securityOrigin()),
+    protect(frame->navigationScheduler())->scheduleLocationChange(*activeDocument, protect(activeDocument->securityOrigin()),
         // FIXME: What if activeDocument()->frame() is 0?
         completedURL, activeDocument->frame()->loader().outgoingReferrer(),
         lockHistory, lockBackForwardList,
@@ -2898,7 +2893,7 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
         newFrame->changeLocation(WTF::move(frameLoadRequest));
     } else if (!urlString.isEmpty()) {
         LockHistory lockHistory = UserGestureIndicator::processingUserGesture() ? LockHistory::No : LockHistory::Yes;
-        newFrame->protectedNavigationScheduler()->scheduleLocationChange(*activeDocument, protect(activeDocument->securityOrigin()), completedURL, referrer, lockHistory, LockBackForwardList::No);
+        protect(newFrame->navigationScheduler())->scheduleLocationChange(*activeDocument, protect(activeDocument->securityOrigin()), completedURL, referrer, lockHistory, LockBackForwardList::No);
     }
 
     // Navigating the new frame could result in it being detached from its page by a navigation policy delegate.
@@ -2991,7 +2986,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
         // For whatever reason, Firefox uses the first window rather than the active window to
         // determine the outgoing referrer. We replicate that behavior here.
         LockHistory lockHistory = UserGestureIndicator::processingUserGesture() ? LockHistory::No : LockHistory::Yes;
-        targetFrame->protectedNavigationScheduler()->scheduleLocationChange(*activeDocument, protect(activeDocument->securityOrigin()), completedURL, firstFrame->loader().outgoingReferrer(),
+        protect(targetFrame->navigationScheduler())->scheduleLocationChange(*activeDocument, protect(activeDocument->securityOrigin()), completedURL, firstFrame->loader().outgoingReferrer(),
             lockHistory, LockBackForwardList::No);
         return &targetFrame->windowProxy();
     }

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -317,7 +317,6 @@ public:
 #endif
 
     Performance& performance() const;
-    Ref<Performance> protectedPerformance() const;
 
     WEBCORE_EXPORT ReducedResolutionSeconds nowTimestamp() const;
     void freezeNowTimestamp();

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -872,7 +872,7 @@ void LocalFrame::clearTimers(LocalFrameView *view, Document *document)
     view->checkedLayoutContext()->unscheduleLayout();
     if (CheckedPtr timelines = document->timelinesController())
         timelines->suspendAnimations();
-    view->protectedFrame()->eventHandler().stopAutoscrollTimer();
+    protect(view->frame())->eventHandler().stopAutoscrollTimer();
 }
 
 void LocalFrame::clearTimers()
@@ -1686,11 +1686,6 @@ std::optional<DocumentSecurityPolicy> LocalFrame::frameDocumentSecurityPolicy() 
         return std::nullopt;
 
     return DocumentSecurityPolicy { document->crossOriginEmbedderPolicy(), document->crossOriginOpenerPolicy() };
-}
-
-Ref<FrameInspectorController> LocalFrame::protectedInspectorController() const
-{
-    return m_inspectorController.get();
 }
 
 String LocalFrame::frameURLProtocol() const

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -164,8 +164,6 @@ public:
 
     inline Editor& editor(); // Defined in LocalFrameInlines.h
     inline const Editor& editor() const; // Defined in LocalFrameInlines.h
-    inline Ref<Editor> protectedEditor(); // Defined in LocalFrameInlines.h
-    inline Ref<const Editor> protectedEditor() const; // Defined in LocalFrameInlines.h
 
     EventHandler& eventHandler() { return m_eventHandler; }
     const EventHandler& eventHandler() const { return m_eventHandler; }
@@ -358,7 +356,6 @@ public:
 
     FrameInspectorController& inspectorController() { return m_inspectorController.get(); }
     const FrameInspectorController& inspectorController() const { return m_inspectorController.get(); }
-    WEBCORE_EXPORT Ref<FrameInspectorController> protectedInspectorController() const;
     FrameConsoleClient& console() { return m_consoleClient.get(); }
     const FrameConsoleClient& console() const { return m_consoleClient.get(); }
 

--- a/Source/WebCore/page/LocalFrameInlines.h
+++ b/Source/WebCore/page/LocalFrameInlines.h
@@ -54,16 +54,6 @@ inline const Editor& LocalFrame::editor() const
     return protectedDocument()->editor();
 }
 
-inline Ref<Editor> LocalFrame::protectedEditor()
-{
-    return editor();
-}
-
-inline Ref<const Editor> LocalFrame::protectedEditor() const
-{
-    return editor();
-}
-
 inline FrameSelection& LocalFrame::selection()
 {
     return document()->selection();

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6690,11 +6690,6 @@ LocalFrame& LocalFrameView::frame() const
     return m_frame;
 }
 
-Ref<LocalFrame> LocalFrameView::protectedFrame() const
-{
-    return m_frame;
-}
-
 RenderView* LocalFrameView::renderView() const
 {
     return m_frame->contentRenderer();

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -110,7 +110,6 @@ public:
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
 
     WEBCORE_EXPORT LocalFrame& frame() const final;
-    Ref<LocalFrame> protectedFrame() const;
 
     WEBCORE_EXPORT RenderView* renderView() const;
     WEBCORE_EXPORT CheckedPtr<RenderView> checkedRenderView() const;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -906,11 +906,6 @@ LocalFrameView& LocalFrameViewLayoutContext::view() const
     return m_frameView.get();
 }
 
-Ref<LocalFrameView> LocalFrameViewLayoutContext::protectedView() const
-{
-    return m_frameView.get();
-}
-
 RenderView* LocalFrameViewLayoutContext::renderView() const
 {
     return protect(view())->renderView();

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -231,7 +231,6 @@ private:
     LocalFrame& frame() const;
     Ref<LocalFrame> protectedFrame();
     LocalFrameView& view() const;
-    Ref<LocalFrameView> protectedView() const;
     RenderView* renderView() const;
     Document* document() const;
     RefPtr<Document> protectedDocument() const;

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -296,13 +296,13 @@ void Location::reload(LocalDOMWindow& activeWindow)
     if (targetDocument->quirks().shouldDelayReloadWhenRegisteringServiceWorker()) {
         if (RefPtr container = targetDocument->serviceWorkerContainer()) {
             container->whenRegisterJobsAreFinished([localFrame, activeDocument] {
-                localFrame->protectedNavigationScheduler()->scheduleRefresh(activeDocument);
+                protect(localFrame->navigationScheduler())->scheduleRefresh(activeDocument);
             });
             return;
         }
     }
 
-    localFrame->protectedNavigationScheduler()->scheduleRefresh(activeDocument);
+    protect(localFrame->navigationScheduler())->scheduleRefresh(activeDocument);
 }
 
 ExceptionOr<void> Location::setLocation(LocalDOMWindow& incumbentWindow, LocalDOMWindow& firstWindow, const String& urlString)

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -456,7 +456,7 @@ Navigation::Result Navigation::performTraversal(const String& key, Navigation::O
         createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::AbortError, "Navigation aborted"_s);
 
     RefPtr frame = this->frame();
-    if (!frame->isMainFrame() && protect(window->document())->canNavigate(&protect(frame->page())->protectedMainFrame().get()) != CanNavigateState::Able)
+    if (!frame->isMainFrame() && protect(window->document())->canNavigate(protect(protect(frame->page())->mainFrame()).ptr()) != CanNavigateState::Able)
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::SecurityError, "Invalid state"_s);
 
     RefPtr current = currentEntry();
@@ -475,7 +475,7 @@ Navigation::Result Navigation::performTraversal(const String& key, Navigation::O
     RefPtr apiMethodTracker = addUpcomingTraverseAPIMethodTracker(WTF::move(committed), WTF::move(finished), key, options.info);
 
     // FIXME: 11. Let sourceSnapshotParams be the result of snapshotting source snapshot params given document.
-    frame->protectedNavigationScheduler()->scheduleHistoryNavigationByKey(key, [apiMethodTracker] (ScheduleHistoryNavigationResult result) {
+    protect(frame->navigationScheduler())->scheduleHistoryNavigationByKey(key, [apiMethodTracker] (ScheduleHistoryNavigationResult result) {
         if (result == ScheduleHistoryNavigationResult::Aborted)
             createErrorResult(WTF::move(apiMethodTracker->committedPromise), WTF::move(apiMethodTracker->finishedPromise), ExceptionCode::AbortError, "Navigation aborted"_s);
     });

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -414,7 +414,6 @@ public:
     void clearPluginData();
 
     OpportunisticTaskScheduler& opportunisticTaskScheduler() const { return m_opportunisticTaskScheduler.get(); }
-    Ref<OpportunisticTaskScheduler> protectedOpportunisticTaskScheduler() const;
 
     WEBCORE_EXPORT void setCanStartMedia(bool);
     bool canStartMedia() const { return m_canStartMedia; }
@@ -425,11 +424,9 @@ public:
     WEBCORE_EXPORT Document* localTopDocument() const;
 
     Frame& mainFrame() const { return m_mainFrame.get(); }
-    WEBCORE_EXPORT Ref<Frame> protectedMainFrame() const;
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     WEBCORE_EXPORT const URL& mainFrameURL() const;
     SecurityOrigin& mainFrameOrigin() const;
-    Ref<SecurityOrigin> protectedMainFrameOrigin() const;
     WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<uint64_t>& path) const;
 
     WEBCORE_EXPORT void setMainFrameURLAndOrigin(const URL&, RefPtr<SecurityOrigin>&&);
@@ -471,7 +468,6 @@ public:
     WEBCORE_EXPORT CheckedRef<PageGroup> checkedGroup();
 
     BroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry; }
-    WEBCORE_EXPORT Ref<BroadcastChannelRegistry> protectedBroadcastChannelRegistry() const;
     WEBCORE_EXPORT void setBroadcastChannelRegistry(Ref<BroadcastChannelRegistry>&&); // Only used by WebKitLegacy.
 
     WEBCORE_EXPORT static void forEachPage(NOESCAPE const Function<void(Page&)>&);
@@ -764,7 +760,6 @@ public:
 
 #if ENABLE(APPLE_PAY)
     PaymentCoordinator& paymentCoordinator() const { return *m_paymentCoordinator; }
-    WEBCORE_EXPORT Ref<PaymentCoordinator> protectedPaymentCoordinator() const;
     WEBCORE_EXPORT void setPaymentCoordinator(Ref<PaymentCoordinator>&&);
 #endif
 
@@ -997,13 +992,10 @@ public:
     CacheStorageProvider& cacheStorageProvider() { return m_cacheStorageProvider; }
     SocketProvider& socketProvider() { return m_socketProvider; }
     CookieJar& cookieJar() { return m_cookieJar.get(); }
-    WEBCORE_EXPORT Ref<CookieJar> protectedCookieJar() const;
 
     StorageNamespaceProvider& storageNamespaceProvider() { return m_storageNamespaceProvider.get(); }
-    WEBCORE_EXPORT Ref<StorageNamespaceProvider> protectedStorageNamespaceProvider() const;
 
     PluginInfoProvider& pluginInfoProvider();
-    Ref<PluginInfoProvider> protectedPluginInfoProvider() const;
 
     UserContentProvider& userContentProviderForFrame() { return m_userContentProvider; }
     WEBCORE_EXPORT Ref<UserContentProvider> protectedUserContentProviderForFrame();

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -124,7 +124,7 @@ static std::optional<Lab<float>> sampleColor(Document& document, IntPoint&& loca
     auto colorSpace = DestinationColorSpace::SRGB();
 
     ASSERT(document.view());
-    auto snapshot = snapshotFrameRect(document.view()->protectedFrame(), IntRect(location, IntSize(1, 1)), { { SnapshotFlags::ExcludeSelectionHighlighting, SnapshotFlags::PaintEverythingExcludingSelection }, PixelFormat::BGRA8, colorSpace });
+    auto snapshot = snapshotFrameRect(protect(document.view()->frame()), IntRect(location, IntSize(1, 1)), { { SnapshotFlags::ExcludeSelectionHighlighting, SnapshotFlags::PaintEverythingExcludingSelection }, PixelFormat::BGRA8, colorSpace });
     if (!snapshot)
         return std::nullopt;
 

--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -84,7 +84,7 @@ IntRect PageOverlay::bounds() const
     if (!m_overrideFrame.isEmpty())
         return { { }, m_overrideFrame.size() };
 
-    RefPtr frameView = m_page->protectedMainFrame()->virtualView();
+    RefPtr frameView = protect(m_page->mainFrame())->virtualView();
     if (!frameView)
         return IntRect();
 
@@ -135,7 +135,7 @@ IntSize PageOverlay::viewToOverlayOffset() const
         return IntSize();
 
     case OverlayType::Document: {
-        RefPtr frameView = m_page->protectedMainFrame()->virtualView();
+        RefPtr frameView = protect(m_page->mainFrame())->virtualView();
         return frameView ? toIntSize(frameView->viewToContents(IntPoint())) : IntSize();
     }
     }
@@ -186,7 +186,7 @@ void PageOverlay::drawRect(GraphicsContext& graphicsContext, const IntRect& dirt
     GraphicsContextStateSaver stateSaver(graphicsContext);
 
     if (m_overlayType == PageOverlay::OverlayType::Document) {
-        if (RefPtr frameView = m_page->protectedMainFrame()->virtualView()) {
+        if (RefPtr frameView = protect(m_page->mainFrame())->virtualView()) {
             auto offset = frameView->scrollOrigin();
             graphicsContext.translate(toFloatSize(offset));
             paintRect.moveBy(-offset);
@@ -201,7 +201,7 @@ bool PageOverlay::mouseEvent(const PlatformMouseEvent& mouseEvent)
     IntPoint mousePositionInOverlayCoordinates(flooredIntPoint(mouseEvent.position()));
 
     if (m_overlayType == PageOverlay::OverlayType::Document)
-        mousePositionInOverlayCoordinates = m_page->protectedMainFrame()->protectedVirtualView()->windowToContents(mousePositionInOverlayCoordinates);
+        mousePositionInOverlayCoordinates = protect(m_page->mainFrame())->protectedVirtualView()->windowToContents(mousePositionInOverlayCoordinates);
     mousePositionInOverlayCoordinates.moveBy(-frame().location());
 
     // Ignore events outside the bounds.
@@ -307,11 +307,6 @@ void PageOverlay::clear()
 GraphicsLayer& PageOverlay::layer() const
 {
     return controller()->layerForOverlay(*this);
-}
-
-Ref<GraphicsLayer> PageOverlay::protectedLayer() const
-{
-    return layer();
 }
 
 } // namespace WebKit

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -122,7 +122,6 @@ public:
 
     // FIXME: PageOverlay should own its layer, instead of PageOverlayController.
     WEBCORE_EXPORT GraphicsLayer& layer() const;
-    WEBCORE_EXPORT Ref<GraphicsLayer> protectedLayer() const;
 
     bool needsSynchronousScrolling() const { return m_needsSynchronousScrolling; }
     void setNeedsSynchronousScrolling(bool needsSynchronousScrolling) { m_needsSynchronousScrolling = needsSynchronousScrolling; }

--- a/Source/WebCore/page/RemoteDOMWindow.cpp
+++ b/Source/WebCore/page/RemoteDOMWindow.cpp
@@ -146,7 +146,7 @@ void RemoteDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& compl
     // We want a new history item if we are processing a user gesture.
     LockHistory lockHistory = (locking != SetLocationLocking::LockHistoryBasedOnGestureState || !UserGestureIndicator::processingUserGesture()) ? LockHistory::Yes : LockHistory::No;
     LockBackForwardList lockBackForwardList = (locking != SetLocationLocking::LockHistoryBasedOnGestureState) ? LockBackForwardList::Yes : LockBackForwardList::No;
-    frame->protectedNavigationScheduler()->scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(),
+    protect(frame->navigationScheduler())->scheduleLocationChange(*activeDocument, activeDocument->securityOrigin(),
         // FIXME: What if activeDocument()->frame() is 0?
         completedURL, activeDocument->frame()->loader().outgoingReferrer(),
         lockHistory, lockBackForwardList,

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -312,7 +312,7 @@ void AsyncScrollingCoordinator::frameViewEventTrackingRegionsChanged(LocalFrameV
     // FIXME: This needs to disambiguate between event regions in the scrolling tree, and those in GraphicsLayers.
     scheduleTreeStateCommit();
 
-    DebugPageOverlays::didChangeEventHandlers(frameView.protectedFrame());
+    DebugPageOverlays::didChangeEventHandlers(protect(frameView.frame()));
 }
 
 void AsyncScrollingCoordinator::frameViewRootLayerDidChange(LocalFrameView& frameView)

--- a/Source/WebCore/plugins/PluginData.cpp
+++ b/Source/WebCore/plugins/PluginData.cpp
@@ -55,7 +55,7 @@ void PluginData::initPlugins()
 {
     ASSERT(m_plugins.isEmpty());
     Ref page = m_page.get();
-    m_plugins = page->protectedPluginInfoProvider()->pluginInfo(page.get(), m_supportedPluginIdentifiers);
+    m_plugins = protect(page->pluginInfoProvider())->pluginInfo(page.get(), m_supportedPluginIdentifiers);
 
     for (auto& plugin : m_plugins) {
         if (isBuiltInPDFPlugIn(plugin)) {
@@ -76,7 +76,7 @@ const Vector<PluginInfo>& PluginData::webVisiblePlugins() const
     }
 
     if (!m_cachedVisiblePlugins.pluginList)
-        m_cachedVisiblePlugins.pluginList = page->protectedPluginInfoProvider()->webVisiblePluginInfo(page.get(), m_cachedVisiblePlugins.pageURL);
+        m_cachedVisiblePlugins.pluginList = protect(page->pluginInfoProvider())->webVisiblePluginInfo(page.get(), m_cachedVisiblePlugins.pageURL);
 
     return *m_cachedVisiblePlugins.pluginList;
 }
@@ -114,7 +114,7 @@ bool PluginData::supportsWebVisibleMimeTypeForURL(const String& mimeType, const 
 {
     if (!protocolHostAndPortAreEqual(m_cachedVisiblePlugins.pageURL, url)) {
         Ref page = m_page.get();
-        m_cachedVisiblePlugins = { url, page->protectedPluginInfoProvider()->webVisiblePluginInfo(page.get(), url) };
+        m_cachedVisiblePlugins = { url, protect(page->pluginInfoProvider())->webVisiblePluginInfo(page.get(), url) };
     }
     if (!m_cachedVisiblePlugins.pluginList)
         return false;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -5245,7 +5245,7 @@ void RenderLayerCompositor::attachRootLayer(RootLayerAttachment attachment)
             ASSERT_NOT_REACHED();
             break;
         case RootLayerAttachedViaChromeClient: {
-            page().chrome().client().attachRootGraphicsLayer(m_renderView.frameView().protectedFrame(), RefPtr { rootGraphicsLayer() }.get());
+            page().chrome().client().attachRootGraphicsLayer(protect(m_renderView.frameView().frame()), RefPtr { rootGraphicsLayer() }.get());
             break;
         }
         case RootLayerAttachedViaEnclosingFrame: {
@@ -5300,7 +5300,7 @@ void RenderLayerCompositor::detachRootLayer()
     case RootLayerAttachedViaChromeClient: {
         if (RefPtr scrollingCoordinator = this->scrollingCoordinator())
             scrollingCoordinator->frameViewWillBeDetached(m_renderView.frameView());
-        page().chrome().client().attachRootGraphicsLayer(m_renderView.frameView().protectedFrame(), nullptr);
+        page().chrome().client().attachRootGraphicsLayer(protect(m_renderView.frameView().frame()), nullptr);
     }
     break;
     case RootLayerUnattached:

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -681,7 +681,7 @@ bool RenderView::shouldUsePrintingLayout() const
 {
     if (!printing())
         return false;
-    return frameView().protectedFrame()->shouldUsePrintingLayout();
+    return protect(frameView().frame())->shouldUsePrintingLayout();
 }
 
 LayoutRect RenderView::viewRect() const

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -500,7 +500,7 @@ InspectorStubFrontend::InspectorStubFrontend(Page& inspectedPage, LocalFrame& ma
 
     frontendPage()->inspectorController().setInspectorFrontendClient(this);
     inspectedPage.protectedInspectorController()->connectFrontend(*this);
-    mainFrame.protectedInspectorController()->connectFrontend(*this);
+    protect(mainFrame.inspectorController())->connectFrontend(*this);
 }
 
 InspectorStubFrontend::~InspectorStubFrontend()

--- a/Source/WebCore/testing/MockPaymentCoordinator.cpp
+++ b/Source/WebCore/testing/MockPaymentCoordinator.cpp
@@ -167,7 +167,7 @@ bool MockPaymentCoordinator::showPaymentUI(const URL&, const Vector<URL>&, const
     ASSERT(m_showCount == m_hideCount);
     ++m_showCount;
     dispatchIfShowing([page = WTF::move(page)]() {
-        page->protectedPaymentCoordinator()->validateMerchant(URL { "https://webkit.org/"_str });
+        protect(page->paymentCoordinator())->validateMerchant(URL { "https://webkit.org/"_str });
     });
     return true;
 }
@@ -179,7 +179,7 @@ void MockPaymentCoordinator::completeMerchantValidation(const PaymentMerchantSes
         return;
 
     dispatchIfShowing([page = WTF::move(page), shippingAddress = m_shippingAddress]() mutable {
-        page->protectedPaymentCoordinator()->didSelectShippingContact(MockPaymentContact { WTF::move(shippingAddress) });
+        protect(page->paymentCoordinator())->didSelectShippingContact(MockPaymentContact { WTF::move(shippingAddress) });
     });
 }
 
@@ -308,7 +308,7 @@ void MockPaymentCoordinator::changeShippingOption(String&& shippingOption)
     dispatchIfShowing([page = WTF::move(page), shippingOption = WTF::move(shippingOption)]() mutable {
         ApplePayShippingMethod shippingMethod;
         shippingMethod.identifier = WTF::move(shippingOption);
-        page->protectedPaymentCoordinator()->didSelectShippingMethod(shippingMethod);
+        protect(page->paymentCoordinator())->didSelectShippingMethod(shippingMethod);
     });
 }
 
@@ -319,7 +319,7 @@ void MockPaymentCoordinator::changePaymentMethod(ApplePayPaymentMethod&& payment
         return;
 
     dispatchIfShowing([page = WTF::move(page), paymentMethod = WTF::move(paymentMethod)]() mutable {
-        page->protectedPaymentCoordinator()->didSelectPaymentMethod(MockPaymentMethod { WTF::move(paymentMethod) });
+        protect(page->paymentCoordinator())->didSelectPaymentMethod(MockPaymentMethod { WTF::move(paymentMethod) });
     });
 }
 
@@ -332,7 +332,7 @@ void MockPaymentCoordinator::changeCouponCode(String&& couponCode)
         return;
 
     dispatchIfShowing([page = WTF::move(page), couponCode = WTF::move(couponCode)]() mutable {
-        page->protectedPaymentCoordinator()->didChangeCouponCode(WTF::move(couponCode));
+        protect(page->paymentCoordinator())->didChangeCouponCode(WTF::move(couponCode));
     });
 }
 
@@ -349,7 +349,7 @@ void MockPaymentCoordinator::acceptPayment()
         payment.shippingContact = shippingAddress;
         LocalizedApplePayPayment localizedPayment;
         localizedPayment.shippingContact = shippingAddress;
-        page->protectedPaymentCoordinator()->didAuthorizePayment(MockPayment { WTF::move(payment), WTF::move(localizedPayment) });
+        protect(page->paymentCoordinator())->didAuthorizePayment(MockPayment { WTF::move(payment), WTF::move(localizedPayment) });
     });
 }
 
@@ -360,7 +360,7 @@ void MockPaymentCoordinator::cancelPayment()
         return;
 
     dispatchIfShowing([protectedThis = Ref { *this }, page = WTF::move(page)] {
-        page->protectedPaymentCoordinator()->didCancelPaymentSession({ });
+        protect(page->paymentCoordinator())->didCancelPaymentSession({ });
         ++protectedThis->m_hideCount;
         ASSERT(protectedThis->m_showCount == protectedThis->m_hideCount);
     });

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1114,7 +1114,7 @@ void WebAutomationSessionProxy::getCookiesForFrame(WebCore::PageIdentifier pageI
     // This returns the same list of cookies as when evaluating `document.cookies` in JavaScript.
     Vector<WebCore::Cookie> foundCookies;
     if (!document->cookieURL().isEmpty())
-        protect(page->corePage())->protectedCookieJar()->getRawCookies(*document, document->cookieURL(), foundCookies);
+        protect(protect(page->corePage())->cookieJar())->getRawCookies(*document, document->cookieURL(), foundCookies);
 
     completionHandler(std::nullopt, foundCookies);
 }
@@ -1137,7 +1137,7 @@ void WebAutomationSessionProxy::deleteCookie(WebCore::PageIdentifier pageID, std
         return;
     }
 
-    protect(page->corePage())->protectedCookieJar()->deleteCookie(*document, document->cookieURL(), cookieName, [completionHandler = WTF::move(completionHandler)] () mutable {
+    protect(protect(page->corePage())->cookieJar())->deleteCookie(*document, document->cookieURL(), cookieName, [completionHandler = WTF::move(completionHandler)] () mutable {
         completionHandler(std::nullopt);
     });
 }

--- a/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
+++ b/Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp
@@ -341,7 +341,7 @@ void WebFullScreenManager::enterFullScreenForElement(Element& element, HTMLMedia
     m_page->prepareToEnterElementFullScreen();
 
     if (RefPtr page = m_page->corePage()) {
-        if (RefPtr view = page->protectedMainFrame()->virtualView())
+        if (RefPtr view = protect(page->mainFrame())->virtualView())
             m_scrollPosition = view->scrollPosition();
     }
 

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp
@@ -65,7 +65,7 @@ void WebFrameInspectorTarget::connect(Inspector::FrontendChannel::ConnectionType
     m_channel = makeUnique<WebFrameInspectorTargetFrontendChannel>(frame, identifier(), connectionType);
 
     if (RefPtr coreFrame = frame->coreLocalFrame())
-        coreFrame->protectedInspectorController()->connectFrontend(*m_channel);
+        protect(coreFrame->inspectorController())->connectFrontend(*m_channel);
 }
 
 void WebFrameInspectorTarget::disconnect()
@@ -74,7 +74,7 @@ void WebFrameInspectorTarget::disconnect()
         return;
 
     if (RefPtr coreFrame = protectedFrame()->coreLocalFrame())
-        coreFrame->protectedInspectorController()->disconnectFrontend(*m_channel);
+        protect(coreFrame->inspectorController())->disconnectFrontend(*m_channel);
 
     m_channel.reset();
 }
@@ -82,7 +82,7 @@ void WebFrameInspectorTarget::disconnect()
 void WebFrameInspectorTarget::sendMessageToTargetBackend(const String& message)
 {
     if (RefPtr coreFrame = protectedFrame()->coreLocalFrame())
-        coreFrame->protectedInspectorController()->dispatchMessageFromFrontend(message);
+        protect(coreFrame->inspectorController())->dispatchMessageFromFrontend(message);
 }
 
 String WebFrameInspectorTarget::toTargetID(WebCore::FrameIdentifier frameID)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -563,7 +563,7 @@ void WebLoaderStrategy::scheduleLoadFromNetworkProcess(ResourceLoader& resourceL
         RefPtr coreFrame = webFrame ? webFrame->coreFrame() : nullptr;
         RefPtr openerFrame = coreFrame ? coreFrame->opener() : nullptr;
         RefPtr openerDocumentSecurityOrigin = openerFrame ? openerFrame->frameDocumentSecurityOrigin() : nullptr;
-        bool openerDocumentIsSameOriginAsTopDocument = openerDocumentSecurityOrigin ? openerDocumentSecurityOrigin->isSameOriginAs(openerFrame->protectedTopOrigin()) : false;
+        bool openerDocumentIsSameOriginAsTopDocument = openerDocumentSecurityOrigin ? openerDocumentSecurityOrigin->isSameOriginAs(protect(openerFrame->topOrigin())) : false;
         auto openerDocumentSecurityPolicy = openerFrame ? openerFrame->frameDocumentSecurityPolicy() : std::nullopt;
         if (!document->haveInitializedSecurityOrigin() && openerDocumentSecurityPolicy && openerDocumentIsSameOriginAsTopDocument)
             loadParameters.sourceCrossOriginOpenerPolicy = openerDocumentSecurityPolicy->crossOriginOpenerPolicy;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -180,7 +180,7 @@ bool PDFDataDetectorOverlayController::handleMouseEvent(const WebMouseEvent& eve
             previousActiveHighlight->fadeOut();
 
         if (activeHighlight) {
-            installProtectedOverlayIfNeeded()->protectedLayer()->addChild(activeHighlight->layer());
+            protect(installProtectedOverlayIfNeeded()->layer())->addChild(activeHighlight->layer());
             activeHighlight->fadeIn();
         }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -2907,7 +2907,7 @@ bool UnifiedPDFPlugin::takeFindStringFromSelection()
     if (!frame || !frame->coreLocalFrame())
         return false;
 
-    if (CheckedPtr client = protect(frame->coreLocalFrame())->protectedEditor()->client())
+    if (CheckedPtr client = protect(protect(frame->coreLocalFrame())->editor())->client())
         client->updateStringForFind(findString);
     else
         return false;
@@ -2926,7 +2926,7 @@ bool UnifiedPDFPlugin::forwardEditingCommandToEditor(const String& commandName, 
     if (!localFrame)
         return false;
 
-    return localFrame->protectedEditor()->command(commandName).execute(argument);
+    return protect(localFrame->editor())->command(commandName).execute(argument);
 }
 
 void UnifiedPDFPlugin::selectAll()

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -49,7 +49,7 @@ using namespace WebCore;
 RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateShareableBitmapFromImageOptions&& options)
 {
     Ref frame = renderImage.frame();
-    auto colorSpaceForBitmap = screenColorSpace(frame->protectedMainFrame()->protectedVirtualView().get());
+    auto colorSpaceForBitmap = screenColorSpace(protect(frame->mainFrame())->protectedVirtualView().get());
     if (!renderImage.isRenderMedia() && !renderImage.opacity() && options.useSnapshotForTransparentImages == UseSnapshotForTransparentImages::Yes) {
         auto snapshotRect = renderImage.absoluteBoundingBoxRect();
         if (snapshotRect.isEmpty())

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -63,7 +63,7 @@ void WebContextMenuClient::stopSpeaking()
 
 void WebContextMenuClient::searchWithGoogle(const LocalFrame* frame)
 {
-    auto searchString = frame->protectedEditor()->selectedText().trim(deprecatedIsSpaceOrNewline);
+    auto searchString = protect(frame->editor())->selectedText().trim(deprecatedIsSpaceOrNewline);
     protectedPage()->send(Messages::WebPageProxy::SearchTheWeb(searchString));
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -71,7 +71,7 @@ using DragImage = CGImageRef;
 
 static RefPtr<ShareableBitmap> convertDragImageToBitmap(DragImage image, const IntSize& size, Frame& frame)
 {
-    auto bitmap = ShareableBitmap::create({ size, screenColorSpace(frame.protectedMainFrame()->protectedVirtualView().get()) });
+    auto bitmap = ShareableBitmap::create({ size, screenColorSpace(protect(frame.mainFrame())->protectedVirtualView().get()) });
     if (!bitmap)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -549,7 +549,7 @@ Vector<FloatRect> FindController::rectsForTextMatchesInRect(IntRect clipRect)
 #endif
 
     Vector<FloatRect> rects;
-    RefPtr mainFrameView = protect(protectedWebPage()->corePage())->protectedMainFrame()->virtualView();
+    RefPtr mainFrameView = protect(protect(protectedWebPage()->corePage())->mainFrame())->virtualView();
     for (RefPtr frame = m_webPage->corePage()->mainFrame(); frame; frame = frame->tree().traverseNext()) {
         auto* localFrame = dynamicDowncast<LocalFrame>(frame.get());
         if (!localFrame)

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -172,7 +172,7 @@ void WebFoundTextRangeController::replaceFoundTextRangeWithString(const WebFound
     OptionSet temporarySelectionOptions { WebCore::TemporarySelectionOption::DoNotSetFocus, WebCore::TemporarySelectionOption::IgnoreSelectionChanges };
     WebCore::TemporarySelectionChange selectionChange(*document, visibleSelection, temporarySelectionOptions);
 
-    frame->protectedEditor()->replaceSelectionWithText(string, WebCore::Editor::SelectReplacement::Yes, WebCore::Editor::SmartReplace::No, WebCore::EditAction::InsertReplacement);
+    protect(frame->editor())->replaceSelectionWithText(string, WebCore::Editor::SelectReplacement::Yes, WebCore::Editor::SmartReplace::No, WebCore::EditAction::InsertReplacement);
 }
 
 void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextRange& range, FindDecorationStyle style)
@@ -310,13 +310,13 @@ void WebFoundTextRangeController::addLayerForFindOverlay(CompletionHandler<void(
     if (!m_findPageOverlay) {
         Ref findPageOverlay = WebCore::PageOverlay::create(*this, WebCore::PageOverlay::OverlayType::Document, WebCore::PageOverlay::AlwaysTileOverlayLayer::Yes);
         m_webPage->corePage()->pageOverlayController().installPageOverlay(findPageOverlay, WebCore::PageOverlay::FadeMode::DoNotFade);
-        findPageOverlay->protectedLayer()->setOpacity(0);
+        protect(findPageOverlay->layer())->setOpacity(0);
         m_findPageOverlay = WTF::move(findPageOverlay);
     }
 
     RefPtr findPageOverlay = m_findPageOverlay;
 
-    completionHandler(findPageOverlay->protectedLayer()->primaryLayerID());
+    completionHandler(protect(findPageOverlay->layer())->primaryLayerID());
 
     findPageOverlay->setNeedsDisplay();
 }

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -727,7 +727,7 @@ String WebFrame::selectionAsString() const
     if (!localFrame)
         return String();
 
-    return localFrame->displayStringModifiedByEncoding(localFrame->protectedEditor()->selectedText());
+    return localFrame->displayStringModifiedByEncoding(protect(localFrame->editor())->selectedText());
 }
 
 IntSize WebFrame::size() const
@@ -1244,11 +1244,11 @@ void WebFrame::setTextDirection(const String& direction)
         return;
 
     if (direction == "auto"_s)
-        localFrame->protectedEditor()->setBaseWritingDirection(WritingDirection::Natural);
+        protect(localFrame->editor())->setBaseWritingDirection(WritingDirection::Natural);
     else if (direction == "ltr"_s)
-        localFrame->protectedEditor()->setBaseWritingDirection(WritingDirection::LeftToRight);
+        protect(localFrame->editor())->setBaseWritingDirection(WritingDirection::LeftToRight);
     else if (direction == "rtl"_s)
-        localFrame->protectedEditor()->setBaseWritingDirection(WritingDirection::RightToLeft);
+        protect(localFrame->editor())->setBaseWritingDirection(WritingDirection::RightToLeft);
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp
@@ -99,7 +99,7 @@ void WebPageTesting::isEditingCommandEnabled(const String& commandName, Completi
         return completionHandler(pluginView->isEditingCommandEnabled(commandName));
 #endif
 
-    auto command = frame->protectedEditor()->command(commandName);
+    auto command = protect(frame->editor())->command(commandName);
     completionHandler(command.isSupported() && command.isEnabled());
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -182,7 +182,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
 {
     getPlatformEditorStateCommon(frame, result);
 
-    result.canEnableAutomaticSpellingCorrection = result.isContentEditable && frame.protectedEditor()->canEnableAutomaticSpellingCorrection();
+    result.canEnableAutomaticSpellingCorrection = result.isContentEditable && protect(frame.editor())->canEnableAutomaticSpellingCorrection();
     RefPtr document = frame.document();
     result.inputMethodUsesCorrectKeyEventOrder = frame.settings().inputMethodUsesCorrectKeyEventOrder() || (document && document->quirks().inputMethodUsesCorrectKeyEventOrder());
 
@@ -203,12 +203,12 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
     if (!selectionStartBoundary || !selectionEnd || !paragraphStart)
         return;
 
-    auto contextRangeForCandidateRequest = frame.protectedEditor()->contextRangeForCandidateRequest();
+    auto contextRangeForCandidateRequest = protect(frame.editor())->contextRangeForCandidateRequest();
 
     postLayoutData.candidateRequestStartPosition = characterCount({ *paragraphStart, *selectionStartBoundary });
     postLayoutData.selectedTextLength = characterCount({ *selectionStartBoundary, *selectionEnd });
     postLayoutData.paragraphContextForCandidateRequest = contextRangeForCandidateRequest ? plainText(*contextRangeForCandidateRequest) : String();
-    postLayoutData.stringForCandidateRequest = frame.protectedEditor()->stringForCandidateRequest();
+    postLayoutData.stringForCandidateRequest = protect(frame.editor())->stringForCandidateRequest();
 
     auto quads = RenderObject::absoluteTextQuads(*selectedRange);
     if (!quads.isEmpty())
@@ -222,7 +222,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
 void WebPage::handleAcceptedCandidate(WebCore::TextCheckingResult acceptedCandidate)
 {
     if (RefPtr frame = m_page->focusController().focusedLocalFrame())
-        frame->protectedEditor()->handleAcceptedCandidate(acceptedCandidate);
+        protect(frame->editor())->handleAcceptedCandidate(acceptedCandidate);
 }
 
 static String commandNameForSelectorName(const String& selectorName)
@@ -480,7 +480,7 @@ void WebPage::getStringSelectionForPasteboard(CompletionHandler<void(String&&)>&
     if (frame->selection().isNone())
         return completionHandler({ });
 
-    completionHandler(frame->protectedEditor()->stringSelectionForPasteboard());
+    completionHandler(protect(frame->editor())->stringSelectionForPasteboard());
 }
 
 void WebPage::getDataSelectionForPasteboard(const String pasteboardType, CompletionHandler<void(RefPtr<SharedBuffer>&&)>&& completionHandler)
@@ -491,7 +491,7 @@ void WebPage::getDataSelectionForPasteboard(const String pasteboardType, Complet
     if (frame->selection().isNone())
         return completionHandler({ });
 
-    auto buffer = frame->protectedEditor()->dataSelectionForPasteboard(pasteboardType);
+    auto buffer = protect(frame->editor())->dataSelectionForPasteboard(pasteboardType);
     if (!buffer)
         return completionHandler({ });
     completionHandler(buffer.releaseNonNull());

--- a/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp
@@ -166,7 +166,7 @@ public:
             return;
 
         m_channel = makeUnique<FrontendChannel>(identifier(), connectionType, m_handler);
-        Ref { m_frame.get() }->protectedInspectorController()->connectFrontend(*m_channel);
+        protect(Ref { m_frame.get() }->inspectorController())->connectFrontend(*m_channel);
     }
 
     void disconnect() override
@@ -174,13 +174,13 @@ public:
         if (!m_channel)
             return;
 
-        Ref { m_frame.get() }->protectedInspectorController()->disconnectFrontend(*m_channel);
+        protect(Ref { m_frame.get() }->inspectorController())->disconnectFrontend(*m_channel);
         m_channel = nullptr;
     }
 
     void sendMessageToTargetBackend(const String& message) override
     {
-        Ref { m_frame.get() }->protectedInspectorController()->dispatchMessageFromFrontend(message);
+        protect(Ref { m_frame.get() }->inspectorController())->dispatchMessageFromFrontend(message);
     }
 
 private:

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm
@@ -313,7 +313,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
     RefPtr newPage = core(newWebView.get());
     if (newPage) {
         if (!features.wantsNoOpener()) {
-            m_webView.page->protectedStorageNamespaceProvider()->cloneSessionStorageNamespaceForPage(*m_webView.page, *newPage);
+            protect(m_webView.page->storageNamespaceProvider())->cloneSessionStorageNamespaceForPage(*m_webView.page, *newPage);
             newPage->mainFrame().setOpenerForWebKitLegacy(&frame);
             newPage->applyWindowFeatures(features);
         }


### PR DESCRIPTION
#### 3d45824fb8d45b3b3d197dc2ba03e665831535de
<pre>
Reduce use of protected functions in Source/WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=307329">https://bugs.webkit.org/show_bug.cgi?id=307329</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
(WebCore::ApplePaySession::create):
(WebCore::ApplePaySession::supportsVersion):
(WebCore::ApplePaySession::canMakePayments):
(WebCore::ApplePaySession::canMakePaymentsWithActiveCard):
(WebCore::ApplePaySession::openPaymentSetup):
* Source/WebCore/Modules/applepay/ApplePaySetup.cpp:
(WebCore::ApplePaySetup::getSetupFeatures):
(WebCore::ApplePaySetup::begin):
(WebCore::ApplePaySetup::stop):
* Source/WebCore/Modules/cookie-store/CookieStore.cpp:
(WebCore::CookieStore::stop):
* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::getOutputTimestamp):
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::BroadcastChannel::MainThreadBridge::registerChannel):
(WebCore::BroadcastChannel::MainThreadBridge::unregisterChannel):
(WebCore::BroadcastChannel::MainThreadBridge::postMessage):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::attachToCachedFrame):
(WebCore::Document::open):
(WebCore::Document::implicitClose):
(WebCore::Document::navigateFromServiceWorker):
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::didExitFullscreen):
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrameBase::restore):
(WebCore::CachedFrame::open):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::CachedPage):
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::serviceRequestVideoFrameCallbacks):
* Source/WebCore/html/parser/HTMLDocumentParser.cpp:
(WebCore::HTMLDocumentParser::pumpTokenizerLoop):
* Source/WebCore/inspector/CommandLineAPIHost.cpp:
(WebCore::instrumentingAgentsForGlobalObject):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorBackendDispatchTask::dispatchOneMessage):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowHeight):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowWidth):
(WebCore::InspectorFrontendClientLocal::restoreAttachedWindowHeight):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::notifyFinished):
(WebCore::DocumentLoader::responseReceived):
(WebCore::DocumentLoader::commitData):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::loadRequest):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::setDefersLoading):
(WebCore::FrameLoader::submitForm):
(WebCore::FrameLoader::stopLoading):
(WebCore::FrameLoader::didOpenURL):
(WebCore::FrameLoader::didExplicitOpen):
(WebCore::FrameLoader::clear):
(WebCore::FrameLoader::checkCompleted):
(WebCore::FrameLoader::provisionalLoadStarted):
(WebCore::FrameLoader::completed):
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::stopForBackForwardCache):
(WebCore::FrameLoader::willRestoreFromCachedPage):
(WebCore::FrameLoader::navigatorPlatform const):
(WebCore::FrameLoader::scheduleRefreshIfNeeded):
* Source/WebCore/loader/ResourceTimingInformation.cpp:
(WebCore::ResourceTimingInformation::addResourceTiming):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::FrameLoader::SubframeLoader::loadOrRedirectSubframe):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestUserCSSStyleSheet):
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::rectForSettingAtIndex const):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedInternal):
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::~Frame):
(WebCore::Frame::updateFrameTreeSyncData):
(WebCore::Frame::protectedWindowProxy const): Deleted.
(WebCore::Frame::protectedNavigationScheduler const): Deleted.
(WebCore::Frame::protectedTopOrigin const): Deleted.
* Source/WebCore/page/Frame.h:
(WebCore::Frame::windowProxy const):
(WebCore::Frame::mainFrame const):
(WebCore::Frame::navigationScheduler const):
(WebCore::Frame::frameTreeSyncData const):
(WebCore::Frame::protectedMainFrame): Deleted.
(WebCore::Frame::protectedMainFrame const): Deleted.
(WebCore::Frame::protectedFrameTreeSyncData const): Deleted.
* Source/WebCore/page/FrameTree.cpp:
(showFrameTree):
(WebCore::FrameTree::protectedTop const): Deleted.
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/FrameView.cpp:
(WebCore::FrameView::scrollableAreaBoundingBox const):
(WebCore::FrameView::convertToContainingView const):
(WebCore::FrameView::convertFromContainingView const):
(WebCore::FrameView::protectedFrame const): Deleted.
* Source/WebCore/page/FrameView.h:
* Source/WebCore/page/History.cpp:
(WebCore::History::go):
* Source/WebCore/page/LargestContentfulPaintData.cpp:
(WebCore::LargestContentfulPaintData::potentiallyAddLargestContentfulPaintEntry):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::setLocation):
(WebCore::LocalDOMWindow::createWindow):
(WebCore::LocalDOMWindow::open):
(WebCore::LocalDOMWindow::protectedPerformance const): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::clearTimers):
(WebCore::LocalFrame::protectedInspectorController const): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameInlines.h:
(WebCore::LocalFrame::protectedEditor): Deleted.
(WebCore::LocalFrame::protectedEditor const): Deleted.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::protectedFrame const): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::protectedView const): Deleted.
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/Location.cpp:
(WebCore::Location::reload):
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::performTraversal):
* Source/WebCore/page/Page.cpp:
(WebCore::m_mediaSessionManagerFactory):
(WebCore::Page::~Page):
(WebCore::Page::viewportArguments const):
(WebCore::Page::refreshPlugins):
(WebCore::Page::screenPropertiesDidChange):
(WebCore::Page::windowScreenDidChange):
(WebCore::Page::lockAllOverlayScrollbarsToHidden):
(WebCore::Page::setVerticalScrollElasticity):
(WebCore::Page::renderingUpdateCompleted):
(WebCore::Page::advancedPrivacyProtections const):
(WebCore::Page::forEachDocument const):
(WebCore::Page::reloadExecutionContextsForOrigin const):
(WebCore::Page::requiresScriptTrackingPrivacyProtections const):
(WebCore::Page::requiresUserGestureForAudioPlayback const):
(WebCore::Page::requiresUserGestureForVideoPlayback const):
(WebCore::Page::protectedMainFrameOrigin const): Deleted.
(WebCore::Page::protectedBroadcastChannelRegistry const): Deleted.
(WebCore::Page::protectedMainFrame const): Deleted.
(WebCore::Page::protectedOpportunisticTaskScheduler const): Deleted.
(WebCore::Page::protectedCookieJar const): Deleted.
(WebCore::Page::protectedStorageNamespaceProvider const): Deleted.
(WebCore::Page::protectedPluginInfoProvider const): Deleted.
(WebCore::Page::protectedPaymentCoordinator const): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::opportunisticTaskScheduler const):
(WebCore::Page::mainFrame const):
(WebCore::Page::broadcastChannelRegistry):
(WebCore::Page::paymentCoordinator const):
(WebCore::Page::cookieJar):
(WebCore::Page::storageNamespaceProvider):
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::sampleColor):
* Source/WebCore/page/PageOverlay.cpp:
(WebCore::PageOverlay::bounds const):
(WebCore::PageOverlay::viewToOverlayOffset const):
(WebCore::PageOverlay::drawRect):
(WebCore::PageOverlay::mouseEvent):
(WebCore::PageOverlay::protectedLayer const): Deleted.
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/RemoteDOMWindow.cpp:
(WebCore::RemoteDOMWindow::setLocation):
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::frameViewEventTrackingRegionsChanged):
* Source/WebCore/plugins/PluginData.cpp:
(WebCore::PluginData::initPlugins):
(WebCore::PluginData::webVisiblePlugins const):
(WebCore::PluginData::supportsWebVisibleMimeTypeForURL const):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::attachRootLayer):
(WebCore::RenderLayerCompositor::detachRootLayer):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::shouldUsePrintingLayout const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::InspectorStubFrontend::InspectorStubFrontend):
* Source/WebCore/testing/MockPaymentCoordinator.cpp:
(WebCore::MockPaymentCoordinator::showPaymentUI):
(WebCore::MockPaymentCoordinator::completeMerchantValidation):
(WebCore::MockPaymentCoordinator::changeShippingOption):
(WebCore::MockPaymentCoordinator::changePaymentMethod):
(WebCore::MockPaymentCoordinator::changeCouponCode):
(WebCore::MockPaymentCoordinator::acceptPayment):
(WebCore::MockPaymentCoordinator::cancelPayment):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::getCookiesForFrame):
(WebKit::WebAutomationSessionProxy::deleteCookie):
* Source/WebKit/WebProcess/FullScreen/WebFullScreenManager.cpp:
(WebKit::WebFullScreenManager::enterFullScreenForElement):
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp:
(WebKit::WebFrameInspectorTarget::connect):
(WebKit::WebFrameInspectorTarget::disconnect):
(WebKit::WebFrameInspectorTarget::sendMessageToTargetBackend):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::scheduleLoadFromNetworkProcess):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::handleMouseEvent):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::takeFindStringFromSelection):
(WebKit::UnifiedPDFPlugin::forwardEditingCommandToEditor const):
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
(WebKit::createShareableBitmap):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::searchWithGoogle):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::convertDragImageToBitmap):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::insertDictatedTextAsync):
(WebKit::WebPage::getPlatformEditorStateCommon const):
(WebKit::WebPage::replaceImageForRemoveBackground):
(WebKit::WebPage::readSelectionFromPasteboard):
(WebKit::WebPage::handleAlternativeTextUIResult):
(WebKit::WebPage::setTextAsync):
(WebKit::WebPage::getMarkedRangeAsync):
(WebKit::WebPage::getSelectedRangeAsync):
(WebKit::WebPage::firstRectForCharacterRangeAsync):
(WebKit::WebPage::setCompositionAsync):
(WebKit::WebPage::setWritingSuggestion):
(WebKit::WebPage::confirmCompositionAsync):
(WebKit::WebPage::insertTextPlaceholder):
(WebKit::WebPage::removeTextPlaceholder):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::replaceFoundTextRangeWithString):
(WebKit::WebFoundTextRangeController::addLayerForFindOverlay):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::selectionAsString const):
(WebKit::WebFrame::setTextDirection):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_isPopup):
(WebKit::WebPage::changeFontAttributes):
(WebKit::WebPage::changeFont):
(WebKit::WebPage::executeEditingCommand):
(WebKit::WebPage::setEditable):
(WebKit::WebPage::increaseListLevel):
(WebKit::WebPage::decreaseListLevel):
(WebKit::WebPage::changeListType):
(WebKit::WebPage::setBaseWritingDirection):
(WebKit::WebPage::setSize):
(WebKit::WebPage::didScaleView):
(WebKit::snapshotColorSpace):
(WebKit::WebPage::pageDidScroll):
(WebKit::WebPage::validateCommand):
(WebKit::WebPage::requestFontAttributesAtSelectionStart):
(WebKit::WebPage::insertNewlineInQuotedContent):
(WebKit::WebPage::copyLinkWithHighlight):
(WebKit::WebPage::detectDataInAllFrames):
(WebKit::WebPage::advanceToNextMisspelling):
(WebKit::WebPage::uppercaseWord):
(WebKit::WebPage::lowercaseWord):
(WebKit::WebPage::capitalizeWord):
(WebKit::WebPage::convertToTraditionalChinese):
(WebKit::WebPage::convertToSimplifiedChinese):
(WebKit::WebPage::replaceSelectionWithText):
(WebKit::WebPage::cancelComposition):
(WebKit::WebPage::setAlwaysShowsHorizontalScroller):
(WebKit::WebPage::setAlwaysShowsVerticalScroller):
(WebKit::WebPage::insertAttachment):
(WebKit::WebPage::updateLastNodeBeforeWritingSuggestions):
* Source/WebKit/WebProcess/WebPage/WebPageTesting.cpp:
(WebKit::WebPageTesting::isEditingCommandEnabled):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::getPlatformEditorState const):
(WebKit::WebPage::handleAcceptedCandidate):
(WebKit::WebPage::getStringSelectionForPasteboard):
(WebKit::WebPage::getDataSelectionForPasteboard):
* Source/WebKitLegacy/WebCoreSupport/LegacyWebPageInspectorController.cpp:
* Source/WebKitLegacy/mac/WebCoreSupport/WebChromeClient.mm:
(WebChromeClient::createWindow):

Canonical link: <a href="https://commits.webkit.org/307148@main">https://commits.webkit.org/307148@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2db27cf706b590330c2db4645c433cc455ed9cdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143522 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16003 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7612 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152187 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9d17010-53a1-4fef-b744-d31abc9097f7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145397 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16091 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110369 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d07669ee-3712-48de-8f67-64f72f36703a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146485 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12816 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128985 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91288 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/489d126e-140c-4719-8254-9a37885af75a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10023 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2189 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121739 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154499 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16050 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6539 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118379 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16086 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118733 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30425 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14677 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71464 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15671 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5316 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15406 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15618 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15470 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->