### PR TITLE
processContentsBetweenOffsets: reduce scope of checked pointer

### DIFF
--- a/LayoutTests/fast/dom/rangeDeleteContents-crash-expected.txt
+++ b/LayoutTests/fast/dom/rangeDeleteContents-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/dom/rangeDeleteContents-crash.html
+++ b/LayoutTests/fast/dom/rangeDeleteContents-crash.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<div><div id="container"><span id="span1"></span><span id="span2"></span><span></span><div></div><dialog id="dialog"></dialog>&#xA;</div>
+<script>
+  window.testRunner?.dumpAsText();
+  window.testRunner?.waitUntilDone();
+  span1.addEventListener("DOMNodeRemoved", _ => {
+      let range =  document.createRange();
+      range.setEndAfter(span2);
+      range.deleteContents();
+      container.addEventListener("DOMCharacterDataModified", _ => {
+        container.removeChild(container.firstChild);
+        window.testRunner?.notifyDone();
+      }, {once: true});
+      dialog.outerHTML = "PASS if no crash.";
+      for(var i=0;i<100;i++) new Uint8Array(1024*1024);
+  }, {once: true});
+  let range = document.createRange();
+  range.setEndAfter(span2);
+  range.deleteContents();
+</script>

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -523,14 +523,15 @@ static ExceptionOr<RefPtr<Node>> processContentsBetweenOffsets(Range::ActionType
                 result = container->cloneNode(false);
         }
         Vector<Ref<Node>> nodes;
-        CheckedPtr n = container->firstChild();
-        for (unsigned i = startOffset; n && i; i--)
-            n = n->nextSibling();
-        for (unsigned i = startOffset; n && i < endOffset; i++, n = n->nextSibling()) {
-            if (action != Range::Delete && n->isDocumentTypeNode()) {
-                return Exception { ExceptionCode::HierarchyRequestError };
+        {
+            CheckedPtr n = container->firstChild();
+            for (unsigned i = startOffset; n && i; i--)
+                n = n->nextSibling();
+            for (unsigned i = startOffset; n && i < endOffset; i++, n = n->nextSibling()) {
+                if (action != Range::Delete && n->isDocumentTypeNode())
+                    return Exception { ExceptionCode::HierarchyRequestError };
+                nodes.append(*n);
             }
-            nodes.append(*n);
         }
         auto processResult = processNodes(action, nodes, container.get(), result);
         if (processResult.hasException())


### PR DESCRIPTION
#### 3eb27b72430fa7f8a4c9e8f0743de665e6ae1f73
<pre>
processContentsBetweenOffsets: reduce scope of checked pointer
<a href="https://bugs.webkit.org/show_bug.cgi?id=307338">https://bugs.webkit.org/show_bug.cgi?id=307338</a>

Reviewed by Ryosuke Niwa.

After 306021@main introduced smart pointers in processContentsBetweenOffsets,
it&apos;s possible to hit an assertion when the checked pointer in
processContentsBetweenOffsets() goes out of scope at the end
of the function. Since this variable is only needed briefly, it&apos;s better
to reduce its scope as later calls in that method might delete the underlying
object.

Test: fast/dom/rangeDeleteContents-crash.html

* LayoutTests/fast/dom/rangeDeleteContents-crash-expected.txt: Added.
* LayoutTests/fast/dom/rangeDeleteContents-crash.html: Added.
* Source/WebCore/dom/Range.cpp:
(WebCore::processContentsBetweenOffsets): Reduce scope of n.

Canonical link: <a href="https://commits.webkit.org/307116@main">https://commits.webkit.org/307116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dbe65ee1617aac7fc4e7d0978ac56cd8881c3d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15818 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96590 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145210 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15899 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110249 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79387 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146292 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12708 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91158 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12178 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9892 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2017 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121631 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5321 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154330 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118267 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15899 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118608 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30407 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14547 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71257 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15487 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5182 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15221 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79207 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15432 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15283 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->