### PR TITLE
Test SRGBLinear tiles

### DIFF
--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -366,7 +366,8 @@ void GraphicsContextSkia::drawLine(const FloatPoint& point1, const FloatPoint& p
         return;
 
     SkPaint paint = createStrokePaint();
-    paint.setColor(SkColor(strokeColor().colorWithAlphaMultipliedBy(alpha())));
+    // paint.setColor(SkColor(strokeColor().colorWithAlphaMultipliedBy(alpha())));
+    paint.setColor(SkColor4f::FromColor(SkColor(strokeColor().colorWithAlphaMultipliedBy(alpha()))), SkColorSpace::MakeSRGBLinear().get());
 
     const bool isVertical = (point1.x() + strokeThickness() == point2.x());
     float strokeWidth = isVertical ? point2.y() - point1.y() : point2.x() - point1.x();
@@ -621,7 +622,8 @@ void GraphicsContextSkia::setupFillSource(SkPaint& paint)
     } else if (auto fillGradient = fillBrush().gradient())
         paint.setShader(fillGradient->shader(alpha(), fillBrush().gradientSpaceTransform()));
     else
-        paint.setColor(SkColor(fillColor().colorWithAlphaMultipliedBy(alpha())));
+        // paint.setColor(SkColor(fillColor().colorWithAlphaMultipliedBy(alpha())));
+        paint.setColor(SkColor4f::FromColor(SkColor(fillColor().colorWithAlphaMultipliedBy(alpha()))), SkColorSpace::MakeSRGBLinear().get());
 }
 
 SkPaint GraphicsContextSkia::createStrokePaint() const
@@ -646,7 +648,8 @@ void GraphicsContextSkia::setupStrokeSource(SkPaint& paint)
     } else if (auto strokeGradient = strokeBrush().gradient())
         paint.setShader(strokeGradient->shader(alpha(), strokeBrush().gradientSpaceTransform()));
     else
-        paint.setColor(SkColor(strokeBrush().color().colorWithAlphaMultipliedBy(alpha())));
+        // paint.setColor(SkColor(strokeBrush().color().colorWithAlphaMultipliedBy(alpha())));
+        paint.setColor(SkColor4f::FromColor(SkColor(strokeBrush().color().colorWithAlphaMultipliedBy(alpha()))), SkColorSpace::MakeSRGBLinear().get());
 }
 
 void GraphicsContextSkia::drawSkiaRect(const SkRect& boundaries, SkPaint& paint)
@@ -678,7 +681,8 @@ void GraphicsContextSkia::fillRect(const FloatRect& boundaries, const Color& fil
         return;
 
     SkPaint paint = createFillPaint();
-    paint.setColor(SkColor(fillColor));
+    // paint.setColor(SkColor(fillColor));
+    paint.setColor(SkColor4f::FromColor(SkColor(fillColor)), SkColorSpace::MakeSRGBLinear().get());
     drawSkiaRect(boundaries, paint);
 }
 
@@ -829,7 +833,8 @@ void GraphicsContextSkia::drawDotsForDocumentMarker(const FloatRect& boundaries,
         return;
 
     SkPaint paint = createFillPaint();
-    paint.setColor(SkColor(style.color));
+    // paint.setColor(SkColor(style.color));
+    paint.setColor(SkColor4f::FromColor(SkColor(style.color)), SkColorSpace::MakeSRGBLinear().get());
     m_canvas.drawPath(createErrorUnderlinePath(boundaries), paint);
 }
 
@@ -1027,7 +1032,8 @@ void GraphicsContextSkia::fillRoundedRectImpl(const FloatRoundedRect& rect, cons
         return;
 
     SkPaint paint = createFillPaint();
-    paint.setColor(SkColor(color));
+    // paint.setColor(SkColor(color));
+    paint.setColor(SkColor4f::FromColor(SkColor(color)), SkColorSpace::MakeSRGBLinear().get());
     bool inExtraTransparencyLayer = false;
     if (hasDropShadow()) {
         inExtraTransparencyLayer = drawOutsetShadow(paint, [&](const SkPaint& paint) {
@@ -1048,7 +1054,8 @@ void GraphicsContextSkia::fillRectWithRoundedHole(const FloatRect& outerRect, co
         return;
 
     SkPaint paint = createFillPaint();
-    paint.setColor(SkColor(color));
+    // paint.setColor(SkColor(color));
+    paint.setColor(SkColor4f::FromColor(SkColor(color)), SkColorSpace::MakeSRGBLinear().get());
     paint.setImageFilter(createDropShadowFilterIfNeeded(ShadowStyle::Inset));
     m_canvas.drawDRRect(SkRRect::MakeRect(outerRect), innerRRect, paint);
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -148,7 +148,8 @@ bool CoordinatedUnacceleratedTileBuffer::tryEnsureSurface()
     if (m_surface)
         return true;
 
-    auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    // auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGBLinear());
     // FIXME: ref buffer and unref on release proc?
     SkSurfaceProps properties = { 0, FontRenderOptions::singleton().subpixelOrder() };
     m_surface = SkSurfaces::WrapPixels(imageInfo, data(), imageInfo.minRowBytes64(), &properties);
@@ -206,7 +207,8 @@ bool CoordinatedAcceleratedTileBuffer::tryEnsureSurface()
         kTopLeft_GrSurfaceOrigin,
         msaaSampleCount,
         kRGBA_8888_SkColorType,
-        SkColorSpace::MakeSRGB(),
+        // SkColorSpace::MakeSRGB(),
+        SkColorSpace::MakeSRGBLinear(),
         &properties);
 
     return true;


### PR DESCRIPTION
#### 217a6a14fe7d8d7325cd709d6d28de7855802868
<pre>
Test SRGBLinear tiles
Need the bug URL (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp:
(WebCore::CoordinatedUnacceleratedTileBuffer::tryEnsureSurface):
(WebCore::CoordinatedAcceleratedTileBuffer::tryEnsureSurface):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/217a6a14fe7d8d7325cd709d6d28de7855802868

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16065 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7682 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152251 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96820 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16742 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16153 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110416 "Failure limit exceed. At least found 487 new test failures: compositing/animation/repaint-after-clearing-shared-backing.html compositing/filters/filter-region-translated-child.html compositing/masks/reference-clip-path-on-composited-image.html css2.1/20110323/border-conflict-element-001d.htm css3/blending/background-blend-mode-body-image.html css3/filters/drop-shadow-child-clipped.html css3/filters/drop-shadow-current-color.html css3/filters/drop-shadow-target-clipped.html css3/filters/effect-blur-hw.html css3/filters/effect-brightness-hw.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79464 "Exiting early after 60 failures. 4040 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12860 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129036 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91335 "Found 9 new API test failures: TestWebCore:ImageBufferTests/AnyTwoImageBufferOptionsTest.PutPixelBufferAffectsDrawOutput/1byteobject001byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/11byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/051byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/11byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/21byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/51byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/21byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/051byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/51byteobject00 (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12348 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10064 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2251 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5563 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154561 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16112 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6603 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118419 "Failure limit exceed. At least found 487 new test failures: compositing/clipping/cached-cliprect-with-compositing-boundary.html compositing/filters/filter-region-translated-child.html compositing/images/positioned-image-content-rect.html compositing/masks/reference-clip-path-on-composited-image.html css2.1/20110323/border-conflict-element-001d.htm css3/blending/background-blend-mode-body-image.html css3/filters/drop-shadow-child-clipped.html css3/filters/drop-shadow-current-color.html css3/filters/drop-shadow-target-clipped.html css3/filters/effect-blur-hw.html ... (failure)") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13569 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118775 "Found 9 new API test failures: TestWebCore:ImageBufferTests/AnyTwoImageBufferOptionsTest.PutPixelBufferAffectsDrawOutput/1byteobject001byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/11byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/051byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/11byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/21byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.SinkIntoNativeImageWorks/51byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/21byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/051byteobject00, TestWebCore:ImageBufferTests/AnyScaleTest.GetPixelBufferDimensionsContainScale/51byteobject00 (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14713 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126770 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71526 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15733 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5363 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15468 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79505 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15680 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15532 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->