### PR TITLE
Implement HTML video and audio element lazy-loading via the loading attribute

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -4418,6 +4418,20 @@ LazyImageLoadingEnabled:
     WebCore:
       default: false
 
+LazyMediaLoadingEnabled:
+  type: bool
+  status: testable
+  category: html
+  humanReadableName: "Lazy media loading"
+  humanReadableDescription: "Enable lazy loading support for video and audio elements"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 LegacyEncryptedMediaAPIEnabled:
   type: bool
   status: embedder

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1638,6 +1638,7 @@ html/InputTypeNames.cpp
 html/LabelsNodeList.cpp
 html/LazyLoadFrameObserver.cpp
 html/LazyLoadImageObserver.cpp
+html/LazyLoadMediaObserver.cpp
 html/LinkIconCollector.cpp
 html/LinkRelAttribute.cpp
 html/MediaController.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		029D57AA2C506F5900AD086B /* UserGestureTokenIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 029D57A92C506F5900AD086B /* UserGestureTokenIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		02E536BD2984EA6800417C02 /* ScrollerPairMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 024E5F7429844DBD009CC5FC /* ScrollerPairMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		02E536C12984ECE200417C02 /* ScrollerMac.h in Headers */ = {isa = PBXBuildFile; fileRef = 024E5F7129844DBC009CC5FC /* ScrollerMac.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		042A13572F355DE9005405F7 /* LazyLoadMediaObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 042A13542F355DE9005405F7 /* LazyLoadMediaObserver.h */; };
 		0562F9611573F88F0031CA16 /* PlatformLayer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0562F9601573F88F0031CA16 /* PlatformLayer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		056A7AC8256C4F48002F9DDC /* ShadowRootInit.h in Headers */ = {isa = PBXBuildFile; fileRef = 054E3A33256C3BD90072C5B9 /* ShadowRootInit.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		056A7AC8256C4F48002F9DDF /* GetHTMLOptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 054E3A33256C3BD90072C5BF /* GetHTMLOptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -7387,6 +7388,8 @@
 		024E5F7429844DBD009CC5FC /* ScrollerPairMac.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ScrollerPairMac.h; sourceTree = "<group>"; };
 		025F62A92DD69A8700573F15 /* AutoplayPolicy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AutoplayPolicy.h; sourceTree = "<group>"; };
 		029D57A92C506F5900AD086B /* UserGestureTokenIdentifier.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UserGestureTokenIdentifier.h; sourceTree = "<group>"; };
+		042A13542F355DE9005405F7 /* LazyLoadMediaObserver.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LazyLoadMediaObserver.h; sourceTree = "<group>"; };
+		042A13552F355DE9005405F7 /* LazyLoadMediaObserver.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = LazyLoadMediaObserver.cpp; sourceTree = "<group>"; };
 		054E3A33256C3BD90072C5B9 /* ShadowRootInit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ShadowRootInit.h; sourceTree = "<group>"; };
 		054E3A33256C3BD90072C5BF /* GetHTMLOptions.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GetHTMLOptions.h; sourceTree = "<group>"; };
 		054E3A35256C3BD90072C5B9 /* ShadowRootInit.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = ShadowRootInit.idl; sourceTree = "<group>"; };
@@ -32481,6 +32484,8 @@
 				4437C4A724E2AE5F00095128 /* LazyLoadFrameObserver.h */,
 				AAD9D0B121DFA80C001B11C7 /* LazyLoadImageObserver.cpp */,
 				AAD9D0B321DFA80E001B11C7 /* LazyLoadImageObserver.h */,
+				042A13552F355DE9005405F7 /* LazyLoadMediaObserver.cpp */,
+				042A13542F355DE9005405F7 /* LazyLoadMediaObserver.h */,
 				1A4DA41F1CDD3A8300F4473C /* LinkIconCollector.cpp */,
 				1A4DA4201CDD3A8300F4473C /* LinkIconCollector.h */,
 				1A250E0C1CDD632000D0BE63 /* LinkIconType.h */,
@@ -45711,6 +45716,7 @@
 				11310CF220BA4A320065A8D0 /* LayoutTreeBuilder.h in Headers */,
 				141DC0481648348F00371E5A /* LayoutUnit.h in Headers */,
 				E451C6312394027900993190 /* LayoutUnits.h in Headers */,
+				042A13572F355DE9005405F7 /* LazyLoadMediaObserver.h in Headers */,
 				8B5216F72DEE4E75003BC21B /* LazyLoadModelObserver.h in Headers */,
 				CDE555242405CCF2008A3DDB /* LegacyCDM.h in Headers */,
 				CDE555252405CCF2008A3DDB /* LegacyCDMPrivate.h in Headers */,

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -180,6 +180,7 @@
 #include "LargestContentfulPaintData.h"
 #include "LayoutDisallowedScope.h"
 #include "LazyLoadImageObserver.h"
+#include "LazyLoadMediaObserver.h"
 #include "LegacySchemeRegistry.h"
 #include "LoadableSpeculationRules.h"
 #include "LoaderStrategy.h"
@@ -11563,6 +11564,13 @@ LazyLoadImageObserver& Document::lazyLoadImageObserver()
     if (!m_lazyLoadImageObserver)
         m_lazyLoadImageObserver = makeUnique<LazyLoadImageObserver>();
     return *m_lazyLoadImageObserver;
+}
+
+LazyLoadMediaObserver& Document::lazyLoadMediaObserver()
+{
+    if (!m_lazyLoadMediaObserver)
+        m_lazyLoadMediaObserver = makeUnique<LazyLoadMediaObserver>();
+    return *m_lazyLoadMediaObserver;
 }
 
 #if ENABLE(MODEL_ELEMENT)

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -193,6 +193,7 @@ class LargestContentfulPaintData;
 class LayoutPoint;
 class LayoutRect;
 class LazyLoadImageObserver;
+class LazyLoadMediaObserver;
 class LiveNodeList;
 class LocalFrame;
 class LocalFrameView;
@@ -559,7 +560,7 @@ public:
     WEBCORE_EXPORT DocumentType* doctype() const;
 
     WEBCORE_EXPORT DOMImplementation& implementation();
-    
+
     Element* documentElement() const { return m_documentElement.get(); }
     AsyncNodeDeletionQueue& asyncNodeDeletionQueue() { return m_asyncNodeDeletionQueue; };
     static constexpr ptrdiff_t documentElementMemoryOffset() { return OBJECT_OFFSETOF(Document, m_documentElement); }
@@ -935,7 +936,7 @@ public:
 
     bool usesStyleBasedEditability() const;
     void setHasElementUsingStyleBasedEditability();
-    
+
     virtual Ref<DocumentParser> createParser();
     DocumentParser* parser() const { return m_parser.get(); }
     ScriptableDocumentParser* scriptableDocumentParser() const;
@@ -945,7 +946,7 @@ public:
 
     bool paginatedForScreen() const { return m_paginatedForScreen; }
     void setPaginatedForScreen(bool p) { m_paginatedForScreen = p; }
-    
+
     bool paginated() const { return printing() || paginatedForScreen(); }
 
     void setCompatibilityMode(DocumentCompatibilityMode);
@@ -1081,7 +1082,7 @@ public:
 
     Document& contextDocument() const;
     void setContextDocument(Ref<Document>&& document) { m_contextDocument = WTF::move(document); }
-    
+
     OptionSet<ParserContentPolicy> parserContentPolicy() const { return m_parserContentPolicy; }
     void setParserContentPolicy(OptionSet<ParserContentPolicy> policy) { m_parserContentPolicy = policy; }
 
@@ -1972,6 +1973,7 @@ public:
     bool allowsContentJavaScript() const;
 
     LazyLoadImageObserver& lazyLoadImageObserver();
+    LazyLoadMediaObserver& lazyLoadMediaObserver();
 #if ENABLE(MODEL_ELEMENT)
     LazyLoadModelObserver& lazyLoadModelObserver();
 #endif
@@ -2347,7 +2349,7 @@ private:
     RefPtr<Element> m_titleElement;
 
     const std::unique_ptr<DocumentMarkerController> m_markers;
-    
+
     Timer m_styleRecalcTimer;
 
     std::unique_ptr<Style::Update> m_pendingRenderTreeUpdate;
@@ -2355,6 +2357,9 @@ private:
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_cssTarget;
 
     std::unique_ptr<LazyLoadImageObserver> m_lazyLoadImageObserver;
+
+    std::unique_ptr<LazyLoadMediaObserver> m_lazyLoadMediaObserver;
+
 #if ENABLE(MODEL_ELEMENT)
     std::unique_ptr<LazyLoadModelObserver> m_lazyLoadModelObserver;
 #endif
@@ -2471,7 +2476,7 @@ private:
     mutable std::unique_ptr<LargestContentfulPaintData> m_largestContentfulPaintData;
 
     RefPtr<MediaQueryMatcher> m_mediaQueryMatcher;
-    
+
 #if ENABLE(TOUCH_EVENTS)
     EventTargetSet m_touchEventTargets;
 #endif
@@ -2577,7 +2582,7 @@ private:
 
     RegistrableDomain m_registrableDomainRequestedPageSpecificStorageAccessWithUserInteraction { };
     String m_referrerOverride;
-    
+
     std::optional<FixedVector<CSSPropertyID>> m_exposedComputedCSSPropertyIDs;
 
     const RefPtr<PaintWorklet> m_paintWorklet;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -85,6 +85,7 @@
 #include "JSDOMPromiseDeferred.h"
 #include "JSHTMLMediaElement.h"
 #include "JSMediaControlsHost.h"
+#include "LazyLoadMediaObserver.h"
 #include "LoadableTextTrack.h"
 #include "LocalFrame.h"
 #include "LocalFrameLoaderClient.h"
@@ -612,6 +613,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_playing(false)
     , m_isWaitingUntilMediaCanStart(false)
     , m_shouldDelayLoadEvent(false)
+    , m_wasLazyLoaded(false)
     , m_haveFiredLoadedData(false)
     , m_inActiveDocument(true)
     , m_autoplaying(true)
@@ -948,6 +950,14 @@ void HTMLMediaElement::didMoveToNewDocument(Document& oldDocument, Document& new
     ALWAYS_LOG(LOGIDENTIFIER);
 
     ASSERT_WITH_SECURITY_IMPLICATION(&document() == &newDocument);
+
+    // Handle lazy loading observer transfer between documents
+    if (newDocument.settings().lazyMediaLoadingEnabled()) {
+        oldDocument.lazyLoadMediaObserver().unobserve(*this, oldDocument);
+        if (isLazyLoadable())
+            LazyLoadMediaObserver::observe(*this);
+    }
+
     if (m_shouldDelayLoadEvent) {
         oldDocument.decrementLoadEventDelayCount();
         newDocument.incrementLoadEventDelayCount();
@@ -1026,8 +1036,12 @@ void HTMLMediaElement::attributeChanged(const QualifiedName& name, const AtomStr
 
         // If a src attribute of a media element is set or changed, the user
         // agent must invoke the media element's media element load algorithm.
-        if (!newValue.isNull())
-            prepareForLoad();
+        if (!newValue.isNull()) {
+            if (isLazyLoadable() && document().settings().lazyMediaLoadingEnabled() && m_networkState == NETWORK_EMPTY)
+                LazyLoadMediaObserver::observe(*this);
+            else
+                prepareForLoad();
+        }
         return;
     case AttributeNames::controlsAttr:
         configureMediaControls();
@@ -1048,6 +1062,10 @@ void HTMLMediaElement::attributeChanged(const QualifiedName& name, const AtomStr
             m_preload = MediaPlayer::Preload::Auto;
         }
         maybeUpdatePlayerPreload();
+        return;
+    case AttributeNames::loadingAttr:
+        if (!hasLazyLoadableAttributeValue(newValue))
+            loadDeferredMedia();
         return;
     case AttributeNames::mediagroupAttr:
         setMediaGroup(newValue);
@@ -1122,8 +1140,18 @@ void HTMLMediaElement::didFinishInsertingNode()
 
     HTMLMEDIAELEMENT_RELEASE_LOG(DIDFINISHINSERTINGNODE);
 
-    if (m_inActiveDocument && m_networkState == NETWORK_EMPTY && !attributeWithoutSynchronization(srcAttr).isEmpty())
-        prepareForLoad();
+    if (m_inActiveDocument && m_networkState == NETWORK_EMPTY) {
+        if (!attributeWithoutSynchronization(srcAttr).isEmpty()) {
+            if (isLazyLoadable() && document().settings().lazyMediaLoadingEnabled())
+                LazyLoadMediaObserver::observe(*this);
+            else
+                prepareForLoad();
+        } else if (auto firstSource = childrenOfType<HTMLSourceElement>(*this).first()) {
+            // If there are source children, they will trigger sourceWasAdded() which handles lazy loading
+            // But if source children are already present when video is inserted, we need to check here 1
+            sourceWasAdded(*firstSource);
+        }
+    }
 
     visibilityAdjustmentStateDidChange();
 
@@ -1201,6 +1229,9 @@ void HTMLMediaElement::pauseAfterDetachedTask()
 void HTMLMediaElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     HTMLMEDIAELEMENT_RELEASE_LOG(REMOVEDFROMANCESTOR);
+
+    if (document().settings().lazyMediaLoadingEnabled())
+        document().lazyLoadMediaObserver().unobserve(*this, document());
 
     setInActiveDocument(false);
     if (removalType.disconnectedFromDocument) {
@@ -1490,6 +1521,43 @@ void HTMLMediaElement::load()
 
     prepareForLoad();
     queueCancellableTaskKeepingObjectAlive(*this, TaskSource::MediaElement, m_resourceSelectionTaskCancellationGroup, [](auto& element) { element.prepareToPlay(); });
+}
+
+bool HTMLMediaElement::hasLazyLoadableAttributeValue(StringView attributeValue)
+{
+    return equalLettersIgnoringASCIICase(attributeValue, "lazy"_s);
+}
+
+bool HTMLMediaElement::isLazyLoadable() const
+{
+    if (!document().frame() || !document().frame()->checkedScript()->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
+        return false;
+
+    if (document().paginated())
+        return false;
+    return hasLazyLoadableAttributeValue(attributeWithoutSynchronization(HTMLNames::loadingAttr));
+}
+
+void HTMLMediaElement::loadDeferredMedia()
+{
+    if (document().settings().lazyMediaLoadingEnabled())
+        document().lazyLoadMediaObserver().unobserve(*this, document());
+
+    // Load the media - load() will handle both src attribute and source children
+    if (networkState() == NETWORK_EMPTY) {
+        m_wasLazyLoaded = true;
+        load();
+    }
+}
+
+void HTMLMediaElement::resumeLazyLoadingIfNeeded()
+{
+    // Per HTML spec: user-initiated play() triggers lazy load resumption steps
+    if (document().settings().lazyMediaLoadingEnabled()) {
+        auto& observer = document().lazyLoadMediaObserver();
+        if (observer.isObserved(*this))
+            loadDeferredMedia();
+    }
 }
 
 void HTMLMediaElement::prepareForLoad()
@@ -4431,9 +4499,24 @@ void HTMLMediaElement::setPreload(const AtomString& preload)
     setAttributeWithoutSynchronization(preloadAttr, preload);
 }
 
+String HTMLMediaElement::loading() const
+{
+    auto& value = attributeWithoutSynchronization(HTMLNames::loadingAttr);
+    if (equalLettersIgnoringASCIICase(value, "lazy"_s))
+        return "lazy"_s;
+    return "eager"_s;
+}
+
+void HTMLMediaElement::setLoading(const AtomString& loading)
+{
+    setAttributeWithoutSynchronization(HTMLNames::loadingAttr, loading);
+}
+
 void HTMLMediaElement::play(DOMPromiseDeferred<void>&& promise)
 {
     HTMLMEDIAELEMENT_RELEASE_LOG(PLAY);
+
+    resumeLazyLoadingIfNeeded();
 
     Ref mediaSession = this->mediaSession();
     auto permitted = mediaSession->playbackStateChangePermitted(MediaPlaybackState::Playing);
@@ -4467,6 +4550,8 @@ void HTMLMediaElement::play(DOMPromiseDeferred<void>&& promise)
 void HTMLMediaElement::play()
 {
     HTMLMEDIAELEMENT_RELEASE_LOG(PLAY);
+
+    resumeLazyLoadingIfNeeded();
 
     auto permitted = protectedMediaSession()->playbackStateChangePermitted(MediaPlaybackState::Playing);
     if (!permitted) {
@@ -5807,6 +5892,10 @@ void HTMLMediaElement::sourceWasAdded(HTMLSourceElement& source)
     // the media element's resource selection algorithm.
     if (m_networkState == NETWORK_EMPTY) {
         m_nextChildNodeToConsider = source;
+        if (isLazyLoadable() && document().settings().lazyMediaLoadingEnabled()) {
+            LazyLoadMediaObserver::observe(*this);
+            return;
+        }
 #if PLATFORM(IOS_FAMILY)
         if (mediaSession().dataLoadingPermitted())
 #endif
@@ -7944,6 +8033,11 @@ bool HTMLMediaElement::isURLAttribute(const Attribute& attribute) const
 
 void HTMLMediaElement::setShouldDelayLoadEvent(bool shouldDelay)
 {
+    // Per HTML spec: lazy-loaded media that has been resumed must not delay
+    // the document's load event.
+    if (shouldDelay && m_wasLazyLoaded)
+        return;
+
     if (m_shouldDelayLoadEvent == shouldDelay)
         return;
 

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -240,9 +240,9 @@ public:
     void scheduleNotifyAboutPlaying();
     void notifyAboutPlaying(PlayPromiseVector&&);
     void durationChanged();
-    
+
     MediaPlayer::MovieLoadType movieLoadType() const;
-    
+
     bool inActiveDocument() const { return m_inActiveDocument; }
 
     std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final;
@@ -270,6 +270,14 @@ public:
     Ref<TimeRanges> buffered() const override;
     WEBCORE_EXPORT void load();
     WEBCORE_EXPORT String canPlayType(const String& mimeType) const;
+
+// lazy loading
+    String loading() const;
+    void setLoading(const AtomString&);
+    bool isLazyLoadable() const;
+    static bool hasLazyLoadableAttributeValue(StringView);
+    virtual void loadDeferredMedia();
+    void resumeLazyLoadingIfNeeded();
 
 // ready state
     using HTMLMediaElementEnums::ReadyState;
@@ -512,7 +520,7 @@ public:
 
     bool didPassCORSAccessCheck() const { return m_player && protectedPlayer()->didPassCORSAccessCheck(); }
     bool taintsOrigin(const SecurityOrigin&) const;
-    
+
     WEBCORE_EXPORT bool isFullscreen() const override;
     bool isInFullscreenOrPictureInPicture() const;
     bool isStandardFullscreen() const;
@@ -821,7 +829,7 @@ private:
     void didFinishInsertingNode() override;
     void removedFromAncestor(RemovalType, ContainerNode&) override;
     void didRecalcStyle(OptionSet<Style::Change>) override;
-    bool canStartSelection() const override { return false; } 
+    bool canStartSelection() const override { return false; }
     bool isInteractiveContent() const override;
 
     void willStopBeingFullscreenElement() override;
@@ -833,7 +841,7 @@ private:
 
     void stopWithoutDestroyingMediaPlayer();
     void contextDestroyed() override;
-    
+
     void setReadyState(MediaPlayer::ReadyState);
     void setNetworkState(MediaPlayer::NetworkState);
 
@@ -941,7 +949,7 @@ private:
     void finishSeek();
     void clearSeeking();
     void addPlayedRange(const MediaTime& start, const MediaTime& end);
-    
+
     void scheduleTimeupdateEvent(bool periodicEvent);
     virtual void scheduleResizeEvent(const FloatSize&) { }
     virtual void scheduleResizeEventIfSizeChanged(const FloatSize&) { }
@@ -1233,7 +1241,7 @@ private:
     double m_volume { 1 };
     bool m_volumeInitialized { false };
     MediaTime m_lastSeekTime;
-    
+
     MonotonicTime m_previousProgressTime { MonotonicTime::infinity() };
     double m_playbackStartedTime { 0 };
 
@@ -1242,7 +1250,7 @@ private:
 
     // The last time a timeupdate event was sent in movie time.
     MediaTime m_lastTimeUpdateEventMovieTime;
-    
+
     // Loading state.
     enum LoadState { WaitingForSource, LoadingFromSrcAttr, LoadingFromSourceElement };
     LoadState m_loadState { WaitingForSource };
@@ -1302,6 +1310,7 @@ private:
     bool m_playing : 1;
     bool m_isWaitingUntilMediaCanStart : 1;
     bool m_shouldDelayLoadEvent : 1;
+    bool m_wasLazyLoaded : 1;
     bool m_haveFiredLoadedData : 1;
     bool m_inActiveDocument : 1;
     bool m_autoplaying : 1;

--- a/Source/WebCore/html/HTMLMediaElement.idl
+++ b/Source/WebCore/html/HTMLMediaElement.idl
@@ -62,6 +62,7 @@ typedef (
     const unsigned short NETWORK_NO_SOURCE = 3;
     readonly attribute unsigned short networkState;
     [CEReactions=NotNeeded] attribute [AtomString] DOMString preload;
+    [CEReactions=NotNeeded, EnabledBySetting=LazyMediaLoadingEnabled] attribute [AtomString] DOMString loading;
 
     readonly attribute TimeRanges buffered;
     undefined load();

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -39,6 +39,7 @@
 #include "HTMLNames.h"
 #include "ImageBuffer.h"
 #include "JSDOMPromiseDeferred.h"
+#include "LazyLoadMediaObserver.h"
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "Logging.h"
@@ -117,7 +118,7 @@ Ref<HTMLVideoElement> HTMLVideoElement::create(Document& document)
 
 bool HTMLVideoElement::rendererIsNeeded(const RenderStyle& style)
 {
-    return HTMLElement::rendererIsNeeded(style); 
+    return HTMLElement::rendererIsNeeded(style);
 }
 
 RenderPtr<RenderElement> HTMLVideoElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
@@ -234,7 +235,7 @@ bool HTMLVideoElement::supportsFullscreen(HTMLMediaElementEnums::VideoFullscreen
 {
     if (!player())
         return false;
-    
+
     if (videoFullscreenMode == HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) {
         if (!mediaSession().allowsPictureInPicture())
             return false;
@@ -243,7 +244,7 @@ bool HTMLVideoElement::supportsFullscreen(HTMLMediaElementEnums::VideoFullscreen
     }
 
     RefPtr page = document().page();
-    if (!page) 
+    if (!page)
         return false;
 
     if (!player()->supportsFullscreen())
@@ -395,7 +396,7 @@ bool HTMLVideoElement::hasAvailableVideoFrame() const
 {
     if (!player())
         return false;
-    
+
     return player()->hasVideo() && player()->hasAvailableVideoFrame();
 }
 
@@ -437,7 +438,7 @@ ExceptionOr<void> HTMLVideoElement::webkitEnterFullscreen()
     if (isFullscreen())
         return { };
 
-    // Generate an exception if this isn't called in response to a user gesture, or if the 
+    // Generate an exception if this isn't called in response to a user gesture, or if the
     // element does not support fullscreen, or the element is changing fullscreen mode.
     if (!mediaSession().fullscreenPermitted() || !supportsFullscreen(HTMLMediaElementEnums::VideoFullscreenModeStandard) || isChangingVideoFullscreenMode())
         return Exception { ExceptionCode::InvalidStateError };
@@ -861,6 +862,25 @@ ExceptionOr<void> HTMLVideoElement::enterFullscreenIgnoringPermissionsPolicy()
 {
     ignoreFullscreenPermissionPolicyOnNextCallToEnterFullscreen();
     return webkitEnterFullscreen();
+}
+
+void HTMLVideoElement::loadDeferredMedia()
+{
+    // Handle video-specific poster image loading
+    if (shouldDisplayPosterImage()) {
+        if (!m_imageLoader)
+            lazyInitialize(m_imageLoader, makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this));
+        // Load the poster image if it was deferred
+        if (m_imageLoader->isDeferred())
+            m_imageLoader->loadDeferredImage();
+        else
+            m_imageLoader->updateFromElement();
+        if (CheckedPtr renderer = this->renderer())
+            renderer->checkedImageResource()->setCachedImage(protect(m_imageLoader->image()));
+    }
+
+    // Call base class to handle media loading
+    HTMLMediaElement::loadDeferredMedia();
 }
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -136,6 +136,8 @@ public:
 
     WEBCORE_EXPORT void setVideoFullscreenStandby(bool);
 
+    void loadDeferredMedia() override;
+
 #if USE(GSTREAMER)
     void enableGStreamerHolePunching() { m_enableGStreamerHolePunching = true; }
     bool isGStreamerHolePunchingEnabled() const final { return m_enableGStreamerHolePunching; }

--- a/Source/WebCore/html/LazyLoadMediaObserver.cpp
+++ b/Source/WebCore/html/LazyLoadMediaObserver.cpp
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ * Copyright (C) 2026 Squarespace, Inc. www.squarespace.com
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "LazyLoadMediaObserver.h"
+
+#include "HTMLMediaElement.h"
+#include "IntersectionObserverCallback.h"
+#include "IntersectionObserverEntry.h"
+#include "LocalFrame.h"
+#include "NodeDocument.h"
+#include <limits>
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(LazyLoadMediaObserver);
+
+class LazyMediaLoadIntersectionObserverCallback final : public IntersectionObserverCallback {
+public:
+    static Ref<LazyMediaLoadIntersectionObserverCallback> create(Document& document)
+    {
+        return adoptRef(*new LazyMediaLoadIntersectionObserverCallback(document));
+    }
+
+private:
+    LazyMediaLoadIntersectionObserverCallback(Document& document)
+        : IntersectionObserverCallback(&document)
+    {
+    }
+
+    bool hasCallback() const final { return true; }
+
+    CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
+    {
+        ASSERT(!entries.isEmpty());
+
+        for (auto& entry : entries) {
+            if (!entry->isIntersecting())
+                continue;
+            if (RefPtr element = dynamicDowncast<HTMLMediaElement>(entry->target()))
+                element->loadDeferredMedia();
+        }
+        return { };
+    }
+
+    CallbackResult<void> invokeRethrowingException(IntersectionObserver& thisObserver, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver& observer) final
+    {
+        return invoke(thisObserver, entries, observer);
+    }
+};
+
+void LazyLoadMediaObserver::observe(Element& element)
+{
+    auto& observer = element.document().lazyLoadMediaObserver();
+    auto* intersectionObserver = observer.intersectionObserver(protect(element.document()));
+    if (!intersectionObserver)
+        return;
+    intersectionObserver->observe(element);
+}
+
+void LazyLoadMediaObserver::unobserve(Element& element, Document& document)
+{
+    if (auto& observer = document.lazyLoadMediaObserver().m_observer)
+        observer->unobserve(element);
+}
+
+IntersectionObserver* LazyLoadMediaObserver::intersectionObserver(Document& document)
+{
+    if (!m_observer) {
+        auto callback = LazyMediaLoadIntersectionObserverCallback::create(document);
+        static NeverDestroyed<const String> lazyLoadingScrollMarginFallback(MAKE_STATIC_STRING_IMPL("100%"));
+        IntersectionObserver::Init options { std::nullopt, { }, lazyLoadingScrollMarginFallback, { } };
+        auto observer = IntersectionObserver::create(document, WTF::move(callback), WTF::move(options));
+        if (observer.hasException())
+            return nullptr;
+        m_observer = observer.returnValue().ptr();
+    }
+    return m_observer.get();
+}
+
+bool LazyLoadMediaObserver::isObserved(Element& element) const
+{
+    return m_observer && m_observer->isObserving(element);
+}
+
+}

--- a/Source/WebCore/html/LazyLoadMediaObserver.h
+++ b/Source/WebCore/html/LazyLoadMediaObserver.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2020 Igalia S.L.
+ * Copyright (C) 2026 Squarespace, Inc. www.squarespace.com
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "IntersectionObserver.h"
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class Document;
+class Element;
+
+class LazyLoadMediaObserver {
+    WTF_MAKE_TZONE_ALLOCATED(LazyLoadMediaObserver);
+public:
+    static void observe(Element&);
+    static void unobserve(Element&, Document&);
+
+    bool isObserved(Element&) const;
+
+private:
+    IntersectionObserver* intersectionObserver(Document&);
+
+    RefPtr<IntersectionObserver> m_observer;
+};
+
+} // namespace

--- a/Source/WebCore/html/parser/HTMLParserOptions.cpp
+++ b/Source/WebCore/html/parser/HTMLParserOptions.cpp
@@ -27,6 +27,7 @@
 #include "HTMLParserOptions.h"
 
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "LocalFrame.h"
 #include "ScriptController.h"
 #include "Settings.h"

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -340,6 +340,12 @@ private:
                 m_metaIsDisabledAdaptations = equalLettersIgnoringASCIICase(attributeValue, "disabled-adaptations"_s);
             break;
         case TagId::Video:
+            if (document->settings().lazyMediaLoadingEnabled()) {
+                if (match(attributeName, loadingAttr) && m_lazyloadAttribute.isNull()) {
+                    m_lazyloadAttribute = attributeValue.toString();
+                    break;
+                }
+            }
             processVideoAttribute(attributeName, attributeValue);
             break;
         case TagId::Base:

--- a/Source/WebCore/html/shadow/DataListButtonElement.cpp
+++ b/Source/WebCore/html/shadow/DataListButtonElement.cpp
@@ -30,6 +30,7 @@
 #include "EventNames.h"
 #include "HTMLNames.h"
 #include "MouseEvent.h"
+#include "RenderStyle+GettersInlines.h"
 #include "StyleAppearance.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -29,6 +29,7 @@
 
 #include "Chrome.h"
 #include "ContainerNodeInlines.h"
+#include "DocumentPage.h"
 #include "EventHandler.h"
 #include "EventNames.h"
 #include "FrameDestructionObserverInlines.h"
@@ -238,7 +239,7 @@ void SpinButtonElement::step(int amount)
 #endif
     doStepAction(amount);
 }
-    
+
 void SpinButtonElement::repeatingTimerFired()
 {
     if (m_upDownState != Indeterminate)

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -64,6 +64,8 @@
 #include <wtf/text/TextStream.h>
 
 #if ENABLE(VIDEO)
+#include "HTMLMediaElement.h"
+#include "LazyLoadMediaObserver.h"
 #include "RenderVideo.h"
 #endif
 
@@ -281,11 +283,21 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
 #if !LOG_DISABLED
             auto oldState = m_lazyImageLoadState;
 #endif
-            if (m_lazyImageLoadState == LazyImageLoadState::None && imageElement) {
-                if (imageElement->isLazyLoadable() && document->settings().lazyImageLoadingEnabled() && !canReuseFromListOfAvailableImages(request, document)) {
-                    m_lazyImageLoadState = LazyImageLoadState::Deferred;
-                    request.setIgnoreForRequestCount(true);
+            if (m_lazyImageLoadState == LazyImageLoadState::None) {
+                if (imageElement) {
+                    if (imageElement->isLazyLoadable() && document->settings().lazyImageLoadingEnabled() && !canReuseFromListOfAvailableImages(request, document)) {
+                        m_lazyImageLoadState = LazyImageLoadState::Deferred;
+                        request.setIgnoreForRequestCount(true);
+                    }
                 }
+#if ENABLE(VIDEO)
+                else if (RefPtr mediaElement = dynamicDowncast<HTMLMediaElement>(element)) {
+                    if (mediaElement->isLazyLoadable() && document->settings().lazyMediaLoadingEnabled() && !canReuseFromListOfAvailableImages(request, document)) {
+                        m_lazyImageLoadState = LazyImageLoadState::Deferred;
+                        request.setIgnoreForRequestCount(true);
+                    }
+                }
+#endif
             }
             auto imageLoading = (m_lazyImageLoadState == LazyImageLoadState::Deferred) ? ImageLoading::DeferredUntilVisible : ImageLoading::Immediate;
             newImage = protect(document->cachedResourceLoader())->requestImage(WTF::move(request), imageLoading).value_or(nullptr);
@@ -365,8 +377,14 @@ void ImageLoader::didUpdateCachedImage(RelevantMutation relevantMutation, Cached
             else
                 updateRenderer();
 
-            if (m_lazyImageLoadState == LazyImageLoadState::Deferred)
-                LazyLoadImageObserver::observe(protect(element()));
+            if (m_lazyImageLoadState == LazyImageLoadState::Deferred) {
+#if ENABLE(VIDEO)
+                if (is<HTMLMediaElement>(element()))
+                    LazyLoadMediaObserver::observe(protect(element()));
+                else
+#endif
+                    LazyLoadImageObserver::observe(protect(element()));
+                }
 
             // If newImage is cached, addClient() will result in the load event
             // being queued to fire.
@@ -467,7 +485,7 @@ void ImageLoader::notifyFinished(CachedResource& resource, const NetworkLoadMetr
 
         if (hasPendingDecodePromises())
             rejectDecodePromises("Access control error."_s);
-        
+
         ASSERT(!m_hasPendingLoadEvent);
 
         // Only consider updating the protection ref-count of the Element immediately before returning
@@ -577,7 +595,7 @@ void ImageLoader::updatedHasPendingEvent()
     } else {
         ASSERT(!m_derefElementTimer.isActive());
         m_derefElementTimer.startOneShot(0_s);
-    }   
+    }
 }
 
 void ImageLoader::decode(Ref<DeferredPromise>&& promise)
@@ -602,7 +620,7 @@ void ImageLoader::decode(Ref<DeferredPromise>&& promise)
 void ImageLoader::decode()
 {
     ASSERT(hasPendingDecodePromises());
-    
+
     if (!element().document().window()) {
         rejectDecodePromises("Inactive document."_s);
         return;


### PR DESCRIPTION
#### 61d77769a90046b47639c446404f4aab70fb14df
<pre>
Implement HTML video and audio element lazy-loading via the loading attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=303995">https://bugs.webkit.org/show_bug.cgi?id=303995</a>

Reviewed by NOBODY (OOPS!).

Implement proposed loading attribute for video and audio elements.
This patch implements a proposed loading attribute for video and audio elements, enabling lazy loading of media sources and video poster images, and deferring autoplay.

This change is proposed to be added to the HTML spec in the following PR:
<a href="https://github.com/whatwg/html/pull/11980">https://github.com/whatwg/html/pull/11980</a>

This patch is passing video and audio WPT tests from the following PR:
<a href="https://github.com/web-platform-tests/wpt/pull/57051">https://github.com/web-platform-tests/wpt/pull/57051</a>

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::lazyLoadMediaObserver):
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::didMoveToNewDocument):
(WebCore::HTMLMediaElement::attributeChanged):
(WebCore::HTMLMediaElement::didFinishInsertingNode):
(WebCore::HTMLMediaElement::removedFromAncestor):
(WebCore::HTMLMediaElement::hasLazyLoadableAttributeValue):
(WebCore::HTMLMediaElement::isLazyLoadable const):
(WebCore::HTMLMediaElement::loadDeferredMedia):
(WebCore::HTMLMediaElement::resumeLazyLoadingIfNeeded):
(WebCore::HTMLMediaElement::loading const):
(WebCore::HTMLMediaElement::setLoading):
(WebCore::HTMLMediaElement::play):
(WebCore::HTMLMediaElement::sourceWasAdded):
(WebCore::HTMLMediaElement::setShouldDelayLoadEvent):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMediaElement.idl:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::HTMLVideoElement::rendererIsNeeded):
(WebCore::HTMLVideoElement::supportsFullscreen const):
(WebCore::HTMLVideoElement::hasAvailableVideoFrame const):
(WebCore::HTMLVideoElement::webkitEnterFullscreen):
(WebCore::HTMLVideoElement::loadDeferredMedia):
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/html/LazyLoadMediaObserver.cpp: Added.
(WebCore::LazyLoadMediaObserver::observe):
(WebCore::LazyLoadMediaObserver::unobserve):
(WebCore::LazyLoadMediaObserver::intersectionObserver):
(WebCore::LazyLoadMediaObserver::isObserved const):
* Source/WebCore/html/LazyLoadMediaObserver.h: Added.
* Source/WebCore/html/parser/HTMLParserOptions.cpp:
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
* Source/WebCore/html/shadow/DataListButtonElement.cpp:
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::ImageLoader::updateFromElement):
(WebCore::ImageLoader::didUpdateCachedImage):
(WebCore::ImageLoader::notifyFinished):
(WebCore::ImageLoader::updatedHasPendingEvent):
(WebCore::ImageLoader::decode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59d3992f5c7e7e32b122c56db061c0b22135aeb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143355 "Failed to checkout and rebase branch from PR 58208") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15830 "Failed to checkout and rebase branch from PR 58208") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7425 "Failed to checkout and rebase branch from PR 58208") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/152031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145222 "Failed to checkout and rebase branch from PR 58208") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16490 "Failed to checkout and rebase branch from PR 58208") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15911 "Failed to checkout and rebase branch from PR 58208") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/152031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [❌ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146304 "Failed to checkout and rebase branch from PR 58208") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/16490 "Failed to checkout and rebase branch from PR 58208") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/127912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/152031 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/16490 "Failed to checkout and rebase branch from PR 58208") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe-libwebrtc~~](https://ews-build.webkit.org/#/builders/172/builds/2029 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135354 "Failed to checkout and rebase branch from PR 58208") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/16490 "Failed to checkout and rebase branch from PR 58208") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/4449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/154342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4167 "Failed to checkout and rebase branch from PR 58208") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15874 "Failed to checkout and rebase branch from PR 58208") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/5094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/154342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15911 "Failed to checkout and rebase branch from PR 58208") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/13073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/154342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/125275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15499 "Failed to checkout and rebase branch from PR 58208") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/4167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/174652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15233 "Failed to checkout and rebase branch from PR 58208") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79219 "Failed to checkout and rebase branch from PR 58208") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/174652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15444 "Failed to checkout and rebase branch from PR 58208") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15295 "Failed to checkout and rebase branch from PR 58208") | | | 
<!--EWS-Status-Bubble-End-->