### PR TITLE
Improve performance of HTMLSelectElement::selectOption

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-expected.txt
@@ -5,9 +5,9 @@
 
 
     two
-  two
+  two  two
 
 FAIL The <selectedcontent> element should reflect the HTML contents of the selected <option>. assert_equals: The innerHTML of <selectedcontent> should be updated in response to a form reset. expected "\n      <span class=\"one\">span</span> one\n    " but got "\n      <span class=\"two\" data-foo=\"bar\">new span</span> two\n    "
 FAIL When there are multiple <selectedcontent> elements, only the one in tree order should be kept up to date. assert_equals: Second selectedcontent should not be kept up to date. expected "" but got "two"
-FAIL <seletedcontent> behavior in disconnected <select>. assert_equals: <selectedcontent> should not be updated when changing value of a disconnected select. expected "" but got "two"
+PASS <seletedcontent> behavior in disconnected <select>.
 

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -174,7 +174,10 @@ public:
 
     bool isDevolvableWidget() const override { return true; }
 
-    void updateSelectedContent() const;
+    void updateSelectedContent(HTMLOptionElement* = nullptr) const;
+
+    void registerSelectedContentElement();
+    void unregisterSelectedContentElement();
 
 protected:
     HTMLSelectElement(const QualifiedName&, Document&, HTMLFormElement*);
@@ -242,7 +245,7 @@ private:
     bool platformHandleKeydownEvent(KeyboardEvent*);
     void listBoxDefaultEventHandler(Event&);
     void setOptionsChangedOnRenderer();
-    void updateButtonText();
+    void updateButtonText(HTMLOptionElement* = nullptr, int optionIndex = -1);
     size_t searchOptionsForValue(const String&, size_t listIndexStart, size_t listIndexEnd) const;
 
     enum class SkipDirection : bool { Backwards, Forwards };
@@ -278,6 +281,7 @@ private:
     bool m_activeSelectionState;
     bool m_allowsNonContiguousSelection;
     mutable bool m_shouldRecalcListItems;
+    unsigned m_selectedContentDescendantCount { 0 };
 
     std::optional<int> m_lastActiveIndex;
 

--- a/Source/WebCore/html/HTMLSelectedContentElement.cpp
+++ b/Source/WebCore/html/HTMLSelectedContentElement.cpp
@@ -83,7 +83,24 @@ void HTMLSelectedContentElement::didFinishInsertingNode()
     }
     if (m_isDisabled || !nearestAncestorSelect || nearestAncestorSelect->multiple())
         return;
+
+    if (m_owningSelect != nearestAncestorSelect) {
+        if (RefPtr oldSelect = m_owningSelect)
+            oldSelect->unregisterSelectedContentElement();
+        m_owningSelect = nearestAncestorSelect;
+        nearestAncestorSelect->registerSelectedContentElement();
+    }
     nearestAncestorSelect->updateSelectedContent();
+}
+
+void HTMLSelectedContentElement::removedFromAncestor(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
+{
+    HTMLElement::removedFromAncestor(removalType, oldParentOfRemovedTree);
+
+    if (RefPtr select = m_owningSelect; select && !isInclusiveDescendantOf(*select)) {
+        select->unregisterSelectedContentElement();
+        m_owningSelect = nullptr;
+    }
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLSelectedContentElement.h
+++ b/Source/WebCore/html/HTMLSelectedContentElement.h
@@ -29,6 +29,8 @@
 
 namespace WebCore {
 
+class HTMLSelectElement;
+
 class HTMLSelectedContentElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLSelectedContentElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSelectedContentElement);
@@ -42,8 +44,10 @@ private:
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
+    void removedFromAncestor(RemovalType, ContainerNode&) final;
 
     bool m_isDisabled { false };
+    WeakPtr<HTMLSelectElement, WeakPtrImplWithEventTargetData> m_owningSelect;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
@@ -56,20 +56,12 @@ HTMLSelectElement& SelectFallbackButtonElement::selectElement() const
     return downcast<HTMLSelectElement>(*protect(containingShadowRoot())->host());
 }
 
-void SelectFallbackButtonElement::updateText()
+void SelectFallbackButtonElement::updateText(HTMLOptionElement* selectedOption, int optionIndex)
 {
     invalidateStyle();
     if (CheckedPtr buttonTextRenderer = dynamicDowncast<RenderSelectFallbackButton>(renderer()))
-        buttonTextRenderer->updateFromElement();
+        buttonTextRenderer->setTextFromOption(selectedOption, optionIndex);
 }
-
-#if !PLATFORM(COCOA)
-void SelectFallbackButtonElement::setTextFromOption(int optionIndex)
-{
-    if (CheckedPtr buttonTextRenderer = dynamicDowncast<RenderSelectFallbackButton>(renderer()))
-        buttonTextRenderer->setTextFromOption(optionIndex);
-}
-#endif
 
 std::optional<Style::UnadjustedStyle> SelectFallbackButtonElement::resolveCustomStyle(const Style::ResolutionContext& resolutionContext, const RenderStyle* hostStyle)
 {

--- a/Source/WebCore/html/shadow/SelectFallbackButtonElement.h
+++ b/Source/WebCore/html/shadow/SelectFallbackButtonElement.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+class HTMLOptionElement;
 class HTMLSelectElement;
 class RenderSelectFallbackButton;
 
@@ -40,10 +41,7 @@ public:
     static Ref<SelectFallbackButtonElement> create(Document&);
 
     HTMLSelectElement& selectElement() const;
-    void updateText();
-#if !PLATFORM(COCOA)
-    void setTextFromOption(int optionIndex);
-#endif
+    void updateText(HTMLOptionElement* = nullptr, int optionIndex = -1);
 
 private:
     explicit SelectFallbackButtonElement(Document&);

--- a/Source/WebCore/rendering/RenderSelectFallbackButton.cpp
+++ b/Source/WebCore/rendering/RenderSelectFallbackButton.cpp
@@ -76,17 +76,27 @@ static size_t selectedOptionCount(HTMLSelectElement& selectElement)
 
 void RenderSelectFallbackButton::updateFromElement()
 {
+    setTextFromOption(nullptr, -1);
+}
+
+void RenderSelectFallbackButton::setTextFromOption(HTMLOptionElement* selectedOption, int optionIndex)
+{
     Ref selectElement = protect(selectFallbackButtonElement())->selectElement();
-    int optionIndex = selectElement->selectedIndex();
 
-    const auto& listItems = selectElement->listItems();
-    int size = listItems.size();
+    if (optionIndex < 0)
+        optionIndex = selectElement->selectedIndex();
 
-    int i = selectElement->optionToListIndex(optionIndex);
     String text = emptyString();
-    if (i >= 0 && i < size) {
-        if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*listItems[i]))
-            text = option->textIndentedToRespectGroupLabel();
+    if (selectedOption)
+        text = selectedOption->textIndentedToRespectGroupLabel();
+    else {
+        auto& listItems = selectElement->listItems();
+        int size = listItems.size();
+        int i = selectElement->optionToListIndex(optionIndex);
+        if (i >= 0 && i < size) {
+            if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*listItems[i]))
+                text = option->textIndentedToRespectGroupLabel();
+        }
     }
 
 #if PLATFORM(IOS_FAMILY)
@@ -101,27 +111,6 @@ void RenderSelectFallbackButton::updateFromElement()
 
     selectElement->didUpdateActiveOption(optionIndex);
 }
-
-#if !PLATFORM(COCOA)
-void RenderSelectFallbackButton::setTextFromOption(int optionIndex)
-{
-    Ref selectElement = protect(selectFallbackButtonElement())->selectElement();
-
-    const auto& listItems = selectElement->listItems();
-    int size = listItems.size();
-
-    int i = selectElement->optionToListIndex(optionIndex);
-    String text = emptyString();
-    if (i >= 0 && i < size) {
-        if (RefPtr option = dynamicDowncast<HTMLOptionElement>(*listItems[i]))
-            text = option->textIndentedToRespectGroupLabel();
-    }
-
-    setText(text.trim(deprecatedIsSpaceOrNewline));
-
-    selectElement->didUpdateActiveOption(optionIndex);
-}
-#endif
 
 void RenderSelectFallbackButton::setText(const String& s)
 {

--- a/Source/WebCore/rendering/RenderSelectFallbackButton.h
+++ b/Source/WebCore/rendering/RenderSelectFallbackButton.h
@@ -30,6 +30,7 @@
 
 namespace WebCore {
 
+class HTMLOptionElement;
 class HTMLSelectElement;
 class RenderText;
 class SelectFallbackButtonElement;
@@ -50,13 +51,11 @@ public:
     void setDidBeginCheckedPtrDeletion() { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
     void setText(const String&);
-    void updateFromElement() final;
-#if !PLATFORM(COCOA)
-    void setTextFromOption(int optionIndex);
-#endif
+    void setTextFromOption(HTMLOptionElement*, int optionIndex);
 
 private:
     void insertedIntoTree() final;
+    void updateFromElement() final;
 
     ASCIILiteral renderName() const final { return "RenderSelectFallbackButton"_s; }
 


### PR DESCRIPTION
#### 5db5b209f44d2a5f7c58105d32b8db215e4b7603
<pre>
Improve performance of HTMLSelectElement::selectOption
<a href="https://bugs.webkit.org/show_bug.cgi?id=307346">https://bugs.webkit.org/show_bug.cgi?id=307346</a>

Reviewed by Ryosuke Niwa.

Avoid looking up the selected option element multiple times and also
avoid traversing descendants when there are no selectedcontent elements
to be found.

Canonical link: <a href="https://commits.webkit.org/307251@main">https://commits.webkit.org/307251@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d17e61732ffe1c9876be8563f8283bf0714d89f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143864 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152532 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02515717-e8d9-4b5c-bad7-c7ee900ccf0e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145739 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17022 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16433 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110624 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eb984e4a-98b8-4cf5-ac31-6c1338dbf109) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146827 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13054 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91542 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96f4f428-6ac4-48d9-8eb7-f4aba086b5be) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12518 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10251 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5893 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154844 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6938 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118636 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118990 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14912 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127104 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71806 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22185 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16014 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5580 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15748 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79785 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15960 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15813 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->