### PR TITLE
Extend Network Request blocking to all resource requests

### DIFF
--- a/Source/WebCore/page/ScriptTrackingPrivacyCategory.cpp
+++ b/Source/WebCore/page/ScriptTrackingPrivacyCategory.cpp
@@ -125,6 +125,8 @@ String makeLogMessage(const URL& url, ScriptTrackingPrivacyCategory category)
 {
     if (category == ScriptTrackingPrivacyCategory::Cookies)
         return makeString("Prevented "_s, url.string(), " from setting long-lived cookies"_s);
+    if (category == ScriptTrackingPrivacyCategory::NetworkRequests)
+        return makeString("Prevented "_s, url.string(), " from making network request"_s);
     return makeString("Prevented "_s, url.string(), " from accessing "_s, description(category));
 }
 


### PR DESCRIPTION
#### 48f07755b7159a336fdb4876c0c3392596d22084
<pre>
Extend Network Request blocking to all resource requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=307349">https://bugs.webkit.org/show_bug.cgi?id=307349</a>
<a href="https://rdar.apple.com/169976717">rdar://169976717</a>

Reviewed by Charlie Wolfe.

Following 305956@main, this patch includes blocking all resource requests when
the protection is enabled.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm

* Source/WebCore/loader/ResourceLoader.cpp:
(WebCore::ResourceLoader::willSendRequestInternal):
* Source/WebCore/page/ScriptTrackingPrivacyCategory.cpp:
(WebCore::makeLogMessage):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm:
(TestWebKitAPI::setUpWebViewForFingerprintingTests):
(TestWebKitAPI::getBundleResourceAsEncodedString):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ImgElementLoadBlocked)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ScriptElementLoadBlocked)):

Canonical link: <a href="https://commits.webkit.org/307220@main">https://commits.webkit.org/307220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c87c59224fb4771c64f75a8e8772f57da38d0f3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7461 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96623 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11a5279d-d5ab-4da2-9c5f-79c0cc6e1d2f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145261 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16525 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110492 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79475 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0afe2f71-688a-4c7d-a4e6-f954fcdeb4df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12742 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91410 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12232 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9943 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2054 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5397 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154366 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/15916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6432 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118291 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15947 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13416 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118632 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30472 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14596 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71330 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15529 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5230 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/15272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79250 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15484 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->