### PR TITLE
[GFC] Add usedMinimumSize to GridItemSizingFunctions

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -386,28 +386,28 @@ LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSi
     return endPosition - startPosition;
 }
 
-LayoutUnit inlineAxisMinContentContribution(const ElementBox& gridItem, const IntegrationUtils& integrationUtils)
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, const IntegrationUtils& integrationUtils)
 {
-    return integrationUtils.preferredMinWidth(gridItem);
+    return integrationUtils.preferredMinWidth(gridItem.layoutBox());
 }
 
-LayoutUnit inlineAxisMaxContentContribution(const ElementBox& gridItem, const IntegrationUtils& integrationUtils)
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, const IntegrationUtils& integrationUtils)
 {
-    return integrationUtils.preferredMaxWidth(gridItem);
+    return integrationUtils.preferredMaxWidth(gridItem.layoutBox());
 }
 
 GridItemSizingFunctions inlineAxisGridItemSizingFunctions()
 {
-    return { inlineAxisMinContentContribution, inlineAxisMaxContentContribution };
+    return { inlineAxisMinContentContribution, inlineAxisMaxContentContribution, usedInlineMinimumSize };
 }
 
-LayoutUnit blockAxisMinContentContribution(const ElementBox&, const IntegrationUtils&)
+LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, const IntegrationUtils&)
 {
     ASSERT_NOT_IMPLEMENTED_YET();
     return { };
 }
 
-LayoutUnit blockAxisMaxContentContribution(const ElementBox&, const IntegrationUtils&)
+LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, const IntegrationUtils&)
 {
     ASSERT_NOT_IMPLEMENTED_YET();
     return { };
@@ -415,7 +415,7 @@ LayoutUnit blockAxisMaxContentContribution(const ElementBox&, const IntegrationU
 
 GridItemSizingFunctions blockAxisGridItemSizingFunctions()
 {
-    return { blockAxisMinContentContribution, blockAxisMaxContentContribution };
+    return { blockAxisMinContentContribution, blockAxisMaxContentContribution, usedBlockMinimumSize };
 }
 
 bool preferredSizeBehavesAsAuto(const Style::PreferredSize& preferredSize)

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -47,12 +47,12 @@ LayoutUnit usedBlockMinimumSize(const PlacedGridItem&, const TrackSizingFunction
 LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);
 LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSizes&, LayoutUnit gap);
 
-LayoutUnit inlineAxisMinContentContribution(const ElementBox& gridItem, const IntegrationUtils&);
-LayoutUnit inlineAxisMaxContentContribution(const ElementBox& gridItem, const IntegrationUtils&);
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, const IntegrationUtils&);
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, const IntegrationUtils&);
 GridItemSizingFunctions inlineAxisGridItemSizingFunctions();
 
-LayoutUnit blockAxisMinContentContribution(const ElementBox& gridItem, const IntegrationUtils&);
-LayoutUnit blockAxisMaxContentContribution(const ElementBox& gridItem, const IntegrationUtils&);
+LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, const IntegrationUtils&);
+LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, const IntegrationUtils&);
 GridItemSizingFunctions blockAxisGridItemSizingFunctions();
 
 bool preferredSizeBehavesAsAuto(const Style::PreferredSize&);

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -154,7 +154,7 @@ static Vector<LayoutUnit> minContentContributions(const PlacedGridItems& gridIte
     const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     return gridItemIndexes.map([&](size_t gridItemIndex) {
-        return gridItemSizingFunctions.minContentContribution(gridItems[gridItemIndex].layoutBox(), integrationUtils);
+        return gridItemSizingFunctions.minContentContribution(gridItems[gridItemIndex], integrationUtils);
     });
 }
 
@@ -162,7 +162,7 @@ static Vector<LayoutUnit> maxContentContributions(const PlacedGridItems& gridIte
     const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     return gridItemIndexes.map([&](size_t gridItemIndex) {
-        return gridItemSizingFunctions.maxContentContribution(gridItems[gridItemIndex].layoutBox(), integrationUtils);
+        return gridItemSizingFunctions.maxContentContribution(gridItems[gridItemIndex], integrationUtils);
     });
 }
 
@@ -180,7 +180,7 @@ static Vector<LayoutUnit> minimumContributions(const PlacedGridItems& gridItems,
             return { };
         }
         // else the item’s minimum contribution is its min-content contribution.
-        return gridItemSizingFunctions.minContentContribution(gridItems[gridItemIndex].layoutBox(), integrationUtils);
+        return gridItemSizingFunctions.minContentContribution(gridItems[gridItemIndex], integrationUtils);
     });
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -36,14 +36,17 @@ namespace Layout {
 class IntegrationUtils;
 
 struct GridItemSizingFunctions {
-    GridItemSizingFunctions(Function<LayoutUnit(const ElementBox& gridItem, const IntegrationUtils&)> minContentContributionFunction, Function<LayoutUnit(const ElementBox& gridItem, const IntegrationUtils&)> maxContentContributionFunction)
-        : minContentContribution(WTF::move(minContentContributionFunction))
-        , maxContentContribution(WTF::move(maxContentContributionFunction))
+    GridItemSizingFunctions(Function<LayoutUnit(const PlacedGridItem&, const IntegrationUtils&)> minContentContributionFunction, Function<LayoutUnit(const PlacedGridItem&, const IntegrationUtils&)> maxContentContributionFunction,
+        Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit availableSpace, const IntegrationUtils&)> usedMinimumSizeFunction)
+            : minContentContribution(WTF::move(minContentContributionFunction))
+            , maxContentContribution(WTF::move(maxContentContributionFunction))
+            , usedMinimumSize(WTF::move(usedMinimumSizeFunction))
     {
     }
 
-    Function<LayoutUnit(const ElementBox& gridItem, const IntegrationUtils&)> minContentContribution;
-    Function<LayoutUnit(const ElementBox& gridItem, const IntegrationUtils&)> maxContentContribution;
+    Function<LayoutUnit(const PlacedGridItem&, const IntegrationUtils&)> minContentContribution;
+    Function<LayoutUnit(const PlacedGridItem&, const IntegrationUtils&)> maxContentContribution;
+    Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit availableSpace, const IntegrationUtils&)> usedMinimumSize;
 };
 
 class TrackSizingAlgorithm {


### PR DESCRIPTION
#### 90852035440508eda5553c97e9a043ebc3701a27
<pre>
[GFC] Add usedMinimumSize to GridItemSizingFunctions
<a href="https://bugs.webkit.org/show_bug.cgi?id=307352">https://bugs.webkit.org/show_bug.cgi?id=307352</a>
<a href="https://rdar.apple.com/169977825">rdar://169977825</a>

Reviewed by Brandon Stewart.

During the track sizing algorithm, we may need to ask a grid item for
its used minimum size:
<a href="https://drafts.csswg.org/css-grid-1/#algo-single-span-items">https://drafts.csswg.org/css-grid-1/#algo-single-span-items</a>

This is similar to how it may need to know its min/max contributions,
which we represent via an API in GridItemSizingFunctions. Let&apos;s add
this API to GridItemSizingFunctions also so that we can use it in
the future during the track sizing algorithm. We already have an
implementation for these functions in the form of
used{Inline,Block}MinimumSize, but we need to get some extra information
into the track sizing algorithm before we can actually use them.

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::inlineAxisMinContentContribution):
(WebCore::Layout::GridLayoutUtils::inlineAxisMaxContentContribution):
(WebCore::Layout::GridLayoutUtils::blockAxisMinContentContribution):
(WebCore::Layout::GridLayoutUtils::blockAxisMaxContentContribution):
The used minimum size functions need access to the PlacedGridItem
because it will need access to data we have on it when determining the
minimum size. We change the min/max contribution functions to just take
a PlacedGridItem as well so the API matches. This is just a mechanical
change that changes the signature of these functions and passes in the
PassedGridItem instead of the layout box at the call sites.

Canonical link: <a href="https://commits.webkit.org/307110@main">https://commits.webkit.org/307110@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd1db1dccd66884b4c83ef155426dc18ac998221

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15918 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152102 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16006 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110304 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/75c542f4-09bb-4d45-979a-b925088029e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146400 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/12769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/128928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91216 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79b67758-ab63-4b3b-a967-54894c8c42d0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/9973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2104 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5432 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154414 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/15965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6468 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118320 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16001 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/13463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118662 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30399 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/14626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126631 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71379 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15586 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5257 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/15321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79300 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15385 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->