### PR TITLE
Port IndexedDB Memory Backing Store to SQLite In-Memory Database

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3843,6 +3843,21 @@ IndexedDBAPIEnabled:
   sharedPreferenceForWebProcess: true
   richJavaScript: true
 
+IndexedDBSQLiteMemoryBackingStoreEnabled:
+  type: bool
+  status: stable
+  category: dom
+  humanReadableName: "IndexedDB SQLite Memory Backing Store"
+  humanReadableDescription: "Use SQLite in-memory database for ephemeral IndexedDB instead of MemoryIDBBackingStore"
+  defaultValue:
+    WebKitLegacy:
+      default: true
+    WebKit:
+      default: true
+    WebCore:
+      default: true
+  sharedPreferenceForWebProcess: true
+
 InlineMediaPlaybackRequiresPlaysInlineAttribute:
   type: bool
   status: embedder

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -533,6 +533,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/indexeddb/server/MemoryBackingStoreTransaction.h
     Modules/indexeddb/server/MemoryIDBBackingStore.h
     Modules/indexeddb/server/SQLiteIDBBackingStore.h
+    Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.h
     Modules/indexeddb/server/SQLiteIDBTransaction.h
     Modules/indexeddb/server/ServerOpenDBRequest.h
     Modules/indexeddb/server/UniqueIDBDatabase.h

--- a/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/IDBServer.cpp
@@ -32,6 +32,7 @@
 #include "MemoryIDBBackingStore.h"
 #include "SQLiteFileSystem.h"
 #include "SQLiteIDBBackingStore.h"
+#include "SQLiteMemoryIDBBackingStore.h"
 #include "SecurityOrigin.h"
 #include <algorithm>
 #include <wtf/CompletionHandler.h>

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -2770,6 +2770,16 @@ void SQLiteIDBBackingStore::closeSQLiteDB()
     m_sqliteDB = nullptr;
 }
 
+void SQLiteIDBBackingStore::setSqliteDB(std::unique_ptr<SQLiteDatabase>&& db)
+{
+    m_sqliteDB = WTF::move(db);
+}
+
+void SQLiteIDBBackingStore::setDatabaseInfo(std::unique_ptr<IDBDatabaseInfo>&& info)
+{
+    m_databaseInfo = WTF::move(info);
+}
+
 bool SQLiteIDBBackingStore::hasTransaction(const IDBResourceIdentifier& transactionIdentifier) const
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp
@@ -63,7 +63,7 @@ IDBError SQLiteIDBTransaction::begin(SQLiteDatabase& database)
         return IDBError { };
     }
 
-    m_sqliteTransaction = makeUnique<SQLiteTransaction>(database, true);
+    m_sqliteTransaction = makeUnique<SQLiteTransaction>(database, false);
     m_sqliteTransaction->begin();
 
     if (m_sqliteTransaction->inProgress())

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SQLiteMemoryIDBBackingStore.h"
+
+#include "IDBDatabaseInfo.h"
+#include "IDBKeyData.h"
+#include "IDBSerialization.h"
+#include "Logging.h"
+#include "SQLiteDatabase.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+namespace IDBServer {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SQLiteMemoryIDBBackingStore);
+
+SQLiteMemoryIDBBackingStore::SQLiteMemoryIDBBackingStore(const IDBDatabaseIdentifier& identifier)
+    : SQLiteIDBBackingStore(identifier, emptyString())
+{
+}
+
+SQLiteMemoryIDBBackingStore::~SQLiteMemoryIDBBackingStore() = default;
+
+IDBError SQLiteMemoryIDBBackingStore::getOrEstablishDatabaseInfo(IDBDatabaseInfo& info)
+{
+    LOG(IndexedDB, "SQLiteMemoryIDBBackingStore::getOrEstablishDatabaseInfo - database %s (in-memory)", identifier().databaseName().utf8().data());
+
+    if (databaseInfo()) {
+        info = *databaseInfo();
+        return IDBError { };
+    }
+
+    // Open SQLite in-memory database using the special ":memory:" path
+    setSqliteDB(makeUnique<SQLiteDatabase>());
+    if (CheckedPtr db = sqliteDB(); !db->open(SQLiteDatabase::inMemoryPath())) {
+        RELEASE_LOG_ERROR(IndexedDB, "%p - SQLiteMemoryIDBBackingStore::getOrEstablishDatabaseInfo: Failed to open in-memory database (%d) - %s", this, db->lastError(), db->lastErrorMsg());
+        db = nullptr;
+        closeSQLiteDB();
+    }
+
+    if (!sqliteDB())
+        return IDBError { ExceptionCode::UnknownError, "Unable to open in-memory database"_s };
+
+    {
+        CheckedRef db = *sqliteDB();
+        db->disableThreadingChecks();
+
+        // Note: WAL mode and automatic truncation are not relevant for in-memory databases
+        // as they are file-based features. In-memory databases use default journaling.
+
+        // Use a smaller cache size for private browsing to reduce memory footprint.
+        // Negative value specifies size in KB rather than number of pages.
+        if (!db->executeCommand("PRAGMA cache_size = -512;"_s))
+            LOG_ERROR("SQLite in-memory database could not set cache_size");
+
+        // Set up the IDBKEY collation function for proper IndexedDB key sorting
+        db->setCollationFunction("IDBKEY"_s, [](int aLength, const void* a, int bLength, const void* b) {
+            IDBKeyData aKey, bKey;
+            if (!deserializeIDBKeyData(unsafeMakeSpan(static_cast<const uint8_t*>(a), aLength), aKey)) {
+                LOG_ERROR("Unable to deserialize key A in collation function.");
+                return 1;
+            }
+            if (!deserializeIDBKeyData(unsafeMakeSpan(static_cast<const uint8_t*>(b), bLength), bKey)) {
+                LOG_ERROR("Unable to deserialize key B in collation function.");
+                return -1;
+            }
+
+            auto comparison = aKey <=> bKey;
+            if (is_eq(comparison))
+                return 0;
+            if (is_lt(comparison))
+                return -1;
+            return 1;
+        });
+    }
+
+    // Create the required tables
+    IDBError error = ensureValidRecordsTable();
+    if (!error.isNull()) {
+        closeSQLiteDB();
+        return error;
+    }
+
+    error = ensureValidIndexRecordsTable();
+    if (!error.isNull()) {
+        closeSQLiteDB();
+        return error;
+    }
+
+    error = ensureValidIndexRecordsIndex();
+    if (!error.isNull()) {
+        closeSQLiteDB();
+        return error;
+    }
+
+    error = ensureValidIndexRecordsRecordIndex();
+    if (!error.isNull()) {
+        closeSQLiteDB();
+        return error;
+    }
+
+    // Create blob tables for schema compatibility with the base class.
+    // Note: Blobs are not actually supported in ephemeral sessions - see webkit.org/b/156347.
+    // The blob rejection happens at the SerializedScriptValue level, so these tables stay empty.
+    error = ensureValidBlobTables();
+    if (!error.isNull()) {
+        closeSQLiteDB();
+        return error;
+    }
+
+    auto result = extractExistingDatabaseInfo();
+    if (!result) {
+        ASSERT(!result.error().isNull());
+        closeSQLiteDB();
+        return result.error();
+    }
+
+    auto databaseInfoResult = result.value() ? std::exchange(result.value(), nullptr) : createAndPopulateInitialDatabaseInfo();
+    if (!databaseInfoResult) {
+        LOG_ERROR("Unable to establish IDB in-memory database");
+        closeSQLiteDB();
+        return IDBError { ExceptionCode::UnknownError, "Unable to establish IDB in-memory database"_s };
+    }
+
+    setDatabaseInfo(WTF::move(databaseInfoResult));
+    info = *databaseInfo();
+    return IDBError { };
+}
+
+} // namespace IDBServer
+} // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/SQLiteIDBBackingStore.h>
+
+namespace WebCore {
+namespace IDBServer {
+
+// SQLite-backed in-memory IndexedDB backing store.
+// Unlike MemoryIDBBackingStore (which uses HashMaps), this uses SQLite's
+// in-memory database (":memory:") for better scalability and ACID guarantees.
+// Unlike SQLiteIDBBackingStore (which persists to disk), all data is ephemeral
+// and lost when the backing store is destroyed.
+class SQLiteMemoryIDBBackingStore final : public SQLiteIDBBackingStore {
+    WTF_MAKE_TZONE_ALLOCATED_EXPORT(SQLiteMemoryIDBBackingStore, WEBCORE_EXPORT);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SQLiteMemoryIDBBackingStore);
+public:
+    WEBCORE_EXPORT explicit SQLiteMemoryIDBBackingStore(const IDBDatabaseIdentifier&);
+    WEBCORE_EXPORT ~SQLiteMemoryIDBBackingStore() final;
+
+    // Override database initialization to use in-memory SQLite database
+    IDBError getOrEstablishDatabaseInfo(IDBDatabaseInfo&) final;
+
+    // Override to indicate this is an ephemeral, in-memory backing store
+    bool isEphemeral() final { return true; }
+
+    // SQLite only allows one transaction per connection, even for in-memory databases
+    bool supportsSimultaneousReadWriteTransactions() final { return false; }
+
+    // No database file path for in-memory databases
+    String fullDatabasePath() const final { return nullString(); }
+
+    // No-op for in-memory databases - nothing to delete from disk
+    void deleteBackingStore() final { }
+};
+
+} // namespace IDBServer
+} // namespace WebCore

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -196,6 +196,7 @@ Modules/indexeddb/server/MemoryIndexCursor.cpp
 Modules/indexeddb/server/MemoryObjectStore.cpp
 Modules/indexeddb/server/MemoryObjectStoreCursor.cpp
 Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.cpp
 Modules/indexeddb/server/SQLiteIDBCursor.cpp
 Modules/indexeddb/server/SQLiteIDBTransaction.cpp
 Modules/indexeddb/server/ServerOpenDBRequest.cpp

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageManager.h
@@ -56,7 +56,7 @@ public:
     static bool migrateOriginData(const String& oldOriginDirectory, const String& newOriginDirectory);
 
     using QuotaCheckFunction = Function<void(uint64_t spaceRequested, CompletionHandler<void(bool)>&&)>;
-    IDBStorageManager(const String& path, IDBStorageRegistry&, QuotaCheckFunction&&);
+    IDBStorageManager(const String& path, IDBStorageRegistry&, QuotaCheckFunction&&, bool useSQLiteMemoryBackingStore);
     ~IDBStorageManager();
     bool isActive() const;
     bool hasDataInMemory() const;
@@ -85,6 +85,7 @@ private:
     const CheckedRef<IDBStorageRegistry> m_registry;
     QuotaCheckFunction m_quotaCheckFunction;
     HashMap<WebCore::IDBDatabaseIdentifier, std::unique_ptr<WebCore::IDBServer::UniqueIDBDatabase>> m_databases;
+    bool m_useSQLiteMemoryBackingStore { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -165,6 +165,7 @@ private:
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
     bool isStorageTypeEnabled(IPC::Connection&, WebCore::StorageType) const;
     bool isStorageAreaTypeEnabled(IPC::Connection&, StorageAreaBase::StorageType) const;
+    bool useSQLiteMemoryBackingStore() const;
 
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
@@ -330,6 +331,7 @@ private:
     using ConnectionSitesMap = HashMap<IPC::Connection::UniqueID, HashSet<WebCore::RegistrableDomain>>;
     std::optional<ConnectionSitesMap> m_allowedSitesForConnections WTF_GUARDED_BY_CAPABILITY(workQueue());
     HashMap<IPC::Connection::UniqueID, SharedPreferencesForWebProcess> m_preferencesForConnections WTF_GUARDED_BY_CAPABILITY(workQueue());
+    bool m_useSQLiteMemoryBackingStore WTF_GUARDED_BY_CAPABILITY(workQueue()) { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -28,6 +28,7 @@
 #include "Connection.h"
 #include "OriginQuotaManager.h"
 #include "WebsiteDataType.h"
+#include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
@@ -76,7 +77,7 @@ public:
     LocalStorageManager* existingLocalStorageManager();
     SessionStorageManager& sessionStorageManager(StorageAreaRegistry&);
     SessionStorageManager* existingSessionStorageManager();
-    IDBStorageManager& idbStorageManager(IDBStorageRegistry&);
+    IDBStorageManager& idbStorageManager(IDBStorageRegistry&, bool useSQLiteMemoryBackingStore);
     IDBStorageManager* existingIDBStorageManager();
     CacheStorageManager& cacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, Ref<WorkQueue>&&);
     CacheStorageManager* existingCacheStorageManager();


### PR DESCRIPTION
#### fe93cad5c7fc5a0494b02be9a0d1572a17ba396b
<pre>
Port IndexedDB Memory Backing Store to SQLite In-Memory Database
<a href="https://bugs.webkit.org/show_bug.cgi?id=245764">https://bugs.webkit.org/show_bug.cgi?id=245764</a>
<a href="https://rdar.apple.com/100182155">rdar://100182155</a>

Reviewed by NOBODY (OOPS\!).

Add SQLiteMemoryIDBBackingStore, which uses SQLite&apos;s in-memory database (&quot;:memory:&quot;)
for private browsing instead of the custom MemoryIDBBackingStore. This gives ephemeral
IndexedDB the same ACID guarantees and SQL query engine as persistent storage.

This feature is controlled by the &apos;IndexedDBSQLiteMemoryBackingStoreEnabled&apos; preference.

Note: Blob support in ephemeral sessions is not enabled by this change and will be
addressed separately (webkit.org/b/156347).

Key changes:
- New SQLiteMemoryIDBBackingStore subclasses SQLiteIDBBackingStore, opens &quot;:memory:&quot; DB.
- SQLiteIDBBackingStore is no longer final; helper methods and data members are protected.
- SQLiteIDBTransaction uses deferred (non-exclusive) transactions.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
  Added IndexedDBSQLiteMemoryBackingStoreEnabled preference.
* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/indexeddb/server/IDBServer.cpp:
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp:
(WebCore::IDBServer::SQLiteIDBBackingStore::setSqliteDB):
(WebCore::IDBServer::SQLiteIDBBackingStore::setDatabaseInfo):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h:
(WebCore::IDBServer::SQLiteIDBBackingStore::identifier const):
(WebCore::IDBServer::SQLiteIDBBackingStore::sqliteDB const):
(WebCore::IDBServer::SQLiteIDBBackingStore::databaseInfo const):
* Source/WebCore/Modules/indexeddb/server/SQLiteIDBTransaction.cpp:
(WebCore::IDBServer::SQLiteIDBTransaction::begin):
* Source/WebCore/Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.cpp: Added.
(WebCore::IDBServer::SQLiteMemoryIDBBackingStore::SQLiteMemoryIDBBackingStore):
(WebCore::IDBServer::SQLiteMemoryIDBBackingStore::getOrEstablishDatabaseInfo):
* Source/WebCore/Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.h: Added.
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.cpp:
(WebKit::IDBStorageManager::IDBStorageManager):
(WebKit::IDBStorageManager::createBackingStore):
* Source/WebKit/NetworkProcess/storage/IDBStorageManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::openDatabase):
(WebKit::NetworkStorageManager::openDBRequestCancelled):
(WebKit::NetworkStorageManager::deleteDatabase):
(WebKit::NetworkStorageManager::databaseConnectionClosed):
(WebKit::NetworkStorageManager::getAllDatabaseNamesAndVersions):
(WebKit::NetworkStorageManager::useSQLiteMemoryBackingStore const):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::StorageBucket::idbStorageManager):
(WebKit::OriginStorageManager::idbStorageManager):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:

Canonical link: <a href="https://commits.webkit.org/307572@main">https://commits.webkit.org/307572@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fde8e3b6d5d01ce472122e1cbc3d2e7012196f8b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17382 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8986 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153374 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98338 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/033bc19c-3eee-4ee5-b6fe-0fc7d6989d4e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17865 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17276 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111281 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79779 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c75bd31d-bc28-4114-8b7b-2d9322888f2d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147666 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129919 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92176 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b67e440-3f3d-49cb-b8c3-982db87518a6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13052 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10768 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/819 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136694 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122525 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155686 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5512 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7709 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119289 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17273 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14404 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119618 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30689 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15423 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127871 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72776 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16856 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6225 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175991 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16592 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80635 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45308 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16801 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16656 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->