### PR TITLE
[Site Isolation] Add test coverage for session restore after iframe navigation.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -3863,6 +3863,28 @@ TEST(SiteIsolation, RestoreSessionFromAnotherWebView)
     EXPECT_WK_STREQ([webView2 _test_waitForAlert], "done");
 }
 
+TEST(SiteIsolation, RestoreSessionFromAnotherWebViewAfterIframeNavigation)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe id='testFrame' src='https://webkit.org/frame1'></iframe>"_s } },
+        { "/frame1"_s, { "Frame 1 - No Alert"_s } },
+        { "/frame2"_s, { "<script> alert('frame2-loaded'); </script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView1, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    [webView1 loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Navigate iframe to frame2 (which shows an alert)
+    [webView1 evaluateJavaScript:@"document.getElementById('testFrame').src = 'https://webkit.org/frame2'" completionHandler:nil];
+    EXPECT_WK_STREQ([webView1 _test_waitForAlert], "frame2-loaded");
+
+    // Restore session to webView2 - should restore iframe at frame2, not frame1
+    auto [webView2, navigationDelegate2] = siteIsolatedViewAndDelegate(server);
+    [webView2 _restoreSessionState:[webView1 _sessionState] andNavigate:YES];
+    EXPECT_WK_STREQ([webView2 _test_waitForAlert], "frame2-loaded");
+}
+
 static void testNavigateIframeBackForward(NSString *navigationURL, bool restoreSessionState)
 {
     HTTPServer server({


### PR DESCRIPTION
#### 108e0f2e42ed97dbf8a41eceaa1f95c5d42e7cfb
<pre>
[Site Isolation] Add test coverage for session restore after iframe navigation.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307354">https://bugs.webkit.org/show_bug.cgi?id=307354</a>
<a href="https://rdar.apple.com/169979589">rdar://169979589</a>

Reviewed by NOBODY (OOPS!).

When an iframe navigates to a different URL, and the session state is restored to another
WebView, the restored iframe should show the navigated URL, not the original URL from the
HTML.

This test case adds coverage for the fix in bug 307121, which ensures that session restoration
correctly handles iframes that have navigated via JavaScript.

Test Scenario:
1. Load a page with an iframe initially pointing to frame1
2. Navigate the iframe to frame2 using JavaScript
3. Save the session state
4. Restore the session state to a new WebView
5. Verify that the iframe loads frame2 (the navigated state), not frame1 (the initial state)

The test verifies that the two-tier lookup strategy (by uniqueName, then by frame index) in
HistoryItem::childItemForFrame() works correctly during session restoration.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
(TestWebKitAPI::TEST(SiteIsolation, RestoreSessionFromAnotherWebViewAfterIframeNavigation)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/108e0f2e42ed97dbf8a41eceaa1f95c5d42e7cfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143396 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/15878 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96633 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74b887af-48bc-4c5b-8fb2-e6cf69c33c1e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145271 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16555 "Failed to checkout and rebase branch from PR 58218") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110277 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79400 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93d55f8c-eec2-448b-b9f5-4d747f811a4b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146357 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/16555 "Failed to checkout and rebase branch from PR 58218") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91189 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10935ed0-8930-4ed5-a647-508ef2c31a4b) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/16555 "Failed to checkout and rebase branch from PR 58218") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9950 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2064 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/16555 "Failed to checkout and rebase branch from PR 58218") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5411 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154375 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15926 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118301 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13436 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118642 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14597 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126610 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71340 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15547 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5241 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15282 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15346 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->