### PR TITLE
[check-webkit-style] Fix false positive in safercpp/protected_getter_for_init checker

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3808,19 +3808,19 @@ def check_safer_cpp(clean_lines, line_number, error):
 
     # FIXME: Remove protectedFoo() check once all protectedFoo() getters are removed from WebKit.
     # See: https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#do-not-call-protect-free-function-to-initialize-local-variables
-    if search(r'= [a-zA-Z0-9_.(),\s\->]*protected[a-zA-Z0-9]+\(\)(;|\))(?!;)', line):
+    if search(r'= [a-zA-Z0-9_.(),\s\->]*(?<!\()protected[a-zA-Z0-9]+\(\)(;|\))(?!;)', line):
         error(line_number, 'safercpp/protected_getter_for_init', 4, "Use m_foo or foo() instead of protectedFoo() for variable initialization.")
 
     # FIXME: Remove checkedFoo() check once all checkedFoo() getters are removed from WebKit.
     # See: https://github.com/WebKit/WebKit/wiki/Safer-CPP-Guidelines#do-not-call-protect-free-function-to-initialize-local-variables
-    if search(r'= [a-zA-Z0-9_.(),\s\->]*checked[a-zA-Z0-9]+\(\)(;|\))(?!;)', line):
+    if search(r'= [a-zA-Z0-9_.(),\s\->]*(?<!\()checked[a-zA-Z0-9]+\(\)(;|\))(?!;)', line):
         error(line_number, 'safercpp/checked_getter_for_init', 4, "Use m_foo or foo() instead of checkedFoo() for variable initialization.")
 
     # Check for protect() free function used in variable initialization (violates SaferCPP guidelines).
     # Valid uses: protect(foo)->method(), protect(foo).method(), func(protect(foo)), return protect(foo), lambda captures
     # The regex handles one level of nested parentheses in the argument (e.g., protect(bar()) is correctly parsed).
     # Deeper nesting (e.g., protect(a(b()))) is not supported but is rare in practice.
-    if search(r'=\s*[a-zA-Z0-9_.(),\s\->]*protect\((?:[^()]|\([^()]*\))*\)\s*(;|\))(?!;)', line):
+    if search(r'=\s*[a-zA-Z0-9_<>,\s]*protect\((?:[^()]|\([^()]*\))*\)\s*(;|\))(?!;)', line):
         error(line_number, 'safercpp/protected_getter_for_init', 4,
               "Do not use protect() for variable initialization. Use the declared type (not auto) and remove the call to protect().")
 

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6850,6 +6850,12 @@ class WebKitStyleTest(CppStyleTestBase):
         self.assert_lint('postTask([foo = protect(m_foo)] {', '', 'foo.cpp')
         self.assert_lint('postTask([foo = protect(m_foo), bar] {', '', 'foo.cpp')
 
+        # Nested function calls - should NOT warn (protect/protectedFoo/checkedFoo is an argument, not the direct initializer)
+        self.assert_lint('if (RefPtr bar = someFunc(protect(foo())))', '', 'foo.cpp')
+        # FIXME: Remove protectedFoo() and checkedFoo() test cases once all these getters are removed from WebKit.
+        self.assert_lint('if (RefPtr document = viewportDocumentForFrame(protectedMainFrame()))', '', 'foo.cpp')
+        self.assert_lint('if (RefPtr foo = someFunction(checkedBar()))', '', 'foo.cpp')
+
     def test_ctype_fucntion(self):
         self.assert_lint(
             'int i = isascii(8);',


### PR DESCRIPTION
#### d93063803637c13838d638be397f263044d67e75
<pre>
[check-webkit-style] Fix false positive in safercpp/protected_getter_for_init checker
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=307347">https://bugs.webkit.org/show_bug.cgi?id=307347</a>&gt;
&lt;<a href="https://rdar.apple.com/169975626">rdar://169975626</a>&gt;

Reviewed by Chris Dumez.

The checker was incorrectly flagging code where `protect()`, `protectedFoo()`,
or `checkedFoo()` was used as an argument to another function, not as the
direct initializer.  For example, `viewportDocumentForFrame(protect(mainFrame()))`
was flagged even though `protect()` is just an argument, not the initializer.

The original regex patterns included `(` and `)` in their character classes,
allowing them to match through function call boundaries.

For `protectedFoo()` and `checkedFoo()` checks, add negative lookbehind
`(?&lt;!\()` before `protected` and `checked` patterns to prevent matching
when immediately preceded by `(`:

  Before: r&apos;= [a-zA-Z0-9_.(),\s\-&gt;]*protected[a-zA-Z0-9]+\(\)(;|\))(?!;)&apos;
  After:  r&apos;= [a-zA-Z0-9_.(),\s\-&gt;]*(?&lt;!\()protected[a-zA-Z0-9]+\(\)(;|\))(?!;)&apos;

For `protect()` check, change character class from `[a-zA-Z0-9_.(),\s\-&gt;]*`
to `[a-zA-Z0-9_&lt;&gt;,\s]*` to remove `()` and prevent matching through nested
function calls, while adding `&lt;&gt;` to support template parameters like
`RefPtr&lt;Document&gt;`:

  Before: r&apos;=\s*[a-zA-Z0-9_.(),\s\-&gt;]*protect\(...
  After:  r&apos;=\s*[a-zA-Z0-9_&lt;&gt;,\s]*protect\(...

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_safer_cpp):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):

Canonical link: <a href="https://commits.webkit.org/307125@main">https://commits.webkit.org/307125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e56240b7f53d0aef72d00256db3767197cc8972

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7493 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/152073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fde76ddf-75ad-48cf-a568-e6513a6793ee) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16566 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/15977 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/152073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecaf7a0a-45fe-453d-a770-805428435f7d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128905 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/152073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a1d41a2-ebfa-4d0e-8f8b-1951dea736be) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/142734 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12235 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/9958 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2075 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121667 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5406 "Passed tests") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/154385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/15936 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6442 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/154385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/15972 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13445 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/154385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14601 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126605 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71350 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22121 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15557 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5236 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15292 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15504 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15356 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->