### PR TITLE
Web Inspector: Remove the unused WebInspector::canAttachWindow and places storing its return value

### DIFF
--- a/Source/WebCore/inspector/InspectorBackendClient.h
+++ b/Source/WebCore/inspector/InspectorBackendClient.h
@@ -56,7 +56,6 @@ public:
 
     virtual Inspector::FrontendChannel* openLocalFrontend(PageInspectorController*) = 0;
     virtual void bringFrontendToFront() = 0;
-    virtual void didResizeMainFrame(LocalFrame*) { }
 
     virtual void highlight() = 0;
     virtual void hideHighlight() = 0;

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -91,6 +91,7 @@
 #include "NodeList.h"
 #include "NodeTraversal.h"
 #include "Page.h"
+#include "PageInspectorController.h"
 #include "PaymentSession.h"
 #include "ProcessWarming.h"
 #include "RemoteFrame.h"

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -75,7 +75,6 @@
 #include "HTMLPlugInElement.h"
 #include "HighlightRegistry.h"
 #include "ImageDocument.h"
-#include "InspectorBackendClient.h"
 #include "InspectorInstrumentation.h"
 #include "LegacyRenderSVGRoot.h"
 #include "LocalDOMWindow.h"
@@ -88,7 +87,6 @@
 #include "NullGraphicsContext.h"
 #include "Page.h"
 #include "PageColorSampler.h"
-#include "PageInspectorController.h"
 #include "PageOverlayController.h"
 #include "PerformanceLoggingClient.h"
 #include "ProgressTracker.h"
@@ -4842,12 +4840,6 @@ void LocalFrameView::scheduleResizeEventIfNeeded()
 
     LOG_WITH_STREAM(Events, stream << "LocalFrameView " << this << " scheduleResizeEventIfNeeded scheduling resize event for document" << document << ", size " << currentSize);
     document->setNeedsDOMWindowResizeEvent();
-
-    bool isMainFrame = m_frame->isMainFrame();
-    if (InspectorInstrumentation::hasFrontends() && isMainFrame) {
-        if (InspectorBackendClient* inspectorBackendClient = page ? page->inspectorController().inspectorBackendClient() : nullptr)
-            inspectorBackendClient->didResizeMainFrame(m_frame.ptr());
-    }
 }
 
 void LocalFrameView::willStartLiveResize()

--- a/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
+++ b/Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp
@@ -345,8 +345,9 @@ private:
     {
     }
 
-    void didChangeAttachAvailability(WebInspectorUIProxy&, bool available) override
+    void didChangeAttachAvailability(WebInspectorUIProxy& webInspector) override
     {
+        bool available = webInspector.platformCanAttach();
         if (m_inspector->priv->canAttach == available)
             return;
         m_inspector->priv->canAttach = available;

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp
@@ -66,9 +66,4 @@ void WebInspectorBackendProxy::setEmulatedConditions(std::optional<int64_t> byte
 }
 #endif
 
-void WebInspectorBackendProxy::attachAvailabilityChanged(bool available)
-{
-    protect(m_proxy)->attachAvailabilityChanged(available);
-}
-
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h
@@ -61,10 +61,7 @@ public:
     void setEmulatedConditions(std::optional<int64_t>);
 #endif
 
-    void attachAvailabilityChanged(bool);
-
 private:
-
     const WeakRef<WebInspectorUIProxy> m_proxy;
 };
 

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.messages.in
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.messages.in
@@ -35,6 +35,4 @@ messages -> WebInspectorBackendProxy {
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     SetEmulatedConditions(std::optional<int64_t> bytesPerSecondLimit)
 #endif
-
-    AttachAvailabilityChanged(bool available)
 }

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp
@@ -315,7 +315,7 @@ void WebInspectorUIProxy::attachLeft()
 void WebInspectorUIProxy::attach(AttachmentSide side)
 {
     ASSERT(m_inspectorPage);
-    if (!m_inspectedPage || !m_inspectorPage || (!m_isAttached && !platformCanAttach(m_canAttach)))
+    if (!m_inspectedPage || !m_inspectorPage || (!m_isAttached && !platformCanAttach()))
         return;
 
     m_isAttached = true;
@@ -326,8 +326,6 @@ void WebInspectorUIProxy::attach(AttachmentSide side)
 
     if (m_isVisible)
         preferences->setInspectorStartsAttached(true);
-
-    protect(protect(inspectedPage())->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::SetAttached(true), m_inspectedPage->webPageIDInMainFrameProcess());
 
     switch (m_attachmentSide) {
     case AttachmentSide::Bottom:
@@ -358,7 +356,6 @@ void WebInspectorUIProxy::detach()
     if (m_isVisible)
         protect(inspectorPagePreferences())->setInspectorStartsAttached(false);
 
-    protect(protect(inspectedPage())->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::SetAttached(false), m_inspectedPage->webPageIDInMainFrameProcess());
     protect(protect(inspectorPage())->legacyMainFrameProcess())->send(Messages::WebInspectorUI::Detached(), m_inspectorPage->webPageIDInMainFrameProcess());
 
     platformDetach();
@@ -501,16 +498,10 @@ void WebInspectorUIProxy::openLocalInspectorFrontend()
     inspectedPage->inspectorController().connectFrontend(*this);
 
     if (!m_underTest) {
-        // FIXME <https://webkit.org/b/283435>: Remove the webProcessCanAttach argument from platformCanAttach.
-        // The value canAttach in the web process is no longer used or respected.
-        const bool webProcessCanAttach = false;
-        m_canAttach = platformCanAttach(webProcessCanAttach);
         m_isAttached = shouldOpenAttached();
         m_attachmentSide = static_cast<AttachmentSide>(protect(inspectorPagePreferences())->inspectorAttachmentSide());
 
-        protect(inspectedPage->legacyMainFrameProcess())->send(Messages::WebInspectorBackend::SetAttached(m_isAttached), inspectedPage->webPageIDInMainFrameProcess());
-
-        Ref inspectorPageProcess = inspectorPage->legacyMainFrameProcess();
+        Ref inspectorPageProcess = inspectorPage->siteIsolatedProcess();
         if (m_isAttached) {
             switch (m_attachmentSide) {
             case AttachmentSide::Bottom:
@@ -528,7 +519,7 @@ void WebInspectorUIProxy::openLocalInspectorFrontend()
         } else
             inspectorPageProcess->send(Messages::WebInspectorUI::Detached(), inspectorPage->webPageIDInMainFrameProcess());
 
-        inspectorPageProcess->send(Messages::WebInspectorUI::SetDockingUnavailable(!m_canAttach), inspectorPage->webPageIDInMainFrameProcess());
+        inspectorPageProcess->send(Messages::WebInspectorUI::SetDockingUnavailable { !platformCanAttach() }, inspectorPage->webPageIDInMainFrameProcess());
 
         dispatchDidChangeLocalInspectorAttachment();
     }
@@ -563,7 +554,7 @@ void WebInspectorUIProxy::open()
     m_isVisible = true;
     protect(protect(inspectorPage())->legacyMainFrameProcess())->send(Messages::WebInspectorUI::SetIsVisible(m_isVisible), m_inspectorPage->webPageIDInMainFrameProcess());
 
-    if (m_isAttached && platformCanAttach(m_canAttach))
+    if (m_isAttached && platformCanAttach())
         platformAttach();
     else {
         m_isAttached = false;
@@ -682,19 +673,12 @@ void WebInspectorUIProxy::bringToFront()
         open();
 }
 
-void WebInspectorUIProxy::attachAvailabilityChanged(bool available)
+void WebInspectorUIProxy::attachAvailabilityChanged()
 {
-    bool previousCanAttach = m_canAttach;
-
-    m_canAttach = m_isAttached || platformCanAttach(available);
-
-    if (previousCanAttach == m_canAttach)
-        return;
-
     if (RefPtr inspectorPage = m_inspectorPage.get(); inspectorPage && !m_underTest)
-        protect(inspectorPage->legacyMainFrameProcess())->send(Messages::WebInspectorUI::SetDockingUnavailable(!m_canAttach), inspectorPage->webPageIDInMainFrameProcess());
+        protect(inspectorPage->siteIsolatedProcess())->send(Messages::WebInspectorUI::SetDockingUnavailable { !platformCanAttach() }, inspectorPage->webPageIDInMainFrameProcess());
 
-    platformAttachAvailabilityChanged(m_canAttach);
+    platformAttachAvailabilityChanged();
 }
 
 void WebInspectorUIProxy::setForcedAppearance(InspectorFrontendClient::Appearance appearance)
@@ -1026,11 +1010,6 @@ DebuggableInfoData WebInspectorUIProxy::infoForLocalDebuggable()
 }
 
 void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned)
-{
-    notImplemented();
-}
-
-void WebInspectorUIProxy::platformAttachAvailabilityChanged(bool)
 {
     notImplemented();
 }

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h
@@ -247,15 +247,10 @@ private:
     void platformBringInspectedPageToFront();
     void platformHide();
     bool platformIsFront();
-    void platformAttachAvailabilityChanged(bool);
     void platformSetForcedAppearance(WebCore::InspectorFrontendClient::Appearance);
     void platformOpenURLExternally(const String&);
     void platformInspectedURLChanged(const String&);
     void platformShowCertificate(const WebCore::CertificateInfo&);
-    void platformAttach();
-    void platformDetach();
-    void platformSetAttachedWindowHeight(unsigned);
-    void platformSetAttachedWindowWidth(unsigned);
     void platformSetSheetRect(const WebCore::FloatRect&);
     void platformStartWindowDrag();
     void platformRevealFileExternally(const String&);
@@ -263,12 +258,19 @@ private:
     void platformLoad(const String& path, CompletionHandler<void(const String&)>&&);
     void platformPickColorFromScreen(CompletionHandler<void(const std::optional<WebCore::Color>&)>&&);
 
+    void platformAttach();
+    void platformDetach();
+    void platformSetAttachedWindowHeight(unsigned);
+    void platformSetAttachedWindowWidth(unsigned);
 #if PLATFORM(MAC) || PLATFORM(GTK) || PLATFORM(WIN)
-    bool platformCanAttach(bool webProcessCanAttach);
-#elif PLATFORM(WPE)
-    bool platformCanAttach(bool) { return false; }
+    bool platformCanAttach();
 #else
-    bool platformCanAttach(bool webProcessCanAttach) { return webProcessCanAttach; }
+    bool platformCanAttach() { return false; }
+#endif
+#if PLATFORM(GTK)
+    void platformAttachAvailabilityChanged();
+#else
+    void platformAttachAvailabilityChanged() { }
 #endif
 
     // Called by WebInspectorBackendProxy and WebInspectorUIProxy messages
@@ -281,7 +283,7 @@ private:
     void didClose();
     void bringToFront();
     void bringInspectedPageToFront();
-    void attachAvailabilityChanged(bool);
+    void attachAvailabilityChanged();
     void setForcedAppearance(WebCore::InspectorFrontendClient::Appearance);
     void effectiveAppearanceDidChange(WebCore::InspectorFrontendClient::Appearance);
     void inspectedURLChanged(const String&);

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyClient.h
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyClient.h
@@ -42,7 +42,7 @@ public:
     virtual bool detach(WebInspectorUIProxy&) = 0;
     virtual void didChangeAttachedHeight(WebInspectorUIProxy&, unsigned height) = 0;
     virtual void didChangeAttachedWidth(WebInspectorUIProxy&, unsigned width) = 0;
-    virtual void didChangeAttachAvailability(WebInspectorUIProxy&, bool available) = 0;
+    virtual void didChangeAttachAvailability(WebInspectorUIProxy&) = 0;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
+++ b/Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp
@@ -573,10 +573,10 @@ void WebInspectorUIProxy::platformPickColorFromScreen(CompletionHandler<void(con
     completionHandler({ });
 }
 
-void WebInspectorUIProxy::platformAttachAvailabilityChanged(bool available)
+void WebInspectorUIProxy::platformAttachAvailabilityChanged()
 {
     if (m_client)
-        m_client->didChangeAttachAvailability(*this, available);
+        m_client->didChangeAttachAvailability(*this);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -615,15 +615,16 @@ bool WebInspectorUIProxy::platformIsFront()
     return m_isVisible && [m_inspectorViewController webView].window.isMainWindow;
 }
 
-bool WebInspectorUIProxy::platformCanAttach(bool webProcessCanAttach)
+bool WebInspectorUIProxy::platformCanAttach()
 {
     RefPtr inspectedPage = m_inspectedPage.get();
     if (!inspectedPage)
         return false;
 
+    // Don't allow attaching an inspector to an inspector.
     RetainPtr inspectedView = inspectedPage->inspectorAttachmentView();
     if ([WKInspectorViewController viewIsInspectorWebView:inspectedView.get()])
-        return webProcessCanAttach;
+        return false;
 
     if (inspectedView.get().hidden)
         return false;
@@ -636,11 +637,6 @@ bool WebInspectorUIProxy::platformCanAttach(bool webProcessCanAttach)
 
     float maximumAttachedHeight = NSHeight(inspectedViewFrame) * maximumAttachedHeightRatio;
     return minimumAttachedHeight <= maximumAttachedHeight && minimumAttachedWidth <= NSWidth(inspectedViewFrame);
-}
-
-void WebInspectorUIProxy::platformAttachAvailabilityChanged(bool available)
-{
-    // Do nothing.
 }
 
 void WebInspectorUIProxy::platformSetForcedAppearance(InspectorFrontendClient::Appearance appearance)
@@ -755,7 +751,7 @@ void WebInspectorUIProxy::windowFullScreenDidChange()
     if (m_isAttached || !m_isVisible || !m_inspectorWindow)
         return;
 
-    attachAvailabilityChanged(platformCanAttach(canAttach()));    
+    attachAvailabilityChanged();
 }
 
 void WebInspectorUIProxy::inspectedViewFrameDidChange(CGFloat currentDimension)
@@ -766,7 +762,7 @@ void WebInspectorUIProxy::inspectedViewFrameDidChange(CGFloat currentDimension)
     if (!m_isAttached) {
         // Check if the attach availability changed. We need to do this here in case
         // the attachment view is not the WKView.
-        attachAvailabilityChanged(platformCanAttach(canAttach()));
+        attachAvailabilityChanged();
         return;
     }
 

--- a/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
+++ b/Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp
@@ -509,11 +509,6 @@ void WebInspectorUIProxy::platformPickColorFromScreen(CompletionHandler<void(con
     completionHandler({ });
 }
 
-void WebInspectorUIProxy::platformAttachAvailabilityChanged(bool /* available */)
-{
-    notImplemented();
-}
-
 void WebInspectorUIProxy::platformCreateFrontendWindow()
 {
     platformDetach();

--- a/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
+++ b/Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp
@@ -332,11 +332,6 @@ void WebInspectorUIProxy::platformSetAttachedWindowWidth(unsigned)
     notImplemented();
 }
 
-void WebInspectorUIProxy::platformAttachAvailabilityChanged(bool)
-{
-    notImplemented();
-}
-
 } // namespace WebKit
 
 #endif // ENABLE(WPE_PLATFORM)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -47,10 +47,6 @@
 #include <WebCore/PageInspectorController.h>
 #include <WebCore/ScriptController.h>
 #include <WebCore/WindowFeatures.h>
-
-static const float minimumAttachedHeight = 250;
-static const float maximumAttachedHeightRatio = 0.75;
-static const float minimumAttachedWidth = 500;
 
 namespace WebKit {
 using namespace WebCore;
@@ -111,9 +107,6 @@ void WebInspectorBackend::closeFrontendConnection()
     }
 
     m_frontendConnectionActions.clear();
-
-    m_attached = false;
-    m_previousCanAttach = false;
 }
 
 void WebInspectorBackend::bringToFront()
@@ -260,44 +253,5 @@ void WebInspectorBackend::setEmulatedConditions(std::optional<int64_t>&& bytesPe
 }
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
-
-// FIXME <https://webkit.org/b/283435>: Remove this unused canAttachWindow function. Its return value is no longer used
-// or respected by the UI process.
-bool WebInspectorBackend::canAttachWindow()
-{
-    if (!m_page->corePage())
-        return false;
-
-    // Don't allow attaching to another inspector -- two inspectors in one window is too much!
-    if (m_page->isInspectorPage())
-        return false;
-
-    // If we are already attached, allow attaching again to allow switching sides.
-    if (m_attached)
-        return true;
-
-    // Don't allow the attach if the window would be too small to accommodate the minimum inspector size.
-    RefPtr localMainFrame = RefPtr { m_page.get() }->localMainFrame();
-    if (!localMainFrame)
-        return false;
-    unsigned inspectedPageHeight = protect(localMainFrame->view())->visibleHeight();
-    unsigned inspectedPageWidth = protect(localMainFrame->view())->visibleWidth();
-    unsigned maximumAttachedHeight = inspectedPageHeight * maximumAttachedHeightRatio;
-    return minimumAttachedHeight <= maximumAttachedHeight && minimumAttachedWidth <= inspectedPageWidth;
-}
-
-void WebInspectorBackend::updateDockingAvailability()
-{
-    if (m_attached)
-        return;
-
-    bool canAttachWindow = this->canAttachWindow();
-    if (m_previousCanAttach == canAttachWindow)
-        return;
-
-    m_previousCanAttach = canAttachWindow;
-
-    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebInspectorBackendProxy::AttachAvailabilityChanged(canAttachWindow), m_page->identifier());
-}
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,8 +49,6 @@ public:
 
     WebPage* page() const;
 
-    void updateDockingAvailability();
-
     // Implemented in generated WebInspectorBackendMessageReceiver.cpp
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 
@@ -61,14 +59,10 @@ public:
     void show(CompletionHandler<void()>&&);
     void close();
 
-    void canAttachWindow(bool& result);
-
     void showConsole();
     void showResources();
 
     void showMainResourceForFrame(WebCore::FrameIdentifier);
-
-    void setAttached(bool attached) { m_attached = attached; }
 
     void evaluateScriptForTest(const String& script);
 
@@ -94,8 +88,6 @@ private:
 
     explicit WebInspectorBackend(WebPage&);
 
-    bool canAttachWindow();
-
     // Called from WebInspectorBackendClient
     void openLocalInspectorFrontend();
     void closeFrontendConnection();
@@ -108,9 +100,6 @@ private:
 
     RefPtr<IPC::Connection> m_frontendConnection;
     Vector<Function<void(IPC::Connection&)>> m_frontendConnectionActions;
-
-    bool m_attached { false };
-    bool m_previousCanAttach { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2020 Apple Inc. All rights reserved.
+# Copyright (C) 2010-2026 Apple Inc. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -27,8 +27,6 @@
 messages -> WebInspectorBackend {
     Show() -> () Async
     Close()
-
-    SetAttached(bool attached)
 
     ShowConsole()
     ShowResources()

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp
@@ -119,16 +119,6 @@ void WebInspectorBackendClient::bringFrontendToFront()
         inspector->bringToFront();
 }
 
-void WebInspectorBackendClient::didResizeMainFrame(LocalFrame*)
-{
-    RefPtr page = m_page.get();
-    if (!page)
-        return;
-
-    if (RefPtr inspector = page->inspector())
-        inspector->updateDockingAvailability();
-}
-
 void WebInspectorBackendClient::highlight()
 {
     RefPtr page = m_page.get();

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h
@@ -56,7 +56,6 @@ private:
 
     Inspector::FrontendChannel* openLocalFrontend(WebCore::PageInspectorController*) override;
     void bringFrontendToFront() override;
-    void didResizeMainFrame(WebCore::LocalFrame*) override;
 
     void highlight() override;
     void hideHighlight() override;

--- a/Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp
+++ b/Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp
@@ -63,43 +63,43 @@ static void deleteSetting(const String& key)
     CFPreferencesSetAppValue(createKeyForPreferences(key).get(), nullptr, kCFPreferencesCurrentApplication);
 }
 
-void WebInspectorClient::sendMessageToFrontend(const String& message)
+void WebInspectorBackendClient::sendMessageToFrontend(const String& message)
 {
     ASSERT(m_frontendClient);
     m_frontendClient->frontendAPIDispatcher().dispatchMessageAsync(message);
 }
 
-bool WebInspectorClient::inspectorAttachDisabled()
+bool WebInspectorBackendClient::inspectorAttachDisabled()
 {
     return loadSetting(inspectorAttachDisabledSetting) == "true"_s;
 }
 
-void WebInspectorClient::setInspectorAttachDisabled(bool disabled)
+void WebInspectorBackendClient::setInspectorAttachDisabled(bool disabled)
 {
     storeSetting(inspectorAttachDisabledSetting, disabled ? "true"_s : "false"_s);
 }
 
-void WebInspectorClient::deleteInspectorStartsAttached()
+void WebInspectorBackendClient::deleteInspectorStartsAttached()
 {
     deleteSetting(inspectorAttachDisabledSetting);
 }
 
-bool WebInspectorClient::inspectorStartsAttached()
+bool WebInspectorBackendClient::inspectorStartsAttached()
 {
     return loadSetting(inspectorStartsAttachedSetting) == "true"_s;
 }
 
-void WebInspectorClient::setInspectorStartsAttached(bool attached)
+void WebInspectorBackendClient::setInspectorStartsAttached(bool attached)
 {
     storeSetting(inspectorStartsAttachedSetting, attached ? "true"_s : "false"_s);
 }
 
-void WebInspectorClient::deleteInspectorAttachDisabled()
+void WebInspectorBackendClient::deleteInspectorAttachDisabled()
 {
     deleteSetting(inspectorStartsAttachedSetting);
 }
 
-std::unique_ptr<WebCore::InspectorFrontendClientLocal::Settings> WebInspectorClient::createFrontendSettings()
+std::unique_ptr<WebCore::InspectorFrontendClientLocal::Settings> WebInspectorBackendClient::createFrontendSettings()
 {
     class InspectorFrontendSettingsCF : public WebCore::InspectorFrontendClientLocal::Settings {
     private:

--- a/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
+++ b/Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm
@@ -69,11 +69,6 @@ void WebInspectorClient::bringFrontendToFront()
     // iOS does not have a local inspector, nothing to do here.
 }
 
-void WebInspectorClient::didResizeMainFrame(LocalFrame*)
-{
-    // iOS does not have a local inspector, nothing to do here.
-}
-
 void WebInspectorClient::highlight()
 {
     [m_highlighter.get() highlight];

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h
@@ -56,17 +56,16 @@ class PageInspectorController;
 
 class WebInspectorFrontendClient;
 
-class WebInspectorClient final : public WebCore::InspectorBackendClient, public Inspector::FrontendChannel {
-    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebInspectorClient);
+class WebInspectorBackendClient final : public WebCore::InspectorBackendClient, public Inspector::FrontendChannel {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(WebInspectorBackendClient);
 public:
-    explicit WebInspectorClient(WebView *inspectedWebView);
-    virtual ~WebInspectorClient();
+    explicit WebInspectorBackendClient(WebView *inspectedWebView);
+    virtual ~WebInspectorBackendClient();
 
     void inspectedPageDestroyed() override;
 
     Inspector::FrontendChannel* openLocalFrontend(WebCore::PageInspectorController*) override;
     void bringFrontendToFront() override;
-    void didResizeMainFrame(WebCore::LocalFrame*) override;
 
     void highlight() override;
     void hideHighlight() override;

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm
@@ -72,7 +72,7 @@ static const CGFloat initialWindowHeight = 650;
     RetainPtr<WebView> _inspectedWebView;
     RetainPtr<WebView> _frontendWebView;
     NakedPtr<WebInspectorFrontendClient> _frontendClient;
-    WebInspectorClient* _inspectorClient;
+    WebInspectorBackendClient* _backendClient;
     BOOL _attachedToInspectedWebView;
     BOOL _shouldAttach;
     BOOL _visible;
@@ -86,8 +86,8 @@ static const CGFloat initialWindowHeight = 650;
 - (void)detach;
 - (BOOL)attached;
 - (void)setFrontendClient:(NakedPtr<WebInspectorFrontendClient>)frontendClient;
-- (void)setInspectorClient:(NakedPtr<WebInspectorClient>)inspectorClient;
-- (NakedPtr<WebInspectorClient>)inspectorClient;
+- (void)setInspectorClient:(NakedPtr<WebInspectorBackendClient>)inspectorClient;
+- (NakedPtr<WebInspectorBackendClient>)inspectorClient;
 - (void)setAttachedWindowHeight:(unsigned)height;
 - (void)setDockingUnavailable:(BOOL)unavailable;
 - (void)destroyInspectorView;
@@ -96,19 +96,19 @@ static const CGFloat initialWindowHeight = 650;
 
 // MARK: -
 
-WebInspectorClient::WebInspectorClient(WebView* inspectedWebView)
+WebInspectorBackendClient::WebInspectorBackendClient(WebView* inspectedWebView)
     : m_inspectedWebView(inspectedWebView)
     , m_highlighter(adoptNS([[WebNodeHighlighter alloc] initWithInspectedWebView:inspectedWebView]))
 {
 }
 
-WebInspectorClient::~WebInspectorClient() = default;
+WebInspectorBackendClient::~WebInspectorBackendClient() = default;
 
-void WebInspectorClient::inspectedPageDestroyed()
+void WebInspectorBackendClient::inspectedPageDestroyed()
 {
 }
 
-FrontendChannel* WebInspectorClient::openLocalFrontend(PageInspectorController* inspectedPageController)
+FrontendChannel* WebInspectorBackendClient::openLocalFrontend(PageInspectorController* inspectedPageController)
 {
     RetainPtr<WebInspectorWindowController> windowController = adoptNS([[WebInspectorWindowController alloc] initWithInspectedWebView:m_inspectedWebView.get().get() isUnderTest:inspectedPageController->isUnderTest()]);
     [windowController.get() setInspectorClient:this];
@@ -127,40 +127,34 @@ FrontendChannel* WebInspectorClient::openLocalFrontend(PageInspectorController* 
     return nullptr;
 }
 
-void WebInspectorClient::bringFrontendToFront()
+void WebInspectorBackendClient::bringFrontendToFront()
 {
     ASSERT(m_frontendClient);
     m_frontendClient->bringToFront();
 }
 
-void WebInspectorClient::didResizeMainFrame(LocalFrame*)
+void WebInspectorBackendClient::windowFullScreenDidChange()
 {
     if (m_frontendClient)
         m_frontendClient->attachAvailabilityChanged(canAttach());
 }
 
-void WebInspectorClient::windowFullScreenDidChange()
-{
-    if (m_frontendClient)
-        m_frontendClient->attachAvailabilityChanged(canAttach());
-}
-
-bool WebInspectorClient::canAttach()
+bool WebInspectorBackendClient::canAttach()
 {
     return m_frontendClient->canAttach() && !inspectorAttachDisabled();
 }
 
-void WebInspectorClient::highlight()
+void WebInspectorBackendClient::highlight()
 {
     [m_highlighter.get() highlight];
 }
 
-void WebInspectorClient::hideHighlight()
+void WebInspectorBackendClient::hideHighlight()
 {
     [m_highlighter.get() hideHighlight];
 }
 
-void WebInspectorClient::didSetSearchingForNode(bool enabled)
+void WebInspectorBackendClient::didSetSearchingForNode(bool enabled)
 {
     RetainPtr inspector = [m_inspectedWebView.get() inspector];
 
@@ -174,7 +168,7 @@ void WebInspectorClient::didSetSearchingForNode(bool enabled)
         [[NSNotificationCenter defaultCenter] postNotificationName:WebInspectorDidStopSearchingForNode object:inspector.get()];
 }
 
-void WebInspectorClient::releaseFrontend()
+void WebInspectorBackendClient::releaseFrontend()
 {
     m_frontendClient = nullptr;
     m_frontendPage = nullptr;
@@ -596,12 +590,12 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
 
 - (void)windowDidEnterFullScreen:(NSNotification *)notification
 {
-    _inspectorClient->windowFullScreenDidChange();
+    _backendClient->windowFullScreenDidChange();
 }
 
 - (void)windowDidExitFullScreen:(NSNotification *)notification
 {
-    _inspectorClient->windowFullScreenDidChange();
+    _backendClient->windowFullScreenDidChange();
 }
 
 - (void)close
@@ -648,7 +642,7 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
 
     _visible = YES;
 
-    _shouldAttach = _inspectorClient->inspectorStartsAttached() && _frontendClient->canAttach();
+    _shouldAttach = _backendClient->inspectorStartsAttached() && _frontendClient->canAttach();
 
     if (_shouldAttach) {
         WebFrameView *frameView = [[_inspectedWebView.get() mainFrame] frameView];
@@ -681,7 +675,7 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
     if (_attachedToInspectedWebView)
         return;
 
-    _inspectorClient->setInspectorStartsAttached(true);
+    _backendClient->setInspectorStartsAttached(true);
     _frontendClient->setAttachedWindow(InspectorFrontendClient::DockSide::Bottom);
 
     [self close];
@@ -693,7 +687,7 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
     if (!_attachedToInspectedWebView)
         return;
 
-    _inspectorClient->setInspectorStartsAttached(false);
+    _backendClient->setInspectorStartsAttached(false);
     _frontendClient->setAttachedWindow(InspectorFrontendClient::DockSide::Undocked);
 
     [self close];
@@ -710,14 +704,14 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
     _frontendClient = frontendClient;
 }
 
-- (void)setInspectorClient:(NakedPtr<WebInspectorClient>)inspectorClient
+- (void)setInspectorClient:(NakedPtr<WebInspectorBackendClient>)inspectorClient
 {
-    _inspectorClient = inspectorClient;
+    _backendClient = inspectorClient;
 }
 
-- (NakedPtr<WebInspectorClient>)inspectorClient
+- (NakedPtr<WebInspectorBackendClient>)inspectorClient
 {
-    return _inspectorClient;
+    return _backendClient;
 }
 
 - (void)setAttachedWindowHeight:(unsigned)height
@@ -749,10 +743,10 @@ void WebInspectorFrontendClient::sendMessageToBackend(const String& message)
 
     if (Page* frontendPage = _frontendClient->frontendPage())
         frontendPage->inspectorController().setInspectorFrontendClient(nullptr);
-    RefPtr { [_inspectedWebView.get() inspectorController] }->disconnectFrontend(*_inspectorClient);
+    RefPtr { [_inspectedWebView.get() inspectorController] }->disconnectFrontend(*_backendClient);
 
     [[_inspectedWebView.get() inspector] releaseFrontend];
-    _inspectorClient->releaseFrontend();
+    _backendClient->releaseFrontend();
 
     if (_destroyingInspectorView)
         return;

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -1522,7 +1522,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 #if !PLATFORM(IOS_FAMILY)
     pageConfiguration.validationMessageClient = makeUnique<WebValidationMessageClient>(self);
 #endif
-    pageConfiguration.inspectorBackendClient = makeUnique<WebInspectorClient>(self);
+    pageConfiguration.inspectorBackendClient = makeUnique<WebInspectorBackendClient>(self);
 
 #if ENABLE(DRAG_SUPPORT)
     pageConfiguration.dragClient = makeUnique<WebDragClient>(self);


### PR DESCRIPTION
#### 0773e64914c9fc41a8acbec2ab1cd7cc48ba4053
<pre>
Web Inspector: Remove the unused WebInspector::canAttachWindow and places storing its return value
<a href="https://bugs.webkit.org/show_bug.cgi?id=283435">https://bugs.webkit.org/show_bug.cgi?id=283435</a>
<a href="https://rdar.apple.com/140290531">rdar://140290531</a>

Reviewed by NOBODY (OOPS!).

This change removes unnecessary window attachment-related code from WebInspectorBackend[Proxy] and its
associated IPC message definitions. We don&apos;t want to have to maintain this unused code post-Site Isolation.
Some code still remains from when WebInspectorBackend and WebInspectorFrontend were one class with a
single client, WebInspectorClient.

Previously, code in WebProcess helped decide whether WebInspectorUI is eligible to become docked.
Now that UIProcess is solely in charge of listening for window resizes and other availability-affecting
events, we can remove the associated code in WebProcess that listens for frame resize events and computes
availability.

No new tests, this removes unused code.

* Source/WebCore/inspector/InspectorBackendClient.h:
(WebCore::InspectorBackendClient::didResizeMainFrame): Deleted.
* Source/WebCore/page/LocalFrame.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::scheduleResizeEventIfNeeded):
Remove call to `inspectorBackendClient-&gt;didResizeMainFrame()`. Backend client is no longer responsible for this.

* Source/WebKit/UIProcess/API/gtk/WebKitWebInspector.cpp: Recompute.
* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.cpp:
(WebKit::WebInspectorBackendProxy::attachAvailabilityChanged): Deleted.
* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.h:
* Source/WebKit/UIProcess/Inspector/WebInspectorBackendProxy.messages.in:
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.cpp:
(WebKit::WebInspectorUIProxy::attach):
(WebKit::WebInspectorUIProxy::detach):
(WebKit::WebInspectorUIProxy::openLocalInspectorFrontend):
(WebKit::WebInspectorUIProxy::open):
(WebKit::WebInspectorUIProxy::attachAvailabilityChanged):
(WebKit::WebInspectorUIProxy::platformAttachAvailabilityChanged): Deleted.
* Source/WebKit/UIProcess/Inspector/WebInspectorUIProxy.h:
(WebKit::WebInspectorUIProxy::platformCanAttach):
(WebKit::WebInspectorUIProxy::platformAttachAvailabilityChanged):
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyClient.h:
* Source/WebKit/UIProcess/Inspector/gtk/WebInspectorUIProxyGtk.cpp:
(WebKit::WebInspectorUIProxy::platformAttachAvailabilityChanged):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::platformCanAttach):
(WebKit::WebInspectorUIProxy::windowFullScreenDidChange):
(WebKit::WebInspectorUIProxy::inspectedViewFrameDidChange):
(WebKit::WebInspectorUIProxy::platformAttachAvailabilityChanged): Deleted.
* Source/WebKit/UIProcess/Inspector/win/WebInspectorUIProxyWin.cpp:
(WebKit::WebInspectorUIProxy::platformAttachAvailabilityChanged): Deleted.
* Source/WebKit/UIProcess/Inspector/wpe/WebInspectorUIProxyWPE.cpp:
(WebKit::WebInspectorUIProxy::platformAttachAvailabilityChanged): Deleted.
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::closeFrontendConnection):
(WebKit::WebInspectorBackend::canAttachWindow): Deleted.
(WebKit::WebInspectorBackend::updateDockingAvailability): Deleted.
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.h:
(WebKit::WebInspectorBackend::setAttached): Deleted.
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.messages.in:
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.cpp:
(WebKit::WebInspectorBackendClient::didResizeMainFrame): Deleted.
* Source/WebKit/WebProcess/Inspector/WebInspectorBackendClient.h:
* Source/WebKitLegacy/cf/WebCoreSupport/WebInspectorClientCF.cpp:
(WebInspectorBackendClient::sendMessageToFrontend):
(WebInspectorBackendClient::inspectorAttachDisabled):
(WebInspectorBackendClient::setInspectorAttachDisabled):
(WebInspectorBackendClient::deleteInspectorStartsAttached):
(WebInspectorBackendClient::inspectorStartsAttached):
(WebInspectorBackendClient::setInspectorStartsAttached):
(WebInspectorBackendClient::deleteInspectorAttachDisabled):
(WebInspectorBackendClient::createFrontendSettings):
(WebInspectorClient::sendMessageToFrontend): Deleted.
(WebInspectorClient::inspectorAttachDisabled): Deleted.
(WebInspectorClient::setInspectorAttachDisabled): Deleted.
(WebInspectorClient::deleteInspectorStartsAttached): Deleted.
(WebInspectorClient::inspectorStartsAttached): Deleted.
(WebInspectorClient::setInspectorStartsAttached): Deleted.
(WebInspectorClient::deleteInspectorAttachDisabled): Deleted.
(WebInspectorClient::createFrontendSettings): Deleted.
* Source/WebKitLegacy/ios/WebCoreSupport/WebInspectorClientIOS.mm:
(WebInspectorClient::didResizeMainFrame): Deleted.

* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.h:
* Source/WebKitLegacy/mac/WebCoreSupport/WebInspectorClient.mm:
(WebInspectorBackendClient::WebInspectorBackendClient):
(WebInspectorBackendClient::inspectedPageDestroyed):
(WebInspectorBackendClient::openLocalFrontend):
(WebInspectorBackendClient::bringFrontendToFront):
(WebInspectorBackendClient::windowFullScreenDidChange):
(WebInspectorBackendClient::canAttach):
(WebInspectorBackendClient::highlight):
(WebInspectorBackendClient::hideHighlight):
(WebInspectorBackendClient::didSetSearchingForNode):
(WebInspectorBackendClient::releaseFrontend):
(-[WebInspectorWindowController windowDidEnterFullScreen:]):
(-[WebInspectorWindowController windowDidExitFullScreen:]):
(-[WebInspectorWindowController showWindow:]):
(-[WebInspectorWindowController attach]):
(-[WebInspectorWindowController detach]):
(-[WebInspectorWindowController setInspectorClient:]):
(-[WebInspectorWindowController inspectorClient]):
(-[WebInspectorWindowController destroyInspectorView]):
(WebInspectorClient::WebInspectorClient): Deleted.
(WebInspectorClient::inspectedPageDestroyed): Deleted.
(WebInspectorClient::openLocalFrontend): Deleted.
(WebInspectorClient::bringFrontendToFront): Deleted.
(WebInspectorClient::didResizeMainFrame): Deleted.
(WebInspectorClient::windowFullScreenDidChange): Deleted.
(WebInspectorClient::canAttach): Deleted.
(WebInspectorClient::highlight): Deleted.
(WebInspectorClient::hideHighlight): Deleted.
(WebInspectorClient::didSetSearchingForNode): Deleted.
(WebInspectorClient::releaseFrontend): Deleted.
Drive-by, rename _inspectorClient to _backendClient and WebInspectorClient to WebInspectorBackendClient
to match the naming now used elsewhere in WebKit.
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebView _commonInitializationWithFrameName:groupName:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0773e64914c9fc41a8acbec2ab1cd7cc48ba4053

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144983 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17663 "Hash 0773e649 for PR 58226 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153654 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98618 "Hash 0773e649 for PR 58226 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d72e163c-1957-4f83-a6d6-4404ab5d1699) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146858 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18147 "Hash 0773e649 for PR 58226 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111480 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/98618 "Hash 0773e649 for PR 58226 does not build (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9efac56f-5eaa-4916-8a1f-055a452a4a1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147946 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/18147 "Hash 0773e649 for PR 58226 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92376 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ede60301-013a-4d5e-8e4a-53bf4b231f9d) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/18147 "Hash 0773e649 for PR 58226 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10974 "Found 4 new API test failures: TestWebKitAPI.WKInspectorExtension.CanEvaluateScriptInExtensionTab, TestWebKitAPI.WKInspectorExtension.EvaluateScriptInExtensionTabCanReturnPromises, TestWebKitAPI.WKInspectorExtensionHost.UnregisterExtension, TestWebKitAPI.WKInspectorExtensionHost.RegisterExtension (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1099 "Hash 0773e649 for PR 58226 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/18147 "Hash 0773e649 for PR 58226 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6933 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155966 "Hash 0773e649 for PR 58226 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17514 "Hash 0773e649 for PR 58226 does not build (failure)") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8021 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/155966 "Hash 0773e649 for PR 58226 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17561 "Hash 0773e649 for PR 58226 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14617 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/155966 "Hash 0773e649 for PR 58226 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73158 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17136 "Hash 0773e649 for PR 58226 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6488 "Passed tests") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16872 "Hash 0773e649 for PR 58226 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80915 "Built successfully") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17081 "Hash 0773e649 for PR 58226 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16936 "Hash 0773e649 for PR 58226 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->