### PR TITLE
Stop using `RenderMenuList` when `appearance: base` is set

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -632,7 +632,6 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/customizable-select-in-page-sizing.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-multiple-popup/select-multiple-popup-appearance.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/border-rendering.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/closed-listbox-rendering.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/focus-ring-rendering.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-accessibility-minimum-target-size.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-active.html [ ImageOnlyFailure ]

--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
@@ -2,9 +2,16 @@
 <html>
 <head>
     <style>
+        /* `appearance: base` selects match `<div>` rendering */
+        .fake-base-select {
+            display: inline-block;
+            background-color: green;
+            color: white;
+        }
         select {
             all: unset; /* Remove all UA styles */
-            background-color: green;
+            display: inline-block;
+            background-color: red;
             color: white;
         }
     </style>
@@ -14,8 +21,8 @@
     <div style="color: orange">This text should be orange (base-select on non-select)</div>
     <div style="color: blue">This text should be blue (base)</div>
 
-    <select><option>This select should be green with white text. (base-select)</option></select>
-    <select><option>This select should be green with white text. (base)</option></select>
-    <select style="background-color: red;"><option>This select should be red with white text. (default)</option></select>
+    <div class="fake-base-select">This select should be green with white text. (base-select)</div>
+    <div class="fake-base-select">This select should be green with white text. (base)</div>
+    <select><option>This select should be red with white text. (default)</option></select>
 </body>
 </html>

--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
@@ -11,6 +11,7 @@
         }
         select {
             all: unset; /* Remove all UA styles */
+            display: inline-block;
             background-color: -internal-auto-base(red, green);
             color: white;
         }

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -397,10 +397,13 @@ bool HTMLSelectElement::canSelectAll() const
     return m_multiple;
 }
 
-RenderPtr<RenderElement> HTMLSelectElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
+RenderPtr<RenderElement> HTMLSelectElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
 {
-    if (usesMenuList())
+    if (usesMenuList()) {
+        if (style.usedAppearance() == StyleAppearance::Base)
+            return HTMLElement::createElementRenderer(WTF::move(style), position);
         return createRenderer<RenderMenuList>(*this, WTF::move(style));
+    }
     return createRenderer<RenderListBox>(*this, WTF::move(style));
 }
 
@@ -827,7 +830,7 @@ void HTMLSelectElement::setOptionsChangedOnRenderer()
     if (CheckedPtr renderer = this->renderer()) {
         if (auto* renderMenuList = dynamicDowncast<RenderMenuList>(*renderer))
             renderMenuList->setOptionsChanged(true);
-        else
+        else if (!usesMenuList())
             downcast<RenderListBox>(*renderer).setOptionsChanged(true);
     }
 

--- a/Source/WebCore/style/StyleChange.cpp
+++ b/Source/WebCore/style/StyleChange.cpp
@@ -61,6 +61,8 @@ OptionSet<Change> determineChanges(const RenderStyle& s1, const RenderStyle& s2)
     auto needsRendererUpdate = [&] {
         if (s1.display() != s2.display())
             return true;
+        if (s1.usedAppearance() != s2.usedAppearance())
+            return s1.usedAppearance() == StyleAppearance::Base || s2.usedAppearance() == StyleAppearance::Base;
         if (s1.hasPseudoStyle(PseudoElementType::FirstLetter) != s2.hasPseudoStyle(PseudoElementType::FirstLetter))
             return true;
         if (columnSpanNeedsNewRenderer())


### PR DESCRIPTION
#### 54ff3284a638412efdbdd730b3a91d5fb77d0545
<pre>
Stop using `RenderMenuList` when `appearance: base` is set
<a href="https://bugs.webkit.org/show_bug.cgi?id=307131">https://bugs.webkit.org/show_bug.cgi?id=307131</a>
<a href="https://rdar.apple.com/169766844">rdar://169766844</a>

Reviewed by Alan Baradlay.

We don&apos;t want the sizing quirks of RenderMenuList when appearance: base is used.

RenderMenuList is also forces the box to be a RenderFlexibleBox regardless of the CSS display value, which is generally unwanted for appearance: base.

* LayoutTests/TestExpectations:
* LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html:
* LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::createElementRenderer):
(WebCore::HTMLSelectElement::setOptionsChangedOnRenderer): This is to dynamically update the width of the renderer, which is only relevant for RenderListBox &amp; RenderMenuList.
* Source/WebCore/style/StyleChange.cpp:
(WebCore::Style::determineChanges):

Canonical link: <a href="https://commits.webkit.org/307136@main">https://commits.webkit.org/307136@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c55e1c92fb9b702e5c98cf9dda68917e319c9fe9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143527 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152192 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f14a829c-119a-48b1-9ca6-43d02ffd4353) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145402 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16096 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/110364 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96763 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95b637f2-d8fe-4737-bf70-66829105f68c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146490 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/12815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/128979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91282 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9f15797-f81a-4bce-9cfc-d7ad1909bbe1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12304 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2194 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154504 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/6532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/16091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/13524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118729 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30417 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126697 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71469 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15676 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5310 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/15411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79448 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15623 "Build is in progress. Recent messages:") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15475 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->