### PR TITLE
[appearance: base] Create shadow trees for base slider controls

### DIFF
--- a/LayoutTests/fast/dom/HTMLMeterElement/meter-element-markup-expected.txt
+++ b/LayoutTests/fast/dom/HTMLMeterElement/meter-element-markup-expected.txt
@@ -18,6 +18,12 @@ Both meter elements should have a nested shadow box with a width specified:
 |           id="value"
 |           style="inline-size: 70%;"
 |           useragentpart="-webkit-meter-optimum-value"
+|     <div>
+|       style="appearance: inherit;"
+|       useragentpart="track"
+|       <div>
+|         style="transform: translate(-30%, 0px);"
+|         useragentpart="fill"
 | "\n    "
 | <meter>
 |   high="6"
@@ -40,6 +46,12 @@ Both meter elements should have a nested shadow box with a width specified:
 |           id="value"
 |           style="inline-size: 100%;"
 |           useragentpart="-webkit-meter-suboptimum-value"
+|     <div>
+|       style="appearance: inherit;"
+|       useragentpart="track"
+|       <div>
+|         style="transform: translate(0%, 0px);"
+|         useragentpart="fill"
 | "\n    "
 | <meter>
 |   high="6"
@@ -62,4 +74,10 @@ Both meter elements should have a nested shadow box with a width specified:
 |           id="value"
 |           style="inline-size: 100%;"
 |           useragentpart="-webkit-meter-even-less-good-value"
+|     <div>
+|       style="appearance: inherit;"
+|       useragentpart="track"
+|       <div>
+|         style="transform: translate(0%, 0px);"
+|         useragentpart="fill"
 | "\n  "

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: calc(100% - 1px);
+        height: calc(100% - 2px);
+        border-radius: 999em;
+        overflow: hidden;
+        background: rgb(230, 230, 230);
+    }
+
+    .auto > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic.html
@@ -1,0 +1,105 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-30436" />
+<style>
+    /* This is supposed to be in the UA sheet. */
+    meter::track {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    meter::fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    meter::track {
+        height: 100%;
+    }
+
+    meter:even-less-good::fill {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    meter:suboptimum::fill {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    meter:optimum::fill {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    /* This is the beginning of the author sheet. */
+    .auto {
+        appearance: auto;
+    }
+
+    .none {
+        appearance: none;
+    }
+
+    .base {
+        appearance: base;
+    }
+
+     meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <script>
+        function switchMetersClasses(meters, oldClass, newClass) {
+            for (const element of meters) {
+                element.classList.remove(oldClass);
+                element.classList.add(newClass);
+            }
+        }
+
+        let noneMeters = document.querySelectorAll(".none");
+        let baseMeters = document.querySelectorAll(".base");
+        let autoMeters = document.querySelectorAll(".auto");
+
+        switchMetersClasses(noneMeters, "none", "auto");
+        switchMetersClasses(autoMeters, "auto", "base");
+        switchMetersClasses(baseMeters, "base", "none");
+    </script>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: calc(100% - 1px);
+        height: calc(100% - 2px);
+        border-radius: 999em;
+        overflow: hidden;
+        background: rgb(230, 230, 230);
+    }
+
+    .auto > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial.html
@@ -1,0 +1,89 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-30416" />
+<style>
+    /* This is supposed to be in the UA sheet. */
+    meter::track {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    meter::fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    meter::track {
+        height: 100%;
+    }
+
+    meter:even-less-good::fill {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    meter:suboptimum::fill {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    meter:optimum::fill {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    /* This is the beginning of the author sheet. */
+    .auto {
+        appearance: auto;
+    }
+
+    .none {
+        appearance: none;
+    }
+
+    .base {
+        appearance: base;
+    }
+
+     meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: calc(100% - 1px);
+        height: calc(100% - 2px);
+        border-radius: 999em;
+        overflow: hidden;
+        background: rgb(230, 230, 230);
+    }
+
+    .auto > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic.html
@@ -1,0 +1,104 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-30402" />
+<style>
+    /* This is supposed to be in the UA sheet. */
+    meter::track {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    meter::fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    meter::track {
+        height: 100%;
+    }
+
+    meter:even-less-good::fill {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    meter:suboptimum::fill {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    meter:optimum::fill {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    /* This is the beginning of the author sheet. */
+    .auto {
+        appearance: auto;
+    }
+
+    .none {
+        appearance: none;
+    }
+
+    .base {
+        appearance: base;
+    }
+
+     meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="10"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="33"></meter>
+    </div>
+    <div>
+        <meter class="auto" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="none" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <div>
+        <meter class="base" min="0" max="100" low="33" high="66" optimum="80" value="66"></meter>
+    </div>
+    <script>
+        function changeMetersValues(meters, newValue) {
+            for (const element of meters) {
+                element.setAttribute("value", newValue);
+            }
+        }
+
+        let evenLessGoodMeters = document.querySelectorAll("meter:is([value='10'])");
+        let suboptimumMeters = document.querySelectorAll("meter:is([value='33'])");
+        let optimumMeters = document.querySelectorAll("meter:is([value='66'])");
+
+        changeMetersValues(evenLessGoodMeters, 33);
+        changeMetersValues(suboptimumMeters, 66);
+        changeMetersValues(optimumMeters, 10);
+    </script>
+</body>

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-boundary-values-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-boundary-values-expected.txt
@@ -22,6 +22,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,36) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderInline {B} at (0,0) size 16x18
@@ -33,6 +34,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,54) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 20x18
@@ -46,6 +48,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,72) size 744x18
@@ -61,6 +64,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 40x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,90) size 744x18
@@ -76,6 +80,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,108) size 744x18
@@ -91,6 +96,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 118x18
             text run at (184,0) width 118: "(should be yellow)"
         RenderListItem {LI} at (40,126) size 744x18
@@ -106,6 +112,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (203,0) size 118x18
             text run at (203,0) width 118: "(should be yellow)"
         RenderListItem {LI} at (40,144) size 744x18
@@ -121,6 +128,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,162) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 60x18
@@ -134,6 +142,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,180) size 744x18
@@ -147,6 +156,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,198) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 40x18
@@ -160,6 +170,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,216) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 40x18
@@ -173,6 +184,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,234) size 744x18
@@ -188,6 +200,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (203,0) size 110x18
             text run at (203,0) width 110: "(should be green)"
         RenderListItem {LI} at (40,252) size 744x18
@@ -203,5 +216,6 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 40x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (184,0) size 110x18
             text run at (184,0) width 110: "(should be green)"

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-expected.txt
@@ -7,8 +7,10 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 18x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderBlock {METER} at (80,0) size 10x60
         RenderBlock {DIV} at (0,0) size 10x60
           RenderBlock {DIV} at (0,0) size 10x60
             RenderBlock {DIV} at (0,0) size 10x42
+        RenderBlock {DIV} at (10,0) size 0x60
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
@@ -7,11 +7,13 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (80,0) size 4x18
         text run at (80,0) width 4: " "
       RenderBlock {METER} at (84,1) size 80x17
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-optimums-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-optimums-expected.txt
@@ -21,6 +21,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,18) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -29,6 +30,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,36) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -37,6 +39,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,54) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 59x18
@@ -45,6 +48,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,72) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 83x18
@@ -53,6 +57,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
       RenderBlock {H2} at (0,253) size 784x28
         RenderText {#text} at (0,0) size 143x27
           text run at (0,0) width 143: "optimum=150"
@@ -65,6 +70,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,18) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -73,6 +79,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,36) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -81,6 +88,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,54) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 59x18
@@ -89,6 +97,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,72) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 83x18
@@ -97,6 +106,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0
       RenderBlock {H2} at (0,409) size 784x28
         RenderText {#text} at (0,0) size 143x27
           text run at (0,0) width 143: "optimum=750"
@@ -109,6 +119,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,18) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -117,6 +128,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,36) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 75x18
@@ -125,6 +137,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,54) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 59x18
@@ -133,6 +146,7 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 0x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (40,72) size 744x18
           RenderListMarker at (-17,0) size 7x18: bullet
           RenderText {#text} at (0,0) size 83x18
@@ -141,3 +155,4 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
+            RenderBlock {DIV} at (0,16) size 80x0

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
@@ -14,4 +14,5 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080]
               RenderBlock {DIV} at (0,0) size 72x16 [bgcolor=#008000]
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-expected.txt
+++ b/LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-expected.txt
@@ -12,35 +12,41 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (80,0) size 4x18
             text run at (80,0) width 4: " "
           RenderBlock {METER} at (84,1) size 80x17
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (164,0) size 4x18
             text run at (164,0) width 4: " "
           RenderBlock {METER} at (168,1) size 80x17
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (43,21) size 732x41
           RenderBlock {METER} at (0,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 8x40
+            RenderBlock {DIV} at (0,40) size 30x0
           RenderText {#text} at (30,22) size 4x18
             text run at (30,22) width 4: " "
           RenderBlock {METER} at (34,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 14x40
+            RenderBlock {DIV} at (0,40) size 30x0
           RenderText {#text} at (64,22) size 4x18
             text run at (64,22) width 4: " "
           RenderBlock {METER} at (68,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 23x40
+            RenderBlock {DIV} at (0,40) size 30x0
       RenderBlock {H2} at (3,85) size 778x19
         RenderText {#text} at (0,0) size 150x18
           text run at (0,0) width 150: "Providing meter styles"
@@ -51,6 +57,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (10,5) size 50x6
                 RenderBlock {DIV} at (0,0) size 50x6
                   RenderBlock {DIV} at (0,0) size 40x6
+              RenderBlock {DIV} at (10,11) size 50x0
             RenderText {#text} at (80,0) size 70x18
               text run at (80,0) width 70: " has border"
           RenderListItem {LI} at (43,21) size 732x19
@@ -58,6 +65,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (10,5) size 50x6
                 RenderBlock {DIV} at (0,0) size 50x6
                   RenderBlock {DIV} at (0,0) size 40x6
+              RenderBlock {DIV} at (10,11) size 50x0
             RenderText {#text} at (80,0) size 80x18
               text run at (80,0) width 80: " has padding"
           RenderListItem {LI} at (43,42) size 732x27
@@ -65,6 +73,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (110,8) size 73x18
               text run at (110,8) width 73: " has margin"
       RenderBlock {H2} at (3,178) size 778x19
@@ -80,6 +89,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 212x18
               text run at (80,0) width 212: " has bar style but should ignore it."
           RenderListItem {LI} at (43,42) size 732x19
@@ -87,6 +97,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 226x18
               text run at (80,0) width 226: " has value style but should ignore it."
           RenderListItem {LI} at (43,63) size 732x19
@@ -94,6 +105,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 249x18
               text run at (80,0) width 249: " has both styles but should ignore them."
         RenderBlock {UL} at (3,84) size 778x83
@@ -105,6 +117,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 270x18
               text run at (80,0) width 270: " has bar style, should have solid value part."
           RenderListItem {LI} at (43,42) size 732x19
@@ -112,6 +125,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 255x18
               text run at (80,0) width 255: " has value style, should be solid bar part."
           RenderListItem {LI} at (43,63) size 732x19
@@ -119,6 +133,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 235x18
               text run at (80,0) width 235: " should have solid bar and value part."
       RenderBlock {H2} at (3,369) size 778x19
@@ -131,6 +146,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 375x18
               text run at (80,0) width 375: " has \"none\" appearance, should be styled with default style."
           RenderListItem {LI} at (43,21) size 732x19
@@ -138,6 +154,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 276x18
               text run at (80,0) width 276: " has \"meter\" appearance, should be themed."
       RenderBlock {H2} at (3,433) size 778x19
@@ -148,5 +165,6 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (5,5) size 35x6
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (80,0) size 165x18
           text run at (80,0) width 165: " has \"padding\" on the bar."

--- a/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
+++ b/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
+++ b/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
+++ b/LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
@@ -10,5 +10,6 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
@@ -14,4 +14,5 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080]
               RenderBlock {DIV} at (0,0) size 72x16 [bgcolor=#008000]
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-expected.txt
+++ b/LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-expected.txt
@@ -12,35 +12,41 @@ layer at (0,0) size 800x600
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 20x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (80,0) size 4x20
             text run at (80,0) width 4: " "
           RenderBlock {METER} at (84,2) size 80x17
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 36x16
+            RenderBlock {DIV} at (0,16) size 80x0
           RenderText {#text} at (164,0) size 4x20
             text run at (164,0) width 4: " "
           RenderBlock {METER} at (168,2) size 80x17
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 60x16
+            RenderBlock {DIV} at (0,16) size 80x0
         RenderListItem {LI} at (43,23) size 732x42
           RenderBlock {METER} at (0,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 8x40
+            RenderBlock {DIV} at (0,40) size 30x0
           RenderText {#text} at (30,21) size 4x20
             text run at (30,21) width 4: " "
           RenderBlock {METER} at (34,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 14x40
+            RenderBlock {DIV} at (0,40) size 30x0
           RenderText {#text} at (64,21) size 4x20
             text run at (64,21) width 4: " "
           RenderBlock {METER} at (68,0) size 30x40
             RenderBlock {DIV} at (0,0) size 30x40
               RenderBlock {DIV} at (0,0) size 30x40
                 RenderBlock {DIV} at (0,0) size 23x40
+            RenderBlock {DIV} at (0,40) size 30x0
       RenderBlock {H2} at (3,90) size 778x21
         RenderText {#text} at (0,0) size 153x20
           text run at (0,0) width 153: "Providing meter styles"
@@ -51,6 +57,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (10,5) size 50x6
                 RenderBlock {DIV} at (0,0) size 50x6
                   RenderBlock {DIV} at (0,0) size 40x6
+              RenderBlock {DIV} at (10,11) size 50x0
             RenderText {#text} at (80,0) size 72x20
               text run at (80,0) width 72: " has border"
           RenderListItem {LI} at (43,23) size 732x21
@@ -58,6 +65,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (10,5) size 50x6
                 RenderBlock {DIV} at (0,0) size 50x6
                   RenderBlock {DIV} at (0,0) size 40x6
+              RenderBlock {DIV} at (10,11) size 50x0
             RenderText {#text} at (80,0) size 81x20
               text run at (80,0) width 81: " has padding"
           RenderListItem {LI} at (43,46) size 732x28
@@ -65,6 +73,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (110,7) size 75x20
               text run at (110,7) width 75: " has margin"
       RenderBlock {H2} at (3,190) size 778x21
@@ -96,6 +105,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 276x20
               text run at (80,0) width 276: " has bar style, should have solid value part."
           RenderListItem {LI} at (43,46) size 732x21
@@ -103,6 +113,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 261x20
               text run at (80,0) width 261: " has value style, should be solid bar part."
           RenderListItem {LI} at (43,69) size 732x21
@@ -110,6 +121,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080] [border: (2px solid #222222)]
                   RenderBlock {DIV} at (2,2) size 61x12 [bgcolor=#008000] [border: (2px solid #77CC77)]
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 240x20
               text run at (80,0) width 240: " should have solid bar and value part."
       RenderBlock {H2} at (3,399) size 778x21
@@ -122,6 +134,7 @@ layer at (0,0) size 800x600
               RenderBlock {DIV} at (0,0) size 80x16
                 RenderBlock {DIV} at (0,0) size 80x16
                   RenderBlock {DIV} at (0,0) size 64x16
+              RenderBlock {DIV} at (0,16) size 80x0
             RenderText {#text} at (80,0) size 381x20
               text run at (80,0) width 381: " has \"none\" appearance, should be styled with default style."
           RenderListItem {LI} at (43,23) size 732x21
@@ -136,5 +149,6 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16
               RenderBlock {DIV} at (5,5) size 35x6
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (80,0) size 166x20
           text run at (80,0) width 166: " has \"padding\" on the bar."

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: 100%;
+        height: 41%;
+        overflow: hidden;
+        box-sizing: border-box;
+        background: rgb(237, 237, 237);
+        border: 0.5px solid rgb(206, 206, 206);
+    }
+
+    .auto > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: 100%;
+        height: 41%;
+        overflow: hidden;
+        box-sizing: border-box;
+        background: rgb(237, 237, 237);
+        border: 0.5px solid rgb(206, 206, 206);
+    }
+
+    .auto > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
+++ b/LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
@@ -1,0 +1,126 @@
+<style>
+    .auto {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        font: 11px system-ui;
+        width: 100%;
+        height: 41%;
+        overflow: hidden;
+        box-sizing: border-box;
+        background: rgb(237, 237, 237);
+        border: 0.5px solid rgb(206, 206, 206);
+    }
+
+    .auto > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-67%, 0); background: rgb(255, 204, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-34%, 0); background: rgb(52, 199, 89);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="auto">
+            <div class="fill" style="transform: translate(-90%, 0); background: rgb(255, 57, 60);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
@@ -10,5 +10,6 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
+++ b/LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
@@ -14,4 +14,5 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080]
               RenderBlock {DIV} at (0,0) size 72x16 [bgcolor=#008000]
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-expected.txt
@@ -7,8 +7,10 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 18x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderBlock {METER} at (80,0) size 10x60
         RenderBlock {DIV} at (0,0) size 10x60
           RenderBlock {DIV} at (0,0) size 10x60
             RenderBlock {DIV} at (0,0) size 10x42
+        RenderBlock {DIV} at (10,0) size 0x60
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt
@@ -13,5 +13,6 @@ layer at (0,0) size 800x600
         RenderBlock {DIV} at (0,0) size 80x16
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 40x16
+        RenderBlock {DIV} at (0,16) size 80x0
       RenderText {#text} at (0,0) size 0x0
       RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt
@@ -14,4 +14,5 @@ layer at (0,0) size 800x600
           RenderBlock {DIV} at (0,0) size 80x16
             RenderBlock {DIV} at (0,0) size 80x16 [bgcolor=#808080]
               RenderBlock {DIV} at (0,0) size 72x16 [bgcolor=#008000]
+          RenderBlock {DIV} at (0,16) size 80x0
         RenderText {#text} at (0,0) size 0x0

--- a/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
+++ b/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
+++ b/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-initial-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
+++ b/LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html
@@ -1,0 +1,104 @@
+<style>
+    .none {
+        font: 11px system-ui;
+        width: 100%;
+        height: 100%; 
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .none > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        overflow: hidden;
+    }
+
+    .base {
+        font: 11px system-ui;
+        position: relative;
+        top: 50%;
+        transform: translateY(-50%);
+        width: 100%;
+        height: 100%; 
+        border: darkgray 1px solid;
+        border-radius: 999em;
+        overflow: hidden;
+        background: linear-gradient(to bottom, #ddd, #eee 20%, #ccc 45%, #ccc 55%, #ddd);
+    }
+
+    .base > .fill {
+        height: 100%; 
+        width: 100%; 
+        block-size: 100%;
+        box-sizing: border-box;
+        border-radius: 999em;
+        overflow: hidden;
+    }
+
+    .even-less-good-gradient {
+        background: linear-gradient(to bottom, #f77, #fcc 20%, #d44 45%, #d44 55%, #f77);
+    }
+
+    .suboptimum-gradient {
+        background: linear-gradient(to bottom, #fe7, #ffc 20%, #db3 45%, #db3 55%, #fe7);
+    }
+
+    .optimum-gradient {
+        background: linear-gradient(to bottom, #ad7, #cea 20%, #7a3 45%, #7a3 55%, #ad7);
+    }
+
+    .meter {
+        width: 400px;
+        height: 40px;
+        margin-bottom: 10px;
+    }
+</style>
+<body>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="suboptimum-gradient fill" style="transform: translate(-67%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="optimum-gradient fill" style="transform: translate(-34%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="none">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+    <div class="meter">
+        <div class="base">
+            <div class="even-less-good-gradient fill" style="transform: translate(-90%, 0);"></div>
+        </div>
+    </div>
+</body>

--- a/Source/JavaScriptCore/inspector/protocol/CSS.json
+++ b/Source/JavaScriptCore/inspector/protocol/CSS.json
@@ -49,6 +49,8 @@
                 "target-text",
                 "checkmark",
                 "picker-icon",
+                "track",
+                "fill",
                 "view-transition",
                 "view-transition-group",
                 "view-transition-image-pair",

--- a/Source/WebCore/css/CSSPseudoSelectors.json
+++ b/Source/WebCore/css/CSSPseudoSelectors.json
@@ -119,6 +119,7 @@
             "comment": "For scrollbar styling.",
             "status": "non-standard"
         },
+        "even-less-good": {},
         "first-child": {},
         "first-of-type": {},
         "focus": {},
@@ -197,6 +198,7 @@
         "open": {
             "settings-flag": "openPseudoClassEnabled"
         },
+        "optimum": {},
         "optional": {},
         "out-of-range": {},
         "past": {
@@ -237,6 +239,7 @@
             "comment": "For scrollbar styling.",
             "status": "non-standard"
         },
+        "suboptimum": {},
         "target": {},
         "user-invalid": {},
         "user-valid": {},
@@ -536,6 +539,10 @@
             "aliases": [
                 "-webkit-file-upload-button"
             ],
+            "user-agent-part": true
+        },
+        "fill": {
+            "settings-flag": "cssAppearanceBaseEnabled",
             "user-agent-part": true
         },
         "first-letter": {

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -1270,6 +1270,13 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         case CSSSelector::PseudoClass::ActiveViewTransitionType: {
             ASSERT(selector.stringList() && !selector.stringList()->isEmpty());
             return matchesActiveViewTransitionTypePseudoClass(element, *selector.stringList());
+
+        case CSSSelector::PseudoClass::EvenLessGood:
+            return matchesEvenLessGoodPseudoClass(element);
+        case CSSSelector::PseudoClass::Optimum:
+            return matchesOptimumPseudoClass(element);
+        case CSSSelector::PseudoClass::Suboptimum:
+            return matchesSuboptimumPseudoClass(element);
         }
 
         }

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -36,6 +36,7 @@
 #include "HTMLIFrameElement.h"
 #include "HTMLImageElement.h"
 #include "HTMLInputElement.h"
+#include "HTMLMeterElement.h"
 #include "HTMLOptionElement.h"
 #include "HTMLSelectElement.h"
 #include "InspectorInstrumentation.h"
@@ -619,6 +620,27 @@ ALWAYS_INLINE bool matchesActiveViewTransitionPseudoClass(const Element& element
     if (&element != element.document().documentElement())
         return false;
     return !!element.document().activeViewTransition();
+}
+
+ALWAYS_INLINE bool matchesEvenLessGoodPseudoClass(const Element& element)
+{
+    if (RefPtr meterElement = dynamicDowncast<HTMLMeterElement>(element))
+        return meterElement->gaugeRegion() == HTMLMeterElement::GaugeRegion::EvenLessGood;
+    return false;
+}
+
+ALWAYS_INLINE bool matchesOptimumPseudoClass(const Element& element)
+{
+    if (RefPtr meterElement = dynamicDowncast<HTMLMeterElement>(element))
+        return meterElement->gaugeRegion() == HTMLMeterElement::GaugeRegion::Optimum;
+    return false;
+}
+
+ALWAYS_INLINE bool matchesSuboptimumPseudoClass(const Element& element)
+{
+    if (RefPtr meterElement = dynamicDowncast<HTMLMeterElement>(element))
+        return meterElement->gaugeRegion() == HTMLMeterElement::GaugeRegion::Suboptimal;
+    return false;
 }
 
 ALWAYS_INLINE bool matchesUsesMenulistPseudoClass(const Element& element)

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -136,6 +136,9 @@ using PseudoClassesSet = UncheckedKeyHashSet<CSSSelector::PseudoClass, IntHash<C
     v(operationMatchesUsesMenulistPseudoClass) \
     v(operationIsUserInvalid) \
     v(operationIsUserValid) \
+    v(operationMatchesEvenLessGoodPseudoClass) \
+    v(operationMatchesOptimumPseudoClass) \
+    v(operationMatchesSuboptimumPseudoClass) \
     v(operationAddStyleRelationFunction) \
     v(operationModuloHelper) \
     v(operationAttributeValueBeginsWithCaseSensitive) \
@@ -294,6 +297,10 @@ static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesS
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesUsesMenulistPseudoClass, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationIsUserInvalid, bool, (const Element&));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationIsUserValid, bool, (const Element&));
+
+static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesEvenLessGoodPseudoClass, bool, (const Element&));
+static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesOptimumPseudoClass, bool, (const Element&));
+static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationMatchesSuboptimumPseudoClass, bool, (const Element&));
 
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationAttributeValueBeginsWithCaseSensitive, bool, (const Attribute* attribute, AtomStringImpl* expectedString));
 static JSC_DECLARE_NOEXCEPT_JIT_OPERATION_WITHOUT_WTF_INTERNAL(operationAttributeValueBeginsWithCaseInsensitive, bool, (const Attribute* attribute, AtomStringImpl* expectedString));
@@ -1077,6 +1084,24 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesUsesMenulistPseudoClass, bool,
     return matchesUsesMenulistPseudoClass(element);
 }
 
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesEvenLessGoodPseudoClass, bool, (const Element& element))
+{
+    COUNT_SELECTOR_OPERATION(operationMatchesEvenLessGoodPseudoClass);
+    return matchesEvenLessGoodPseudoClass(element);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesOptimumPseudoClass, bool, (const Element& element))
+{
+    COUNT_SELECTOR_OPERATION(operationMatchesOptimumPseudoClass);
+    return matchesOptimumPseudoClass(element);
+}
+
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMatchesSuboptimumPseudoClass, bool, (const Element& element))
+{
+    COUNT_SELECTOR_OPERATION(operationMatchesSuboptimumPseudoClass);
+    return matchesSuboptimumPseudoClass(element);
+}
+
 static inline FunctionType addPseudoClassType(const CSSSelector& selector, SelectorFragment& fragment, SelectorContext selectorContext, FragmentsLevel fragmentLevel, FragmentPositionInRootFragments positionInRootFragments, bool visitedMatchEnabled, VisitedMode& visitedMode, PseudoElementMatchingBehavior pseudoElementMatchingBehavior)
 {
     auto type = selector.pseudoClass();
@@ -1285,6 +1310,18 @@ static inline FunctionType addPseudoClassType(const CSSSelector& selector, Selec
     case CSSSelector::PseudoClass::PlaceholderShown:
     case CSSSelector::PseudoClass::Root:
         fragment.pseudoClasses.add(type);
+        return FunctionType::SimpleSelectorChecker;
+
+    case CSSSelector::PseudoClass::EvenLessGood:
+        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesEvenLessGoodPseudoClass));
+        return FunctionType::SimpleSelectorChecker;
+
+    case CSSSelector::PseudoClass::Optimum:
+        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesOptimumPseudoClass));
+        return FunctionType::SimpleSelectorChecker;
+
+    case CSSSelector::PseudoClass::Suboptimum:
+        fragment.unoptimizedPseudoClasses.append(CodePtr<JSC::OperationPtrTag>(operationMatchesSuboptimumPseudoClass));
         return FunctionType::SimpleSelectorChecker;
 
     case CSSSelector::PseudoClass::Visited:

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -22,18 +23,12 @@
 #include "HTMLMeterElement.h"
 
 #include "Attribute.h"
-#include "ContainerNodeInlines.h"
-#include "ElementInlines.h"
-#include "ElementIterator.h"
 #include "HTMLDivElement.h"
-#include "HTMLFormElement.h"
 #include "HTMLNames.h"
 #include "HTMLParserIdioms.h"
 #include "HTMLStyleElement.h"
 #include "NodeName.h"
-#include "Page.h"
 #include "RenderMeter.h"
-#include "RenderStyle+GettersInlines.h"
 #include "RenderTheme.h"
 #include "ScriptDisallowedScope.h"
 #include "ShadowRoot.h"
@@ -84,12 +79,13 @@ void HTMLMeterElement::attributeChanged(const QualifiedName& name, const AtomStr
     case AttributeNames::lowAttr:
     case AttributeNames::highAttr:
     case AttributeNames::optimumAttr:
-        didElementStateChange();
+        didChangeElementValue();
         break;
     default:
-        HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
         break;
     }
+
+    HTMLElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);
 }
 
 double HTMLMeterElement::min() const
@@ -189,14 +185,21 @@ static void setValueClass(HTMLElement& element, HTMLMeterElement::GaugeRegion ga
     ASSERT_NOT_REACHED();
 }
 
-void HTMLMeterElement::didElementStateChange()
+void HTMLMeterElement::didChangeElementValue()
 {
-    Ref valueElement = *m_valueElement;
-    valueElement->setInlineStyleProperty(CSSPropertyInlineSize, valueRatio() * 100, CSSUnitType::CSS_PERCENTAGE);
-    setValueClass(valueElement, gaugeRegion());
+    RefPtr shadowRoot = userAgentShadowRoot();
+    if (!shadowRoot)
+        return;
 
-    if (CheckedPtr renderer = renderMeter())
-        renderer->updateFromElement();
+    if (RefPtr valueElement = m_valueElement) {
+        valueElement->setInlineStyleProperty(CSSPropertyInlineSize, valueRatio() * 100, CSSUnitType::CSS_PERCENTAGE);
+        setValueClass(*valueElement, gaugeRegion());
+    }
+
+    if (RefPtr fillElement = m_fillElement) {
+        fillElement->setInlineStyleProperty(CSSPropertyTransform, makeString("translate(-"_s, (1 - valueRatio()) * 100, "%, 0)"_s));
+        fillElement->invalidateStyleInternal();
+    }
 }
 
 RenderMeter* HTMLMeterElement::renderMeter() const
@@ -204,39 +207,61 @@ RenderMeter* HTMLMeterElement::renderMeter() const
     return dynamicDowncast<RenderMeter>(renderer());
 }
 
-void HTMLMeterElement::didAddUserAgentShadowRoot(ShadowRoot& root)
+void HTMLMeterElement::appendShadowTreeForAutoAppearance(ShadowRoot& root)
 {
-    ASSERT(!m_valueElement);
-
     static MainThreadNeverDestroyed<const String> shadowStyle(StringImpl::createWithoutCopying(meterElementShadowUserAgentStyleSheet));
 
     Ref document = this->document();
-    Ref style = HTMLStyleElement::create(document);
-    ScriptDisallowedScope::EventAllowedScope styleScope { style };
-    style->setTextContent(String { shadowStyle });
+    Ref styleElement = HTMLStyleElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope styleScope { styleElement };
+    styleElement->setTextContent(String { shadowStyle });
     ScriptDisallowedScope::EventAllowedScope rootScope { root };
-    root.appendChild(WTF::move(style));
+    root.appendChild(WTF::move(styleElement));
 
     // Pseudos are set to allow author styling.
-    Ref inner = HTMLDivElement::create(document);
-    ScriptDisallowedScope::EventAllowedScope innerScope { inner };
-    inner->setIdAttribute("inner"_s);
-    inner->setUserAgentPart(UserAgentParts::webkitMeterInnerElement());
-    root.appendChild(inner);
+    Ref innerElement = HTMLDivElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope innerScope { innerElement };
+    innerElement->setIdAttribute("inner"_s);
+    innerElement->setUserAgentPart(UserAgentParts::webkitMeterInnerElement());
+    innerElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(inline-block, none) !important"_s);
+    root.appendChild(innerElement);
 
-    Ref bar = HTMLDivElement::create(document);
-    ScriptDisallowedScope::EventAllowedScope barScope { bar };
-    bar->setIdAttribute("bar"_s);
-    bar->setUserAgentPart(UserAgentParts::webkitMeterBar());
-    inner->appendChild(bar);
+    Ref barElement = HTMLDivElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope barScope { barElement };
+    barElement->setIdAttribute("bar"_s);
+    barElement->setUserAgentPart(UserAgentParts::webkitMeterBar());
+    innerElement->appendChild(barElement);
 
     Ref valueElement = HTMLDivElement::create(document);
     ScriptDisallowedScope::EventAllowedScope valueElementScope { valueElement };
     valueElement->setIdAttribute("value"_s);
-    bar->appendChild(valueElement);
-    m_valueElement = WTF::move(valueElement);
-
-    didElementStateChange();
+    barElement->appendChild(valueElement);
+    m_valueElement = valueElement;
 }
 
-} // namespace
+void HTMLMeterElement::appendShadowTreeForBaseAppearance(ShadowRoot& root)
+{
+    Ref document = this->document();
+    Ref trackElement = HTMLDivElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope trackScope { trackElement };
+    trackElement->setUserAgentPart(UserAgentParts::track());
+    trackElement->setInlineStyleProperty(CSSPropertyAppearance, "inherit"_s);
+    trackElement->setInlineStyleProperty(CSSPropertyDisplay, "-internal-auto-base(none, inline-block) !important"_s);
+    root.appendChild(trackElement);
+
+    Ref fillElement = HTMLDivElement::create(document);
+    ScriptDisallowedScope::EventAllowedScope fillScope { fillElement };
+    fillElement->setUserAgentPart(UserAgentParts::fill());
+    trackElement->appendChild(fillElement);
+    m_fillElement = fillElement;
+}
+
+void HTMLMeterElement::didAddUserAgentShadowRoot(ShadowRoot& root)
+{
+    appendShadowTreeForAutoAppearance(root);
+    if (document().settings().cssAppearanceBaseEnabled())
+        appendShadowTreeForBaseAppearance(root);
+    didChangeElementValue();
+}
+
+} // namespace WebCore

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Library General Public
@@ -65,10 +66,14 @@ private:
     bool childShouldCreateRenderer(const Node&) const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 
-    void didElementStateChange();
+    void appendShadowTreeForAutoAppearance(ShadowRoot&);
+    void appendShadowTreeForBaseAppearance(ShadowRoot&);
+
+    void didChangeElementValue();
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 
-    RefPtr<HTMLElement> m_valueElement;
+    WeakPtr<HTMLDivElement, WeakPtrImplWithEventTargetData> m_valueElement;
+    WeakPtr<HTMLDivElement, WeakPtrImplWithEventTargetData> m_fillElement;
 };
 
 } // namespace WebCore

--- a/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js
@@ -214,6 +214,10 @@ WI.CSSManager = class CSSManager extends WI.Object
             return WI.unlocalizedString("::checkmark");
         case CSSManager.PseudoSelectorNames.PickerIcon:
             return WI.unlocalizedString("::picker-icon");
+        case CSSManager.PseudoSelectorNames.Track:
+            return WI.unlocalizedString("::track");
+        case CSSManager.PseudoSelectorNames.Fill:
+            return WI.unlocalizedString("::fill");
         case CSSManager.PseudoSelectorNames.TargetText:
             return WI.unlocalizedString("::target-text");
         case CSSManager.PseudoSelectorNames.ViewTransition:
@@ -861,6 +865,7 @@ WI.CSSManager.PseudoSelectorNames = {
     Before: "before",
     Backdrop: "backdrop",
     Checkmark: "checkmark",
+    Fill: "fill",
     FirstLetter: "first-letter",
     FirstLine: "first-line",
     Highlight: "highlight",
@@ -870,6 +875,7 @@ WI.CSSManager.PseudoSelectorNames = {
     Selection: "selection",
     SpellingError: "spelling-error",
     TargetText: "target-text",
+    Track: "track",
     ViewTransition: "view-transition",
     ViewTransitionGroup: "view-transition-group",
     ViewTransitionImagePair: "view-transition-image-pair",


### PR DESCRIPTION
#### 5c7d9687b3f3301a590ecf4a5d3606fdc7018bd8
<pre>
[appearance: base] Create shadow trees for base slider controls
<a href="https://bugs.webkit.org/show_bug.cgi?id=305895">https://bugs.webkit.org/show_bug.cgi?id=305895</a>
<a href="https://rdar.apple.com/168599962">rdar://168599962</a>

Reviewed by NOBODY (OOPS!).

Support appearance: base for the &lt;meter&gt; element. Add pseudo elements for the
track and fill. Create a shadow tree elements for the these pseudo elements.
These new shadow tree elements have to coexist with the shadow tree elements of
the appearance: none case. Only a shadow sub-tree should be shown at any time.
Switching between them will happen in HTMLMeterElement::didRecalcStyle().

Also we need to add three pseudo classes for the meter gauge regions. The right
pseudo class will be chosen in SelectorChecker::checkOne() based on the value
attribute of the &lt;meter&gt; element.

Tests: fast/forms/appearance-base/appearance-base-meter-dynamic.html
       fast/forms/appearance-base/appearance-base-meter-initial.html
       fast/forms/appearance-base/appearance-base-meter-value-dynamic.html

* LayoutTests/fast/dom/HTMLMeterElement/meter-element-markup-expected.txt:
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-dynamic.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-initial.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/appearance-base-meter-value-dynamic.html: Added.
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-boundary-values-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-optimums-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt:
* LayoutTests/platform/glib/fast/dom/HTMLMeterElement/meter-styles-expected.txt:
* LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html: Added.
* LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-initial-expected.html: Added.
* LayoutTests/platform/glib/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html: Added.
* LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt:
* LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt:
* LayoutTests/platform/ios/fast/dom/HTMLMeterElement/meter-styles-expected.txt:
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html: Added.
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-initial-expected.html: Added.
* LayoutTests/platform/mac-sequoia-wk2/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html: Added.
* LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt:
* LayoutTests/platform/mac/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-element-repaint-on-update-value-expected.txt:
* LayoutTests/platform/win/fast/dom/HTMLMeterElement/meter-styles-changing-pseudo-expected.txt:
* LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-dynamic-expected.html: Added.
* LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-initial-expected.html: Added.
* LayoutTests/platform/win/fast/forms/appearance-base/appearance-base-meter-value-dynamic-expected.html: Added.
* Source/JavaScriptCore/inspector/protocol/CSS.json:
* Source/WebCore/css/CSSPseudoSelectors.json:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesEvenLessGoodPseudoClass):
(WebCore::matchesOptimumPseudoClass):
(WebCore::matchesSuboptimumPseudoClass):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
(WebCore::SelectorCompiler::addPseudoClassType):
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::attributeChanged):
(WebCore::HTMLMeterElement::didChangeElementValue):
(WebCore::HTMLMeterElement::appendShadowTreeForAutoAppearance):
(WebCore::HTMLMeterElement::appendShadowTreeForBaseAppearance):
(WebCore::HTMLMeterElement::didAddUserAgentShadowRoot):
(WebCore::HTMLMeterElement::didElementStateChange): Deleted.
* Source/WebCore/html/HTMLMeterElement.h:
* Source/WebInspectorUI/UserInterface/Controllers/CSSManager.js:
(WI.CSSManager.displayNameForPseudoId):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c7d9687b3f3301a590ecf4a5d3606fdc7018bd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145983 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18672 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10821 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99519 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9115c428-a28e-4037-b26e-efc0477d5beb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19152 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112292 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80388 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/899ac72f-461a-44f4-8285-4cceeec670db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14674 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131139 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93192 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7395c1ab-207b-47df-aa52-cf912c265675) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13956 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11711 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2107 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137965 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123512 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8073 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156973 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6787 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/194 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9314 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120303 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15471 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120638 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18539 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74217 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16344 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7430 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177287 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18125 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81893 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45507 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17861 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18041 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17921 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->