### PR TITLE
REGRESSION(Xcode 26): Broke WebPushD tests (ASSERTION FAILED: m_shouldIncrementProtocolVersionForTesting)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -53,9 +53,9 @@
 #import <WebKit/_WKWebPushSubscriptionData.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <WebKit/_WKWebsiteDataStoreDelegate.h>
+#import <algorithm>
 #import <mach/mach_init.h>
 #import <mach/task.h>
-#import <ranges>
 #import <wtf/BlockPtr.h>
 #import <wtf/OSObjectPtr.h>
 #import <wtf/StdLibExtras.h>
@@ -473,10 +473,10 @@ void WebPushXPCConnectionMessageSender::sendWithAsyncReplyWithoutUsingIPCConnect
     encoder.encodeHeader<M>();
     message.encode(encoder);
     auto dictionary = messageDictionaryFromEncoder(WTF::move(encoder));
-    xpc_connection_send_message_with_reply(m_connection.get(), dictionary.get(), mainDispatchQueueSingleton(), makeBlockPtr([this, completionHandler = WTF::move(completionHandler)] (xpc_object_t reply) mutable {
+    xpc_connection_send_message_with_reply(m_connection.get(), dictionary.get(), mainDispatchQueueSingleton(), makeBlockPtr([shouldIncrementProtocolVersion = m_shouldIncrementProtocolVersionForTesting, completionHandler = WTF::move(completionHandler)] (xpc_object_t reply) mutable {
         if (xpc_get_type(reply) == XPC_TYPE_ERROR) {
             // We only expect an error if we were purposefully testing the wrong protocol version.
-            RELEASE_ASSERT(m_shouldIncrementProtocolVersionForTesting);
+            RELEASE_ASSERT(shouldIncrementProtocolVersion);
             return IPC::cancelReplyWithoutUsingConnection<M>(WTF::move(completionHandler));
         }
 
@@ -1471,7 +1471,7 @@ TEST_F(WebPushDTest, SubscribeTest)
     };
     auto topics = getPushTopics();
     auto& subscribed = topics.first;
-    std::ranges::sort(subscribed, lessThan);
+    std::sort(subscribed.begin(), subscribed.end(), lessThan);
 
     Vector<String> expected {
         "com.apple.WebKit.TestWebKitAPI ds:0bf5053b-164c-4b7d-8179-832e6bf158df https://example.com/"_s,
@@ -1528,7 +1528,7 @@ TEST_F(WebPushDNavigatorTest, SubscribeTest)
     };
     auto topics = getPushTopics();
     auto& subscribed = topics.first;
-    std::ranges::sort(subscribed, lessThan);
+    std::sort(subscribed.begin(), subscribed.end(), lessThan);
 
     Vector<String> expected {
         "com.apple.WebKit.TestWebKitAPI ds:0bf5053b-164c-4b7d-8179-832e6bf158df https://example.com/"_s,


### PR DESCRIPTION
#### d6836200a1f2bccccb0d942f97052bf4bc016056
<pre>
REGRESSION(Xcode 26): Broke WebPushD tests (ASSERTION FAILED: m_shouldIncrementProtocolVersionForTesting)
<a href="https://rdar.apple.com/169991396">rdar://169991396</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307362">https://bugs.webkit.org/show_bug.cgi?id=307362</a>

Reviewed by NOBODY (OOPS!).

The fix for the broke WebPushD tests which have compatibility issues with Xcode 26.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::(WebPushDTest, SubscribeTest)):
(TestWebKitAPI::(WebPushDNavigatorTest, SubscribeTest)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6836200a1f2bccccb0d942f97052bf4bc016056

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152326 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96895 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e77e426-a672-4876-8afe-2952ca089e59) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145534 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110478 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79492 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/df101e8b-7abb-4112-a708-d8a3338df881) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146622 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12930 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129115 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91395 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0f4ce9c-ed97-4907-88a0-9989e37fffc1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12404 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10124 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2329 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121852 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5695 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154639 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16187 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118482 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16223 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118837 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14785 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126904 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71601 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15808 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5440 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15543 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15755 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15607 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->