### PR TITLE
[Site Isolation] Web Inspector: support cross-origin iframes in Runtime domain

### DIFF
--- a/Source/JavaScriptCore/inspector/protocol/Runtime.json
+++ b/Source/JavaScriptCore/inspector/protocol/Runtime.json
@@ -2,7 +2,7 @@
     "domain": "Runtime",
     "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
     "debuggableTypes": ["itml", "javascript", "service-worker", "web-page", "wasm-debugger"],
-    "targetTypes": ["itml", "javascript", "page", "service-worker", "worker", "wasm-debugger"],
+    "targetTypes": ["frame", "itml", "javascript", "page", "service-worker", "worker", "wasm-debugger"],
     "types": [
         {
             "id": "RemoteObjectId",

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -1906,6 +1906,7 @@ inspector/agents/page/PageNetworkAgent.cpp
 inspector/agents/page/PageRuntimeAgent.cpp
 inspector/agents/page/PageTimelineAgent.cpp
 inspector/agents/page/PageWorkerAgent.cpp
+inspector/agents/frame/FrameRuntimeAgent.cpp
 inspector/agents/worker/ServiceWorkerAgent.cpp
 inspector/agents/worker/WorkerAuditAgent.cpp
 inspector/agents/worker/WorkerCanvasAgent.cpp

--- a/Source/WebCore/inspector/FrameInspectorController.cpp
+++ b/Source/WebCore/inspector/FrameInspectorController.cpp
@@ -34,6 +34,7 @@
 #include "DocumentPage.h"
 #include "FrameConsoleAgent.h"
 #include "FrameInlines.h"
+#include "FrameRuntimeAgent.h"
 #include "InspectorInstrumentation.h"
 #include "InspectorWebAgentBase.h"
 #include "InstrumentingAgents.h"
@@ -44,6 +45,7 @@
 #include "Settings.h"
 #include "WebInjectedScriptHost.h"
 #include "WebInjectedScriptManager.h"
+#include <JavaScriptCore/Debugger.h>
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
 #include <JavaScriptCore/InspectorFrontendRouter.h>
@@ -63,7 +65,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameInspectorController);
 FrameInspectorController::FrameInspectorController(LocalFrame& frame, PageInspectorController& parentPageController)
     : m_frame(frame)
     , m_instrumentingAgents(InstrumentingAgents::create(*this, parentPageController.instrumentingAgents()))
-    , m_injectedScriptManager(parentPageController.injectedScriptManager())
+    , m_injectedScriptManager(WebInjectedScriptManager::create(*this, WebInjectedScriptHost::create()))
     , m_frontendRouter(FrontendRouter::create())
     , m_backendDispatcher(BackendDispatcher::create(m_frontendRouter.copyRef(), &parentPageController.backendDispatcher()))
     , m_executionStopwatch(Stopwatch::create())
@@ -124,12 +126,36 @@ void FrameInspectorController::createConsoleAgent()
     m_didCreateConsoleAgent = true;
 }
 
+void FrameInspectorController::createRuntimeAgent()
+{
+    if (m_didCreateRuntimeAgent)
+        return;
+
+    RefPtr frame = m_frame.get();
+    if (!frame)
+        return;
+
+    auto context = frameAgentContext();
+    m_agents.append(makeUniqueRef<FrameRuntimeAgent>(context));
+    m_didCreateRuntimeAgent = true;
+}
+
 void FrameInspectorController::createLazyAgents()
 {
     if (m_didCreateLazyAgents)
         return;
 
     m_didCreateLazyAgents = true;
+
+    RefPtr frame = m_frame.get();
+    if (!frame || !protect(frame->settings())->siteIsolationEnabled())
+        return;
+
+    // Create debugger before agents that depend on it.
+    // FIXME: <https://webkit.org/b/298909> Add FrameDebuggerAgent to actively use this debugger.
+    m_debugger = makeUnique<JSC::Debugger>(vm());
+
+    createRuntimeAgent();
 }
 
 void FrameInspectorController::connectFrontend(Inspector::FrontendChannel& frontendChannel, bool isAutomaticInspection, bool immediatelyPause)
@@ -227,8 +253,8 @@ Stopwatch& FrameInspectorController::executionStopwatch() const
 
 JSC::Debugger* FrameInspectorController::debugger()
 {
-    // FIXME <https://webkit.org/b/298909> Add Debugger support for frame targets.
-    return nullptr;
+    // FIXME: <https://webkit.org/b/298909> Add full Debugger domain support for frame targets.
+    return m_debugger.get();
 }
 
 JSC::VM& FrameInspectorController::vm()

--- a/Source/WebCore/inspector/FrameInspectorController.h
+++ b/Source/WebCore/inspector/FrameInspectorController.h
@@ -40,6 +40,10 @@
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
+namespace JSC {
+class Debugger;
+}
+
 namespace Inspector {
 class BackendDispatcher;
 class FrontendChannel;
@@ -100,6 +104,7 @@ private:
 
     FrameAgentContext frameAgentContext();
     void createConsoleAgent();
+    void createRuntimeAgent();
     void createLazyAgents();
 
     WeakRef<LocalFrame> m_frame;
@@ -108,9 +113,11 @@ private:
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;
     const Ref<WTF::Stopwatch> m_executionStopwatch;
+    std::unique_ptr<JSC::Debugger> m_debugger;
     Inspector::AgentRegistry m_agents;
 
     bool m_didCreateConsoleAgent { false };
+    bool m_didCreateRuntimeAgent { false };
     bool m_didCreateLazyAgents { false };
     WeakPtr<InspectorFrontendClient> m_inspectorFrontendClient;
 };

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -78,6 +78,7 @@
 #include "WebSocketFrame.h"
 #include "WorkerInspectorController.h"
 #include "WorkerOrWorkletGlobalScope.h"
+#include "agents/frame/FrameRuntimeAgent.h"
 #include <JavaScriptCore/ConsoleMessage.h>
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <JavaScriptCore/InspectorDebuggerAgent.h>
@@ -107,6 +108,13 @@ void InspectorInstrumentation::didClearWindowObjectInWorldImpl(InstrumentingAgen
 {
     if (auto* pageDebuggerAgent = instrumentingAgents.enabledPageDebuggerAgent())
         pageDebuggerAgent->didClearWindowObjectInWorld(frame, world);
+
+    if (auto* frameRuntimeAgent = frame.inspectorController().instrumentingAgents().enabledFrameRuntimeAgent()) {
+        frameRuntimeAgent->didClearWindowObjectInWorld(world);
+        if (CheckedPtr pageAgent = instrumentingAgents.enabledPageAgent())
+            pageAgent->didClearWindowObjectInWorld(frame, world);
+        return;
+    }
 
     if (auto* pageRuntimeAgent = instrumentingAgents.enabledPageRuntimeAgent())
         pageRuntimeAgent->didClearWindowObjectInWorld(frame, world);

--- a/Source/WebCore/inspector/InstrumentingAgents.h
+++ b/Source/WebCore/inspector/InstrumentingAgents.h
@@ -57,6 +57,7 @@ class InspectorNetworkAgent;
 class InspectorPageAgent;
 class InspectorTimelineAgent;
 class InspectorWorkerAgent;
+class FrameRuntimeAgent;
 class PageCanvasAgent;
 class PageDOMDebuggerAgent;
 class PageDebuggerAgent;
@@ -85,6 +86,7 @@ class WebHeapAgent;
 #define DEFINE_INSPECTOR_AGENT_LayerTree(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorLayerTreeAgent, LayerTreeAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Network(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorNetworkAgent, NetworkAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorPageAgent, PageAgent, Getter, Setter)
+#define DEFINE_INSPECTOR_AGENT_Runtime_Frame(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, FrameRuntimeAgent, FrameRuntimeAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Runtime_Page(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, PageRuntimeAgent, PageRuntimeAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_ScriptProfiler(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, Inspector::InspectorScriptProfilerAgent, ScriptProfilerAgent, Getter, Setter)
 #define DEFINE_INSPECTOR_AGENT_Timeline(macro, Getter, Setter) DEFINE_INSPECTOR_AGENT(macro, InspectorTimelineAgent, TimelineAgent, Getter, Setter)
@@ -132,6 +134,7 @@ class WebHeapAgent;
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Memory) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Network) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Page) \
+    DEFINE_ENABLED_INSPECTOR_AGENT(macro, Runtime_Frame) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Runtime_Page) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Timeline) \
     DEFINE_ENABLED_INSPECTOR_AGENT(macro, Timeline_Page) \

--- a/Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.cpp
@@ -1,0 +1,270 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameRuntimeAgent.h"
+
+#include "DOMWrapperWorld.h"
+#include "Document.h"
+#include "DocumentLoader.h"
+#include "DocumentPage.h"
+#include "FrameConsoleClient.h"
+#include "FrameLoader.h"
+#include "InstrumentingAgents.h"
+#include "JSDOMWindowCustom.h"
+#include "JSExecState.h"
+#include "LocalDOMWindow.h"
+#include "LocalFrame.h"
+#include "LocalFrameInlines.h"
+#include "Page.h"
+#include "ScriptController.h"
+#include "SecurityOrigin.h"
+#include "UserGestureEmulationScope.h"
+#include "WindowProxy.h"
+#include <JavaScriptCore/InjectedScript.h>
+#include <JavaScriptCore/InjectedScriptManager.h>
+#include <JavaScriptCore/InspectorProtocolObjects.h>
+#include <wtf/CheckedRef.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/MakeString.h>
+
+namespace WebCore {
+
+using namespace Inspector;
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(FrameRuntimeAgent);
+
+FrameRuntimeAgent::FrameRuntimeAgent(FrameAgentContext& context)
+    : InspectorRuntimeAgent(context)
+    , m_frontendDispatcher(makeUniqueRef<RuntimeFrontendDispatcher>(context.frontendRouter))
+    , m_backendDispatcher(RuntimeBackendDispatcher::create(Ref { context.backendDispatcher }, this))
+    , m_instrumentingAgents(context.instrumentingAgents)
+    , m_inspectedFrame(context.inspectedFrame)
+    , m_frameIdentifier(context.inspectedFrame->frameID())
+{
+}
+
+FrameRuntimeAgent::~FrameRuntimeAgent() = default;
+
+CommandResult<void> FrameRuntimeAgent::enable()
+{
+    Ref agents = m_instrumentingAgents.get();
+    if (agents->enabledFrameRuntimeAgent() == this)
+        return { };
+
+    auto result = InspectorRuntimeAgent::enable();
+    if (!result)
+        return result;
+
+    reportExecutionContextCreation();
+    agents->setEnabledFrameRuntimeAgent(this);
+
+    return result;
+}
+
+CommandResult<void> FrameRuntimeAgent::disable()
+{
+    Ref { m_instrumentingAgents.get() }->setEnabledFrameRuntimeAgent(nullptr);
+
+    return InspectorRuntimeAgent::disable();
+}
+
+CommandResultOf<Ref<Inspector::Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */> FrameRuntimeAgent::evaluate(const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    auto injectedScript = injectedScriptForEval(errorString, WTF::move(executionContextId));
+    if (injectedScript.hasNoValue())
+        return makeUnexpected(errorString);
+
+    RefPtr frame = m_inspectedFrame.get();
+    RefPtr page = frame ? frame->page() : nullptr;
+    if (!page)
+        return makeUnexpected("Frame or page not available"_s);
+
+    UserGestureEmulationScope userGestureScope(*page, emulateUserGesture.value_or(false), dynamicDowncast<Document>(executionContext(injectedScript.globalObject())));
+    return InspectorRuntimeAgent::evaluate(injectedScript, expression, objectGroup, WTF::move(includeCommandLineAPI), WTF::move(doNotPauseOnExceptionsAndMuteConsole), WTF::move(returnByValue), WTF::move(generatePreview), WTF::move(saveResult), WTF::move(emulateUserGesture));
+}
+
+void FrameRuntimeAgent::callFunctionOn(const Inspector::Protocol::Runtime::RemoteObjectId& objectId, const String& expression, RefPtr<JSON::Array>&& optionalArguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& emulateUserGesture, std::optional<bool>&& awaitPromise, Ref<CallFunctionOnCallback>&& callback)
+{
+    auto injectedScript = injectedScriptManager().injectedScriptForObjectId(objectId);
+    if (injectedScript.hasNoValue()) {
+        callback->sendFailure("Missing injected script for given objectId"_s);
+        return;
+    }
+
+    RefPtr frame = m_inspectedFrame.get();
+    RefPtr page = frame ? frame->page() : nullptr;
+    if (!page) {
+        callback->sendFailure("Frame or page not available"_s);
+        return;
+    }
+
+    UserGestureEmulationScope userGestureScope(*page, emulateUserGesture.value_or(false), dynamicDowncast<Document>(executionContext(injectedScript.globalObject())));
+    return InspectorRuntimeAgent::callFunctionOn(objectId, expression, WTF::move(optionalArguments), WTF::move(doNotPauseOnExceptionsAndMuteConsole), WTF::move(returnByValue), WTF::move(generatePreview), WTF::move(emulateUserGesture), WTF::move(awaitPromise), WTF::move(callback));
+}
+
+InjectedScript FrameRuntimeAgent::injectedScriptForEval(Inspector::Protocol::ErrorString& errorString, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&& executionContextId)
+{
+    if (!executionContextId) {
+        RefPtr frame = m_inspectedFrame.get();
+        if (!frame)
+            return InjectedScript();
+
+        Ref protectedFrame = *frame;
+        CheckedRef script = protectedFrame->script();
+        auto* globalObject = script->globalObject(mainThreadNormalWorldSingleton());
+        if (!globalObject)
+            return InjectedScript();
+
+        auto result = injectedScriptManager().injectedScriptFor(globalObject);
+        if (result.hasNoValue())
+            errorString = "Internal error: main world execution context not found"_s;
+        return result;
+    }
+
+    auto injectedScript = injectedScriptManager().injectedScriptForId(*executionContextId);
+    if (injectedScript.hasNoValue())
+        errorString = "Missing injected script for given executionContextId"_s;
+    return injectedScript;
+}
+
+void FrameRuntimeAgent::muteConsole()
+{
+    FrameConsoleClient::mute();
+}
+
+void FrameRuntimeAgent::unmuteConsole()
+{
+    FrameConsoleClient::unmute();
+}
+
+String FrameRuntimeAgent::frameIdForProtocol() const
+{
+    return makeString("frame-"_s, m_frameIdentifier.toUInt64());
+}
+
+static Inspector::Protocol::Runtime::ExecutionContextType toProtocol(DOMWrapperWorld::Type type)
+{
+    switch (type) {
+    case DOMWrapperWorld::Type::Normal:
+        return Inspector::Protocol::Runtime::ExecutionContextType::Normal;
+    case DOMWrapperWorld::Type::User:
+        return Inspector::Protocol::Runtime::ExecutionContextType::User;
+    case DOMWrapperWorld::Type::Internal:
+        return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
+    }
+
+    ASSERT_NOT_REACHED();
+    return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
+}
+
+void FrameRuntimeAgent::reportExecutionContextCreation()
+{
+    RefPtr frame = m_inspectedFrame.get();
+    if (!frame)
+        return;
+
+    Ref protectedFrame = *frame;
+    CheckedRef script = protectedFrame->script();
+
+    if (!script->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
+        return;
+
+    // Don't report contexts if we're still on about:blank - wait for didClearWindowObjectInWorld after navigation
+    RefPtr document = protectedFrame->document();
+    if (!document || document->url().isAboutBlank())
+        return;
+
+    // Always send the main world first
+    auto* mainGlobalObjectPtr = script->globalObject(mainThreadNormalWorldSingleton());
+    if (!mainGlobalObjectPtr)
+        return;
+
+    auto& mainGlobalObject = *mainGlobalObjectPtr;
+    notifyContextCreated(&mainGlobalObject, mainThreadNormalWorldSingleton());
+
+    // Then iterate isolated worlds
+    Ref windowProxy = protectedFrame->windowProxy();
+    for (auto& jsWindowProxy : windowProxy->jsWindowProxiesAsVector()) {
+        auto* globalObject = jsWindowProxy->window();
+        if (globalObject == &mainGlobalObject)
+            continue;
+
+        RefPtr domDocument = downcast<LocalDOMWindow>(jsWindowProxy->wrapped()).document();
+        if (!domDocument)
+            continue;
+
+        Ref securityOrigin = domDocument->securityOrigin();
+        notifyContextCreated(globalObject, jsWindowProxy->world(), securityOrigin.ptr());
+    }
+}
+
+void FrameRuntimeAgent::notifyContextCreated(JSC::JSGlobalObject* globalObject, const DOMWrapperWorld& world, SecurityOrigin* securityOrigin)
+{
+    auto injectedScript = injectedScriptManager().injectedScriptFor(globalObject);
+    if (injectedScript.hasNoValue())
+        return;
+
+    RefPtr frame = m_inspectedFrame.get();
+    if (!frame)
+        return;
+
+    auto name = world.name();
+    if (name.isEmpty()) {
+        if (securityOrigin)
+            name = securityOrigin->toRawString();
+        else if (RefPtr document = frame->document())
+            name = document->url().string();
+    }
+
+    auto frameId = frameIdForProtocol();
+    auto contextId = injectedScriptManager().injectedScriptIdFor(globalObject);
+
+    m_frontendDispatcher->executionContextCreated(Inspector::Protocol::Runtime::ExecutionContextDescription::create()
+        .setId(contextId)
+        .setType(toProtocol(world.type()))
+        .setName(name)
+        .setFrameId(frameId)
+        .release());
+}
+
+void FrameRuntimeAgent::didClearWindowObjectInWorld(DOMWrapperWorld& world)
+{
+    RefPtr frame = m_inspectedFrame.get();
+    if (!frame)
+        return;
+
+    Ref protectedFrame = *frame;
+    CheckedRef script = protectedFrame->script();
+    auto* globalObject = script->globalObject(world);
+    if (!globalObject)
+        return;
+
+    notifyContextCreated(globalObject, world);
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "FrameIdentifier.h"
+#include "InspectorWebAgentBase.h"
+#include <JavaScriptCore/InspectorBackendDispatcher.h>
+#include <JavaScriptCore/InspectorFrontendDispatchers.h>
+#include <JavaScriptCore/InspectorRuntimeAgent.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/WeakRef.h>
+
+namespace JSC {
+class JSGlobalObject;
+}
+
+namespace WebCore {
+
+class DOMWrapperWorld;
+class LocalFrame;
+class SecurityOrigin;
+
+class FrameRuntimeAgent final : public Inspector::InspectorRuntimeAgent {
+    WTF_MAKE_NONCOPYABLE(FrameRuntimeAgent);
+    WTF_MAKE_TZONE_ALLOCATED(FrameRuntimeAgent);
+public:
+    FrameRuntimeAgent(FrameAgentContext&);
+    ~FrameRuntimeAgent();
+
+    // RuntimeBackendDispatcherHandler
+    Inspector::CommandResult<void> enable() override;
+    Inspector::CommandResult<void> disable() override;
+    Inspector::CommandResultOf<Ref<Inspector::Protocol::Runtime::RemoteObject>, std::optional<bool> /* wasThrown */, std::optional<int> /* savedResultIndex */> evaluate(const String& expression, const String& objectGroup, std::optional<bool>&& includeCommandLineAPI, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& saveResult, std::optional<bool>&& emulateUserGesture) override;
+    void callFunctionOn(const Inspector::Protocol::Runtime::RemoteObjectId&, const String& functionDeclaration, RefPtr<JSON::Array>&& arguments, std::optional<bool>&& doNotPauseOnExceptionsAndMuteConsole, std::optional<bool>&& returnByValue, std::optional<bool>&& generatePreview, std::optional<bool>&& emulateUserGesture, std::optional<bool>&& awaitPromise, Ref<CallFunctionOnCallback>&&) override;
+
+    // InspectorInstrumentation
+    void didClearWindowObjectInWorld(DOMWrapperWorld&);
+
+private:
+    Inspector::InjectedScript injectedScriptForEval(Inspector::Protocol::ErrorString&, std::optional<Inspector::Protocol::Runtime::ExecutionContextId>&&) override;
+    void muteConsole() override;
+    void unmuteConsole() override;
+    void reportExecutionContextCreation();
+    void notifyContextCreated(JSC::JSGlobalObject*, const DOMWrapperWorld&, SecurityOrigin* = nullptr);
+    String frameIdForProtocol() const;
+
+    const UniqueRef<Inspector::RuntimeFrontendDispatcher> m_frontendDispatcher;
+    const Ref<Inspector::RuntimeBackendDispatcher> m_backendDispatcher;
+
+    WeakRef<InstrumentingAgents> m_instrumentingAgents;
+    WeakRef<LocalFrame> m_inspectedFrame;
+    const FrameIdentifier m_frameIdentifier;
+};
+
+} // namespace WebCore

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -835,6 +835,8 @@ localizedStrings["Frames"] = "Frames";
 localizedStrings["Frames %d \u2013 %d"] = "Frames %d \u2013 %d";
 /* Title for list of HTML subframe JavaScript execution contexts */
 localizedStrings["Frames @ Execution Context Picker"] = "Frames";
+/* Title for list of site-isolated frame JavaScript execution contexts */
+localizedStrings["Frame Targets"] = "Frame Targets";
 /* Title for Frames row in Media Sidebar */
 localizedStrings["Frames @ Media Sidebar Frame Count"] = "Frames";
 localizedStrings["Full Garbage Collection"] = "Full Garbage Collection";

--- a/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js
@@ -1164,7 +1164,8 @@ WI.NetworkManager = class NetworkManager extends WI.Object
     executionContextCreated(payload)
     {
         let frame = this.frameForIdentifier(payload.frameId);
-        console.assert(frame);
+        // Under site isolation, FrameTargets report their own contexts.
+        // PageTarget should only handle contexts for frames in its own frame tree.
         if (!frame)
             return;
 

--- a/Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js
@@ -54,10 +54,6 @@ WI.RuntimeManager = class RuntimeManager extends WI.Object
 
     initializeTarget(target)
     {
-        // FIXME: <https://webkit.org/b/298910> Add Runtime support for FrameTarget.
-        if (target instanceof WI.FrameTarget)
-            return;
-
         target.RuntimeAgent.enable();
 
         if (WI.settings.showJavaScriptTypeInformation.value)

--- a/Source/WebInspectorUI/UserInterface/Models/ExecutionContext.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ExecutionContext.js
@@ -31,7 +31,8 @@ WI.ExecutionContext = class ExecutionContext
         console.assert(typeof id === "number" || id === WI.RuntimeManager.TopLevelExecutionContextIdentifier);
         console.assert(Object.values(WI.ExecutionContext.Type).includes(type));
         console.assert(!name || typeof name === "string");
-        console.assert(frame instanceof WI.Frame || id === WI.RuntimeManager.TopLevelExecutionContextIdentifier);
+        // Frame is required unless: (1) it's a top-level context, or (2) target is a FrameTarget (site isolation).
+        console.assert(frame instanceof WI.Frame || id === WI.RuntimeManager.TopLevelExecutionContextIdentifier || target instanceof WI.FrameTarget);
 
         this._target = target;
         this._id = id;

--- a/Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js
@@ -29,6 +29,44 @@ WI.FrameTarget = class FrameTarget extends WI.Target
     {
         super(parentTarget, targetId, name, WI.TargetType.Frame, connection, options);
 
-        this._executionContext = new WI.ExecutionContext(this, WI.RuntimeManager.TopLevelContextExecutionIdentifier, WI.ExecutionContext.Type.Normal, this.displayName);
+        this._executionContextList = new WI.ExecutionContextList;
     }
+
+    // Public
+
+    get executionContextList()
+    {
+        return this._executionContextList;
+    }
+
+    get executionContext()
+    {
+        return this._executionContext;
+    }
+
+    addExecutionContext(context)
+    {
+        // On navigation, a new Normal context replaces all prior contexts.
+        if (context.type === WI.ExecutionContext.Type.Normal && this._executionContext) {
+            this._executionContextList.clear();
+            this._executionContext = null;
+        }
+
+        this._executionContextList.add(context);
+
+        if (context.type === WI.ExecutionContext.Type.Normal)
+            this._executionContext = context;
+
+        this.dispatchEventToListeners(WI.FrameTarget.Event.ExecutionContextAdded, {context});
+    }
+
+    clearExecutionContexts()
+    {
+        this._executionContextList.clear();
+        this._executionContext = null;
+    }
+};
+
+WI.FrameTarget.Event = {
+    ExecutionContextAdded: "frame-target-execution-context-added",
 };

--- a/Source/WebInspectorUI/UserInterface/Protocol/RuntimeObserver.js
+++ b/Source/WebInspectorUI/UserInterface/Protocol/RuntimeObserver.js
@@ -29,6 +29,13 @@ WI.RuntimeObserver = class RuntimeObserver extends InspectorBackend.Dispatcher
 
     executionContextCreated(contextPayload)
     {
+        if (this._target instanceof WI.FrameTarget) {
+            let type = WI.ExecutionContext.typeFromPayload(contextPayload);
+            let executionContext = new WI.ExecutionContext(this._target, contextPayload.id, type, contextPayload.name);
+            this._target.addExecutionContext(executionContext);
+            return;
+        }
+
         WI.networkManager.executionContextCreated(contextPayload);
     }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
+++ b/Source/WebInspectorUI/UserInterface/Views/QuickConsole.js
@@ -71,6 +71,8 @@ WI.QuickConsole = class QuickConsole extends WI.View
         WI.Frame.addEventListener(WI.Frame.Event.ExecutionContextsCleared, this._handleFrameExecutionContextsCleared, this);
         WI.Frame.addEventListener(WI.Frame.Event.ExecutionContextAdded, this._handleFrameExecutionContextAdded, this);
 
+        WI.FrameTarget.addEventListener(WI.FrameTarget.Event.ExecutionContextAdded, this._handleFrameTargetExecutionContextAdded, this);
+
         WI.debuggerManager.addEventListener(WI.DebuggerManager.Event.ActiveCallFrameDidChange, this._handleDebuggerActiveCallFrameDidChange, this);
 
         WI.runtimeManager.addEventListener(WI.RuntimeManager.Event.ActiveExecutionContextChanged, this._handleActiveExecutionContextChanged, this);
@@ -105,6 +107,8 @@ WI.QuickConsole = class QuickConsole extends WI.View
 
         WI.Frame.removeEventListener(WI.Frame.Event.PageExecutionContextChanged, this._handleFramePageExecutionContextChanged, this);
         WI.Frame.removeEventListener(WI.Frame.Event.ExecutionContextsCleared, this._handleFrameExecutionContextsCleared, this);
+
+        WI.FrameTarget.removeEventListener(WI.FrameTarget.Event.ExecutionContextAdded, this._handleFrameTargetExecutionContextAdded, this);
 
         WI.debuggerManager.removeEventListener(WI.DebuggerManager.Event.ActiveCallFrameDidChange, this._handleDebuggerActiveCallFrameDidChange, this);
 
@@ -213,7 +217,10 @@ WI.QuickConsole = class QuickConsole extends WI.View
             return;
         }
 
-        if (WI.networkManager.frames.length === 1 && !WI.targetManager.workerTargets.length) {
+        // Check if we should show the picker: multiple frames, workers, or frame targets
+        let frameTargets = this._frameTargetsWithExecutionContext();
+
+        if (WI.networkManager.frames.length === 1 && !WI.targetManager.workerTargets.length && !frameTargets.length) {
             let mainFrameContexts = WI.networkManager.mainFrame.executionContextList.contexts;
             let contextsToShow = mainFrameContexts.filter((context) => context.type !== WI.ExecutionContext.Type.Internal || WI.settings.engineeringShowInternalExecutionContexts.value);
             if (contextsToShow.length <= 1) {
@@ -315,6 +322,35 @@ WI.QuickConsole = class QuickConsole extends WI.View
             for (let workerTarget of workerTargets) {
                 if (!workerTargets.includes(workerTarget.parentTarget))
                     addExecutionContextsForWorker(workerTarget, 1);
+            }
+        }
+
+        // Add FrameTarget execution contexts (for site-isolated frames)
+        let frameTargets = this._frameTargetsWithExecutionContext();
+        if (frameTargets.length) {
+            contextMenu.appendHeader(WI.UIString("Frame Targets"));
+
+            for (let frameTarget of frameTargets) {
+                let mainExecutionContext = frameTarget.executionContext;
+
+                let contexts = frameTarget.executionContextList.contexts.sort((a, b) => {
+                    if (a === mainExecutionContext)
+                        return -1;
+                    if (b === mainExecutionContext)
+                        return 1;
+
+                    const executionContextTypeRanking = [
+                        WI.ExecutionContext.Type.Normal,
+                        WI.ExecutionContext.Type.User,
+                        WI.ExecutionContext.Type.Internal,
+                    ];
+                    return executionContextTypeRanking.indexOf(a.type) - executionContextTypeRanking.indexOf(b.type);
+                });
+
+                for (let context of contexts) {
+                    let indent = (context === mainExecutionContext) ? 1 : 2;
+                    addExecutionContext(context, indent);
+                }
             }
         }
     }
@@ -458,9 +494,19 @@ WI.QuickConsole = class QuickConsole extends WI.View
         this._setActiveExecutionContext(this._resolveDesiredActiveExecutionContext());
     }
 
+    _handleFrameTargetExecutionContextAdded(event)
+    {
+        this._updateActiveExecutionContextDisplay();
+    }
+
     _canUseExecutionContextOfInspectedNode()
     {
         return InspectorBackend.hasDomain("DOM");
+    }
+
+    _frameTargetsWithExecutionContext()
+    {
+        return WI.targetManager.targets.filter((target) => target instanceof WI.FrameTarget && target.executionContext);
     }
 
     _toggleOrFocus(event)


### PR DESCRIPTION
#### 1a86de0bf48e776d1b8ad1bbc4a27cf1f6eab79b
<pre>
[Site Isolation] Web Inspector: support cross-origin iframes in Runtime domain
<a href="https://bugs.webkit.org/show_bug.cgi?id=307370">https://bugs.webkit.org/show_bug.cgi?id=307370</a>
<a href="https://rdar.apple.com/143598571">rdar://143598571</a>

Reviewed by BJ Burg.

Introducing FrameRuntimeAgent to enable JavaScript evaluation in cross-origin iframes under site
isolation. When cross-origin iframes run in separate WebProcesses, they need their own Runtime
agents to handle protocol commands independently since PageRuntimeAgent can only operate within
a single process.

Each FrameInspectorController creates its own InjectedScriptManager instance rather than sharing
with the parent PageInspectorController. Even when frames happen to share a process, isolating
the InjectedScriptManager per frame ensures independent runtime state — objectId namespaces,
saved result indices, and execution context IDs — so the frontend can treat each frame target
as a fully independent target. This also prevents entanglement when tearing down one frame&apos;s
inspector state while another remains live.

InspectorInstrumentation routing was updated to direct didClearWindowObjectInWorld notifications
to the appropriate agent based on frame type. Subframes with FrameInspectorControllers route to
their FrameRuntimeAgent for context updates and return early, completely skipping PageRuntimeAgent.
Main frames continue using PageRuntimeAgent for backwards compatibility. The routing preserves
InspectorPageAgent calls for bootstrap script injection in both code paths.

On the frontend, FrameTarget stores its main execution context directly via the inherited
_executionContext field on WI.Target rather than going through
ExecutionContextList.pageExecutionContext.
Navigation-reset logic lives in FrameTarget.addExecutionContext, keeping ExecutionContextList
free of frame-target-specific concerns. RuntimeObserver dispatches context creation events to
FrameTarget.addExecutionContext for frame-type targets instead of routing through NetworkManager.

FrameRuntimeAgent stores the FrameIdentifier directly and converts to a protocol string on demand
in frameIdForProtocol rather than caching the string at construction time.

* Source/JavaScriptCore/inspector/protocol/Runtime.json:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/inspector/FrameInspectorController.cpp:
(WebCore::FrameInspectorController::FrameInspectorController):
(WebCore::FrameInspectorController::createRuntimeAgent):
(WebCore::FrameInspectorController::createLazyAgents):
(WebCore::FrameInspectorController::debugger):
* Source/WebCore/inspector/FrameInspectorController.h:
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didClearWindowObjectInWorldImpl):
* Source/WebCore/inspector/InstrumentingAgents.h:
* Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.cpp: Added.
(WebCore::FrameRuntimeAgent::FrameRuntimeAgent):
(WebCore::m_frameIdentifier):
(WebCore::FrameRuntimeAgent::enable):
(WebCore::FrameRuntimeAgent::disable):
(WebCore::FrameRuntimeAgent::callFunctionOn):
(WebCore::FrameRuntimeAgent::injectedScriptForEval):
(WebCore::FrameRuntimeAgent::muteConsole):
(WebCore::FrameRuntimeAgent::unmuteConsole):
(WebCore::FrameRuntimeAgent::frameIdForProtocol const):
(WebCore::toProtocol):
(WebCore::FrameRuntimeAgent::reportExecutionContextCreation):
(WebCore::FrameRuntimeAgent::notifyContextCreated):
(WebCore::FrameRuntimeAgent::didClearWindowObjectInWorld):
* Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.h: Added.
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Controllers/NetworkManager.js:
(WI.NetworkManager.prototype.executionContextCreated):
* Source/WebInspectorUI/UserInterface/Controllers/RuntimeManager.js:
(WI.RuntimeManager.prototype.initializeTarget):
* Source/WebInspectorUI/UserInterface/Models/ExecutionContext.js:
(WI.ExecutionContext):
* Source/WebInspectorUI/UserInterface/Protocol/FrameTarget.js:
(WI.FrameTarget.prototype.get executionContextList):
(WI.FrameTarget.prototype.get executionContext):
(WI.FrameTarget.prototype.addExecutionContext):
(WI.FrameTarget.prototype.clearExecutionContexts):
(WI.FrameTarget):
* Source/WebInspectorUI/UserInterface/Protocol/RuntimeObserver.js:
(WI.RuntimeObserver.prototype.executionContextCreated):
(WI.RuntimeObserver):
* Source/WebInspectorUI/UserInterface/Views/QuickConsole.js:
(WI.QuickConsole):
(WI.QuickConsole.prototype.closed):
(WI.QuickConsole.prototype._updateActiveExecutionContextDisplay):
(WI.QuickConsole.prototype._populateActiveExecutionContextNavigationItemContextMenu):
(WI.QuickConsole.prototype._handleFrameTargetExecutionContextAdded):
(WI.QuickConsole.prototype._frameTargetsWithExecutionContext):

Canonical link: <a href="https://commits.webkit.org/308589@main">https://commits.webkit.org/308589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/138fa40b29ee0f73854ffb0f0b1c04416216c099

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147912 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20599 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14194 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156594 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/91ad8f4a-c4ba-4035-82b5-f9ea75058885) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149786 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20503 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114030 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff8fe26a-f106-47a1-bc43-acd0a9773cad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150874 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16274 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132853 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94794 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15420 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13216 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4034 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139881 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125026 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158929 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8701 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2064 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12244 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122065 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31336 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132551 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76549 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/17757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9313 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179334 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20014 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83774 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45936 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19744 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19892 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->