### PR TITLE
Fix PerformanceResourceTiming in cross origin resources

### DIFF
--- a/Source/WebCore/page/PerformanceResourceTiming.cpp
+++ b/Source/WebCore/page/PerformanceResourceTiming.cpp
@@ -119,10 +119,10 @@ double PerformanceResourceTiming::workerStart() const
 
 double PerformanceResourceTiming::redirectStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (m_resourceTiming.isLoadedFromServiceWorker())
         return 0.0;
 
-    if (m_resourceTiming.isLoadedFromServiceWorker())
+    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
 
     if (!m_resourceTiming.networkLoadMetrics().redirectCount)
@@ -133,10 +133,10 @@ double PerformanceResourceTiming::redirectStart() const
 
 double PerformanceResourceTiming::redirectEnd() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+    if (m_resourceTiming.isLoadedFromServiceWorker())
         return 0.0;
 
-    if (m_resourceTiming.isLoadedFromServiceWorker())
+    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
 
     if (!m_resourceTiming.networkLoadMetrics().redirectCount)
@@ -154,11 +154,11 @@ double PerformanceResourceTiming::fetchStart() const
 
 double PerformanceResourceTiming::domainLookupStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
-        return 0.0;
-
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return fetchStart();
+
+    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+        return 0.0;
 
     if (!m_resourceTiming.networkLoadMetrics().domainLookupStart)
         return fetchStart();
@@ -168,11 +168,11 @@ double PerformanceResourceTiming::domainLookupStart() const
 
 double PerformanceResourceTiming::domainLookupEnd() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
-        return 0.0;
-
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return fetchStart();
+
+    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+        return 0.0;
 
     if (!m_resourceTiming.networkLoadMetrics().domainLookupEnd)
         return domainLookupStart();
@@ -182,11 +182,11 @@ double PerformanceResourceTiming::domainLookupEnd() const
 
 double PerformanceResourceTiming::connectStart() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
-        return 0.0;
-
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return fetchStart();
+
+    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+        return 0.0;
 
     if (!m_resourceTiming.networkLoadMetrics().connectStart)
         return domainLookupEnd();
@@ -196,11 +196,11 @@ double PerformanceResourceTiming::connectStart() const
 
 double PerformanceResourceTiming::connectEnd() const
 {
-    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
-        return 0.0;
-
     if (m_resourceTiming.isLoadedFromServiceWorker())
         return fetchStart();
+
+    if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
+        return 0.0;
 
     if (!m_resourceTiming.networkLoadMetrics().connectEnd)
         return connectStart();
@@ -210,6 +210,9 @@ double PerformanceResourceTiming::connectEnd() const
 
 double PerformanceResourceTiming::secureConnectionStart() const
 {
+    if (m_resourceTiming.isLoadedFromServiceWorker())
+        return fetchStart();
+
     if (m_resourceTiming.networkLoadMetrics().failsTAOCheck)
         return 0.0;
 


### PR DESCRIPTION
#### 1297cb7f59763e23a932703022c1572ef579a0ec
<pre>
Fix PerformanceResourceTiming in cross origin resources
<a href="https://rdar.apple.com/170007989">rdar://170007989</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307382">https://bugs.webkit.org/show_bug.cgi?id=307382</a>

Reviewed by NOBODY (OOPS!).

PerformanceResourceTiming has a number of fields that are
returning 0 on a TAO failure. The spec says that this behavior
should only happen for opaque entries, which is a TAO failure
for a cross-origin resource.
<a href="https://w3c.github.io/resource-timing/#sec-cross-origin-resources">https://w3c.github.io/resource-timing/#sec-cross-origin-resources</a>

I addressed this by only returning 0 for opaque entries.

* Source/WebCore/page/PerformanceResourceTiming.cpp:
(WebCore::isOpaqueEntry):
(WebCore::PerformanceResourceTiming::workerStart const):
(WebCore::PerformanceResourceTiming::redirectStart const):
(WebCore::PerformanceResourceTiming::redirectEnd const):
(WebCore::PerformanceResourceTiming::domainLookupStart const):
(WebCore::PerformanceResourceTiming::domainLookupEnd const):
(WebCore::PerformanceResourceTiming::connectStart const):
(WebCore::PerformanceResourceTiming::connectEnd const):
(WebCore::PerformanceResourceTiming::secureConnectionStart const):
I changed this to match with Chrome&apos;s behavior. This change also matches some
of the behavior for the other fields that are not available in workers.
(WebCore::PerformanceResourceTiming::requestStart const):
(WebCore::PerformanceResourceTiming::finalResponseHeadersStart const):
(WebCore::PerformanceResourceTiming::firstInterimResponseStart const):
(WebCore::PerformanceResourceTiming::responseStart const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1297cb7f59763e23a932703022c1572ef579a0ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143918 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152588 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97157 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/478ba16e-5fe1-498a-93d8-5ffcb762248f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16490 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110667 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79580 "1 flakes 7 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2cb41ed2-98d5-47da-a6f2-0eeb7d5ef291) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129325 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91585 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12564 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10294 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5962 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154900 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16447 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118677 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16485 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13830 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119030 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14948 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127173 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71870 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16071 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5628 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79850 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16014 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15871 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->