### PR TITLE
[JSC] GreedyRegAlloc: amortize cost of clearing the visited set in the evict loop

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		A3E4DD931F3A803400DED0B4 /* TextStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3E4DD911F3A803400DED0B4 /* TextStream.cpp */; };
 		A3EE5C3A21FFAC5F00FABD61 /* OSAllocatorPOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3EE5C3921FFAC5E00FABD61 /* OSAllocatorPOSIX.cpp */; };
 		A3EE5C3D21FFAC7D00FABD61 /* SchedulePairCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A3EE5C3B21FFAC7C00FABD61 /* SchedulePairCF.cpp */; };
+		A400B8FB2F3AB62E009E21AF /* GenerationalSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A400B8FA2F3AB62E009E21AF /* GenerationalSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A4F0F47D2E3056A3001BF35C /* IntervalSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A4F0F47C2E3056A3001BF35C /* IntervalSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A5BA15F3182433A900A82E69 /* StringCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F2182433A900A82E69 /* StringCocoa.mm */; };
 		A5BA15F51824348000A82E69 /* StringImplCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F41824348000A82E69 /* StringImplCocoa.mm */; };
@@ -1520,6 +1521,7 @@
 		A3E4DD921F3A803400DED0B4 /* TextStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextStream.h; sourceTree = "<group>"; };
 		A3EE5C3921FFAC5E00FABD61 /* OSAllocatorPOSIX.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OSAllocatorPOSIX.cpp; sourceTree = "<group>"; };
 		A3EE5C3B21FFAC7C00FABD61 /* SchedulePairCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SchedulePairCF.cpp; sourceTree = "<group>"; };
+		A400B8FA2F3AB62E009E21AF /* GenerationalSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GenerationalSet.h; sourceTree = "<group>"; };
 		A4F0F47C2E3056A3001BF35C /* IntervalSet.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntervalSet.h; sourceTree = "<group>"; };
 		A5BA15F2182433A900A82E69 /* StringCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = StringCocoa.mm; sourceTree = "<group>"; };
 		A5BA15F41824348000A82E69 /* StringImplCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = StringImplCocoa.mm; sourceTree = "<group>"; };
@@ -2449,6 +2451,7 @@
 				1A1D8B9B173186CE00141DA4 /* FunctionDispatcher.h */,
 				FEC26BF2289DBBD300639A59 /* FunctionPtr.h */,
 				53F1D98620477B9800EBC6BF /* FunctionTraits.h */,
+				A400B8FA2F3AB62E009E21AF /* GenerationalSet.h */,
 				E3FD6D6627A1F6AD00935000 /* GenericHashKey.h */,
 				E3831F922703101A00EF5EB3 /* GenericTimeMixin.h */,
 				A8A472A8151A825A004123FF /* GetPtr.h */,
@@ -3599,6 +3602,7 @@
 				DDF3080227C08A77006A526F /* generate-unified-source-bundles.rb in Headers */,
 				07F5EA702EE8A7660085B185 /* GenerateModuleVerifierInputsTask.py in Headers */,
 				DDF3080327C08A77006A526F /* GeneratePreferences.rb in Headers */,
+				A400B8FB2F3AB62E009E21AF /* GenerationalSet.h in Headers */,
 				DDCAF31D27B1E7C500C45308 /* GenericHashKey.h in Headers */,
 				DD3DC93127A4BF8E007E5B61 /* GenericTimeMixin.h in Headers */,
 				DD3DC94727A4BF8E007E5B61 /* GetPtr.h in Headers */,

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -111,6 +111,7 @@ set(WTF_PUBLIC_HEADERS
     FunctionDispatcher.h
     FunctionPtr.h
     FunctionTraits.h
+    GenerationalSet.h
     GenericHashKey.h
     GenericTimeMixin.h
     GetPtr.h

--- a/Source/WTF/wtf/GenerationalSet.h
+++ b/Source/WTF/wtf/GenerationalSet.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <type_traits>
+#include <wtf/Vector.h>
+
+namespace WTF {
+
+// A set of integers in the range [0, size) optimized for repeated clear() operations.
+// clear() is amortized O(1) by using a generation counter instead of clearing storage.
+
+template<typename GenerationType, template<typename> typename VectorType = Vector>
+    requires std::is_unsigned_v<GenerationType>
+class GenerationalSet {
+    WTF_FORBID_HEAP_ALLOCATION;
+public:
+    GenerationalSet() = default;
+
+    explicit GenerationalSet(size_t size)
+        : m_map(size, 0)
+    {
+    }
+
+    void resize(size_t newSize)
+    {
+        size_t oldSize = m_map.size();
+        m_map.resize(newSize);
+        for (size_t i = oldSize; i < newSize; ++i)
+            m_map[i] = GenerationType { 0 };
+    }
+
+    size_t size() const
+    {
+        return m_map.size();
+    }
+
+    void clear()
+    {
+        ++m_generation;
+        if (!m_generation) [[unlikely]] {
+            m_map.fill(0);
+            m_generation = 1;
+        }
+    }
+
+    bool contains(size_t index) const
+    {
+        return m_map[index] == m_generation;
+    }
+
+    void add(size_t index)
+    {
+        m_map[index] = m_generation;
+    }
+
+private:
+    VectorType<GenerationType> m_map;
+    GenerationType m_generation { 1 };
+};
+
+} // namespace WTF
+
+using WTF::GenerationalSet;

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -55,6 +55,7 @@ set(TestWTF_SOURCES
     Tests/WTF/FixedBitVector.cpp
     Tests/WTF/FixedVector.cpp
     Tests/WTF/Function.cpp
+    Tests/WTF/GenerationalSet.cpp
     Tests/WTF/HashCountedSet.cpp
     Tests/WTF/HashMap.cpp
     Tests/WTF/HashSet.cpp

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1307,6 +1307,7 @@
 		A1FCFF2D2C292D0D0014463B /* NowPlayingSession.mm in Sources */ = {isa = PBXBuildFile; fileRef = A1FCFF2C2C292A600014463B /* NowPlayingSession.mm */; };
 		A310827221F296FF00C28B97 /* FileSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A310827121F296EC00C28B97 /* FileSystem.cpp */; };
 		A4EC3A792E305163002E3744 /* IntervalSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A4EC3A782E305163002E3744 /* IntervalSet.cpp */; };
+		A4FA03B82F3ABEA8006EE264 /* GenerationalSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A4FA03B72F3ABEA8006EE264 /* GenerationalSet.cpp */; };
 		A57D54F31F338C3600A97AA7 /* NeverDestroyed.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F21F338C3600A97AA7 /* NeverDestroyed.cpp */; };
 		A57D54F61F3395D000A97AA7 /* Logger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F41F3395D000A97AA7 /* Logger.cpp */; };
 		A57D54F91F3397B400A97AA7 /* LifecycleLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A57D54F71F3397B400A97AA7 /* LifecycleLogger.cpp */; };
@@ -3860,6 +3861,7 @@
 		A1FDFD2E19C288BB005148A4 /* WKImageCreateCGImageCrash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WKImageCreateCGImageCrash.cpp; sourceTree = "<group>"; };
 		A310827121F296EC00C28B97 /* FileSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FileSystem.cpp; sourceTree = "<group>"; };
 		A4EC3A782E305163002E3744 /* IntervalSet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IntervalSet.cpp; sourceTree = "<group>"; };
+		A4FA03B72F3ABEA8006EE264 /* GenerationalSet.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = GenerationalSet.cpp; sourceTree = "<group>"; };
 		A57A34EF16AF677200C2501F /* PageVisibilityStateWithWindowChanges.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = PageVisibilityStateWithWindowChanges.mm; sourceTree = "<group>"; };
 		A57A34F116AF69E200C2501F /* PageVisibilityStateWithWindowChanges.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = PageVisibilityStateWithWindowChanges.html; sourceTree = "<group>"; };
 		A57D54F21F338C3600A97AA7 /* NeverDestroyed.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NeverDestroyed.cpp; sourceTree = "<group>"; };
@@ -6486,6 +6488,7 @@
 				FF910E9D297A0D1100D1A24D /* FixedBitVector.cpp */,
 				E3210518261979F300157C67 /* FixedVector.cpp */,
 				9310CD361EF708FB0050FFE0 /* Function.cpp */,
+				A4FA03B72F3ABEA8006EE264 /* GenerationalSet.cpp */,
 				7A38D7E51C752D5F004F157D /* HashCountedSet.cpp */,
 				933D631B1FCB76180032ECD6 /* Hasher.cpp */,
 				0BCD833414857CE400EA2003 /* HashMap.cpp */,
@@ -7671,6 +7674,7 @@
 				FF910EA5297A0D1100D1A24D /* FixedBitVector.cpp in Sources */,
 				E3210519261979F300157C67 /* FixedVector.cpp in Sources */,
 				9310CD381EF708FB0050FFE0 /* Function.cpp in Sources */,
+				A4FA03B82F3ABEA8006EE264 /* GenerationalSet.cpp in Sources */,
 				6BFD294C1D5E6C1D008EC968 /* HashCountedSet.cpp in Sources */,
 				933D631D1FCB76200032ECD6 /* Hasher.cpp in Sources */,
 				7C83DED21D0A590C00FEBCF3 /* HashMap.cpp in Sources */,

--- a/Tools/TestWebKitAPI/Tests/WTF/GenerationalSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/GenerationalSet.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/GenerationalSet.h>
+
+#include "Test.h"
+
+namespace TestWebKitAPI {
+
+TEST(WTF_GenerationalSet, Basic)
+{
+    GenerationalSet<uint8_t> set(100);
+
+    EXPECT_FALSE(set.contains(0));
+    EXPECT_FALSE(set.contains(42));
+
+    set.add(42);
+    EXPECT_TRUE(set.contains(42));
+    EXPECT_FALSE(set.contains(0));
+
+    set.add(0);
+    EXPECT_TRUE(set.contains(0));
+    EXPECT_TRUE(set.contains(42));
+
+    set.clear();
+    EXPECT_FALSE(set.contains(0));
+    EXPECT_FALSE(set.contains(42));
+
+    set.add(0);
+    EXPECT_TRUE(set.contains(0));
+    EXPECT_FALSE(set.contains(42));
+}
+
+TEST(WTF_GenerationalSet, GenerationWrapAround)
+{
+    // Use uint8_t so wrap-around happens after 255 clears
+    GenerationalSet<uint8_t> set(10);
+
+    set.add(0);
+    set.add(5);
+    set.add(9);
+    EXPECT_TRUE(set.contains(0));
+    EXPECT_TRUE(set.contains(5));
+    EXPECT_TRUE(set.contains(9));
+    EXPECT_FALSE(set.contains(1));
+
+    // Do 300 clear cycles to ensure we wrap around at least once
+    for (unsigned cycle = 0; cycle < 300; ++cycle) {
+        set.clear();
+        // After clear, elements should be not present (and remain not present even after the generation counter wraps)
+        EXPECT_FALSE(set.contains(0));
+        EXPECT_FALSE(set.contains(5));
+        EXPECT_FALSE(set.contains(9));
+        EXPECT_FALSE(set.contains(1));
+    }
+}
+
+TEST(WTF_GenerationalSet, Resize)
+{
+    GenerationalSet<uint8_t> set(10);
+
+    set.add(5);
+    EXPECT_TRUE(set.contains(5));
+    EXPECT_EQ(set.size(), 10u);
+
+    // Grow the set
+    set.resize(20);
+    EXPECT_EQ(set.size(), 20u);
+
+    // Existing element still present
+    EXPECT_TRUE(set.contains(5));
+
+    // Can add to new indices
+    set.add(15);
+    EXPECT_TRUE(set.contains(15));
+
+    // Clear works after resize
+    set.clear();
+    EXPECT_FALSE(set.contains(5));
+    EXPECT_FALSE(set.contains(15));
+
+    // Shrink the set
+    set.add(3);
+    set.add(7);
+    EXPECT_TRUE(set.contains(3));
+    EXPECT_TRUE(set.contains(7));
+
+    set.resize(10);
+    EXPECT_EQ(set.size(), 10u);
+
+    // Elements within new size still present
+    EXPECT_TRUE(set.contains(3));
+    EXPECT_TRUE(set.contains(7));
+
+    // Clear works after shrinking
+    set.clear();
+    EXPECT_FALSE(set.contains(3));
+    EXPECT_FALSE(set.contains(7));
+}
+
+TEST(WTF_GenerationalSet, DifferentGenerationTypes)
+{
+    GenerationalSet<uint16_t> set16(50);
+    set16.add(25);
+    EXPECT_TRUE(set16.contains(25));
+    set16.clear();
+    EXPECT_FALSE(set16.contains(25));
+
+    GenerationalSet<uint64_t> set64(50);
+    set64.add(25);
+    EXPECT_TRUE(set64.contains(25));
+    set64.clear();
+    EXPECT_FALSE(set64.contains(25));
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### a78705db7c08d5354b03bd114d338603a88e4834
<pre>
[JSC] GreedyRegAlloc: amortize cost of clearing the visited set in the evict loop
<a href="https://bugs.webkit.org/show_bug.cgi?id=307389">https://bugs.webkit.org/show_bug.cgi?id=307389</a>
<a href="https://rdar.apple.com/170013416">rdar://170013416</a>

Reviewed by Yusuke Suzuki and Marcus Plutowski.

When there are a lot of Tmps, the visited.clearAll() can be too
expensive to do for each eviction attempt of each register.
Amortize this overhead by introducing a generation based set.

Tests: Tools/TestWebKitAPI/Tests/WTF/GenerationalSet.cpp
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::tryEvict):
* Source/WTF/WTF.xcodeproj/project.pbxproj:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WTF/wtf/GenerationalSet.h: Added.
(WTF::GenerationalSet::GenerationalSet):
(WTF::GenerationalSet::resize):
(WTF::GenerationalSet::size const):
(WTF::GenerationalSet::clear):
(WTF::GenerationalSet::contains const):
(WTF::GenerationalSet::add):
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WTF/GenerationalSet.cpp: Added.
(TestWebKitAPI::TEST(WTF_GenerationalSet, Basic)):
(TestWebKitAPI::TEST(WTF_GenerationalSet, GenerationWrapAround)):
(TestWebKitAPI::TEST(WTF_GenerationalSet, Resize)):
(TestWebKitAPI::TEST(WTF_GenerationalSet, DifferentGenerationTypes)):

Canonical link: <a href="https://commits.webkit.org/307222@main">https://commits.webkit.org/307222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/11e4bf2efde3209907c7882ac9caa3ca7bab637e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16218 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152405 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c70a3610-5dbf-45ae-886c-8b49541a6206) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145612 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16895 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110536 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/602ef248-6887-417c-bef7-bf00c70acd6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91454 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b655de59-93bc-407e-985c-63b8f16fe714) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12452 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10176 "Passed tests") | [  ~~🛠 wpe-libwebrtc~~](https://ews-build.webkit.org/#/builders/172/builds/2407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135725 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121906 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5762 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154717 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4543 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6805 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118540 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16301 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118898 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14838 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126971 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22172 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15887 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5494 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175023 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15621 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45153 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->