### PR TITLE
[iOS] Populate the AirPlay placard with MediaDeviceRoute's routeDisplayName

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/device-name-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/device-name-expected.txt
@@ -1,0 +1,13 @@
+
+Test that the AirPlay placard is populated with the MediaDeviceRoute's deviceName.
+
+EXPECTED (video.remote.state == 'disconnected') OK
+RUN(video.src = findMediaFile('video', '../content/test'))
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+EVENT(connect)
+EXPECTED (placardDescription.innerText == 'This video is playing on “test”.') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/device-name.html
+++ b/LayoutTests/media/wireless-playback-media-player/device-name.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <meta charset='UTF-8'>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+            var placardDescription;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.getElementsByTagName('video')[0];
+                testExpected('video.remote.state', 'disconnected');
+
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                const connectPromise = waitFor(video.remote, 'connect');
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                route.deviceName = 'test';
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+                await connectPromise;
+
+                const videoShadowRoot = internals.shadowRoot(video);
+
+                const checkPlacard = () => {
+                    placardDescription = videoShadowRoot.querySelector('.placard .description');
+                    if (!placardDescription)
+                        return false;
+
+                    testExpected('placardDescription.innerText', 'This video is playing on “test”.');
+                    return true;
+                };
+
+                if (checkPlacard()) {
+                    endTest();
+                    return;
+                }
+
+                const mutationObserver = new MutationObserver((mutationList, observer) => {
+                    if (checkPlacard()) {
+                        observer.disconnect();
+                        endTest();
+                        return;
+                    }
+                });
+
+                mutationObserver.observe(videoShadowRoot, { childList: true, subtree: true });
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that the AirPlay placard is populated with the MediaDeviceRoute's deviceName.</p> 
+    </body>
+</html>

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -123,6 +123,7 @@ public:
     void setClient(MediaDeviceRouteClient* client) { m_client = client; }
 
     const WTF::UUID& identifier() const { return m_identifier; }
+    String deviceName() const;
     WebMediaDevicePlatformRoute *platformRoute() const;
 
     void loadURL(const URL&, CompletionHandler<void(const MediaDeviceRouteLoadURLResult&)>&&);

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -199,6 +199,11 @@ MediaDeviceRoute::MediaDeviceRoute(WebMediaDevicePlatformRoute *platformRoute)
 {
 }
 
+String MediaDeviceRoute::deviceName() const
+{
+    return [m_platformRoute routeDisplayName];
+}
+
 WebMediaDevicePlatformRoute *MediaDeviceRoute::platformRoute() const
 {
     return m_platformRoute.get();

--- a/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp
@@ -68,9 +68,8 @@ MediaDeviceRoute* MediaPlaybackTargetWirelessPlayback::route() const
 
 String MediaPlaybackTargetWirelessPlayback::deviceName() const
 {
-    // FIXME: provide a real device name
-    if (auto identifier = this->identifier())
-        return identifier->toString();
+    if (RefPtr route = m_route)
+        return m_route->deviceName();
     return { };
 }
 

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -47,6 +47,9 @@ public:
 
     void setURLCallback(MockMediaDeviceRouteURLCallback*);
 
+    String deviceName() const;
+    void setDeviceName(const String&);
+
 private:
     MockMediaDeviceRoute();
 

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -29,4 +29,6 @@
     LegacyNoInterfaceObject,
 ] interface MockMediaDeviceRoute {
     undefined setURLCallback(MockMediaDeviceRouteURLCallback? callback);
+
+    attribute DOMString deviceName;
 };

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -55,6 +55,16 @@ void MockMediaDeviceRoute::setURLCallback(MockMediaDeviceRouteURLCallback* urlCa
     [m_platformRoute setURLCallback:urlCallback];
 }
 
+String MockMediaDeviceRoute::deviceName() const
+{
+    return [m_platformRoute routeDisplayName];
+}
+
+void MockMediaDeviceRoute::setDeviceName(const String& deviceName)
+{
+    [m_platformRoute setRouteDisplayName:deviceName.createNSString().get()];
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface WebMockMediaDeviceRoute : NSObject <AVMediaSource, WebMediaDevicePlatformRoute>
 @property (nonatomic, nullable, setter=setURLCallback:) WebCore::MockMediaDeviceRouteURLCallback* urlCallback;
+@property (copy) NSString *routeDisplayName;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
@@ -69,6 +69,7 @@ typedef NS_ENUM(NSInteger, WebMockMediaDeviceRouteErrorCode) {
 @synthesize muted;
 @synthesize volume;
 @synthesize metadata;
+@synthesize routeDisplayName;
 
 - (WebCore::MockMediaDeviceRouteURLCallback* _Nullable)urlCallback
 {


### PR DESCRIPTION
#### 27e4e35ef59933cfb05ac758f9aaab7a79c17faf
<pre>
[iOS] Populate the AirPlay placard with MediaDeviceRoute&apos;s routeDisplayName
<a href="https://bugs.webkit.org/show_bug.cgi?id=307391">https://bugs.webkit.org/show_bug.cgi?id=307391</a>
<a href="https://rdar.apple.com/170014863">rdar://170014863</a>

Reviewed by Jean-Yves Avenard.

Implemented MediaPlaybackTargetWirelessPlayback::deviceName() in terms of
MediaDeviceRoute::deviceName() and added the ability to set a device name for testing to
MockMediaDeviceRoute.

Test: media/wireless-playback-media-player/device-name.html

* LayoutTests/media/wireless-playback-media-player/device-name-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/device-name.html: Added.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(WebCore::MediaDeviceRoute::deviceName const):
* Source/WebCore/platform/graphics/MediaPlaybackTargetWirelessPlayback.cpp:
(WebCore::MediaPlaybackTargetWirelessPlayback::deviceName const):
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::deviceName const):
(WebCore::MockMediaDeviceRoute::setDeviceName):
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:

Canonical link: <a href="https://commits.webkit.org/307186@main">https://commits.webkit.org/307186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/819a0274ed4d9bffaf76467eb580816c23abda86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/15999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96754 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30fe85e5-6d3f-4d60-80a3-a4c056c44db5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145393 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16676 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16087 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110359 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79438 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/804f874a-6aa3-4932-8c2e-032bd4e5c050) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146481 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12818 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91276 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/693c939d-ceb7-4e9a-a5d3-9b8f81def453) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12307 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10019 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2185 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121741 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154495 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16046 "Built successfully") | [⏳ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118369 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118722 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30452 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14666 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126689 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71460 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15667 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15402 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79439 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15614 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15466 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->