### PR TITLE
[macOS] NSTextInputClient protocol methods should return rects in the screen's coordinate space

### DIFF
--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -746,12 +746,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
 - (NSRect)unionRectInVisibleSelectedRange
 {
-    return _impl->unionRectInVisibleSelectedRange();
+    return _impl->unionRectInVisibleSelectedRangeInScreen();
 }
 
 - (NSRect)documentVisibleRect
 {
-    return _impl->documentVisibleRect();
+    return _impl->documentVisibleRectInScreen();
 }
 
 - (void)showContextMenuForSelection:(id)sender

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -681,8 +681,8 @@ public:
     void characterIndexForPoint(NSPoint, void(^)(NSUInteger));
     void typingAttributesWithCompletionHandler(void(^)(NSDictionary<NSString *, id> *));
 
-    NSRect unionRectInVisibleSelectedRange() const;
-    NSRect documentVisibleRect() const;
+    NSRect unionRectInVisibleSelectedRangeInScreen() const;
+    NSRect documentVisibleRectInScreen() const;
 
     bool isContentRichlyEditable() const;
 
@@ -899,6 +899,8 @@ private:
     RetainPtr<AVTouchBarScrubber> m_mediaPlaybackControlsView;
 #endif // ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
 #endif // HAVE(TOUCH_BAR)
+
+    NSRect convertFromViewToScreen(NSRect rectInView) const;
 
     bool supportsArbitraryLayoutModes() const;
     float intrinsicDeviceScaleFactor() const;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -949,7 +949,6 @@ public:
 
 #if PLATFORM(COCOA)
     void updatePluginsActiveAndFocusedState();
-    const WebCore::FloatRect& windowFrameInScreenCoordinates() const { return m_windowFrameInScreenCoordinates; }
     const WebCore::FloatRect& windowFrameInUnflippedScreenCoordinates() const { return m_windowFrameInUnflippedScreenCoordinates; }
     const WebCore::FloatRect& viewFrameInWindowCoordinates() const { return m_viewFrameInWindowCoordinates; }
 


### PR DESCRIPTION
#### 914fb1fe0ddac13d3d0fec2e25beaecd109fae06
<pre>
[macOS] NSTextInputClient protocol methods should return rects in the screen&apos;s coordinate space
<a href="https://bugs.webkit.org/show_bug.cgi?id=307392">https://bugs.webkit.org/show_bug.cgi?id=307392</a>
<a href="https://rdar.apple.com/169985581">rdar://169985581</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

The two `NSTextInputClient` methods `documentVisibleRect` and `unionRectInVisibleSelectedRange`
expect rects in screen coordinates rather than view coordinates (which is the current coordinate
space for these resulting rects). This patch addresses this disparity in coordinate spaces.

See below for more details.

Test: EditorStateTests.UnionRectInVisibleSelectedRangeAndDocumentVisibleRect

* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView unionRectInVisibleSelectedRange]):
(-[WKWebView documentVisibleRect]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::convertFromViewToScreen const):

Add a helper method to convert the given rect from web view to screen coordinates.

(WebKit::WebViewImpl::selectionDidChange):

Drive-by fix: in the case where `-textInputClientDidUpdateSelection` is called, the call to
`-scheduleShowAffordanceForSelectionRect:ofView:forDelegate:` becomes redundant in the case where
`textInputClientSelectionUpdatesEnabled` is on. Adjust this to avoid doing both, in that scenario.

(WebKit::WebViewImpl::unionRectInVisibleSelectedRangeInScreen const):
(WebKit::WebViewImpl::documentVisibleRectInScreen const):

Rename these internal view impl methods to clarify that their returned values are in screen
coordinates already, and use the `convertFromViewToScreen` helper above.

(WebKit::WebViewImpl::firstRectForCharacterRange):
(WebKit::WebViewImpl::unionRectInVisibleSelectedRange const): Deleted.
(WebKit::WebViewImpl::documentVisibleRect const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeAndDocumentVisibleRect)):

Adjust this API test to also sanity check the resulting rects against the bounds of the view. In
doing so, we assume that the rects are in screen coordinates, and first map them back to the view&apos;s
coordinate space before comparing them with the view&apos;s bounds.

Canonical link: <a href="https://commits.webkit.org/307151@main">https://commits.webkit.org/307151@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/154e05a41941d79749e9ca0a535b42dffe27ccf5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16044 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7658 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152228 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e23c7ac2-7086-4e86-9cf0-1e2a82605c06) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110394 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ba84b4bd-3a8d-447f-b5a5-1d5f791f8a6b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91313 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fffe9d85-a086-416b-8177-2b83f160627f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2230 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5532 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154540 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16091 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118402 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16127 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13549 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118758 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30428 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14696 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71505 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15712 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5339 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15447 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15659 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->