### PR TITLE
[GFC] Pass in constraints from opposite axis to track sizing algorithm

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -386,13 +386,15 @@ LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSi
     return endPosition - startPosition;
 }
 
-LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, const IntegrationUtils& integrationUtils)
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
 {
+    UNUSED_PARAM(blockAxisConstraint);
     return integrationUtils.preferredMinWidth(gridItem.layoutBox());
 }
 
-LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, const IntegrationUtils& integrationUtils)
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem& gridItem, LayoutUnit blockAxisConstraint, const IntegrationUtils& integrationUtils)
 {
+    UNUSED_PARAM(blockAxisConstraint);
     return integrationUtils.preferredMaxWidth(gridItem.layoutBox());
 }
 
@@ -401,14 +403,16 @@ GridItemSizingFunctions inlineAxisGridItemSizingFunctions()
     return { inlineAxisMinContentContribution, inlineAxisMaxContentContribution, usedInlineMinimumSize };
 }
 
-LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, const IntegrationUtils&)
+LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const IntegrationUtils&)
 {
+    UNUSED_PARAM(inlineAxisConstraint);
     ASSERT_NOT_IMPLEMENTED_YET();
     return { };
 }
 
-LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, const IntegrationUtils&)
+LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const IntegrationUtils&)
 {
+    UNUSED_PARAM(inlineAxisConstraint);
     ASSERT_NOT_IMPLEMENTED_YET();
     return { };
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -47,12 +47,12 @@ LayoutUnit usedBlockMinimumSize(const PlacedGridItem&, const TrackSizingFunction
 LayoutUnit computeGridLinePosition(size_t gridLineIndex, const TrackSizes&, LayoutUnit gap);
 LayoutUnit gridAreaDimensionSize(size_t startLine, size_t endLine, const TrackSizes&, LayoutUnit gap);
 
-LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, const IntegrationUtils&);
-LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, const IntegrationUtils&);
+LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, const IntegrationUtils&);
+LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, const IntegrationUtils&);
 GridItemSizingFunctions inlineAxisGridItemSizingFunctions();
 
-LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, const IntegrationUtils&);
-LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, const IntegrationUtils&);
+LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const IntegrationUtils&);
+LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const IntegrationUtils&);
 GridItemSizingFunctions blockAxisGridItemSizingFunctions();
 
 bool preferredSizeBehavesAsAuto(const Style::PreferredSize&);

--- a/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridTypeAliases.h
@@ -57,6 +57,7 @@ using PlacedGridItems = Vector<PlacedGridItem>;
 using PlacedGridItemSpanList = Vector<WTF::Range<size_t>>;
 using TrackSizes = Vector<LayoutUnit>;
 using TrackSizingFunctionsList = Vector<TrackSizingFunctions>;
+using TrackSizingGridItemConstraintList = Vector<LayoutUnit>;
 using UnsizedTracks = Vector<UnsizedTrack>;
 using UsedBlockSizes = Vector<LayoutUnit>;
 using UsedBorderAndPaddingList = Vector<LayoutUnit>;

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -162,23 +162,23 @@ static TrackIndexes tracksWithAutoMaxTrackSizingFunction(const UnsizedTracks& un
 }
 
 static Vector<LayoutUnit> minContentContributions(const PlacedGridItems& gridItems, const GridItemIndexes& gridItemIndexes,
-    const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
+    const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     return gridItemIndexes.map([&](size_t gridItemIndex) {
-        return gridItemSizingFunctions.minContentContribution(gridItems[gridItemIndex], integrationUtils);
+        return gridItemSizingFunctions.minContentContribution(gridItems[gridItemIndex], oppositeAxisConstraints[gridItemIndex], integrationUtils);
     });
 }
 
 static Vector<LayoutUnit> maxContentContributions(const PlacedGridItems& gridItems, const GridItemIndexes& gridItemIndexes,
-    const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
+    const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     return gridItemIndexes.map([&](size_t gridItemIndex) {
-        return gridItemSizingFunctions.maxContentContribution(gridItems[gridItemIndex], integrationUtils);
+        return gridItemSizingFunctions.maxContentContribution(gridItems[gridItemIndex], oppositeAxisConstraints[gridItemIndex], integrationUtils);
     });
 }
 
 static Vector<LayoutUnit> minimumContributions(const PlacedGridItems& gridItems, const ComputedSizesList& gridItemComputedSizesList, const UsedBorderAndPaddingList&,
-    const GridItemIndexes& gridItemIndexes, const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
+    const GridItemIndexes& gridItemIndexes, const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     // The minimum contribution of an item is the smallest outer size it can have. Specifically,
     return gridItemIndexes.map([&](size_t gridItemIndex) -> LayoutUnit {
@@ -191,14 +191,14 @@ static Vector<LayoutUnit> minimumContributions(const PlacedGridItems& gridItems,
             return { };
         }
         // else the item’s minimum contribution is its min-content contribution.
-        return gridItemSizingFunctions.minContentContribution(gridItems[gridItemIndex], integrationUtils);
+        return gridItemSizingFunctions.minContentContribution(gridItems[gridItemIndex], oppositeAxisConstraints[gridItemIndex], integrationUtils);
     });
 }
 
 // https://drafts.csswg.org/css-grid-1/#algo-single-span-items
 static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const PlacedGridItems& gridItems,
     const ComputedSizesList& gridItemComputedSizesList, const UsedBorderAndPaddingList& borderAndPaddingList, const PlacedGridItemSpanList& gridItemSpanList,
-    const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
+    const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     // For each track with an intrinsic track sizing function and not a flexible sizing function, consider the items in it with a span of 1:
     for (auto trackIndex : tracksWithIntrinsicSizingFunction(unsizedTracks)) {
@@ -210,7 +210,7 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
             [&](const CSS::Keyword::MinContent&) -> LayoutUnit {
                 // If the track has a min-content min track sizing function, set its base size
                 // to the maximum of the items’ min-content contributions, floored at zero.
-                auto itemContributions = minContentContributions(gridItems, singleSpanningItemsIndexes, integrationUtils, gridItemSizingFunctions);
+                auto itemContributions = minContentContributions(gridItems, singleSpanningItemsIndexes, oppositeAxisConstraints, integrationUtils, gridItemSizingFunctions);
                 ASSERT(itemContributions.size() == singleSpanningItemsIndexes.size());
                 if (itemContributions.isEmpty())
                     return { };
@@ -219,7 +219,7 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
             [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
                 // If the track has a max-content min track sizing function, set its base
                 // size to the maximum of the items’ max-content contributions, floored at zero.
-                auto itemContributions = maxContentContributions(gridItems, singleSpanningItemsIndexes, integrationUtils, gridItemSizingFunctions);
+                auto itemContributions = maxContentContributions(gridItems, singleSpanningItemsIndexes, oppositeAxisConstraints, integrationUtils, gridItemSizingFunctions);
                 ASSERT(itemContributions.size() == singleSpanningItemsIndexes.size());
                 if (itemContributions.isEmpty())
                     return { };
@@ -240,7 +240,7 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
                 }
                 // Otherwise, set the track’s base size to the maximum of its items’ minimum
                 // contributions, floored at zero.
-                auto contributions = minimumContributions(gridItems, gridItemComputedSizesList, borderAndPaddingList, singleSpanningItemsIndexes, integrationUtils, gridItemSizingFunctions);
+                auto contributions = minimumContributions(gridItems, gridItemComputedSizesList, borderAndPaddingList, singleSpanningItemsIndexes, oppositeAxisConstraints, integrationUtils, gridItemSizingFunctions);
                 if (contributions.isEmpty())
                     return { };
                 return std::max({ }, std::ranges::max(contributions));
@@ -256,7 +256,7 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
             [&](const CSS::Keyword::MinContent&) -> LayoutUnit {
                 // If the track has a min-content max track sizing function, set its growth
                 // limit to the maximum of the items’ min-content contributions.
-                auto itemContributions = minContentContributions(gridItems, singleSpanningItemsIndexes, integrationUtils, gridItemSizingFunctions);
+                auto itemContributions = minContentContributions(gridItems, singleSpanningItemsIndexes, oppositeAxisConstraints, integrationUtils, gridItemSizingFunctions);
                 ASSERT(itemContributions.size() == singleSpanningItemsIndexes.size());
                 if (itemContributions.isEmpty())
                     return { };
@@ -265,7 +265,7 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
             [&](const CSS::Keyword::MaxContent&) -> LayoutUnit {
                 // If the track has a max-content max track sizing function, set its growth
                 // limit to the maximum of the items’ max-content contributions.
-                auto itemContributions = maxContentContributions(gridItems, singleSpanningItemsIndexes, integrationUtils, gridItemSizingFunctions);
+                auto itemContributions = maxContentContributions(gridItems, singleSpanningItemsIndexes, oppositeAxisConstraints, integrationUtils, gridItemSizingFunctions);
                 auto maximumMaxContentContribution = itemContributions.isEmpty() ? 0_lu : std::ranges::max(itemContributions);
 
                 auto hasFitContentMaximum = [] {
@@ -295,7 +295,7 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
 // https://drafts.csswg.org/css-grid-1/#algo-content
 static void resolveIntrinsicTrackSizes(UnsizedTracks& unsizedTracks, const PlacedGridItems& gridItems,
     const ComputedSizesList& gridItemComputedSizesList, const UsedBorderAndPaddingList& borderAndPaddingList, const PlacedGridItemSpanList& gridItemSpanList,
-    const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
+    const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const IntegrationUtils& integrationUtils, const GridItemSizingFunctions& gridItemSizingFunctions)
 {
     // 1. Shim baseline-aligned items so their intrinsic size contributions reflect their
     // baseline alignment.
@@ -306,7 +306,7 @@ static void resolveIntrinsicTrackSizes(UnsizedTracks& unsizedTracks, const Place
 
     // 2. Size tracks to fit non-spanning items.
     sizeTracksToFitNonSpanningItems(unsizedTracks, gridItems, gridItemComputedSizesList, borderAndPaddingList,
-        gridItemSpanList, integrationUtils, gridItemSizingFunctions);
+        gridItemSpanList, oppositeAxisConstraints, integrationUtils, gridItemSizingFunctions);
 
     // 3. Increase sizes to accommodate spanning items crossing content-sized tracks:
     // Next, consider the items with a span of 2 that do not span a track with a flexible
@@ -381,9 +381,8 @@ static void stretchAutoTracks(std::optional<LayoutUnit> freeSpace, UnsizedTracks
 // https://drafts.csswg.org/css-grid-1/#algo-track-sizing
 TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, const ComputedSizesList& gridItemComputedSizesList,
     const UsedBorderAndPaddingList& borderAndPaddingList, const PlacedGridItemSpanList& gridItemSpanList, const TrackSizingFunctionsList& trackSizingFunctions,
-    std::optional<LayoutUnit> availableGridSpace, const GridItemSizingFunctions& gridItemSizingFunctions,
-    const IntegrationUtils& integrationUtils, const FreeSpaceScenario& freeSpaceScenario, const LayoutUnit& gapSize,
-    const StyleContentAlignmentData& usedContentAlignment)
+    std::optional<LayoutUnit> availableGridSpace, const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const GridItemSizingFunctions& gridItemSizingFunctions,
+    const IntegrationUtils& integrationUtils, const FreeSpaceScenario& freeSpaceScenario, const LayoutUnit& gapSize, const StyleContentAlignmentData& usedContentAlignment)
 {
     ASSERT(gridItems.size() == gridItemSpanList.size());
 
@@ -391,7 +390,7 @@ TrackSizes TrackSizingAlgorithm::sizeTracks(const PlacedGridItems& gridItems, co
     auto unsizedTracks = initializeTrackSizes(trackSizingFunctions);
 
     // 2. Resolve Intrinsic Track Sizes
-    resolveIntrinsicTrackSizes(unsizedTracks, gridItems, gridItemComputedSizesList, borderAndPaddingList, gridItemSpanList, integrationUtils, gridItemSizingFunctions);
+    resolveIntrinsicTrackSizes(unsizedTracks, gridItems, gridItemComputedSizesList, borderAndPaddingList, gridItemSpanList, oppositeAxisConstraints, integrationUtils, gridItemSizingFunctions);
 
     // 3. Maximize Tracks
     auto maximizeTracks = [] {

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -36,7 +36,7 @@ namespace Layout {
 class IntegrationUtils;
 
 struct GridItemSizingFunctions {
-    GridItemSizingFunctions(Function<LayoutUnit(const PlacedGridItem&, const IntegrationUtils&)> minContentContributionFunction, Function<LayoutUnit(const PlacedGridItem&, const IntegrationUtils&)> maxContentContributionFunction,
+    GridItemSizingFunctions(Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint, const IntegrationUtils&)> minContentContributionFunction, Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint, const IntegrationUtils&)> maxContentContributionFunction,
         Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit availableSpace, const IntegrationUtils&)> usedMinimumSizeFunction)
             : minContentContribution(WTF::move(minContentContributionFunction))
             , maxContentContribution(WTF::move(maxContentContributionFunction))
@@ -44,8 +44,8 @@ struct GridItemSizingFunctions {
     {
     }
 
-    Function<LayoutUnit(const PlacedGridItem&, const IntegrationUtils&)> minContentContribution;
-    Function<LayoutUnit(const PlacedGridItem&, const IntegrationUtils&)> maxContentContribution;
+    Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint, const IntegrationUtils&)> minContentContribution;
+    Function<LayoutUnit(const PlacedGridItem&, LayoutUnit oppositeAxisConstraint, const IntegrationUtils&)> maxContentContribution;
     Function<LayoutUnit(const PlacedGridItem&, const TrackSizingFunctionsList&, LayoutUnit borderAndPadding, LayoutUnit availableSpace, const IntegrationUtils&)> usedMinimumSize;
 };
 
@@ -53,8 +53,8 @@ class TrackSizingAlgorithm {
 public:
     static TrackSizes sizeTracks(const PlacedGridItems&, const ComputedSizesList&, const UsedBorderAndPaddingList&,
         const PlacedGridItemSpanList&, const TrackSizingFunctionsList&, std::optional<LayoutUnit> availableGridSpace,
-        const GridItemSizingFunctions&, const IntegrationUtils&, const FreeSpaceScenario&, const LayoutUnit& gapSize,
-        const StyleContentAlignmentData& usedContentAlignment);
+        const TrackSizingGridItemConstraintList& oppositeAxisConstraints, const GridItemSizingFunctions&, const IntegrationUtils&,
+        const FreeSpaceScenario&, const LayoutUnit& gapSize, const StyleContentAlignmentData& usedContentAlignment);
 
 private:
 


### PR DESCRIPTION
#### b0467f4a9803fa3ccefe2a38ec9e0678acf30b80
<pre>
[GFC] Pass in constraints from opposite axis to track sizing algorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=307393">https://bugs.webkit.org/show_bug.cgi?id=307393</a>
<a href="https://rdar.apple.com/170014799">rdar://170014799</a>

Reviewed by Alan Baradlay.

During the track sizing algorithm, we may need to get a grid item&apos;s
min/max content contributions in a given axis when trying to determine
the sizes of the track. In some cases, we may need to know the
constraint/available space from the opposite dimension in order to
compute this properly. For example, in horizontal-tb content when we
size the rows, the min/max content contributions for the grid item&apos;s
block size will depend on the available space in the inline axis.

For each iteration of the track sizing algorithm, the spec defines how
we can compute this available space. Generally, this comes just from
the size of the tracks in the previous steps except for the first step
in which the track sizing algorithm defines some special behavior:
<a href="https://drafts.csswg.org/css-grid-1/#algo-grid-sizing">https://drafts.csswg.org/css-grid-1/#algo-grid-sizing</a>

In this patch, we compute the constraints for each grid item for the
first iteration of column/row sizing and pass this into the track sizing
algorithm so that the various sizing APIs can use them. This space will
always be available to the API since the spec defines how to compute
this for each iteration of the algorithm, but it will be up to the API
to determine whether or not it will need to use it to get the grid
item&apos;s size.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::rowSizesForFirstIterationColumnSizing):
Determines the &quot;row sizes,&quot; that will be used to compute the constraints
from for the first iteration of column sizing. Since we have not run any
sort of row sizing, we cannot use any actual row sizes that were the
output of the track sizing algorithm. Instead, the spec defines a method
in which to compute an alternate set of sizes based on the track sizing
functions.
<a href="https://drafts.csswg.org/css-grid-1/#algo-grid-sizing">https://drafts.csswg.org/css-grid-1/#algo-grid-sizing</a>

(WebCore::Layout::oppositeAxisConstraintForTrackSizing):
Computes the available space for a grid item in the opposite dimension
that we will compute track sizing for. The caller will pass in the used
track sizes from the previous step along with the placement of the grid
item which will be used together to compute the space.

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::inlineAxisMinContentContribution):
(WebCore::Layout::GridLayoutUtils::inlineAxisMaxContentContribution):
(WebCore::Layout::GridLayoutUtils::blockAxisMinContentContribution):
(WebCore::Layout::GridLayoutUtils::blockAxisMaxContentContribution):
Add in the available space as an argument to these sizing functions that
will be passed in during the track sizing algorithm.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::minContentContributions):
(WebCore::Layout::maxContentContributions):
(WebCore::Layout::minimumContributions):
(WebCore::Layout::sizeTracksToFitNonSpanningItems):
(WebCore::Layout::resolveIntrinsicTrackSizes):
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
Pass in the constraints in the opposite axis that were computed by
GridLayout and plumb them all the way to the various sizing functions
that get the different contributions of grid items.

Canonical link: <a href="https://commits.webkit.org/307172@main">https://commits.webkit.org/307172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d21ebdb1324e2c799d2ea95bf703c872284ee2c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16039 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152223 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96794 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c7824a4-8d7d-4f5a-a30b-1ae153c922c8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110387 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79451 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57c11d7d-9fa2-407a-bcc1-4a57ea07b523) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12836 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/128998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91306 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57abb58b-d474-413f-adf4-dc68288e40d9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12325 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10041 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2225 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154535 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16086 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6561 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118396 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13542 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118752 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30447 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14688 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126728 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71500 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15707 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5329 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15442 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15654 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15506 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->