### PR TITLE
[Scroll anchoring] Suppress scrollbar reveal for scroll anchoring changes

### DIFF
--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp
@@ -421,9 +421,9 @@ bool AsyncScrollingCoordinator::requestScrollToPosition(ScrollableArea& scrollab
     tracePoint(ProgrammaticScroll, scrollPosition.y(), frameView->frame().isMainFrame());
 
     if (options.originalScrollDelta)
-        stateNode->setRequestedScrollData({ ScrollRequestType::DeltaUpdate, *options.originalScrollDelta, options.type, options.clamping, options.animated });
+        stateNode->setRequestedScrollData({ ScrollRequestType::DeltaUpdate, *options.originalScrollDelta, options.type, options.clamping, options.animated, scrollableArea.scrollbarRevealBehavior() });
     else
-        stateNode->setRequestedScrollData({ ScrollRequestType::PositionUpdate, scrollPosition, options.type, options.clamping, options.animated });
+        stateNode->setRequestedScrollData({ ScrollRequestType::PositionUpdate, scrollPosition, options.type, options.clamping, options.animated, scrollableArea.scrollbarRevealBehavior() });
 
     LOG_WITH_STREAM(Scrolling, stream << "AsyncScrollingCoordinator::requestScrollToPosition " << scrollPosition << " for nodeID " << scrollingNodeID << " requestedScrollData " << stateNode->requestedScrollData());
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -578,6 +578,8 @@ void ScrollAnchoringController::adjustScrollPositionForAnchoring()
     auto options = ScrollPositionChangeOptions::createProgrammatic();
     options.originalScrollDelta = adjustment;
 
+    auto revealScope = ScrollbarRevealBehaviorScope(m_owningScrollableArea.get(), ScrollbarRevealBehavior::DontReveal);
+
     auto oldScrollType = m_owningScrollableArea->currentScrollType();
     m_owningScrollableArea->setCurrentScrollType(ScrollType::Programmatic);
 

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp
@@ -57,6 +57,11 @@ void RequestedScrollData::merge(RequestedScrollData&& other)
             break;
         }
     }
+
+    // Don't let `DontReveal` clobber `Default`.
+    if (scrollbarRevealBehavior == ScrollbarRevealBehavior::Default)
+        other.scrollbarRevealBehavior = ScrollbarRevealBehavior::Default;
+
     *this = WTF::move(other);
 }
 
@@ -235,6 +240,9 @@ TextStream& operator<<(TextStream& ts, const RequestedScrollData& requestedScrol
 
     if (requestedScrollData.animated == ScrollIsAnimated::Yes)
         ts.dumpProperty("animated"_s, requestedScrollData.animated == ScrollIsAnimated::Yes);
+
+    if (requestedScrollData.scrollbarRevealBehavior == ScrollbarRevealBehavior::DontReveal)
+        ts.dumpProperty("scrollbar-reveal"_s, requestedScrollData.scrollbarRevealBehavior);
 
     if (requestedScrollData.requestedDataBeforeAnimatedScroll) {
         auto oldType = std::get<0>(*requestedScrollData.requestedDataBeforeAnimatedScroll);

--- a/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h
@@ -112,6 +112,7 @@ struct RequestedScrollData {
     ScrollType scrollType { ScrollType::User };
     ScrollClamping clamping { ScrollClamping::Clamped };
     ScrollIsAnimated animated { ScrollIsAnimated::No };
+    ScrollbarRevealBehavior scrollbarRevealBehavior { ScrollbarRevealBehavior::Default };
     std::optional<std::tuple<ScrollRequestType, Variant<FloatPoint, FloatSize>, ScrollType, ScrollClamping>> requestedDataBeforeAnimatedScroll { };
 
     void merge(RequestedScrollData&&);
@@ -135,6 +136,7 @@ struct RequestedScrollData {
             && scrollType == other.scrollType
             && clamping == other.clamping
             && animated == other.animated
+            && scrollbarRevealBehavior == other.scrollbarRevealBehavior
             && requestedDataBeforeAnimatedScroll == other.requestedDataBeforeAnimatedScroll;
     }
 };

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -419,6 +419,7 @@ void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScro
         return;
     }
 
+    m_scrollbarRevealBehaviorForNextScrollbarUpdate = requestedScrollData.scrollbarRevealBehavior;
     scrollTo(destinationPosition, requestedScrollData.scrollType, requestedScrollData.clamping);
     didStopProgrammaticScroll();
 }
@@ -552,6 +553,11 @@ void ScrollingTreeScrollingNode::setCurrentHorizontalSnapPointIndex(std::optiona
 void ScrollingTreeScrollingNode::setCurrentVerticalSnapPointIndex(std::optional<unsigned> index)
 {
     m_currentVerticalSnapPointIndex = index;
+}
+
+ScrollbarRevealBehavior ScrollingTreeScrollingNode::takeScrollbarRevealBehaviorForNextScrollbarUpdate()
+{
+    return std::exchange(m_scrollbarRevealBehaviorForNextScrollbarUpdate, ScrollbarRevealBehavior::Default);
 }
 
 PlatformWheelEvent ScrollingTreeScrollingNode::eventForPropagation(const PlatformWheelEvent& wheelEvent) const

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -142,6 +142,8 @@ public:
     void scrollbarVisibilityDidChange(ScrollbarOrientation, bool);
     void scrollbarMinimumThumbLengthDidChange(ScrollbarOrientation, int);
 
+    ScrollbarRevealBehavior takeScrollbarRevealBehaviorForNextScrollbarUpdate();
+
 protected:
     ScrollingTreeScrollingNode(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
 
@@ -221,6 +223,7 @@ private:
 #endif
     bool m_isFirstCommit { true };
     bool m_scrolledSinceLastCommit { false };
+    ScrollbarRevealBehavior m_scrollbarRevealBehaviorForNextScrollbarUpdate { ScrollbarRevealBehavior::Default };
 
     LayerRepresentation m_scrollContainerLayer;
     LayerRepresentation m_scrolledContentsLayer;

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm
@@ -257,7 +257,9 @@ void ScrollerPairMac::updateValues()
     auto offset = node->currentScrollOffset();
 
     if (offset != m_lastScrollOffset) {
-        if (m_lastScrollOffset) {
+        auto scrollbarRevealBehavior = node->takeScrollbarRevealBehaviorForNextScrollbarUpdate();
+
+        if (m_lastScrollOffset && scrollbarRevealBehavior == ScrollbarRevealBehavior::Default) {
             ensureOnMainThreadWithProtectedThis([delta = offset - *m_lastScrollOffset](auto& scrollerPair) {
                 [scrollerPair.m_scrollerImpPair contentAreaScrolledInDirection:NSMakePoint(delta.width(), delta.height())];
             });

--- a/Source/WebCore/platform/ScrollTypes.cpp
+++ b/Source/WebCore/platform/ScrollTypes.cpp
@@ -125,6 +125,19 @@ TextStream& operator<<(TextStream& ts, ScrollbarMode behavior)
     return ts;
 }
 
+TextStream& operator<<(TextStream& ts, ScrollbarRevealBehavior behavior)
+{
+    switch (behavior) {
+    case ScrollbarRevealBehavior::DontReveal:
+        ts << "dont-reveal"_s;
+        break;
+    case ScrollbarRevealBehavior::Default:
+        ts << "default"_s;
+        break;
+    }
+    return ts;
+}
+
 TextStream& operator<<(TextStream& ts, OverflowAnchor behavior)
 {
     switch (behavior) {

--- a/Source/WebCore/platform/ScrollTypes.h
+++ b/Source/WebCore/platform/ScrollTypes.h
@@ -312,6 +312,11 @@ enum class ScrollbarOverlayStyle : uint8_t {
     Light
 };
 
+enum class ScrollbarRevealBehavior : bool {
+    DontReveal,
+    Default,
+};
+
 enum class ScrollPinningBehavior : uint8_t {
     DoNotPin,
     PinToTop,
@@ -401,6 +406,7 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollBehavior);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollElasticity);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, RubberBandingBehavior);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarMode);
+WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollbarRevealBehavior);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, OverflowAnchor);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollDirection);
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, ScrollGranularity);

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -1065,4 +1065,20 @@ void ScrollableArea::scrollbarColorDidChange(std::optional<ScrollbarColor> scrol
     scrollbarsController().scrollbarColorChanged(scrollbarColor);
 }
 
+// MARK: -
+
+ScrollbarRevealBehaviorScope::ScrollbarRevealBehaviorScope(ScrollableArea& scrollableArea, ScrollbarRevealBehavior reveal)
+    : m_scrollableArea(scrollableArea)
+    , m_oldBehavior(scrollableArea.scrollbarRevealBehavior())
+{
+    scrollableArea.setScrollbarRevealBehavior(reveal);
+}
+
+ScrollbarRevealBehaviorScope::~ScrollbarRevealBehaviorScope()
+{
+    CheckedRef scrollableArea = m_scrollableArea.get();
+    scrollableArea->setScrollbarRevealBehavior(m_oldBehavior);
+}
+
+
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -152,6 +152,9 @@ public:
     virtual OverscrollBehavior horizontalOverscrollBehavior() const { return OverscrollBehavior::Auto; }
     virtual OverscrollBehavior verticalOverscrollBehavior() const { return OverscrollBehavior::Auto; }
 
+    void setScrollbarRevealBehavior(ScrollbarRevealBehavior behavior) { m_scrollbarRevealBehavior = behavior; }
+    ScrollbarRevealBehavior scrollbarRevealBehavior() const { return m_scrollbarRevealBehavior; }
+
     WEBCORE_EXPORT virtual Color scrollbarThumbColorStyle() const;
     WEBCORE_EXPORT virtual Color scrollbarTrackColorStyle() const;
     WEBCORE_EXPORT virtual Style::ScrollbarGutter scrollbarGutterStyle() const;
@@ -532,8 +535,19 @@ private:
     bool m_scrollOriginChanged { false };
     bool m_scrollShouldClearLatchedState { false };
     bool m_isAwaitingScrollend { false };
+    ScrollbarRevealBehavior m_scrollbarRevealBehavior { ScrollbarRevealBehavior::Default };
 
     Markable<ScrollingNodeID> m_scrollingNodeIDForTesting;
+};
+
+class ScrollbarRevealBehaviorScope {
+public:
+    ScrollbarRevealBehaviorScope(ScrollableArea&, ScrollbarRevealBehavior);
+    ~ScrollbarRevealBehaviorScope();
+
+private:
+    WeakRef<ScrollableArea> m_scrollableArea;
+    ScrollbarRevealBehavior m_oldBehavior;
 };
 
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const ScrollableArea&);

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp
@@ -97,6 +97,7 @@ static void dump(TextStream& ts, const ScrollingStateScrollingNode& node, bool c
             ts.dumpProperty("requested-scroll-position-is-programatic"_s, requestedScrollData.scrollType);
             ts.dumpProperty("requested-scroll-position-clamping"_s, requestedScrollData.clamping);
             ts.dumpProperty("requested-scroll-position-animated"_s, requestedScrollData.animated == ScrollIsAnimated::Yes);
+            ts.dumpProperty("requested-scroll-scrollbars-reveal-behavior"_s, requestedScrollData.scrollbarRevealBehavior);
         }
     }
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -356,6 +356,7 @@ header: <WebCore/ScrollbarTrackCornerSystemImageMac.h>
 
 header: <WebCore/ScrollTypes.h>
 enum class WebCore::ScrollIsAnimated : bool;
+enum class WebCore::ScrollbarRevealBehavior : bool;
 
 enum class WebCore::ScrollGranularity : uint8_t {
     Line,
@@ -4313,6 +4314,7 @@ enum class WebCore::ScrollType : bool;
     WebCore::ScrollType scrollType;
     WebCore::ScrollClamping clamping;
     WebCore::ScrollIsAnimated animated;
+    WebCore::ScrollbarRevealBehavior scrollbarRevealBehavior;
     std::optional<std::tuple<WebCore::ScrollRequestType, Variant<WebCore::FloatPoint, WebCore::FloatSize>, WebCore::ScrollType, WebCore::ScrollClamping>> requestedDataBeforeAnimatedScroll;
 }
 


### PR DESCRIPTION
#### 636e5ac94706004b7ac8b5408c5431a15cbf86d0
<pre>
[Scroll anchoring] Suppress scrollbar reveal for scroll anchoring changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307402">https://bugs.webkit.org/show_bug.cgi?id=307402</a>
<a href="https://rdar.apple.com/170023562">rdar://170023562</a>

Reviewed by Aditya Keerthi.

When scroll anchoring adjusts the scroll position, we want to suppress the flash of
the overlay scrollbars that would otherwise occur, both to avoid user distraction,
and to save power. This is a different concept to the existing &quot;scrollbar suppression&quot;.

Introduce `ScrollbarRevealBehavior`, and plumb it through to `ScrollingTreeScrollingNode`.
`ScrollAnchoringController::adjustScrollPositionForAnchoring()` uses a stack-based class
to flip to `ScrollbarRevealBehavior::DontReveal` around the adjustment.

ScrollbarRevealBehavior isn&apos;t a state on the node; it&apos;s state on a `RequestedScrollData`,
and we do a one-shot read via `takeScrollbarRevealBehaviorForNextScrollbarUpdate()`
in `ScrollerPairMac`.

This PR only fixes macOS. UIScrollView doesn&apos;t seem to support suppressing indicator.

* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.cpp:
(WebCore::AsyncScrollingCoordinator::requestScrollToPosition):
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.cpp:
(WebCore::RequestedScrollData::merge):
(WebCore::operator&lt;&lt;):
* Source/WebCore/page/scrolling/ScrollingCoordinatorTypes.h:
(WebCore::RequestedScrollData::operator== const):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
(WebCore::ScrollingTreeScrollingNode::takeScrollbarRevealBehaviorForNextScrollbarUpdate):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.mm:
(WebCore::ScrollerPairMac::updateValues):
* Source/WebCore/platform/ScrollTypes.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/ScrollTypes.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollbarRevealBehaviorScope::ScrollbarRevealBehaviorScope):
(WebCore::ScrollbarRevealBehaviorScope::~ScrollbarRevealBehaviorScope):
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::setScrollbarRevealBehavior):
(WebCore::ScrollableArea::scrollbarRevealBehavior const):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.cpp:
(WebKit::dump):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/307178@main">https://commits.webkit.org/307178@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/997d85a53641a8e6defb27b4cc686a3e7667ff8f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16126 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/7796 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152312 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6e9551a-a09b-42fb-bbb7-68f0a76a1709) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145520 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16803 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16214 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/110469 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17d738ba-b1e0-453d-bbe2-ef3d7f7dc4f7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12916 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/91386 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12390 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10112 "Passed tests") | [  ~~🛠 wpe-libwebrtc~~](https://ews-build.webkit.org/#/builders/172/builds/2315 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121837 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/5673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154625 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16173 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/6716 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118474 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16209 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/13626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118829 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30449 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/14774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/126882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71587 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15794 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15529 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15593 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->