### PR TITLE
Reduce use of protected functions in Source/WebCore/platform

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -214,14 +214,14 @@ void AccessibilityScrollView::updateScrollbars()
     }
 
     if (scrollView->horizontalScrollbar() && !m_horizontalScrollbar)
-        m_horizontalScrollbar = addChildScrollbar(scrollView->protectedHorizontalScrollbar().get());
+        m_horizontalScrollbar = addChildScrollbar(protect(scrollView->horizontalScrollbar()).get());
     else if (!scrollView->horizontalScrollbar() && m_horizontalScrollbar) {
         removeChildScrollbar(m_horizontalScrollbar.get());
         m_horizontalScrollbar = nullptr;
     }
 
     if (scrollView->verticalScrollbar() && !m_verticalScrollbar)
-        m_verticalScrollbar = addChildScrollbar(scrollView->protectedVerticalScrollbar().get());
+        m_verticalScrollbar = addChildScrollbar(protect(scrollView->verticalScrollbar()).get());
     else if (!scrollView->verticalScrollbar() && m_verticalScrollbar) {
         removeChildScrollbar(m_verticalScrollbar.get());
         m_verticalScrollbar = nullptr;

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -1771,7 +1771,7 @@ private:
             return;
         }
 
-        auto arrayBuffer = pixelBuffer->protectedData()->possiblySharedBuffer();
+        auto arrayBuffer = protect(pixelBuffer->data())->possiblySharedBuffer();
         if (!arrayBuffer) {
             code = SerializationReturnCode::ValidationError;
             return;

--- a/Source/WebCore/platform/MediaSamplesBlock.h
+++ b/Source/WebCore/platform/MediaSamplesBlock.h
@@ -70,7 +70,6 @@ public:
 
     void setInfo(RefPtr<const TrackInfo>&& info) { m_info = WTF::move(info); }
     const TrackInfo* info() const { return m_info.get(); }
-    RefPtr<const TrackInfo> protectedInfo() const { return m_info; }
     MediaTime presentationTime() const { return isEmpty() ? MediaTime::invalidTime() : first().presentationTime; }
     MediaTime duration() const
     {

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -116,9 +116,7 @@ public:
     // If the scroll view does not use a native widget, then it will have cross-platform Scrollbars. These functions
     // can be used to obtain those scrollbars.
     Scrollbar* horizontalScrollbar() const final { return m_horizontalScrollbar.get(); }
-    RefPtr<Scrollbar> protectedHorizontalScrollbar() const { return horizontalScrollbar(); }
     Scrollbar* verticalScrollbar() const final { return m_verticalScrollbar.get(); }
-    RefPtr<Scrollbar> protectedVerticalScrollbar() const { return verticalScrollbar(); }
     bool isScrollViewScrollbar(const Widget* child) const { return horizontalScrollbar() == child || verticalScrollbar() == child; }
 
     void positionScrollbarLayers();

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -253,9 +253,7 @@ public:
     WEBCORE_EXPORT IntSize scrollbarIntrusion() const;
 
     virtual Scrollbar* horizontalScrollbar() const { return nullptr; }
-    RefPtr<Scrollbar> protectedHorizontalScrollbar() const { return horizontalScrollbar(); }
     virtual Scrollbar* verticalScrollbar() const { return nullptr; }
-    RefPtr<Scrollbar> protectedVerticalScrollbar() const { return verticalScrollbar(); }
     virtual void scrollbarFrameRectChanged(const Scrollbar&) const { };
 
     Scrollbar* scrollbarForDirection(ScrollDirection direction) const

--- a/Source/WebCore/platform/SearchPopupMenu.h
+++ b/Source/WebCore/platform/SearchPopupMenu.h
@@ -41,7 +41,6 @@ class SearchPopupMenu : public RefCounted<SearchPopupMenu> {
 public:
     virtual ~SearchPopupMenu() = default;
     virtual PopupMenu* popupMenu() = 0;
-    RefPtr<PopupMenu> protectedPopupMenu() { return popupMenu(); }
     virtual void saveRecentSearches(const AtomString& name, const Vector<RecentSearch>&) = 0;
     virtual void loadRecentSearches(const AtomString& name, Vector<RecentSearch>&) = 0;
     virtual bool enabled() = 0;

--- a/Source/WebCore/platform/SharedBuffer.h
+++ b/Source/WebCore/platform/SharedBuffer.h
@@ -390,7 +390,6 @@ public:
         updateBufferIfNeeded();
         return m_buffer.get();
     }
-    RefPtr<FragmentedSharedBuffer> protectedBuffer() const { return buffer(); }
     Ref<FragmentedSharedBuffer> copyBuffer() const { return createBuffer(); }
 
     WEBCORE_EXPORT RefPtr<ArrayBuffer> tryCreateArrayBuffer() const;

--- a/Source/WebCore/platform/Widget.cpp
+++ b/Source/WebCore/platform/Widget.cpp
@@ -46,11 +46,6 @@ ScrollView* Widget::parent() const
     return m_parent.get();
 }
 
-RefPtr<ScrollView> Widget::protectedParent() const
-{
-    return m_parent.get();
-}
-
 void Widget::setParent(ScrollView* view)
 {
     ASSERT(!view || !m_parent);

--- a/Source/WebCore/platform/Widget.h
+++ b/Source/WebCore/platform/Widget.h
@@ -143,7 +143,6 @@ public:
     WEBCORE_EXPORT void removeFromParent();
     WEBCORE_EXPORT virtual void setParent(ScrollView* view);
     WEBCORE_EXPORT ScrollView* NODELETE parent() const;
-    WEBCORE_EXPORT RefPtr<ScrollView> protectedParent() const;
     FrameView* root() const;
 
     virtual void handleEvent(Event&) { }

--- a/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
+++ b/Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h
@@ -39,7 +39,6 @@ public:
     WEBCORE_EXPORT static RefPtr<ByteArrayPixelBuffer> tryCreate(const PixelBufferFormat&, const IntSize&, Ref<JSC::ArrayBuffer>&&);
 
     JSC::Uint8ClampedArray& data() const LIFETIME_BOUND { return m_data.get(); }
-    Ref<JSC::Uint8ClampedArray> protectedData() const { return m_data; }
     Ref<JSC::Uint8ClampedArray>&& takeData() { return WTF::move(m_data); }
 
     Type type() const override { return Type::ByteArray; }

--- a/Source/WebCore/platform/graphics/Color.cpp
+++ b/Source/WebCore/platform/graphics/Color.cpp
@@ -175,7 +175,7 @@ Color Color::semanticColor() const
         return *this;
     
     if (isOutOfLine())
-        return { protectedAsOutOfLine(), colorSpace(), Flags::Semantic };
+        return { protect(asOutOfLine()), colorSpace(), Flags::Semantic };
     return { asInline(), Flags::Semantic };
 }
 
@@ -194,7 +194,7 @@ ColorComponents<float, 4> Color::toResolvedColorComponentsInColorSpace(const Des
 std::pair<ColorSpace, ColorComponents<float, 4>> Color::colorSpaceAndResolvedColorComponents() const
 {
     if (isOutOfLine())
-        return { colorSpace(), resolveColorComponents(protectedAsOutOfLine()->resolvedComponents()) };
+        return { colorSpace(), resolveColorComponents(protect(asOutOfLine())->resolvedComponents()) };
     return { ColorSpace::SRGB, asColorComponents(convertColor<SRGBA<float>>(asInline()).resolved()) };
 }
 

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -268,8 +268,7 @@ private:
     SRGBA<uint8_t> asInline() const;
     PackedColor::RGBA asPackedInline() const;
 
-    const OutOfLineComponents& asOutOfLine() const;
-    Ref<OutOfLineComponents> protectedAsOutOfLine() const;
+    OutOfLineComponents& asOutOfLine() const;
 
 #if CPU(ADDRESS64)
     static constexpr unsigned maxNumberOfBitsInPointer = 48;
@@ -531,13 +530,7 @@ inline bool Color::isInline() const
     return !flags().contains(FlagsIncludingPrivate::OutOfLine);
 }
 
-inline const Color::OutOfLineComponents& Color::asOutOfLine() const
-{
-    ASSERT(isOutOfLine());
-    return decodedOutOfLineComponents(m_colorAndFlags);
-}
-
-inline Ref<Color::OutOfLineComponents> Color::protectedAsOutOfLine() const
+inline Color::OutOfLineComponents& Color::asOutOfLine() const
 {
     ASSERT(isOutOfLine());
     return decodedOutOfLineComponents(m_colorAndFlags);

--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -161,11 +161,8 @@ public:
     bool variantCapsSupportedForSynthesis(FontVariantCaps) const;
 
     const Font& verticalRightOrientationFont() const;
-    Ref<const Font> protectedVerticalRightOrientationFont() const { return verticalRightOrientationFont(); }
     const Font& uprightOrientationFont() const;
-    Ref<const Font> protectedUprightOrientationFont() const { return uprightOrientationFont(); }
     const Font& invisibleFont() const;
-    Ref<const Font> protectedInvisibleFont() const { return invisibleFont(); }
 
     bool hasVerticalGlyphs() const { return m_hasVerticalGlyphs; }
     bool isTextOrientationFallback() const { return m_attributes.isTextOrientationFallback == IsOrientationFallback::Yes; }

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -444,7 +444,7 @@ GlyphData FontCascade::glyphDataForCharacter(char32_t c, bool mirror, FontVarian
 
     auto emojiPolicy = resolvedEmojiPolicy.value_or(resolveEmojiPolicy(m_fontDescription.variantEmoji(), c));
 
-    return protectedFonts()->glyphDataForCharacter(c, m_fontDescription, protect(fontSelector()).get(), variant, emojiPolicy);
+    return protect(fonts())->glyphDataForCharacter(c, m_fontDescription, protect(fontSelector()).get(), variant, emojiPolicy);
 }
 
 

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -299,7 +299,6 @@ public:
 
     bool useBackslashAsYenSymbol() const { return m_useBackslashAsYenSymbol; }
     FontCascadeFonts* fonts() const { return m_fonts.get(); }
-    RefPtr<FontCascadeFonts> protectedFonts() const { return m_fonts; }
     bool isLoadingCustomFonts() const;
 
     static ResolvedEmojiPolicy resolveEmojiPolicy(FontVariantEmoji, char32_t);
@@ -377,28 +376,24 @@ private:
 
 inline Ref<const Font> FontCascade::primaryFont() const
 {
-    ASSERT(m_fonts);
-    Ref font = protectedFonts()->primaryFont(m_fontDescription, protect(fontSelector()).get());
+    Ref font = protect(m_fonts)->primaryFont(m_fontDescription, protect(fontSelector()).get());
     m_fontDescription.resolveFontSizeAdjustFromFontIfNeeded(font);
     return font;
 }
 
 inline const FontRanges& FontCascade::fallbackRangesAt(unsigned index) const
 {
-    ASSERT(m_fonts);
-    return protectedFonts()->realizeFallbackRangesAt(m_fontDescription, protect(fontSelector()).get(), index);
+    return protect(m_fonts)->realizeFallbackRangesAt(m_fontDescription, protect(fontSelector()).get(), index);
 }
 
 inline bool FontCascade::isFixedPitch() const
 {
-    ASSERT(m_fonts);
-    return protectedFonts()->isFixedPitch(m_fontDescription, protect(fontSelector()).get());
+    return protect(m_fonts)->isFixedPitch(m_fontDescription, protect(fontSelector()).get());
 }
 
 inline bool FontCascade::canTakeFixedPitchFastContentMeasuring() const
 {
-    ASSERT(m_fonts);
-    return protectedFonts()->canTakeFixedPitchFastContentMeasuring(m_fontDescription, protect(fontSelector()).get());
+    return protect(m_fonts)->canTakeFixedPitchFastContentMeasuring(m_fontDescription, protect(fontSelector()).get());
 }
 
 inline FontSelector* FontCascade::fontSelector() const

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -316,7 +316,7 @@ static GlyphData glyphDataForNonCJKCharacterWithGlyphOrientation(char32_t charac
 {
     bool syntheticOblique = data.font->platformData().syntheticOblique();
     if (orientation == NonCJKGlyphOrientation::Upright || shouldIgnoreRotation(character)) {
-        GlyphData uprightData = Ref { *data.font }->protectedUprightOrientationFont()->glyphDataForCharacter(character);
+        GlyphData uprightData = protect(protect(data.font)->uprightOrientationFont())->glyphDataForCharacter(character);
         // If the glyphs are the same, then we know we can just use the horizontal glyph rotated vertically
         // to be upright. For synthetic oblique, however, we will always return the uprightData to ensure
         // that non-CJK and CJK runs are broken up. This guarantees that vertical
@@ -329,7 +329,7 @@ static GlyphData glyphDataForNonCJKCharacterWithGlyphOrientation(char32_t charac
         if (uprightData.font)
             return uprightData;
     } else if (orientation == NonCJKGlyphOrientation::Mixed) {
-        GlyphData verticalRightData = Ref { *data.font }->protectedVerticalRightOrientationFont()->glyphDataForCharacter(character);
+        GlyphData verticalRightData = protect(protect(data.font)->verticalRightOrientationFont())->glyphDataForCharacter(character);
 
         // If there is a baked-in rotated glyph, we will use it unless syntheticOblique is set. If
         // synthetic oblique is set, we fall back to the horizontal glyph. This guarantees that vertical
@@ -526,7 +526,7 @@ static RefPtr<GlyphPage> glyphPageFromFontRanges(unsigned pageNumber, const Font
         return nullptr;
 
     if (desiredVisibility == FallbackVisibility::Invisible && font->visibility() == Font::Visibility::Visible)
-        return const_cast<GlyphPage*>(font->protectedInvisibleFont()->glyphPage(pageNumber));
+        return const_cast<GlyphPage*>(protect(font->invisibleFont())->glyphPage(pageNumber));
     return const_cast<GlyphPage*>(font->glyphPage(pageNumber));
 }
 

--- a/Source/WebCore/platform/graphics/FontCustomPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontCustomPlatformData.h
@@ -109,9 +109,4 @@ public:
     RenderingResourceIdentifier m_renderingResourceIdentifier;
 };
 
-inline RefPtr<const FontCustomPlatformData> FontPlatformData::protectedCustomPlatformData() const
-{
-    return m_customPlatformData.get();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/FontPlatformData.h
+++ b/Source/WebCore/platform/graphics/FontPlatformData.h
@@ -473,7 +473,6 @@ public:
     {
         return m_customPlatformData.get();
     }
-    inline RefPtr<const FontCustomPlatformData> protectedCustomPlatformData() const; // Defined in FontCustomPlatformData.h
 
     WEBCORE_EXPORT Attributes attributes() const;
 

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -149,7 +149,6 @@ public:
     WEBCORE_EXPORT virtual String debugName() const;
 
     GraphicsLayer* parent() const { return m_parent; }
-    RefPtr<GraphicsLayer> protectedParent() const { return m_parent; }
     void setParent(GraphicsLayer*); // Internal use only.
     
     // Returns true if the layer has the given layer as an ancestor (excluding self).

--- a/Source/WebCore/platform/graphics/Image.cpp
+++ b/Source/WebCore/platform/graphics/Image.cpp
@@ -141,11 +141,6 @@ void Image::subresourcesAreFinished(Document*, CompletionHandler<void()>&& compl
     completionHandler();
 }
 
-RefPtr<FragmentedSharedBuffer> Image::protectedData() const
-{
-    return m_encodedImageData;
-}
-
 EncodedDataStatus Image::setData(RefPtr<FragmentedSharedBuffer>&& data, bool allDataReceived)
 {
     m_encodedImageData = WTF::move(data);

--- a/Source/WebCore/platform/graphics/Image.h
+++ b/Source/WebCore/platform/graphics/Image.h
@@ -125,7 +125,6 @@ public:
 
     FragmentedSharedBuffer* data() { return m_encodedImageData.get(); }
     const FragmentedSharedBuffer* data() const { return m_encodedImageData.get(); }
-    WEBCORE_EXPORT RefPtr<FragmentedSharedBuffer> protectedData() const;
 
     virtual DestinationColorSpace colorSpace();
     virtual bool hasHDRContent() const { return false; }

--- a/Source/WebCore/platform/graphics/MediaPlayer.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayer.cpp
@@ -640,7 +640,7 @@ CheckedPtr<const MediaPlayerFactory> MediaPlayer::nextBestMediaEngine(const Medi
 
 void MediaPlayer::reloadAndResumePlaybackIfNeeded()
 {
-    protectedClient()->mediaPlayerReloadAndResumePlaybackIfNeeded();
+    protect(client())->mediaPlayerReloadAndResumePlaybackIfNeeded();
 }
 
 void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
@@ -660,7 +660,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
 
     ASSERT(!m_initializingMediaEngine);
     m_initializingMediaEngine = true;
-    protectedClient()->mediaPlayerWillInitializeMediaEngine();
+    protect(client())->mediaPlayerWillInitializeMediaEngine();
 
     CheckedPtr<const MediaPlayerFactory> engine;
 
@@ -682,7 +682,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
         RefPtr playerPrivate = engine->createMediaEnginePlayer(*this);
         m_private = playerPrivate;
         if (playerPrivate) {
-            protectedClient()->mediaPlayerEngineUpdated();
+            protect(client())->mediaPlayerEngineUpdated();
             playerPrivate->setMessageClientForTesting(m_internalMessageClient);
 
             if (m_pageIsVisible)
@@ -740,7 +740,7 @@ void MediaPlayer::loadWithNextMediaEngine(const MediaPlayerFactory* current)
 void MediaPlayer::queueTaskOnEventLoop(Function<void()>&& task)
 {
     ASSERT(isMainThread());
-    protectedClient()->mediaPlayerQueueTaskOnEventLoop(WTF::move(task));
+    protect(client())->mediaPlayerQueueTaskOnEventLoop(WTF::move(task));
 }
 
 bool MediaPlayer::hasAvailableVideoFrame() const
@@ -895,7 +895,7 @@ void MediaPlayer::seekWhenPossible(const MediaTime& time)
 
 void MediaPlayer::seeked(const MediaTime& time)
 {
-    protectedClient()->mediaPlayerSeeked(time);
+    protect(client())->mediaPlayerSeeked(time);
 }
 
 bool MediaPlayer::paused() const
@@ -987,7 +987,7 @@ void MediaPlayer::setVideoFullscreenMode(MediaPlayer::VideoFullscreenMode mode)
 
 MediaPlayer::VideoFullscreenMode MediaPlayer::fullscreenMode() const
 {
-    return protectedClient()->mediaPlayerFullscreenMode();
+    return protect(client())->mediaPlayerFullscreenMode();
 }
 
 void MediaPlayer::videoFullscreenStandbyChanged()
@@ -997,20 +997,20 @@ void MediaPlayer::videoFullscreenStandbyChanged()
 
 bool MediaPlayer::isVideoFullscreenStandby() const
 {
-    return protectedClient()->mediaPlayerIsVideoFullscreenStandby();
+    return protect(client())->mediaPlayerIsVideoFullscreenStandby();
 }
 
 #endif
 
 FloatSize MediaPlayer::videoLayerSize() const
 {
-    return protectedClient()->mediaPlayerVideoLayerSize();
+    return protect(client())->mediaPlayerVideoLayerSize();
 }
 
 #if PLATFORM(IOS_FAMILY)
 bool MediaPlayer::canShowWhileLocked() const
 {
-    return protectedClient()->canShowWhileLocked();
+    return protect(client())->canShowWhileLocked();
 }
 
 void MediaPlayer::setSceneIdentifier(const String& identifier)
@@ -1024,7 +1024,7 @@ void MediaPlayer::setSceneIdentifier(const String& identifier)
 
 void MediaPlayer::videoLayerSizeDidChange(const FloatSize& size)
 {
-    protectedClient()->mediaPlayerVideoLayerSizeDidChange(size);
+    protect(client())->mediaPlayerVideoLayerSizeDidChange(size);
 }
 
 void MediaPlayer::setVideoLayerSizeFenced(const FloatSize& size, WTF::MachSendRightAnnotated&& fence)
@@ -1116,7 +1116,7 @@ double MediaPlayer::effectiveRate() const
 
 double MediaPlayer::requestedRate() const
 {
-    return protectedClient()->mediaPlayerRequestedPlaybackRate();
+    return protect(client())->mediaPlayerRequestedPlaybackRate();
 }
 
 bool MediaPlayer::preservesPitch() const
@@ -1171,12 +1171,12 @@ double MediaPlayer::seekableTimeRangesLastModifiedTime()
 
 void MediaPlayer::bufferedTimeRangesChanged()
 {
-    protectedClient()->mediaPlayerBufferedTimeRangesChanged();
+    protect(client())->mediaPlayerBufferedTimeRangesChanged();
 }
 
 void MediaPlayer::seekableTimeRangesChanged()
 {
-    protectedClient()->mediaPlayerSeekableTimeRangesChanged();
+    protect(client())->mediaPlayerSeekableTimeRangesChanged();
 }
 
 double MediaPlayer::liveUpdateInterval()
@@ -1349,7 +1349,7 @@ void MediaPlayer::setWirelessVideoPlaybackDisabled(bool disabled)
 
 void MediaPlayer::currentPlaybackTargetIsWirelessChanged(bool isCurrentPlaybackTargetWireless)
 {
-    protectedClient()->mediaPlayerCurrentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless);
+    protect(client())->mediaPlayerCurrentPlaybackTargetIsWirelessChanged(isCurrentPlaybackTargetWireless);
 }
 
 OptionSet<MediaPlaybackTargetType> MediaPlayer::supportedPlaybackTargetTypes() const
@@ -1526,7 +1526,7 @@ void MediaPlayer::networkStateChanged()
 
 void MediaPlayer::readyStateChanged()
 {
-    protectedClient()->mediaPlayerReadyStateChanged();
+    protect(client())->mediaPlayerReadyStateChanged();
     if (m_pendingSeekRequest && protectedPrivate()->readyState() == MediaPlayer::ReadyState::HaveMetadata)
         seekToTime(*std::exchange(m_pendingSeekRequest, std::nullopt));
 }
@@ -1539,7 +1539,7 @@ void MediaPlayer::volumeChanged(double newVolume)
 #else
     m_volume = newVolume;
 #endif
-    protectedClient()->mediaPlayerVolumeChanged();
+    protect(client())->mediaPlayerVolumeChanged();
 }
 
 void MediaPlayer::muteChanged(bool newMuted)
@@ -1548,47 +1548,47 @@ void MediaPlayer::muteChanged(bool newMuted)
         return;
 
     m_muted = newMuted;
-    protectedClient()->mediaPlayerMuteChanged();
+    protect(client())->mediaPlayerMuteChanged();
 }
 
 void MediaPlayer::timeChanged()
 {
-    protectedClient()->mediaPlayerTimeChanged();
+    protect(client())->mediaPlayerTimeChanged();
 }
 
 void MediaPlayer::sizeChanged()
 {
-    protectedClient()->mediaPlayerSizeChanged();
+    protect(client())->mediaPlayerSizeChanged();
 }
 
 void MediaPlayer::repaint()
 {
-    protectedClient()->mediaPlayerRepaint();
+    protect(client())->mediaPlayerRepaint();
 }
 
 void MediaPlayer::durationChanged()
 {
-    protectedClient()->mediaPlayerDurationChanged();
+    protect(client())->mediaPlayerDurationChanged();
 }
 
 void MediaPlayer::rateChanged()
 {
-    protectedClient()->mediaPlayerRateChanged();
+    protect(client())->mediaPlayerRateChanged();
 }
 
 void MediaPlayer::playbackStateChanged()
 {
-    protectedClient()->mediaPlayerPlaybackStateChanged();
+    protect(client())->mediaPlayerPlaybackStateChanged();
 }
 
 void MediaPlayer::firstVideoFrameAvailable()
 {
-    protectedClient()->mediaPlayerFirstVideoFrameAvailable();
+    protect(client())->mediaPlayerFirstVideoFrameAvailable();
 }
 
 void MediaPlayer::characteristicChanged()
 {
-    protectedClient()->mediaPlayerCharacteristicChanged();
+    protect(client())->mediaPlayerCharacteristicChanged();
 }
 
 #if ENABLE(WEB_AUDIO)
@@ -1604,17 +1604,17 @@ AudioSourceProvider* MediaPlayer::audioSourceProvider()
 
 RefPtr<ArrayBuffer> MediaPlayer::cachedKeyForKeyId(const String& keyId) const
 {
-    return protectedClient()->mediaPlayerCachedKeyForKeyId(keyId);
+    return protect(client())->mediaPlayerCachedKeyForKeyId(keyId);
 }
 
 void MediaPlayer::keyNeeded(const SharedBuffer& initData)
 {
-    protectedClient()->mediaPlayerKeyNeeded(initData);
+    protect(client())->mediaPlayerKeyNeeded(initData);
 }
 
 String MediaPlayer::mediaKeysStorageDirectory() const
 {
-    return protectedClient()->mediaPlayerMediaKeysStorageDirectory();
+    return protect(client())->mediaPlayerMediaKeysStorageDirectory();
 }
 
 #endif
@@ -1623,12 +1623,12 @@ String MediaPlayer::mediaKeysStorageDirectory() const
 
 void MediaPlayer::initializationDataEncountered(const String& initDataType, RefPtr<ArrayBuffer>&& initData)
 {
-    protectedClient()->mediaPlayerInitializationDataEncountered(initDataType, WTF::move(initData));
+    protect(client())->mediaPlayerInitializationDataEncountered(initDataType, WTF::move(initData));
 }
 
 void MediaPlayer::waitingForKeyChanged()
 {
-    protectedClient()->mediaPlayerWaitingForKeyChanged();
+    protect(client())->mediaPlayerWaitingForKeyChanged();
 }
 
 bool MediaPlayer::waitingForKey() const
@@ -1641,12 +1641,12 @@ bool MediaPlayer::waitingForKey() const
 
 String MediaPlayer::referrer() const
 {
-    return protectedClient()->mediaPlayerReferrer();
+    return protect(client())->mediaPlayerReferrer();
 }
 
 String MediaPlayer::userAgent() const
 {
-    return protectedClient()->mediaPlayerUserAgent();
+    return protect(client())->mediaPlayerUserAgent();
 }
 
 String MediaPlayer::engineDescription() const
@@ -1665,45 +1665,45 @@ long MediaPlayer::platformErrorCode() const
 
 CachedResourceLoader* MediaPlayer::cachedResourceLoader() const
 {
-    return protectedClient()->mediaPlayerCachedResourceLoader();
+    return protect(client())->mediaPlayerCachedResourceLoader();
 }
 
 Ref<PlatformMediaResourceLoader> MediaPlayer::mediaResourceLoader()
 {
     if (!m_mediaResourceLoader)
-        m_mediaResourceLoader = protectedClient()->mediaPlayerCreateResourceLoader();
+        m_mediaResourceLoader = protect(client())->mediaPlayerCreateResourceLoader();
 
     return *m_mediaResourceLoader;
 }
 
 void MediaPlayer::addAudioTrack(AudioTrackPrivate& track)
 {
-    protectedClient()->mediaPlayerDidAddAudioTrack(track);
+    protect(client())->mediaPlayerDidAddAudioTrack(track);
 }
 
 void MediaPlayer::removeAudioTrack(AudioTrackPrivate& track)
 {
-    protectedClient()->mediaPlayerDidRemoveAudioTrack(track);
+    protect(client())->mediaPlayerDidRemoveAudioTrack(track);
 }
 
 void MediaPlayer::addTextTrack(InbandTextTrackPrivate& track)
 {
-    protectedClient()->mediaPlayerDidAddTextTrack(track);
+    protect(client())->mediaPlayerDidAddTextTrack(track);
 }
 
 void MediaPlayer::removeTextTrack(InbandTextTrackPrivate& track)
 {
-    protectedClient()->mediaPlayerDidRemoveTextTrack(track);
+    protect(client())->mediaPlayerDidRemoveTextTrack(track);
 }
 
 void MediaPlayer::addVideoTrack(VideoTrackPrivate& track)
 {
-    protectedClient()->mediaPlayerDidAddVideoTrack(track);
+    protect(client())->mediaPlayerDidAddVideoTrack(track);
 }
 
 void MediaPlayer::removeVideoTrack(VideoTrackPrivate& track)
 {
-    protectedClient()->mediaPlayerDidRemoveVideoTrack(track);
+    protect(client())->mediaPlayerDidRemoveVideoTrack(track);
 }
 
 void MediaPlayer::setTextTrackRepresentation(TextTrackRepresentation* representation)
@@ -1729,7 +1729,7 @@ void MediaPlayer::notifyTrackModeChanged()
 
 Vector<Ref<PlatformTextTrack>> MediaPlayer::outOfBandTrackSources()
 {
-    return protectedClient()->outOfBandTrackSources();
+    return protect(client())->outOfBandTrackSources();
 }
 
 void MediaPlayer::resetMediaEngines()
@@ -1756,7 +1756,7 @@ void MediaPlayer::simulateAudioInterruption()
 
 bool MediaPlayer::isGStreamerHolePunchingEnabled()
 {
-    return protectedClient()->isGStreamerHolePunchingEnabled();
+    return protect(client())->isGStreamerHolePunchingEnabled();
 }
 #endif
 
@@ -1774,7 +1774,7 @@ size_t MediaPlayer::extraMemoryCost() const
 
 void MediaPlayer::reportGPUMemoryFootprint(uint64_t footPrint) const
 {
-    protectedClient()->mediaPlayerDidReportGPUMemoryFootprint(footPrint);
+    protect(client())->mediaPlayerDidReportGPUMemoryFootprint(footPrint);
 }
 
 unsigned long long MediaPlayer::fileSize() const
@@ -1810,12 +1810,12 @@ Ref<MediaPlayer::VideoPlaybackQualityMetricsPromise> MediaPlayer::asyncVideoPlay
 
 String MediaPlayer::sourceApplicationIdentifier() const
 {
-    return protectedClient()->mediaPlayerSourceApplicationIdentifier();
+    return protect(client())->mediaPlayerSourceApplicationIdentifier();
 }
 
 Vector<String> MediaPlayer::preferredAudioCharacteristics() const
 {
-    return protectedClient()->mediaPlayerPreferredAudioCharacteristics();
+    return protect(client())->mediaPlayerPreferredAudioCharacteristics();
 }
 
 void MediaPlayerFactorySupport::callRegisterMediaEngine(MediaEngineRegister registerMediaEngine)
@@ -1825,18 +1825,18 @@ void MediaPlayerFactorySupport::callRegisterMediaEngine(MediaEngineRegister regi
 
 bool MediaPlayer::doesHaveAttribute(const AtomString& attribute, AtomString* value) const
 {
-    return protectedClient()->doesHaveAttribute(attribute, value);
+    return protect(client())->doesHaveAttribute(attribute, value);
 }
 
 #if PLATFORM(IOS_FAMILY)
 String MediaPlayer::mediaPlayerNetworkInterfaceName() const
 {
-    return protectedClient()->mediaPlayerNetworkInterfaceName();
+    return protect(client())->mediaPlayerNetworkInterfaceName();
 }
 
 void MediaPlayer::getRawCookies(const URL& url, MediaPlayerClient::GetRawCookiesCallback&& completionHandler) const
 {
-    protectedClient()->mediaPlayerGetRawCookies(url, WTF::move(completionHandler));
+    protect(client())->mediaPlayerGetRawCookies(url, WTF::move(completionHandler));
 }
 #endif
 
@@ -1848,7 +1848,7 @@ void MediaPlayer::setShouldDisableSleep(bool flag)
 
 bool MediaPlayer::shouldDisableSleep() const
 {
-    return protectedClient()->mediaPlayerShouldDisableSleep();
+    return protect(client())->mediaPlayerShouldDisableSleep();
 }
 
 String MediaPlayer::contentMIMEType() const
@@ -1868,32 +1868,32 @@ bool MediaPlayer::contentMIMETypeWasInferredFromExtension() const
 
 const Vector<ContentType>& MediaPlayer::mediaContentTypesRequiringHardwareSupport() const
 {
-    return protectedClient()->mediaContentTypesRequiringHardwareSupport();
+    return protect(client())->mediaContentTypesRequiringHardwareSupport();
 }
 
 const std::optional<Vector<String>>& MediaPlayer::allowedMediaContainerTypes() const
 {
-    return protectedClient()->allowedMediaContainerTypes();
+    return protect(client())->allowedMediaContainerTypes();
 }
 
 const std::optional<Vector<String>>& MediaPlayer::allowedMediaCodecTypes() const
 {
-    return protectedClient()->allowedMediaCodecTypes();
+    return protect(client())->allowedMediaCodecTypes();
 }
 
 const std::optional<Vector<FourCC>>& MediaPlayer::allowedMediaVideoCodecIDs() const
 {
-    return protectedClient()->allowedMediaVideoCodecIDs();
+    return protect(client())->allowedMediaVideoCodecIDs();
 }
 
 const std::optional<Vector<FourCC>>& MediaPlayer::allowedMediaAudioCodecIDs() const
 {
-    return protectedClient()->allowedMediaAudioCodecIDs();
+    return protect(client())->allowedMediaAudioCodecIDs();
 }
 
 const std::optional<Vector<FourCC>>& MediaPlayer::allowedMediaCaptionFormatTypes() const
 {
-    return protectedClient()->allowedMediaCaptionFormatTypes();
+    return protect(client())->allowedMediaCaptionFormatTypes();
 }
 
 void MediaPlayer::applicationWillResignActive()
@@ -1932,12 +1932,12 @@ void MediaPlayer::isLoopingChanged()
 
 void MediaPlayer::remoteEngineFailedToLoad()
 {
-    protectedClient()->mediaPlayerEngineFailedToLoad();
+    protect(client())->mediaPlayerEngineFailedToLoad();
 }
 
 SecurityOriginData MediaPlayer::documentSecurityOrigin() const
 {
-    return protectedClient()->documentSecurityOrigin();
+    return protect(client())->documentSecurityOrigin();
 }
 
 void MediaPlayer::setPreferredDynamicRangeMode(DynamicRangeMode mode)
@@ -1999,13 +1999,13 @@ void MediaPlayer::playerContentBoxRectChanged(const LayoutRect& rect)
 #if PLATFORM(COCOA)
 void MediaPlayer::onNewVideoFrameMetadata(VideoFrameMetadata&& metadata, RetainPtr<CVPixelBufferRef>&& buffer)
 {
-    protectedClient()->mediaPlayerOnNewVideoFrameMetadata(WTF::move(metadata), WTF::move(buffer));
+    protect(client())->mediaPlayerOnNewVideoFrameMetadata(WTF::move(metadata), WTF::move(buffer));
 }
 #endif
 
 String MediaPlayer::elementId() const
 {
-    return protectedClient()->mediaPlayerElementId();
+    return protect(client())->mediaPlayerElementId();
 }
 
 bool MediaPlayer::supportsPlayAtHostTime() const
@@ -2079,7 +2079,7 @@ void MediaPlayer::setPrefersSpatialAudioExperience(bool value)
 
 auto MediaPlayer::soundStageSize() const -> SoundStageSize
 {
-    return protectedClient()->mediaPlayerSoundStageSize();
+    return protect(client())->mediaPlayerSoundStageSize();
 }
 
 void MediaPlayer::soundStageSizeDidChange()
@@ -2111,7 +2111,7 @@ bool MediaPlayer::supportsLinearMediaPlayer() const
 #if !RELEASE_LOG_DISABLED
 const Logger& MediaPlayer::mediaPlayerLogger()
 {
-    return protectedClient()->mediaPlayerLogger();
+    return protect(client())->mediaPlayerLogger();
 }
 #endif
 
@@ -2135,7 +2135,7 @@ void MediaPlayer::elementIdChanged(const String& id) const
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
 MediaPlaybackTargetType MediaPlayer::playbackTargetType() const
 {
-    return protectedClient()->playbackTargetType();
+    return protect(client())->playbackTargetType();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/MediaPlayer.h
+++ b/Source/WebCore/platform/graphics/MediaPlayer.h
@@ -531,7 +531,7 @@ public:
 
     double volume() const;
     void setVolume(double);
-    bool platformVolumeConfigurationRequired() const { return protectedClient()->mediaPlayerPlatformVolumeConfigurationRequired(); }
+    bool platformVolumeConfigurationRequired() const { return protect(client())->mediaPlayerPlatformVolumeConfigurationRequired(); }
 
     bool muted() const;
     void setMuted(bool);
@@ -716,7 +716,7 @@ public:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger();
-    uint64_t mediaPlayerLogIdentifier() { return protectedClient()->mediaPlayerLogIdentifier(); }
+    uint64_t mediaPlayerLogIdentifier() { return protect(client())->mediaPlayerLogIdentifier(); }
 #endif
 
     void applicationWillResignActive();
@@ -730,18 +730,18 @@ public:
 
     bool shouldIgnoreIntrinsicSize();
 
-    bool renderingCanBeAccelerated() const { return protectedClient()->mediaPlayerRenderingCanBeAccelerated(); }
-    void renderingModeChanged() const  { protectedClient()->mediaPlayerRenderingModeChanged(); }
-    bool acceleratedCompositingEnabled() { return protectedClient()->mediaPlayerAcceleratedCompositingEnabled(); }
-    void activeSourceBuffersChanged() { protectedClient()->mediaPlayerActiveSourceBuffersChanged(); }
-    LayoutRect playerContentBoxRect() const { return protectedClient()->mediaPlayerContentBoxRect(); }
-    float playerContentsScale() const { return protectedClient()->mediaPlayerContentsScale(); }
-    bool shouldUsePersistentCache() const { return protectedClient()->mediaPlayerShouldUsePersistentCache(); }
-    const String& mediaCacheDirectory() const { return protectedClient()->mediaPlayerMediaCacheDirectory(); }
-    bool isVideoPlayer() const { return protectedClient()->mediaPlayerIsVideo(); }
-    void mediaEngineUpdated() { protectedClient()->mediaPlayerEngineUpdated(); }
-    void resourceNotSupported() { protectedClient()->mediaPlayerResourceNotSupported(); }
-    bool isLooping() const { return protectedClient()->mediaPlayerIsLooping(); }
+    bool renderingCanBeAccelerated() const { return protect(client())->mediaPlayerRenderingCanBeAccelerated(); }
+    void renderingModeChanged() const  { protect(client())->mediaPlayerRenderingModeChanged(); }
+    bool acceleratedCompositingEnabled() { return protect(client())->mediaPlayerAcceleratedCompositingEnabled(); }
+    void activeSourceBuffersChanged() { protect(client())->mediaPlayerActiveSourceBuffersChanged(); }
+    LayoutRect playerContentBoxRect() const { return protect(client())->mediaPlayerContentBoxRect(); }
+    float playerContentsScale() const { return protect(client())->mediaPlayerContentsScale(); }
+    bool shouldUsePersistentCache() const { return protect(client())->mediaPlayerShouldUsePersistentCache(); }
+    const String& mediaCacheDirectory() const { return protect(client())->mediaPlayerMediaCacheDirectory(); }
+    bool isVideoPlayer() const { return protect(client())->mediaPlayerIsVideo(); }
+    void mediaEngineUpdated() { protect(client())->mediaPlayerEngineUpdated(); }
+    void resourceNotSupported() { protect(client())->mediaPlayerResourceNotSupported(); }
+    bool isLooping() const { return protect(client())->mediaPlayerIsLooping(); }
     void isLoopingChanged();
 
     void remoteEngineFailedToLoad();
@@ -775,7 +775,7 @@ public:
     void renderVideoWillBeDestroyed();
 
     void setShouldDisableHDR(bool);
-    bool shouldDisableHDR() const { return protectedClient()->mediaPlayerShouldDisableHDR(); }
+    bool shouldDisableHDR() const { return protect(client())->mediaPlayerShouldDisableHDR(); }
 
     void setResourceOwner(const ProcessIdentity&);
 
@@ -800,8 +800,8 @@ public:
     void setInFullscreenOrPictureInPicture(bool);
     bool isInFullscreenOrPictureInPicture() const;
 
-    PlatformVideoTarget videoTarget() const { return protectedClient()->mediaPlayerVideoTarget(); }
-    MediaPlayerClientIdentifier clientIdentifier() const { return protectedClient()->mediaPlayerClientIdentifier(); }
+    PlatformVideoTarget videoTarget() const { return protect(client())->mediaPlayerVideoTarget(); }
+    MediaPlayerClientIdentifier clientIdentifier() const { return protect(client())->mediaPlayerClientIdentifier(); }
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     bool supportsLinearMediaPlayer() const;
@@ -823,7 +823,6 @@ private:
     MediaPlayer(MediaPlayerClient&, MediaPlayerEnums::MediaEngineIdentifier);
 
     MediaPlayerClient& client() const { return *m_client; }
-    Ref<MediaPlayerClient> protectedClient() const { return client(); }
 
     RefPtr<MediaPlayerPrivateInterface> protectedPrivate() const;
 

--- a/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
+++ b/Source/WebCore/platform/graphics/MediaResourceSniffer.cpp
@@ -85,7 +85,7 @@ void MediaResourceSniffer::dataReceived(PlatformMediaResource&, const SharedBuff
 {
     m_received += buffer.size();
     m_content.append(buffer);
-    auto contiguousBuffer = m_content.protectedBuffer()->makeContiguous();
+    auto contiguousBuffer = protect(m_content.buffer())->makeContiguous();
     auto mimeType = MIMESniffer::getMIMETypeFromContent(contiguousBuffer->span());
     if (mimeType.isEmpty() && m_received < m_maxSize)
         return;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm
@@ -167,13 +167,13 @@ MediaPlayerPrivateMediaStreamAVFObjC::~MediaPlayerPrivateMediaStreamAVFObjC()
         mediaStreamPrivate->removeObserver(*this);
 
     for (auto& track : m_audioTrackMap.values())
-        track->protectedStreamTrack()->removeObserver(*this);
+        protect(track->streamTrack())->removeObserver(*this);
 
     for (auto& track : m_videoTrackMap.values())
-        track->protectedStreamTrack()->removeObserver(*this);
+        protect(track->streamTrack())->removeObserver(*this);
 
     if (m_activeVideoTrack)
-        m_activeVideoTrack->protectedStreamTrack()->protectedSource()->removeVideoFrameObserver(*this);
+        protect(protect(m_activeVideoTrack->streamTrack())->source())->removeVideoFrameObserver(*this);
 
     [m_boundsChangeListener invalidate];
 
@@ -977,12 +977,12 @@ void MediaPlayerPrivateMediaStreamAVFObjC::checkSelectedVideoTrack()
 
     if (oldVideoTrack != m_activeVideoTrack) {
         if (oldVideoTrack)
-            oldVideoTrack->protectedStreamTrack()->protectedSource()->removeVideoFrameObserver(*this);
+            protect(protect(oldVideoTrack->streamTrack())->source())->removeVideoFrameObserver(*this);
         m_isActiveVideoTrackEnabled = m_activeVideoTrack ? m_activeVideoTrack->streamTrack().enabled() : true;
         if (m_activeVideoTrack) {
-            if (m_sampleBufferDisplayLayer && m_activeVideoTrack->protectedStreamTrack()->source().isCaptureSource())
+            if (m_sampleBufferDisplayLayer && protect(m_activeVideoTrack->streamTrack())->source().isCaptureSource())
                 m_sampleBufferDisplayLayer->setRenderPolicy(SampleBufferDisplayLayer::RenderPolicy::Immediately);
-            m_activeVideoTrack->protectedStreamTrack()->protectedSource()->addVideoFrameObserver(*this);
+            protect(protect(m_activeVideoTrack->streamTrack())->source())->addVideoFrameObserver(*this);
             ALWAYS_LOG(LOGIDENTIFIER, "observing video source ", m_activeVideoTrack->streamTrack().logIdentifier());
         }
     } else
@@ -1006,12 +1006,12 @@ void MediaPlayerPrivateMediaStreamAVFObjC::updateTracks()
 
         switch (state) {
         case TrackState::Remove:
-            track.protectedStreamTrack()->removeObserver(*protectedThis);
+            protect(track.streamTrack())->removeObserver(*protectedThis);
             track.clear();
             player->removeAudioTrack(track);
             break;
         case TrackState::Add:
-            track.protectedStreamTrack()->addObserver(*protectedThis);
+            protect(track.streamTrack())->addObserver(*protectedThis);
             player->addAudioTrack(track);
             break;
         case TrackState::Configure:
@@ -1040,12 +1040,12 @@ void MediaPlayerPrivateMediaStreamAVFObjC::updateTracks()
 
         switch (state) {
         case TrackState::Remove:
-            track.protectedStreamTrack()->removeObserver(*protectedThis);
+            protect(track.streamTrack())->removeObserver(*protectedThis);
             player->removeVideoTrack(track);
             protectedThis->checkSelectedVideoTrack();
             break;
         case TrackState::Add:
-            track.protectedStreamTrack()->addObserver(*protectedThis);
+            protect(track.streamTrack())->addObserver(*protectedThis);
             player->addVideoTrack(track);
             break;
         case TrackState::Configure:

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -2562,7 +2562,7 @@ void GraphicsLayerCA::updateGeometry(float pageScaleFactor, const FloatPoint& po
 
 void GraphicsLayerCA::updateTransform()
 {
-    protectedPrimaryLayer()->setTransform(transform());
+    protect(primaryLayer())->setTransform(transform());
 
     if (LayerMap* layerCloneMap = primaryLayerClones()) {
         for (auto& clone : *layerCloneMap) {
@@ -2579,7 +2579,7 @@ void GraphicsLayerCA::updateTransform()
 
 void GraphicsLayerCA::updateChildrenTransform()
 {
-    protectedPrimaryLayer()->setSublayerTransform(childrenTransform());
+    protect(primaryLayer())->setSublayerTransform(childrenTransform());
 
     if (LayerMap* layerCloneMap = primaryLayerClones()) {
         for (auto& layer : layerCloneMap->values())
@@ -2665,7 +2665,7 @@ void GraphicsLayerCA::updateBackfaceVisibility()
 
 void GraphicsLayerCA::updateFilters()
 {
-    protectedPrimaryLayer()->setFilters(m_filters);
+    protect(primaryLayer())->setFilters(m_filters);
 
     if (LayerMap* layerCloneMap = primaryLayerClones()) {
         for (auto& clone : *layerCloneMap) {
@@ -2800,7 +2800,7 @@ void GraphicsLayerCA::updateBackdropRoot()
 
 void GraphicsLayerCA::updateBlendMode()
 {
-    protectedPrimaryLayer()->setBlendMode(m_blendMode);
+    protect(primaryLayer())->setBlendMode(m_blendMode);
 
     if (LayerMap* layerCloneMap = primaryLayerClones()) {
         for (auto& clone : *layerCloneMap) {
@@ -2909,7 +2909,7 @@ bool GraphicsLayerCA::ensureStructuralLayer(StructuralLayerPurpose purpose)
             // If m_layer doesn't have a parent, it means it's the root layer and
             // is likely hosted by something that is not expecting to be changed
             ASSERT(structuralLayer->superlayer());
-            structuralLayer->protectedSuperlayer()->replaceSublayer(*structuralLayer, *layer);
+            protect(structuralLayer->superlayer())->replaceSublayer(*structuralLayer, *layer);
 
             moveAnimations(structuralLayer.get(), layer.get());
 
@@ -4820,7 +4820,7 @@ void GraphicsLayerCA::dumpAdditionalProperties(TextStream& textStream, OptionSet
 String GraphicsLayerCA::platformLayerTreeAsText(OptionSet<PlatformLayerTreeAsTextFlags> flags) const
 {
     TextStream ts(TextStream::LineMode::MultipleLine, TextStream::Formatting::SVGStyleRect);
-    dumpInnerLayer(ts, protectedPrimaryLayer().get(), flags);
+    dumpInnerLayer(ts, protect(primaryLayer()).get(), flags);
     return ts.release();
 }
 
@@ -4893,7 +4893,7 @@ void GraphicsLayerCA::changeLayerTypeTo(PlatformCALayer::LayerType newLayerType)
         // Skip this step if we don't have a superlayer. This is probably a benign
         // case that happens while restructuring the layer tree, and also occurs with
         // WebKit2 page overlays, which can become tiled but are out-of-tree.
-        oldLayer->protectedSuperlayer()->replaceSublayer(*oldLayer, newLayer);
+        protect(oldLayer->superlayer())->replaceSublayer(*oldLayer, newLayer);
     }
 
     addUncommittedChanges(ChildrenChanged
@@ -5176,7 +5176,7 @@ Ref<PlatformCALayer> GraphicsLayerCA::cloneLayer(PlatformCALayer *layer, CloneLe
 
 void GraphicsLayerCA::updateOpacityOnLayer()
 {
-    protectedPrimaryLayer()->setOpacity(m_opacity);
+    protect(primaryLayer())->setOpacity(m_opacity);
 
     if (LayerMap* layerCloneMap = primaryLayerClones()) {
         for (auto& clone : *layerCloneMap) {

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -75,7 +75,6 @@ public:
 
     WEBCORE_EXPORT PlatformLayer* platformLayer() const override;
     PlatformCALayer* platformCALayer() const { return primaryLayer(); }
-    RefPtr<PlatformCALayer> protectedPlatformCALayer() const { return platformCALayer(); }
 
     WEBCORE_EXPORT bool setChildren(Vector<Ref<GraphicsLayer>>&&) override;
     WEBCORE_EXPORT void addChild(Ref<GraphicsLayer>&&) override;
@@ -334,7 +333,6 @@ private:
     RefPtr<PlatformCALayer> protectedBackdropLayer() const { return m_backdropLayer; }
     RefPtr<PlatformCALayer> protectedStructuralLayer() const { return m_structuralLayer; }
     PlatformCALayer* primaryLayer() const { return m_structuralLayer.get() ? m_structuralLayer.get() : m_layer.get(); }
-    RefPtr<PlatformCALayer> protectedPrimaryLayer() const { return primaryLayer(); }
     PlatformCALayer* hostLayerForSublayers() const;
     PlatformCALayer* layerForSuperlayer() const;
     PlatformCALayer* animatedLayer(AnimatedProperty) const;

--- a/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
+++ b/Source/WebCore/platform/graphics/ca/PlatformCALayer.h
@@ -169,7 +169,6 @@ public:
     bool canHaveBackingStore() const;
 
     virtual PlatformCALayer* superlayer() const = 0;
-    RefPtr<PlatformCALayer> protectedSuperlayer() const { return superlayer(); }
     virtual void removeFromSuperlayer() = 0;
     virtual void setSublayers(const PlatformCALayerList&) = 0;
     virtual PlatformCALayerList sublayersForLogging() const = 0;

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -476,7 +476,7 @@ Expected<RetainPtr<CMSampleBufferRef>, CString> toCMSampleBuffer(const MediaSamp
     if (!samples.info())
         return makeUnexpected("No TrackInfo found");
 
-    RetainPtr format = formatDescription ? retainPtr(formatDescription) : createFormatDescriptionFromTrackInfo(*samples.protectedInfo());
+    RetainPtr format = formatDescription ? retainPtr(formatDescription) : createFormatDescriptionFromTrackInfo(*protect(samples.info()));
     if (!format)
         return makeUnexpected("No CMFormatDescription available");
 

--- a/Source/WebCore/platform/graphics/controls/ApplePayButtonPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ApplePayButtonPart.cpp
@@ -52,7 +52,7 @@ ApplePayButtonPart::ApplePayButtonPart(ApplePayButtonType buttonType, ApplePayBu
 
 std::unique_ptr<PlatformControl> ApplePayButtonPart::createPlatformControl()
 {
-    return protectedControlFactory()->createPlatformApplePayButton(*this);
+    return protect(controlFactory())->createPlatformApplePayButton(*this);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/controls/ControlPart.cpp
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.cpp
@@ -41,11 +41,6 @@ ControlFactory& ControlPart::controlFactory() const
     return m_overrideControlFactory ? *m_overrideControlFactory : ControlFactory::singleton();
 }
 
-Ref<ControlFactory> ControlPart::protectedControlFactory() const
-{
-    return controlFactory();
-}
-
 PlatformControl* ControlPart::platformControl() const
 {
     if (!m_platformControl)

--- a/Source/WebCore/platform/graphics/controls/ControlPart.h
+++ b/Source/WebCore/platform/graphics/controls/ControlPart.h
@@ -44,7 +44,6 @@ public:
     StyleAppearance type() const { return m_type; }
 
     WEBCORE_EXPORT ControlFactory& controlFactory() const;
-    WEBCORE_EXPORT Ref<ControlFactory> protectedControlFactory() const;
     void setOverrideControlFactory(RefPtr<ControlFactory>&& controlFactory) { m_overrideControlFactory = WTF::move(controlFactory); }
 
     FloatSize sizeForBounds(const FloatRect& bounds, const ControlStyle&);

--- a/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCoreText.cpp
@@ -532,7 +532,7 @@ RefPtr<Font> Font::createFontWithoutSynthesizableFeatures() const
     RetainPtr ctFont = this->ctFont();
     CTFontSymbolicTraits fontTraits = CTFontGetSymbolicTraits(ctFont.get());
     RetainPtr newCTFont = createCTFontWithoutSynthesizableFeatures(ctFont.get());
-    return createDerivativeFont(newCTFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.protectedCustomPlatformData().get());
+    return createDerivativeFont(newCTFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get());
 }
 
 RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleFactor) const
@@ -543,7 +543,7 @@ RefPtr<Font> Font::platformCreateScaledFont(const FontDescription&, float scaleF
     RetainPtr<CTFontDescriptorRef> fontDescriptor = adoptCF(CTFontCopyFontDescriptor(ctFont.get()));
     RetainPtr<CTFontRef> scaledFont = adoptCF(CTFontCreateWithFontDescriptor(fontDescriptor.get(), size, nullptr));
 
-    return createDerivativeFont(scaledFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.protectedCustomPlatformData().get());
+    return createDerivativeFont(scaledFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get());
 }
 
 bool supportsOpenTypeFeature(CTFontRef font, CFStringRef featureTag)
@@ -600,7 +600,7 @@ RefPtr<Font> Font::platformCreateHalfWidthFont() const
     auto attributesDescriptor = adoptCF(CTFontDescriptorCreateWithAttributes(attributes.get()));
     auto halfWidthFont = adoptCF(CTFontCreateCopyWithAttributes(ctFont.get(), size, nullptr, attributesDescriptor.get()));
 
-    return createDerivativeFont(halfWidthFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), m_platformData.protectedCustomPlatformData().get());
+    return createDerivativeFont(halfWidthFont.get(), size, m_platformData.orientation(), fontTraits, m_platformData.syntheticBold(), m_platformData.syntheticOblique(), m_platformData.widthVariant(), m_platformData.textRenderingMode(), protect(m_platformData.customPlatformData()).get());
 }
 
 float Font::platformWidthForGlyph(Glyph glyph) const

--- a/Source/WebCore/platform/ios/LegacyTileGrid.h
+++ b/Source/WebCore/platform/ios/LegacyTileGrid.h
@@ -56,7 +56,6 @@ public:
     ~LegacyTileGrid();
 
     LegacyTileCache& tileCache() const { return m_tileCache; }
-    Ref<LegacyTileCache> protectedTileCache() const { return tileCache(); }
 
     CALayer *tileHostLayer() const;
     IntRect bounds() const;

--- a/Source/WebCore/platform/ios/LegacyTileGrid.mm
+++ b/Source/WebCore/platform/ios/LegacyTileGrid.mm
@@ -103,7 +103,7 @@ void LegacyTileGrid::dropTilesBetweenRects(const IntRect& dropRect, const IntRec
 unsigned LegacyTileGrid::tileByteSize() const
 {
     IntSize tilePixelSize = m_tileSize;
-    tilePixelSize.scale(protectedTileCache()->screenScale());
+    tilePixelSize.scale(protect(tileCache())->screenScale());
     return LegacyTileLayerPool::bytesBackingLayerWithPixelSize(tilePixelSize);
 }
 
@@ -118,7 +118,7 @@ bool LegacyTileGrid::dropDistantTiles(unsigned tilesNeeded, double shortestDista
     unsigned bytesPerTile = tileByteSize();
     unsigned bytesNeeded = tilesNeeded * bytesPerTile;
     unsigned bytesUsed = tileCount() * bytesPerTile;
-    unsigned maximumBytes = protectedTileCache()->tileCapacityForGrid(this);
+    unsigned maximumBytes = protect(tileCache())->tileCapacityForGrid(this);
 
     int bytesToReclaim = int(bytesUsed) - (int(maximumBytes) - bytesNeeded);
     if (bytesToReclaim <= 0)
@@ -302,7 +302,7 @@ bool LegacyTileGrid::checkDoSingleTileLayout()
 
 void LegacyTileGrid::updateHostLayerSize()
 {
-    CALayer* hostLayer = protectedTileCache()->hostLayer();
+    CALayer* hostLayer = protect(tileCache())->hostLayer();
     CGRect tileHostBounds = [hostLayer convertRect:[hostLayer bounds] toLayer:tileHostLayer()];
     CGSize transformedSize;
     transformedSize.width = CGRound(tileHostBounds.size.width);
@@ -549,7 +549,7 @@ void LegacyTileGrid::createTiles(LegacyTileCache::SynchronousTileCreationMode cr
 
     bool didCreateTiles = !!tilesToCreateCount;
     bool createMoreTiles = pendingTileCount > tilesToCreateCount;
-    protectedTileCache()->finishedCreatingTiles(didCreateTiles, createMoreTiles);
+    protect(tileCache())->finishedCreatingTiles(didCreateTiles, createMoreTiles);
 }
 
 void LegacyTileGrid::dumpTiles()

--- a/Source/WebCore/platform/ios/LegacyTileGridTile.mm
+++ b/Source/WebCore/platform/ios/LegacyTileGridTile.mm
@@ -125,7 +125,7 @@ void LegacyTileGridTile::showBorder(bool flag)
 {
     LegacyTileLayer* layer = m_tileLayer.get();
     if (flag) {
-        [layer setBorderColor:cachedCGColor(m_tileGrid->protectedTileCache()->colorForGridTileBorder(m_tileGrid)).get()];
+        [layer setBorderColor:cachedCGColor(protect(m_tileGrid->tileCache())->colorForGridTileBorder(m_tileGrid)).get()];
         [layer setBorderWidth:0.5f];
     } else {
         [layer setBorderColor:nil];

--- a/Source/WebCore/platform/ios/LegacyTileLayer.mm
+++ b/Source/WebCore/platform/ios/LegacyTileLayer.mm
@@ -93,7 +93,7 @@ using WebCore::LegacyTileCache;
         WebThreadLock();
     // This may trigger WebKit layout and generate more repaint rects.
     if (_tileGrid)
-        _tileGrid->protectedTileCache()->prepareToDraw();
+        protect(_tileGrid->tileCache())->prepareToDraw();
 }
 
 - (void)renderInContext:(CGContextRef)context
@@ -114,7 +114,7 @@ using WebCore::LegacyTileCache;
         WebThreadLock();
 
     if (_tileGrid)
-        _tileGrid->protectedTileCache()->drawLayer(self, context, self.isRenderingInContext ? LegacyTileCache::DrawingFlags::Snapshotting : LegacyTileCache::DrawingFlags::None);
+        protect(_tileGrid->tileCache())->drawLayer(self, context, self.isRenderingInContext ? LegacyTileCache::DrawingFlags::Snapshotting : LegacyTileCache::DrawingFlags::None);
 }
 
 - (id<CAAction>)actionForKey:(NSString *)key

--- a/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
+++ b/Source/WebCore/platform/mac/ScrollbarsControllerMac.mm
@@ -1098,12 +1098,12 @@ static String scrollbarState(Scrollbar* scrollbar)
 
 String ScrollbarsControllerMac::horizontalScrollbarStateForTesting() const
 {
-    return scrollbarState(checkedScrollableArea()->protectedHorizontalScrollbar().get());
+    return scrollbarState(protect(checkedScrollableArea()->horizontalScrollbar()).get());
 }
 
 String ScrollbarsControllerMac::verticalScrollbarStateForTesting() const
 {
-    return scrollbarState(checkedScrollableArea()->protectedVerticalScrollbar().get());
+    return scrollbarState(protect(checkedScrollableArea()->verticalScrollbar()).get());
 }
 
 WheelEventTestMonitor* ScrollbarsControllerMac::wheelEventTestMonitor() const

--- a/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h
@@ -58,7 +58,6 @@ public:
     void deref() const final { AudioTrackPrivate::deref(); }
 
     MediaStreamTrackPrivate& streamTrack() { return m_streamTrack.get(); }
-    Ref<MediaStreamTrackPrivate> protectedStreamTrack() { return m_streamTrack; }
 
     void clear();
 

--- a/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp
@@ -314,7 +314,7 @@ void MediaStreamPrivate::monitorOrientation(OrientationNotifier& notifier)
 {
     for (Ref track : m_trackSet.values()) {
         if (track->isCaptureTrack() && track->deviceType() == CaptureDevice::DeviceType::Camera)
-            track->protectedSource()->monitorOrientation(notifier);
+            protect(track->source())->monitorOrientation(notifier);
     }
 }
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp
@@ -370,7 +370,7 @@ bool MediaStreamTrackPrivate::isOnCreationThread()
 
 void MediaStreamTrackPrivate::updateLabelIfRemoteTrack()
 {
-    if (!isMainThread() || !(protectedSource()->isIncomingAudioSource() || protectedSource()->isIncomingVideoSource()))
+    if (!isMainThread() || !(protect(source())->isIncomingAudioSource() || protect(source())->isIncomingVideoSource()))
         return;
 
     m_label = makeString(m_label, " - "_s, m_id);
@@ -499,16 +499,6 @@ const RealtimeMediaSource& MediaStreamTrackPrivate::source() const
 {
     ASSERT(isMainThread());
     return m_sourceObserver->source();
-}
-
-Ref<RealtimeMediaSource> MediaStreamTrackPrivate::protectedSource()
-{
-    return source();
-}
-
-Ref<const RealtimeMediaSource> MediaStreamTrackPrivate::protectedSource() const
-{
-    return source();
 }
 
 RealtimeMediaSource& MediaStreamTrackPrivate::sourceForProcessor()

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h
@@ -134,8 +134,6 @@ public:
 
     WEBCORE_EXPORT RealtimeMediaSource& source();
     const RealtimeMediaSource& source() const;
-    Ref<RealtimeMediaSource> protectedSource();
-    Ref<const RealtimeMediaSource> protectedSource() const;
     RealtimeMediaSource& sourceForProcessor();
     bool hasSource(const RealtimeMediaSource*) const;
 

--- a/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
+++ b/Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h
@@ -46,7 +46,6 @@ public:
     void setTrackIndex(int index) { m_index = index; }
 
     MediaStreamTrackPrivate& streamTrack() { return m_streamTrack.get(); }
-    Ref<MediaStreamTrackPrivate> protectedStreamTrack() { return m_streamTrack; }
 
 private:
     VideoTrackPrivateMediaStream(MediaStreamTrackPrivate& track)

--- a/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp
@@ -52,7 +52,7 @@ RealtimeOutgoingAudioSourceCocoa::RealtimeOutgoingAudioSourceCocoa(Ref<MediaStre
     : RealtimeOutgoingAudioSource(WTF::move(audioSource))
     , m_sampleConverter(AudioSampleDataSource::create(LibWebRTCAudioFormat::sampleRate * 2, source()))
 {
-    if (auto* description = source().protectedSource()->audioStreamDescription())
+    if (auto* description = protect(source().source())->audioStreamDescription())
         updateSampleConverter(*description);
 }
 
@@ -163,7 +163,7 @@ void RealtimeOutgoingAudioSourceCocoa::pullAudioData()
 
 void RealtimeOutgoingAudioSourceCocoa::sourceUpdated()
 {
-    if (auto* description = source().protectedSource()->audioStreamDescription())
+    if (auto* description = protect(source().source())->audioStreamDescription())
         updateSampleConverter(*description);
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebCore/platform/network/BlobData.cpp
+++ b/Source/WebCore/platform/network/BlobData.cpp
@@ -53,7 +53,7 @@ long long BlobDataItem::length() const
         ASSERT_NOT_REACHED();
         return m_length;
     case Type::File:
-        return protectedFile()->size();
+        return protect(file())->size();
     }
 
     ASSERT_NOT_REACHED();

--- a/Source/WebCore/platform/network/BlobData.h
+++ b/Source/WebCore/platform/network/BlobData.h
@@ -62,7 +62,6 @@ public:
         ASSERT(type() == Type::Data);
         return std::get<Ref<DataSegment>>(m_data).get();
     }
-    Ref<DataSegment> protectedData() const { return data(); }
 
     // For File type.
     BlobDataFileReference& file() const
@@ -70,7 +69,6 @@ public:
         ASSERT(type() == Type::File);
         return std::get<Ref<BlobDataFileReference>>(m_data).get();
     }
-    Ref<BlobDataFileReference> protectedFile() const { return file(); }
 
     long long offset() const { return m_offset; }
     WEBCORE_EXPORT long long length() const; // Computes file length if it's not known yet.

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -115,7 +115,7 @@ void BlobRegistryImpl::appendStorageItems(BlobData* blobData, const BlobDataItem
             blobData->appendData(item.data(), item.offset() + offset, newLength);
             break;
         case BlobDataItem::Type::File:
-            blobData->appendFile(item.protectedFile(), item.offset() + offset, newLength);
+            blobData->appendFile(protect(item.file()), item.offset() + offset, newLength);
             break;
         }
         length -= newLength;
@@ -350,10 +350,10 @@ bool BlobRegistryImpl::populateBlobsForFileWriting(const Vector<String>& blobURL
         for (auto& item : blobData->items()) {
             switch (item.type()) {
             case BlobDataItem::Type::Data:
-                blobsForWriting.last().filePathsOrDataBuffers.append(item.protectedData());
+                blobsForWriting.last().filePathsOrDataBuffers.append(protect(item.data()));
                 break;
             case BlobDataItem::Type::File:
-                blobsForWriting.last().filePathsOrDataBuffers.append(item.protectedFile()->path().isolatedCopy());
+                blobsForWriting.last().filePathsOrDataBuffers.append(protect(item.file())->path().isolatedCopy());
                 break;
             }
         }
@@ -426,7 +426,7 @@ Vector<Ref<BlobDataFileReference>> BlobRegistryImpl::filesInBlob(const URL& url,
     Vector<Ref<BlobDataFileReference>> result;
     for (const BlobDataItem& item : blobData->items()) {
         if (item.type() == BlobDataItem::Type::File)
-            result.append(item.protectedFile());
+            result.append(protect(item.file()));
     }
 
     return result;

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -209,7 +209,7 @@ int BlobResourceHandle::readDataSync(const BlobDataItem& item, std::span<uint8_t
 
     uint64_t remaining = item.length() - currentItemReadSize();
     uint64_t bytesToRead = std::min(std::min<uint64_t>(remaining, buffer.size()), totalRemainingSize());
-    memcpySpan(buffer, item.protectedData()->span().subspan(item.offset() + currentItemReadSize()).first(bytesToRead));
+    memcpySpan(buffer, protect(item.data())->span().subspan(item.offset() + currentItemReadSize()).first(bytesToRead));
     decrementTotalRemainingSizeBy(bytesToRead);
 
     setCurrentItemReadSize(currentItemReadSize() + bytesToRead);
@@ -231,7 +231,7 @@ int BlobResourceHandle::readFileSync(const BlobDataItem& item, std::span<uint8_t
         auto bytesToRead = lengthOfItemBeingRead() - currentItemReadSize();
         if (bytesToRead > totalRemainingSize())
             bytesToRead = totalRemainingSize();
-        bool success = syncStream()->openForRead(item.protectedFile()->path(), item.offset() + currentItemReadSize(), bytesToRead);
+        bool success = syncStream()->openForRead(protect(item.file())->path(), item.offset() + currentItemReadSize(), bytesToRead);
         setCurrentItemReadSize(0);
         if (!success) {
             m_errorCode = Error::NotReadableError;

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
@@ -288,7 +288,7 @@ bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item)
     if (bytesToRead > m_totalRemainingSize)
         bytesToRead = m_totalRemainingSize;
 
-    auto data = item.protectedData()->span().subspan(item.offset() + m_currentItemReadSize, bytesToRead);
+    auto data = protect(item.data())->span().subspan(item.offset() + m_currentItemReadSize, bytesToRead);
     m_currentItemReadSize = 0;
 
     return consumeData(data);
@@ -306,7 +306,7 @@ void BlobResourceHandleBase::readFileAsync(const BlobDataItem& item)
     uint64_t bytesToRead = lengthOfItemBeingRead() - m_currentItemReadSize;
     if (bytesToRead > m_totalRemainingSize)
         bytesToRead = static_cast<int>(m_totalRemainingSize);
-    asyncStream()->openForRead(item.protectedFile()->path(), item.offset() + m_currentItemReadSize, bytesToRead);
+    asyncStream()->openForRead(protect(item.file())->path(), item.offset() + m_currentItemReadSize, bytesToRead);
     m_isFileOpen = true;
     m_currentItemReadSize = 0;
 }

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -322,7 +322,7 @@ static void appendBlobResolved(BlobRegistryImpl* blobRegistry, FormData& formDat
     for (const auto& blobItem : blobData->items()) {
         switch (blobItem.type()) {
         case BlobDataItem::Type::Data:
-            formData.appendData(blobItem.protectedData()->span().subspan(blobItem.offset(), blobItem.length()));
+            formData.appendData(protect(blobItem.data())->span().subspan(blobItem.offset(), blobItem.length()));
             break;
         case BlobDataItem::Type::File: {
             Ref file = blobItem.file();

--- a/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
+++ b/Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm
@@ -137,7 +137,7 @@ void RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived(WebCoreNSU
     if (!taskData)
         return;
 
-    auto giveBytesToTask = [task = retainPtr(task), buffer = data.buffer.protectedBuffer(), bufferSize, weakTaskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }, targetQueue = m_targetDispatcher] {
+    auto giveBytesToTask = [task = retainPtr(task), buffer = protect(data.buffer.buffer()), bufferSize, weakTaskData = WeakPtr { *taskData }, weakGenerator = ThreadSafeWeakPtr { *this }, targetQueue = m_targetDispatcher] {
         assertIsCurrent(targetQueue);
         if ([task state] != NSURLSessionTaskStateRunning)
             return;

--- a/Source/WebCore/rendering/RenderSearchField.cpp
+++ b/Source/WebCore/rendering/RenderSearchField.cpp
@@ -75,7 +75,7 @@ RenderSearchField::~RenderSearchField() = default;
 void RenderSearchField::willBeDestroyed()
 {
     if (RefPtr searchPopup = std::exchange(m_searchPopup, nullptr))
-        searchPopup->protectedPopupMenu()->disconnectClient();
+        protect(searchPopup->popupMenu())->disconnectClient();
 
     RenderTextControlSingleLine::willBeDestroyed();
 }
@@ -123,13 +123,13 @@ void RenderSearchField::showPopup()
     FloatPoint absTopLeft = localToAbsolute(FloatPoint(), UseTransforms);
     IntRect absBounds = absoluteBoundingBoxRectIgnoringTransforms();
     absBounds.setLocation(roundedIntPoint(absTopLeft));
-    protectedSearchPopup()->protectedPopupMenu()->show(absBounds, view().frameView(), -1);
+    protect(protectedSearchPopup()->popupMenu())->show(absBounds, view().frameView(), -1);
 }
 
 void RenderSearchField::hidePopup()
 {
     if (RefPtr searchPopup = m_searchPopup)
-        searchPopup->protectedPopupMenu()->hide();
+        protect(searchPopup->popupMenu())->hide();
 }
 
 LayoutUnit RenderSearchField::computeControlLogicalHeight(LayoutUnit lineHeight, LayoutUnit nonContentHeight) const
@@ -171,7 +171,7 @@ void RenderSearchField::updateFromElement()
         updateCancelButtonVisibility();
 
     if (m_searchPopupIsVisible)
-        protectedSearchPopup()->protectedPopupMenu()->updateFromElement();
+        protect(protectedSearchPopup()->popupMenu())->updateFromElement();
 }
 
 void RenderSearchField::updateCancelButtonVisibility() const

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -537,7 +537,7 @@ void RenderView::repaintViewRectangle(const LayoutRect& repaintRect)
             // left scrollbar (if one exists).
             Ref frameView = this->frameView();
             if (frameView->verticalScrollbar() && frameView->shouldPlaceVerticalScrollbarOnLeft())
-                adjustedRect.move(LayoutSize(frameView->protectedVerticalScrollbar()->occupiedWidth(), 0));
+                adjustedRect.move(LayoutSize(frameView->verticalScrollbar()->occupiedWidth(), 0));
 
             ownerBox->repaintRectangle(adjustedRect);
         }
@@ -599,7 +599,7 @@ void RenderView::flushAccumulatedRepaintRegion() const
         // left scrollbar (if one exists).
         Ref frameView = this->frameView();
         if (frameView->verticalScrollbar() && frameView->shouldPlaceVerticalScrollbarOnLeft())
-            rectOffsetLayoutSize += LayoutSize { frameView->protectedVerticalScrollbar()->occupiedWidth(), 0 };
+            rectOffsetLayoutSize += LayoutSize { frameView->verticalScrollbar()->occupiedWidth(), 0 };
 
         rectOffset = roundedIntSize(rectOffsetLayoutSize);
     }

--- a/Source/WebCore/workers/ScriptBuffer.cpp
+++ b/Source/WebCore/workers/ScriptBuffer.cpp
@@ -58,7 +58,7 @@ String ScriptBuffer::toString() const
         return String();
 
     StringBuilder builder;
-    m_buffer.protectedBuffer()->forEachSegment([&](auto segment) {
+    protect(m_buffer.buffer())->forEachSegment([&](auto segment) {
         builder.append(byteCast<char8_t>(segment));
     });
     return builder.toString();

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1161,10 +1161,10 @@ void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLo
 #endif
 
     if (isSynchronous())
-        sendReplyToSynchronousRequest(*m_synchronousLoadData, m_bufferedData.protectedBuffer().get(), networkLoadMetrics);
+        sendReplyToSynchronousRequest(*m_synchronousLoadData, protect(m_bufferedData.buffer()).get(), networkLoadMetrics);
     else {
         if (!m_bufferedData.isEmpty()) {
-            sendBuffer(*m_bufferedData.protectedBuffer());
+            sendBuffer(*protect(m_bufferedData.buffer()));
         }
 #if ENABLE(CONTENT_FILTERING)
         if (RefPtr contentFilter = m_contentFilter) {

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -462,7 +462,7 @@ void PDFScrollingPresentationController::setSelectionLayerEnabled(bool enabled)
     if (!enabled)
         selectionLayer->removeFromParent();
     else
-        m_contentsLayer->protectedParent()->addChild(WTF::move(selectionLayer));
+        protect(m_contentsLayer->parent())->addChild(WTF::move(selectionLayer));
 #endif
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -899,7 +899,7 @@ void PluginView::viewGeometryDidChange()
 
         float pageScaleFactor = frame->page() ? frame->page()->pageScaleFactor() : 1;
         IntPoint scaledFrameRectLocation { frameRect().location().scaled(pageScaleFactor) };
-        IntPoint scaledLocationInRootViewCoordinates { protectedParent()->contentsToRootView(scaledFrameRectLocation) };
+        IntPoint scaledLocationInRootViewCoordinates { protect(parent())->contentsToRootView(scaledFrameRectLocation) };
 
         transform.translate(scaledLocationInRootViewCoordinates);
         transform.scale(pageScaleFactor);
@@ -929,7 +929,7 @@ void PluginView::viewVisibilityDidChange()
 IntRect PluginView::clipRectInWindowCoordinates() const
 {
     // Get the frame rect in window coordinates.
-    IntRect frameRectInWindowCoordinates = protectedParent()->contentsToWindow(frameRect());
+    IntRect frameRectInWindowCoordinates = protect(parent())->contentsToWindow(frameRect());
 
     RefPtr frame = this->frame();
 


### PR DESCRIPTION
#### 8134c4eaafc392d787e5fce6232a3cee61e3a57d
<pre>
Reduce use of protected functions in Source/WebCore/platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=307401">https://bugs.webkit.org/show_bug.cgi?id=307401</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::updateScrollbars):
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneSerializer::dumpImageBitmap):
* Source/WebCore/platform/MediaSamplesBlock.h:
(WebCore::MediaSamplesBlock::info const):
(WebCore::MediaSamplesBlock::protectedInfo const): Deleted.
* Source/WebCore/platform/ScrollView.h:
(WebCore::ScrollView::protectedHorizontalScrollbar const): Deleted.
(WebCore::ScrollView::protectedVerticalScrollbar const): Deleted.
* Source/WebCore/platform/ScrollableArea.h:
(WebCore::ScrollableArea::horizontalScrollbar const):
(WebCore::ScrollableArea::verticalScrollbar const):
(WebCore::ScrollableArea::protectedHorizontalScrollbar const): Deleted.
(WebCore::ScrollableArea::protectedVerticalScrollbar const): Deleted.
* Source/WebCore/platform/SearchPopupMenu.h:
(WebCore::SearchPopupMenu::protectedPopupMenu): Deleted.
* Source/WebCore/platform/SharedBuffer.h:
(WebCore::SharedBufferBuilder::protectedBuffer const): Deleted.
* Source/WebCore/platform/Widget.cpp:
(WebCore::Widget::protectedParent const): Deleted.
* Source/WebCore/platform/Widget.h:
* Source/WebCore/platform/graphics/ByteArrayPixelBuffer.h:
(WebCore::ByteArrayPixelBuffer::protectedData const): Deleted.
* Source/WebCore/platform/graphics/Color.cpp:
(WebCore::Color::semanticColor const):
(WebCore::Color::colorSpaceAndResolvedColorComponents const):
* Source/WebCore/platform/graphics/Color.h:
(WebCore::Color::asOutOfLine const):
(WebCore::Color::protectedAsOutOfLine const): Deleted.
* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::protectedVerticalRightOrientationFont const): Deleted.
(WebCore::Font::protectedUprightOrientationFont const): Deleted.
(WebCore::Font::protectedInvisibleFont const): Deleted.
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::glyphDataForCharacter const):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::primaryFont const):
(WebCore::FontCascade::fallbackRangesAt const):
(WebCore::FontCascade::isFixedPitch const):
(WebCore::FontCascade::canTakeFixedPitchFastContentMeasuring const):
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::glyphDataForNonCJKCharacterWithGlyphOrientation):
(WebCore::glyphPageFromFontRanges):
* Source/WebCore/platform/graphics/FontCustomPlatformData.h:
(WebCore::FontPlatformData::protectedCustomPlatformData const): Deleted.
* Source/WebCore/platform/graphics/FontPlatformData.h:
(WebCore::FontPlatformData::customPlatformData const):
* Source/WebCore/platform/graphics/GraphicsLayer.h:
(WebCore::GraphicsLayer::parent const):
(WebCore::GraphicsLayer::protectedParent const): Deleted.
* Source/WebCore/platform/graphics/Image.cpp:
(WebCore::Image::protectedData const): Deleted.
* Source/WebCore/platform/graphics/Image.h:
(WebCore::Image::data const):
* Source/WebCore/platform/graphics/MediaPlayer.cpp:
(WebCore::MediaPlayer::reloadAndResumePlaybackIfNeeded):
(WebCore::MediaPlayer::loadWithNextMediaEngine):
(WebCore::MediaPlayer::queueTaskOnEventLoop):
(WebCore::MediaPlayer::seeked):
(WebCore::MediaPlayer::fullscreenMode const):
(WebCore::MediaPlayer::isVideoFullscreenStandby const):
(WebCore::MediaPlayer::videoLayerSize const):
(WebCore::MediaPlayer::canShowWhileLocked const):
(WebCore::MediaPlayer::videoLayerSizeDidChange):
(WebCore::MediaPlayer::requestedRate const):
(WebCore::MediaPlayer::bufferedTimeRangesChanged):
(WebCore::MediaPlayer::seekableTimeRangesChanged):
(WebCore::MediaPlayer::currentPlaybackTargetIsWirelessChanged):
(WebCore::MediaPlayer::readyStateChanged):
(WebCore::MediaPlayer::volumeChanged):
(WebCore::MediaPlayer::muteChanged):
(WebCore::MediaPlayer::timeChanged):
(WebCore::MediaPlayer::sizeChanged):
(WebCore::MediaPlayer::repaint):
(WebCore::MediaPlayer::durationChanged):
(WebCore::MediaPlayer::rateChanged):
(WebCore::MediaPlayer::playbackStateChanged):
(WebCore::MediaPlayer::firstVideoFrameAvailable):
(WebCore::MediaPlayer::characteristicChanged):
(WebCore::MediaPlayer::cachedKeyForKeyId const):
(WebCore::MediaPlayer::keyNeeded):
(WebCore::MediaPlayer::mediaKeysStorageDirectory const):
(WebCore::MediaPlayer::initializationDataEncountered):
(WebCore::MediaPlayer::waitingForKeyChanged):
(WebCore::MediaPlayer::referrer const):
(WebCore::MediaPlayer::userAgent const):
(WebCore::MediaPlayer::cachedResourceLoader const):
(WebCore::MediaPlayer::mediaResourceLoader):
(WebCore::MediaPlayer::addAudioTrack):
(WebCore::MediaPlayer::removeAudioTrack):
(WebCore::MediaPlayer::addTextTrack):
(WebCore::MediaPlayer::removeTextTrack):
(WebCore::MediaPlayer::addVideoTrack):
(WebCore::MediaPlayer::removeVideoTrack):
(WebCore::MediaPlayer::outOfBandTrackSources):
(WebCore::MediaPlayer::isGStreamerHolePunchingEnabled):
(WebCore::MediaPlayer::reportGPUMemoryFootprint const):
(WebCore::MediaPlayer::sourceApplicationIdentifier const):
(WebCore::MediaPlayer::preferredAudioCharacteristics const):
(WebCore::MediaPlayer::doesHaveAttribute const):
(WebCore::MediaPlayer::mediaPlayerNetworkInterfaceName const):
(WebCore::MediaPlayer::getRawCookies const):
(WebCore::MediaPlayer::shouldDisableSleep const):
(WebCore::MediaPlayer::mediaContentTypesRequiringHardwareSupport const):
(WebCore::MediaPlayer::allowedMediaContainerTypes const):
(WebCore::MediaPlayer::allowedMediaCodecTypes const):
(WebCore::MediaPlayer::allowedMediaVideoCodecIDs const):
(WebCore::MediaPlayer::allowedMediaAudioCodecIDs const):
(WebCore::MediaPlayer::allowedMediaCaptionFormatTypes const):
(WebCore::MediaPlayer::remoteEngineFailedToLoad):
(WebCore::MediaPlayer::documentSecurityOrigin const):
(WebCore::MediaPlayer::onNewVideoFrameMetadata):
(WebCore::MediaPlayer::elementId const):
(WebCore::MediaPlayer::soundStageSize const):
(WebCore::MediaPlayer::mediaPlayerLogger):
(WebCore::MediaPlayer::playbackTargetType const):
* Source/WebCore/platform/graphics/MediaPlayer.h:
* Source/WebCore/platform/graphics/MediaResourceSniffer.cpp:
(WebCore::MediaResourceSniffer::dataReceived):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaStreamAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::~MediaPlayerPrivateMediaStreamAVFObjC):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::checkSelectedVideoTrack):
(WebCore::MediaPlayerPrivateMediaStreamAVFObjC::updateTracks):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::updateTransform):
(WebCore::GraphicsLayerCA::updateChildrenTransform):
(WebCore::GraphicsLayerCA::updateFilters):
(WebCore::GraphicsLayerCA::updateBlendMode):
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
(WebCore::GraphicsLayerCA::platformCALayer const):
(WebCore::GraphicsLayerCA::primaryLayer const):
(WebCore::GraphicsLayerCA::protectedPlatformCALayer const): Deleted.
(WebCore::GraphicsLayerCA::protectedPrimaryLayer const): Deleted.
* Source/WebCore/platform/graphics/ca/PlatformCALayer.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::toCMSampleBuffer):
* Source/WebCore/platform/graphics/controls/ApplePayButtonPart.cpp:
(WebCore::ApplePayButtonPart::createPlatformControl):
* Source/WebCore/platform/graphics/controls/ControlPart.cpp:
(WebCore::ControlPart::protectedControlFactory const): Deleted.
* Source/WebCore/platform/graphics/controls/ControlPart.h:
* Source/WebCore/platform/graphics/coretext/FontCoreText.cpp:
(WebCore::Font::createFontWithoutSynthesizableFeatures const):
(WebCore::Font::platformCreateScaledFont const):
(WebCore::Font::platformCreateHalfWidthFont const):
* Source/WebCore/platform/ios/LegacyTileGrid.h:
(WebCore::LegacyTileGrid::tileCache const):
(WebCore::LegacyTileGrid::protectedTileCache const): Deleted.
* Source/WebCore/platform/ios/LegacyTileGrid.mm:
(WebCore::LegacyTileGrid::tileByteSize const):
(WebCore::LegacyTileGrid::dropDistantTiles):
(WebCore::LegacyTileGrid::updateHostLayerSize):
(WebCore::LegacyTileGrid::createTiles):
* Source/WebCore/platform/ios/LegacyTileGridTile.mm:
(WebCore::LegacyTileGridTile::showBorder):
* Source/WebCore/platform/ios/LegacyTileLayer.mm:
(-[LegacyTileLayer layoutSublayers]):
(-[LegacyTileLayer drawInContext:]):
* Source/WebCore/platform/mac/ScrollbarsControllerMac.mm:
(WebCore::ScrollbarsControllerMac::horizontalScrollbarStateForTesting const):
(WebCore::ScrollbarsControllerMac::verticalScrollbarStateForTesting const):
* Source/WebCore/platform/mediastream/AudioTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/MediaStreamPrivate.cpp:
(WebCore::MediaStreamPrivate::monitorOrientation):
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.cpp:
(WebCore::MediaStreamTrackPrivate::updateLabelIfRemoteTrack):
(WebCore::MediaStreamTrackPrivate::protectedSource): Deleted.
(WebCore::MediaStreamTrackPrivate::protectedSource const): Deleted.
* Source/WebCore/platform/mediastream/MediaStreamTrackPrivate.h:
* Source/WebCore/platform/mediastream/VideoTrackPrivateMediaStream.h:
* Source/WebCore/platform/mediastream/mac/RealtimeOutgoingAudioSourceCocoa.cpp:
(WebCore::RealtimeOutgoingAudioSourceCocoa::RealtimeOutgoingAudioSourceCocoa):
(WebCore::RealtimeOutgoingAudioSourceCocoa::sourceUpdated):
* Source/WebCore/platform/network/BlobData.cpp:
(WebCore::BlobDataItem::length const):
* Source/WebCore/platform/network/BlobData.h:
(WebCore::BlobDataItem::data const):
(WebCore::BlobDataItem::file const):
(WebCore::BlobDataItem::protectedData const): Deleted.
(WebCore::BlobDataItem::protectedFile const): Deleted.
* Source/WebCore/platform/network/BlobRegistryImpl.cpp:
(WebCore::BlobRegistryImpl::appendStorageItems):
(WebCore::BlobRegistryImpl::populateBlobsForFileWriting):
(WebCore::BlobRegistryImpl::filesInBlob const):
* Source/WebCore/platform/network/BlobResourceHandle.cpp:
(WebCore::BlobResourceHandle::readDataSync):
(WebCore::BlobResourceHandle::readFileSync):
* Source/WebCore/platform/network/BlobResourceHandleBase.cpp:
(WebCore::BlobResourceHandleBase::readDataAsync):
(WebCore::BlobResourceHandleBase::readFileAsync):
* Source/WebCore/platform/network/FormData.cpp:
(WebCore::appendBlobResolved):
* Source/WebCore/platform/network/cocoa/RangeResponseGenerator.mm:
(WebCore::RangeResponseGenerator::giveResponseToTaskIfBytesInRangeReceived):
* Source/WebCore/rendering/RenderSearchField.cpp:
(WebCore::RenderSearchField::willBeDestroyed):
(WebCore::RenderSearchField::showPopup):
(WebCore::RenderSearchField::hidePopup):
(WebCore::RenderSearchField::updateFromElement):
* Source/WebCore/rendering/RenderView.cpp:
(WebCore::RenderView::repaintViewRectangle):
(WebCore::RenderView::flushAccumulatedRepaintRegion const):
* Source/WebCore/workers/ScriptBuffer.cpp:
(WebCore::ScriptBuffer::toString const):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFinishLoading):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::setSelectionLayerEnabled):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::viewGeometryDidChange):
(WebKit::PluginView::clipRectInWindowCoordinates const):

Canonical link: <a href="https://commits.webkit.org/307205@main">https://commits.webkit.org/307205@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/835ca7b05a78db7f5187481d2deef4e2d845f19c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143624 "17 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16105 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7745 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152291 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96860 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/24d06c16-eac1-4d78-9a47-9fac705d33ae) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145499 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16782 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16193 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110449 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79478 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b60118b-da92-4960-9c32-a0671f0f8d78) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12901 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129075 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91366 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8cd98a39-9bc6-401c-9316-3d255ff8596c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12376 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10093 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2293 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121820 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5623 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154603 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6664 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118453 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16188 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13605 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118809 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30462 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14753 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126830 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71566 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15773 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5399 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15508 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15720 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15572 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->