### PR TITLE
Unreviewed, Disable model for tvOS

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -24,7 +24,7 @@
 internal import Metal
 internal import WebKit_Internal
 
-#if canImport(RealityCoreRenderer, _version: 9) && !os(iOS)
+#if canImport(RealityCoreRenderer, _version: 9) && os(macOS)
 @_spi(RealityCoreRendererAPI) internal import RealityKit
 @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
 @_spi(SwiftAPI) internal import DirectResource
@@ -793,7 +793,7 @@ extension WKBridgeLiteral {
     }
 }
 
-#if canImport(RealityCoreRenderer, _version: 9) && !os(iOS)
+#if canImport(RealityCoreRenderer, _version: 9) && os(macOS)
 
 internal func toData<T>(_ input: [T]) -> Data {
     unsafe input.withUnsafeBytes { bufferPointer in

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 9) && !os(iOS)
+#if canImport(RealityCoreRenderer, _version: 9) && os(macOS)
 
 internal import Metal
 @_spi(RealityCoreRendererAPI) internal import RealityKit

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 9) && !os(iOS)
+#if canImport(RealityCoreRenderer, _version: 9) && os(macOS)
 
 @_spi(RealityCoreRendererAPI) internal import RealityKit
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 9) && !os(iOS)
+#if canImport(RealityCoreRenderer, _version: 9) && os(macOS)
 
 internal import QuartzCore
 @_spi(RealityCoreRendererAPI) @_spi(Private) internal import RealityKit

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if canImport(RealityCoreRenderer, _version: 9) && !os(iOS)
+#if canImport(RealityCoreRenderer, _version: 9) && os(macOS)
 
 internal import DirectResource
 internal import Metal

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -26,7 +26,7 @@ internal import OSLog
 internal import WebKit_Internal
 internal import simd
 
-#if canImport(RealityCoreRenderer, _version: 9) && !os(iOS)
+#if canImport(RealityCoreRenderer, _version: 9) && os(macOS)
 @_spi(RealityCoreRendererAPI) internal import RealityKit
 @_spi(RealityCoreTextureProcessingAPI) internal import RealityCoreTextureProcessing
 @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit


### PR DESCRIPTION
#### 8bd0453849b49c3399871a6026f3783f1988104c
<pre>
Unreviewed, Disable model for tvOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=307406">https://bugs.webkit.org/show_bug.cgi?id=307406</a>
<a href="https://rdar.apple.com/170027294">rdar://170027294</a>

Unreviewed, no need to build Model for tvOS

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/307145@main">https://commits.webkit.org/307145@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/458d0201acd93aab3db032848e0dee10eeae95e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143559 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/7653 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152224 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16128 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/110388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146522 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/12846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/91307 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12335 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10043 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2226 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154536 "Failed to checkout and rebase branch from PR 58273") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/6574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/154536 "Failed to checkout and rebase branch from PR 58273") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/16123 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/13544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/154536 "Failed to checkout and rebase branch from PR 58273") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/126741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22132 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/15708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/15443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15655 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/15507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->