### PR TITLE
REGRESSION(305314@main): DataListButtonElement::canAdjustStyleForAppearance behaved inconsistently

### DIFF
--- a/Source/WebCore/html/shadow/DataListButtonElement.h
+++ b/Source/WebCore/html/shadow/DataListButtonElement.h
@@ -45,17 +45,19 @@ public:
 
     static Ref<DataListButtonElement> create(Document&, DataListButtonOwner&);
 
-    bool canAdjustStyleForAppearance() const;
+    bool canAdjustStyleForAppearance() const { return m_canAdjustStyleForAppearance; }
 
 private:
     explicit DataListButtonElement(Document&, DataListButtonOwner&);
 
     bool isDataListButtonElement() const final { return true; }
+    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) final;
 
     void defaultEventHandler(Event&) final;
     bool isDisabledFormControl() const final;
 
     DataListButtonOwner& m_owner;
+    bool m_canAdjustStyleForAppearance { true };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### d4e98dfdcb5014c16bdb9afc962e55c9c4719138
<pre>
REGRESSION(305314@main): DataListButtonElement::canAdjustStyleForAppearance behaved inconsistently
<a href="https://bugs.webkit.org/show_bug.cgi?id=305709">https://bugs.webkit.org/show_bug.cgi?id=305709</a>

Reviewed by Antti Koivisto.

After &lt;<a href="https://commits.webkit.org/305314@main">https://commits.webkit.org/305314@main</a>&gt;, GTK has observed a random
assertion failure for fast/forms/datalist/data-list-search-input-with-appearance-none.html.

&gt; ASSERTION FAILED: mode == Verify =&gt; !geometryChanged
&gt; ../../../Source/WebCore/rendering/RenderLayer.cpp(2207) : bool WebCore::RenderLayer::updateLayerPosition(WTF::OptionSet&lt;UpdateLayerPositionsFlag&gt;*, UpdateLayerPositionsMode)

This meant the RenderLayer position was changed unexpectedly. It was a
-webkit-list-button shadow element for datalist suggestions.

The change added DataListButtonElement::canAdjustStyleForAppearance() which
returned true unless the shadow host style has none appearance by using
existingComputedStyle(). However, existingComputedStyle() doesn&apos;t returns a
style for the first time in this function. This function returned true for the
first time, but false for the next time in the test case.

SearchFieldResultsButtonElement class also checks the shadow host style, but it
takes another approach. It overrides resolveCustomStyle() to get the shadow
host style. Take the same approach for DataListButtonElement.

* Source/WebCore/html/shadow/DataListButtonElement.cpp:
(WebCore::DataListButtonElement::DataListButtonElement):
(WebCore::DataListButtonElement::isDisabledFormControl const):
(WebCore::DataListButtonElement::resolveCustomStyle):
(WebCore::DataListButtonElement::canAdjustStyleForAppearance const): Deleted.
* Source/WebCore/html/shadow/DataListButtonElement.h:

Canonical link: <a href="https://commits.webkit.org/307703@main">https://commits.webkit.org/307703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9ce9fd3d13b6bb61925829e3ec2358d54ae3157a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9680 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153889 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147092 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17790 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111658 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148180 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14021 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92558 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13378 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11143 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1334 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122903 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7191 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156201 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17749 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8279 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119668 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120002 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15770 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128449 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73421 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22399 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17370 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6707 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17107 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81149 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17315 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17170 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->