### PR TITLE
Further reduce use of protected member functions in Source/WebCore

### DIFF
--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -242,7 +242,7 @@ bool DocumentTimeline::animationCanBeRemoved(WebAnimation& animation)
         return false;
 
     auto target = keyframeEffect->targetStyleable();
-    if (!target || !target->protectedElement()->isDescendantOf(Ref { *m_document }))
+    if (!target || !protect(target->element)->isDescendantOf(Ref { *m_document }))
         return false;
 
 IGNORE_GCC_WARNINGS_BEGIN("dangling-reference")

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -8982,7 +8982,7 @@ Variant<Document::SkipTransition, Vector<AtomString>> Document::resolveViewTrans
     if (hidden())
         return SkipTransition { };
 
-    RefPtr rule = styleScope().protectedResolver()->viewTransitionRule();
+    RefPtr rule = protect(styleScope().resolver())->viewTransitionRule();
     if (rule && rule->computedNavigation() == ViewTransitionNavigation::Auto)
         return rule->types();
     return SkipTransition { };

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -611,7 +611,7 @@ bool ViewTransition::updatePropertiesForGroupPseudo(CapturedElement& capturedEle
         // group styles rule
         if (!capturedElement.groupStyleProperties) {
             capturedElement.groupStyleProperties = properties;
-            protect(document())->styleScope().protectedResolver()->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, *properties);
+            protect(protect(document())->styleScope().resolver())->setViewTransitionStyles(CSSSelector::PseudoElement::ViewTransitionGroup, name, *properties);
             return true;
         }
         return protect(*capturedElement.groupStyleProperties)->mergeAndOverrideOnConflict(*properties);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -487,7 +487,7 @@ void LocalDOMWindow::prewarmLocalStorageIfNecessary()
     if (!localStorage)
         return;
 
-    localStorage->protectedArea()->prewarm();
+    protect(localStorage->area())->prewarm();
 }
 
 LocalDOMWindow::~LocalDOMWindow()

--- a/Source/WebCore/storage/Storage.cpp
+++ b/Source/WebCore/storage/Storage.cpp
@@ -143,11 +143,6 @@ Vector<AtomString> Storage::supportedPropertyNames() const
     });
 }
 
-Ref<StorageArea> Storage::protectedArea() const
-{
-    return m_storageArea;
-}
-
 bool Storage::requiresScriptTrackingPrivacyProtection() const
 {
     RefPtr document = window() ? protect(window())->document() : nullptr;

--- a/Source/WebCore/storage/Storage.h
+++ b/Source/WebCore/storage/Storage.h
@@ -52,7 +52,6 @@ public:
     Vector<AtomString> supportedPropertyNames() const;
 
     StorageArea& area() const { return m_storageArea.get(); }
-    Ref<StorageArea> protectedArea() const;
 
 private:
     Storage(LocalDOMWindow&, Ref<StorageArea>&&);

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -122,7 +122,6 @@ public:
     const RenderStyle* rootElementRenderStyle() const { return m_context.rootElementStyle; }
 
     const Document& document() const { return *m_context.document; }
-    Ref<const Document> protectedDocument() const { return *m_context.document; }
     const Element* element() const { return m_context.element.get(); }
 
     inline void setZoom(Zoom);

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -115,11 +115,6 @@ Resolver& Scope::resolver()
     return *m_resolver;
 }
 
-Ref<Resolver> Scope::protectedResolver()
-{
-    return resolver();
-}
-
 void Scope::createDocumentResolver()
 {
     ASSERT(!m_resolver);

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -137,7 +137,6 @@ public:
 #endif
 
     WEBCORE_EXPORT Resolver& resolver();
-    Ref<Resolver> protectedResolver();
     Resolver* resolverIfExists() { return m_resolver.get(); }
     const Resolver* resolverIfExists() const { return m_resolver.get(); }
     void clearResolver();

--- a/Source/WebCore/style/Styleable.h
+++ b/Source/WebCore/style/Styleable.h
@@ -66,7 +66,6 @@ struct Styleable {
     }
 
     RenderElement* renderer() const;
-    Ref<Element> protectedElement() const { return element; }
 
     std::unique_ptr<RenderStyle> computeAnimatedStyle() const;
 

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper+Blending.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper+Blending.h
@@ -45,7 +45,7 @@ template<typename T> struct LengthWrapperBlendingSupport {
             if (value.isPercent())
                 return Calculation::percentage(value.m_value.value());
             if (value.isCalculated())
-                return value.m_value.protectedCalculationValue()->copyRoot();
+                return protect(value.m_value.calculationValue())->copyRoot();
             ASSERT(value.isFixed());
             return Calculation::dimension(value.m_value.value());
         };
@@ -53,7 +53,7 @@ template<typename T> struct LengthWrapperBlendingSupport {
         auto isTooDeepToBlendWithNode = [](const T& value) {
             if (!value.isCalculated())
                 return false;
-            auto treeDepth = computeDepth(value.m_value.protectedCalculationValue()->tree());
+            auto treeDepth = computeDepth(protect(value.m_value.calculationValue())->tree());
             return treeDepth > maximumBlendTreeDepth;
         };
 

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp
@@ -45,11 +45,6 @@ Calculation::Value& LengthWrapperData::calculationValue() const
     return Calculation::ValueMap::calculationValues().get(m_calculationValueHandle);
 }
 
-Ref<Calculation::Value> LengthWrapperData::protectedCalculationValue() const
-{
-    return calculationValue();
-}
-
 void LengthWrapperData::ref() const
 {
     ASSERT(m_kind == LengthWrapperDataKind::Calculation);
@@ -84,7 +79,7 @@ auto LengthWrapperData::ipcData() const -> IPCData
 float LengthWrapperData::nonNanCalculatedValue(float maxValue, const ZoomFactor& usedZoom) const
 {
     ASSERT(m_kind == LengthWrapperDataKind::Calculation);
-    float result = protectedCalculationValue()->evaluate(maxValue, usedZoom);
+    float result = protect(calculationValue())->evaluate(maxValue, usedZoom);
     if (std::isnan(result))
         return 0;
     return result;
@@ -93,7 +88,7 @@ float LengthWrapperData::nonNanCalculatedValue(float maxValue, const ZoomFactor&
 float LengthWrapperData::nonNanCalculatedValue(float maxValue, const ZoomNeeded& token) const
 {
     ASSERT(m_kind == LengthWrapperDataKind::Calculation);
-    float result = protectedCalculationValue()->evaluate(maxValue, token);
+    float result = protect(calculationValue())->evaluate(maxValue, token);
     if (std::isnan(result))
         return 0;
     return result;

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
@@ -67,7 +67,6 @@ struct LengthWrapperData {
 
     float value() const { ASSERT(m_kind != LengthWrapperDataKind::Calculation); return m_floatValue; }
     Calculation::Value& calculationValue() const;
-    Ref<Calculation::Value> protectedCalculationValue() const;
 
     struct IPCData {
         float value;

--- a/Source/WebCore/xml/XPathExpressionNode.h
+++ b/Source/WebCore/xml/XPathExpressionNode.h
@@ -38,8 +38,6 @@ struct EvaluationContext {
     unsigned position;
     HashMap<String, String> variableBindings;
     bool hadTypeConversionError;
-
-    RefPtr<Node> protectedNode() const { return node; }
 };
 
 class Expression {

--- a/Source/WebCore/xml/XPathFunctions.cpp
+++ b/Source/WebCore/xml/XPathFunctions.cpp
@@ -407,7 +407,7 @@ Value FunLocalName::evaluate() const
         return node ? expandedNameLocalPart(*node) : emptyString();
     }
 
-    return expandedNameLocalPart(*evaluationContext().protectedNode());
+    return expandedNameLocalPart(*protect(evaluationContext().node));
 }
 
 Value FunNamespaceURI::evaluate() const
@@ -421,7 +421,7 @@ Value FunNamespaceURI::evaluate() const
         return node ? node->namespaceURI().string() : emptyString();
     }
 
-    return evaluationContext().protectedNode()->namespaceURI().string();
+    return protect(evaluationContext().node)->namespaceURI().string();
 }
 
 Value FunName::evaluate() const
@@ -435,7 +435,7 @@ Value FunName::evaluate() const
         return node ? expandedName(*node) : emptyString();
     }
 
-    return expandedName(*evaluationContext().protectedNode());
+    return expandedName(*protect(evaluationContext().node));
 }
 
 Value FunCount::evaluate() const

--- a/Source/WebCore/xml/XSLImportRule.cpp
+++ b/Source/WebCore/xml/XSLImportRule.cpp
@@ -48,7 +48,7 @@ XSLImportRule::XSLImportRule(XSLStyleSheet& parent, const String& href)
 XSLImportRule::~XSLImportRule()
 {
     if (m_styleSheet)
-        protectedStyleSheet()->setParentStyleSheet(nullptr);
+        protect(styleSheet())->setParentStyleSheet(nullptr);
 
     if (m_cachedSheet)
         m_cachedSheet->removeClient(*this);
@@ -57,13 +57,13 @@ XSLImportRule::~XSLImportRule()
 void XSLImportRule::setXSLStyleSheet(const String& href, const URL& baseURL, const String& sheet)
 {
     if (m_styleSheet)
-        protectedStyleSheet()->setParentStyleSheet(nullptr);
+        protect(styleSheet())->setParentStyleSheet(nullptr);
 
     // FIXME: parentStyleSheet() should never be null here.
     RefPtr parent = parentStyleSheet();
     m_styleSheet = XSLStyleSheet::create(parent.get(), href, baseURL);
 
-    protectedStyleSheet()->parseString(sheet);
+    protect(styleSheet())->parseString(sheet);
     m_loading = false;
 
     if (parent)

--- a/Source/WebCore/xml/XSLImportRule.h
+++ b/Source/WebCore/xml/XSLImportRule.h
@@ -41,7 +41,6 @@ public:
     
     const String& href() const { return m_strHref; }
     XSLStyleSheet* styleSheet() const { return m_styleSheet.get(); }
-    RefPtr<XSLStyleSheet> protectedStyleSheet() const { return styleSheet(); }
 
     XSLStyleSheet* parentStyleSheet() const { return m_parentStyleSheet.get(); }
     void setParentStyleSheet(XSLStyleSheet* styleSheet) { m_parentStyleSheet = styleSheet; }


### PR DESCRIPTION
#### 85b5c56998a5a2ed2e6e3d146c819ef156b1e12d
<pre>
Further reduce use of protected member functions in Source/WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=307411">https://bugs.webkit.org/show_bug.cgi?id=307411</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/animation/DocumentTimeline.cpp:
(WebCore::DocumentTimeline::animationCanBeRemoved):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::resolveViewTransitionRule):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::updatePropertiesForGroupPseudo):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::prewarmLocalStorageIfNecessary):
* Source/WebCore/storage/Storage.cpp:
(WebCore::Storage::protectedArea const): Deleted.
* Source/WebCore/storage/Storage.h:
* Source/WebCore/style/StyleBuilderState.h:
(WebCore::Style::BuilderState::document const):
(WebCore::Style::BuilderState::protectedDocument const): Deleted.
* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::protectedResolver): Deleted.
* Source/WebCore/style/StyleScope.h:
* Source/WebCore/style/Styleable.h:
(WebCore::Styleable::protectedElement const): Deleted.
* Source/WebCore/style/values/primitives/StyleLengthWrapper+Blending.h:
(WebCore::Style::LengthWrapperBlendingSupport::blendMixedSpecifiedTypes):
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.cpp:
(WebCore::Style::LengthWrapperData::nonNanCalculatedValue const):
(WebCore::Style::LengthWrapperData::protectedCalculationValue const): Deleted.
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
* Source/WebCore/xml/XPathExpressionNode.h:
(WebCore::XPath::EvaluationContext::protectedNode const): Deleted.
* Source/WebCore/xml/XPathFunctions.cpp:
(WebCore::XPath::FunLocalName::evaluate const):
(WebCore::XPath::FunNamespaceURI::evaluate const):
(WebCore::XPath::FunName::evaluate const):
* Source/WebCore/xml/XSLImportRule.cpp:
(WebCore::XSLImportRule::~XSLImportRule):
(WebCore::XSLImportRule::setXSLStyleSheet):
* Source/WebCore/xml/XSLImportRule.h:
(WebCore::XSLImportRule::styleSheet const):
(WebCore::XSLImportRule::protectedStyleSheet const): Deleted.

Canonical link: <a href="https://commits.webkit.org/307166@main">https://commits.webkit.org/307166@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99a11ddd275927fe58dba24f94656ff5ebd92515

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16087 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7709 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152273 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b24d4e8d-e7a2-4cb3-85e6-26f8c3dd1312) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145481 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16764 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16175 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110435 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146569 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91353 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/06fa60e5-2085-4fc9-be9b-fb4ae0feba7b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10082 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2280 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121801 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154588 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16134 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118440 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16170 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13588 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118796 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30441 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14734 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71548 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15755 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5378 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15490 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15702 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15554 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->