### PR TITLE
[GFC] Refactor findColumnPosition and growGridToFit lambdas to ImplicitGrid member functions.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -51,6 +51,9 @@ public:
 
 private:
     std::optional<size_t> findFirstAvailableColumnPosition(size_t rowStart, size_t rowEnd, size_t columnSpan, size_t startSearchColumn) const;
+    std::optional<size_t> findColumnPosition(GridAutoFlowOptions, size_t normalizedRowStart, size_t normalizedRowEnd, size_t columnSpan
+    , HashMap<size_t, size_t, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>* rowCursors) const;
+    void growGridToFit(size_t columnSpan, size_t normalizedRowStart, size_t normalizedRowEnd, size_t currentColumnsCount);
     bool isCellRangeEmpty(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd) const;
     void insertItemInArea(const UnplacedGridItem&, size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd);
 


### PR DESCRIPTION
#### 824bd4e409593fbc42f7368492409457bb78eab0
<pre>
[GFC] Refactor findColumnPosition and growGridToFit lambdas to ImplicitGrid member functions.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307407">https://bugs.webkit.org/show_bug.cgi?id=307407</a>
&lt;<a href="https://rdar.apple.com/170028401">rdar://170028401</a>&gt;

Reviewed by Sammy Gill.

This PR moves the functionality for inline lambdas:

findColumnPosition and growGridToFit

into member functions in the ImplicitGrid.

This will allow us to build upon these funtions without
rendering insertDefiniteRowItem unreadable.

This PR does not have any behavior change.

* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp:
(WebCore::Layout::ImplicitGrid::insertDefiniteRowItem):
(WebCore::Layout::ImplicitGrid::findColumnPosition const):
(WebCore::Layout::ImplicitGrid::growGridToFit):
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h:

Canonical link: <a href="https://commits.webkit.org/307201@main">https://commits.webkit.org/307201@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0eed1a93f44fc06dae3f61b7ae2ccecfea5839b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96807 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee12a06a-1721-4f6d-bdc5-3e4e715c41cd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145446 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16729 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16140 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110400 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79459 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57b26dfe-1438-463f-8773-f5f6774fff3a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12848 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129019 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91319 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6abcbaa2-231b-447b-b685-c4b533e9d60b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12337 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10054 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2238 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121773 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5544 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154548 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16099 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6584 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118406 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118762 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/30460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14704 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126751 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71513 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22158 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15720 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5349 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15455 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79492 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15667 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15519 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->