### PR TITLE
[GFC] Implement rowSpanSize() in UnplacedGridItem.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp
@@ -130,16 +130,19 @@ bool UnplacedGridItem::hasAutoColumnPosition() const
     return m_columnPosition.first.isAuto() && m_columnPosition.second.isAuto();
 }
 
+bool UnplacedGridItem::hasAutoRowPosition() const
+{
+    return m_rowPosition.first.isAuto() && m_rowPosition.second.isAuto();
+}
+
 size_t UnplacedGridItem::columnSpanSize() const
 {
     auto firstPosition = m_columnPosition.first;
     auto secondPosition = m_columnPosition.second;
 
     // Case 1: Both positions are explicit - calculate span size
-    if (firstPosition.isExplicit() && secondPosition.isExplicit()) {
-        auto spanSize = explicitColumnEnd() - explicitColumnStart();
-        return spanSize;
-    }
+    if (firstPosition.isExplicit() && secondPosition.isExplicit())
+        return explicitColumnEnd() - explicitColumnStart();
 
     // Case 2: One position is a span - extract its span size.
     ASSERT(!(firstPosition.isSpan() && secondPosition.isSpan()));
@@ -150,6 +153,27 @@ size_t UnplacedGridItem::columnSpanSize() const
 
     // Default to span 1
     ASSERT(hasAutoColumnPosition());
+    return 1;
+}
+
+size_t UnplacedGridItem::rowSpanSize() const
+{
+    auto& firstPosition = m_rowPosition.first;
+    auto& secondPosition = m_rowPosition.second;
+
+    // Case 1: Both positions are explicit - calculate span size
+    if (firstPosition.isExplicit() && secondPosition.isExplicit())
+        return explicitRowEnd() - explicitRowStart();
+
+    // Case 2: One position is a span - extract its span size.
+    ASSERT(!(firstPosition.isSpan() && secondPosition.isSpan()));
+    if (firstPosition.isSpan())
+        return firstPosition.spanPosition();
+    if (secondPosition.isSpan())
+        return secondPosition.spanPosition();
+
+    // Default to span 1
+    ASSERT(hasAutoRowPosition());
     return 1;
 }
 

--- a/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h
@@ -52,7 +52,9 @@ public:
     bool hasDefiniteRowPosition() const;
     bool hasDefiniteColumnPosition() const;
     bool hasAutoColumnPosition() const;
+    bool hasAutoRowPosition() const;
     size_t columnSpanSize() const;
+    size_t rowSpanSize() const;
 
     std::pair<size_t, size_t> normalizedRowStartEnd() const;
     std::pair<size_t, size_t> normalizedColumnStartEnd() const;


### PR DESCRIPTION
#### 1d54d435548d63e2f45605ce3400b6b00916a123
<pre>
[GFC] Implement rowSpanSize() in UnplacedGridItem.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307409">https://bugs.webkit.org/show_bug.cgi?id=307409</a>
&lt;<a href="https://rdar.apple.com/170029410">rdar://170029410</a>&gt;

Reviewed by Sammy Gill.

This PR lays some groundwork for finishing the grid item
auto placement algorithm. The function is currently unused but
is needed to fully implement the spec.

* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.cpp:
(WebCore::Layout::UnplacedGridItem::hasAutoRowPosition const):
(WebCore::Layout::UnplacedGridItem::columnSpanSize const):
(WebCore::Layout::UnplacedGridItem::rowSpanSize const):
* Source/WebCore/layout/formattingContexts/grid/UnplacedGridItem.h:

Canonical link: <a href="https://commits.webkit.org/307200@main">https://commits.webkit.org/307200@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4f8f361a3eff67f7a3841fb827dc37ff968a63a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16054 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152238 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96809 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e6cbbde-6859-4d75-8b74-4b884572441e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16731 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16142 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110404 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79460 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b0c67ee-11c2-43b9-b511-26d8ad1a1e65) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12855 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91323 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3857def7-2544-4a83-86eb-015c41878c20) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12344 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10056 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2240 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154550 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16101 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6586 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118410 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16137 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13558 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118766 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14706 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126753 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71515 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22157 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15722 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5351 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15457 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79494 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15521 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->