### PR TITLE
[YARR] Fix infinite loop in JIT for non-greedy backreference to zero-width capture

### DIFF
--- a/JSTests/stress/regexp-nongreedy-backref-zero-width.js
+++ b/JSTests/stress/regexp-nongreedy-backref-zero-width.js
@@ -1,0 +1,85 @@
+// Regression test for non-greedy backreference infinite loop when the
+// referenced capture is undefined or empty. The backtrack code for \N*?
+// must detect that repeating zero-width matches cannot make progress and
+// fail, rather than looping forever.
+//
+// These patterns must all terminate promptly. On buggy engines they hang
+// because the non-greedy quantifier keeps retrying zero-width matches.
+
+function shouldBe(actual, expected, description) {
+    let actualStr = JSON.stringify(actual);
+    let expectedStr = JSON.stringify(expected);
+    if (actualStr !== expectedStr)
+        throw new Error(description + ": expected " + expectedStr + ", got " + actualStr);
+}
+
+// ---- Backreference to capture in a different alternative (undefined) ----
+
+// \1 refers to group 1 which is in alternative 1. When alternative 2 is
+// tried, group 1 is undefined, so \1*? matches zero-width on every attempt.
+shouldBe(/(a)|\1*?X/.exec("YYYYYY"), null,
+    "backref to group in other alternative, no match");
+
+shouldBe(/(a)|\1*?X/.exec("X"), ["X", undefined],
+    "backref to group in other alternative, X matches");
+
+shouldBe(/(a)|\1*?X/.exec("aYYYYY"), ["a", "a"],
+    "backref to group in other alternative, alt 1 matches");
+
+// ---- Backreference to empty capture ----
+
+// Group 1 captures the empty string. \1*? repeatedly matches empty.
+shouldBe(/()\1*?X/.exec("YYYYYY"), null,
+    "backref to empty capture, no match");
+
+shouldBe(/()\1*?X/.exec("X"), ["X", ""],
+    "backref to empty capture, X matches");
+
+// ---- Backreference to unmatched optional group ----
+
+// (a)? may or may not capture. When it doesn't, \1 is undefined.
+shouldBe(/(a)?\1*?X/.exec("YYYYYY"), null,
+    "backref to unmatched optional group, no match");
+
+shouldBe(/(a)?\1*?X/.exec("X"), ["X", undefined],
+    "backref to unmatched optional group, X matches");
+
+shouldBe(/(a)?\1*?X/.exec("aaX"), ["aaX", "a"],
+    "backref to matched optional group, a then backref then X");
+
+// ---- Named backreference to undefined capture in another alternative ----
+
+shouldBe(/(?<t>A)|(?<t>\k<t>*?B)/.exec("BBBB"), ["B", undefined, "B"],
+    "named backref to group in other alternative");
+
+// ---- Multiple undefined backreferences with non-greedy quantifiers ----
+
+shouldBe(/(a)(b)|\1*?\2*?X/.exec("YYYYYY"), null,
+    "two undefined backrefs with non-greedy quantifiers");
+
+shouldBe(/(a)(b)|\1*?\2*?X/.exec("X"), ["X", undefined, undefined],
+    "two undefined backrefs, X matches");
+
+// ---- Case-insensitive with undefined backref ----
+
+shouldBe(/(a)|\1*?X/i.exec("yyyyyy"), null,
+    "case-insensitive undefined backref, no match");
+
+// ---- Non-greedy backref that does match (should still work correctly) ----
+
+shouldBe(/^(.)\1*?(X)/.exec("======X"), ["======X", "=", "X"],
+    "non-greedy backref to non-empty capture");
+
+shouldBe(/^(.)\1*?(.+)/.exec("======="), ["=======", "=", "======"],
+    "non-greedy backref greedy suffix");
+
+// ---- The original crashing pattern from regexp-backreference-backtrack-interpreter.js ----
+
+shouldBe(/A(B(\k<t>C)D(?<t>))EFGHIJKLM|(?<t>\k<t>*?B)B/.exec("aabbbccc"), null,
+    "complex pattern with forward ref and non-greedy backref");
+
+shouldBe(/A(B(\k<t>C)D(?<t>))EFGHIJKLM|(?<t>\k<t>*B)B/.exec("aabbbccc"), null,
+    "complex pattern with greedy backref (should not hang)");
+
+shouldBe(/A(B(\k<t>C)D(?<t>))EFGHIJKLM|(?<t>\k<t>*?B)B/.exec("aabbbccc"), null,
+    "complex pattern with non-greedy variant");


### PR DESCRIPTION
#### 437e137889eae81f02f1c27a384a6da3c94803f8
<pre>
[YARR] Fix infinite loop in JIT for non-greedy backreference to zero-width capture
<a href="https://bugs.webkit.org/show_bug.cgi?id=307415">https://bugs.webkit.org/show_bug.cgi?id=307415</a>

Reviewed by Yusuke Suzuki.

A non-greedy backreference like \1*? can loop forever in the JIT when
the referenced capture is undefined or empty. Each match succeeds
without consuming input, but the backtrack code keeps retrying.

Add a zero-width progress check to backtrackBackReference NonGreedy,
similar to existing guards in ParenthesesSubpatternEnd

Test: JSTests/stress/regexp-nongreedy-backref-zero-width.js

* JSTests/stress/regexp-nongreedy-backref-zero-width.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307156@main">https://commits.webkit.org/307156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07260a8032b09adbb183802790f8c4b6aba198e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143575 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7672 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152240 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16733 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110405 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96811 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146538 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12854 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129023 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91324 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2242 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135563 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121780 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5548 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154552 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4381 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16103 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118413 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13560 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118769 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30433 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14709 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126755 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71517 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15724 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5352 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174861 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15459 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45125 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15523 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->