### PR TITLE
Perform setup for Banner View overlays once added to the web view

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp
@@ -80,6 +80,9 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     int footerHeight,
     ScrollBehaviorForFixedElements&& scrollBehaviorForFixedElements,
     FloatBoxExtent&& obscuredContentInsets,
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    float bannerViewHeight,
+#endif
     bool visualViewportIsSmallerThanLayoutViewport,
     bool asyncFrameOrOverflowScrollingEnabled,
     bool wheelEventGesturesBecomeNonBlocking,
@@ -135,6 +138,9 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(
     , m_overrideVisualViewportSize(overrideVisualViewportSize)
     , m_frameScaleFactor(frameScaleFactor)
     , m_obscuredContentInsets(obscuredContentInsets)
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    , m_bannerViewHeight(bannerViewHeight)
+#endif
     , m_headerHeight(headerHeight)
     , m_footerHeight(footerHeight)
     , m_behaviorForFixed(WTF::move(scrollBehaviorForFixedElements))
@@ -164,6 +170,9 @@ ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode(const Scrolli
     , m_overrideVisualViewportSize(stateNode.overrideVisualViewportSize())
     , m_frameScaleFactor(stateNode.frameScaleFactor())
     , m_obscuredContentInsets(stateNode.obscuredContentInsets())
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    , m_bannerViewHeight(stateNode.bannerViewHeight())
+#endif
     , m_headerHeight(stateNode.headerHeight())
     , m_footerHeight(stateNode.footerHeight())
     , m_behaviorForFixed(stateNode.scrollBehaviorForFixedElements())
@@ -214,6 +223,9 @@ OptionSet<ScrollingStateNode::Property> ScrollingStateFrameScrollingNode::applic
         Property::FooterLayer,
         Property::BehaviorForFixedElements,
         Property::ObscuredContentInsets,
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+        Property::BannerViewHeight,
+#endif
         Property::VisualViewportIsSmallerThanLayoutViewport,
         Property::AsyncFrameOrOverflowScrollingEnabled,
         Property::WheelEventGesturesBecomeNonBlocking,
@@ -330,6 +342,19 @@ void ScrollingStateFrameScrollingNode::setObscuredContentInsets(const FloatBoxEx
     m_obscuredContentInsets = obscuredContentInsets;
     setPropertyChanged(Property::ObscuredContentInsets);
 }
+
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+
+void ScrollingStateFrameScrollingNode::setBannerViewHeight(float bannerViewHeight)
+{
+    if (m_bannerViewHeight == bannerViewHeight)
+        return;
+
+    m_bannerViewHeight = bannerViewHeight;
+    setPropertyChanged(Property::BannerViewHeight);
+}
+
+#endif
 
 void ScrollingStateFrameScrollingNode::setRootContentsLayer(const LayerRepresentation& layerRepresentation)
 {
@@ -464,6 +489,10 @@ void ScrollingStateFrameScrollingNode::dumpProperties(TextStream& ts, OptionSet<
         ts.dumpProperty("left content inset"_s, m_obscuredContentInsets.left());
     if (m_obscuredContentInsets.right())
         ts.dumpProperty("right content inset"_s, m_obscuredContentInsets.right());
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    if (m_bannerViewHeight)
+        ts.dumpProperty("banner view height"_s, m_bannerViewHeight);
+#endif
     if (m_headerHeight)
         ts.dumpProperty("header height"_s, m_headerHeight);
     if (m_footerHeight)

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -81,6 +81,13 @@ public:
     FloatBoxExtent obscuredContentInsets() const { return m_obscuredContentInsets; }
     WEBCORE_EXPORT void setObscuredContentInsets(const FloatBoxExtent&);
 
+    // The target offset for rubber band animations when a banner view overlay is present.
+    // When non-zero, rubber banding will snap to this offset instead of the edge.
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    float bannerViewHeight() const { return m_bannerViewHeight; }
+    WEBCORE_EXPORT void setBannerViewHeight(float);
+#endif
+
     const LayerRepresentation& rootContentsLayer() const { return m_rootContentsLayer; }
     WEBCORE_EXPORT void setRootContentsLayer(const LayerRepresentation&);
 
@@ -170,6 +177,9 @@ private:
         int footerHeight,
         ScrollBehaviorForFixedElements&&,
         FloatBoxExtent&& obscuredContentInsets,
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+        float bannerViewHeight,
+#endif
         bool visualViewportIsSmallerThanLayoutViewport,
         bool asyncFrameOrOverflowScrollingEnabled,
         bool wheelEventGesturesBecomeNonBlocking,
@@ -204,6 +214,9 @@ private:
 
     float m_frameScaleFactor { 1 };
     FloatBoxExtent m_obscuredContentInsets;
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    float m_bannerViewHeight { 0 };
+#endif
     int m_headerHeight { 0 };
     int m_footerHeight { 0 };
     ScrollBehaviorForFixedElements m_behaviorForFixed { ScrollBehaviorForFixedElements::StickToDocumentBounds };

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -246,7 +246,12 @@ enum class ScrollingStateNodeProperty : uint64_t {
     FooterLayer                                 = 1LLU << 43, // Not serialized
     BehaviorForFixedElements                    = FooterHeight << 1,
     ObscuredContentInsets                       = BehaviorForFixedElements << 1,
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    BannerViewHeight                            = ObscuredContentInsets << 1,
+    VisualViewportIsSmallerThanLayoutViewport   = BannerViewHeight << 1,
+#else
     VisualViewportIsSmallerThanLayoutViewport   = ObscuredContentInsets << 1,
+#endif
     AsyncFrameOrOverflowScrollingEnabled        = VisualViewportIsSmallerThanLayoutViewport << 1,
     WheelEventGesturesBecomeNonBlocking         = AsyncFrameOrOverflowScrollingEnabled << 1,
     ScrollingPerformanceTestingEnabled          = WheelEventGesturesBecomeNonBlocking << 1,

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -238,6 +238,13 @@ public:
 
     WEBCORE_EXPORT FloatBoxExtent mainFrameObscuredContentInsets() const;
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    virtual float bannerViewHeight() const { return 0; }
+    virtual bool hasBannerViewOverlay() const { return false; }
+#endif
+
+    virtual void triggerMainFrameRubberBandSnapBack() { }
+
     WEBCORE_EXPORT FloatPoint mainFrameScrollPosition() const;
 
     WEBCORE_EXPORT ScrollbarWidth mainFrameScrollbarWidth() const;

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp
@@ -72,6 +72,11 @@ bool ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(const ScrollingS
     if (state->hasChangedProperty(ScrollingStateNode::Property::ObscuredContentInsets))
         m_obscuredContentInsets = state->obscuredContentInsets();
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    if (state->hasChangedProperty(ScrollingStateNode::Property::BannerViewHeight))
+        m_bannerViewHeight = state->bannerViewHeight();
+#endif
+
     if (state->hasChangedProperty(ScrollingStateNode::Property::VisualViewportIsSmallerThanLayoutViewport))
         m_visualViewportIsSmallerThanLayoutViewport = state->visualViewportIsSmallerThanLayoutViewport();
 
@@ -171,6 +176,10 @@ void ScrollingTreeFrameScrollingNode::dumpProperties(TextStream& ts, OptionSet<S
         ts.dumpProperty("left content inset"_s, m_obscuredContentInsets.left());
     if (m_obscuredContentInsets.right())
         ts.dumpProperty("right content inset"_s, m_obscuredContentInsets.right());
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    if (m_bannerViewHeight)
+        ts.dumpProperty("banner view height"_s, m_bannerViewHeight);
+#endif
 
     if (m_headerHeight)
         ts.dumpProperty("header height"_s, m_headerHeight);

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -57,6 +57,9 @@ public:
     int headerHeight() const { return m_headerHeight; }
     int footerHeight() const { return m_footerHeight; }
     FloatBoxExtent obscuredContentInsets() const { return m_obscuredContentInsets; }
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    float bannerViewHeight() const { return m_bannerViewHeight; }
+#endif
     virtual void viewWillStartLiveResize() { }
     virtual void viewWillEndLiveResize() { }
     virtual void viewSizeDidChange() { }
@@ -91,6 +94,9 @@ private:
     
     float m_frameScaleFactor { 1 };
     FloatBoxExtent m_obscuredContentInsets;
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    float m_bannerViewHeight { 0 };
+#endif
 
     int m_headerHeight { 0 };
     int m_footerHeight { 0 };

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -49,6 +49,8 @@ public:
 
     RetainPtr<CALayer> rootContentsLayer() const { return m_rootContentsLayer; }
 
+    void startRubberBandSnapBack();
+
 protected:
     ScrollingTreeFrameScrollingNodeMac(ScrollingTree&, ScrollingNodeType, ScrollingNodeID);
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm
@@ -68,6 +68,11 @@ ScrollingTreeScrollingNodeDelegateMac& ScrollingTreeFrameScrollingNodeMac::deleg
     return *static_cast<ScrollingTreeScrollingNodeDelegateMac*>(m_delegate.get());
 }
 
+void ScrollingTreeFrameScrollingNodeMac::startRubberBandSnapBack()
+{
+    delegate().startRubberBandSnapBack();
+}
+
 void ScrollingTreeFrameScrollingNodeMac::willBeDestroyed()
 {
     delegate().nodeWillBeDestroyed();

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -59,6 +59,7 @@ public:
     void currentScrollPositionChanged();
 
     bool isRubberBandInProgress() const;
+    void startRubberBandSnapBack();
 
     void updateScrollbarPainters();
     void updateScrollbarLayers() final;
@@ -84,6 +85,10 @@ private:
     bool shouldRubberBandOnSide(BoxSide, FloatSize) const final;
     void didStopRubberBandAnimation() final;
     void rubberBandingStateChanged(bool) final;
+    FloatSize rubberBandTargetOffset() const final;
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    bool hasBannerViewOverlay() const final;
+#endif
     bool scrollPositionIsNotRubberbandingEdge(const FloatPoint&) const;
 
     const Ref<ScrollerPairMac> m_scrollerPair;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -203,6 +203,11 @@ bool ScrollingTreeScrollingNodeDelegateMac::isRubberBandInProgress() const
     return m_scrollController.isRubberBandInProgress();
 }
 
+void ScrollingTreeScrollingNodeDelegateMac::startRubberBandSnapBack()
+{
+    m_scrollController.startRubberBandSnapBack();
+}
+
 bool ScrollingTreeScrollingNodeDelegateMac::allowsHorizontalStretching(const PlatformWheelEvent& wheelEvent) const
 {
     switch (horizontalScrollElasticity()) {
@@ -320,6 +325,28 @@ void ScrollingTreeScrollingNodeDelegateMac::rubberBandingStateChanged(bool inRub
 {
     scrollingTree()->setRubberBandingInProgressForNode(scrollingNode()->scrollingNodeID(), inRubberBand);
 }
+
+FloatSize ScrollingTreeScrollingNodeDelegateMac::rubberBandTargetOffset() const
+{
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    // Only the main frame supports banner views.
+    if (scrollingNode()->nodeType() == ScrollingNodeType::MainFrame) {
+        auto topOffset = scrollingTree()->bannerViewHeight();
+        if (topOffset)
+            return FloatSize(0, -topOffset);
+    }
+#endif
+    return { };
+}
+
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+
+bool ScrollingTreeScrollingNodeDelegateMac::hasBannerViewOverlay() const
+{
+    return scrollingNode()->nodeType() == ScrollingNodeType::MainFrame && scrollingTree()->hasBannerViewOverlay();
+}
+
+#endif
 
 void ScrollingTreeScrollingNodeDelegateMac::updateScrollbarPainters()
 {

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -108,6 +108,9 @@ public:
     virtual void didStopRubberBandAnimation() { }
 
     virtual void rubberBandingStateChanged(bool) { }
+
+    virtual FloatSize rubberBandTargetOffset() const { return { }; }
+    virtual bool hasBannerViewOverlay() const { return false; }
 #endif
 
     virtual void deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason) const { /* Do nothing */ }
@@ -193,8 +196,10 @@ public:
     bool processWheelEventForScrollSnap(const PlatformWheelEvent&);
 
     void stopRubberBanding();
+    void startRubberBandSnapBack();
     bool isRubberBandInProgress() const;
     RectEdges<bool> rubberBandingEdges() const { return m_rubberBandingEdges; }
+    FloatSize deltaWithAdditionalAdjustments(const FloatSize& adjustedDelta, bool);
 #endif
 
 private:
@@ -285,6 +290,9 @@ private:
     bool m_momentumScrollInProgress { false };
     bool m_ignoreMomentumScrolls { false };
     bool m_isRubberBanding { false };
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    bool m_skipAdditionalDeltaAdjustments { false };
+#endif
 
     Deque<FloatSize> m_recentDiscreteWheelDeltas;
     std::unique_ptr<ScrollingEffectsControllerTimer> m_discreteSnapTransitionTimer;

--- a/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
+++ b/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
@@ -38,7 +38,9 @@ public:
     virtual ~ScrollAnimationRubberBand();
 
     // targetOffset is the scroll offset when the animation has finished (i.e. scrolled to an edge).
-    bool startRubberBandAnimation(const FloatSize& initialVelocity, const FloatSize& initialOverscroll);
+    // The optional targetOverscroll parameter specifies where the animation should snap to (defaults to zero).
+    // This is used so that rubber banding does not obscure banner view overlays.
+    bool startRubberBandAnimation(const FloatSize& initialVelocity, const FloatSize& initialOverscroll, const FloatSize& targetOverscroll = { });
 
 private:
     void updateScrollExtents() final;
@@ -51,6 +53,7 @@ private:
 
     FloatSize m_initialVelocity;
     FloatSize m_initialOverscroll;
+    FloatSize m_targetOverscroll;
 };
 
 } // namespace WebCore

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in
@@ -107,6 +107,9 @@ header: <WebCore/ScrollingStatePositionedNode.h>
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::FooterHeight] int footerHeight()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::BehaviorForFixedElements] WebCore::ScrollBehaviorForFixedElements scrollBehaviorForFixedElements()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::ObscuredContentInsets] WebCore::FloatBoxExtent obscuredContentInsets()
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    [OptionalTupleBit=WebCore::ScrollingStateNode::Property::BannerViewHeight] float bannerViewHeight()
+#endif
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::VisualViewportIsSmallerThanLayoutViewport] bool visualViewportIsSmallerThanLayoutViewport()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::AsyncFrameOrOverflowScrollingEnabled] bool asyncFrameOrOverflowScrollingEnabled()
     [OptionalTupleBit=WebCore::ScrollingStateNode::Property::WheelEventGesturesBecomeNonBlocking] bool wheelEventGesturesBecomeNonBlocking();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7568,7 +7568,7 @@ static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtract
 
 - (CGFloat)_bannerViewOverlayHeight
 {
-    return 0;
+    return _impl->bannerViewHeight();
 }
 
 #endif

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -286,6 +286,7 @@ public:
 
 #if PLATFORM(COCOA)
     virtual bool canTakeForegroundAssertions() = 0;
+    virtual void scrollingCoordinatorWasCreated() { }
 #endif
 
     // Return whether the view is visible, or occluded by another window.

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -289,6 +289,24 @@ WebCore::FloatBoxExtent RemoteScrollingCoordinatorProxy::obscuredContentInsets()
     return m_scrollingTree->mainFrameObscuredContentInsets();
 }
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+
+void RemoteScrollingCoordinatorProxy::setBannerViewHeight(float offset)
+{
+    auto previousOffset = m_scrollingTree->bannerViewHeight();
+    m_scrollingTree->setBannerViewHeight(offset);
+
+    if (offset < previousOffset)
+        m_scrollingTree->triggerMainFrameRubberBandSnapBack();
+}
+
+void RemoteScrollingCoordinatorProxy::setHasBannerViewOverlay(bool hasBannerView)
+{
+    m_scrollingTree->setHasBannerViewOverlay(hasBannerView);
+}
+
+#endif
+
 WebCore::FloatPoint RemoteScrollingCoordinatorProxy::currentMainFrameScrollPosition() const
 {
     return m_scrollingTree->mainFrameScrollPosition();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -179,6 +179,10 @@ public:
     virtual void windowScreenDidChange(WebCore::PlatformDisplayID, std::optional<WebCore::FramesPerSecond>) { }
 
     WebCore::FloatBoxExtent obscuredContentInsets() const;
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    void setBannerViewHeight(float);
+    void setHasBannerViewOverlay(bool);
+#endif
     WebCore::FloatPoint currentMainFrameScrollPosition() const;
     WebCore::FloatRect computeVisibleContentRect();
     WebCore::IntPoint scrollOrigin() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -96,6 +96,15 @@ public:
 
     void tryToApplyLayerPositions();
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    float bannerViewHeight() const override { return m_bannerViewHeight; }
+    void setBannerViewHeight(float height) { m_bannerViewHeight = height; }
+    void triggerMainFrameRubberBandSnapBack() override { }
+
+    bool hasBannerViewOverlay() const override { return m_hasBannerViewOverlay; }
+    void setHasBannerViewOverlay(bool hasBannerViewOverlay) { m_hasBannerViewOverlay = hasBannerViewOverlay; }
+#endif
+
 #if ENABLE(THREADED_ANIMATIONS)
     void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const;
@@ -115,6 +124,10 @@ protected:
     // This gets nulled out via invalidate(), since the scrolling thread can hold a ref to the ScrollingTree after the RemoteScrollingCoordinatorProxy has gone away.
     WeakPtr<RemoteScrollingCoordinatorProxy> m_scrollingCoordinatorProxy;
     bool m_hasNodesWithSynchronousScrollingReasons WTF_GUARDED_BY_LOCK(m_treeLock) { false };
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    float m_bannerViewHeight { 0 };
+    bool m_hasBannerViewOverlay { false };
+#endif
 
 #if ENABLE(THREADED_ANIMATIONS)
     void updateProgressBasedTimelinesForNode(const WebCore::ScrollingTreeScrollingNode&);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h
@@ -51,6 +51,8 @@ public:
     void scrollingTreeNodeScrollbarVisibilityDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, bool) override;
     void scrollingTreeNodeScrollbarMinimumThumbLengthDidChange(WebCore::ScrollingNodeID, WebCore::ScrollbarOrientation, int) override;
 
+    void triggerMainFrameRubberBandSnapBack() override;
+
 private:
     void handleWheelEventPhase(WebCore::ScrollingNodeID, WebCore::PlatformWheelEventPhase) override;
     RefPtr<WebCore::ScrollingTreeNode> scrollingNodeForPoint(WebCore::FloatPoint) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm
@@ -592,6 +592,15 @@ void RemoteScrollingTreeMac::scrollingTreeNodeScrollbarMinimumThumbLengthDidChan
     });
 }
 
+void RemoteScrollingTreeMac::triggerMainFrameRubberBandSnapBack()
+{
+    RefPtr rootScrollingNode = dynamicDowncast<ScrollingTreeFrameScrollingNodeMac>(rootNode());
+    if (!rootScrollingNode)
+        return;
+
+    rootScrollingNode->startRubberBandSnapBack();
+}
+
 } // namespace WebKit
 
 #endif // PLATFORM(MAC) && ENABLE(UI_SIDE_COMPOSITING)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1746,8 +1746,11 @@ void WebPageProxy::setDrawingArea(RefPtr<DrawingAreaProxy>&& newDrawingArea)
     drawingArea->setSize(viewSize());
 
 #if PLATFORM(COCOA)
-    if (RefPtr drawingAreaProxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(*drawingArea))
+    if (RefPtr drawingAreaProxy = dynamicDowncast<RemoteLayerTreeDrawingAreaProxy>(*drawingArea)) {
         m_scrollingCoordinatorProxy = drawingAreaProxy->createScrollingCoordinatorProxy();
+        if (RefPtr pageClient = this->pageClient())
+            pageClient->scrollingCoordinatorWasCreated();
+    }
 #endif
 }
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -82,6 +82,7 @@ private:
     bool isActiveViewVisible() override;
     bool isMainViewVisible() override;
     bool canTakeForegroundAssertions() override { return true; };
+    void scrollingCoordinatorWasCreated() override;
     bool isViewVisibleOrOccluded() override;
     bool isViewInWindow() override;
     bool isVisuallyIdle() override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -287,6 +287,11 @@ void PageClientImpl::pageClosed()
     PageClientImplCocoa::pageClosed();
 }
 
+void PageClientImpl::scrollingCoordinatorWasCreated()
+{
+    protect(m_impl)->scrollingCoordinatorWasCreated();
+}
+
 void PageClientImpl::didRelaunchProcess()
 {
     protect(m_impl)->didRelaunchProcess();
@@ -798,6 +803,9 @@ void PageClientImpl::setEditableElementIsFocused(bool editableElementIsFocused)
 void PageClientImpl::scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID)
 {
     protect(m_impl)->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::TemporarilyRemove);
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    protect(m_impl)->updateBannerViewFrame();
+#endif
 }
 
 void PageClientImpl::willBeginViewGesture()

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -230,6 +230,10 @@ static NSString * const textSelectionClickGestureName = @"";
     if ([panGesture state] == NSGestureRecognizerStateBegan)
         viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
 
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    viewImpl->updateBannerViewForPanGesture([panGesture state]);
+#endif
+
     // FIXME: Need to supply a real event here.
     if (viewImpl->allowsBackForwardNavigationGestures() && viewImpl->ensureProtectedGestureController()->handleScrollWheelEvent(nil)) {
         WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "View gesture controller handled gesture");

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -66,6 +66,7 @@
 #include <WebKitAdditions/AppKitSPIAdditions.h>
 #endif
 
+OBJC_CLASS CAShapeLayer;
 OBJC_CLASS NSAccessibilityRemoteUIElement;
 OBJC_CLASS NSImmediateActionGestureRecognizer;
 OBJC_CLASS NSPanGestureRecognizer;
@@ -258,6 +259,7 @@ public:
     void processDidExit();
     void pageClosed();
     void didRelaunchProcess();
+    void scrollingCoordinatorWasCreated();
 
     void setDrawsBackground(bool);
     bool drawsBackground() const;
@@ -840,9 +842,14 @@ public:
 #endif
 
 #if ENABLE(BANNER_VIEW_OVERLAYS)
-void setBannerView(WKBannerView *);
-WKBannerView *bannerView() const { return m_bannerView.get(); }
-void applyBannerViewOverlayHeight(CGFloat, bool);
+    void setBannerView(WKBannerView *);
+    WKBannerView *bannerView() const { return m_bannerView.get(); }
+
+    void applyBannerViewOverlayHeight(CGFloat, bool);
+    CGFloat bannerViewHeight() const;
+    void updateBannerViewForWheelEvent(NSEvent *);
+    void updateBannerViewForPanGesture(NSGestureRecognizerState);
+    void updateBannerViewFrame();
 #endif
 
 #if ENABLE(VIDEO)
@@ -1147,6 +1154,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ENABLE(BANNER_VIEW_OVERLAYS)
     RetainPtr<WKBannerView> m_bannerView;
+    RetainPtr<CAShapeLayer> m_bannerViewMask;
+    CGFloat m_bannerViewHeight { 0 };
+    bool m_canShowBannerViewOverlay { false };
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)


### PR DESCRIPTION
#### 5f72cefb47b4a524b02cf4b875802220c1136b66
<pre>
Perform setup for Banner View overlays once added to the web view
<a href="https://bugs.webkit.org/show_bug.cgi?id=307386">https://bugs.webkit.org/show_bug.cgi?id=307386</a>
<a href="https://rdar.apple.com/170009747">rdar://170009747</a>

Reviewed by Abrar Rahman Protyasha and Simon Fraser.

When a banner view overlay is added to the web view, we now layout
the view and adjust our scrolling logic as needed.

Since a banner view must display over the web view without obscuring
the actual content of the site, we display it between the top obscured
content inset and the web content. As a result, when a banner view with height
h is present and scroll stretching occurs, rather than rubber band back to
zero, we need to rubber band back to -h.

To achieve this, `RemoteScrollingCoordinatorProxy` now notifies the
`ScrollingTree` of the banner height, which is then used in
`ScrollAnimationRubberBand` for the target overscroll.

When a banner view is removed, or if the height shrinks, we now call
a new method `triggerMainFrameRubberBandSnapBack` from
`RemoteScrollingCoordinatorProxy` as well to rubber band to the new
location.

Tests will be added in a later patch.

* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.cpp:
(WebCore::ScrollingStateFrameScrollingNode::ScrollingStateFrameScrollingNode):
(WebCore::ScrollingStateFrameScrollingNode::applicableProperties const):
(WebCore::ScrollingStateFrameScrollingNode::setBannerViewHeight):
(WebCore::ScrollingStateFrameScrollingNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::bannerViewHeight const):
(WebCore::ScrollingTree::hasBannerViewOverlay const):
(WebCore::ScrollingTree::triggerMainFrameRubberBandSnapBack):
* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.cpp:
(WebCore::ScrollingTreeFrameScrollingNode::commitStateBeforeChildren):
(WebCore::ScrollingTreeFrameScrollingNode::dumpProperties const):
* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.mm:
(WebCore::ScrollingTreeFrameScrollingNodeMac::startRubberBandSnapBack):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::startRubberBandSnapBack):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::rubberBandTargetOffset const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::hasBannerViewOverlay const):
* Source/WebCore/platform/ScrollingEffectsController.h:
(WebCore::ScrollingEffectsControllerClient::rubberBandTargetOffset const):
(WebCore::ScrollingEffectsControllerClient::hasBannerViewOverlay const):
* Source/WebCore/platform/mac/ScrollAnimationRubberBand.h:
* Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm:
(WebCore::ScrollAnimationRubberBand::startRubberBandAnimation):
(WebCore::ScrollAnimationRubberBand::serviceAnimation):
(WebCore::ScrollAnimationRubberBand::debugDescription const):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::deltaWithAdditionalAdjustments):
(WebCore::ScrollingEffectsController::applyScrollDeltaWithStretching):
(WebCore::ScrollingEffectsController::startRubberBandAnimation):
(WebCore::ScrollingEffectsController::startRubberBandSnapBack):
* Source/WebKit/Shared/RemoteLayerTree/RemoteScrollingCoordinatorTransaction.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _bannerViewOverlayHeight]):
* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::scrollingCoordinatorWasCreated):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::setBannerViewHeight):
(WebKit::RemoteScrollingCoordinatorProxy::setHasBannerViewOverlay):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteScrollingTree::setBannerViewHeight):
(WebKit::RemoteScrollingTree::setHasBannerViewOverlay):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteScrollingTreeMac.mm:
(WebKit::RemoteScrollingTreeMac::triggerMainFrameRubberBandSnapBack):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::setDrawingArea):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::scrollingCoordinatorWasCreated):
(WebKit::PageClientImpl::scrollingNodeScrollViewDidScroll):
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController panGestureRecognized:]):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::scrollingCoordinatorWasCreated):
(WebKit::WebViewImpl::setFrameSize):
(WebKit::WebViewImpl::setObscuredContentInsets):
(WebKit::WebViewImpl::scrollWheel):
(WebKit::WebViewImpl::setBannerView): Deleted.
(WebKit::WebViewImpl::applyBannerViewOverlayHeight): Deleted.

Canonical link: <a href="https://commits.webkit.org/307332@main">https://commits.webkit.org/307332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26a8efed435d0945c2988fcb8776fe0775fe6b61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144010 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16689 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8242 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152680 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145885 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16582 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110736 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146973 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91655 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/621b376b-97ed-40d2-99eb-8564896e5de4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12629 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10358 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/126 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122100 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154992 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16541 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7100 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118748 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119103 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30541 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15012 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71962 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16163 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5703 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15897 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79942 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16108 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15963 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->