### PR TITLE
Try to fix the Safer CPP build after 307114@main.

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -263,6 +263,7 @@ extension WKBridgeUpdateMesh {
             return []
         }
 
+#if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -271,6 +272,16 @@ extension WKBridgeUpdateMesh {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<instanceTransformsCount).map { unsafe matrices[$0] }
         }
+#else
+        return data.withUnsafeBytes { rawBufferPointer in
+            guard let baseAddress = rawBufferPointer.baseAddress else {
+                return []
+            }
+
+            let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
+            return (0..<instanceTransformsCount).map { matrices[$0] }
+        }
+#endif
     }
 }
 
@@ -796,9 +807,15 @@ extension WKBridgeLiteral {
 #if canImport(RealityCoreRenderer, _version: 9) && os(macOS)
 
 internal func toData<T>(_ input: [T]) -> Data {
+#if compiler(>=6.2)
     unsafe input.withUnsafeBytes { bufferPointer in
         Data(bufferPointer)
     }
+#else
+    input.withUnsafeBytes { bufferPointer in
+        Data(bufferPointer)
+    }
+#endif
 }
 
 private func toDataArray<T>(_ input: [[T]]) -> [Data] {
@@ -873,6 +890,7 @@ extension WKBridgeSkinningData {
             return []
         }
 
+#if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -881,6 +899,16 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<jointTransformsCount).map { unsafe matrices[$0] }
         }
+#else
+        return data.withUnsafeBytes { rawBufferPointer in
+            guard let baseAddress = rawBufferPointer.baseAddress else {
+                return []
+            }
+
+            let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
+            return (0..<jointTransformsCount).map { matrices[$0] }
+        }
+#endif
     }
 
     var inverseBindPoses: [simd_float4x4] {
@@ -901,6 +929,7 @@ extension WKBridgeSkinningData {
             return []
         }
 
+#if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -909,6 +938,16 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: simd_float4x4.self)
             return (0..<inverseBindPosesCount).map { unsafe matrices[$0] }
         }
+#else
+        return data.withUnsafeBytes { rawBufferPointer in
+            guard let baseAddress = rawBufferPointer.baseAddress else {
+                return []
+            }
+
+            let matrices = baseAddress.assumingMemoryBound(to: simd_float4x4.self)
+            return (0..<inverseBindPosesCount).map { matrices[$0] }
+        }
+#endif
     }
 
     var influenceJointIndices: [UInt32] {
@@ -929,6 +968,7 @@ extension WKBridgeSkinningData {
             return []
         }
 
+#if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -937,6 +977,16 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: UInt32.self)
             return (0..<influenceJointIndicesCount).map { unsafe matrices[$0] }
         }
+#else
+        return data.withUnsafeBytes { rawBufferPointer in
+            guard let baseAddress = rawBufferPointer.baseAddress else {
+                return []
+            }
+
+            let matrices = baseAddress.assumingMemoryBound(to: UInt32.self)
+            return (0..<influenceJointIndicesCount).map { matrices[$0] }
+        }
+#endif
     }
 
     var influenceWeights: [Float] {
@@ -957,6 +1007,7 @@ extension WKBridgeSkinningData {
             return []
         }
 
+#if compiler(>=6.2)
         return unsafe data.withUnsafeBytes { rawBufferPointer in
             guard let baseAddress = rawBufferPointer.baseAddress else {
                 return []
@@ -965,6 +1016,16 @@ extension WKBridgeSkinningData {
             let matrices = unsafe baseAddress.assumingMemoryBound(to: Float.self)
             return (0..<influenceWeightsCount).map { unsafe matrices[$0] }
         }
+#else
+        return data.withUnsafeBytes { rawBufferPointer in
+            guard let baseAddress = rawBufferPointer.baseAddress else {
+                return []
+            }
+
+            let matrices = baseAddress.assumingMemoryBound(to: Float.self)
+            return (0..<influenceWeightsCount).map { matrices[$0] }
+        }
+#endif
     }
 
     @nonobjc


### PR DESCRIPTION
#### fa2885356ea28320626debb4e0c1c99713fe3d51
<pre>
Try to fix the Safer CPP build after 307114@main.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307417">https://bugs.webkit.org/show_bug.cgi?id=307417</a>

Reviewed by Richard Robinson.

This bot is using an older Swift compiler which does not support the
`unsafe` keyword which got introduced in 6.2.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
(WKBridgeUpdateMesh.instanceTransforms):
(WKBridgeSkinningData.jointTransforms):
(WKBridgeSkinningData.inverseBindPoses):
(WKBridgeSkinningData.influenceJointIndices):
(WKBridgeSkinningData.influenceWeights):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/307157@main">https://commits.webkit.org/307157@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a914821048e5cc081abee91b0fe9481956ab1604

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143586 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16067 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7685 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152252 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57509ba3-3398-4b52-bcfb-2654b6642395) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16744 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16155 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/110417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96822 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c45ad0c-429c-48ad-89f6-8c435ad1086a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146549 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12861 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91336 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0680c9ae-160e-497d-85cb-beb2d4320106) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2253 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/121787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154563 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16114 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6599 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118422 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16150 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13570 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118778 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30430 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14716 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126766 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71528 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15735 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15470 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15534 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->