### PR TITLE
[TextureMapper] Add GLES 3.0 compatibility to our shader programs

### DIFF
--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -50,6 +50,31 @@ static inline bool compositingLogEnabled()
         GLSL_DIRECTIVE(define TextureSpaceMatrixPrecision mediump) \
     GLSL_DIRECTIVE(endif)
 
+// ES 3.0 Compatibility Macros
+#define ES3_COMPATIBILITY_VERTEX \
+    GLSL_DIRECTIVE(if __VERSION__ >= 300) \
+        GLSL_DIRECTIVE(define texture2D texture) \
+        GLSL_DIRECTIVE(define texture2DProj textureProj) \
+        GLSL_DIRECTIVE(define texture2DLod textureLod) \
+        GLSL_DIRECTIVE(define texture2DProjLod textureProjLod) \
+        GLSL_DIRECTIVE(define textureCube texture) \
+        GLSL_DIRECTIVE(define textureCubeLod textureLod) \
+        GLSL_DIRECTIVE(define attribute in) \
+        GLSL_DIRECTIVE(define varying out) \
+    GLSL_DIRECTIVE(endif)
+
+#define ES3_COMPATIBILITY_FRAGMENT \
+    GLSL_DIRECTIVE(if __VERSION__ >= 300) \
+        GLSL_DIRECTIVE(define texture2D texture) \
+        GLSL_DIRECTIVE(define texture2DProj textureProj) \
+        GLSL_DIRECTIVE(define texture2DLod textureLod) \
+        GLSL_DIRECTIVE(define texture2DProjLod textureProjLod) \
+        GLSL_DIRECTIVE(define textureCube texture) \
+        GLSL_DIRECTIVE(define textureCubeLod textureLod) \
+        GLSL_DIRECTIVE(define varying in) \
+        "out mediump vec4 fragColor;\n" \
+        GLSL_DIRECTIVE(define gl_FragColor fragColor) \
+    GLSL_DIRECTIVE(endif)
 
 // Input/output variables definition for OpenGL ES < 3.2.
 static const char* vertexTemplateLT320Vars =
@@ -149,7 +174,11 @@ static const char* vertexTemplateCommon =
 
 #define OES_EGL_IMAGE_EXTERNAL_DIRECTIVE \
     GLSL_DIRECTIVE(ifdef ENABLE_TextureExternalOES) \
-        GLSL_DIRECTIVE(extension GL_OES_EGL_image_external : require) \
+        GLSL_DIRECTIVE(if __VERSION__ >= 300) \
+            GLSL_DIRECTIVE(extension GL_OES_EGL_image_external_essl3 : require) \
+        GLSL_DIRECTIVE(else) \
+            GLSL_DIRECTIVE(extension GL_OES_EGL_image_external : require) \
+        GLSL_DIRECTIVE(endif) \
         GLSL_DIRECTIVE(define SamplerExternalOESType samplerExternalOES) \
         STRINGIFY( \
             precision mediump samplerExternalOES;\n \
@@ -640,6 +669,11 @@ Ref<TextureMapperShaderProgram> TextureMapperShaderProgram::create(TextureMapper
 
     StringBuilder vertexShaderBuilder;
 
+    if (glVersion >= 300) {
+        vertexShaderBuilder.append(unsafeSpan(GLSL_DIRECTIVE(version 300 es)));
+        vertexShaderBuilder.append(unsafeSpan(ES3_COMPATIBILITY_VERTEX));
+    }
+
     // Append the options.
     vertexShaderBuilder.append(optionsApplierBuilder.toString());
 
@@ -650,6 +684,11 @@ Ref<TextureMapperShaderProgram> TextureMapperShaderProgram::create(TextureMapper
     vertexShaderBuilder.append(unsafeSpan(vertexTemplateCommon));
 
     StringBuilder fragmentShaderBuilder;
+
+    if (glVersion >= 300) {
+        fragmentShaderBuilder.append(unsafeSpan(GLSL_DIRECTIVE(version 300 es)));
+        fragmentShaderBuilder.append(unsafeSpan(ES3_COMPATIBILITY_FRAGMENT));
+    }
 
     // Append the options.
     fragmentShaderBuilder.append(optionsApplierBuilder.toString());


### PR DESCRIPTION
#### d88ed65373f3a9560b001abcf05dd264c967df62
<pre>
[TextureMapper] Add GLES 3.0 compatibility to our shader programs
<a href="https://bugs.webkit.org/show_bug.cgi?id=307418">https://bugs.webkit.org/show_bug.cgi?id=307418</a>

Reviewed by Miguel Gomez.

This is a requirement for usage of GLES 3.0 extensions such as EXT_YUV_target within our shader
programs.

* Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:
(WebCore::TextureMapperShaderProgram::create):

Canonical link: <a href="https://commits.webkit.org/307162@main">https://commits.webkit.org/307162@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2d690a467abd618a040991e7258a00ae63a53deb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143591 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16072 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152257 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145466 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16160 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110420 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129031 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91339 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2258 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121789 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5557 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154568 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16119 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6597 "Found 1 new test failure: fast/images/mac/play-pause-individual-animation-context-menu-items.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118425 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118781 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/30437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14721 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126764 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71533 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15740 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5358 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15475 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79512 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15687 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->