### PR TITLE
Eagerly clear active DOM callbacks

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.cpp
@@ -363,6 +363,7 @@ private:
     }
 
     bool hasCallback() const final { return true; }
+    void clearCallback() final { }
 
     CallbackResult<void> invoke(double, const VideoFrameMetadata&) override
     {

--- a/Source/WebCore/Modules/model-element/LazyLoadModelObserver.cpp
+++ b/Source/WebCore/Modules/model-element/LazyLoadModelObserver.cpp
@@ -55,6 +55,7 @@ private:
     }
 
     bool hasCallback() const final { return true; }
+    void clearCallback() final { }
 
     CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
     {

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -658,6 +658,7 @@ public:
     }
 
     bool hasCallback() const final { return true; }
+    void clearCallback() final { }
 
 private:
     InlineRequestAnimationFrameCallback(ScriptExecutionContext& scriptExecutionContext, Function<void()>&& callback)

--- a/Source/WebCore/bindings/js/JSCallbackData.h
+++ b/Source/WebCore/bindings/js/JSCallbackData.h
@@ -78,6 +78,8 @@ public:
         return JSCallbackData::invokeCallback(*globalObject, callback(), thisValue, args, callbackType, functionName, returnedException);
     }
 
+    void clear() { m_callback.clear(); }
+
 private:
     JSC::Weak<JSDOMGlobalObject> m_globalObject;
 

--- a/Source/WebCore/bindings/js/JSCustomElementInterface.h
+++ b/Source/WebCore/bindings/js/JSCustomElementInterface.h
@@ -131,6 +131,7 @@ private:
 
     template<typename Function>
     void invokeCallback(Element&, JSC::JSObject* callback, NOESCAPE const Function& addArguments);
+    void clearCallback() final { }
 
     QualifiedName m_name;
     JSC::Weak<JSC::JSObject> m_constructor;

--- a/Source/WebCore/bindings/js/JSDOMGuardedObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGuardedObject.h
@@ -61,6 +61,7 @@ protected:
     JSC::Weak<JSDOMGlobalObject> m_globalObject;
 
 private:
+    void clearCallback() final { clear(); };
     void removeFromGlobalObject();
 };
 

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -7418,6 +7418,7 @@ sub GenerateCallbackHeaderContent
 
     push(@$contentRef, "    ${className}(JSC::JSObject*, JSDOMGlobalObject*);\n\n");
 
+    push(@$contentRef, "    void clearCallback() final;\n");
     push(@$contentRef, "    bool hasCallback() const final { return m_data && m_data->callback(); }\n\n");
     push(@$contentRef, "    bool is${className}() const final { return true; }\n\n");
 
@@ -7671,6 +7672,12 @@ sub GenerateCallbackImplementationContent
         push(@$contentRef, "    m_data->visitJSFunction(visitor);\n");
         push(@$contentRef, "}\n\n");
     }
+
+    push(@$contentRef, "void ${className}::clearCallback()\n");
+    push(@$contentRef, "{\n");
+    push(@$contentRef, "    if (m_data)\n");
+    push(@$contentRef, "        m_data->clear();\n");
+    push(@$contentRef, "}\n\n");
 
     push(@$contentRef, "JSC::JSValue toJS(${name}& impl)\n");
     push(@$contentRef, "{\n");

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.cpp
@@ -126,6 +126,12 @@ void JSTestCallbackFunction::visitJSFunction(JSC::SlotVisitor& visitor)
     m_data->visitJSFunction(visitor);
 }
 
+void JSTestCallbackFunction::clearCallback()
+{
+    if (m_data)
+        m_data->clear();
+}
+
 JSC::JSValue toJS(TestCallbackFunction& impl)
 {
     if (auto* callbackData = downcast<JSTestCallbackFunction>(impl).callbackData())

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunction.h
@@ -47,6 +47,7 @@ public:
 private:
     JSTestCallbackFunction(JSC::JSObject*, JSDOMGlobalObject*);
 
+    void clearCallback() final;
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
     bool isJSTestCallbackFunction() const final { return true; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.cpp
@@ -116,6 +116,12 @@ CallbackResult<typename IDLDOMString::CallbackReturnType> JSTestCallbackFunction
     return { returnValue.releaseReturnValue() };
 }
 
+void JSTestCallbackFunctionGenerateIsReachable::clearCallback()
+{
+    if (m_data)
+        m_data->clear();
+}
+
 JSC::JSValue toJS(TestCallbackFunctionGenerateIsReachable& impl)
 {
     if (auto* callbackData = downcast<JSTestCallbackFunctionGenerateIsReachable>(impl).callbackData())

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionGenerateIsReachable.h
@@ -48,6 +48,7 @@ public:
 private:
     JSTestCallbackFunctionGenerateIsReachable(JSC::JSObject*, JSDOMGlobalObject*);
 
+    void clearCallback() final;
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
     bool isJSTestCallbackFunctionGenerateIsReachable() const final { return true; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.cpp
@@ -122,6 +122,12 @@ void JSTestCallbackFunctionWithThisObject::visitJSFunction(JSC::SlotVisitor& vis
     m_data->visitJSFunction(visitor);
 }
 
+void JSTestCallbackFunctionWithThisObject::clearCallback()
+{
+    if (m_data)
+        m_data->clear();
+}
+
 JSC::JSValue toJS(TestCallbackFunctionWithThisObject& impl)
 {
     if (auto* callbackData = downcast<JSTestCallbackFunctionWithThisObject>(impl).callbackData())

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithThisObject.h
@@ -47,6 +47,7 @@ public:
 private:
     JSTestCallbackFunctionWithThisObject(JSC::JSObject*, JSDOMGlobalObject*);
 
+    void clearCallback() final;
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
     bool isJSTestCallbackFunctionWithThisObject() const final { return true; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.cpp
@@ -124,6 +124,12 @@ void JSTestCallbackFunctionWithTypedefs::visitJSFunction(JSC::SlotVisitor& visit
     m_data->visitJSFunction(visitor);
 }
 
+void JSTestCallbackFunctionWithTypedefs::clearCallback()
+{
+    if (m_data)
+        m_data->clear();
+}
+
 JSC::JSValue toJS(TestCallbackFunctionWithTypedefs& impl)
 {
     if (auto* callbackData = downcast<JSTestCallbackFunctionWithTypedefs>(impl).callbackData())

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithTypedefs.h
@@ -47,6 +47,7 @@ public:
 private:
     JSTestCallbackFunctionWithTypedefs(JSC::JSObject*, JSDOMGlobalObject*);
 
+    void clearCallback() final;
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
     bool isJSTestCallbackFunctionWithTypedefs() const final { return true; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.cpp
@@ -129,6 +129,12 @@ void JSTestCallbackFunctionWithVariadic::visitJSFunction(JSC::SlotVisitor& visit
     m_data->visitJSFunction(visitor);
 }
 
+void JSTestCallbackFunctionWithVariadic::clearCallback()
+{
+    if (m_data)
+        m_data->clear();
+}
+
 JSC::JSValue toJS(TestCallbackFunctionWithVariadic& impl)
 {
     if (auto* callbackData = downcast<JSTestCallbackFunctionWithVariadic>(impl).callbackData())

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackFunctionWithVariadic.h
@@ -49,6 +49,7 @@ public:
 private:
     JSTestCallbackFunctionWithVariadic(JSC::JSObject*, JSDOMGlobalObject*);
 
+    void clearCallback() final;
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
     bool isJSTestCallbackFunctionWithVariadic() const final { return true; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -772,6 +772,12 @@ void JSTestCallbackInterface::visitJSFunction(JSC::SlotVisitor& visitor)
     m_data->visitJSFunction(visitor);
 }
 
+void JSTestCallbackInterface::clearCallback()
+{
+    if (m_data)
+        m_data->clear();
+}
+
 JSC::JSValue toJS(TestCallbackInterface& impl)
 {
     if (auto* callbackData = downcast<JSTestCallbackInterface>(impl).callbackData())

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.h
@@ -71,6 +71,7 @@ public:
 private:
     JSTestCallbackInterface(JSC::JSObject*, JSDOMGlobalObject*);
 
+    void clearCallback() final;
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
     bool isJSTestCallbackInterface() const final { return true; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.cpp
@@ -124,6 +124,12 @@ void JSTestCallbackWithFunctionOrDict::visitJSFunction(JSC::SlotVisitor& visitor
     m_data->visitJSFunction(visitor);
 }
 
+void JSTestCallbackWithFunctionOrDict::clearCallback()
+{
+    if (m_data)
+        m_data->clear();
+}
+
 JSC::JSValue toJS(TestCallbackWithFunctionOrDict& impl)
 {
     if (auto* callbackData = downcast<JSTestCallbackWithFunctionOrDict>(impl).callbackData())

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackWithFunctionOrDict.h
@@ -47,6 +47,7 @@ public:
 private:
     JSTestCallbackWithFunctionOrDict(JSC::JSObject*, JSDOMGlobalObject*);
 
+    void clearCallback() final;
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
     bool isJSTestCallbackWithFunctionOrDict() const final { return true; }

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.cpp
@@ -140,6 +140,12 @@ void JSTestVoidCallbackFunction::visitJSFunction(JSC::SlotVisitor& visitor)
     m_data->visitJSFunction(visitor);
 }
 
+void JSTestVoidCallbackFunction::clearCallback()
+{
+    if (m_data)
+        m_data->clear();
+}
+
 JSC::JSValue toJS(TestVoidCallbackFunction& impl)
 {
     if (auto* callbackData = downcast<JSTestVoidCallbackFunction>(impl).callbackData())

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestVoidCallbackFunction.h
@@ -49,6 +49,7 @@ public:
 private:
     JSTestVoidCallbackFunction(JSC::JSObject*, JSDOMGlobalObject*);
 
+    void clearCallback() final;
     bool hasCallback() const final { return m_data && m_data->callback(); }
 
     bool isJSTestVoidCallbackFunction() const final { return true; }

--- a/Source/WebCore/dom/ActiveDOMCallback.cpp
+++ b/Source/WebCore/dom/ActiveDOMCallback.cpp
@@ -32,12 +32,15 @@
 #include "ActiveDOMCallback.h"
 
 #include "ContextDestructionObserverInlines.h"
+#include "WorkerOrWorkletGlobalScope.h"
 
 namespace WebCore {
 
 ActiveDOMCallback::ActiveDOMCallback(ScriptExecutionContext* context)
     : ContextDestructionObserver(context)
 {
+    if (RefPtr scope = dynamicDowncast<WorkerOrWorkletGlobalScope>(context))
+        scope->addActiveDOMCallback(*this);
 }
 
 ActiveDOMCallback::~ActiveDOMCallback() = default;

--- a/Source/WebCore/dom/ActiveDOMCallback.h
+++ b/Source/WebCore/dom/ActiveDOMCallback.h
@@ -53,6 +53,7 @@ public:
     WEBCORE_EXPORT virtual ~ActiveDOMCallback();
 
     WEBCORE_EXPORT bool canInvokeCallback() const;
+    virtual void clearCallback() = 0;
 
     WEBCORE_EXPORT bool activeDOMObjectsAreSuspended() const;
     WEBCORE_EXPORT bool activeDOMObjectAreStopped() const;

--- a/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
+++ b/Source/WebCore/dom/ContentVisibilityDocumentState.cpp
@@ -63,6 +63,7 @@ private:
     }
 
     bool hasCallback() const final { return true; }
+    void clearCallback() final { }
 
     CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
     {

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -82,6 +82,7 @@ public:
         { }
 
         bool hasCallback() const final { return true; }
+        void clearCallback() final { }
 
         const Ref<Observable> m_sourceObservable;
         uint64_t m_amount;

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -83,6 +83,7 @@ public:
         { }
 
         bool hasCallback() const final { return true; }
+        void clearCallback() final { }
 
         const Ref<Observable> m_sourceObservable;
         const Ref<PredicateCallback> m_predicate;

--- a/Source/WebCore/dom/InternalObserverInspect.cpp
+++ b/Source/WebCore/dom/InternalObserverInspect.cpp
@@ -96,6 +96,7 @@ public:
 
     private:
         bool hasCallback() const final { return true; }
+        void clearCallback() final { }
 
         SubscriberCallbackInspect(ScriptExecutionContext& context, Ref<Observable>&& source, ObservableInspector&& inspector)
             : SubscriberCallback(&context)

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -83,6 +83,7 @@ public:
         { }
 
         bool hasCallback() const final { return true; }
+        void clearCallback() final { }
 
         const Ref<Observable> m_sourceObservable;
         const Ref<MapperCallback> m_mapper;

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -82,6 +82,7 @@ public:
         { }
 
         bool hasCallback() const final { return true; }
+        void clearCallback() final { }
 
         const Ref<Observable> m_sourceObservable;
         uint64_t m_amount;

--- a/Source/WebCore/dom/NativeNodeFilter.h
+++ b/Source/WebCore/dom/NativeNodeFilter.h
@@ -45,6 +45,7 @@ private:
     WEBCORE_EXPORT explicit NativeNodeFilter(ScriptExecutionContext*, Ref<NodeFilterCondition>&&);
 
     bool hasCallback() const final;
+    void clearCallback() final { }
 
     const Ref<NodeFilterCondition> m_condition;
 };

--- a/Source/WebCore/html/LazyLoadFrameObserver.cpp
+++ b/Source/WebCore/html/LazyLoadFrameObserver.cpp
@@ -54,6 +54,7 @@ private:
     }
 
     bool hasCallback() const final { return true; }
+    void clearCallback() final { }
 
     CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
     {

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -52,6 +52,7 @@ private:
     }
 
     bool hasCallback() const final { return true; }
+    void clearCallback() final { }
 
     CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
     {

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -77,6 +77,10 @@ void WorkerOrWorkletGlobalScope::prepareForDestruction()
     removeRejectedPromiseTracker();
 
     m_inspectorController->workerTerminating();
+
+    m_activeDOMCallbacks.forEach([](auto& callback) {
+        callback.clearCallback();
+    });
 }
 
 void WorkerOrWorkletGlobalScope::clearScript()
@@ -156,6 +160,11 @@ OptionSet<NoiseInjectionPolicy> WorkerOrWorkletGlobalScope::noiseInjectionPolici
 RefPtr<WorkerOrWorkletThread> WorkerOrWorkletGlobalScope::workerOrWorkletThread() const
 {
     return m_thread.get();
+}
+
+void WorkerOrWorkletGlobalScope::addActiveDOMCallback(ActiveDOMCallback& callback)
+{
+    m_activeDOMCallbacks.add(callback);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
+#include <WebCore/ActiveDOMCallback.h>
 #include <WebCore/EventTarget.h>
 #include <WebCore/EventTargetInlines.h>
 #include <WebCore/FetchOptions.h>
 #include <WebCore/ScriptExecutionContext.h>
 #include <WebCore/WorkerThreadType.h>
 #include <pal/SessionID.h>
+#include <wtf/WeakHashSet.h>
 
 namespace WebCore {
 
@@ -88,6 +90,8 @@ public:
     OptionSet<NoiseInjectionPolicy> noiseInjectionPolicies() const final;
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final { return m_advancedPrivacyProtections; }
 
+    void addActiveDOMCallback(ActiveDOMCallback&);
+
 protected:
     WorkerOrWorkletGlobalScope(WorkerThreadType, PAL::SessionID, Ref<JSC::VM>&&, ReferrerPolicy, WorkerOrWorkletThread*, std::optional<uint64_t>, OptionSet<AdvancedPrivacyProtections>, std::optional<ScriptExecutionContextIdentifier> = std::nullopt);
 
@@ -123,6 +127,7 @@ private:
     bool m_isClosing { false };
     std::optional<uint64_t> m_noiseInjectionHashSalt;
     OptionSet<AdvancedPrivacyProtections> m_advancedPrivacyProtections;
+    WeakHashSet<ActiveDOMCallback> m_activeDOMCallbacks;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 38d6f048921d4da002295e634dec02afc7480b57
<pre>
Eagerly clear active DOM callbacks
<a href="https://rdar.apple.com/170041723">rdar://170041723</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307419">https://bugs.webkit.org/show_bug.cgi?id=307419</a>

Reviewed by NOBODY (OOPS!).

DOM callbacks can keep alive JS objects.
We eagerly clear DOM callbacks to release JS resources earlier than before.
To do this, we add a clearCallback virtual method to ActiveDOMCallback and have it implemented for JS binding generated code.
This is easier to do it this way instead of making sure callbacks ref count goes to zero as soon as possible, especially with the const Ref pattern.
We leave it as a no-op for native callbacks and enable this mechanism in workers for now.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc89a4ae78c7e9a3caba2368c1d3d7a9d252cb70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143613 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16094 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7725 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152280 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96849 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/967e6da7-d510-4da8-aaa7-d57e7d69e6e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145488 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110440 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79477 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146576 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91357 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d70814dd-e1b4-4cdd-a5ed-8304b6de6ec7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12367 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10085 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2282 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121806 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5603 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154592 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16141 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6644 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118444 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118800 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14745 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126810 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71555 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15762 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5387 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79534 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15709 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15561 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->