### PR TITLE
[WGSL] webgpu:shader,validation,expression,call,builtin,clamp,* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
@@ -987,78 +987,54 @@ FAIL :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=true assert_unre
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=false
-PASS :invalid_rhs_fn_override:op="%26%26";rhs="overflow";short_circuit=true
-FAIL :invalid_rhs_fn_override:op="%26%26";rhs="overflow";short_circuit=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:213:25
+FAIL :invalid_rhs_fn_override:op="%26%26";rhs="overflow";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-PASS :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_i32";short_circuit=true
-FAIL :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_i32";short_circuit=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:213:25
+PASS :invalid_rhs_fn_override:op="%26%26";rhs="overflow";short_circuit=false
+FAIL :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_i32";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-PASS :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_f32";short_circuit=true
-FAIL :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_f32";short_circuit=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:213:25
+PASS :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_i32";short_circuit=false
+FAIL :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_f32";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-PASS :invalid_rhs_fn_override:op="%26%26";rhs="builtin";short_circuit=true
-FAIL :invalid_rhs_fn_override:op="%26%26";rhs="builtin";short_circuit=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:213:25
+PASS :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_f32";short_circuit=false
+FAIL :invalid_rhs_fn_override:op="%26%26";rhs="builtin";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="overflow";short_circuit=true
-FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="overflow";short_circuit=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:213:25
+PASS :invalid_rhs_fn_override:op="%26%26";rhs="builtin";short_circuit=false
+FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="overflow";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=true
-FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:213:25
+PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="overflow";short_circuit=false
+FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=true
-FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:213:25
+PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=false
+FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="builtin";short_circuit=true
-FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="builtin";short_circuit=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:213:25
+PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=false
+FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="builtin";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
+PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="builtin";short_circuit=false
 FAIL :invalid_rhs_override:op="%26%26";rhs="overflow";short_circuit=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
   - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
@@ -1107,78 +1083,54 @@ FAIL :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=true assert_u
     attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
 PASS :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=false
-PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=false;cond_b_val=false
-PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=false;cond_b_val=true
-PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=true;cond_b_val=false
-FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=true;cond_b_val=true assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:287:25
+FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=false;cond_b_val=false assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=false;cond_b_val=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:287:25
+FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=false;cond_b_val=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=false;cond_b_val=true assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:287:25
+FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=true;cond_b_val=false assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=true;cond_b_val=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:287:25
+PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=true;cond_b_val=true
+PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=false;cond_b_val=false
+PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=false;cond_b_val=true
+PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=true;cond_b_val=false
+FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=true;cond_b_val=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=true;cond_b_val=true
-PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=false;cond_b_val=false
-FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=false;cond_b_val=true assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:287:25
+FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=false;cond_b_val=false assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=true;cond_b_val=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:287:25
+PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=false;cond_b_val=true
+PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=true;cond_b_val=false
+PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=true;cond_b_val=true
+PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=false;cond_b_val=false
+FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=false;cond_b_val=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=true;cond_b_val=true assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:287:25
+FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=true;cond_b_val=false assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=false;cond_b_val=false assert_unreached:
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or.spec.js:287:25
+FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=true;cond_b_val=true assert_unreached:
   - (in subcase: ) INFO: subcase ran
+  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
+    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:457:44
  Reached unreachable code
-PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=false;cond_b_val=true
-PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=true;cond_b_val=false
-PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=true;cond_b_val=true
 PASS :invalid_array_count_on_rhs:op="%26%26";rhs="negative";control=true
 PASS :invalid_array_count_on_rhs:op="%26%26";rhs="negative";control=false
 PASS :invalid_array_count_on_rhs:op="%26%26";rhs="sqrt_neg1";control=true

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/early_evaluation-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/early_evaluation-expected.txt
@@ -8,20 +8,8 @@ PASS :composites:case="const_let_struct_comp"
 PASS :composites:case="const_let_matrix"
 PASS :composites:case="const_let_matrix_vec"
 PASS :composites:case="const_let_matrix_comp"
-FAIL :composites:case="override_scalar" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/early_evaluation.spec.js:133:27
- Reached unreachable code
-FAIL :composites:case="override_vector" assert_unreached:
-  - EXPECTATION FAILED: Expected validation error
-    eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
-    expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/early_evaluation.spec.js:133:27
- Reached unreachable code
+PASS :composites:case="override_scalar"
+PASS :composites:case="override_vector"
 PASS :composites:case="override_let_vector"
 PASS :composites:case="override_let_vector_comp"
 PASS :composites:case="override_let_array_comp"

--- a/Source/WebGPU/WGSL/AST/ASTCallExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTCallExpression.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ASTExpression.h"
+#include "Overload.h"
 #include "Types.h"
 #include <wtf/OptionSet.h>
 
@@ -96,6 +97,8 @@ public:
 
     const String& resolvedTarget() const { return m_resolvedTarget; }
 
+    ValidationFunction validationFunction() const { return m_validationFunction; }
+
 private:
     CallExpression(SourceSpan span, Expression::Ref&& target, Expression::List&& arguments)
         : Expression(span)
@@ -113,6 +116,7 @@ private:
 
     bool m_isConstructor { false };
     OptionSet<ShaderStage> m_visibility { ShaderStage::Compute, ShaderStage::Vertex, ShaderStage::Fragment };
+    ValidationFunction m_validationFunction { nullptr };
 };
 
 } // namespace AST

--- a/Source/WebGPU/WGSL/AST/ASTExpression.h
+++ b/Source/WebGPU/WGSL/AST/ASTExpression.h
@@ -39,6 +39,12 @@ class RewriteGlobalVariables;
 class TypeChecker;
 struct Type;
 
+enum class Evaluation : uint8_t {
+    Constant = 1,
+    Override = 2,
+    Runtime = 3,
+};
+
 namespace AST {
 
 class Expression : public Node {
@@ -62,6 +68,9 @@ public:
     const std::optional<ConstantValue>& constantValue() const { return m_constantValue; }
     void setConstantValue(ConstantValue value) { m_constantValue = value; }
 
+    const std::optional<Evaluation>& maybeEvaluation() const { return m_evaluation; }
+    Evaluation evaluation() const { return *m_evaluation; }
+
 protected:
     Expression(SourceSpan span)
         : Node(span)
@@ -70,6 +79,7 @@ protected:
     const Type* m_inferredType { nullptr };
 
 private:
+    std::optional<Evaluation> m_evaluation { std::nullopt };
     std::optional<ConstantValue> m_constantValue { std::nullopt };
 };
 

--- a/Source/WebGPU/WGSL/ConstantValue.h
+++ b/Source/WebGPU/WGSL/ConstantValue.h
@@ -31,6 +31,7 @@
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/FixedVector.h>
 #include <wtf/HashMap.h>
+#include <wtf/StringPrintStream.h>
 #include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
@@ -402,3 +403,29 @@ static bool convertValueImpl(const SourceSpan& span, const Type* type, ConstantV
 }
 
 } // namespace WGSL
+
+namespace WTF {
+
+template<> class StringTypeAdapter<WGSL::ConstantValue> {
+public:
+    StringTypeAdapter(const WGSL::ConstantValue& value)
+    {
+        StringPrintStream valueString;
+        value.dump(valueString);
+        m_string = valueString.toString();
+    }
+
+    unsigned length() const { return m_string.length(); }
+    bool is8Bit() const { return m_string.is8Bit(); }
+    template<typename CharacterType>
+    void writeTo(std::span<CharacterType> destination) const
+    {
+        StringView { m_string }.getCharacters(destination);
+        WTF_STRINGTYPEADAPTER_COPIED_WTF_STRING();
+    }
+
+private:
+    String m_string;
+};
+
+} // namespace WTF

--- a/Source/WebGPU/WGSL/EntryPointRewriter.cpp
+++ b/Source/WebGPU/WGSL/EntryPointRewriter.cpp
@@ -146,6 +146,7 @@ void EntryPointRewriter::checkReturnType()
                     AST::Identifier::make(returnStructName)
                 );
                 returnType.m_inferredType = m_shaderModule.types().structType(returnStruct);
+                returnType.m_evaluation = namedTypeName->evaluation();
                 m_shaderModule.replace(*namedTypeName, returnType);
             };
 
@@ -189,6 +190,7 @@ void EntryPointRewriter::checkReturnType()
         AST::Identifier::make(returnStructName)
     );
     returnType.m_inferredType = m_shaderModule.types().structType(returnStruct);
+    returnType.m_evaluation = m_function.maybeReturnType()->evaluation();
 
     if (namedTypeName)
         m_shaderModule.replace(*namedTypeName, returnType);

--- a/Source/WebGPU/WGSL/Overload.h
+++ b/Source/WebGPU/WGSL/Overload.h
@@ -122,6 +122,8 @@ struct OverloadCandidate {
     AbstractType result;
 };
 
+using ValidationFunction = std::optional<String>(*)(const FixedVector<std::optional<ConstantValue>>&);
+
 struct OverloadedDeclaration {
     enum Kind : uint8_t {
         Operator,
@@ -133,6 +135,7 @@ struct OverloadedDeclaration {
     bool mustUse;
 
     Expected<ConstantValue, String> (*constantFunction)(const Type*, const FixedVector<ConstantValue>&);
+    ValidationFunction validationFunction;
     OptionSet<ShaderStage> visibility;
     Vector<OverloadCandidate> overloads;
 };

--- a/Source/WebGPU/WGSL/TypeDeclarations.rb
+++ b/Source/WebGPU/WGSL/TypeDeclarations.rb
@@ -478,6 +478,7 @@ function :ceil, {
 function :clamp, {
     must_use: true,
     const: true,
+    validate: true,
 
     [T < Number].(T, T, T) => T,
     [T < Number, N].(vec[N][T], vec[N][T], vec[N][T]) => vec[N][T],

--- a/Source/WebGPU/WGSL/generator/main.rb
+++ b/Source/WebGPU/WGSL/generator/main.rb
@@ -302,6 +302,7 @@ module DSL
         properties = {
             must_use: false,
             const: false,
+            validate: false,
             stage: [:fragment, :compute, :vertex],
         }
         map.each do |key, value|
@@ -372,6 +373,15 @@ module DSL
                 entry[:const]
             end
 
+            validation_function = case entry[:validate]
+            when false
+                "nullptr"
+            when true
+                "validate#{name[0].upcase}#{name[1..]}"
+            else
+                entry[:const]
+            end
+
             stages = entry[:stage].kind_of?(Array) ? entry[:stage] : [entry[:stage]]
             visibility = stages.map { |s| "ShaderStage::#{s.to_s.capitalize}" }.join ", "
 
@@ -380,6 +390,7 @@ module DSL
             out << "    .kind = OverloadedDeclaration::#{entry[:kind].to_s.capitalize},"
             out << "    .mustUse = #{entry[:must_use]},"
             out << "    .constantFunction = #{constant_function},"
+            out << "    .validationFunction = #{validation_function},"
             out << "    .visibility = { #{visibility} },"
             out << "    .overloads = { }"
             out << "});"


### PR DESCRIPTION
#### 914006fabddf5fa8f9db1030c2e0a540b0c425bc
<pre>
[WGSL] webgpu:shader,validation,expression,call,builtin,clamp,* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=307429">https://bugs.webkit.org/show_bug.cgi?id=307429</a>
<a href="https://rdar.apple.com/170052903">rdar://170052903</a>

Reviewed by Mike Wyrzykowski.

We were missing the validation that `clamp(x, low, high)` should error
if `low &gt; high`. It also required storing extra information to handle
the case where `low` and/or `high` might be override values.

We&apos;re still failing a few tests, but they appear to be invalid tests
and we&apos;re waiting for the test suite to correct them.

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/clamp-expected.txt:
* Source/WebGPU/WGSL/AST/ASTCallExpression.h:
* Source/WebGPU/WGSL/AST/ASTExpression.h:
(WGSL::AST::Expression::maybeEvaluation const):
(WGSL::AST::Expression::evaluation const):
* Source/WebGPU/WGSL/ConstantFunctions.h:
(WGSL::TERNARY_OPERATION):
(WGSL::VALIDATION_FUNCTION):
* Source/WebGPU/WGSL/ConstantValue.h:
(WTF::StringTypeAdapter&lt;WGSL::ConstantValue&gt;::StringTypeAdapter):
(WTF::StringTypeAdapter&lt;WGSL::ConstantValue&gt;::length const):
(WTF::StringTypeAdapter&lt;WGSL::ConstantValue&gt;::is8Bit const):
(WTF::StringTypeAdapter&lt;WGSL::ConstantValue&gt;::writeTo const):
* Source/WebGPU/WGSL/EntryPointRewriter.cpp:
(WGSL::EntryPointRewriter::checkReturnType):
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::pack):
* Source/WebGPU/WGSL/Overload.h:
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::visit):
(WGSL::TypeChecker::bitcast):
(WGSL::TypeChecker::evaluated):
* Source/WebGPU/WGSL/TypeDeclarations.rb:
* Source/WebGPU/WGSL/generator/main.rb:

Canonical link: <a href="https://commits.webkit.org/307259@main">https://commits.webkit.org/307259@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70ef4257168914ab8b22a81337884e3855a8e66b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143716 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7894 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152384 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96953 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e5b3227-d460-43c7-b640-f166950b3a9d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16285 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110527 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79520 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bbf040f-5699-4e77-9605-f86002876c67) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91445 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12445 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10167 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2386 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121899 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5751 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154696 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16245 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6794 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118530 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13684 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30500 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14827 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71658 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15866 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5486 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79637 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15812 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15664 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->