### PR TITLE
[GStreamer] TrackID parsing fallback to hashing stream-id

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -93,7 +93,7 @@ bool isProtocolAllowed(const WTF::URL&);
 CStringView capsMediaType(const GstCaps*);
 std::optional<TrackID> getStreamIdFromPad(const GRefPtr<GstPad>&);
 std::optional<TrackID> getStreamIdFromStream(const GRefPtr<GstStream>&);
-std::optional<TrackID> parseStreamId(const String& stringId);
+TrackID parseStreamId(const String& stringId);
 bool doCapsHaveType(const GstCaps*, ASCIILiteral);
 bool areEncryptedCaps(const GstCaps*);
 Vector<String> extractGStreamerOptionsFromCommandLine();

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -1264,11 +1264,14 @@ void MediaPlayerPrivateGStreamer::notifyPlayerOfTrack()
         if (!pad)
             continue;
 
-        TrackID streamId(getStreamIdFromPad(pad).value_or(i));
-        validStreams.append(streamId);
+        std::optional<TrackID> streamId(getStreamIdFromPad(pad));
+        ASSERT(streamId);
+        if (!streamId)
+            continue;
+        validStreams.append(streamId.value());
 
         if (i < tracks.size()) {
-            RefPtr<TrackPrivateType> existingTrack = tracks.get(streamId);
+            RefPtr<TrackPrivateType> existingTrack = tracks.get(streamId.value());
             if (existingTrack) {
                 ASSERT(existingTrack->index() == i);
                 // TODO: Position of index should remain the same on replay.

--- a/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp
@@ -92,7 +92,7 @@ TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer(TrackType type, TrackPrivat
     : m_notifier(MainThreadNotifier<MainThreadNotification>::create())
     , m_index(index)
     , m_gstStreamId(byteCast<Latin1Character>(unsafeSpan(gst_stream_get_stream_id(stream))))
-    , m_id(parseStreamId(m_gstStreamId).value_or(index))
+    , m_id(parseStreamId(m_gstStreamId))
     , m_stream(stream)
     , m_type(type)
     , m_owner(owner)
@@ -119,7 +119,7 @@ void TrackPrivateBaseGStreamer::setPad(GRefPtr<GstPad>&& pad)
     m_gstStreamId = byteCast<Latin1Character>(unsafeSpan(gst_pad_get_stream_id(m_pad.get())));
 
     if (m_shouldUsePadStreamId)
-        m_id = parseStreamId(m_gstStreamId).value_or(m_index);
+        m_id = parseStreamId(m_gstStreamId);
 
     if (!m_bestUpstreamPad)
         return;
@@ -285,14 +285,10 @@ void TrackPrivateBaseGStreamer::notifyTrackOfStreamChanged()
     if (!m_pad)
         return;
 
-    String gstStreamId = byteCast<Latin1Character>(unsafeSpan(gst_pad_get_stream_id(m_pad.get())));
-    auto streamId = parseStreamId(gstStreamId);
-    if (!streamId)
-        return;
-
     ASSERT(isMainThread());
-    m_gstStreamId = gstStreamId;
-    m_id = streamId.value();
+    m_gstStreamId = byteCast<Latin1Character>(unsafeSpan(gst_pad_get_stream_id(m_pad.get())));
+    m_id = parseStreamId(m_gstStreamId);
+
     GST_INFO("Track %" PRIu64 " got stream start. GStreamer stream-id: %s", m_id, m_gstStreamId.utf8().data());
 }
 
@@ -315,7 +311,7 @@ void TrackPrivateBaseGStreamer::installUpdateConfigurationHandlers()
                 return;
 
             track->m_taskQueue.enqueueTask([track, caps = WTF::move(caps)]() mutable {
-                track->capsChanged(getStreamIdFromPad(track->m_pad.get()).value_or(track->m_index), WTF::move(caps));
+                track->capsChanged(track->m_id, WTF::move(caps));
             });
         }), this);
         g_signal_connect_swapped(m_pad.get(), "notify::tags", G_CALLBACK(+[](TrackPrivateBaseGStreamer* track) {
@@ -329,7 +325,7 @@ void TrackPrivateBaseGStreamer::installUpdateConfigurationHandlers()
         g_signal_connect_swapped(m_stream.get(), "notify::caps", G_CALLBACK(+[](TrackPrivateBaseGStreamer* track) {
             track->m_taskQueue.enqueueTask([track]() {
                 auto caps = adoptGRef(gst_stream_get_caps(track->m_stream.get()));
-                track->capsChanged(getStreamIdFromStream(track->m_stream.get()).value_or(track->m_index), WTF::move(caps));
+                track->capsChanged(track->m_id, WTF::move(caps));
             });
         }), this);
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp
@@ -119,7 +119,6 @@ TEST_F(GStreamerTest, streamIdParsing)
     ASSERT_EQ(parseStreamId("bec5903f-df6d-4773-85bb-05be65fc1bb8"_s), 0x85bb05be65fc1bb8);
     ASSERT_EQ(parseStreamId("647a4b9b3856ef43869870dc9e8b490e7c76512c47f9cfa7e9cf236fb9d9693d/001"_s), 1);
     ASSERT_EQ(parseStreamId("123"_s), 123);
-    ASSERT_TRUE(!parseStreamId("foo"_s).has_value());
 }
 
 TEST_F(GStreamerTest, hevcProfileParsing)


### PR DESCRIPTION
#### ef5a71c3f3067a3f070dae47da382e57b135526f
<pre>
[GStreamer] TrackID parsing fallback to hashing stream-id
<a href="https://bugs.webkit.org/show_bug.cgi?id=307432">https://bugs.webkit.org/show_bug.cgi?id=307432</a>

Reviewed by Philippe Normand.

If GStreamer reports a stream-id that we aren&apos;t able to
parse into an integer, we currently just use the track index instead.

This however makes it difficult to identify a track from looking at a pad,
and when getStreamIdFromPad() fails, it&apos;s not clear if this is due
to failing to parse the id, or if there is no stream-start event altogether.
This may happen for example in MediaPlayerPrivateGStreamer::setupCodecProbe().

Just hashing the stream-id if we can&apos;t otherwise parse it solves both
of these issues.

Test: Tools/TestWebKitAPI/Tests/WebCore/gstreamer/GStreamerTest.cpp

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::getStreamIdFromPad): the only error case here is now missing stream-start
(WebCore::parseStreamId): fall back to hashing, thus never fail parsing
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::notifyPlayerOfTrack): if we can&apos;t find an id at this point, just bail out.
* Source/WebCore/platform/graphics/gstreamer/TrackPrivateBaseGStreamer.cpp:
(WebCore::TrackPrivateBaseGStreamer::TrackPrivateBaseGStreamer): no need to fallback to index anymore
(WebCore::TrackPrivateBaseGStreamer::setPad): ditto
(WebCore::TrackPrivateBaseGStreamer::installUpdateConfigurationHandlers): we don&apos;t even need to parse an id here.

Canonical link: <a href="https://commits.webkit.org/307493@main">https://commits.webkit.org/307493@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38feffd803a1db7bd1cb528f4b924acf654db805

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16115 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7764 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152301 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96870 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145509 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16792 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110457 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79481 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146597 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12906 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129086 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91374 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12380 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10100 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5642 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154613 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16162 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6683 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118462 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118817 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30644 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14756 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126849 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71576 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15783 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5410 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15518 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79555 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15582 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->