### PR TITLE
StreamTeeState does not need to ref its branch streams

### DIFF
--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -208,8 +208,8 @@ private:
     bool m_canceled2 = false;
     Ref<DeferredPromise> m_cancelDeferredPromise;
     Ref<DOMPromise> m_cancelPromise;
-    RefPtr<ReadableStream> m_branch1;
-    RefPtr<ReadableStream> m_branch2;
+    WeakPtr<ReadableStream> m_branch1;
+    WeakPtr<ReadableStream> m_branch2;
     JSValueInWrappedObject m_branch1Reason;
     JSValueInWrappedObject m_branch2Reason;
 };
@@ -227,11 +227,13 @@ ExceptionOr<Vector<Ref<ReadableStream>>> byteStreamTee(JSDOMGlobalObject& global
     Ref state = StreamTeeState::create(globalObject, stream, reader.copyRef());
 
     ReadableByteStreamController::PullAlgorithm pull1Algorithm = [state = Ref { state }](auto& globalObject, auto&&) {
-        return pull1Steps(globalObject, state, Ref { *state->branch1() });
+        Ref branch1 = *state->branch1();
+        return pull1Steps(globalObject, state, branch1.get());
     };
 
     ReadableByteStreamController::PullAlgorithm pull2Algorithm = [state = Ref { state }](auto& globalObject, auto&&) {
-        return pull2Steps(globalObject, state, Ref { *state->branch2() });
+        Ref branch2 = *state->branch2();
+        return pull2Steps(globalObject, state, branch2.get());
     };
 
     ReadableByteStreamController::CancelAlgorithm cancel1Algorithm = [state = Ref { state }](auto& globalObject, auto&&, auto&& reason) {


### PR DESCRIPTION
#### a378e22f623ef41307b58c93347a4559e41d6465
<pre>
StreamTeeState does not need to ref its branch streams
<a href="https://rdar.apple.com/170057522">rdar://170057522</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307434">https://bugs.webkit.org/show_bug.cgi?id=307434</a>

Reviewed by Chris Dumez.

It is unnecessary for StreamTeeUtilities to keep a RefPtr of branch1 and branch2.
We replace them with WeakPtr, which reduces potential ref cycles.

In the pull algorithm, we can dereference the WeakPtrs into Ref as the pull algorithm is called by the controller which is owned by the stream. This therefore means that the stream is alive at the time the pull algorithm is called.

Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/307241@main">https://commits.webkit.org/307241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92f3fe0019db1373c2f37b6ebcdcf72761bbd417

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143639 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152306 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96875 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad9c97b7-db10-4fd0-9c4e-1f7321de2be2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145514 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16208 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110459 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79484 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43c55881-6012-4090-b6a1-b1d318a5fa74) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146602 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91376 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4db34f9d-25e8-4bb3-9181-c7fa9587a98a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12382 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10103 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2309 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121828 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5654 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154618 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16167 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118464 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16203 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13617 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118819 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30486 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14764 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126862 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71581 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15788 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5420 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15523 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79560 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15587 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->