### PR TITLE
Make BlobDataItem Variant-like

### DIFF
--- a/Source/WebCore/platform/network/BlobData.cpp
+++ b/Source/WebCore/platform/network/BlobData.cpp
@@ -48,16 +48,7 @@ long long BlobDataItem::length() const
     if (m_length != toEndOfFile)
         return m_length;
 
-    switch (type()) {
-    case Type::Data:
-        ASSERT_NOT_REACHED();
-        return m_length;
-    case Type::File:
-        return protect(file())->size();
-    }
-
-    ASSERT_NOT_REACHED();
-    return m_length;
+    return protect(std::get<Ref<BlobDataFileReference>>(m_data))->size();
 }
 
 void BlobData::appendData(Ref<DataSegment>&& data)
@@ -74,9 +65,11 @@ void BlobData::appendData(Ref<DataSegment>&& data, long long offset, long long l
 void BlobData::replaceData(const DataSegment& oldData, Ref<DataSegment>&& newData)
 {
     for (auto& blobItem : m_items) {
-        if (blobItem.type() == BlobDataItem::Type::Data && &blobItem.data() == &oldData) {
-            blobItem.m_data = WTF::move(newData);
-            break;
+        if (auto* data = std::get_if<Ref<DataSegment>>(&blobItem.m_data)) {
+            if (&data->get() == &oldData) {
+                blobItem.m_data = WTF::move(newData);
+                break;
+            }
         }
     }
 }

--- a/Source/WebCore/platform/network/BlobData.h
+++ b/Source/WebCore/platform/network/BlobData.h
@@ -44,30 +44,21 @@ class BlobDataItem {
 public:
     WEBCORE_EXPORT static const long long toEndOfFile;
 
-    enum class Type : bool {
-        Data,
-        File
-    };
-
-    Type type() const
+#if PLATFORM(GTK)
+    template<typename... F> constexpr decltype(auto) switchOn(F&&... f) const
+#else
+    template<typename... F> constexpr decltype(auto) switchOn(NOESCAPE F&&... f) const
+#endif
     {
-        static_assert(std::is_same_v<Ref<DataSegment>, WTF::variant_alternative_t<static_cast<bool>(Type::Data), decltype(m_data)>>);
-        static_assert(std::is_same_v<Ref<BlobDataFileReference>, WTF::variant_alternative_t<static_cast<bool>(Type::File), decltype(m_data)>>);
-        return static_cast<Type>(m_data.index());
-    }
-
-    // For Data type.
-    DataSegment& data() const
-    {
-        ASSERT(type() == Type::Data);
-        return std::get<Ref<DataSegment>>(m_data).get();
-    }
-
-    // For File type.
-    BlobDataFileReference& file() const
-    {
-        ASSERT(type() == Type::File);
-        return std::get<Ref<BlobDataFileReference>>(m_data).get();
+        auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
+        return WTF::switchOn(m_data,
+            [&](const Ref<DataSegment>& data) {
+                return visitor(data.get());
+            },
+            [&](const Ref<BlobDataFileReference>& file) {
+                return visitor(file.get());
+            }
+        );
     }
 
     long long offset() const { return m_offset; }

--- a/Source/WebCore/platform/network/BlobRegistryImpl.cpp
+++ b/Source/WebCore/platform/network/BlobRegistryImpl.cpp
@@ -110,14 +110,14 @@ void BlobRegistryImpl::appendStorageItems(BlobData* blobData, const BlobDataItem
         auto& item = items[itemsIndex];
         long long currentLength = item.length() - offset;
         long long newLength = currentLength > length ? length : currentLength;
-        switch (item.type()) {
-        case BlobDataItem::Type::Data:
-            blobData->appendData(item.data(), item.offset() + offset, newLength);
-            break;
-        case BlobDataItem::Type::File:
-            blobData->appendFile(protect(item.file()), item.offset() + offset, newLength);
-            break;
-        }
+        WTF::switchOn(item,
+            [&](DataSegment& data) {
+                blobData->appendData(data, item.offset() + offset, newLength);
+            },
+            [&](BlobDataFileReference& file) {
+                blobData->appendFile(file, item.offset() + offset, newLength);
+            }
+        );
         length -= newLength;
         offset = 0;
     }
@@ -343,14 +343,14 @@ bool BlobRegistryImpl::populateBlobsForFileWriting(const Vector<String>& blobURL
             return false;
 
         for (auto& item : blobData->items()) {
-            switch (item.type()) {
-            case BlobDataItem::Type::Data:
-                blobsForWriting.last().filePathsOrDataBuffers.append(protect(item.data()));
-                break;
-            case BlobDataItem::Type::File:
-                blobsForWriting.last().filePathsOrDataBuffers.append(protect(item.file())->path().isolatedCopy());
-                break;
-            }
+            WTF::switchOn(item,
+                [&](DataSegment& data) {
+                    blobsForWriting.last().filePathsOrDataBuffers.append(data);
+                },
+                [&](BlobDataFileReference& file) {
+                    blobsForWriting.last().filePathsOrDataBuffers.append(file.path().isolatedCopy());
+                }
+            );
         }
     }
     return true;
@@ -419,9 +419,13 @@ Vector<Ref<BlobDataFileReference>> BlobRegistryImpl::filesInBlob(const URL& url,
         return { };
 
     Vector<Ref<BlobDataFileReference>> result;
-    for (const BlobDataItem& item : blobData->items()) {
-        if (item.type() == BlobDataItem::Type::File)
-            result.append(protect(item.file()));
+    for (auto& item : blobData->items()) {
+        WTF::switchOn(item,
+            [](const DataSegment&) { },
+            [&](BlobDataFileReference& file) {
+                result.append(file);
+            }
+        );
     }
 
     return result;

--- a/Source/WebCore/platform/network/BlobResourceHandle.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandle.cpp
@@ -171,14 +171,15 @@ int BlobResourceHandle::readSync(std::span<uint8_t> buffer)
         if (!totalRemainingSize() || readItemCount() >= blobData()->items().size())
             break;
 
-        const BlobDataItem& item = blobData()->items().at(readItemCount());
-        int bytesRead = 0;
-        if (item.type() == BlobDataItem::Type::Data)
-            bytesRead = readDataSync(item, buffer.subspan(offset));
-        else if (item.type() == BlobDataItem::Type::File)
-            bytesRead = readFileSync(item, buffer.subspan(offset));
-        else
-            ASSERT_NOT_REACHED();
+        auto& item = blobData()->items().at(readItemCount());
+        int bytesRead = WTF::switchOn(item,
+            [&](DataSegment& data) {
+                return readDataSync(item, data, buffer.subspan(offset));
+            },
+            [&](BlobDataFileReference& file) {
+                return readFileSync(item, file, buffer.subspan(offset));
+            }
+        );
 
         if (bytesRead > 0) {
             offset += bytesRead;
@@ -201,7 +202,7 @@ int BlobResourceHandle::readSync(std::span<uint8_t> buffer)
     return result;
 }
 
-int BlobResourceHandle::readDataSync(const BlobDataItem& item, std::span<uint8_t> buffer)
+int BlobResourceHandle::readDataSync(const BlobDataItem& item, DataSegment& data, std::span<uint8_t> buffer)
 {
     ASSERT(isMainThread());
 
@@ -209,7 +210,7 @@ int BlobResourceHandle::readDataSync(const BlobDataItem& item, std::span<uint8_t
 
     uint64_t remaining = item.length() - currentItemReadSize();
     uint64_t bytesToRead = std::min(std::min<uint64_t>(remaining, buffer.size()), totalRemainingSize());
-    memcpySpan(buffer, protect(item.data())->span().subspan(item.offset() + currentItemReadSize()).first(bytesToRead));
+    memcpySpan(buffer, data.span().subspan(item.offset() + currentItemReadSize()).first(bytesToRead));
     decrementTotalRemainingSizeBy(bytesToRead);
 
     setCurrentItemReadSize(currentItemReadSize() + bytesToRead);
@@ -221,7 +222,7 @@ int BlobResourceHandle::readDataSync(const BlobDataItem& item, std::span<uint8_t
     return bytesToRead;
 }
 
-int BlobResourceHandle::readFileSync(const BlobDataItem& item, std::span<uint8_t> buffer)
+int BlobResourceHandle::readFileSync(const BlobDataItem& item, BlobDataFileReference& file, std::span<uint8_t> buffer)
 {
     ASSERT(isMainThread());
 
@@ -231,7 +232,7 @@ int BlobResourceHandle::readFileSync(const BlobDataItem& item, std::span<uint8_t
         auto bytesToRead = lengthOfItemBeingRead() - currentItemReadSize();
         if (bytesToRead > totalRemainingSize())
             bytesToRead = totalRemainingSize();
-        bool success = syncStream()->openForRead(protect(item.file())->path(), item.offset() + currentItemReadSize(), bytesToRead);
+        bool success = syncStream()->openForRead(file.path(), item.offset() + currentItemReadSize(), bytesToRead);
         setCurrentItemReadSize(0);
         if (!success) {
             m_errorCode = Error::NotReadableError;

--- a/Source/WebCore/platform/network/BlobResourceHandle.h
+++ b/Source/WebCore/platform/network/BlobResourceHandle.h
@@ -73,8 +73,8 @@ private:
 
     void doStart();
 
-    int readDataSync(const BlobDataItem&, std::span<uint8_t>);
-    int readFileSync(const BlobDataItem&, std::span<uint8_t>);
+    int readDataSync(const BlobDataItem&, DataSegment&, std::span<uint8_t>);
+    int readFileSync(const BlobDataItem&, BlobDataFileReference&, std::span<uint8_t>);
 
     Error m_errorCode { Error::NoError };
     bool m_aborted { false };

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.cpp
@@ -181,21 +181,19 @@ void BlobResourceHandleBase::getSizeForNext()
         return;
     }
 
-    const BlobDataItem& item = m_blobData->items().at(m_sizeItemCount);
-    switch (item.type()) {
-    case BlobDataItem::Type::Data:
-        didGetSize(item.length());
-        break;
-    case BlobDataItem::Type::File: {
-        // Files know their sizes, but asking the stream to verify that the file wasn't modified.
-        Ref file = item.file();
-        if (async())
-            asyncStream()->getSize(file->path(), file->expectedModificationTime());
-        else
-            didGetSize(syncStream()->getSize(file->path(), file->expectedModificationTime()));
-        break;
-    }
-    }
+    auto& item = m_blobData->items().at(m_sizeItemCount);
+    WTF::switchOn(item,
+        [&](const DataSegment&) {
+            didGetSize(item.length());
+        },
+        [&](BlobDataFileReference& file) {
+            // Files know their sizes, but asking the stream to verify that the file wasn't modified.
+            if (async())
+                asyncStream()->getSize(file.path(), file.expectedModificationTime());
+            else
+                didGetSize(syncStream()->getSize(file.path(), file.expectedModificationTime()));
+        }
+    );
 }
 
 void BlobResourceHandleBase::didGetSize(long long size)
@@ -214,7 +212,7 @@ void BlobResourceHandleBase::didGetSize(long long size)
     }
 
     // The size passed back is the size of the whole file. If the underlying item is a sliced file, we need to use the slice length.
-    const BlobDataItem& item = m_blobData->items().at(m_sizeItemCount);
+    auto& item = m_blobData->items().at(m_sizeItemCount);
     uint64_t updatedSize = static_cast<uint64_t>(item.length());
 
     // Cache the size.
@@ -265,21 +263,23 @@ void BlobResourceHandleBase::readAsync()
         return;
 
     while (m_totalRemainingSize && m_readItemCount < m_blobData->items().size()) {
-        const BlobDataItem& item = m_blobData->items().at(m_readItemCount);
-        switch (item.type()) {
-        case BlobDataItem::Type::Data:
-            if (!readDataAsync(item))
-                return; // error occurred
-            break;
-        case BlobDataItem::Type::File:
-            readFileAsync(item);
+        auto& item = m_blobData->items().at(m_readItemCount);
+        bool done = WTF::switchOn(item,
+            [&](DataSegment& data) {
+                return !readDataAsync(item, data);
+            },
+            [&](BlobDataFileReference& file) {
+                readFileAsync(item, file);
+                return true;
+            }
+        );
+        if (done)
             return;
-        }
     }
     didFinish();
 }
 
-bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item)
+bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item, DataSegment& data)
 {
     ASSERT(isMainThread());
 
@@ -288,13 +288,13 @@ bool BlobResourceHandleBase::readDataAsync(const BlobDataItem& item)
     if (bytesToRead > m_totalRemainingSize)
         bytesToRead = m_totalRemainingSize;
 
-    auto data = protect(item.data())->span().subspan(item.offset() + m_currentItemReadSize, bytesToRead);
+    auto span = data.span().subspan(item.offset() + m_currentItemReadSize, bytesToRead);
     m_currentItemReadSize = 0;
 
-    return consumeData(data);
+    return consumeData(span);
 }
 
-void BlobResourceHandleBase::readFileAsync(const BlobDataItem& item)
+void BlobResourceHandleBase::readFileAsync(const BlobDataItem& item, BlobDataFileReference& file)
 {
     ASSERT(isMainThread());
 
@@ -306,7 +306,7 @@ void BlobResourceHandleBase::readFileAsync(const BlobDataItem& item)
     uint64_t bytesToRead = lengthOfItemBeingRead() - m_currentItemReadSize;
     if (bytesToRead > m_totalRemainingSize)
         bytesToRead = static_cast<int>(m_totalRemainingSize);
-    asyncStream()->openForRead(protect(item.file())->path(), item.offset() + m_currentItemReadSize, bytesToRead);
+    asyncStream()->openForRead(file.path(), item.offset() + m_currentItemReadSize, bytesToRead);
     m_isFileOpen = true;
     m_currentItemReadSize = 0;
 }

--- a/Source/WebCore/platform/network/BlobResourceHandleBase.h
+++ b/Source/WebCore/platform/network/BlobResourceHandleBase.h
@@ -81,8 +81,8 @@ private:
     std::optional<Error> NODELETE seek();
     std::optional<Error> NODELETE adjustAndValidateRangeBounds();
     bool consumeData(std::span<const uint8_t>);
-    bool readDataAsync(const BlobDataItem&);
-    void readFileAsync(const BlobDataItem&);
+    bool readDataAsync(const BlobDataItem&, DataSegment&);
+    void readFileAsync(const BlobDataItem&, BlobDataFileReference&);
     void dispatchDidReceiveResponse();
     void doStart();
 

--- a/Source/WebCore/platform/network/FormData.cpp
+++ b/Source/WebCore/platform/network/FormData.cpp
@@ -320,16 +320,14 @@ static void appendBlobResolved(BlobRegistryImpl* blobRegistry, FormData& formDat
     }
 
     for (const auto& blobItem : blobData->items()) {
-        switch (blobItem.type()) {
-        case BlobDataItem::Type::Data:
-            formData.appendData(protect(blobItem.data())->span().subspan(blobItem.offset(), blobItem.length()));
-            break;
-        case BlobDataItem::Type::File: {
-            Ref file = blobItem.file();
-            formData.appendFileRange(file->path(), blobItem.offset(), blobItem.length(), file->expectedModificationTime());
-            break;
-        }
-        }
+        WTF::switchOn(blobItem,
+            [&](const DataSegment& data) {
+                formData.appendData(data.span().subspan(blobItem.offset(), blobItem.length()));
+            },
+            [&](BlobDataFileReference& file) {
+                formData.appendFileRange(file.path(), blobItem.offset(), blobItem.length(), file.expectedModificationTime());
+            }
+        );
     }
 }
 


### PR DESCRIPTION
#### 90b737abd3af0b9bda20612df485fa6501eb6c13
<pre>
Make BlobDataItem Variant-like
<a href="https://bugs.webkit.org/show_bug.cgi?id=307435">https://bugs.webkit.org/show_bug.cgi?id=307435</a>

Reviewed by Sam Weinig.

This allows us to remove type() and makes it more consistent with other
modern code.

Canonical link: <a href="https://commits.webkit.org/311537@main">https://commits.webkit.org/311537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/456dacfcddff4c3b897226cec23ea7f9788da18c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/157236 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/30573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/23765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/166059 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/111318 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d807372b-972b-4bae-a6e0-cf766cdb7642) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/159107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/30708 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/30575 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/121770 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/85494 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcd41ec7-dd89-48f9-97d8-61acd77dee4a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/160194 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/141187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/102438 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c2d803c-f39b-4d75-9833-6575bdbf37e8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23066 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/21314 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/13831 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/132746 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/19015 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/168544 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/12703 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/20635 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/129903 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/30174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/25392 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130011 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35228 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/30097 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/140809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/87926 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/24829 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/17614 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/29808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/93822 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/29330 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/29560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/29457 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->