### PR TITLE
[Re-land] [Site Isolation] Dispatch pageswap event on navigation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/pageswap-event-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/pageswap-event-expected.txt
@@ -1,0 +1,12 @@
+Tests that pageswap is fired when site isolation is enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data.name is "pageswap"
+PASS event.data.activation is null
+PASS event.data.viewTransition is null
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/pageswap-event.html
+++ b/LayoutTests/http/tests/site-isolation/pageswap-event.html
@@ -1,0 +1,49 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!-- This test is adapted from LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub.html -->
+
+<!DOCTYPE html>
+<title>Tests that pageswap is fired when site isolation is enabled.</title>
+
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that pageswap is fired when site isolation is enabled.");
+jsTestIsAsync = true;
+
+const params = new URLSearchParams(location.search);
+// The page the popup navigates to.
+const is_new_page = params.has('new');
+// The initial page in the popup.
+const is_popup_page = params.has('popup');
+// The test page itself.
+const is_test_page = !is_popup_page && !is_new_page;
+
+if (is_test_page) {
+  onload = () => {
+    popup = window.open("?popup");
+  };
+
+  onmessage = (event) => {
+    shouldBeEqualToString("event.data.name", "pageswap");
+    shouldBe("event.data.activation", "null");
+    shouldBe("event.data.viewTransition", "null");
+    popup.close();
+    finishJSTest();
+  };
+}
+
+if (is_popup_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      location.href = "http://localhost:8000/site-isolation/pageswap-event.html?new";
+    }));
+  };
+
+  onpageswap = (event) => {
+    window.opener.postMessage({
+      name: "pageswap",
+      activation: event.activation,
+      viewTransition: event.viewTransition
+    }, "*")
+  };
+}
+</script>

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2149,6 +2149,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     page/MediaProducer.h
     page/MemoryRelease.h
     page/ModalContainerTypes.h
+    page/NavigationActivation.h
+    page/NavigationHistoryEntry.h
     page/NavigationNavigationType.h
     page/Navigator.h
     page/NavigatorBase.h

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1435,7 +1435,7 @@ public:
     void queueTaskToDispatchEventOnWindow(TaskSource, Ref<Event>&&);
     void dispatchPageshowEvent(PageshowEventPersistence);
     void dispatchPagehideEvent(PageshowEventPersistence);
-    void dispatchPageswapEvent(CanTriggerCrossDocumentViewTransition, RefPtr<NavigationActivation>&&);
+    WEBCORE_EXPORT void dispatchPageswapEvent(CanTriggerCrossDocumentViewTransition, RefPtr<NavigationActivation>&&);
     void transferViewTransitionParams(Document&);
     WEBCORE_EXPORT void enqueueSecurityPolicyViolationEvent(SecurityPolicyViolationEventInit&&);
     void enqueueHashchangeEvent(const String& oldURL, const String& newURL);

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "BackForwardItemIdentifier.h"
 #include "EventTarget.h"
 #include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferred.h"

--- a/Source/WebCore/page/NavigationActivation.h
+++ b/Source/WebCore/page/NavigationActivation.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "NavigationHistoryEntry.h"
-#include "ScriptWrappable.h"
+#include <WebCore/ScriptWrappable.h>
+#include <wtf/RefCounted.h>
 
 namespace WebCore {
 
@@ -41,7 +41,7 @@ public:
         return adoptRef(*new NavigationActivation(type, WTF::move(entry), WTF::move(fromEntry)));
     }
 
-    ~NavigationActivation();
+    WEBCORE_EXPORT ~NavigationActivation();
 
     NavigationNavigationType navigationType() { return m_navigationType; };
     NavigationHistoryEntry* from() const { return m_fromEntry.get(); };

--- a/Source/WebCore/page/NavigationHistoryEntry.cpp
+++ b/Source/WebCore/page/NavigationHistoryEntry.cpp
@@ -36,6 +36,7 @@
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
 #include "HistoryController.h"
+#include "HistoryItem.h"
 #include "JSDOMGlobalObject.h"
 #include "LocalDOMWindow.h"
 #include "Navigation.h"

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -25,13 +25,11 @@
 
 #pragma once
 
-#include "ActiveDOMObject.h"
-#include "EventHandler.h"
-#include "EventTarget.h"
-#include "EventTargetInterfaces.h"
-#include "HistoryItem.h"
-#include "ReferrerPolicy.h"
-#include "ScriptExecutionContextIdentifier.h"
+#include <WebCore/ActiveDOMObject.h>
+#include <WebCore/EventTarget.h>
+#include <WebCore/EventTargetInterfaces.h>
+#include <WebCore/ReferrerPolicy.h>
+#include <WebCore/ScriptExecutionContextIdentifier.h>
 #include <wtf/RefCounted.h>
 
 namespace JSC {
@@ -40,6 +38,7 @@ class JSValue;
 
 namespace WebCore {
 
+class HistoryItem;
 class JSDOMGlobalObject;
 class Navigation;
 class SerializedScriptValue;


### PR DESCRIPTION
#### 2ec53fd7f1557b1dd25687a6ceb0e1b7a6a26f6e
<pre>
[Re-land] [Site Isolation] Dispatch pageswap event on navigation
<a href="https://rdar.apple.com/169951382">rdar://169951382</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307320">https://bugs.webkit.org/show_bug.cgi?id=307320</a>

Reviewed by Ryosuke Niwa.

Re-land, last attempt was reverted because it broke internal iOS builds.
Original commit message follows:

pageswap event is dispatched by FrameLoader::commitProvisionalLoad, which is
only called on same-origin navigation when Site Isolation is enabled. For
cross-origin navigation, WebFrame::loadDidCommitInAnotherProcess is called
instead, so this commit adds code to dispatch pageswap there.

Test: http/tests/site-isolation/pageswap-event.html

* LayoutTests/http/tests/site-isolation/pageswap-event-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/pageswap-event.html: Added.
* Source/WebCore/Headers.cmake:
    - Add headers that exist but were not listed in Headers.cmake.

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
    - Add headers that exist but were not added to the Xcode project.

* Source/WebCore/dom/Document.h:
   - WEBCORE_EXPORT Document::dispatchPageswapEvent so it can be called from WebKit.

* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationActivation.h:
   - Optimize includes and uses angle brackets to include.

* Source/WebCore/page/NavigationHistoryEntry.cpp:
* Source/WebCore/page/NavigationHistoryEntry.h:
   - Optimize includes and uses angle brackets to include.

* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::loadDidCommitInAnotherProcess):
    - Add code to dispatch pageswap event.

Canonical link: <a href="https://commits.webkit.org/307249@main">https://commits.webkit.org/307249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7f4c984ceba7f3a66556b5394f1ea5153f8015c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143854 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8045 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152522 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/58565bf1-f3dd-4703-8ed7-a7de772185d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110619 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6aa844fc-8993-4645-8eb5-7458ba20a23c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129254 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91537 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd774778-fcc3-4a93-98a3-de842277e27e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12515 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10247 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2524 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154834 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16383 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118626 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16418 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118981 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30493 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14904 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127086 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71796 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16004 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5571 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15738 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15950 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15803 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->