### PR TITLE
Adopt FastFloat in XPathValue

### DIFF
--- a/Source/WTF/wtf/FastFloat.cpp
+++ b/Source/WTF/wtf/FastFloat.cpp
@@ -49,6 +49,23 @@ double parseDouble(std::span<const char16_t> string, size_t& parsedLength)
     return doubleValue;
 }
 
+double parseFixedDouble(std::span<const Latin1Character> string, size_t& parsedLength)
+{
+    double doubleValue = 0;
+    auto stringData = byteCast<char>(string);
+    auto result = fast_float::from_chars(std::to_address(stringData.begin()), std::to_address(stringData.end()), doubleValue, fast_float::chars_format::fixed | fast_float::chars_format::no_infnan);
+    parsedLength = result.ptr - stringData.data();
+    return doubleValue;
+}
+
+double parseFixedDouble(std::span<const char16_t> string, size_t& parsedLength)
+{
+    double doubleValue = 0;
+    auto result = fast_float::from_chars(std::to_address(string.begin()), std::to_address(string.end()), doubleValue, fast_float::chars_format::fixed | fast_float::chars_format::no_infnan);
+    parsedLength = result.ptr - string.data();
+    return doubleValue;
+}
+
 std::optional<double> parseJSONDouble(std::span<const Latin1Character> string, size_t& parsedLength)
 {
     double doubleValue = 0;

--- a/Source/WTF/wtf/FastFloat.h
+++ b/Source/WTF/wtf/FastFloat.h
@@ -35,6 +35,9 @@ namespace WTF {
 WTF_EXPORT_PRIVATE double parseDouble(std::span<const Latin1Character> string, size_t& parsedLength);
 WTF_EXPORT_PRIVATE double parseDouble(std::span<const char16_t> string, size_t& parsedLength);
 
+WTF_EXPORT_PRIVATE double parseFixedDouble(std::span<const Latin1Character> string, size_t& parsedLength);
+WTF_EXPORT_PRIVATE double parseFixedDouble(std::span<const char16_t> string, size_t& parsedLength);
+
 WTF_EXPORT_PRIVATE std::optional<double> parseJSONDouble(std::span<const Latin1Character> string, size_t& parsedLength);
 WTF_EXPORT_PRIVATE std::optional<double> parseJSONDouble(std::span<const char16_t> string, size_t& parsedLength);
 

--- a/Source/WTF/wtf/text/WTFString.cpp
+++ b/Source/WTF/wtf/text/WTFString.cpp
@@ -522,14 +522,24 @@ String String::fromCodePoint(char32_t codePoint)
 
 // String Operations
 
-template<typename CharacterType, TrailingJunkPolicy policy>
+enum class WhitespacePolicy : bool { Skip, Preserve };
+enum class ParseMode : bool { General, Fixed };
+
+template<typename CharacterType, TrailingJunkPolicy trailingJunkPolicy, WhitespacePolicy whitespacePolicy, ParseMode mode>
 static inline double toDoubleType(std::span<const CharacterType> data, bool* ok, size_t& parsedLength)
 {
     size_t leadingSpacesLength = 0;
-    while (leadingSpacesLength < data.size() && isUnicodeCompatibleASCIIWhitespace(data[leadingSpacesLength]))
-        ++leadingSpacesLength;
+    if constexpr (whitespacePolicy == WhitespacePolicy::Skip) {
+        while (leadingSpacesLength < data.size() && isUnicodeCompatibleASCIIWhitespace(data[leadingSpacesLength]))
+            ++leadingSpacesLength;
+    }
 
-    double number = parseDouble(data.subspan(leadingSpacesLength), parsedLength);
+    double number;
+    if constexpr (mode == ParseMode::Fixed)
+        number = parseFixedDouble(data.subspan(leadingSpacesLength), parsedLength);
+    else
+        number = parseDouble(data.subspan(leadingSpacesLength), parsedLength);
+
     if (!parsedLength) {
         if (ok)
             *ok = false;
@@ -538,46 +548,58 @@ static inline double toDoubleType(std::span<const CharacterType> data, bool* ok,
 
     parsedLength += leadingSpacesLength;
     if (ok)
-        *ok = policy == TrailingJunkPolicy::Allow || parsedLength == data.size();
+        *ok = trailingJunkPolicy == TrailingJunkPolicy::Allow || parsedLength == data.size();
     return number;
 }
 
 double charactersToDouble(std::span<const Latin1Character> data, bool* ok)
 {
     size_t parsedLength;
-    return toDoubleType<Latin1Character, TrailingJunkPolicy::Disallow>(data, ok, parsedLength);
+    return toDoubleType<Latin1Character, TrailingJunkPolicy::Disallow, WhitespacePolicy::Skip, ParseMode::General>(data, ok, parsedLength);
 }
 
 double charactersToDouble(std::span<const char16_t> data, bool* ok)
 {
     size_t parsedLength;
-    return toDoubleType<char16_t, TrailingJunkPolicy::Disallow>(data, ok, parsedLength);
+    return toDoubleType<char16_t, TrailingJunkPolicy::Disallow, WhitespacePolicy::Skip, ParseMode::General>(data, ok, parsedLength);
+}
+
+double charactersToFixedDouble(std::span<const Latin1Character> data, bool* ok)
+{
+    size_t parsedLength;
+    return toDoubleType<Latin1Character, TrailingJunkPolicy::Disallow, WhitespacePolicy::Preserve, ParseMode::Fixed>(data, ok, parsedLength);
+}
+
+double charactersToFixedDouble(std::span<const char16_t> data, bool* ok)
+{
+    size_t parsedLength;
+    return toDoubleType<char16_t, TrailingJunkPolicy::Disallow, WhitespacePolicy::Preserve, ParseMode::Fixed>(data, ok, parsedLength);
 }
 
 float charactersToFloat(std::span<const Latin1Character> data, bool* ok)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
     size_t parsedLength;
-    return static_cast<float>(toDoubleType<Latin1Character, TrailingJunkPolicy::Disallow>(data, ok, parsedLength));
+    return static_cast<float>(toDoubleType<Latin1Character, TrailingJunkPolicy::Disallow, WhitespacePolicy::Skip, ParseMode::General>(data, ok, parsedLength));
 }
 
 float charactersToFloat(std::span<const char16_t> data, bool* ok)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
     size_t parsedLength;
-    return static_cast<float>(toDoubleType<char16_t, TrailingJunkPolicy::Disallow>(data, ok, parsedLength));
+    return static_cast<float>(toDoubleType<char16_t, TrailingJunkPolicy::Disallow, WhitespacePolicy::Skip, ParseMode::General>(data, ok, parsedLength));
 }
 
 float charactersToFloat(std::span<const Latin1Character> data, size_t& parsedLength)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
-    return static_cast<float>(toDoubleType<Latin1Character, TrailingJunkPolicy::Allow>(data, nullptr, parsedLength));
+    return static_cast<float>(toDoubleType<Latin1Character, TrailingJunkPolicy::Allow, WhitespacePolicy::Skip, ParseMode::General>(data, nullptr, parsedLength));
 }
 
 float charactersToFloat(std::span<const char16_t> data, size_t& parsedLength)
 {
     // FIXME: This will return ok even when the string fits into a double but not a float.
-    return static_cast<float>(toDoubleType<char16_t, TrailingJunkPolicy::Allow>(data, nullptr, parsedLength));
+    return static_cast<float>(toDoubleType<char16_t, TrailingJunkPolicy::Allow, WhitespacePolicy::Skip, ParseMode::General>(data, nullptr, parsedLength));
 }
 
 const StaticString nullStringData { nullptr };

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -46,6 +46,8 @@ namespace WTF {
 
 WTF_EXPORT_PRIVATE double charactersToDouble(std::span<const Latin1Character>, bool* ok = nullptr);
 WTF_EXPORT_PRIVATE double charactersToDouble(std::span<const char16_t>, bool* ok = nullptr);
+WTF_EXPORT_PRIVATE double charactersToFixedDouble(std::span<const Latin1Character>, bool* ok = nullptr);
+WTF_EXPORT_PRIVATE double charactersToFixedDouble(std::span<const char16_t>, bool* ok = nullptr);
 WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const Latin1Character>, bool* ok = nullptr);
 WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const char16_t>, bool* ok = nullptr);
 WTF_EXPORT_PRIVATE float charactersToFloat(std::span<const Latin1Character>, size_t& parsedLength);
@@ -583,6 +585,7 @@ inline String operator""_str(const char16_t* characters, size_t length)
 using WTF::TrailingZerosPolicy;
 using WTF::String;
 using WTF::charactersToDouble;
+using WTF::charactersToFixedDouble;
 using WTF::charactersToFloat;
 using WTF::emptyString;
 using WTF::makeStringByJoining;

--- a/Source/WebCore/xml/XPathValue.cpp
+++ b/Source/WebCore/xml/XPathValue.cpp
@@ -88,16 +88,13 @@ double Value::toNumber() const
         [](const String& string) -> double {
             auto simplified = string.simplifyWhiteSpace(deprecatedIsSpaceOrNewline);
 
-            // String::toDouble() supports exponential notation, which is not allowed in XPath.
-            unsigned len = simplified.length();
-            for (unsigned i = 0; i < len; ++i) {
-                char16_t c = simplified[i];
-                if (!isASCIIDigit(c) && c != '.' && c != '-')
-                    return std::numeric_limits<double>::quiet_NaN();
-            }
-
+            // XPath does not allow exponential notation in numbers, so use fixed parsing.
             bool canConvert;
-            auto value = simplified.toDouble(&canConvert);
+            double value;
+            if (simplified.is8Bit())
+                value = charactersToFixedDouble(simplified.span8(), &canConvert);
+            else
+                value = charactersToFixedDouble(simplified.span16(), &canConvert);
             if (canConvert)
                 return value;
             return std::numeric_limits<double>::quiet_NaN();


### PR DESCRIPTION
#### 14b38f063efce6a5edd36def5a12721266e11678
<pre>
Adopt FastFloat in XPathValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=307443">https://bugs.webkit.org/show_bug.cgi?id=307443</a>

Reviewed by Yusuke Suzuki.

Add parseFixedDouble() (fixed-point, no Infinity/NaN, no leading +) and
charactersToFixedDouble(), then use them in XPathValue::toNumber() to
reject exponential notation without a manual character-validation loop.

Canonical link: <a href="https://commits.webkit.org/311008@main">https://commits.webkit.org/311008@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7902ce2dc272de97853838e262d8e7b1b0d3a366

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/29014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/22173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/164529 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/109570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5e8030b-dfbc-4835-9e98-7d5dfa03610f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157627 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/29161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120569 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/109570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9de3f253-3714-4b4f-941c-794de360d214) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/101258 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cfe88fcb-c8ca-40af-86df-4254f8ff800b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21831 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19971 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/12347 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/147804 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131500 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17706 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166998 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/16586 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/11172 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/19317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128685 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/28558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/24005 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128817 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/28482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/139499 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/86316 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23720 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/16297 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/187639 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/28176 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/92279 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/48233 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27753 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27983 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27826 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->