### PR TITLE
[threaded-animations] multiple View Transitions tests crash with "Threaded Time-based Animations" enabled

### DIFF
--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -151,9 +151,7 @@ public:
     const RenderStyle& currentStyle() const final;
     bool triggersStackingContext() const { return m_triggersStackingContext; }
     bool isRunningAccelerated() const;
-
-    // FIXME: These ignore the fact that some timing functions can prevent acceleration.
-    bool isAboutToRunAccelerated() const { return m_acceleratedPropertiesState != AcceleratedProperties::None && m_lastRecordedAcceleratedAction != AcceleratedAction::Stop; }
+    bool isAboutToRunAccelerated() const;
 
     std::optional<unsigned> transformFunctionListPrefix() const override;
 
@@ -249,6 +247,7 @@ private:
     void computeHasSizeDependentTransform();
     void analyzeAcceleratedProperties();
     void updateIsAssociatedWithProgressBasedTimeline();
+    bool isRunningAccountingForSuspension() const;
 
     void abilityToBeAcceleratedDidChange();
     void updateAcceleratedAnimationIfNecessary();


### PR DESCRIPTION
#### 24fe4db710ae0a219b161d854249fe24e5d64f51
<pre>
[threaded-animations] multiple View Transitions tests crash with &quot;Threaded Time-based Animations&quot; enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=307446">https://bugs.webkit.org/show_bug.cgi?id=307446</a>
<a href="https://rdar.apple.com/170065802">rdar://170065802</a>

Reviewed by Simon Fraser.

There are two distinct methods to query a keyframe effect about its acceleration state:

- `KeyframeEffect::isAboutToRunAccelerated()` indicates that the animation qualifies for acceleration
  but is pending processing.

- `KeyframeEffect::isRunningAccelerated()` indicates that the animation has been processed and is actively
  running with acceleration.

We had an implementation of the latter that accounted for threaded animations, but not for the former.
In `KeyframeEffect::isRunningAccelerated()` we returned true as long as an animation could be accelerated
as a threaded animation and was running (and not suspended), but we neglected to account for the possibility
that it had not actually been accelerated inside of `RenderLayerBacking::updateAcceleratedEffectsAndBaseValues()`.

This had some bad implications in the case of View Transitions where a simple navigation between two pages with
`navigation: auto` will yield a set of layers like so:

    ::view-transition-group (animates width / height / transform / backdrop-filter)
    +- ::view-transition-old (animates opacity)
    +- ::view-transition-new (animates opacity)

The two child layers will have their animations accelerated because of the simple opacity animation. Meanwhile,
the parent `::view-transition-group` may not since `transform` may not be accelerated if width and height are
also accelerated and it contains a relative unit.

In the soon-to-be legacy codebase for accelerated animations, we tracked whether an animation was rejected for
acceleration during processing with `enum RunningAccelerated { NotStarted, Yes, Prevented, Failed }`, and
`isRunningAccelerated()` would only return true in the case of `RunningAccelerated::Yes`. This matters because
`RenderLayerCompositor::computeCompositingRequirements()` has an assertion that ensures compositing-related
state did not change without the compositor being told, and in that assertion `needsToBeComposited()` would
return `true` because our incorrect implementation of `isRunningAccelerated()` indicated so.

We address this by correctly implementing the two methods introduced above. Now:

- `KeyframeEffect::isAboutToRunAccelerated()` has awareness of threaded animations and will return true
  only if it does not have an accelerated representation, since its mere existence indicates that it
  has been processed and is not longer pending.

- `KeyframeEffect::isRunningAccelerated()` correctly checks whether the accelerated representation has
  been processed by only returning true if it has an accelerated representation that has animated
  properties.

Note that there is no test change in this patch since the flag is not yet enabled on bots. This
was caught in preparation of that running animation tests locally using
`--experimental-feature ThreadedTimeBasedAnimationsEnabled=true`.

* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::isRunningAccountingForSuspension const):
(WebCore::KeyframeEffect::isRunningAccelerated const):
(WebCore::KeyframeEffect::isAboutToRunAccelerated const):
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/307197@main">https://commits.webkit.org/307197@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/861ad8fa62632178b5681b2184b57f7f1e72c9c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143658 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16139 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7826 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152325 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/96894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/273a3e31-8309-4854-b19c-6c54a95142df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16816 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16227 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110475 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/96894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12926 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129116 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91392 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d24d1c4-5321-43cd-b970-425174a89b3a) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12400 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10122 "Passed tests") | [  ~~🛠 wpe-libwebrtc~~](https://ews-build.webkit.org/#/builders/172/builds/2328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121847 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5696 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154638 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4464 "Build is in progress. Recent messages:") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16186 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6739 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118481 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118836 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14782 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126905 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71600 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22156 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15807 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15542 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79579 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15754 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15606 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->