### PR TITLE
[iOS] Update MediaPlayerPrivateWirelessPlayback's ready and network states based on the state of the MediaDeviceRoute

### DIFF
--- a/LayoutTests/media/wireless-playback-media-player/canplaythrough-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/canplaythrough-expected.txt
@@ -1,0 +1,10 @@
+
+Test that a 'canplaythrough' event is dispatched when a MediaDeviceRoute becomes ready after loading a URL.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+RUN(route.ready = true)
+EVENT(canplaythrough)
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/canplaythrough.html
+++ b/LayoutTests/media/wireless-playback-media-player/canplaythrough.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                run(`route.ready = true`);
+                await canplaythroughPromise;
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a 'canplaythrough' event is dispatched when a MediaDeviceRoute becomes ready after loading a URL.</p> 
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/error-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/error-expected.txt
@@ -1,0 +1,11 @@
+
+Test that a 'error' event is dispatched when a MediaDeviceRoute encounters a playback error after becoming ready to play a URL.
+
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(video.src = findMediaFile('video', '../content/test'))
+RUN(video.play())
+EVENT(canplaythrough)
+RUN(route.hasPlaybackError = true)
+EVENT(error)
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/error.html
+++ b/LayoutTests/media/wireless-playback-media-player/error.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+
+                const urlPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                video = document.getElementsByTagName('video')[0];
+                run(`video.src = findMediaFile('video', '../content/test')`);
+                run(`video.play()`);
+                await urlPromise;
+
+                const canplaythroughPromise = waitFor(video, 'canplaythrough');
+                route.ready = true;
+                await canplaythroughPromise;
+
+                const errorPromise = waitFor(video, 'error');
+                await new Promise((resolve) => {
+                    setTimeout(() => {
+                        run(`route.hasPlaybackError = true`);
+                        resolve();
+                    }, 0);
+                });
+
+                await errorPromise;
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <video controls></video>
+        <p>Test that a 'error' event is dispatched when a MediaDeviceRoute encounters a playback error after becoming ready to play a URL.</p> 
+    </body>
+</html>

--- a/LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback-2-expected.txt
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback-2-expected.txt
@@ -1,0 +1,11 @@
+Test that a video's second <source> element's URL is loaded if the MediaDeviceRoute rejects encounters a playback error loading the first URL prior to becoming ready.
+
+
+EVENT(canplaythrough)
+RUN(video.play())
+EVENT(playing)
+RUN(internals.mockMediaDeviceRouteController.activateRoute(route))
+RUN(route.hasPlaybackError = true)
+EXPECTED (actualURL == '/LayoutTests/media/content/test.mp4') OK
+END OF TEST
+

--- a/LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback-2.html
+++ b/LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback-2.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html><!-- webkit-test-runner [ WirelessPlaybackMediaPlayerEnabled=true ] -->
+<html>
+    <head>
+        <script src='../media-file.js'></script>
+        <script src='../video-test.js'></script>
+        <script>
+            var route;
+            var video;
+            var actualURL;
+
+            async function start()
+            {
+                if (window.internals)
+                    internals.mockMediaDeviceRouteController.enabled = true;
+
+                video = document.createElement('video');
+
+                const mediaType = 'video/mp4';
+                const mediaURL = findMediaFile('video', '../content/test');
+                const mediaURLToReject = findMediaFile('video', '../content/test_yuv420');
+
+                const firstSource = document.createElement('source');
+                firstSource.src = mediaURLToReject;
+                firstSource.type = mediaType;
+                video.appendChild(firstSource);
+
+                const secondSource = document.createElement('source');
+                secondSource.src = mediaURL;
+                secondSource.type = mediaType;
+                video.appendChild(secondSource);
+
+                document.body.appendChild(video);
+
+                await waitFor(video, 'canplaythrough');
+
+                run(`video.play()`)
+                await waitFor(video, 'playing');
+
+                route = internals.mockMediaDeviceRouteController.createMockMediaDeviceRoute();
+
+                const firstURLPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                run(`internals.mockMediaDeviceRouteController.activateRoute(route)`);
+                await firstURLPromise;
+
+                const secondURLPromise = new Promise((resolve) => {
+                    route.setURLCallback(async (url) => {
+                        resolve(url);
+                    });
+                });
+
+                run(`route.hasPlaybackError = true`);
+
+                const loadedURL = await secondURLPromise;
+                const expectedURL = new URL(mediaURL, document.baseURI).href.substring(document.baseURI.indexOf('/LayoutTests/'));
+                actualURL = loadedURL.substring(loadedURL.indexOf('/LayoutTests/'));
+
+                testExpected('actualURL', expectedURL);
+
+                endTest();
+            }
+        </script>
+    </head>
+    <body onload='start()'>
+        <p>Test that a video's second &lt;source&gt; element's URL is loaded if the MediaDeviceRoute rejects encounters a playback error loading the first URL prior to becoming ready.</p>
+    </body>
+</html>

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -99,17 +99,17 @@ class MediaDeviceRouteClient : public AbstractRefCountedAndCanMakeWeakPtr<MediaD
 public:
     virtual ~MediaDeviceRouteClient() = default;
 
-    virtual void timeRangeDidChange(MediaDeviceRoute&) = 0;
-    virtual void readyDidChange(MediaDeviceRoute&) = 0;
-    virtual void bufferingDidChange(MediaDeviceRoute&) = 0;
-    virtual void playbackErrorDidChange(MediaDeviceRoute&) = 0;
-    virtual void hasAudioDidChange(MediaDeviceRoute&) = 0;
-    virtual void currentValueDidChange(MediaDeviceRoute&) = 0;
-    virtual void playingDidChange(MediaDeviceRoute&) = 0;
-    virtual void playbackSpeedDidChange(MediaDeviceRoute&) = 0;
-    virtual void scanSpeedDidChange(MediaDeviceRoute&) = 0;
-    virtual void mutedDidChange(MediaDeviceRoute&) = 0;
-    virtual void volumeDidChange(MediaDeviceRoute&) = 0;
+    virtual void timeRangeDidChange(MediaDeviceRoute&) { }
+    virtual void readyDidChange(MediaDeviceRoute&) { }
+    virtual void bufferingDidChange(MediaDeviceRoute&) { }
+    virtual void playbackErrorDidChange(MediaDeviceRoute&) { }
+    virtual void hasAudioDidChange(MediaDeviceRoute&) { }
+    virtual void currentValueDidChange(MediaDeviceRoute&) { }
+    virtual void playingDidChange(MediaDeviceRoute&) { }
+    virtual void playbackSpeedDidChange(MediaDeviceRoute&) { }
+    virtual void scanSpeedDidChange(MediaDeviceRoute&) { }
+    virtual void mutedDidChange(MediaDeviceRoute&) { }
+    virtual void volumeDidChange(MediaDeviceRoute&) { }
 };
 
 class MediaDeviceRoute final : public RefCountedAndCanMakeWeakPtr<MediaDeviceRoute> {

--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm
@@ -61,12 +61,16 @@
     [_mediaSource removeObserver:self forKeyPath:@#KeyPath context:WebMediaSourceObserverContext]; \
 \
 
+#define NOTIFY_CLIENT(KeyPath, SetterSuffix, Type) \
+    if (RefPtr route = _route.get()) { \
+        if (RefPtr client = route->client()) \
+            client->KeyPath##DidChange(*route); \
+    } \
+\
+
 #define OBSERVE_VALUE(KeyPath, SetterSuffix, Type) \
     if ([keyPath isEqualToString:@#KeyPath]) { \
-        if (RefPtr route = _route.get()) { \
-            if (RefPtr client = route->client()) \
-                client->KeyPath##DidChange(*route); \
-        } \
+        NOTIFY_CLIENT(KeyPath, SetterSuffix, Type) \
         return; \
     } \
 \
@@ -120,6 +124,7 @@ static void* WebMediaSourceObserverContext = &WebMediaSourceObserverContext;
     FOR_EACH_KEY_PATH(REMOVE_OBSERVER)
     _mediaSource = mediaSource;
     FOR_EACH_KEY_PATH(ADD_OBSERVER)
+    FOR_EACH_KEY_PATH(NOTIFY_CLIENT)
 }
 
 - (void)observeValueForKeyPath:(nullable NSString *)keyPath ofObject:(nullable id)object change:(nullable NSDictionary *)change context:(nullable void*)context

--- a/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
+++ b/Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm
@@ -140,7 +140,7 @@ void MediaSessionManageriOS::sessionWillBeginPlayback(PlatformMediaSessionInterf
             return;
         }
 
-#if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR) && !PLATFORM(MACCATALYST) && !PLATFORM(WATCHOS)
+#if PLATFORM(IOS_FAMILY)
         auto playbackTargetSupportsAirPlayVideo = MediaSessionHelper::sharedHelper().activeVideoRouteSupportsAirPlayVideo();
         ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "Playback Target Supports AirPlay Video = ", playbackTargetSupportsAirPlayVideo);
         if (auto target = MediaSessionHelper::sharedHelper().playbackTarget(); target && playbackTargetSupportsAirPlayVideo)

--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h
@@ -28,6 +28,7 @@
 #if ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)
 
 #include "DestinationColorSpace.h"
+#include "MediaDeviceRoute.h"
 #include "MediaPlayerPrivate.h"
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/LoggerHelper.h>
@@ -39,10 +40,12 @@
 
 namespace WebCore {
 
+class MediaDeviceRoute;
 class MediaPlaybackTarget;
 
 class MediaPlayerPrivateWirelessPlayback final
     : public MediaPlayerPrivateInterface
+    , private MediaDeviceRouteClient
 #if !RELEASE_LOG_DISABLED
     , private LoggerHelper
 #endif
@@ -61,6 +64,8 @@ private:
     friend class MediaPlayerFactoryWirelessPlayback;
 
     explicit MediaPlayerPrivateWirelessPlayback(MediaPlayer&);
+
+    MediaDeviceRoute* route() const;
 
     void updateURLIfNeeded();
 
@@ -104,6 +109,10 @@ private:
     void setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&&) final;
     void setShouldPlayToPlaybackTarget(bool) final;
 #endif
+
+    // MediaDeviceRouteClient
+    void readyDidChange(MediaDeviceRoute&) final;
+    void playbackErrorDidChange(MediaDeviceRoute&) final;
 
 #if !RELEASE_LOG_DISABLED
     // LoggerHelper

--- a/Source/WebCore/testing/MockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.h
@@ -50,6 +50,12 @@ public:
     String deviceName() const;
     void setDeviceName(const String&);
 
+    bool ready() const;
+    void setReady(bool);
+
+    bool hasPlaybackError() const;
+    void setHasPlaybackError(bool);
+
 private:
     MockMediaDeviceRoute();
 

--- a/Source/WebCore/testing/MockMediaDeviceRoute.idl
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.idl
@@ -31,4 +31,6 @@
     undefined setURLCallback(MockMediaDeviceRouteURLCallback? callback);
 
     attribute DOMString deviceName;
+    attribute boolean ready;
+    attribute boolean hasPlaybackError;
 };

--- a/Source/WebCore/testing/MockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/MockMediaDeviceRoute.mm
@@ -65,6 +65,27 @@ void MockMediaDeviceRoute::setDeviceName(const String& deviceName)
     [m_platformRoute setRouteDisplayName:deviceName.createNSString().get()];
 }
 
+bool MockMediaDeviceRoute::ready() const
+{
+    return [m_platformRoute isReady];
+}
+
+void MockMediaDeviceRoute::setReady(bool ready)
+{
+    [m_platformRoute setReady:ready];
+}
+
+bool MockMediaDeviceRoute::hasPlaybackError() const
+{
+    return !![m_platformRoute playbackError];
+}
+
+void MockMediaDeviceRoute::setHasPlaybackError(bool)
+{
+    RetainPtr error = [NSError errorWithDomain:WebMockMediaDeviceRouteErrorDomain code:WebMockMediaDeviceRouteErrorPlaybackError userInfo:nil];
+    [m_platformRoute setPlaybackError:error.get()];
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(WIRELESS_PLAYBACK_MEDIA_PLAYER)

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h
@@ -29,15 +29,25 @@
 
 #import <WebKitAdditions/WebMockMediaDeviceRouteAdditions.h>
 
+typedef NS_ENUM(NSInteger, WebMockMediaDeviceRouteErrorCode) {
+    WebMockMediaDeviceRouteErrorCodeInvalidState,
+    WebMockMediaDeviceRouteErrorCodeUnsupportedURL,
+    WebMockMediaDeviceRouteErrorPlaybackError,
+};
+
 namespace WebCore {
 class MockMediaDeviceRouteURLCallback;
 }
 
 NS_ASSUME_NONNULL_BEGIN
 
+extern NSErrorDomain const WebMockMediaDeviceRouteErrorDomain;
+
 @interface WebMockMediaDeviceRoute : NSObject <AVMediaSource, WebMediaDevicePlatformRoute>
 @property (nonatomic, nullable, setter=setURLCallback:) WebCore::MockMediaDeviceRouteURLCallback* urlCallback;
 @property (copy) NSString *routeDisplayName;
+@property (nonatomic, getter=isReady) BOOL ready;
+@property (nonatomic, strong, nullable) NSError *playbackError;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
+++ b/Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm
@@ -35,12 +35,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRouteErrorDomain";
-
-typedef NS_ENUM(NSInteger, WebMockMediaDeviceRouteErrorCode) {
-    WebMockMediaDeviceRouteErrorCodeInvalidState,
-    WebMockMediaDeviceRouteErrorCodeURLPromiseRejected,
-};
+NSErrorDomain const WebMockMediaDeviceRouteErrorDomain = @"WebMockMediaDeviceRouteErrorDomain";
 
 @implementation WebMockMediaDeviceRoute {
     RefPtr<WebCore::MockMediaDeviceRouteURLCallback> _urlCallback;
@@ -96,7 +91,7 @@ typedef NS_ENUM(NSInteger, WebMockMediaDeviceRouteErrorCode) {
         case WebCore::DOMPromise::Status::Fulfilled:
             return completionHandler(nil, strongSelf.get());
         case WebCore::DOMPromise::Status::Rejected:
-            return completionHandler([NSError errorWithDomain:WebMockMediaDeviceRouteErrorDomain code:WebMockMediaDeviceRouteErrorCodeURLPromiseRejected userInfo:nil], nil);
+            return completionHandler([NSError errorWithDomain:WebMockMediaDeviceRouteErrorDomain code:WebMockMediaDeviceRouteErrorCodeUnsupportedURL userInfo:nil], nil);
         case WebCore::DOMPromise::Status::Pending:
             break;
         }


### PR DESCRIPTION
#### 82dd3189538f0c94958047e7b0fe0e16aafabc9f
<pre>
[iOS] Update MediaPlayerPrivateWirelessPlayback&apos;s ready and network states based on the state of the MediaDeviceRoute
<a href="https://bugs.webkit.org/show_bug.cgi?id=307457">https://bugs.webkit.org/show_bug.cgi?id=307457</a>
<a href="https://rdar.apple.com/170077959">rdar://170077959</a>

Reviewed by Jer Noble.

Updated MediaPlayerPrivateWirelessPlayback such that (a) its ready state advances to HaveEnoughData
once its MediaDeviceRoute becomes ready for playback after loading a URL, and (b) its network state
advances to FormatError if a playback error occurs prior to the MediaDeviceRoute becoming ready and
DeviceError otherwise. Prior to loading a URL we now advance the network state to Loading, and if
the MediaDeviceRoute then becomes ready without a playback error occuring we advance it to Idle.

Tests: media/wireless-playback-media-player/canplaythrough.html
       media/wireless-playback-media-player/error.html
       media/wireless-playback-media-player/load-url-source-element-fallback-2.html

* LayoutTests/media/wireless-playback-media-player/canplaythrough-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/canplaythrough.html: Added.
* LayoutTests/media/wireless-playback-media-player/error-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/error.html: Added.
* LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback-2-expected.txt: Added.
* LayoutTests/media/wireless-playback-media-player/load-url-source-element-fallback-2.html: Added.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
(WebCore::MediaDeviceRouteClient::timeRangeDidChange):
(WebCore::MediaDeviceRouteClient::readyDidChange):
(WebCore::MediaDeviceRouteClient::bufferingDidChange):
(WebCore::MediaDeviceRouteClient::playbackErrorDidChange):
(WebCore::MediaDeviceRouteClient::hasAudioDidChange):
(WebCore::MediaDeviceRouteClient::currentValueDidChange):
(WebCore::MediaDeviceRouteClient::playingDidChange):
(WebCore::MediaDeviceRouteClient::playbackSpeedDidChange):
(WebCore::MediaDeviceRouteClient::scanSpeedDidChange):
(WebCore::MediaDeviceRouteClient::mutedDidChange):
(WebCore::MediaDeviceRouteClient::volumeDidChange):
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(-[WebMediaSourceObserver setMediaSource:]):
* Source/WebCore/platform/audio/ios/MediaSessionManagerIOS.mm:
(WebCore::MediaSessionManageriOS::sessionWillBeginPlayback):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::setShouldPlayToPlaybackTarget):
(WebCore::MediaPlayerPrivateWirelessPlayback::route const):
(WebCore::MediaPlayerPrivateWirelessPlayback::updateURLIfNeeded):
(WebCore::MediaPlayerPrivateWirelessPlayback::readyDidChange):
(WebCore::MediaPlayerPrivateWirelessPlayback::playbackErrorDidChange):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.h:
* Source/WebCore/testing/MockMediaDeviceRoute.h:
* Source/WebCore/testing/MockMediaDeviceRoute.idl:
* Source/WebCore/testing/MockMediaDeviceRoute.mm:
(WebCore::MockMediaDeviceRoute::ready const):
(WebCore::MockMediaDeviceRoute::setReady):
(WebCore::MockMediaDeviceRoute::hasPlaybackError const):
(WebCore::MockMediaDeviceRoute::setHasPlaybackError):
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.h:
* Source/WebCore/testing/cocoa/WebMockMediaDeviceRoute.mm:
(-[WebMockMediaDeviceRoute startWithURL:completionHandler:]):

Canonical link: <a href="https://commits.webkit.org/307233@main">https://commits.webkit.org/307233@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6094f7dd34d8ca363e1bab98bc2df804679ff5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143689 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16170 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7867 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96926 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a2e8476-1dce-47e7-bddd-0935b90c4e66) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145564 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16847 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110502 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2d4e4418-9ad8-4706-b847-9527e59eee1c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146652 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12949 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129144 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91420 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83db8bd4-c837-4846-9a6a-b9b7819c14da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12422 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10146 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2359 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121872 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5728 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154669 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16217 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118508 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16253 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13661 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118864 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30478 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14804 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126937 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71631 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15838 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5466 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15573 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79610 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15785 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15637 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->