### PR TITLE
[AutoInstall] don't mutate sys.path

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -653,7 +653,7 @@ class AutoInstall(importlib.abc.MetaPathFinder):
     def register(cls, package, local=False):
         if isinstance(package, Package):
             if cls.packages.get(package.name):
-                if cls.packages.get(package.name)[0].version != package.version:
+                if package.name not in cls.local_packages and cls.packages.get(package.name)[0].version != package.version:
                     raise ValueError('Registered version of {} uses {}, but requested version uses {}'.format(package.name, cls.packages.get(package.name)[0].version, package.version))
                 return cls.packages.get(package.name)
         else:

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -574,7 +574,6 @@ class AutoInstall(importlib.abc.MetaPathFinder):
         except (IOError, OSError, ValueError):
             pass
 
-        sys.path.insert(0, directory)
         cls.directory = directory
 
     @classmethod

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/autoinstall.py
@@ -40,6 +40,7 @@ import zipfile
 from collections import defaultdict
 from contextlib import contextmanager
 from logging import NullHandler
+from typing import Optional
 from webkitcorepy import log
 from webkitcorepy.version import Version
 from webkitcorepy.file_lock import FileLock
@@ -633,7 +634,7 @@ class AutoInstall(importlib.abc.MetaPathFinder):
         cls.timeout = math.ceil(timeout)
 
     @classmethod
-    def _find_local(cls, package: Package) -> str | None:
+    def _find_local(cls, package: Package) -> Optional[str]:
         containing_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         libraries = os.path.dirname(containing_path)
         checkout_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(libraries))))


### PR DESCRIPTION
#### c72309177bd9
<pre>
fixup! squash! [AutoInstall] don&apos;t mutate sys.path <a href="https://bugs.webkit.org/show_bug.cgi?id=284088">https://bugs.webkit.org/show_bug.cgi?id=284088</a> rdar://141332934
</pre>
----------------------------------------------------------------------
#### 037bbfacd98e
<pre>
fixup! squash! [AutoInstall] don&apos;t mutate sys.path <a href="https://bugs.webkit.org/show_bug.cgi?id=284088">https://bugs.webkit.org/show_bug.cgi?id=284088</a> rdar://141332934
</pre>
----------------------------------------------------------------------
#### 3845b0eba357
<pre>
squash! [AutoInstall] don&apos;t mutate sys.path <a href="https://bugs.webkit.org/show_bug.cgi?id=284088">https://bugs.webkit.org/show_bug.cgi?id=284088</a> <a href="https://rdar.apple.com/141332934">rdar://141332934</a>

Also handle local paths.
</pre>
----------------------------------------------------------------------
#### 75aa24852c73
<pre>
[AutoInstall] don&apos;t mutate sys.path
<a href="https://bugs.webkit.org/show_bug.cgi?id=284088">https://bugs.webkit.org/show_bug.cgi?id=284088</a>
rdar://141332934
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c72309177bd9c2c411e85a09a77326aded219da8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143690 "check-webkit-style (failure)") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7868 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152358 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96927 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb990fee-943c-4a57-8eda-5c4e760f9d6d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16259 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110503 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79507 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a4f6750-25d0-49ef-92ec-dcabb9846687) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12950 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129148 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecordsForMultipleContexts (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91421 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32fe7afc-a596-41a3-bf13-4521f9f1baf0) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/143016 "webkitpy-tests (failure)") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12423 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10148 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2360 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121873 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5722 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154670 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16218 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6765 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118510 "Passed tests") | | 
| [❌ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/143095 "Failed resultsdbpy unit tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13664 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118866 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14805 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126931 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71632 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15839 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5460 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15574 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15786 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15638 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->