### PR TITLE
Change RemoteLayerTreeDrawingAreaProxy::ProcessState to track a set of pending commits, rather than a single state machine.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -292,7 +292,8 @@ AllowMultiElementImplicitSubmission:
 
 AllowMultipleCommitLayerTreePending:
   type: bool
-  status: internal
+  status: testable
+  category: dom
   humanReadableName: "Allow requesting CommitLayerTree before the previous has completed"
   humanReadableDescription: "Allow requesting CommitLayerTree before the previous has completed"
   defaultValue:

--- a/Source/WebKit/Shared/MonotonicObjectIdentifier.h
+++ b/Source/WebKit/Shared/MonotonicObjectIdentifier.h
@@ -46,6 +46,7 @@ public:
     { }
 
     bool isHashTableDeletedValue() const { return m_identifier == hashTableDeletedValue(); }
+    bool isHashTableEmptyValue() const { return !*this; }
 
     friend auto operator<=>(MonotonicObjectIdentifier, MonotonicObjectIdentifier) = default;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.messages.in
@@ -28,6 +28,7 @@
 messages -> RemoteLayerTreeDrawingAreaProxy : DrawingAreaProxy {
     void SetPreferredFramesPerSecond(unsigned preferredFramesPerSecond)
     void NotifyPendingCommitLayerTree(std::optional<WebKit::TransactionID> transactionID) CanDispatchOutOfOrder
+    void NotifyFlushingLayerTree(WebKit::TransactionID transactionID) CanDispatchOutOfOrder
     void CommitLayerTree(struct WebKit::RemoteLayerTreeCommitBundle bundle, HashMap<WebKit::ImageBufferSetIdentifier, std::unique_ptr<WebKit::BufferSetBackendHandle>> handlesMap) CanDispatchOutOfOrder
     void AsyncSetLayerContents(WebCore::PlatformLayerIdentifier layer, WebKit::RemoteLayerBackingStoreProperties properties)
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm
@@ -98,6 +98,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteLayerTreeDrawingAreaProxy);
 RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy(WebPageProxy& pageProxy, WebProcessProxy& webProcessProxy)
     : DrawingAreaProxy(pageProxy, webProcessProxy)
     , m_remoteLayerTreeHost(makeUnique<RemoteLayerTreeHost>(*this))
+    , m_webPageProxyProcessState(webProcessProxy)
 {
     // We don't want to pool surfaces in the UI process.
     // FIXME: We should do this somewhere else.
@@ -120,13 +121,20 @@ std::span<IPC::ReceiverName> RemoteLayerTreeDrawingAreaProxy::messageReceiverNam
 
 void RemoteLayerTreeDrawingAreaProxy::addRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy& proxy)
 {
-    m_remotePageProcessState.add(proxy.process().coreProcessIdentifier(), ProcessState { });
+    m_remotePageProcessState.add(proxy.process().coreProcessIdentifier(), ProcessState(proxy.process()));
 }
 
 void RemoteLayerTreeDrawingAreaProxy::removeRemotePageDrawingAreaProxy(RemotePageDrawingAreaProxy& proxy)
 {
     ASSERT(m_remotePageProcessState.contains(proxy.process().coreProcessIdentifier()));
     m_remotePageProcessState.remove(proxy.process().coreProcessIdentifier());
+}
+
+ProcessState::ProcessState(WebProcessProxy& webProcess)
+    : nextLayerTreeTransactionID(TransactionID(TransactionIdentifier(), webProcess.coreProcessIdentifier()).next())
+{
+    pendingCommits.insert(0, { nextLayerTreeTransactionID, PendingCommitMessage::NotifyPendingCommitLayerTree, CommitDelayState::IntentionallyDeferred });
+    nextLayerTreeTransactionID.increment();
 }
 
 std::unique_ptr<RemoteLayerTreeHost> RemoteLayerTreeDrawingAreaProxy::detachRemoteLayerTreeHost()
@@ -150,7 +158,11 @@ void RemoteLayerTreeDrawingAreaProxy::sizeDidChange()
 
 TransactionID RemoteLayerTreeDrawingAreaProxy::nextMainFrameLayerTreeTransactionID() const
 {
-    return m_webPageProxyProcessState.pendingLayerTreeTransactionID.value_or(TransactionID(TransactionIdentifier(), webProcessProxy().coreProcessIdentifier())).next();
+    for (int i = m_webPageProxyProcessState.pendingCommits.size() - 1; i >= 0; i--) {
+        if (m_webPageProxyProcessState.pendingCommits[i].pendingMessage > PendingCommitMessage::NotifyPendingCommitLayerTree)
+            return m_webPageProxyProcessState.pendingCommits[i].transactionID;
+    }
+    return lastCommittedMainFrameLayerTreeTransactionID();
 }
 
 TransactionID RemoteLayerTreeDrawingAreaProxy::lastCommittedMainFrameLayerTreeTransactionID() const
@@ -230,7 +242,7 @@ void RemoteLayerTreeDrawingAreaProxy::sendUpdateGeometry()
     });
 }
 
-RemoteLayerTreeDrawingAreaProxy::ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForConnection(IPC::Connection& connection)
+ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForConnection(IPC::Connection& connection)
 {
     for (auto& [key, value] : m_remotePageProcessState) {
         RefPtr webProcess = WebProcessProxy::processForIdentifier(key);
@@ -252,7 +264,7 @@ void RemoteLayerTreeDrawingAreaProxy::forEachProcessState(NOESCAPE Function<void
     }
 }
 
-const RemoteLayerTreeDrawingAreaProxy::ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForIdentifier(WebCore::ProcessIdentifier identifier) const
+const ProcessState& RemoteLayerTreeDrawingAreaProxy::processStateForIdentifier(WebCore::ProcessIdentifier identifier) const
 {
     if (webProcessProxy().coreProcessIdentifier() == identifier)
         return m_webPageProxyProcessState;
@@ -273,32 +285,25 @@ IPC::Connection* RemoteLayerTreeDrawingAreaProxy::connectionForIdentifier(WebCor
 void RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree(IPC::Connection& connection, std::optional<TransactionID> transactionID)
 {
     ProcessState& state = processStateForConnection(connection);
-    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree " << transactionID << " old state: " << state.commitLayerTreeMessageState);
+    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree " << transactionID << " old state: " << state.pendingCommits);
     if (transactionID) {
-        MESSAGE_CHECK_BASE(std::holds_alternative<CommitLayerTreePending>(state.commitLayerTreeMessageState) || std::holds_alternative<Idle>(state.commitLayerTreeMessageState), connection);
-        MESSAGE_CHECK_BASE(!state.pendingLayerTreeTransactionID || *transactionID == state.pendingLayerTreeTransactionID->next(), connection);
-        state.pendingLayerTreeTransactionID = *transactionID;
-        if (auto* commitLayerTreePending = std::get_if<CommitLayerTreePending>(&state.commitLayerTreeMessageState)) {
-            MESSAGE_CHECK_BASE(commitLayerTreePending->requestedNotifyPendingCommitLayerTree, connection);
-            commitLayerTreePending->requestedNotifyPendingCommitLayerTree--;
-
-            if (state.canSendDisplayDidRefresh(*this) && commitLayerTreePending->missedDisplayDidRefresh) {
-                LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree - sending missed didRefreshDisplay");
-                commitLayerTreePending->missedDisplayDidRefresh = false;
-                didRefreshDisplay(&connection);
-            }
-        } else
-            state.commitLayerTreeMessageState = CommitLayerTreePending { 0, 1, false };
-    } else {
-        MESSAGE_CHECK_BASE(std::holds_alternative<CommitLayerTreePending>(state.commitLayerTreeMessageState), connection);
-        auto& commitLayerTreePending = std::get<CommitLayerTreePending>(state.commitLayerTreeMessageState);
-        MESSAGE_CHECK_BASE(commitLayerTreePending.requestedNotifyPendingCommitLayerTree, connection);
-
-        commitLayerTreePending.requestedNotifyPendingCommitLayerTree--;
-        if (!--commitLayerTreePending.requestedCommitLayerTree) {
-            LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTre all pending commits received, becoming idle");
-            state.commitLayerTreeMessageState = Idle { };
+        if (state.pendingCommits.isEmpty()) {
+            // The very first commit is initiated by WebContent, all others get
+            // started in response to displayDidRefresh.
+            MESSAGE_CHECK_BASE(state.nextLayerTreeTransactionID.object() == TransactionIdentifier().next(), connection);
+            MESSAGE_CHECK_BASE(state.nextLayerTreeTransactionID == *transactionID, connection);
+            state.pendingCommits.insert(0, { *transactionID, PendingCommitMessage::NotifyFlushingLayerTree, CommitDelayState::Pending });
+            state.nextLayerTreeTransactionID = transactionID->next();
+        } else {
+            MESSAGE_CHECK_BASE(state.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyPendingCommitLayerTree && state.pendingCommits[0].transactionID == *transactionID, connection);
+            state.pendingCommits[0].pendingMessage = PendingCommitMessage::NotifyFlushingLayerTree;
         }
+    } else {
+        // This frame is still pending, it'll be sent when the WebProcess decides it's ready.
+        // Use the IntentionallyDeferred state so that we don't think that it's late
+        // when displayDidRefresh arrives.
+        MESSAGE_CHECK_BASE(state.pendingCommits.size() && state.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyPendingCommitLayerTree, connection);
+        state.pendingCommits[0].delayState = CommitDelayState::IntentionallyDeferred;
 
         maybePauseDisplayRefreshCallbacks();
 
@@ -309,19 +314,32 @@ void RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree(IPC::Connecti
     }
 }
 
+void RemoteLayerTreeDrawingAreaProxy::notifyFlushingLayerTree(IPC::Connection& connection, TransactionID transactionID)
+{
+    ProcessState& state = processStateForConnection(connection);
+    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyFlushingLayerTree " << transactionID << " old state: " << state.pendingCommits);
+
+    MESSAGE_CHECK_BASE(state.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyFlushingLayerTree && state.pendingCommits[0].transactionID == transactionID, connection);
+    state.pendingCommits[0].pendingMessage = PendingCommitMessage::CommitLayerTree;
+
+    if (state.canSendDisplayDidRefresh(*this) && state.pendingCommits[0].delayState == CommitDelayState::Delayed) {
+        LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::notifyFlushingLayerTree - sending missed didRefreshDisplay");
+        didRefreshDisplay(&connection);
+    }
+}
+
 void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connection, const RemoteLayerTreeCommitBundle& bundle, HashMap<ImageBufferSetIdentifier, std::unique_ptr<BufferSetBackendHandle>>&& handlesMap)
 {
     {
         ProcessState& state = processStateForConnection(connection);
-        LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree old state: " << state.commitLayerTreeMessageState);
+        LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree old state: " << state.pendingCommits);
         LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree page data: " << bundle.pageData.description());
         if (bundle.mainFrameData)
             LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree main frame data: " << bundle.mainFrameData->description());
         LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree bundle data: " << bundle.description());
-        MESSAGE_CHECK_BASE(std::holds_alternative<CommitLayerTreePending>(state.commitLayerTreeMessageState), connection);
-        MESSAGE_CHECK_BASE(std::get<CommitLayerTreePending>(state.commitLayerTreeMessageState).requestedCommitLayerTree, connection);
-        MESSAGE_CHECK_BASE(state.pendingLayerTreeTransactionID, connection);
-        MESSAGE_CHECK_BASE(bundle.transactionID.lessThanOrEqualSameProcess(*state.pendingLayerTreeTransactionID), connection);
+        MESSAGE_CHECK_BASE(state.pendingCommits.size(), connection);
+        MESSAGE_CHECK_BASE(state.pendingCommits.last().pendingMessage == PendingCommitMessage::CommitLayerTree, connection);
+        MESSAGE_CHECK_BASE(state.pendingCommits.last().transactionID == bundle.transactionID, connection);
         MESSAGE_CHECK_BASE(!state.committedLayerTreeTransactionID || bundle.transactionID == state.committedLayerTreeTransactionID->next(), connection);
     }
 
@@ -349,6 +367,12 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
         }
     }
 
+    PendingCommit completedCommit = [&]() {
+        ProcessState& state = processStateForConnection(connection);
+        state.committedLayerTreeTransactionID = bundle.transactionID;
+        return state.pendingCommits.takeLast();
+    }();
+
     RefPtr page = this->page();
     if (!page)
         return;
@@ -374,11 +398,6 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
 
         if (auto milestones = bundle.mainFrameData->newlyReachedPaintingMilestones)
             page->didReachLayoutMilestone(milestones, WallTime::now());
-    }
-
-    {
-        ProcessState& state = processStateForConnection(connection);
-        state.committedLayerTreeTransactionID = bundle.transactionID;
     }
 
     WeakPtr weakThis { *this };
@@ -410,16 +429,14 @@ void RemoteLayerTreeDrawingAreaProxy::commitLayerTree(IPC::Connection& connectio
 
     {
         ProcessState& state = processStateForConnection(connection);
-        auto& commitLayerTreePending = std::get<CommitLayerTreePending>(state.commitLayerTreeMessageState);
-        ASSERT(commitLayerTreePending.requestedCommitLayerTree);
-        commitLayerTreePending.requestedCommitLayerTree--;
-        if (state.canSendDisplayDidRefresh(*this) && commitLayerTreePending.missedDisplayDidRefresh) {
+        if (state.canSendDisplayDidRefresh(*this) && completedCommit.delayState == CommitDelayState::Delayed) {
             LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree - sending missed didRefreshDisplay");
             didRefreshDisplay(&connection);
-        } else if (!commitLayerTreePending.requestedCommitLayerTree) {
+        } else if (!state.pendingCommits.size()) {
             LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::commitLayerTree all pending commits received, waiting for display did refresh");
-            state.commitLayerTreeMessageState = NeedsDisplayDidRefresh { };
         }
+        if (completedCommit.delayState != CommitDelayState::Delayed && state.delayedCommits)
+            state.delayedCommits--;
     }
 
     updateSlowFrameIndicator();
@@ -715,11 +732,11 @@ void RemoteLayerTreeDrawingAreaProxy::drawSlowFrameIndicator(WebCore::GraphicsCo
 
 bool RemoteLayerTreeDrawingAreaProxy::maybePauseDisplayRefreshCallbacks()
 {
-    if (!std::holds_alternative<Idle>(m_webPageProxyProcessState.commitLayerTreeMessageState))
+    if (!m_webPageProxyProcessState.pendingCommits.size() || m_webPageProxyProcessState.pendingCommits[0].delayState != CommitDelayState::IntentionallyDeferred)
         return false;
 
     for (auto& pair : m_remotePageProcessState) {
-        if (std::holds_alternative<Idle>(pair.value.commitLayerTreeMessageState))
+        if (!pair.value.pendingCommits.size() || pair.value.pendingCommits[0].delayState != CommitDelayState::IntentionallyDeferred)
             return false;
     }
 
@@ -732,19 +749,27 @@ void RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay()
     didRefreshDisplay(nullptr);
 }
 
-TextStream& operator<<(TextStream& ts, const RemoteLayerTreeDrawingAreaProxy::Idle&)
+TextStream& operator<<(TextStream& ts, const PendingCommitMessage& state)
 {
-    return ts << "Idle";
+    if (state == PendingCommitMessage::NotifyPendingCommitLayerTree)
+        return ts << "NotifyPendingCommitLayerTree";
+    if (state == PendingCommitMessage::NotifyFlushingLayerTree)
+        return ts << "NotifyFlushingLayerTree";
+    return ts << "CommitLayerTree";
 }
 
-TextStream& operator<<(TextStream& ts, const RemoteLayerTreeDrawingAreaProxy::NeedsDisplayDidRefresh&)
+TextStream& operator<<(TextStream& ts, const CommitDelayState& state)
 {
-    return ts << "NeedsDisplayDidRefresh";
+    switch (state) {
+    case CommitDelayState::Pending: return ts << "Pending";
+    case CommitDelayState::Delayed: return ts << "Delayed";
+    case CommitDelayState::IntentionallyDeferred: return ts << "IntentionallyDeferred";
+    }
 }
 
-TextStream& operator<<(TextStream& ts, const RemoteLayerTreeDrawingAreaProxy::CommitLayerTreePending& commitLayerTreePending)
+TextStream& operator<<(TextStream& ts, const PendingCommit& pendingCommit)
 {
-    return ts << "CommitLayerTreePending(" << commitLayerTreePending.requestedNotifyPendingCommitLayerTree << ", " << commitLayerTreePending.requestedCommitLayerTree << ", " << commitLayerTreePending.missedDisplayDidRefresh << ")";
+    return ts << "{ " << pendingCommit.transactionID << ", pending(" << pendingCommit.pendingMessage << "), delay(" << pendingCommit.delayState << ") } ";
 }
 
 bool RemoteLayerTreeDrawingAreaProxy::allowMultipleCommitLayerTreePending()
@@ -754,39 +779,35 @@ bool RemoteLayerTreeDrawingAreaProxy::allowMultipleCommitLayerTreePending()
     return false;
 }
 
-bool RemoteLayerTreeDrawingAreaProxy::ProcessState::canSendDisplayDidRefresh(RemoteLayerTreeDrawingAreaProxy& drawingArea)
+bool ProcessState::canSendDisplayDidRefresh(RemoteLayerTreeDrawingAreaProxy& drawingArea)
 {
-    return WTF::switchOn(commitLayerTreeMessageState,
-        [&](const CommitLayerTreePending& commitLayerTreePending) {
-            if (commitLayerTreePending.requestedNotifyPendingCommitLayerTree)
-                return false;
-            if (drawingArea.allowMultipleCommitLayerTreePending())
-                return commitLayerTreePending.requestedCommitLayerTree <= 1;
-            return !commitLayerTreePending.requestedCommitLayerTree;
-        },
-        [](const NeedsDisplayDidRefresh&) { return true; },
-        [](const Idle&) { return false; }
-    );
+    if (pendingCommits.size() >= 2)
+        return false;
+    if (pendingCommits.size() == 1)
+#if PLATFORM(IOS_FAMILY)
+        return false;
+#else
+        return drawingArea.allowMultipleCommitLayerTreePending() && pendingCommits[0].pendingMessage == PendingCommitMessage::CommitLayerTree && delayedCommits >= 4;
+#endif
+    return true;
 }
 
 IPC::Error RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay(ProcessState& state, IPC::Connection& connection)
 {
     if (!state.canSendDisplayDidRefresh(*this)) {
-        if (auto* commitLayerTreePending = std::get_if<CommitLayerTreePending>(&state.commitLayerTreeMessageState)) {
-            LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay stil waiting on commit, marked as missed");
-            commitLayerTreePending->missedDisplayDidRefresh = true;
+        ASSERT(state.pendingCommits.size());
+        if (state.pendingCommits.last().delayState == CommitDelayState::Pending) {
+            state.pendingCommits.last().delayState = CommitDelayState::Delayed;
+            LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay still waiting on commit, marked as delayed");
+            state.delayedCommits++;
         }
         return IPC::Error::NoError;
     }
 
-    if (auto* commitLayerTreePending = std::get_if<CommitLayerTreePending>(&state.commitLayerTreeMessageState)) {
-        commitLayerTreePending->requestedNotifyPendingCommitLayerTree++;
-        commitLayerTreePending->requestedCommitLayerTree++;
-        commitLayerTreePending->missedDisplayDidRefresh = false;
-    } else
-        state.commitLayerTreeMessageState = CommitLayerTreePending { };
+    state.pendingCommits.insert(0, { state.nextLayerTreeTransactionID, PendingCommitMessage::NotifyPendingCommitLayerTree, CommitDelayState::Pending });
+    state.nextLayerTreeTransactionID.increment();
 
-    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay new state " << state.commitLayerTreeMessageState);
+    LOG_WITH_STREAM(RemoteLayerTree, stream << "RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay new state " << state.pendingCommits);
 
     if (&state == &m_webPageProxyProcessState) {
         if (RefPtr page = this->page())
@@ -841,17 +862,18 @@ void RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState(ActivityStat
     auto startTime = MonotonicTime::now();
 
     do {
-        IPC::Error error = WTF::switchOn(m_webPageProxyProcessState.commitLayerTreeMessageState,
-            [&](const CommitLayerTreePending& commitLayerTreePending) {
-                if (commitLayerTreePending.requestedNotifyPendingCommitLayerTree)
-                    return connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
-                return connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
-            }, [&](const NeedsDisplayDidRefresh&) {
-                return didRefreshDisplay(m_webPageProxyProcessState, connection.get());
-            }, [&](const Idle&) {
-                return connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
-            }
-        );
+        IPC::Error error;
+        if (!m_webPageProxyProcessState.pendingCommits.size())
+            error = didRefreshDisplay(m_webPageProxyProcessState, connection.get());
+        else {
+            // Only the most recent outstanding frame can be in NotifyPendingCommitLayerTree state
+            if (m_webPageProxyProcessState.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyPendingCommitLayerTree)
+                error = connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::NotifyPendingCommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+            else if (m_webPageProxyProcessState.pendingCommits[0].pendingMessage == PendingCommitMessage::NotifyFlushingLayerTree)
+                error = connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::NotifyFlushingLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+            else
+                error = connection->waitForAndDispatchImmediately<Messages::RemoteLayerTreeDrawingAreaProxy::CommitLayerTree>(identifier(), activityStateUpdateTimeout - (MonotonicTime::now() - startTime), IPC::WaitForOption::InterruptWaitingIfSyncMessageArrives);
+        }
 
         if (error != IPC::Error::NoError)
             return;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -71,7 +71,6 @@ private:
 
     RetainPtr<WKDisplayLinkHandler> m_displayLinkHandler;
 
-    bool m_needsDisplayRefreshCallbacksForDrawing { false };
     bool m_needsDisplayRefreshCallbacksForMonotonicAnimations { false };
 };
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm
@@ -462,6 +462,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::sendCommitTransientZoom(double scale, F
 void RemoteLayerTreeDrawingAreaProxyMac::scheduleDisplayRefreshCallbacks()
 {
     LOG_WITH_STREAM(DisplayLink, stream << "[UI ] RemoteLayerTreeDrawingAreaProxyMac " << this << " scheduleDisplayLink for display " << m_displayID << " - existing observer " << m_displayRefreshObserverID);
+    m_needsDisplayRefreshCallbacksForDrawing = true;
     if (m_displayRefreshObserverID)
         return;
 
@@ -487,6 +488,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::pauseDisplayRefreshCallbacks()
 {
     LOG_WITH_STREAM(DisplayLink, stream << "[UI ] RemoteLayerTreeDrawingAreaProxyMac " << this << " pauseDisplayLink for display " << m_displayID << " - observer " << m_displayRefreshObserverID);
     removeObserver(m_displayRefreshObserverID);
+    m_needsDisplayRefreshCallbacksForDrawing = false;
 }
 
 void RemoteLayerTreeDrawingAreaProxyMac::setPreferredFramesPerSecond(IPC::Connection& connection,  WebCore::FramesPerSecond preferredFramesPerSecond)
@@ -530,6 +532,7 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
     if (displayID == m_displayID)
         return;
 
+    bool needsDisplayRefreshCallbacksForDrawing = m_needsDisplayRefreshCallbacksForDrawing;
     bool hadFullSpeedOberver = m_fullSpeedUpdateObserverID.has_value();
     if (hadFullSpeedOberver)
         removeObserver(m_fullSpeedUpdateObserverID);
@@ -546,7 +549,8 @@ void RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange(PlatformDisplayID
     if (page)
         protect(page->scrollingCoordinatorProxy())->windowScreenDidChange(displayID, m_displayNominalFramesPerSecond);
 
-    scheduleDisplayRefreshCallbacks();
+    if (needsDisplayRefreshCallbacksForDrawing)
+        scheduleDisplayRefreshCallbacks();
     if (hadFullSpeedOberver) {
         m_fullSpeedUpdateObserverID = DisplayLinkObserverID::generate();
         if (auto* displayLink = existingDisplayLink())

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -422,6 +422,8 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
     m_backingStoreFlusher->markHasPendingFlush();
 
+    send(Messages::RemoteLayerTreeDrawingAreaProxy::NotifyFlushingLayerTree(transactionID));
+
     auto pageID = webPage->identifier();
     m_commitQueue->dispatch([backingStoreFlusher = m_backingStoreFlusher, commitEncoder = WTF::move(commitEncoder), flushers = WTF::move(flushers), pageID] () mutable {
         bool flushSucceeded = backingStoreFlusher->flush(WTF::move(commitEncoder), WTF::move(flushers));


### PR DESCRIPTION
#### 43bbbfd786ab4d6759dfaddfd37f79dbb8a86274
<pre>
Change RemoteLayerTreeDrawingAreaProxy::ProcessState to track a set of pending commits, rather than a single state machine.
<a href="https://bugs.webkit.org/show_bug.cgi?id=303715">https://bugs.webkit.org/show_bug.cgi?id=303715</a>
&lt;<a href="https://rdar.apple.com/170082383">rdar://170082383</a>&gt;

Reviewed by Gerald Squelart.

Trying to track potentially multiple commits with a single state machine is
complicated as the set of potential states is large.

Replace the state variant with a vector of pending commits, so that each
potential state can be tracked per-commit.

Fixes a bug where the existing MESSAGE_CHECKs failed, where we thought the next
step was waiting for display did refresh, but another commit arrives.

This also enables the multiple frame setting by default so that EWS tests run
and expose bugs like the above.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/Shared/MonotonicObjectIdentifier.h:
(WebKit::MonotonicObjectIdentifier::isHashTableEmptyValue const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::ProcessState::ProcessState):
(WTF::HashTraits&lt;WebKit::ProcessState&gt;::emptyValue):
(WTF::HashTraits&lt;WebKit::ProcessState&gt;::isEmptyValue):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxy::RemoteLayerTreeDrawingAreaProxy):
(WebKit::RemoteLayerTreeDrawingAreaProxy::addRemotePageDrawingAreaProxy):
(WebKit::ProcessState::ProcessState):
(WebKit::RemoteLayerTreeDrawingAreaProxy::nextMainFrameLayerTreeTransactionID const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::processStateForConnection):
(WebKit::RemoteLayerTreeDrawingAreaProxy::processStateForIdentifier const):
(WebKit::RemoteLayerTreeDrawingAreaProxy::notifyPendingCommitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::commitLayerTree):
(WebKit::RemoteLayerTreeDrawingAreaProxy::maybePauseDisplayRefreshCallbacks):
(WebKit::operator&lt;&lt;):
(WebKit::ProcessState::canSendDisplayDidRefresh):
(WebKit::RemoteLayerTreeDrawingAreaProxy::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxy::waitForDidUpdateActivityState):
(WebKit::RemoteLayerTreeDrawingAreaProxy::ProcessState::canSendDisplayDidRefresh):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeDrawingAreaProxyMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyMac::windowScreenDidChange):

Canonical link: <a href="https://commits.webkit.org/307235@main">https://commits.webkit.org/307235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1c39b4b3e00e4b4787dba028682073faf3c78ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7876 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96935 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c091b36e-84f6-48ec-95d7-aff6f761ca6c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16856 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16267 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110512 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79511 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4d39f14-60c5-4241-8016-1289e687529d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146661 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129151 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91430 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eed75d2c-e631-48f9-862c-e636eddaa140) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12431 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10153 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2368 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135686 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5736 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154678 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4504 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16226 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118516 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16262 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118873 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30479 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14814 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126945 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71640 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15848 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5472 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/174984 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15582 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79619 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45151 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15794 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->