### PR TITLE
Unused forward declarations to WebModel namespaced types

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h
@@ -37,20 +37,10 @@
 #include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 
-namespace WebModel {
-struct MeshDescriptor;
-}
-
 namespace WebCore {
-class ConvertToBackingContext;
 class GraphicsContext;
 class IntSize;
 class NativeImage;
-}
-
-namespace WebKit {
-class Mesh;
-class ModelConvertToBackingContext;
 }
 
 namespace WebCore::WebGPU {

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h
@@ -32,19 +32,10 @@
 #include <wtf/RefCounted.h>
 #include <wtf/RefPtr.h>
 
-namespace WebModel {
-struct ImageAsset;
-struct MeshDescriptor;
-}
-
 namespace WebCore {
 class NativeImage;
 class IntSize;
 class GraphicsContext;
-}
-
-namespace WebKit {
-class Mesh;
 }
 
 namespace WebCore::WebGPU {
@@ -62,8 +53,6 @@ class Device;
 class ExternalTexture;
 class GPU;
 class GPUImpl;
-class GraphicsContext;
-class NativeImage;
 class PipelineLayout;
 class PresentationContext;
 class QuerySet;

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -39,16 +39,11 @@
 #import <wtf/WeakObjCPtr.h>
 #import <wtf/WeakPtr.h>
 
-struct WebModelCreateMeshDescriptor;
 struct WGPUInstanceImpl {
 };
 
 namespace WTF {
 class MachSendRight;
-}
-
-namespace WebModel {
-class Mesh;
 }
 
 namespace WebGPU {

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -44,14 +44,12 @@ struct MeshDescriptor;
 namespace WebCore {
 class IntSize;
 class GraphicsContext;
-class Mesh;
 class NativeImage;
-class Mesh;
-class ModelConvertToBackingContext;
 }
 
 namespace WebKit {
 class ConvertToBackingContext;
+class Mesh;
 class ModelConvertToBackingContext;
 class RemoteRenderingBackendProxy;
 class WebPage;


### PR DESCRIPTION
#### df351800e79c853c1762268845eee4bf462cd71e
<pre>
Unused forward declarations to WebModel namespaced types
<a href="https://bugs.webkit.org/show_bug.cgi?id=307462">https://bugs.webkit.org/show_bug.cgi?id=307462</a>

Reviewed by Mike Wyrzykowski.

Cleans up some unused forward declarations.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUImpl.h:
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPU.h:
* Source/WebGPU/WebGPU/Instance.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:

Canonical link: <a href="https://commits.webkit.org/307250@main">https://commits.webkit.org/307250@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ce0f964e612155f2337aca48eba4c0032622d5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96941 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145579 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16862 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16273 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110515 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79513 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146667 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/12961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91433 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12433 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10157 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2374 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154684 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16233 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118519 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118876 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30494 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14830 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/126947 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71646 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15854 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5474 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15588 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79625 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15800 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15652 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->