### PR TITLE
Throttle visible content rect updates when changing obscured insets interactively.

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -452,6 +452,10 @@ struct PerWebProcessState {
     BOOL _didScrollSinceLastTimerFire;
     BOOL _needsScrollend;
 
+#if PLATFORM(IOS_FAMILY)
+    RefPtr<RunLoop::DispatchTimer> _pendingInteractiveObscuredInsetsChangeTimer;
+#endif
+
     // This value tracks the current adjustment added to the bottom inset due to the keyboard sliding out from the bottom
     // when computing obscured content insets. This is used when updating the visible content rects where we should not
     // include this adjustment.

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -102,6 +102,8 @@
 
 - (UIView *)_colorExtensionViewForTesting:(UIRectEdge)edge;
 
+@property (nonatomic, readonly) BOOL _hasPendingVisibleContentRectUpdateTimerForTesting;
+
 @end
 
 #endif // TARGET_OS_IPHONE

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -544,6 +544,11 @@ static void dumpUIView(TextStream& ts, UIView *view, bool traverse)
 #endif
 }
 
+- (BOOL)_hasPendingVisibleContentRectUpdateTimerForTesting
+{
+    return _pendingInteractiveObscuredInsetsChangeTimer && _pendingInteractiveObscuredInsetsChangeTimer->isActive();
+}
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm
@@ -41,6 +41,7 @@
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/WKWebViewPrivateForTestingIOS.h>
 #import <WebKit/_WKFeature.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/darwin/DispatchExtras.h>
@@ -50,6 +51,10 @@ constexpr CGFloat whiteColorComponents[4] = { 1, 1, 1, 1 };
 
 @interface UIView (TestWebKitAPI)
 - (BOOL)_appearsBeforeViewInSubviewOrder:(UIView *)view;
+@end
+
+@interface WKWebView (WKScrollViewTestsInternal)
+- (void)_scheduleForcedVisibleContentRectUpdate;
 @end
 
 @implementation UIView (TestWebKitAPI)
@@ -894,6 +899,114 @@ TEST(WKScrollViewTests, ContentInsetAdjustmentBehaviorChangeAfterViewportFitChan
     EXPECT_EQ([scrollView adjustedContentInset], insets);
 
     EXPECT_WK_STREQ([webView stringByEvaluatingJavaScript:@"document.body.clientWidth"], "280");
+}
+
+TEST(WKScrollViewTests, VisibleContentRectUpdatesDuringInteractiveObscuredInsetsChangeAreThrottled)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 800)]);
+
+    auto insets = UIEdgeInsetsMake(50, 0, 0, 0);
+    [webView _setObscuredInsets:insets];
+
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+
+    [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
+    [webView waitForNextPresentationUpdate];
+
+    [scrollView setContentOffset:CGPointMake(0, 500)];
+    [webView waitForNextVisibleContentRectUpdate];
+
+    [webView _beginInteractiveObscuredInsetsChange];
+
+    // First scroll within interactive mode triggers a timer.
+    [scrollView setContentOffset:CGPointMake(0, 510)];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_TRUE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+
+    // Second scroll should be throttled too.
+    [scrollView setContentOffset:CGPointMake(0, 520)];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_TRUE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+}
+
+TEST(WKScrollViewTests, ThrottledVisibleContentRectUpdateTimerCancelledWhenEndingInteractiveUpdates)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 800)]);
+
+    auto insets = UIEdgeInsetsMake(50, 0, 0, 0);
+    [webView _setObscuredInsets:insets];
+
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+
+    [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
+    [webView waitForNextPresentationUpdate];
+
+    [scrollView setContentOffset:CGPointMake(0, 500)];
+    [webView waitForNextVisibleContentRectUpdate];
+
+    [webView _beginInteractiveObscuredInsetsChange];
+
+    // First scroll within interactive mode triggers a timer.
+    [scrollView setContentOffset:CGPointMake(0, 510)];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_TRUE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+
+    // Second scroll should be throttled too.
+    [scrollView setContentOffset:CGPointMake(0, 520)];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_TRUE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+
+    // Ending interactive mode should cancel the timer.
+    [webView _endInteractiveObscuredInsetsChange];
+    EXPECT_FALSE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+
+    // Verify we can still do normal updates
+    [webView waitForNextVisibleContentRectUpdate];
+    [scrollView setContentOffset:CGPointMake(0, 510)];
+    [webView waitForNextPresentationUpdate];
+
+    [scrollView setContentOffset:CGPointMake(0, 520)];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_FALSE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+}
+
+TEST(WKScrollViewTests, ForcedVisibleContentRectUpdateCancelsPendingThrottleTimer)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 800)]);
+
+    auto insets = UIEdgeInsetsMake(50, 0, 0, 0);
+    [webView _setObscuredInsets:insets];
+
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+
+    [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
+    [webView waitForNextPresentationUpdate];
+
+    [scrollView setContentOffset:CGPointMake(0, 500)];
+    [webView waitForNextVisibleContentRectUpdate];
+
+    [webView _beginInteractiveObscuredInsetsChange];
+
+    // First scroll within interactive mode triggers a timer.
+    [scrollView setContentOffset:CGPointMake(0, 510)];
+    [webView waitForNextPresentationUpdate];
+
+    // Second scroll should be throttled too.
+    [scrollView setContentOffset:CGPointMake(0, 520)];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_TRUE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+
+    // Force an update which should cancel pending throttle timer.
+    [webView _scheduleForcedVisibleContentRectUpdate];
+    EXPECT_FALSE([webView _hasPendingVisibleContentRectUpdateTimerForTesting]);
+
+    [webView _endInteractiveObscuredInsetsChange];
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### c45540108d1deae5e94310fa66f8ea7b0287cfe2
<pre>
Throttle visible content rect updates when changing obscured insets interactively.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307463">https://bugs.webkit.org/show_bug.cgi?id=307463</a>
<a href="https://rdar.apple.com/156417823">rdar://156417823</a>

Reviewed by Simon Fraser.

When changing obscured insets interactively we will get visible content rect updates every frame.
We update bookkeeping, scrolling tree state, trigger rendering update and tile painting,
as well as firing resize and viewport events. These things all add up to be expensive in terms
of power use. By throttling these updates we can save significant power, up to 2% as measured by
an iOS browsing power benchmark on iPhones.

* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _scheduleForcedVisibleContentRectUpdate]):
(-[WKWebView _cancelPendingVisibleContentRectUpdateTimer]):
(-[WKWebView _scheduleVisibleContentRectUpdateWithDelay:]):
(-[WKWebView _updateVisibleContentRects]):
(-[WKWebView _endInteractiveObscuredInsetsChange]):
* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _hasPendingVisibleContentRectUpdateTimerForTesting]):
* Tools/TestWebKitAPI/Tests/ios/WKScrollViewTests.mm:
(TestWebKitAPI::TEST(WKScrollViewTests, VisibleContentRectUpdatesDuringInteractiveObscuredInsetsChangeAreThrottled)):
(TestWebKitAPI::TEST(WKScrollViewTests, ThrottledVisibleContentRectUpdateTimerCancelledWhenEndingInteractiveUpdates)):
(TestWebKitAPI::TEST(WKScrollViewTests, ForcedVisibleContentRectUpdateCancelsPendingThrottleTimer)):

Canonical link: <a href="https://commits.webkit.org/307417@main">https://commits.webkit.org/307417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/601ce1fd43c75c9f90eb669aab0b722ac9064c1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144219 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16898 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152889 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97458 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146094 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110904 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91820 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12752 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10497 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/335 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6229 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155201 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16750 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7284 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118922 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16787 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119279 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30596 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15152 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72171 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16372 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5876 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16107 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80151 "Built successfully") | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16317 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16172 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->