### PR TITLE
Conditionalize More Features

### DIFF
--- a/Tools/CISupport/ews-build/events.py
+++ b/Tools/CISupport/ews-build/events.py
@@ -42,6 +42,11 @@ from .utils import load_password, get_custom_suffix
 
 custom_suffix = get_custom_suffix()
 
+# Configuration for local commit classes loading
+USE_LOCAL_COMMIT_CLASSES = load_password('USE_LOCAL_COMMIT_CLASSES', default=False)
+COMMIT_CLASSES_PATH = load_password('COMMIT_CLASSES_PATH', default='commit_classes.json')
+DEBUG_EWS_EVENTS = load_password('DEBUG_EWS_EVENTS', default=False)
+
 
 class Events(service.BuildbotService):
 
@@ -64,7 +69,7 @@ class Events(service.BuildbotService):
         'bindings-tests', 'check-webkit-style',
         'webkitperl-tests', 're-run-webkitperl-tests', 'webkitpy-tests'
     ]
-    QUEUES_TO_SKIP_REPORTING = ['__Janitor', 'Safe-Merge-Queue']
+    QUEUES_TO_SKIP_REPORTING = load_password('QUEUES_TO_SKIP_REPORTING', default=['__Janitor', 'Safe-Merge-Queue'])
 
     def __init__(self, master_hostname, type_prefix='', name='Events'):
         """
@@ -84,6 +89,9 @@ class Events(service.BuildbotService):
         if load_password('EWS_API_KEY'):
             data['EWS_API_KEY'] = load_password('EWS_API_KEY')
 
+        if DEBUG_EWS_EVENTS:
+            log.msg('Sending data to EWS')
+
         TwistedAdditions.request(
             url=self.EVENT_SERVER_ENDPOINT,
             type=b'POST',
@@ -93,6 +101,9 @@ class Events(service.BuildbotService):
 
     def sendDataToGitHub(self, repository, sha, data, user=None):
         username, access_token = GitHub.credentials(user=user)
+
+        if DEBUG_EWS_EVENTS:
+            log.msg(f'Sending data to GitHub for {sha}')
 
         data['description'] = data.get('description', '')
         if len(data['description']) > self.MAX_GITHUB_DESCRIPTION:
@@ -403,19 +414,26 @@ class GitHubEventHandlerNoEdits(GitHubEventHandler):
             return defer.returnValue(cls._commit_classes)
 
         try:
-            response = yield TwistedAdditions.request(
-                url=cls.COMMIT_CLASSES_URL,
-                type=b'GET',
-                timeout=60,
-                logger=log.msg,
-            )
-            if not response or response.status_code // 100 != 2:
-                log.msg(f'Failed to fetch metadata/commit_classes.json from network with status code {response.status_code}')
-            else:
-                cls._commit_classes = [CommitClassifier(**node) for node in response.json()]
+            if USE_LOCAL_COMMIT_CLASSES:
+                # Local file mode
+                with open(COMMIT_CLASSES_PATH, 'r') as f:
+                    cls._commit_classes = [CommitClassifier(**node) for node in json.load(f)]
                 cls._last_commit_classes_refresh = current_time
+            else:
+                # Network fetch mode
+                response = yield TwistedAdditions.request(
+                    url=cls.COMMIT_CLASSES_URL,
+                    type=b'GET',
+                    timeout=60,
+                    logger=log.msg,
+                )
+                if not response or response.status_code // 100 != 2:
+                    log.msg(f'Failed to fetch metadata/commit_classes.json from network with status code {response.status_code if response else "no response"}')
+                else:
+                    cls._commit_classes = [CommitClassifier(**node) for node in response.json()]
+                    cls._last_commit_classes_refresh = current_time
         except Exception as e:
-            log.msg('Exception while fetching metadata/commit_classes.json from network')
+            log.msg('Exception while loading metadata/commit_classes.json')
             log.msg(f'    {e}')
 
         return defer.returnValue(cls._commit_classes)

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -56,18 +56,18 @@ BUG_SERVER_URL = 'https://bugs.webkit.org/'
 COMMITS_INFO_URL = 'https://commits.webkit.org/'
 S3URL = 'https://s3-us-west-2.amazonaws.com/'
 S3_BUCKET = f'ews-archives.webkit{custom_suffix}.org'
-S3_RESULTS_URL = f'https://ews-build{custom_suffix}.s3-us-west-2.amazonaws.com/'
+S3_RESULTS_URL = load_password('S3_RESULTS_URL', default=f'https://ews-build{custom_suffix}.s3-us-west-2.amazonaws.com/')
 CURRENT_HOSTNAME = socket.gethostname().strip()
 EWS_BUILD_HOSTNAMES = load_password('EWS_BUILD_HOSTNAMES', default=['ews-build.webkit.org', 'ews-build'])
 TESTING_ENVIRONMENT_HOSTNAMES = ['ews-build.webkit-uat.org', 'ews-build-uat', 'ews-build.webkit-dev.org', 'ews-build-dev']
-EWS_URL = load_password('EWS_BUILD_HOSTNAMES', default='https://ews.webkit.org/')
+EWS_URL = load_password('EWS_URL', default='https://ews.webkit.org/')
 RESULTS_DB_URL = 'https://results.webkit.org/'
 RESULTS_SERVER_API_KEY = 'RESULTS_SERVER_API_KEY'
 WithProperties = properties.WithProperties
 Interpolate = properties.Interpolate
 GITHUB_URL = 'https://github.com/'
 # First project is treated as the default
-GITHUB_PROJECTS = ['WebKit/WebKit', 'WebKit/WebKit-security']
+GITHUB_PROJECTS = load_password('GITHUB_PROJECTS', default=['WebKit/WebKit', 'WebKit/WebKit-security'])
 CANONICAL_GITHUB_PROJECT = 'WebKit/WebKit'
 HASH_LENGTH_TO_DISPLAY = 8
 DEFAULT_BRANCH = 'main'
@@ -81,8 +81,10 @@ SCAN_BUILD_OUTPUT_DIR = 'scan-build-output'
 LLVM_DIR = 'llvm-project'
 STATIC_ANALYSIS_ARCHIVE_PATH = '/tmp/static-analysis.zip'
 SHOULD_FILTER_LOGS = load_password('SHOULD_FILTER_LOGS', default=True)
-SHOULD_LOAD_CONTRIBUTORS_FROM_NETWORK = load_password('SHOULD_FILTER_LOGS', default=True)
+SHOULD_LOAD_CONTRIBUTORS_FROM_NETWORK = load_password('SHOULD_LOAD_CONTRIBUTORS_FROM_NETWORK', default=True)
 SUFFIX_WITHOUT_CHANGE = '-without-change'
+USE_S3 = load_password('USE_S3', default=True)
+USE_GITHUB_PROJECTS_FOR_HOOKS = load_password('USE_GITHUB_PROJECTS_FOR_HOOKS', default=True)
 
 if CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES:
     CURRENT_HOSTNAME = 'ews-build.webkit.org'
@@ -1013,8 +1015,12 @@ class InstallHooks(steps.ShellSequence):
         ]
         source = self.getProperty('github.head.repo.full_name', None)
         project = self.getProperty('project', None)
-        if project in GITHUB_PROJECTS and source:
-            install_hooks_command += ['--level', 'github.com:{}={}'.format(source, GITHUB_PROJECTS.index(project))]
+
+        if USE_GITHUB_PROJECTS_FOR_HOOKS:
+            if project in GITHUB_PROJECTS and source:
+                install_hooks_command += ['--level', 'github.com:{}={}'.format(source, GITHUB_PROJECTS.index(project))]
+        else:
+            install_hooks_command += ['--level', 'github.com:{}={}'.format(source, 2)]
 
         self.commands = []
         for command in [
@@ -3412,20 +3418,19 @@ class CompileWebKit(shell.Compile, AddToLogMixin, ShellMixin):
         self.build.buildFinished([MSG_FOR_EXCESSIVE_LOGS], FAILURE)
 
     def follow_up_steps(self):
-        if self.getProperty('platform') in self.APPLE_PLATFORMS and CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES:
-            if SHOULD_FILTER_LOGS is True:
-                return [
-                    GenerateS3URL(
-                        f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}-{self.name}",
-                        extension='txt',
-                        additions=f'{self.build.number}',
-                        content_type='text/plain',
-                    ), UploadFileToS3(
-                        'build-log.txt',
-                        links={self.name: 'Full build log'},
-                        content_type='text/plain',
-                    )
-                ]
+        if self.getProperty('platform') in self.APPLE_PLATFORMS and USE_S3 and SHOULD_FILTER_LOGS and CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES:
+            return [
+                GenerateS3URL(
+                    f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}-{self.name}",
+                    extension='txt',
+                    additions=f'{self.build.number}',
+                    content_type='text/plain',
+                ), UploadFileToS3(
+                    'build-log.txt',
+                    links={self.name: 'Full build log'},
+                    content_type='text/plain',
+                )
+            ]
         return []
 
     def evaluateCommand(self, cmd):
@@ -3447,13 +3452,12 @@ class CompileWebKit(shell.Compile, AddToLogMixin, ShellMixin):
             triggers = self.getProperty('triggers', None)
             if triggers or not self.skipUpload:
                 steps_to_add += [ArchiveBuiltProduct()]
-                if CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES:
+                if USE_S3 and CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES:
                     steps_to_add.extend([
                         GenerateS3URL(f"{self.getProperty('fullPlatform')}-{self.getProperty('archForUpload')}-{self.getProperty('configuration')}"),
                         UploadFileToS3(f"WebKitBuild/{self.getProperty('configuration')}.zip", links={self.name: 'Archive'}),
                     ])
                 else:
-                    # S3 might not be configured on local instances, achieve similar functionality without S3.
                     steps_to_add.extend([UploadBuiltProduct()])
                 if triggers:
                     steps_to_add.append(Trigger(
@@ -5550,7 +5554,7 @@ class UploadFileToS3(shell.ShellCommand, AddToLogMixin):
         return defer.returnValue(rc)
 
     def doStepIf(self, step):
-        return CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES
+        return USE_S3 and CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES
 
     def getResultSummary(self):
         if self.results == FAILURE:
@@ -5613,7 +5617,7 @@ class GenerateS3URL(master.MasterShellCommand):
         return results == SUCCESS
 
     def doStepIf(self, step):
-        return CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES
+        return USE_S3 and CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES
 
     def getResultSummary(self):
         if self.results == FAILURE:
@@ -5652,7 +5656,7 @@ class TransferToS3(master.MasterShellCommand):
         defer.returnValue(rc)
 
     def doStepIf(self, step):
-        return CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES
+        return USE_S3 and CURRENT_HOSTNAME in EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES
 
     def hideStepIf(self, results, step):
         return results == SUCCESS and self.getProperty('sensitive', False)
@@ -5684,6 +5688,11 @@ class DownloadBuiltProduct(shell.ShellCommand):
 
     @defer.inlineCallbacks
     def run(self):
+        # Skip S3 if USE_S3 is False
+        if not USE_S3:
+            self.build.addStepsAfterCurrentStep([DownloadBuiltProductFromMaster()])
+            return defer.returnValue(SKIPPED)
+
         # Only try to download from S3 on the official deployments <https://webkit.org/b/230006>
         if CURRENT_HOSTNAME not in (EWS_BUILD_HOSTNAMES + TESTING_ENVIRONMENT_HOSTNAMES):
             self.build.addStepsAfterCurrentStep([DownloadBuiltProductFromMaster()])

--- a/Tools/CISupport/ews-build/twisted_additions.py
+++ b/Tools/CISupport/ews-build/twisted_additions.py
@@ -32,11 +32,22 @@ import re
 import twisted
 
 from twisted.internet import defer, error, interfaces, protocol, reactor, task
+from twisted.python import log
 from twisted.web.client import Agent, ResponseFailed
 from twisted.web.http_headers import Headers
 from twisted.web import iweb, http, _newclient
 
 from zope.interface import implementer
+
+from .utils import load_password
+
+# Proxy configuration environment variables
+# When PROXY_ALLOWED_HOSTS is set, proxy is only used for hosts in that list
+# When empty (default), proxy is determined from standard http_proxy/https_proxy env vars
+HTTPS_PROXY_HOST = load_password('HTTPS_PROXY_HOST', default='')
+HTTPS_PROXY_PORT = int(load_password('HTTPS_PROXY_PORT', default='0') or '0')
+PROXY_ALLOWED_HOSTS = load_password('PROXY_ALLOWED_HOSTS', default=[])
+DEBUG_PROXY = load_password('DEBUG_PROXY', default=False)
 
 
 @implementer(interfaces.IReactorTCP, interfaces.IReactorSSL)
@@ -242,13 +253,35 @@ class TwistedAdditions(object):
             headers['Content-Type'] = ['application/json']
 
         try:
-            proxy = os.getenv('http_proxy') or os.getenv('https_proxy') or os.getenv('HTTP_PROXY') or os.getenv('HTTPS_PROXY')
-            match = cls.PROXY_RE.match(proxy) if proxy else None
-            if match:
-                proxy = HTTPProxyConnector(match.group('host'), int(match.group('port')))
-                agent = Agent(proxy, connectTimeout=timeout)
+            agent = None
+
+            if PROXY_ALLOWED_HOSTS:
+                # Allowlist-based proxy
+                # Only use proxy for specific allowed hosts
+                should_use_proxy = any(allowed_host in url for allowed_host in PROXY_ALLOWED_HOSTS)
+                if should_use_proxy and HTTPS_PROXY_HOST and HTTPS_PROXY_PORT:
+                    if DEBUG_PROXY:
+                        log.msg(f'Using proxy {HTTPS_PROXY_HOST}:{HTTPS_PROXY_PORT} for {hostname}')
+                    proxy = HTTPProxyConnector(HTTPS_PROXY_HOST, HTTPS_PROXY_PORT)
+                    agent = Agent(proxy, connectTimeout=timeout)
+                else:
+                    if DEBUG_PROXY:
+                        log.msg(f'Direct connection for {hostname} (Allowlist mode)')
+                    agent = Agent(reactor, connectTimeout=timeout)
             else:
-                agent = Agent(reactor, connectTimeout=timeout)
+                # Environment-based proxy
+                # Use standard http_proxy/https_proxy environment variables
+                proxy = os.getenv('http_proxy') or os.getenv('https_proxy') or os.getenv('HTTP_PROXY') or os.getenv('HTTPS_PROXY')
+                match = cls.PROXY_RE.match(proxy) if proxy else None
+                if match:
+                    if DEBUG_PROXY:
+                        log.msg(f'Using env proxy {match.group("host")}:{match.group("port")} for {hostname}')
+                    proxy = HTTPProxyConnector(match.group('host'), int(match.group('port')))
+                    agent = Agent(proxy, connectTimeout=timeout)
+                else:
+                    if DEBUG_PROXY:
+                        log.msg(f'Direct connection for {hostname} (no proxy)')
+                    agent = Agent(reactor, connectTimeout=timeout)
 
             body = cls.JSONProducer(json) if json else None
             response_d = agent.request(typ, url.encode('utf-8'), Headers(headers), body)

--- a/Tools/CISupport/ews-build/utils.py
+++ b/Tools/CISupport/ews-build/utils.py
@@ -27,7 +27,21 @@ import socket
 
 def load_password(name, default=None, master_prefix_path=os.path.dirname(os.path.abspath(__file__))):
     if os.getenv(name):
-        return os.getenv(name)
+        value = os.getenv(name)
+        # If the default is a list, dict, or bool, try to parse the env var as JSON
+        if isinstance(default, (list, dict)):
+            try:
+                return json.loads(value)
+            except (json.JSONDecodeError, TypeError):
+                return value
+        elif isinstance(default, bool):
+            # Handle boolean strings
+            if value.lower() in ('true', '1', 'yes'):
+                return True
+            elif value.lower() in ('false', '0', 'no'):
+                return False
+            return value
+        return value
     try:
         passwords = json.load(open(os.path.join(master_prefix_path, 'passwords.json')))
         return passwords.get(name, default)


### PR DESCRIPTION
#### 8cc940d357e25596b6183a5513906665aab6b705
<pre>
Conditionalize More Features
<a href="https://rdar.apple.com/170086776">rdar://170086776</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307466">https://bugs.webkit.org/show_bug.cgi?id=307466</a>

Reviewed by Jonathan Bedard.

Conditionalize More Features

* Tools/CISupport/ews-build/events.py:
(Events):
(Events.sendDataToEWS):
(Events.sendDataToGitHub):
(GitHubEventHandlerNoEdits.commit_classes):
* Tools/CISupport/ews-build/steps.py:
(InstallHooks.run):
(CompileWebKit.follow_up_steps):
(CompileWebKit.evaluateCommand):
(UploadFileToS3.doStepIf):
(GenerateS3URL.doStepIf):
(TransferToS3.doStepIf):
(DownloadBuiltProduct.run):
* Tools/CISupport/ews-build/twisted_additions.py:
(TwistedAdditions.request):
* Tools/CISupport/ews-build/utils.py:
(load_password):

Canonical link: <a href="https://commits.webkit.org/309627@main">https://commits.webkit.org/309627@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74cf7d5fa72be318ab91a757954d805d7f01f7e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/151272 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/24035 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/160001 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/104710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/153145 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/24466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/24282 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/116798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/104710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/154232 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/18927 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/135729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97516 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/18019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/15970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7846 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/127641 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13639 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/162473 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/15210 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/124808 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/150672 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23836 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/20024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124991 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23826 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/135436 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/80308 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23239 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/20057 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/12210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/23436 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/23148 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/23300 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/23202 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->