### PR TITLE
Text transformations transform the character adjacent to the selection

### DIFF
--- a/LayoutTests/editing/mac/context-menu/text-transformations-partial-selection-chinese-expected.txt
+++ b/LayoutTests/editing/mac/context-menu/text-transformations-partial-selection-chinese-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that Chinese text transformations only affect the selected text, leaving unselected text unchanged.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS actualText is "我們买书"
+
+PASS actualText is "我们買书"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/editing/mac/context-menu/text-transformations-partial-selection-chinese.html
+++ b/LayoutTests/editing/mac/context-menu/text-transformations-partial-selection-chinese.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <script src="../../../resources/js-test.js"></script>
+    <style>
+        .test-field {
+            font-size: 20px;
+            padding: 10px;
+            margin: 10px;
+            width: 300px;
+        }
+    </style>
+</head>
+<body>
+    <p id="description"></p>
+    <div id="editable1" class="test-field" contenteditable>我们买书</div>
+    <div id="editable2" class="test-field" contenteditable>我们买书</div>
+    <div id="console"></div>
+    <script>
+        description("This test verifies that Chinese text transformations only affect the selected text, leaving unselected text unchanged.");
+
+        window.jsTestIsAsync = true;
+
+        var actualText;
+
+        function findMenuItem(items, title) {
+            for (let item of items) {
+                if (item.title === title)
+                    return item;
+            }
+            return null;
+        }
+
+        function findTransformationsSubmenu(items) {
+            return findMenuItem(items, "Transformations");
+        }
+
+        function getTransformationItems(items) {
+            let menu = findTransformationsSubmenu(items);
+            if (!menu)
+                return null;
+            return menu.children;
+        }
+
+        async function selectRangeAndContextClick(elementId, startOffset, endOffset) {
+            let element = document.getElementById(elementId);
+            element.focus();
+            let textNode = element.firstChild;
+            let range = document.createRange();
+            range.setStart(textNode, startOffset);
+            range.setEnd(textNode, endOffset);
+            window.getSelection().removeAllRanges();
+            window.getSelection().addRange(range);
+
+            let rangeRect = range.getBoundingClientRect();
+            eventSender.mouseMoveTo(rangeRect.left + 2, rangeRect.top + 2);
+            return eventSender.contextClick();
+        }
+
+        async function runTests() {
+            if (!window.eventSender || !window.testRunner) {
+                debug("This test requires eventSender and testRunner.");
+                finishJSTest();
+                return;
+            }
+
+            // Select only the first 2 characters (我们)
+            let items = await selectRangeAndContextClick("editable1", 0, 2);
+            let transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                let menuItem = findMenuItem(transformItems, "Convert to Traditional Chinese");
+                if (!menuItem) {
+                    testFailed("Convert to Traditional Chinese menu item not found");
+                } else {
+                    menuItem.click();
+                    actualText = editable1.innerText;
+                    // Only 我们 should become 我們, the rest should remain simplified.
+                    shouldBeEqualToString("actualText", "我們买书");
+                }
+            }
+            debug("");
+
+            // Select the third character (买)
+            items = await selectRangeAndContextClick("editable2", 2, 3);
+            transformItems = getTransformationItems(items);
+            if (!transformItems) {
+                testFailed("Transformations submenu not found");
+            } else {
+                let menuItem = findMenuItem(transformItems, "Convert to Traditional Chinese");
+                if (!menuItem) {
+                    testFailed("Convert to Traditional Chinese menu item not found");
+                } else {
+                    menuItem.click();
+                    actualText = editable2.innerText;
+                    // Only 买 should become 買, the rest should remain simplified
+                    shouldBeEqualToString("actualText", "我们買书");
+                }
+            }
+
+            editable1.innerText = "";
+            editable2.innerText = "";
+            finishJSTest();
+        }
+
+        window.addEventListener("load", runTests);
+    </script>
+</body>
+</html>

--- a/Source/WebCore/editing/VisibleSelection.cpp
+++ b/Source/WebCore/editing/VisibleSelection.cpp
@@ -289,22 +289,23 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
             // last word to the line break (also RightWordIfOnBoundary);
             VisiblePosition start = VisiblePosition(m_start, m_affinity);
             VisiblePosition originalEnd(m_end, m_affinity);
+            VisiblePosition lastSelectedChar = (m_start != m_end) ? originalEnd.previous() : originalEnd;
             WordSide side = WordSide::RightWordIfOnBoundary;
             if (isEndOfEditableOrNonEditableContent(start) || (isEndOfLine(start) && !isStartOfLine(start) && !isEndOfParagraph(start)))
                 side = WordSide::LeftWordIfOnBoundary;
             m_start = startOfWord(start, side).deepEquivalent();
             side = WordSide::RightWordIfOnBoundary;
-            if (isEndOfEditableOrNonEditableContent(originalEnd) || (isEndOfLine(originalEnd) && !isStartOfLine(originalEnd) && !isEndOfParagraph(originalEnd)))
+            if (isEndOfEditableOrNonEditableContent(lastSelectedChar) || (isEndOfLine(lastSelectedChar) && !isStartOfLine(lastSelectedChar) && !isEndOfParagraph(lastSelectedChar)))
                 side = WordSide::LeftWordIfOnBoundary;
 
-            VisiblePosition wordEnd(endOfWord(originalEnd, side));
+            VisiblePosition wordEnd(endOfWord(lastSelectedChar, side));
             VisiblePosition end(wordEnd);
-            
+
             if (isEndOfParagraph(originalEnd) && !isEmptyTableCell(protect(m_start.deprecatedNode()).get())) {
-                // Select the paragraph break (the space from the end of a paragraph to the start of 
+                // Select the paragraph break (the space from the end of a paragraph to the start of
                 // the next one) to match TextEdit.
                 end = wordEnd.next();
-                
+
                 if (RefPtr table = isFirstPositionAfterTable(end)) {
                     // The paragraph break after the last paragraph in the last cell of a block table ends
                     // at the start of the paragraph after the table.
@@ -313,12 +314,12 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
                     else
                         end = wordEnd;
                 }
-                
+
                 if (end.isNull())
                     end = wordEnd;
-                    
+
             }
-                
+
             m_end = end.deepEquivalent();
 
             // End must not be before start.
@@ -333,7 +334,7 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
         case TextGranularity::LineGranularity: {
             m_start = startOfLine(VisiblePosition(m_start, m_affinity)).deepEquivalent();
             VisiblePosition end = endOfLine(VisiblePosition(m_end, m_affinity));
-            // If the end of this line is at the end of a paragraph, include the space 
+            // If the end of this line is at the end of a paragraph, include the space
             // after the end of the line in the selection.
             if (isEndOfParagraph(end)) {
                 VisiblePosition next = end.next();
@@ -353,7 +354,7 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
                 position = position.previous();
             m_start = startOfParagraph(position).deepEquivalent();
             VisiblePosition visibleParagraphEnd = endOfParagraph(VisiblePosition(m_end, m_affinity));
-            
+
             // Include the "paragraph break" (the space from the end of this paragraph to the start
             // of the next one) in the selection.
             VisiblePosition end(visibleParagraphEnd.next());
@@ -390,14 +391,13 @@ void VisibleSelection::adjustSelectionRespectingGranularity(TextGranularity gran
             ASSERT_NOT_REACHED();
             break;
     }
-    
+
     // Make sure we do not have a dangling start or end.
     if (m_start.isNull())
         m_start = m_end;
     if (m_end.isNull())
         m_end = m_start;
 }
-
 void VisibleSelection::updateSelectionType()
 {
     if (m_start.isNull()) {


### PR DESCRIPTION
#### 807aeff90572d0c9814c1c696718ffced20ca097
<pre>
Text transformations transform the character adjacent to the selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=307467">https://bugs.webkit.org/show_bug.cgi?id=307467</a>
<a href="https://rdar.apple.com/170087056">rdar://170087056</a>

Reviewed by NOBODY (OOPS!).

When performing a text transformation from the context menu, the character
right to the selected text is included. This doesn&apos;t matter for latin text
since spaces break up words, but for Chinese text, it can lead to unintended
transformations.

Fix this by adjusting `VisibleSelection::adjustSelectionRespectingGranularity`
for the word granularity so that the last character is the last character in
the selection, not the first character after.

Test: editing/mac/context-menu/text-transformations-partial-selection-chinese.html

* LayoutTests/editing/mac/context-menu/text-transformations-partial-selection-chinese-expected.txt: Added.
* LayoutTests/editing/mac/context-menu/text-transformations-partial-selection-chinese.html: Added.
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::adjustSelectionRespectingGranularity):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/807aeff90572d0c9814c1c696718ffced20ca097

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152763 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97332 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afb69f66-171c-4853-b47a-df05ce45a36f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17254 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16666 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110800 "Found 5 new test failures: editing/selection/5195166-1.html editing/selection/extend-after-mouse-selection.html editing/selection/select-from-textfield-outwards.html editing/selection/shift-click-live-range.html editing/undo/undo-smart-delete-reversed-selection.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79627 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eaa8d6f3-11b8-414e-b052-d6c904e2cd28) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13217 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129461 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91718 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/984ee5b8-2e23-4f5a-803a-6a32f49b44bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12674 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10411 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/209 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6111 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155075 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16624 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7166 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118814 "Found 5 new test failures: editing/selection/5195166-1.html editing/selection/extend-after-mouse-selection.html editing/selection/select-from-textfield-outwards.html editing/selection/shift-click-live-range.html editing/undo/undo-smart-delete-reversed-selection.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16660 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13959 "Found 6 new test failures: editing/mac/selection/double-click-and-drag-over-anchor-to-select.html editing/selection/5195166-1.html editing/selection/extend-after-mouse-selection.html editing/selection/select-from-textfield-outwards.html editing/selection/shift-click-live-range.html editing/undo/undo-smart-delete-reversed-selection.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119172 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15056 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127322 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72045 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16246 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5762 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80025 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16191 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16046 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->