### PR TITLE
[macOS] Support `:open` pseudo-class on `<select>` elements

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-accessibility-minimum-target-size-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-accessibility-minimum-target-size-expected.txt
@@ -1,9 +1,9 @@
 
 
-FAIL horizontal-tb "": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button height must be at least 24 pixels. expected a number greater than or equal to 24 but got 20
-FAIL vertical-lr "": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 20
-FAIL vertical-rl "": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 20
-FAIL horizontal-tb "i": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button height must be at least 24 pixels. expected a number greater than or equal to 24 but got 20
-FAIL vertical-lr "i": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 20
-FAIL vertical-rl "i": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 20
+FAIL horizontal-tb "": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 2
+FAIL vertical-lr "": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 15
+FAIL vertical-rl "": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 15
+FAIL horizontal-tb "i": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 4.796875
+FAIL vertical-lr "i": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 15
+FAIL vertical-rl "i": Select with appearance:base-select should have targets for pointer inputs be at least 24x24 CSS pixels. assert_greater_than_equal: Button width must be at least 24 pixels. expected a number greater than or equal to 24 but got 15
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Hover styles should be present for appearance:base-select options. assert_true: dropdown should open after calling showPicker(). expected true got false
+FAIL Hover styles should be present for appearance:base-select options. assert_equals: Option background-color while hovering. expected "lab(0 0 0 / 0.1)" but got "rgba(0, 0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Top layer exit animations should work on ::picker(select) just like a popover. assert_equals: color should transition based on the exit animation. expected "rgb(128, 128, 128)" but got "rgba(0, 0, 0, 0.847)"
+FAIL Top layer exit animations should work on ::picker(select) just like a popover. assert_equals: color should transition based on the exit animation. expected "rgb(128, 128, 128)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL @starting-style should work on ::picker(select) just like a popover. assert_equals: color should transition based on @starting-style. expected "rgb(128, 128, 128)" but got "rgba(0, 0, 0, 0.847)"
+FAIL @starting-style should work on ::picker(select) just like a popover. assert_equals: color should transition based on @starting-style. expected "rgb(128, 128, 128)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL defaultbutton: Synthetic events should not trigger behaviors of select element. assert_true: This test requires appearance:base-select in order to run. expected true got false
-FAIL custombutton: Synthetic events should not trigger behaviors of select element. assert_true: This test requires appearance:base-select in order to run. expected true got false
+FAIL defaultbutton: Synthetic events should not trigger behaviors of select element. assert_true: Select should open after a real click occurs. expected true got false
+FAIL custombutton: Synthetic events should not trigger behaviors of select element. assert_false: Synthetic mouse/pointer events should not open the picker. expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-many-options.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-many-options.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL The popover should be bottom left positioned assert_equals: expected 0 but got 20
+FAIL The popover should be bottom left positioned assert_equals: expected 0 but got 15
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-popover-position-with-zoom.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-popover-position-with-zoom.tentative-expected.txt
@@ -1,8 +1,8 @@
 
 
 
-FAIL The popover should be bottom left positioned assert_true: Expected 20 but got 0 expected true got false
-FAIL The popover should be top left positioned assert_true: Expected 381.3333435058594 but got 0 expected true got false
-FAIL The popover should be bottom right positioned assert_true: Expected 20 but got 0 expected true got false
-FAIL The popover should be top right positioned assert_true: Expected 130 but got 0 expected true got false
+FAIL The popover should be bottom left positioned assert_true: Expected 30 but got 0 expected true got false
+FAIL The popover should be top left positioned assert_true: Expected 579 but got 0 expected true got false
+FAIL The popover should be bottom right positioned assert_true: Expected 45 but got 0 expected true got false
+FAIL The popover should be top right positioned assert_true: Expected 540 but got 0 expected true got false
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-cross-origin-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-cross-origin-iframe-expected.txt
@@ -1,9 +1,7 @@
 
 
-Harness Error (TIMEOUT), message = null
-
 PASS Test showPicker() called from cross-origin iframe
 PASS Test showPicker() called from cross-origin iframe 1
 PASS Test showPicker() called from cross-origin iframe 2
-TIMEOUT Test showPicker() called from cross-origin iframe 3 Test timed out
+PASS Test showPicker() called from cross-origin iframe 3
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3791,19 +3791,10 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of
 imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of-widget-fallback-textarea-border-top-right-radius-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/grouped-kind-of-widget-fallback-border-top-left-radius-001.html [ ImageOnlyFailure ]
 
+# Customizable select feature.
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/customizable-select-in-page-keyboard-behavior.tentative.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select-in-page/customizable-select-in-page-mouse-behavior.tentative.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup-detailed.optional.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-keyboard-behavior.optional.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-accessibility-minimum-target-size.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-click-drag-option.optional.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-hover-active-pseudo.html [ Skip ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance.html [ Skip ]
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-listbox-touch.optional.html [ Skip ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-marker-end-aligned.tentative.html [ Skip ]
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
@@ -1,0 +1,7 @@
+details
+
+
+PASS The dialog element should support :open.
+PASS The details element should support :open.
+PASS The select element should support :open.
+

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt
@@ -1,0 +1,6 @@
+
+
+FAIL Validate <option> is focusable when is a descendant of <select> assert_equals: expected Element node <option id="select0-option2">two</option> but got Element node <select id="select0">
+  <option>one</option>
+  <option id...
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt
@@ -9,5 +9,5 @@ PASS :open pseudo-class invalidation with dialog.showModal() + dialog.requestClo
 PASS :open pseudo-class invalidation with dialog.showModal() + dialog.open = false
 PASS :open pseudo-class invalidation with dialog.open = true/false
 PASS :open pseudo-class invalidation with details.open = true/false
-PASS :open pseudo-class invalidation with select.showPicker()
+FAIL :open pseudo-class invalidation with select.showPicker() assert_equals: ancestor should be green since select is open expected "rgb(255, 0, 0)" but got "rgb(0, 0, 0)"
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt
@@ -1,0 +1,4 @@
+
+
+FAIL Hover styles should be present for appearance:base-select options. assert_true: dropdown should open after calling showPicker(). expected true got false
+

--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -1349,6 +1349,8 @@ fast/shadow-dom/shadow-host-move-to-different-document.html [ Skip ] # ImageOnly
 fast/shadow-dom/shadow-host-transition.html [ Skip ] # ImageOnlyFailure
 fast/shadow-dom/shadow-host-with-before-after.html [ Skip ] # ImageOnlyFailure
 fast/shadow-dom/shadow-layout-after-toggling-display-slot-parent.html [ Skip ] # ImageOnlyFailure
+
+imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select [ Skip ]
  
 #//////////////////////////////////////////////////////////////////////////////////////////
 # Editing

--- a/Source/WebCore/css/SelectorCheckerTestFunctions.h
+++ b/Source/WebCore/css/SelectorCheckerTestFunctions.h
@@ -597,6 +597,8 @@ ALWAYS_INLINE bool matchesOpenPseudoClass(const Element& element)
         return dialog->isOpen();
     if (auto* details = dynamicDowncast<HTMLDetailsElement>(element))
         return details->isOpen();
+    if (auto* select = dynamicDowncast<HTMLSelectElement>(element))
+        return select->isOpen();
 
     return false;
 }

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -116,7 +116,10 @@ public:
 #if !PLATFORM(IOS_FAMILY)
     void hidePopup();
     bool popupIsVisible() const { return m_popupIsVisible; }
+    void setPopupIsVisible(bool);
 #endif
+
+    bool isOpen() const;
 
     void didUpdateActiveOption(int optionIndex);
 


### PR DESCRIPTION
#### af169a2af05391ca6c04a3f1d304b63f34d4db53
<pre>
[macOS] Support `:open` pseudo-class on `&lt;select&gt;` elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=307470">https://bugs.webkit.org/show_bug.cgi?id=307470</a>
<a href="https://rdar.apple.com/170088926">rdar://170088926</a>

Reviewed by Aditya Keerthi.

Add selector checker and invalidation support.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-accessibility-minimum-target-size-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-exit-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-starting-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-synthetic-events-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-many-options.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-popover-position-with-zoom.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/show-picker-cross-origin-iframe-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/select-option-focusable.tentative-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/open-pseudo-class-in-has-expected.txt.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt: Copied from LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-option-hover-styles-expected.txt.
* LayoutTests/platform/win/TestExpectations:
* Source/WebCore/css/SelectorCheckerTestFunctions.h:
(WebCore::matchesOpenPseudoClass):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::didDetachRenderers):
(WebCore::HTMLSelectElement::showPopup):
(WebCore::HTMLSelectElement::setPopupIsVisible):
(WebCore::HTMLSelectElement::isOpen const):
(WebCore::HTMLSelectElement::popupDidHide):
* Source/WebCore/html/HTMLSelectElement.h:

Canonical link: <a href="https://commits.webkit.org/307253@main">https://commits.webkit.org/307253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e28406fa535a82a628ca152437ac2ddb11ce324

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143851 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152519 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145726 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17009 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/852ae451-2016-4099-9be9-548b731e2a1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13045 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129252 "Found 1 new API test failure: TestWebKitAPI.MediaLoading.LockdownModeHLS (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91534 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d8388ca-52cc-4750-9379-f7dcd5095ab3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12511 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10244 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2521 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121972 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5875 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154831 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16380 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6918 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118623 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16415 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13770 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118978 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/30483 "The change is no longer eligible for processing.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14900 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127084 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71793 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22187 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16001 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5569 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15735 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79772 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15947 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15800 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->