### PR TITLE
Fix repaint shift for legacy SVG when sibling starts compositing animation

### DIFF
--- a/LayoutTests/interaction-region/svg-luminance-expected.txt
+++ b/LayoutTests/interaction-region/svg-luminance-expected.txt
@@ -12,8 +12,8 @@
 
       (interaction regions [
         (guard (30.50,30) width=40 height=43),
-        (guard (30.27,24.53) width=21.33 height=36),
-        (interaction (30.27,34.53) width=21.33 height=16)
+        (guard (30.77,24.53) width=21.33 height=36),
+        (interaction (30.77,34.53) width=21.33 height=16)
         (clipPath move to (1.20,0), add line to (20.13,0), add curve to (20.80,0) (21.33,0.54) (21.33,1.20), add line to (21.33,14.80), add curve to (21.33,15.46) (20.80,16) (20.13,16), add line to (1.20,16), add curve to (0.54,16) (0,15.46) (0,14.80), add line to (0,1.20), add curve to (0,0.54) (0.54,0) (1.20,0), close subpath),
         (guard (147,30) width=40 height=43),
         (guard (147.27,24.53) width=21.33 height=36),
@@ -32,19 +32,19 @@
         (interaction (699.50,0) width=100 height=103)
         (cornerRadius 8.00),
         (guard (0.50,119) width=100 height=103),
-        (interaction (0.67,130.33) width=53.33 height=40)
+        (interaction (1.17,130.33) width=53.33 height=40)
         (clipPath move to (3,0), add line to (50.33,0), add curve to (51.99,0) (53.33,1.34) (53.33,3), add line to (53.33,37), add curve to (53.33,38.66) (51.99,40) (50.33,40), add line to (3,40), add curve to (1.34,40) (0,38.66) (0,37), add line to (0,3), add curve to (0,1.34) (1.34,0) (3,0), close subpath),
         (guard (127,129) width=80 height=83),
         (interaction (127.53,138.07) width=42.67 height=32)
         (clipPath move to (2.40,0), add line to (40.27,0), add curve to (41.59,0) (42.67,1.07) (42.67,2.40), add line to (42.67,29.60), add curve to (42.67,30.93) (41.59,32) (40.27,32), add line to (2.40,32), add curve to (1.07,32) (0,30.93) (0,29.60), add line to (0,2.40), add curve to (0,1.07) (1.07,0) (2.40,0), close subpath),
         (guard (243.50,129) width=80 height=83),
-        (interaction (243.53,138.07) width=42.67 height=32)
+        (interaction (244.03,138.07) width=42.67 height=32)
         (clipPath move to (2.40,0), add line to (40.27,0), add curve to (41.59,0) (42.67,1.07) (42.67,2.40), add line to (42.67,29.60), add curve to (42.67,30.93) (41.59,32) (40.27,32), add line to (2.40,32), add curve to (1.07,32) (0,30.93) (0,29.60), add line to (0,2.40), add curve to (0,1.07) (1.07,0) (2.40,0), close subpath),
         (interaction (391,160) width=18 height=21)
         (cornerRadius 8.00),
         (guard (507.50,160) width=18 height=21),
-        (guard (501.50,153.50) width=31.50 height=31.50),
-        (interaction (511.50,163.50) width=11.50 height=11.50)
+        (guard (501,153.50) width=31.50 height=31.50),
+        (interaction (511,163.50) width=11.50 height=11.50)
         (clipPath move to (0,11.50), add line to (11.50,0))])
       )
     )

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1854,6 +1854,7 @@ webkit.org/b/131347 fast/repaint/hidpi-device-pixel-based-repaint-rect-tracking.
 webkit.org/b/131347 fast/repaint/hidpi-transform-on-subpixel-repaintrect.html [ Failure ]
 webkit.org/b/131347 fast/repaint/hidpi-wrong-repaint-rect-when-parent-has-noncompositing-transform.html [ Failure ]
 webkit.org/b/131347 fast/block/inside-inlines/hidpi-missing-hugging-outline.html [ ImageOnlyFailure ]
+webkit.org/b/131347 svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift.html [ ImageOnlyFailure ]
 
 webkit.org/b/179948 fast/hidpi/filters-reference.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift-expected.html
+++ b/LayoutTests/svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift-expected.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test that legacy SVG does not shift when sibling becomes composited</title>
+<style>
+    body {
+        margin: 0;
+        padding: 40px;
+    }
+    .container {
+        position: relative;
+        width: 50px;
+        height: 50px;
+        padding: 9.53px;
+        background: #eee;
+        margin: 20px;
+        display: inline-block;
+    }
+    .container > svg {
+        position: relative;
+        z-index: 2;
+    }
+    .overlay {
+        position: absolute;
+        inset: 0;
+        background: black;
+        z-index: 1;
+        opacity: 0.1;
+    }
+</style>
+</head>
+<body>
+<p>Test passes if the green circle does not shift when the sibling becomes composited.</p>
+<div class="container">
+    <svg viewBox="0 0 50 50">
+        <circle cx="25" cy="25" r="20" fill="green" />
+    </svg>
+    <div class="overlay"></div>
+</div>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift.html
+++ b/LayoutTests/svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Test that legacy SVG does not shift when sibling becomes composited</title>
+<meta name="fuzzy" content="maxDifference=0-5;totalPixels=0-100">
+<script src="../repaint/resources/reftest-repaint.js"></script>
+<style>
+    body {
+        margin: 0;
+        padding: 40px;
+    }
+    .container {
+        position: relative;
+        width: 50px;
+        height: 50px;
+        /* Use awkward padding to create subpixel position at 2x scale */
+        padding: 9.53px;
+        background: #eee;
+        margin: 20px;
+        display: inline-block;
+    }
+    .container > svg {
+        position: relative;
+        z-index: 2;
+    }
+    .overlay {
+        position: absolute;
+        inset: 0;
+        background: black;
+        z-index: 1;
+        opacity: 0.1;
+    }
+</style>
+</head>
+<body onload="runRepaintRefTest()">
+<p>Test passes if the green circle does not shift when the sibling becomes composited.</p>
+<div class="container">
+    <svg viewBox="0 0 50 50">
+        <circle cx="25" cy="25" r="20" fill="green" />
+    </svg>
+    <div id="overlay" class="overlay"></div>
+</div>
+<script>
+function repaintRefTest() {
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            document.getElementById("overlay").style.transform = "translateZ(0)";
+        });
+    });
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -299,7 +299,7 @@ void LegacyRenderSVGRoot::paintReplaced(PaintInfo& paintInfo, const LayoutPoint&
 
     // Convert from container offsets (html renderers) to a relative transform (svg renderers).
     // Transform from our paint container's coordinate system to our local coords.
-    IntPoint adjustedPaintOffset = roundedIntPoint(paintOffset);
+    FloatPoint adjustedPaintOffset = roundPointToDevicePixels(paintOffset, document().deviceScaleFactor());
     auto transform = AffineTransform::makeTranslation(toFloatSize(adjustedPaintOffset)) * localToBorderBoxTransform();
     childPaintInfo.applyTransform(transform);
     if (paintInfo.phase == PaintPhase::EventRegion && childPaintInfo.eventRegionContext())


### PR DESCRIPTION
#### 195fe2ac4459d89f6a54973fa2bc88c0f973ecf0
<pre>
Fix repaint shift for legacy SVG when sibling starts compositing animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=307471">https://bugs.webkit.org/show_bug.cgi?id=307471</a>
<a href="https://rdar.apple.com/126342948">rdar://126342948</a>

Reviewed by Simon Fraser.

When a sibling element starts a compositing animation (opacity transition),
legacy SVG content could shift by up to 0.5 pixels. This occurred because the
non-composited and composited paint paths used different pixel snapping methods

For ex, a paint offset of 69.515625 would round to 70 in the non-composited
path but snap to 69.5 in the composited path, causing a visible shift when the
SVG&apos;s layer became composited due to overlap with the animating sibling.

This fix subpixelizes to use roundPointToDevicePixels, so both (non-composited and composited)
paths have consistent device snapping.

* LayoutTests/svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift-expected.html: Added.
* LayoutTests/svg/compositing/hidpi-legacy-svg-compositing-sibling-no-shift.html: Added.

The container uses awkward padding (9.53px) to create subpixel positioning at 2x
scale, which is necessary to expose the snapping discrepancy. Notably, using
will-change on the overlay does not reproduce the bug. Similarly,
CSS transitions pre-composite elements in anticipation of
animation, which also masks the bug.

To actually trigger the problematic code path, we apply transform: translateZ(0)
after initial layout, forcing a compositing state change at runtime.

The expected file intentionally has no compositing, showing the baseline SVG position.

* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::paintReplaced):

Canonical link: <a href="https://commits.webkit.org/307371@main">https://commits.webkit.org/307371@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba7f2ca8e629b278407a6d262097894b1c4aef3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16885 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152876 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5773dee8-f549-485b-985f-6c9e88c40c7c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146081 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110892 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6613e677-7950-4c23-92af-4ca7ec0a1b05) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129561 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91808 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d89321b-e64b-4c95-b626-c3782670fed1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10484 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/322 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155188 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16737 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118910 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16774 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14057 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119267 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30573 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15143 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127427 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72158 "Built successfully") | | 
| [❌ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22239 "") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16359 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5863 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16094 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80138 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16304 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16159 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->