### PR TITLE
[iOS] Support `:open` pseudo-class on `<select>` elements

### DIFF
--- a/LayoutTests/fast/forms/ios/select-open-pseudo-class-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-open-pseudo-class-expected.txt
@@ -1,0 +1,17 @@
+This test verifies that the :open pseudo-class matches when a select element's picker is shown.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS getComputedStyle(select).color is "rgb(0, 0, 0)"
+PASS select.matches(':open') is false
+Opening select picker...
+PASS getComputedStyle(select).color is "rgb(0, 128, 0)"
+PASS select.matches(':open') is true
+Closing select picker...
+PASS getComputedStyle(select).color is "rgb(0, 0, 0)"
+PASS select.matches(':open') is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-open-pseudo-class.html
+++ b/LayoutTests/fast/forms/ios/select-open-pseudo-class.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+        <style>
+            select {
+                color: black;
+            }
+            select:open {
+                color: green;
+            }
+        </style>
+    </head>
+<body>
+<select id="select">
+    <option>January</option>
+    <option>February</option>
+    <option>March</option>
+    <option>April</option>
+    <option>May</option>
+    <option>June</option>
+</select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that the :open pseudo-class matches when a select element's picker is shown.");
+
+    shouldBeEqualToString("getComputedStyle(select).color", "rgb(0, 0, 0)");
+    shouldBeFalse("select.matches(':open')");
+
+    debug("Opening select picker...");
+    await UIHelper.activateElement(select);
+    await UIHelper.waitForContextMenuToShow();
+
+    shouldBeEqualToString("getComputedStyle(select).color", "rgb(0, 128, 0)");
+    shouldBeTrue("select.matches(':open')");
+
+    debug("Closing select picker...");
+    await UIHelper.dismissMenu();
+    await UIHelper.waitForContextMenuToHide();
+
+    shouldBeEqualToString("getComputedStyle(select).color", "rgb(0, 0, 0)");
+    shouldBeFalse("select.matches(':open')");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt
@@ -1,0 +1,7 @@
+details
+
+
+PASS The dialog element should support :open.
+PASS The details element should support :open.
+PASS The select element should support :open.
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
@@ -1,0 +1,5 @@
+invoker
+
+FAIL Buttons in the popover should be rendered and should not close the popover when clicked. promise_test: Unhandled rejection with value: object "Error: element click intercepted error"
+FAIL Non-interactive content in the popover should not close the popover when clicked. assert_false: Select should be closed at the start of the test. expected false got true
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-iterate-before-beginning.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-iterate-before-beginning.optional-expected.txt
@@ -1,0 +1,7 @@
+button
+
+FAIL Attempting to focus the previous option while focused on the first option should not crash. assert_equals: The first option should be focused after opening the select. expected Element node <option class="one">one</option> but got Element node <select id="s1">
+  <button>button</button>
+  <option clas...
+FAIL Keyboard navigating backwards over an <hr> and <optgroup> should not crash. assert_true: select should open after clicking it. expected true got false
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt
@@ -1,0 +1,12 @@
+light dismiss
+custom button button fallback button
+
+FAIL fallbackbutton: Select with appearance:base-select should open and close when clicking the button. assert_false: Select should be closed after clicking the button a second time. expected false got true
+FAIL fallbackbutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_false: Select should be closed at the start of the test. expected false got true
+FAIL fallbackbutton: Clicking the label should focus the select button without opening the picker. assert_false: select picker should be closed after clicking the label. expected false got true
+FAIL fallbackbutton: Touch input should work the same as mouse input. assert_equals: select.value should be updated after touching another option. expected "two" but got "one"
+FAIL custombutton: Select with appearance:base-select should open and close when clicking the button. assert_false: Select should be closed after clicking the button a second time. expected false got true
+FAIL custombutton: Clicking an option in an appearance:base-select select should choose the option and close the popover. assert_false: Select should be closed at the start of the test. expected false got true
+FAIL custombutton: Clicking the label should focus the select button without opening the picker. assert_false: select picker should be closed after clicking the label. expected false got true
+FAIL custombutton: Touch input should work the same as mouse input. assert_equals: select.value should be updated after touching another option. expected "two" but got "one"
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS select should support :open pseudo selector.
+FAIL select :open and :not(:open) should invalidate correctly. assert_equals: The style rules from :open should apply when the select is open. expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
+

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1874,21 +1874,17 @@ void HTMLSelectElement::hidePopup()
     if (RefPtr popup = m_popup)
         popup->hide();
 }
+#endif
 
 void HTMLSelectElement::setPopupIsVisible(bool visible)
 {
     Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Open, visible);
     m_popupIsVisible = visible;
 }
-#endif
 
 bool HTMLSelectElement::isOpen() const
 {
-#if PLATFORM(IOS_FAMILY)
-    return false;
-#else
-    return popupIsVisible();
-#endif
+    return m_popupIsVisible;
 }
 
 ExceptionOr<void> HTMLSelectElement::showPicker()

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -115,9 +115,10 @@ public:
     void showPopup();
 #if !PLATFORM(IOS_FAMILY)
     void hidePopup();
-    bool popupIsVisible() const { return m_popupIsVisible; }
-    void setPopupIsVisible(bool);
 #endif
+
+    bool popupIsVisible() const { return m_popupIsVisible; }
+    WEBCORE_EXPORT void setPopupIsVisible(bool);
 
     bool isOpen() const;
 
@@ -292,8 +293,8 @@ private:
 
 #if !PLATFORM(IOS_FAMILY)
     RefPtr<PopupMenu> m_popup;
-    bool m_popupIsVisible { false };
 #endif
+    bool m_popupIsVisible { false };
 };
 
 } // namespace

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -1252,6 +1252,7 @@ public:
     void focusNextFocusedElement(bool isForward, CompletionHandler<void()>&&);
     void setFocusedElementValue(const WebCore::ElementContext&, const String&);
     void setFocusedElementSelectedIndex(const WebCore::ElementContext&, uint32_t index, bool allowMultipleSelection = false);
+    void setSelectElementIsOpen(const WebCore::ElementContext&, bool isOpen);
     void applicationDidEnterBackground();
     void applicationDidFinishSnapshottingAfterEnteringBackground();
     void applicationWillEnterForeground();

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1101,6 +1101,11 @@ void WebPageProxy::setFocusedElementSelectedIndex(const WebCore::ElementContext&
     protect(legacyMainFrameProcess())->send(Messages::WebPage::SetFocusedElementSelectedIndex(context, index, allowMultipleSelection), webPageIDInMainFrameProcess());
 }
 
+void WebPageProxy::setSelectElementIsOpen(const WebCore::ElementContext& context, bool isOpen)
+{
+    protect(legacyMainFrameProcess())->send(Messages::WebPage::SetSelectElementIsOpen(context, isOpen), webPageIDInMainFrameProcess());
+}
+
 void WebPageProxy::didPerformDictionaryLookup(const DictionaryPopupInfo& dictionaryPopupInfo)
 {
     if (RefPtr pageClient = this->pageClient())

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1159,6 +1159,7 @@ public:
     void autofillLoginCredentials(const String&, const String&);
     void setFocusedElementValue(const WebCore::ElementContext&, const String&);
     void setFocusedElementSelectedIndex(const WebCore::ElementContext&, uint32_t index, bool allowMultipleSelection);
+    void setSelectElementIsOpen(const WebCore::ElementContext&, bool isOpen);
     void setIsShowingInputViewForFocusedElement(bool);
     bool isShowingInputViewForFocusedElement() const { return m_isShowingInputViewForFocusedElement; }
     void updateSelectionAppearance();

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -127,6 +127,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     AutofillLoginCredentials(String username, String password)
     SetFocusedElementValue(struct WebCore::ElementContext context, String value)
     SetFocusedElementSelectedIndex(struct WebCore::ElementContext context, uint32_t index, bool allowMultipleSelection)
+    SetSelectElementIsOpen(struct WebCore::ElementContext context, bool isOpen)
     ApplicationWillResignActive()
     ApplicationDidEnterBackground(bool isSuspendedUnderLock)
     ApplicationDidFinishSnapshottingAfterEnteringBackground()

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -1659,6 +1659,12 @@ void WebPage::setFocusedElementSelectedIndex(const WebCore::ElementContext& cont
         select->optionSelectedByUser(index, true, allowMultipleSelection);
 }
 
+void WebPage::setSelectElementIsOpen(const WebCore::ElementContext& context, bool isOpen)
+{
+    if (RefPtr select = dynamicDowncast<HTMLSelectElement>(elementForContext(context)))
+        select->setPopupIsVisible(isOpen);
+}
+
 void WebPage::setIsShowingInputViewForFocusedElement(bool showingInputView)
 {
     m_isShowingInputViewForFocusedElement = showingInputView;

--- a/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
+++ b/Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py
@@ -74,7 +74,7 @@ def _platform_name_for_bot(bot_name):
     if "-debug" in name:
         name = name.replace("-debug", "")
     if "-wpt" in name:
-        name = name.replace("-wpt", "")
+        return "ios"
     return name
 
 


### PR DESCRIPTION
#### 6e1bf0271cf08b4371172b3844ef97bba8c8e96f
<pre>
[iOS] Support `:open` pseudo-class on `&lt;select&gt;` elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=307473">https://bugs.webkit.org/show_bug.cgi?id=307473</a>
<a href="https://rdar.apple.com/170091970">rdar://170091970</a>

Reviewed by Aditya Keerthi.

Use IPC from WKFormSelectPicker to report the open state.

* LayoutTests/fast/forms/ios/select-open-pseudo-class-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-open-pseudo-class.html: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/selectors/open-pseudo-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-iterate-before-beginning.optional-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mouse-behavior-expected.txt: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt: Added.
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::setPopupIsVisible):
(WebCore::HTMLSelectElement::isOpen const):
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::setSelectElementIsOpen):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPicker contextMenuInteraction:willDisplayMenuForConfiguration:animator:]):
(-[WKSelectPicker contextMenuInteraction:willEndForConfiguration:animator:]):
(-[WKSelectPicker resetContextMenuPresenter]):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::setSelectElementIsOpen):
* Tools/Scripts/webkitpy/common/net/bugzilla/results_fetcher.py:
(_platform_name_for_bot):

Canonical link: <a href="https://commits.webkit.org/307294@main">https://commits.webkit.org/307294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92165c0718276c7611c43c0edc96706f80149265

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144002 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/8234 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152672 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145877 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/17163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16574 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/110733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146965 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/17163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/91652 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/143328 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/17163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/17163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/6037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154984 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/7092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/16569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/13893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/119098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/127248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71954 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22207 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/16155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/15889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/15955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->