### PR TITLE
[JSC] Let fast_float parse numbers in JSON

### DIFF
--- a/LayoutTests/js/dom/JSON-parse-complex-expected.txt
+++ b/LayoutTests/js/dom/JSON-parse-complex-expected.txt
@@ -304,11 +304,11 @@ PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable 
 function(jsonObject){
         return jsonObject.parse('2e-+10');
     }
-PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Exponent symbols should be followed by an optional '+' or '-' and then by at least one number.
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
 function(jsonObject){
         return jsonObject.parse('2e+-10');
     }
-PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Exponent symbols should be followed by an optional '+' or '-' and then by at least one number.
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
 function(jsonObject){
         return jsonObject.parse('2e3e4');
     }

--- a/LayoutTests/js/dom/JSON-parse-expected.txt
+++ b/LayoutTests/js/dom/JSON-parse-expected.txt
@@ -304,11 +304,11 @@ PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable 
 function(jsonObject){
         return jsonObject.parse('2e-+10');
     }
-PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Exponent symbols should be followed by an optional '+' or '-' and then by at least one number.
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
 function(jsonObject){
         return jsonObject.parse('2e+-10');
     }
-PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Exponent symbols should be followed by an optional '+' or '-' and then by at least one number.
+PASS tests[i](nativeJSON) threw exception SyntaxError: JSON Parse error: Unable to parse JSON string.
 function(jsonObject){
         return jsonObject.parse('2e3e4');
     }

--- a/Source/JavaScriptCore/runtime/LiteralParser.h
+++ b/Source/JavaScriptCore/runtime/LiteralParser.h
@@ -268,6 +268,7 @@ private:
         ALWAYS_INLINE TokenType lexString(LiteralParserToken<CharType>&, CharType terminator);
         TokenType lexStringSlow(LiteralParserToken<CharType>&, const CharType* runStart, CharType terminator);
         ALWAYS_INLINE TokenType lexNumber(LiteralParserToken<CharType>&);
+        TokenType lexNumberError(LiteralParserToken<CharType>&);
 
         String m_lexErrorMessage;
         LiteralParserToken<CharType> m_currentToken;

--- a/Source/WTF/wtf/FastFloat.cpp
+++ b/Source/WTF/wtf/FastFloat.cpp
@@ -49,4 +49,29 @@ double parseDouble(std::span<const char16_t> string, size_t& parsedLength)
     return doubleValue;
 }
 
+std::optional<double> parseJSONDouble(std::span<const Latin1Character> string, size_t& parsedLength)
+{
+    double doubleValue = 0;
+    auto stringData = byteCast<char>(string);
+    auto result = fast_float::from_chars(std::to_address(stringData.begin()), std::to_address(stringData.end()), doubleValue, fast_float::chars_format::json);
+    if (!result) [[unlikely]] {
+        if (result.ec != std::errc::result_out_of_range)
+            return std::nullopt;
+    }
+    parsedLength = result.ptr - stringData.data();
+    return doubleValue;
+}
+
+std::optional<double> parseJSONDouble(std::span<const char16_t> string, size_t& parsedLength)
+{
+    double doubleValue = 0;
+    auto result = fast_float::from_chars(std::to_address(string.begin()), std::to_address(string.end()), doubleValue, fast_float::chars_format::json);
+    if (!result) [[unlikely]] {
+        if (result.ec != std::errc::result_out_of_range)
+            return std::nullopt;
+    }
+    parsedLength = result.ptr - string.data();
+    return doubleValue;
+}
+
 } // namespace WTF

--- a/Source/WTF/wtf/FastFloat.h
+++ b/Source/WTF/wtf/FastFloat.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <optional>
 #include <span>
 #include <unicode/utypes.h>
 #include <wtf/ASCIICType.h>
@@ -33,5 +34,8 @@ namespace WTF {
 
 WTF_EXPORT_PRIVATE double parseDouble(std::span<const Latin1Character> string, size_t& parsedLength);
 WTF_EXPORT_PRIVATE double parseDouble(std::span<const char16_t> string, size_t& parsedLength);
+
+WTF_EXPORT_PRIVATE std::optional<double> parseJSONDouble(std::span<const Latin1Character> string, size_t& parsedLength);
+WTF_EXPORT_PRIVATE std::optional<double> parseJSONDouble(std::span<const char16_t> string, size_t& parsedLength);
 
 } // namespace WTF


### PR DESCRIPTION
#### 1625d084a7f47cc70ff6bba2ad08b4fe7c29c3dc
<pre>
[JSC] Let fast_float parse numbers in JSON
<a href="https://bugs.webkit.org/show_bug.cgi?id=307476">https://bugs.webkit.org/show_bug.cgi?id=307476</a>
<a href="https://rdar.apple.com/170092076">rdar://170092076</a>

Reviewed by Keith Miller.

Let fast_float parse complex numbers directly. It is supporting JSON
format strictly so we do not need to parse the same format twice.

* LayoutTests/js/dom/JSON-parse-complex-expected.txt:
* LayoutTests/js/dom/JSON-parse-expected.txt:
* Source/JavaScriptCore/runtime/LiteralParser.cpp:
(JSC::reviverMode&gt;::Lexer::lexNumber):
(JSC::reviverMode&gt;::Lexer::lexNumberError):
* Source/JavaScriptCore/runtime/LiteralParser.h:
* Source/WTF/wtf/FastFloat.cpp:
(WTF::parseJSONDouble):
* Source/WTF/wtf/FastFloat.h:

Canonical link: <a href="https://commits.webkit.org/307673@main">https://commits.webkit.org/307673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9f057d915af4f3e7ba79ec57cee1194aea49f6e6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17772 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9547 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153762 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/569925d8-bdf7-4c3e-8949-70bdd318d1b7) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18255 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111562 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e45845bb-9bad-4370-8839-9e3258551727) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148054 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92460 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d78b6f0-c1f4-41a7-be6a-1b3dd75ffd90) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13290 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11053 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1207 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137082 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7083 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156074 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5900 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17623 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119568 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17669 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14707 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119898 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15687 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128341 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22387 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17244 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6600 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176380 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16980 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81023 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45371 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17044 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->