### PR TITLE
[WTF] Respect Malloc param for Vector/SegmentedVector self-alloc

### DIFF
--- a/Source/WTF/wtf/SegmentedVector.h
+++ b/Source/WTF/wtf/SegmentedVector.h
@@ -37,7 +37,7 @@ namespace WTF {
     // An iterator for SegmentedVector. It supports only the pre ++ operator
     template <typename T, size_t SegmentSize, typename Malloc> class SegmentedVector;
     template <typename T, size_t SegmentSize = 8, typename Malloc = SegmentedVectorMalloc> class SegmentedVectorIterator {
-        WTF_MAKE_CONFIGURABLE_ALLOCATED(FastMalloc);
+        WTF_MAKE_CONFIGURABLE_ALLOCATED(Malloc);
     private:
         friend class SegmentedVector<T, SegmentSize, Malloc>;
     public:

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -573,7 +573,7 @@ struct UnsafeVectorOverflow {
 // Template default values are in Forward.h.
 template<typename T, size_t inlineCapacity, typename OverflowHandler, size_t minCapacity, typename Malloc>
 class Vector : private VectorBuffer<T, inlineCapacity, Malloc> {
-    WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(Vector, FastMalloc);
+    WTF_MAKE_CONFIGURABLE_ALLOCATED_WITH_HEAP_IDENTIFIER(Vector, Malloc);
 private:
     typedef VectorBuffer<T, inlineCapacity, Malloc> Base;
     typedef VectorTypeOperations<T> TypeOperations;


### PR DESCRIPTION
#### 6cf69abe47bdfb208cd90a9b98a0ea4d9da61401
<pre>
[WTF] Respect Malloc param for Vector/SegmentedVector self-alloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=307481">https://bugs.webkit.org/show_bug.cgi?id=307481</a>
<a href="https://rdar.apple.com/170095922">rdar://170095922</a>

Reviewed by NOBODY (OOPS!).

They correctly use the Malloc template parameter when allocating their
backing stores, but as-is not for if you heap-allocate the
Vector/SegmentedVector itself.
This patch fixes that by passing the right Malloc param through.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6cf69abe47bdfb208cd90a9b98a0ea4d9da61401

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143746 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16227 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7926 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152414 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/96983 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d411168-1721-4b47-b981-a3e605454402) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16904 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16315 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/152414 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/96983 "Hash 6cf69abe for PR 58341 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146709 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/16904 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/7926 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/152414 "Hash 6cf69abe for PR 58341 does not build (failure)") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec5882dc-a5ff-43db-8e0a-350625e64b05) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/16904 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/7926 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2416 "Hash 6cf69abe for PR 58341 does not build (failure)") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135734 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/16904 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/7926 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154726 "Hash 6cf69abe for PR 58341 does not build (failure)") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4552 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16275 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/7926 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/154726 "Hash 6cf69abe for PR 58341 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16310 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/16315 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/154726 "Hash 6cf69abe for PR 58341 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/7926 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71688 "Hash 6cf69abe for PR 58341 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15896 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/7926 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175032 "Hash 6cf69abe for PR 58341 does not build (failure)") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15630 "Hash 6cf69abe for PR 58341 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79667 "Failed to build and analyze WebKit") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/175032 "Hash 6cf69abe for PR 58341 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15842 "Hash 6cf69abe for PR 58341 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15694 "Hash 6cf69abe for PR 58341 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->