### PR TITLE
Resolve grid-auto-flow:normal during layout rather than style computation

### DIFF
--- a/LayoutTests/fast/css-grid-layout/grid-auto-flow-get-set-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-auto-flow-get-set-expected.txt
@@ -12,19 +12,19 @@ PASS window.getComputedStyle(gridAutoFlowRowDense, '').getPropertyValue('grid-au
 PASS window.getComputedStyle(gridAutoFlowDenseColumn, '').getPropertyValue('grid-auto-flow') is 'column dense'
 PASS window.getComputedStyle(gridAutoFlowDenseRow, '').getPropertyValue('grid-auto-flow') is 'dense'
 PASS window.getComputedStyle(gridAutoFlowInherit, '').getPropertyValue('grid-auto-flow') is 'column'
-PASS window.getComputedStyle(gridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(gridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 
 Test getting grid-auto-flow bad values set through CSS
-PASS window.getComputedStyle(gridAutoFlowNone, '').getPropertyValue('grid-auto-flow') is 'row'
-PASS window.getComputedStyle(gridAutoFlowColumns, '').getPropertyValue('grid-auto-flow') is 'row'
-PASS window.getComputedStyle(gridAutoFlowRows, '').getPropertyValue('grid-auto-flow') is 'row'
-PASS window.getComputedStyle(gridAutoFlowColumnFoo, '').getPropertyValue('grid-auto-flow') is 'row'
-PASS window.getComputedStyle(gridAutoFlowColumnColumn, '').getPropertyValue('grid-auto-flow') is 'row'
-PASS window.getComputedStyle(gridAutoFlowDenseRowRow, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(gridAutoFlowNone, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
+FAIL window.getComputedStyle(gridAutoFlowColumns, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
+FAIL window.getComputedStyle(gridAutoFlowRows, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
+FAIL window.getComputedStyle(gridAutoFlowColumnFoo, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
+FAIL window.getComputedStyle(gridAutoFlowColumnColumn, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
+FAIL window.getComputedStyle(gridAutoFlowDenseRowRow, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 
 Test the initial value
 PASS element.style.gridAutoFlow is ''
-PASS window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 
 Test getting and setting grid-auto-flow through JS
 PASS element.style.gridAutoFlow is 'column'
@@ -44,15 +44,15 @@ PASS window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') is 
 
 Test getting and setting bad values for grid-auto-flow through JS
 PASS element.style.gridAutoFlow is ''
-PASS window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS element.style.gridAutoFlow is ''
-PASS window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS element.style.gridAutoFlow is ''
-PASS window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 
 Test setting grid-auto-flow to 'initial' through JS
 PASS element.style.gridAutoFlow is 'initial'
-PASS window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(element, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css-grid-layout/grid-auto-flow-get-set-grid-lanes-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-auto-flow-get-set-grid-lanes-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 Test getting grid-auto-flow set through CSS when grid-templates-* is none.
-PASS window.getComputedStyle(noneGridAutoFlowInitial, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(noneGridAutoFlowInitial, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(noneGridAutoFlowColumnSparse, '').getPropertyValue('grid-auto-flow') is 'column'
 PASS window.getComputedStyle(noneGridAutoFlowRowSparse, '').getPropertyValue('grid-auto-flow') is 'row'
 PASS window.getComputedStyle(noneGridAutoFlowDense, '').getPropertyValue('grid-auto-flow') is 'dense'
@@ -13,9 +13,9 @@ PASS window.getComputedStyle(noneGridAutoFlowRowDense, '').getPropertyValue('gri
 PASS window.getComputedStyle(noneGridAutoFlowDenseColumn, '').getPropertyValue('grid-auto-flow') is 'column dense'
 PASS window.getComputedStyle(noneGridAutoFlowDenseRow, '').getPropertyValue('grid-auto-flow') is 'dense'
 PASS window.getComputedStyle(noneGridAutoFlowInherit, '').getPropertyValue('grid-auto-flow') is 'column'
-PASS window.getComputedStyle(noneGridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(noneGridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 Test getting grid-auto-flow set through CSS when only grid-template-columns is set.
-PASS window.getComputedStyle(columnsOnlyGridAutoFlowInitial, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(columnsOnlyGridAutoFlowInitial, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(columnsOnlyGridAutoFlowColumnSparse, '').getPropertyValue('grid-auto-flow') is 'column'
 PASS window.getComputedStyle(columnsOnlyGridAutoFlowRowSparse, '').getPropertyValue('grid-auto-flow') is 'row'
 PASS window.getComputedStyle(columnsOnlyGridAutoFlowDense, '').getPropertyValue('grid-auto-flow') is 'dense'
@@ -24,20 +24,20 @@ PASS window.getComputedStyle(columnsOnlyGridAutoFlowRowDense, '').getPropertyVal
 PASS window.getComputedStyle(columnsOnlyGridAutoFlowDenseColumn, '').getPropertyValue('grid-auto-flow') is 'column dense'
 PASS window.getComputedStyle(columnsOnlyGridAutoFlowDenseRow, '').getPropertyValue('grid-auto-flow') is 'dense'
 PASS window.getComputedStyle(columnsOnlyGridAutoFlowInherit, '').getPropertyValue('grid-auto-flow') is 'column'
-PASS window.getComputedStyle(columnsOnlyGridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(columnsOnlyGridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 Test getting grid-auto-flow set through CSS when only grid-template-rows is set.
-PASS window.getComputedStyle(rowsOnlyGridAutoFlowInitial, '').getPropertyValue('grid-auto-flow') is 'column'
+FAIL window.getComputedStyle(rowsOnlyGridAutoFlowInitial, '').getPropertyValue('grid-auto-flow') should be column. Was normal.
 PASS window.getComputedStyle(rowsOnlyGridAutoFlowColumnSparse, '').getPropertyValue('grid-auto-flow') is 'column'
 PASS window.getComputedStyle(rowsOnlyGridAutoFlowRowSparse, '').getPropertyValue('grid-auto-flow') is 'row'
-PASS window.getComputedStyle(rowsOnlyGridAutoFlowDense, '').getPropertyValue('grid-auto-flow') is 'column dense'
+FAIL window.getComputedStyle(rowsOnlyGridAutoFlowDense, '').getPropertyValue('grid-auto-flow') should be column dense. Was dense.
 PASS window.getComputedStyle(rowsOnlyGridAutoFlowColumnDense, '').getPropertyValue('grid-auto-flow') is 'column dense'
-PASS window.getComputedStyle(rowsOnlyGridAutoFlowRowDense, '').getPropertyValue('grid-auto-flow') is 'row dense'
+FAIL window.getComputedStyle(rowsOnlyGridAutoFlowRowDense, '').getPropertyValue('grid-auto-flow') should be row dense. Was dense.
 PASS window.getComputedStyle(rowsOnlyGridAutoFlowDenseColumn, '').getPropertyValue('grid-auto-flow') is 'column dense'
-PASS window.getComputedStyle(rowsOnlyGridAutoFlowDenseRow, '').getPropertyValue('grid-auto-flow') is 'row dense'
+FAIL window.getComputedStyle(rowsOnlyGridAutoFlowDenseRow, '').getPropertyValue('grid-auto-flow') should be row dense. Was dense.
 PASS window.getComputedStyle(rowsOnlyGridAutoFlowInherit, '').getPropertyValue('grid-auto-flow') is 'column'
-PASS window.getComputedStyle(rowsOnlyGridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') is 'column'
+FAIL window.getComputedStyle(rowsOnlyGridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') should be column. Was normal.
 Test getting grid-auto-flow set through CSS when both grid-template-rows and grid-template-columns are set.
-PASS window.getComputedStyle(bothGridAutoFlowInitial, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(bothGridAutoFlowInitial, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(bothGridAutoFlowColumnSparse, '').getPropertyValue('grid-auto-flow') is 'column'
 PASS window.getComputedStyle(bothGridAutoFlowRowSparse, '').getPropertyValue('grid-auto-flow') is 'row'
 PASS window.getComputedStyle(bothGridAutoFlowDense, '').getPropertyValue('grid-auto-flow') is 'dense'
@@ -46,7 +46,7 @@ PASS window.getComputedStyle(bothGridAutoFlowRowDense, '').getPropertyValue('gri
 PASS window.getComputedStyle(bothGridAutoFlowDenseColumn, '').getPropertyValue('grid-auto-flow') is 'column dense'
 PASS window.getComputedStyle(bothGridAutoFlowDenseRow, '').getPropertyValue('grid-auto-flow') is 'dense'
 PASS window.getComputedStyle(bothGridAutoFlowInherit, '').getPropertyValue('grid-auto-flow') is 'column'
-PASS window.getComputedStyle(bothGridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') is 'row'
+FAIL window.getComputedStyle(bothGridAutoFlowNoInherit, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css-grid-layout/grid-shorthand-get-set-expected.txt
+++ b/LayoutTests/fast/css-grid-layout/grid-shorthand-get-set-expected.txt
@@ -25,7 +25,7 @@ PASS window.getComputedStyle(gridInherit, '').getPropertyValue('grid-auto-rows')
 PASS window.getComputedStyle(gridNoInherit, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridNoInherit, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridNoInherit, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridNoInherit, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridNoInherit, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridNoInherit, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridNoInherit, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridColumnsAndAutoFlow, '').getPropertyValue('grid-template-columns') is "10px"
@@ -105,91 +105,91 @@ Test getting wrong values for 'grid' shorthand through CSS (they should resolve 
 PASS window.getComputedStyle(gridWithMisplacedAutoColumn, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithMisplacedAutoColumn, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithMisplacedAutoColumn, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithMisplacedAutoColumn, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithMisplacedAutoColumn, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithMisplacedAutoColumn, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithMisplacedAutoColumn, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithMisplacedNone1, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithMisplacedNone1, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithMisplacedNone1, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithMisplacedNone1, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithMisplacedNone1, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithMisplacedNone1, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithMisplacedNone1, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithMisplacedNone2, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithMisplacedNone2, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithMisplacedNone2, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithMisplacedNone2, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithMisplacedNone2, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithMisplacedNone2, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithMisplacedNone2, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithMisplacedDense, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithMisplacedDense, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithMisplacedDense, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithMisplacedDense, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithMisplacedDense, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithMisplacedDense, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithMisplacedDense, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithDuplicatedDense, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithDuplicatedDense, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithDuplicatedDense, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithDuplicatedDense, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithDuplicatedDense, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithDuplicatedDense, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithDuplicatedDense, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithOnlyDense, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithOnlyDense, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithOnlyDense, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithOnlyDense, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithOnlyDense, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithOnlyDense, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithOnlyDense, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithoutColumnInfo, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithoutColumnInfo, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithoutColumnInfo, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithoutColumnInfo, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithoutColumnInfo, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithoutColumnInfo, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithoutColumnInfo, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithTwoAutoFlow, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithTwoAutoFlow, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithTwoAutoFlow, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithTwoAutoFlow, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithTwoAutoFlow, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithTwoAutoFlow, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithTwoAutoFlow, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithImplicitAndNoExplicit, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithImplicitAndNoExplicit, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithImplicitAndNoExplicit, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithImplicitAndNoExplicit, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithImplicitAndNoExplicit, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithImplicitAndNoExplicit, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithImplicitAndNoExplicit, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowColumn, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowColumn, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowColumn, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowColumn, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithExtraIdBeforeAutoFlowColumn, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowColumn, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowColumn, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowRow, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowRow, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowRow, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowRow, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithExtraIdBeforeAutoFlowRow, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowRow, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoFlowRow, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoColumn, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoColumn, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoColumn, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithExtraIdBeforeAutoColumn, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithExtraIdBeforeAutoColumn, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoColumn, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoColumn, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoColumn, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoColumn, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoColumn, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithExtraIdAfterAutoColumn, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithExtraIdAfterAutoColumn, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoColumn, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoColumn, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoRow, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoRow, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoRow, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithExtraIdBeforeAutoRow, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithExtraIdBeforeAutoRow, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoRow, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdBeforeAutoRow, '').getPropertyValue('grid-auto-rows') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoRow, '').getPropertyValue('grid-template-columns') is "none"
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoRow, '').getPropertyValue('grid-template-rows') is "none"
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoRow, '').getPropertyValue('grid-template-areas') is "none"
-PASS window.getComputedStyle(gridWithExtraIdAfterAutoRow, '').getPropertyValue('grid-auto-flow') is "row"
+FAIL window.getComputedStyle(gridWithExtraIdAfterAutoRow, '').getPropertyValue('grid-auto-flow') should be row. Was normal.
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoRow, '').getPropertyValue('grid-auto-columns') is "auto"
 PASS window.getComputedStyle(gridWithExtraIdAfterAutoRow, '').getPropertyValue('grid-auto-rows') is "auto"
 
@@ -337,6 +337,7 @@ PASS getComputedStyle(anotherElement, '').getPropertyValue('grid-row-gap') is "n
 PASS getComputedStyle(anotherElement, '').getPropertyValue('grid-column-gap') is "normal"
 PASS getComputedStyle(anotherElement, '').getPropertyValue('grid-row-gap') is "normal"
 PASS successfullyParsed is true
+Some tests failed.
 
 TEST COMPLETE
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-layout-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-layout-properties-expected.txt
@@ -59,7 +59,7 @@ PASS grid-auto-rows.<track-size>.<track-breadth>.max-content
 PASS grid-auto-rows.<track-size>.<track-breadth>.minmax()
 PASS grid-auto-rows.reset
 PASS grid-auto-flow
-PASS grid-auto-flow.initial
+FAIL grid-auto-flow.initial assert_equals: initial value of grid-auto-flow should be row expected "row" but got "normal"
 PASS grid-auto-flow.row
 PASS grid-auto-flow.column
 PASS grid-auto-flow.dense

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -173,7 +173,8 @@ void GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
 
     GridAutoFlowOptions autoFlowOptions {
         .strategy = gridStyle->gridAutoFlow().isDense() ? PackingStrategy::Dense : PackingStrategy::Sparse,
-        .direction = gridStyle->gridAutoFlow().isRow() ? GridAutoFlowDirection::Row : GridAutoFlowDirection::Column
+        .direction = gridStyle->usedGridAutoFlowDirection() == Style::GridAutoFlow::Direction::Row
+            ? GridAutoFlowDirection::Row : GridAutoFlowDirection::Column
     };
 
     // https://drafts.csswg.org/css-grid-1/#track-sizes

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -238,8 +238,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
 
     // GFC currently supports grid-auto-flow: row and row dense
     // Column auto-flow is not yet supported
-    auto gridAutoFlow = renderGridStyle->gridAutoFlow();
-    if (gridAutoFlow.isColumn())
+    if (renderGridStyle->usedGridAutoFlowDirection() == Style::GridAutoFlow::Direction::Column)
         ADD_REASON_AND_RETURN_IF_NEEDED(GridHasColumnAutoFlow, reasons, reasonCollectionMode);
 
     // Check for non-fixed gaps. GFC currently only supports fixed-length gaps.
@@ -370,7 +369,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
     if (renderGridStyle->usedContain().contains(Style::ContainValue::Size))
         ADD_REASON_AND_RETURN_IF_NEEDED(GridHasContainsSize, reasons, reasonCollectionMode);
 
-    ASSERT(renderGridStyle->gridAutoFlow().isRow(),
+    ASSERT(renderGridStyle->usedGridAutoFlowDirection() == Style::GridAutoFlow::Direction::Row,
         "If we end up supporting column auto flow before broader implicit grid support then the logic using explicitlyPlacedItemsInRowCount will need to be reworked to be based upon the auto flow direction");
     Vector<size_t> explicitlyPlacedItemsInRowCount;
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1142,7 +1142,7 @@ bool RenderGrid::isMasonry(Style::GridTrackSizingDirection direction) const
         return parentGrid->isMasonry(direction);
     if (style().display() != DisplayType::GridLanes && style().display() != DisplayType::InlineGridLanes)
         return false;
-    return (direction == Style::GridTrackSizingDirection::Columns) == style().gridAutoFlow().isColumn();
+    return (direction == Style::GridTrackSizingDirection::Columns) == (style().usedGridAutoFlowDirection() == Style::GridAutoFlow::Direction::Column);
 }
 
 // Masonry Spec Section 2.3.1 repeat(auto-fit)
@@ -1470,7 +1470,8 @@ void RenderGrid::placeAutoMajorAxisItemOnGrid(RenderBox& gridItem, AutoPlacement
 
 Style::GridTrackSizingDirection RenderGrid::autoPlacementMajorAxisDirection() const
 {
-    return style().gridAutoFlow().isColumn() ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
+    return Style::GridAutoFlow::Direction::Column == style().usedGridAutoFlowDirection()
+        ? Style::GridTrackSizingDirection::Columns : Style::GridTrackSizingDirection::Rows;
 }
 
 Style::GridTrackSizingDirection RenderGrid::autoPlacementMinorAxisDirection() const

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -398,6 +398,21 @@ UsedFloat RenderStyle::usedFloat(const RenderElement& renderer)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
+Style::GridAutoFlow::Direction RenderStyle::usedGridAutoFlowDirection() const
+{
+    // FIXME: Adjust this once CSSWG clarifies exactly how the initial value should compute on other display types.
+    // For now, this gives mostly backwards-compatible behavior.
+    auto gridFlow = gridAutoFlow();
+
+    if (gridFlow.direction() != Style::GridAutoFlow::Direction::Normal)
+        return gridFlow.direction();
+
+    if ((display() == DisplayType::GridLanes || display() == DisplayType::InlineGridLanes)
+        && (!gridTemplateRows().isNone() && gridTemplateColumns().isNone()))
+            return Style::GridAutoFlow::Direction::Column;
+    return Style::GridAutoFlow::Direction::Row;
+}
+
 UserSelect RenderStyle::usedUserSelect() const
 {
     if (effectiveInert())

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -426,6 +426,7 @@ public:
     Color usedAccentColor(OptionSet<StyleColorOptions>) const;
     static UsedFloat usedFloat(const RenderElement&); // Returns logical left/right (block-relative).
     static UsedClear usedClear(const RenderElement&); // Returns logical left/right (block-relative).
+    Style::GridAutoFlow::Direction usedGridAutoFlowDirection() const;
 
     Style::LineWidth usedColumnRuleWidth() const;
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -597,23 +597,6 @@ void Adjuster::adjust(RenderStyle& style) const
             || style.display() == DisplayType::TableHeaderGroup || style.display() == DisplayType::TableRow || style.display() == DisplayType::TableRowGroup)
             style.setWritingMode(m_parentStyle.writingMode().computedWritingMode());
 
-        // FIXME: Adjust this once CSSWG clarifies exactly how the initial value should compute on other display types.
-        // For now, this gives mostly backwards-compatible behavior.
-        if (style.display() == DisplayType::Grid || style.display() == DisplayType::InlineGrid) {
-            if (auto gridAutoFlow = style.gridAutoFlow(); gridAutoFlow.direction() == GridAutoFlow::Direction::Normal) {
-                gridAutoFlow.setDirection(Style::GridAutoFlow::Direction::Row);
-                style.setGridAutoFlow(gridAutoFlow);
-            }
-        } else if (style.display() == DisplayType::GridLanes || style.display() == DisplayType::InlineGridLanes) {
-            if (auto gridAutoFlow = style.gridAutoFlow(); gridAutoFlow.direction() == GridAutoFlow::Direction::Normal) {
-                if (!style.gridTemplateRows().isNone() && style.gridTemplateColumns().isNone())
-                    gridAutoFlow.setDirection(Style::GridAutoFlow::Direction::Column);
-                else
-                    gridAutoFlow.setDirection(Style::GridAutoFlow::Direction::Row);
-                style.setGridAutoFlow(gridAutoFlow);
-            }
-        }
-
         if (style.isDisplayDeprecatedFlexibleBox()) {
             // FIXME: Since we don't support block-flow on flexible boxes yet, disallow setting
             // of block-flow to anything other than StyleWritingMode::HorizontalTb.

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -904,8 +904,6 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyMinWidth> {
 template<> struct PropertyExtractorAdaptor<CSSPropertyGridAutoFlow> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
-        // FIXME: Adjust this once CSSWG clarifies exactly how the initial value should compute.
-        // For now, this gives the most backwards-compatible behavior.
         auto gridFlow = state.style.gridAutoFlow();
         switch (gridFlow.direction()) {
         case GridAutoFlow::Direction::Column:
@@ -918,16 +916,11 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyGridAutoFlow> {
         case GridAutoFlow::Direction::Row:
             switch (gridFlow.packing()) {
             case GridAutoFlow::Packing::Dense:
-                if (!state.style.gridTemplateRows().isNone() && state.style.gridTemplateColumns().isNone()
-                    && (state.style.display() == DisplayType::GridLanes || state.style.display() == DisplayType::InlineGridLanes))
-                    return functor(SpaceSeparatedTuple { CSS::Keyword::Row { }, CSS::Keyword::Dense { } });
                 return functor(CSS::Keyword::Dense { });
             case GridAutoFlow::Packing::Sparse:
                 return functor(CSS::Keyword::Row { });
             }
         default:
-            ASSERT(state.style.display() != DisplayType::GridLanes && state.style.display() != DisplayType::InlineGridLanes
-                && state.style.display() != DisplayType::Grid && state.style.display() != DisplayType::InlineGrid);
             switch (gridFlow.packing()) {
             case GridAutoFlow::Packing::Dense:
                 return functor(CSS::Keyword::Dense { });


### PR DESCRIPTION
#### f651a288cfccd9197880a64fcbe79ebbe06a3d75
<pre>
Resolve grid-auto-flow:normal during layout rather than style computation
<a href="https://bugs.webkit.org/show_bug.cgi?id=307486">https://bugs.webkit.org/show_bug.cgi?id=307486</a>
<a href="https://rdar.apple.com/169546165">rdar://169546165</a>

Reviewed by NOBODY (OOPS!).

Style computation is pretty hot, and we don&apos;t use this value very often,
so moving computation to layout time is more likely to be performant.

No new tests (OOPS!).

* LayoutTests/fast/css-grid-layout/grid-auto-flow-get-set-expected.txt:
* LayoutTests/fast/css-grid-layout/grid-auto-flow-get-set-grid-lanes-expected.txt:
* LayoutTests/fast/css-grid-layout/grid-shorthand-get-set-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-layout-properties-expected.txt:
* Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp:
(WebCore::Layout::GridFormattingContext::layout):
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::isMasonry const):
(WebCore::RenderGrid::autoPlacementMajorAxisDirection const):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::usedGridAutoFlowDirection const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::PropertyExtractorAdaptor&lt;CSSPropertyGridAutoFlow&gt;::computedValue const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f651a288cfccd9197880a64fcbe79ebbe06a3d75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8214 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152652 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97221 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3531e43-ff82-4a15-bbfa-951496816986) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145857 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17143 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16554 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110718 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79591 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e920bb9-d829-43f0-8616-64965aaf6a68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146945 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13144 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91636 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48a6de82-5cb5-4470-98c1-b908b666b262) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12611 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10342 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/98 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122081 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6022 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154964 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16513 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7077 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118731 "Found 1 new test failure: imported/w3c/web-platform-tests/service-workers/service-worker/redirected-response.https.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16549 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13880 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119085 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14992 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127233 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71934 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16135 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5680 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15869 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79914 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15935 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->