### PR TITLE
[Site Isolation] Visibility is not always propagated to all iframe processes

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -303,6 +303,8 @@ public:
     virtual void processDidExit() = 0;
     virtual void processWillSwap() { processDidExit(); }
     virtual void didRelaunchProcess() = 0;
+    virtual void didStartUsingProcessForSiteIsolation(WebProcessProxy&) { }
+    virtual void didStopUsingProcessForSiteIsolation(WebProcessProxy&) { }
     virtual void processDidUpdateThrottleState() { }
     virtual void pageClosed() = 0;
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -96,6 +96,13 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
         m_messageReceiverRegistration.startReceivingMessages(m_process, m_webPageID, *this, page.backForwardListMessageReceiver());
 
     m_process->addRemotePageProxy(*this);
+
+    RefPtr protectedPage = m_page.get();
+    if (!protectedPage)
+        return;
+
+    if (RefPtr client = protectedPage->pageClient())
+        client->didStartUsingProcessForSiteIsolation(process);
 }
 
 void RemotePageProxy::disconnect()
@@ -194,6 +201,13 @@ void RemotePageProxy::processDidTerminate(WebProcessProxy& process, ProcessTermi
 RemotePageProxy::~RemotePageProxy()
 {
     ASSERT(m_disconnected);
+
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    if (RefPtr client = page->pageClient())
+        client->didStopUsingProcessForSiteIsolation(m_process);
 }
 
 void RemotePageProxy::didReceiveMessage(IPC::Connection& connection, IPC::Decoder& decoder)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -87,6 +87,8 @@ private:
     void processDidExit() override;
     void processWillSwap() override;
     void didRelaunchProcess() override;
+    void didStartUsingProcessForSiteIsolation(WebProcessProxy&) override;
+    void didStopUsingProcessForSiteIsolation(WebProcessProxy&) override;
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
     void didCreateContextInWebProcessForVisibilityPropagation(LayerHostingContextID) override;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -264,6 +264,16 @@ void PageClientImpl::didRelaunchProcess()
     [webView() _didRelaunchProcess];
 }
 
+void PageClientImpl::didStartUsingProcessForSiteIsolation(WebProcessProxy& webProcessProxy)
+{
+    [contentView() _didStartUsingProcessForSiteIsolation:webProcessProxy];
+}
+
+void PageClientImpl::didStopUsingProcessForSiteIsolation(WebProcessProxy& webProcessProxy)
+{
+    [contentView() _didStopUsingProcessForSiteIsolation:webProcessProxy];
+}
+
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
 void PageClientImpl::didCreateContextInWebProcessForVisibilityPropagation(LayerHostingContextID)
 {

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -103,6 +103,8 @@ enum class ViewStabilityFlag : uint8_t;
 #endif
 - (void)_processWillSwap;
 - (void)_didRelaunchProcess;
+- (void)_didStartUsingProcessForSiteIsolation:(WebKit::WebProcessProxy&)webProcessProxy;
+- (void)_didStopUsingProcessForSiteIsolation:(WebKit::WebProcessProxy&)webProcessProxy;
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)
 - (void)_webProcessDidCreateContextForVisibilityPropagation;


### PR DESCRIPTION
#### d38519318cc728a13dad839528d367142f395e0f
<pre>
[Site Isolation] Visibility is not always propagated to all iframe processes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307492">https://bugs.webkit.org/show_bug.cgi?id=307492</a>
<a href="https://rdar.apple.com/170099676">rdar://170099676</a>

Reviewed by Sihui Liu.

Notify the page client and WK content view when a process for Site Isolation is being used.

* Source/WebKit/UIProcess/PageClient.h:
(WebKit::PageClient::didStartUsingProcessForSiteIsolation):
(WebKit::PageClient::didStopUsingProcessForSiteIsolation):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::RemotePageProxy):
(WebKit::RemotePageProxy::~RemotePageProxy):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::didStartUsingProcessForSiteIsolation):
(WebKit::PageClientImpl::didStopUsingProcessForSiteIsolation):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _installVisibilityPropagationViews]):
(-[WKContentView _setupVisibilityPropagationForWebProcess:]):
(-[WKContentView _removeVisibilityPropagationForWebProcess:]):
(-[WKContentView _setupVisibilityPropagationForAllWebProcesses]):
(-[WKContentView _didRelaunchProcess]):
(-[WKContentView _didStartUsingProcessForSiteIsolation:]):
(-[WKContentView _didStopUsingProcessForSiteIsolation:]):
(-[WKContentView _webProcessDidCreateContextForVisibilityPropagation]):
(-[WKContentView _createVisibilityPropagationView]):
(-[WKContentView _setupVisibilityPropagationForWebProcess]): Deleted.

Canonical link: <a href="https://commits.webkit.org/307398@main">https://commits.webkit.org/307398@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a29d988160ab124d609001ba262477690fe5f0da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16930 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8486 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152921 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bfc0362-ca11-4a26-862e-86770575146a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16824 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110925 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147214 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13346 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129597 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91842 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ff48448-7267-4eb7-804c-ab7d2138ca96) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10518 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/367 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122275 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155233 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16782 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118943 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16819 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14092 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119301 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15174 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127464 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72203 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22254 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16404 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5897 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16139 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16349 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16204 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->