### PR TITLE
CSSHighlights not repainted when they are re-added to the registry.

### DIFF
--- a/LayoutTests/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
+++ b/LayoutTests/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
@@ -1,0 +1,7 @@
+Highlight this first and then clear highlight, then add it again.
+(repaint rects
+  (rect 8 8 783 37)
+  (rect 8 8 783 37)
+  (rect 8 8 783 37)
+)
+When run, the first "this" should be highlighted, and then the highlight should be removed. Then then highlight should be added again.

--- a/LayoutTests/fast/repaint/highlight-repainted-when-deleted-and-readded.html
+++ b/LayoutTests/fast/repaint/highlight-repainted-when-deleted-and-readded.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+html {
+    font-size: 24pt;
+}
+
+::highlight(yellowHighlight) {
+    background-color: yellow;
+}
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+    <div id="highlight_area">Highlight this first and then clear highlight, then add it again.</div>
+    <pre id="result"></pre>
+    <p>When run, the first "this" should be highlighted, and then the highlight should be removed.  Then then highlight should be added again.</p>
+</body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+(async () => {
+    if (window.internals)
+        internals.startTrackingRepaints();
+
+    let highlightRange = new Range();
+    let highlightOne = new Highlight(highlightRange);
+    CSS.highlights.set("yellowHighlight", highlightOne);
+    let highlightNode = highlight_area;
+
+    highlightRange.setStart(highlightNode.firstChild, 10);
+    highlightRange.setEnd(highlightNode.firstChild, 14);
+
+    await UIHelper.renderingUpdate();
+
+    CSS.highlights.delete("yellowHighlight");
+
+    await UIHelper.renderingUpdate();
+
+    CSS.highlights.set("yellowHighlight", highlightOne);
+
+    if (window.internals) {
+        let repaintRects = internals.repaintRectsAsText();
+        internals.stopTrackingRepaints();
+        result.textContent = repaintRects;
+    }
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+})();
+</script>
+</html>

--- a/LayoutTests/platform/glib/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
@@ -1,0 +1,7 @@
+Highlight this first and then clear highlight, then add it again.
+(repaint rects
+  (rect 8 8 556 37)
+  (rect 8 8 556 37)
+  (rect 8 8 556 37)
+)
+When run, the first "this" should be highlighted, and then the highlight should be removed. Then then highlight should be added again.

--- a/LayoutTests/platform/wpe/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
+++ b/LayoutTests/platform/wpe/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt
@@ -1,0 +1,7 @@
+Highlight this first and then clear highlight, then add it again.
+(repaint rects
+  (rect 8 8 784 37)
+  (rect 8 8 784 37)
+  (rect 8 8 784 37)
+)
+When run, the first "this" should be highlighted, and then the highlight should be removed. Then then highlight should be added again.

--- a/Source/WebCore/Modules/highlight/Highlight.cpp
+++ b/Source/WebCore/Modules/highlight/Highlight.cpp
@@ -55,7 +55,6 @@ Ref<Highlight> Highlight::create(FixedVector<std::reference_wrapper<AbstractRang
 Highlight::Highlight(FixedVector<std::reference_wrapper<AbstractRange>>&& initialRanges)
 {
     m_highlightRanges = WTF::map(initialRanges, [&](std::reference_wrapper<AbstractRange>& range) {
-        repaintRange(Ref { range.get() }.get());
         return HighlightRange::create(range.get());
     });
 }

--- a/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
+++ b/Source/WebCore/Modules/highlight/HighlightRegistry.cpp
@@ -44,6 +44,7 @@ void HighlightRegistry::setFromMapLike(AtomString&& key, Ref<Highlight>&& value)
     if (addResult.isNewEntry) {
         ASSERT(!m_highlightNames.contains(key));
         m_highlightNames.append(WTF::move(key));
+        protect(addResult.iterator->value)->repaint();
     }
 }
 


### PR DESCRIPTION
#### c411b9898504c2c99d86aae7d5d19aa0f67aa99d
<pre>
CSSHighlights not repainted when they are re-added to the registry.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307491">https://bugs.webkit.org/show_bug.cgi?id=307491</a>
<a href="https://rdar.apple.com/170099603">rdar://170099603</a>

Reviewed by Aditya Keerthi.

When adding an existing highlight to the registry, we don&apos;t ensure that
the associated ranges are repainted. We just need to ensure that when we
add a new Highlight we repaint the ranges. We should also not repaint ranges
when the highlight is created, only when the highlight is added to the registry.

Test: fast/repaint/highlight-repainted-when-deleted-and-readded.html

* LayoutTests/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt: Added.
* LayoutTests/fast/repaint/highlight-repainted-when-deleted-and-readded.html: Added.
* LayoutTests/platform/glib/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt: Added.
* LayoutTests/platform/wpe/fast/repaint/highlight-repainted-when-deleted-and-readded-expected.txt: Added.
* Source/WebCore/Modules/highlight/Highlight.cpp:
(WebCore::Highlight::Highlight):
* Source/WebCore/Modules/highlight/HighlightRegistry.cpp:
(WebCore::HighlightRegistry::setFromMapLike):

Canonical link: <a href="https://commits.webkit.org/307842@main">https://commits.webkit.org/307842@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2b27b6a5c24756ce3bb8cae4bbc2ab51b33e8376

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145526 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18208 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99163 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147401 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18693 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111917 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80194 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2a7f57ac-f4d2-49f8-9e31-23684bdbf349) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148489 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130724 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92818 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7d7610f5-2b92-4031-90fd-475f71479a82) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13606 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11373 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1645 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123150 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156511 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8612 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119922 "Found 1 new test failure: fast/repaint/highlight-repainted-when-deleted-and-readded.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18058 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15076 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120264 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30862 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128782 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73787 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16011 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6981 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17679 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81459 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17416 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17624 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->