### PR TITLE
Convert GLTF/GLB models to USDZ in ModelProcess for visionOS rendering

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -369,6 +369,22 @@ void HTMLModelElement::didFailLoading(ModelPlayer& modelPlayer, const ResourceEr
     reportExtraMemoryCost();
 }
 
+#if ENABLE(MODEL_PROCESS)
+
+void HTMLModelElement::didConvertModelData(ModelPlayer& modelPlayer, Ref<SharedBuffer>&& convertedData, const String& convertedMIMEType)
+{
+    ASSERT_UNUSED(modelPlayer, &modelPlayer == m_modelPlayer);
+    ASSERT(m_dataComplete);
+
+    RELEASE_LOG(ModelElement, "%p - HTMLModelElement::didConvertModelData: Received converted model data, size=%zu mimeType=%s", this, convertedData->size(), convertedMIMEType.utf8().data());
+
+    m_model = Model::create(WTF::move(convertedData), convertedMIMEType, m_sourceURL, true /* isConverted */);
+    m_dataMemoryCost.store(m_model->data()->size(), std::memory_order_relaxed);
+    reportExtraMemoryCost();
+}
+
+#endif
+
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
 
 void HTMLModelElement::didFinishEnvironmentMapLoading(ModelPlayer&, bool succeeded)

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -246,6 +246,9 @@ private:
     // ModelPlayerClient overrides.
     void didFinishLoading(ModelPlayer&) final;
     void didFailLoading(ModelPlayer&, const ResourceError&) final;
+#if ENABLE(MODEL_PROCESS)
+    void didConvertModelData(ModelPlayer&, Ref<SharedBuffer>&& convertedData, const String& convertedMIMEType) final;
+#endif
     void didUnload(ModelPlayer&) final;
     void didUpdate(ModelPlayer&) final;
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)

--- a/Source/WebCore/Modules/model-element/ModelPlayerClient.h
+++ b/Source/WebCore/Modules/model-element/ModelPlayerClient.h
@@ -46,6 +46,9 @@ public:
 
     virtual void didFinishLoading(ModelPlayer&) = 0;
     virtual void didFailLoading(ModelPlayer&, const ResourceError&) = 0;
+#if ENABLE(MODEL_PROCESS)
+    virtual void didConvertModelData(ModelPlayer&, Ref<SharedBuffer>&& convertedData, const String& convertedMIMEType) = 0;
+#endif
 #if ENABLE(MODEL_ELEMENT_ENVIRONMENT_MAP)
     // FIXME: This should be made consistent with didFinishLoading/didFailLoading, by splitting it into a didFinishEnvironmentMapLoading and a didFailEnvironmentMapLoading which takes a `const ResourceError&`.
     virtual void didFinishEnvironmentMapLoading(ModelPlayer&, bool succeeded) = 0;

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1291,7 +1291,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         dragImage = DragImage { createDragImageForNode(src, *modelElement) };
 
         PasteboardImage pasteboardImage;
-        pasteboardImage.suggestedName = modelElement->currentSrc().lastPathComponent().toString();
+        pasteboardImage.suggestedName = modelElement->model()->filename();
         pasteboardImage.resourceMIMEType = modelElement->model()->mimeType();
         pasteboardImage.resourceData = modelElement->model()->data();
         dataTransfer->pasteboard().write(pasteboardImage);

--- a/Source/WebKit/ModelProcess/cocoa/WKUSDStageConverter.h
+++ b/Source/WebKit/ModelProcess/cocoa/WKUSDStageConverter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -25,37 +25,17 @@
 
 #pragma once
 
-#include <WebCore/SharedBuffer.h>
-#include <wtf/RefCounted.h>
-#include <wtf/URL.h>
-#include <wtf/text/WTFString.h>
+#import <Foundation/Foundation.h>
+#import <wtf/Platform.h>
 
-namespace WTF {
-class TextStream;
-}
+#if ENABLE(MODEL_PROCESS)
 
-namespace WebCore {
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-class Model final : public RefCounted<Model> {
-public:
-    WEBCORE_EXPORT static Ref<Model> create(Ref<SharedBuffer>&&, String, URL, bool isConverted = false);
-    WEBCORE_EXPORT ~Model();
+@interface WKUSDStageConverter : NSObject
++ (nullable NSData *)convert:(NSData *)data;
+@end
 
-    Ref<SharedBuffer> data() const { return m_data; }
-    const String& mimeType() const { return m_mimeType; }
-    const URL& url() const { return m_url; }
-    bool isConverted() const { return m_isConverted; }
-    WEBCORE_EXPORT String filename() const;
+NS_HEADER_AUDIT_END(nullability, sendability)
 
-private:
-    explicit Model(Ref<SharedBuffer>&&, String, URL, bool isConverted);
-
-    Ref<SharedBuffer> m_data;
-    String m_mimeType;
-    URL m_url;
-    bool m_isConverted { false };
-};
-
-WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const Model&);
-
-} // namespace WebCore
+#endif // ENABLE(MODEL_PROCESS)

--- a/Source/WebKit/ModelProcess/cocoa/WKUSDStageConverter.swift
+++ b/Source/WebKit/ModelProcess/cocoa/WKUSDStageConverter.swift
@@ -1,0 +1,75 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import Foundation
+import os
+
+#if ENABLE_MODEL_PROCESS
+
+internal import WebKit_Internal
+
+#if canImport(_USDKit_RealityKit)
+
+// FIXME: radar://141774327
+@_weakLinked @_spi(Eryx) internal import _USDKit_RealityKit
+
+extension Logger {
+    fileprivate static let usdStageConverter = Logger(subsystem: "com.apple.WebKit", category: "USDStageConverter")
+}
+
+@objc
+@implementation
+extension WKUSDStageConverter {
+    @objc(convert:)
+    class func convert(_ data: Data) -> Data? {
+        let stage: UsdStage
+        do {
+            stage = try UsdStage.open(buffer: data)
+        } catch {
+            Logger.usdStageConverter.error("WKUSDStageConverter: Failed to open stage: \(error)")
+            return nil
+        }
+        do {
+            // FIXME: radar://141774327
+            return try stage.export(options: .preferSmallMeshFiles)
+        } catch {
+            Logger.usdStageConverter.error("WKUSDStageConverter: Failed to export to USDZ: \(error)")
+            return nil
+        }
+    }
+}
+
+#else
+
+@objc
+@implementation
+extension WKUSDStageConverter {
+    @objc(convert:)
+    class func convert(_ data: Data) -> Data? {
+        nil
+    }
+}
+
+#endif // canImport(_USDKit_RealityKit)
+
+#endif // ENABLE_MODEL_PROCESS

--- a/Source/WebKit/Modules/Internal/WebKitInternal.h
+++ b/Source/WebKit/Modules/Internal/WebKitInternal.h
@@ -36,6 +36,7 @@
 #import "WKSeparatedImageView.h"
 #import "WKSurroundingsEffect.h"
 #import "WKUIDelegateInternal.h"
+#import "WKUSDStageConverter.h"
 #import "WKWebViewConfigurationInternal.h"
 #import "WKWebViewInternal.h"
 #import "_WKTextExtractionInternal.h"

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -1773,6 +1773,8 @@
 		86E9F1292EC4D44500BCC96D /* CoreIPCCGColorSpace.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86E9F1282EC4D44500BCC96D /* CoreIPCCGColorSpace.mm */; };
 		86EB7204298D310A00C1DC77 /* SecItemShim.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EB7202298D310900C1DC77 /* SecItemShim.h */; };
 		86F9536518FF58F5001DB2EF /* ProcessAssertion.h in Headers */ = {isa = PBXBuildFile; fileRef = 86F9536018FF4FD4001DB2EF /* ProcessAssertion.h */; };
+		8BFE6BF82F3C2F1300E82291 /* WKUSDStageConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE6BF72F3C2F1300E82291 /* WKUSDStageConverter.swift */; };
+		8BFE6BF92F3C2F1300E82291 /* WKUSDStageConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BFE6BF62F3C2F1300E82291 /* WKUSDStageConverter.h */; };
 		8DC2EF530486A6940098B216 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C1666FE841158C02AAC07 /* InfoPlist.strings */; };
 		909854ED12BC4E18000AD080 /* WebMemorySampler.h in Headers */ = {isa = PBXBuildFile; fileRef = 905620E912BC248B000799B6 /* WebMemorySampler.h */; };
 		9197940523DBC4BB00257892 /* InspectorBrowserAgent.h in Headers */ = {isa = PBXBuildFile; fileRef = 9197940323DBC4BB00257892 /* InspectorBrowserAgent.h */; };
@@ -7285,6 +7287,8 @@
 		86F4FE1E2A98B9AE007378EE /* RemoteGraphicsContextGLInitializationState.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteGraphicsContextGLInitializationState.serialization.in; sourceTree = "<group>"; };
 		86F4FE282A98C162007378EE /* SharedVideoFrame.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = SharedVideoFrame.serialization.in; sourceTree = "<group>"; };
 		86F9536018FF4FD4001DB2EF /* ProcessAssertion.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessAssertion.h; sourceTree = "<group>"; };
+		8BFE6BF62F3C2F1300E82291 /* WKUSDStageConverter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKUSDStageConverter.h; sourceTree = "<group>"; };
+		8BFE6BF72F3C2F1300E82291 /* WKUSDStageConverter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKUSDStageConverter.swift; sourceTree = "<group>"; };
 		8CFECE931490F140002AAA32 /* EditorState.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EditorState.cpp; sourceTree = "<group>"; };
 		8DC2EF5A0486A6940098B216 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8DC2EF5B0486A6940098B216 /* WebKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WebKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -11860,6 +11864,8 @@
 				540D14C72B840E9A007FD5DE /* ModelProcessModelPlayerProxy.mm */,
 				54BD52C82B99787A00B9EF66 /* WKModelProcessModelLayer.h */,
 				54BD52C72B99787A00B9EF66 /* WKModelProcessModelLayer.mm */,
+				8BFE6BF62F3C2F1300E82291 /* WKUSDStageConverter.h */,
+				8BFE6BF72F3C2F1300E82291 /* WKUSDStageConverter.swift */,
 			);
 			path = cocoa;
 			sourceTree = "<group>";
@@ -19407,6 +19413,7 @@
 				51D124351E6DF652002B2820 /* WKURLSchemeTask.h in Headers */,
 				5C62FDF91EFC271C00CE072E /* WKURLSchemeTaskPrivate.h in Headers */,
 				316B8B642054B55800BD4A62 /* WKUSDPreviewView.h in Headers */,
+				8BFE6BF92F3C2F1300E82291 /* WKUSDStageConverter.h in Headers */,
 				1AFA3AC918E61C61003CCBAE /* WKUserContentController.h in Headers */,
 				1AAF08A4192682DA00B6390C /* WKUserContentControllerInternal.h in Headers */,
 				7C89D2B61A6B0DD9003A5FDE /* WKUserContentControllerPrivate.h in Headers */,
@@ -22152,6 +22159,7 @@
 				07152D072F2F037D00B56C0E /* WKTextSelectionController.swift in Sources */,
 				076897F02D07B330006F9FA7 /* WKUIDelegateAdapter.swift in Sources */,
 				079A4DB02D73EA4A00CA387F /* WKURLSchemeHandlerAdapter.swift in Sources */,
+				8BFE6BF82F3C2F1300E82291 /* WKUSDStageConverter.swift in Sources */,
 				079A4DA52D72CE3F00CA387F /* WKWebpagePreferences+Extras.swift in Sources */,
 				07642AEF2DEABBA100561888 /* WKWebsiteDataStore+SwiftOverlay.swift in Sources */,
 				F4E038F82F230571003A8F3A /* WKWebView+SystemTextExtraction.swift in Sources */,

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp
@@ -111,6 +111,14 @@ void ModelProcessModelPlayer::didFinishLoading(const WebCore::FloatPoint3D& boun
     client->didUpdateBoundingBox(*this, boundingBoxCenter, boundingBoxExtents);
 }
 
+void ModelProcessModelPlayer::didConvertModelData(Ref<WebCore::SharedBuffer>&& convertedData, const String& convertedMIMEType)
+{
+    RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer didConvertModelData mimeType=%s id=%" PRIu64, this, convertedMIMEType.utf8().data(), m_id.toUInt64());
+    RELEASE_ASSERT(modelProcessEnabled());
+
+    protect(client())->didConvertModelData(*this, WTF::move(convertedData), convertedMIMEType);
+}
+
 void ModelProcessModelPlayer::didFailLoading()
 {
     RELEASE_LOG(ModelElement, "%p - ModelProcessModelPlayer didFailLoading id=%" PRIu64, this, m_id.toUInt64());

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h
@@ -75,6 +75,7 @@ private:
     // Messages
     void didCreateLayer(WebCore::LayerHostingContextIdentifier);
     void didFinishLoading(const WebCore::FloatPoint3D&, const WebCore::FloatPoint3D&);
+    void didConvertModelData(Ref<WebCore::SharedBuffer>&&, const String& convertedMIMEType);
     void didFailLoading();
     void didUpdateEntityTransform(const WebCore::TransformationMatrix&);
     void didUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp);

--- a/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
+++ b/Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in
@@ -30,6 +30,7 @@
 messages -> ModelProcessModelPlayer {
     DidCreateLayer(WebCore::LayerHostingContextIdentifier identifier)
     DidFinishLoading(WebCore::FloatPoint3D center, WebCore::FloatPoint3D extents)
+    DidConvertModelData(Ref<WebCore::SharedBuffer> convertedData, String convertedMIMEType)
     DidFailLoading()
     DidUpdateEntityTransform(WebCore::TransformationMatrix transform)
     DidUpdateAnimationPlaybackState(bool isPaused, double playbackRate, Seconds duration, Seconds currentTime, MonotonicTime clockTimestamp)


### PR DESCRIPTION
#### 4c2e78a2ce803fdacd55b30d736d91508292396c
<pre>
Convert GLTF/GLB models to USDZ in ModelProcess for visionOS rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=307447">https://bugs.webkit.org/show_bug.cgi?id=307447</a>
<a href="https://rdar.apple.com/168265827">rdar://168265827</a>

Reviewed by Etienne Segonzac.

Add GLTF/GLB conversion to USDZ format in the ModelProcess via USDStageKit,
The converted model data is sent back to WebContent so drag-and-drop operations
export files in USDZ format with the correct extension.

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::didConvertModelData):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/Modules/model-element/ModelPlayerClient.h:
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::startDrag):
* Source/WebCore/platform/graphics/Model.cpp:
(WebCore::Model::create):
(WebCore::Model::Model):
(WebCore::Model::filename const):
(WebCore::operator&lt;&lt;):
* Source/WebCore/platform/graphics/Model.h:
* Source/WebKit/ModelProcess/cocoa/ModelProcessModelPlayerProxy.mm:
(WebKit::ModelProcessModelPlayerProxy::loadModel):
* Source/WebKit/ModelProcess/cocoa/WKUSDStageConverter.h: Added.
* Source/WebKit/ModelProcess/cocoa/WKUSDStageConverter.swift: Added.
(WKUSDStageConverter.convert(_:)):
* Source/WebKit/Modules/Internal/WebKitInternal.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.cpp:
(WebKit::ModelProcessModelPlayer::didConvertModelData):
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.h:
* Source/WebKit/WebProcess/Model/ModelProcessModelPlayer.messages.in:

Canonical link: <a href="https://commits.webkit.org/307516@main">https://commits.webkit.org/307516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ae0bb2a49c0ae9028ee5ccf05bc4f78dec0840d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8847 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153255 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146459 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17746 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17157 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111199 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b7f1b5e-170d-40fb-9fb0-59dab4d01ed7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147547 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13575 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92094 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3abd39f1-1718-4e52-974a-65e31c2b17ae) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10703 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/700 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122465 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155567 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17115 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119210 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17153 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14328 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119546 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30656 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15363 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127763 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72656 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16737 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6149 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16473 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80516 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16682 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16537 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->