### PR TITLE
Replace 'web process' with more generic 'resource owner' in WebGPU.framework

### DIFF
--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.cpp
@@ -44,11 +44,8 @@ WTF_WEAK_LINK_FORCE_IMPORT(wgpuCreateInstance);
 
 namespace WebCore::WebGPU {
 
-RefPtr<GPU> create(ScheduleWorkFunction&& scheduleWorkFunction, const WebCore::ProcessIdentity* webProcessIdentity)
+RefPtr<GPU> create(ScheduleWorkFunction&& scheduleWorkFunction, [[maybe_unused]] const WebCore::ProcessIdentity* resourceOwner)
 {
-#if !HAVE(TASK_IDENTITY_TOKEN)
-    UNUSED_PARAM(webProcessIdentity);
-#endif
     auto scheduleWorkBlock = makeBlockPtr([scheduleWorkFunction = WTF::move(scheduleWorkFunction)](WGPUWorkItem workItem)
     {
         scheduleWorkFunction(Function<void()>(makeBlockPtr(WTF::move(workItem))));
@@ -58,9 +55,9 @@ RefPtr<GPU> create(ScheduleWorkFunction&& scheduleWorkFunction, const WebCore::P
         .cocoaDescriptor = WGPUInstanceCocoaDescriptor {
             .scheduleWorkBlock = scheduleWorkBlock.get(),
 #if HAVE(TASK_IDENTITY_TOKEN)
-            .webProcessResourceOwner = webProcessIdentity ? &webProcessIdentity->taskId() : nullptr,
+            .resourceOwnerTaskID = resourceOwner ? &resourceOwner->taskId() : nullptr,
 #else
-            .webProcessResourceOwner = nullptr,
+            .resourceOwnerTaskID = nullptr,
 #endif
         }
     };

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -514,9 +514,9 @@ Device::ExternalTextureData Device::createExternalTextureFromPixelBuffer(CVPixel
         return { mtlTextures[0], mtlTextures[1], simd::float3x2(1.f), colorSpaceConversionMatrix };
     }
 
-    if (auto optionalWebProcessID = webProcessID()) {
-        if (auto webProcessID = optionalWebProcessID->sendRight())
-            IOSurfaceSetOwnershipIdentity(ioSurface, webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
+    if (auto resourceOwnerTaskID = this->resourceOwnerTaskID()) {
+        if (auto resourceOwnerTaskIDToken = resourceOwnerTaskID->sendRight())
+            IOSurfaceSetOwnershipIdentity(ioSurface, resourceOwnerTaskIDToken, kIOSurfaceMemoryLedgerTagGraphics, 0);
     }
 
     id<MTLTexture> baseTexture = nil;

--- a/Source/WebGPU/WebGPU/Device.h
+++ b/Source/WebGPU/WebGPU/Device.h
@@ -216,7 +216,7 @@ public:
     RefPtr<XRSubImage> getXRViewSubImage(XRProjectionLayer&);
     RefPtr<XRSubImage> getXRViewSubImage() const;
     id<MTLTexture> _Nullable getXRViewSubImageDepthTexture() const;
-    const std::optional<const MachSendRight> webProcessID() const;
+    const std::optional<const MachSendRight> resourceOwnerTaskID() const;
 #if CPU(X86_64)
     bool isIntel() const { return [m_device.name localizedCaseInsensitiveContainsString:@"intel"]; }
 #else

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -422,7 +422,7 @@ void Device::loseTheDevice(WGPUDeviceLostReason reason)
     m_isLost = true;
 }
 
-static void setOwnerWithIdentity(id<MTLResourceSPI> resource, auto webProcessID)
+static void setOwnerWithIdentity(id<MTLResourceSPI> resource, auto resourceOwnerTaskIDToken)
 {
     if (!resource)
         return;
@@ -430,17 +430,17 @@ static void setOwnerWithIdentity(id<MTLResourceSPI> resource, auto webProcessID)
     if (![resource respondsToSelector:@selector(setOwnerWithIdentity:)])
         return;
 
-    [resource setOwnerWithIdentity:webProcessID];
+    [resource setOwnerWithIdentity:resourceOwnerTaskIDToken];
 }
 
 void Device::setOwnerWithIdentity(id<MTLResource> resource) const
 {
-    if (auto optionalWebProcessID = webProcessID()) {
-        auto webProcessID = optionalWebProcessID->sendRight();
-        if (!webProcessID)
+    if (auto resourceOwnerTaskID = this->resourceOwnerTaskID()) {
+        auto resourceOwnerTaskIDToken = resourceOwnerTaskID->sendRight();
+        if (!resourceOwnerTaskIDToken)
             return;
 
-        WebGPU::setOwnerWithIdentity((id<MTLResourceSPI>)resource, webProcessID);
+        WebGPU::setOwnerWithIdentity((id<MTLResourceSPI>)resource, resourceOwnerTaskIDToken);
     }
 }
 
@@ -650,10 +650,10 @@ void Device::setLabel(String&&)
     // Because MTLDevices are process-global, we can't set the label on it, because 2 contexts' labels would fight each other.
 }
 
-const std::optional<const MachSendRight> Device::webProcessID() const
+const std::optional<const MachSendRight> Device::resourceOwnerTaskID() const
 {
     auto scheduler = instance();
-    return scheduler ? scheduler->webProcessID() : std::nullopt;
+    return scheduler ? scheduler->resourceOwnerTaskID() : std::nullopt;
 }
 
 id<MTLBuffer> Device::dispatchCallBuffer()

--- a/Source/WebGPU/WebGPU/ExternalTexture.mm
+++ b/Source/WebGPU/WebGPU/ExternalTexture.mm
@@ -103,9 +103,9 @@ void ExternalTexture::update(CVPixelBufferRef pixelBuffer)
 {
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
     if (RetainPtr ioSurface = CVPixelBufferGetIOSurface(pixelBuffer)) {
-        if (auto optionalWebProcessID = protectedDevice()->webProcessID()) {
-            if (auto webProcessID = optionalWebProcessID->sendRight())
-                IOSurfaceSetOwnershipIdentity(ioSurface.get(), webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
+        if (auto resourceOwnerTaskID = protectedDevice()->resourceOwnerTaskID()) {
+            if (auto resourceOwnerTaskIDToken = resourceOwnerTaskID->sendRight())
+                IOSurfaceSetOwnershipIdentity(ioSurface.get(), resourceOwnerTaskIDToken, kIOSurfaceMemoryLedgerTagGraphics, 0);
         }
     }
 #endif

--- a/Source/WebGPU/WebGPU/Instance.h
+++ b/Source/WebGPU/WebGPU/Instance.h
@@ -75,11 +75,11 @@ public:
     // This can be called on a background thread.
     using WorkItem = Function<void()>;
     void scheduleWork(WorkItem&&);
-    const std::optional<const MachSendRight>& webProcessID() const;
+    const std::optional<const MachSendRight>& resourceOwnerTaskID() const;
     id<MTLDevice> device() const;
 
 private:
-    Instance(WGPUScheduleWorkBlock, const WTF::MachSendRight* webProcessResourceOwner);
+    Instance(WGPUScheduleWorkBlock, const WTF::MachSendRight* resourceOwnerTaskID);
     explicit Instance();
 
     // This can be called on a background thread.
@@ -89,7 +89,7 @@ private:
     Deque<WGPUWorkItem> m_pendingWork WTF_GUARDED_BY_LOCK(m_lock);
     using CommandBufferContainer = Vector<WeakObjCPtr<id<MTLCommandBuffer>>>;
     HashMap<RefPtr<Device>, CommandBufferContainer> retainedDeviceInstances WTF_GUARDED_BY_LOCK(m_lock);
-    const std::optional<const MachSendRight> m_webProcessID;
+    const std::optional<const MachSendRight> m_resourceOwnerTaskID;
     const WGPUScheduleWorkBlock m_scheduleWorkBlock;
     Lock m_lock;
     bool m_isValid { true };

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -57,11 +57,11 @@ Ref<Instance> Instance::create(const WGPUInstanceDescriptor& descriptor)
 {
     const WGPUInstanceCocoaDescriptor& cocoaDescriptor = descriptor.cocoaDescriptor;
 
-    return adoptRef(*new Instance(cocoaDescriptor.scheduleWorkBlock, reinterpret_cast<const WTF::MachSendRight*>(cocoaDescriptor.webProcessResourceOwner)));
+    return adoptRef(*new Instance(cocoaDescriptor.scheduleWorkBlock, reinterpret_cast<const WTF::MachSendRight*>(cocoaDescriptor.resourceOwnerTaskID)));
 }
 
-Instance::Instance(WGPUScheduleWorkBlock scheduleWorkBlock, const MachSendRight* webProcessResourceOwner)
-    : m_webProcessID(webProcessResourceOwner ? std::optional<MachSendRight>(*webProcessResourceOwner) : std::nullopt)
+Instance::Instance(WGPUScheduleWorkBlock scheduleWorkBlock, const MachSendRight* resourceOwnerTaskID)
+    : m_resourceOwnerTaskID(resourceOwnerTaskID ? std::optional { *resourceOwnerTaskID } : std::nullopt)
     , m_scheduleWorkBlock(scheduleWorkBlock ? WTF::move(scheduleWorkBlock) : ^(WGPUWorkItem workItem) { defaultScheduleWork(WTF::move(workItem)); })
 {
 }
@@ -84,9 +84,9 @@ void Instance::scheduleWork(WorkItem&& workItem)
     m_scheduleWorkBlock(makeBlockPtr(WTF::move(workItem)).get());
 }
 
-const std::optional<const MachSendRight>& Instance::webProcessID() const
+const std::optional<const MachSendRight>& Instance::resourceOwnerTaskID() const
 {
-    return m_webProcessID;
+    return m_resourceOwnerTaskID;
 }
 
 void Instance::defaultScheduleWork(WGPUWorkItem&& workItem)

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.h
@@ -75,7 +75,7 @@ private:
     id<MTLComputePipelineState> m_computePipelineState;
     id<MTLComputePipelineState> m_resizeComputePipelineState;
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
-    std::optional<const MachSendRight> m_webProcessID;
+    std::optional<const MachSendRight> m_resourceOwnerTaskID;
 #endif
     WGPUColorSpace m_colorSpace { WGPUColorSpace::SRGB };
     WGPUToneMappingMode m_toneMappingMode { WGPUToneMappingMode_Standard };

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -52,14 +52,11 @@ Ref<PresentationContextIOSurface> PresentationContextIOSurface::create(const WGP
     return presentationContextIOSurface;
 }
 
-PresentationContextIOSurface::PresentationContextIOSurface(const WGPUSurfaceDescriptor&, const Instance& instance)
+PresentationContextIOSurface::PresentationContextIOSurface(const WGPUSurfaceDescriptor&, [[maybe_unused]] const Instance& instance)
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
-    : m_webProcessID(instance.webProcessID())
+    : m_resourceOwnerTaskID(instance.resourceOwnerTaskID())
 #endif
 {
-#if !(HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN))
-    UNUSED_PARAM(instance);
-#endif
 }
 
 PresentationContextIOSurface::~PresentationContextIOSurface() = default;
@@ -69,11 +66,10 @@ void PresentationContextIOSurface::renderBuffersWereRecreated(NSArray<IOSurface 
     m_existingRenderBuffers = WTF::move(m_renderBuffers);
     m_ioSurfaces = ioSurfaces;
 #if HAVE(IOSURFACE_SET_OWNERSHIP_IDENTITY) && HAVE(TASK_IDENTITY_TOKEN)
-    if (m_webProcessID) {
-        mach_port_t webProcessID = m_webProcessID->sendRight();
-        if (webProcessID) {
+    if (m_resourceOwnerTaskID) {
+        if (auto resourceOwnerTaskIDToken = m_resourceOwnerTaskID->sendRight()) {
             for (IOSurface *surface in ioSurfaces)
-                IOSurfaceSetOwnershipIdentity(bridge_cast(surface), webProcessID, kIOSurfaceMemoryLedgerTagGraphics, 0);
+                IOSurfaceSetOwnershipIdentity(bridge_cast(surface), resourceOwnerTaskIDToken, kIOSurfaceMemoryLedgerTagGraphics, 0);
         }
     }
 #endif

--- a/Source/WebGPU/WebGPU/WebGPU.h
+++ b/Source/WebGPU/WebGPU/WebGPU.h
@@ -903,7 +903,7 @@ typedef struct WGPUInstanceCocoaDescriptor {
     // It's fine to pass NULL here, but if you do, you must periodically call
     // wgpuInstanceProcessEvents() to synchronously run the queued callbacks.
     __unsafe_unretained WGPUScheduleWorkBlock scheduleWorkBlock;
-    const void* webProcessResourceOwner;
+    const void* resourceOwnerTaskID;
 } WGPUInstanceCocoaDescriptor;
 
 typedef struct WGPUInstanceDescriptor {


### PR DESCRIPTION
#### 6539efd69afc7e6e62be51b270a0dcf97744733a
<pre>
Replace &apos;web process&apos; with more generic &apos;resource owner&apos; in WebGPU.framework
<a href="https://bugs.webkit.org/show_bug.cgi?id=307497">https://bugs.webkit.org/show_bug.cgi?id=307497</a>

Reviewed by NOBODY (OOPS!).

WebGPU.framework really shouldn&apos;t know about specific processes. This replaces the
uses of &apos;webProcessID&apos; with more generic &apos;resource owner&apos; terminology.

* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCreateImpl.cpp:
* Source/WebGPU/WebGPU/BindGroup.mm:
* Source/WebGPU/WebGPU/Device.h:
* Source/WebGPU/WebGPU/Device.mm:
* Source/WebGPU/WebGPU/ExternalTexture.mm:
* Source/WebGPU/WebGPU/Instance.h:
* Source/WebGPU/WebGPU/Instance.mm:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.h:
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
* Source/WebGPU/WebGPU/WebGPU.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6539efd69afc7e6e62be51b270a0dcf97744733a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143921 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16600 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152591 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97160 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145796 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17082 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110670 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79582 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129326 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91588 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12566 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10295 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/39 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122035 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5964 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154903 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16452 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118680 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16488 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13831 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119033 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14949 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127175 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71873 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running compile-webkit") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16074 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5629 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15808 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79853 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16019 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15874 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->