### PR TITLE
Reduce use of `checked*()` functions in Source/WebCore/dom

### DIFF
--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -123,7 +123,7 @@ ExceptionOr<bool> NavigatorBeacon::sendBeacon(Document& document, const String& 
     if (!document.frame())
         return false;
 
-    if (!document.shouldBypassMainWorldContentSecurityPolicy() && !document.checkedContentSecurityPolicy()->allowConnectToSource(parsedUrl)) {
+    if (!document.shouldBypassMainWorldContentSecurityPolicy() && !protect(document.contentSecurityPolicy())->allowConnectToSource(parsedUrl)) {
         // We simulate a network error so we return true here. This is consistent with Blink.
         return true;
     }

--- a/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp
@@ -92,7 +92,7 @@ void FileSystemDirectoryReader::readEntries(ScriptExecutionContext& context, Ref
             if (result.hasException()) {
                 pendingActivity->object().m_error = result.releaseException();
                 if (errorCallback && document) {
-                    document->checkedEventLoop()->queueTask(TaskSource::Networking, [errorCallback = WTF::move(errorCallback), pendingActivity = WTF::move(pendingActivity)]() mutable {
+                    protect(document->eventLoop())->queueTask(TaskSource::Networking, [errorCallback = WTF::move(errorCallback), pendingActivity = WTF::move(pendingActivity)]() mutable {
                         errorCallback->invoke(DOMException::create(*pendingActivity->object().m_error));
                     });
                 }
@@ -100,7 +100,7 @@ void FileSystemDirectoryReader::readEntries(ScriptExecutionContext& context, Ref
             }
             pendingActivity->object().m_isDone = true;
             if (document) {
-                document->checkedEventLoop()->queueTask(TaskSource::Networking, [successCallback = WTF::move(successCallback), pendingActivity = WTF::move(pendingActivity), result = result.releaseReturnValue()]() mutable {
+                protect(document->eventLoop())->queueTask(TaskSource::Networking, [successCallback = WTF::move(successCallback), pendingActivity = WTF::move(pendingActivity), result = result.releaseReturnValue()]() mutable {
                     successCallback->invoke(WTF::move(result));
                 });
             }

--- a/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
+++ b/Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp
@@ -73,7 +73,7 @@ void FileSystemEntry::getParent(ScriptExecutionContext& context, RefPtr<FileSyst
         if (!document)
             return;
 
-        document->checkedEventLoop()->queueTask(TaskSource::Networking, [successCallback = WTF::move(successCallback), errorCallback = WTF::move(errorCallback), result = std::forward<Result>(result), pendingActivity = WTF::move(pendingActivity)] () mutable {
+        protect(document->eventLoop())->queueTask(TaskSource::Networking, [successCallback = WTF::move(successCallback), errorCallback = WTF::move(errorCallback), result = std::forward<Result>(result), pendingActivity = WTF::move(pendingActivity)] () mutable {
             if (result.hasException()) {
                 if (errorCallback)
                     errorCallback->invoke(DOMException::create(result.releaseException()));

--- a/Source/WebCore/Modules/geolocation/Geolocation.cpp
+++ b/Source/WebCore/Modules/geolocation/Geolocation.cpp
@@ -311,7 +311,7 @@ void Geolocation::getCurrentPosition(Ref<PositionCallback>&& successCallback, Re
             return;
 
         if (RefPtr context = errorCallback->scriptExecutionContext()) {
-            context->checkedEventLoop()->queueTask(TaskSource::Geolocation, [errorCallback = WTF::move(errorCallback)] {
+            protect(context->eventLoop())->queueTask(TaskSource::Geolocation, [errorCallback = WTF::move(errorCallback)] {
                 errorCallback->invoke(GeolocationPositionError::create(GeolocationPositionError::POSITION_UNAVAILABLE, "Document is not fully active"_s));
             });
         }
@@ -332,7 +332,7 @@ int Geolocation::watchPosition(Ref<PositionCallback>&& successCallback, RefPtr<P
             return 0;
 
         if (RefPtr context = errorCallback->scriptExecutionContext()) {
-            context->checkedEventLoop()->queueTask(TaskSource::Geolocation, [errorCallback = WTF::move(errorCallback)] {
+            protect(context->eventLoop())->queueTask(TaskSource::Geolocation, [errorCallback = WTF::move(errorCallback)] {
                 errorCallback->invoke(GeolocationPositionError::create(GeolocationPositionError::POSITION_UNAVAILABLE, "Document is not fully active"_s));
             });
         }

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -104,7 +104,7 @@ IDBTransaction::IDBTransaction(IDBDatabase& database, const IDBTransactionInfo& 
         RefPtr context = scriptExecutionContext();
         ASSERT(context);
 
-        context->checkedEventLoop()->runAtEndOfMicrotaskCheckpoint([protectedThis = Ref { *this }] {
+        protect(context->eventLoop())->runAtEndOfMicrotaskCheckpoint([protectedThis = Ref { *this }] {
             protectedThis->deactivate();
         });
 

--- a/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp
@@ -180,7 +180,7 @@ void RTCEncodedStreamProducer::generateKeyFrame(ScriptExecutionContext& context,
         return;
 
     if (!backend->requestKeyFrame(rid)) {
-        context.checkedEventLoop()->queueTask(TaskSource::Networking, [promise = WTF::move(promise)]() mutable {
+        protect(context.eventLoop())->queueTask(TaskSource::Networking, [promise = WTF::move(promise)]() mutable {
             promise->reject(Exception { ExceptionCode::NotFoundError, "rid was not found or is empty"_s });
         });
         return;

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp
@@ -139,7 +139,7 @@ void RTCRtpScriptTransformer::sendKeyFrameRequest(Ref<DeferredPromise>&& promise
     m_streamProducer->sendKeyFrameRequest();
 
     // FIXME: We should be able to know when the FIR request is sent to resolve the promise at this exact time.
-    context->checkedEventLoop()->queueTask(TaskSource::Networking, [promise = WTF::move(promise)]() mutable {
+    protect(context->eventLoop())->queueTask(TaskSource::Networking, [promise = WTF::move(promise)]() mutable {
         promise->resolve();
     });
 }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -650,7 +650,7 @@ void HTMLModelElement::startLoadModelTimer()
 
     Ref document = this->document();
     Seconds delay = document->page() && document->page()->shouldDisableModelLoadDelaysForTesting() ? 0_s : reloadModelDelay;
-    m_loadModelTimer = document->checkedEventLoop()->scheduleTask(delay, TaskSource::ModelElement, [weakThis = WeakPtr { *this }] {
+    m_loadModelTimer = protect(document->eventLoop())->scheduleTask(delay, TaskSource::ModelElement, [weakThis = WeakPtr { *this }] {
         if (weakThis)
             weakThis->loadModelTimerFired();
     });

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -401,7 +401,7 @@ auto Notification::permission(ScriptExecutionContext& context) -> Permission
 void Notification::requestPermission(Document& document, RefPtr<NotificationPermissionCallback>&& callback, Ref<DeferredPromise>&& promise)
 {
     auto resolvePromiseAndCallback = [document = Ref { document }, callback = WTF::move(callback), promise = WTF::move(promise)](Permission permission) mutable {
-        document->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [callback = WTF::move(callback), promise = WTF::move(promise), permission]() mutable {
+        protect(document->eventLoop())->queueTask(TaskSource::DOMManipulation, [callback = WTF::move(callback), promise = WTF::move(promise), permission]() mutable {
             if (callback)
                 callback->invoke(permission);
             promise->resolve<IDLEnumeration<NotificationPermission>>(permission);

--- a/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
+++ b/Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp
@@ -82,7 +82,7 @@ void WakeLock::request(WakeLockType lockType, Ref<DeferredPromise>&& promise)
                 permission = PermissionState::Denied;
         } else if (*permission == PermissionState::Denied)
             m_wasPreviouslyAuthorizedDueToTransientActivation = false;
-        document->checkedEventLoop()->queueTask(TaskSource::ScreenWakelock, [protectedThis = WTF::move(protectedThis), document = WTF::move(document), promise = WTF::move(promise), lockType, permission]() mutable {
+        protect(document->eventLoop())->queueTask(TaskSource::ScreenWakelock, [protectedThis = WTF::move(protectedThis), document = WTF::move(document), promise = WTF::move(promise), lockType, permission]() mutable {
             if (permission == PermissionState::Denied) {
                 promise->reject(Exception { ExceptionCode::NotAllowedError, "Permission was denied"_s });
                 return;

--- a/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamTeeUtilities.cpp
@@ -165,7 +165,7 @@ public:
             return;
 
         auto& globalObject = *JSC::jsCast<JSDOMGlobalObject*>(context->globalObject());
-        context->checkedEventLoop()->queueMicrotask([task = WTF::move(task), value = JSC::Strong<JSC::Unknown> { globalObject.vm(), value }] {
+        protect(context->eventLoop())->queueMicrotask([task = WTF::move(task), value = JSC::Strong<JSC::Unknown> { globalObject.vm(), value }] {
             task(value.get());
         });
     }

--- a/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseManager.cpp
@@ -219,7 +219,7 @@ ExceptionOr<Ref<Database>> DatabaseManager::openDatabase(Document& document, con
     if (database->isNew() && creationCallback.get()) {
         LOG(StorageAPI, "Scheduling DatabaseCreationCallbackTask for database %p\n", database.get());
         database->setHasPendingCreationEvent(true);
-        database->m_document->checkedEventLoop()->queueTask(TaskSource::Networking, [creationCallback, database] {
+        protect(database->m_document->eventLoop())->queueTask(TaskSource::Networking, [creationCallback, database] {
             creationCallback->invoke(*database);
             database->setHasPendingCreationEvent(false);
         });

--- a/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
+++ b/Source/WebCore/Modules/webdatabase/SQLTransaction.cpp
@@ -138,7 +138,7 @@ void SQLTransaction::callErrorCallbackDueToInterruption()
     if (!errorCallback)
         return;
 
-    m_database->document().checkedEventLoop()->queueTask(TaskSource::Networking, [errorCallback = WTF::move(errorCallback)]() mutable {
+    protect(m_database->document().eventLoop())->queueTask(TaskSource::Networking, [errorCallback = WTF::move(errorCallback)]() mutable {
         errorCallback->invoke(SQLError::create(SQLError::DATABASE_ERR, "the database was closed"_s));
     });
 }
@@ -412,7 +412,7 @@ void SQLTransaction::deliverTransactionErrorCallback()
     // error to have occurred in this transaction.
     RefPtr<SQLTransactionErrorCallback> errorCallback = m_errorCallbackWrapper.unwrap();
     if (errorCallback) {
-        m_database->document().checkedEventLoop()->queueTask(TaskSource::Networking, [errorCallback = WTF::move(errorCallback), transactionError = m_transactionError]() mutable {
+        protect(m_database->document().eventLoop())->queueTask(TaskSource::Networking, [errorCallback = WTF::move(errorCallback), transactionError = m_transactionError]() mutable {
             errorCallback->invoke(*transactionError);
         });
     }
@@ -463,7 +463,7 @@ void SQLTransaction::deliverSuccessCallback()
     // Spec 4.3.2.8: Deliver success callback.
     RefPtr<VoidCallback> successCallback = m_successCallbackWrapper.unwrap();
     if (successCallback) {
-        m_database->document().checkedEventLoop()->queueTask(TaskSource::Networking, [successCallback = WTF::move(successCallback)]() mutable {
+        protect(m_database->document().eventLoop())->queueTask(TaskSource::Networking, [successCallback = WTF::move(successCallback)]() mutable {
             successCallback->invoke();
         });
     }

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -214,7 +214,7 @@ void AnimationTimelinesController::updateAnimationsAndSendEvents(ReducedResoluti
     }
 
     // 3. Perform a microtask checkpoint.
-    protectedDocument()->checkedEventLoop()->performMicrotaskCheckpoint();
+    protect(protectedDocument()->eventLoop())->performMicrotaskCheckpoint();
 
     if (RefPtr documentTimeline = m_document->existingTimeline()) {
         // FIXME: pending animation events should be owned by this controller rather
@@ -350,7 +350,7 @@ void AnimationTimelinesController::cacheCurrentTime(ReducedResolutionSeconds new
     // start time.
     if (!m_pendingAnimationsProcessingTaskCancellationGroup.hasPendingTask()) {
         CancellableTask task(m_pendingAnimationsProcessingTaskCancellationGroup, std::bind(&AnimationTimelinesController::processPendingAnimations, this));
-        protectedDocument()->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, WTF::move(task));
+        protect(protectedDocument()->eventLoop())->queueTask(TaskSource::InternalAsyncTask, WTF::move(task));
     }
 
     if (!m_isSuspended) {

--- a/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
+++ b/Source/WebCore/bindings/js/CachedScriptFetcher.cpp
@@ -52,7 +52,7 @@ CachedResourceHandle<CachedScript> CachedScriptFetcher::requestScriptWithCache(D
         return nullptr;
 
     ASSERT(document.contentSecurityPolicy());
-    bool hasKnownNonce = document.checkedContentSecurityPolicy()->allowScriptWithNonce(m_nonce, m_isInUserAgentShadowTree);
+    bool hasKnownNonce = protect(document.contentSecurityPolicy())->allowScriptWithNonce(m_nonce, m_isInUserAgentShadowTree);
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
     options.contentSecurityPolicyImposition = hasKnownNonce ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
     options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;

--- a/Source/WebCore/bindings/js/JSEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSEventListener.cpp
@@ -160,7 +160,7 @@ void JSEventListener::handleEvent(ScriptExecutionContext& scriptExecutionContext
             return;
         if (wasCreatedFromMarkup()) {
             RefPtr element = dynamicDowncast<Element>(*event.target());
-            if (!scriptExecutionContext.checkedContentSecurityPolicy()->allowInlineEventHandlers(sourceURL().string(), sourcePosition().m_line, code(), element.get()))
+            if (!protect(scriptExecutionContext.contentSecurityPolicy())->allowInlineEventHandlers(sourceURL().string(), sourcePosition().m_line, code(), element.get()))
                 return;
         }
         // FIXME: Is this check needed for other contexts?

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -121,7 +121,7 @@ JSObject* JSLazyEventListener::initializeJSFunction(ScriptExecutionContext& exec
         return nullptr;
 
     RefPtr element = dynamicDowncast<Element>(m_originalNode.get());
-    if (!document->checkedContentSecurityPolicy()->allowInlineEventHandlers(m_sourceURL.string(), m_sourcePosition.m_line, m_code, element.get()))
+    if (!protect(document->contentSecurityPolicy())->allowInlineEventHandlers(m_sourceURL.string(), m_sourcePosition.m_line, m_code, element.get()))
         return nullptr;
 
     RefPtr frame = document->frame();

--- a/Source/WebCore/bindings/js/ScriptController.cpp
+++ b/Source/WebCore/bindings/js/ScriptController.cpp
@@ -326,7 +326,7 @@ void ScriptController::initScriptForWindowProxy(JSWindowProxy& windowProxy)
     windowProxy.window()->setConsoleClient(m_frame->console());
 
     if (RefPtr document = m_frame->document())
-        document->checkedContentSecurityPolicy()->didCreateWindowProxy(windowProxy);
+        protect(document->contentSecurityPolicy())->didCreateWindowProxy(windowProxy);
 
     if (RefPtr page = m_frame->page()) {
         windowProxy.attachDebugger(page->debugger());
@@ -882,7 +882,7 @@ void ScriptController::executeJavaScriptURL(const URL& url, const NavigationActi
     if (preNavigationCheckURLString.isNull())
         return;
 
-    if (!ownerDocument->checkedContentSecurityPolicy()->allowJavaScriptURLs(ownerDocument->url().string(), eventHandlerPosition().m_line, preNavigationCheckURLString, nullptr))
+    if (!protect(ownerDocument->contentSecurityPolicy())->allowJavaScriptURLs(ownerDocument->url().string(), eventHandlerPosition().m_line, preNavigationCheckURLString, nullptr))
         return;
 
     const int javascriptSchemeLength = sizeof("javascript:") - 1;

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -611,7 +611,7 @@ void ScriptModuleLoader::notifyFinished(ModuleScriptLoader& moduleScriptLoader, 
         }
     }
 
-    context->checkedEventLoop()->queueTask(TaskSource::Networking, [promise = WTF::move(promise), sourceCode = WTF::move(sourceCode)]() {
+    protect(context->eventLoop())->queueTask(TaskSource::Networking, [promise = WTF::move(promise), sourceCode = WTF::move(sourceCode)]() {
         promise->resolveWithCallback([&, sourceCode](JSDOMGlobalObject& jsGlobalObject) {
             return JSC::JSSourceCode::create(jsGlobalObject.vm(), JSC::SourceCode { sourceCode });
         });

--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -146,7 +146,7 @@ void ActiveDOMObject::queueTaskInEventLoop(TaskSource source, Function<void ()>&
     RefPtr context = scriptExecutionContext();
     if (!context)
         return;
-    context->checkedEventLoop()->queueTask(source, WTF::move(function));
+    protect(context->eventLoop())->queueTask(source, WTF::move(function));
 }
 
 class ActiveDOMObjectEventDispatchTask : public EventLoopTask {

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -862,7 +862,7 @@ inline void ContainerNode::rebuildSVGExtensionsElementsIfNecessary()
 {
     Ref<Document> document = this->document();
     if (document->svgExtensionsIfExists() && !is<SVGUseElement>(shadowHost()))
-        document->checkedSVGExtensions()->rebuildElements();
+        protect(document->svgExtensions())->rebuildElements();
 }
 
 // this differs from other remove functions because it forcibly removes all the children,

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -121,7 +121,6 @@ public:
     void disconnectDescendantFrames();
 
     inline RenderElement* renderer() const; // Defined in ContainerNodeInlines.h.
-    inline CheckedPtr<RenderElement> checkedRenderer() const; // Defined in ContainerNodeInlines.h.
 
     // Return a bounding box in absolute coordinates enclosing this node and all its descendants.
     // This gives the area within which events may get handled by a hander registered on this node.

--- a/Source/WebCore/dom/ContainerNodeInlines.h
+++ b/Source/WebCore/dom/ContainerNodeInlines.h
@@ -42,9 +42,4 @@ inline RenderElement* ContainerNode::renderer() const
     return downcast<RenderElement>(Node::renderer());
 }
 
-inline CheckedPtr<RenderElement> ContainerNode::checkedRenderer() const
-{
-    return renderer();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -149,7 +149,7 @@ void DeviceMotionEvent::requestPermission(Document& document, PermissionPromise&
         return promise.resolve(PermissionState::Denied);
     }
 
-    document.checkedDeviceOrientationAndMotionAccessController()->shouldAllowAccess(document, [promise = WTF::move(promise)](auto permissionState) mutable {
+    protect(document.deviceOrientationAndMotionAccessController())->shouldAllowAccess(document, [promise = WTF::move(promise)](auto permissionState) mutable {
         if (permissionState == PermissionState::Prompt)
             return promise.reject(Exception { ExceptionCode::NotAllowedError, "Requesting device motion access requires a user gesture to prompt"_s });
         promise.resolve(permissionState);

--- a/Source/WebCore/dom/DeviceOrientationEvent.cpp
+++ b/Source/WebCore/dom/DeviceOrientationEvent.cpp
@@ -133,7 +133,7 @@ void DeviceOrientationEvent::requestPermission(Document& document, PermissionPro
         return promise.resolve(PermissionState::Denied);
     }
 
-    document.checkedDeviceOrientationAndMotionAccessController()->shouldAllowAccess(document, [promise = WTF::move(promise)](PermissionState permissionState) mutable {
+    protect(document.deviceOrientationAndMotionAccessController())->shouldAllowAccess(document, [promise = WTF::move(promise)](PermissionState permissionState) mutable {
         if (permissionState == PermissionState::Prompt)
             return promise.reject(Exception { ExceptionCode::NotAllowedError, "Requesting device orientation access requires a user gesture to prompt"_s });
         promise.resolve(permissionState);

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -724,7 +724,6 @@ public:
 
     ExtensionStyleSheets* extensionStyleSheetsIfExists() { return m_extensionStyleSheets.get(); }
     inline ExtensionStyleSheets& extensionStyleSheets(); // Defined in DocumentInlines.h.
-    inline CheckedRef<ExtensionStyleSheets> checkedExtensionStyleSheets(); // Defined in DocumentInlines.h.
 
     const Style::CustomPropertyRegistry& customPropertyRegistry() const;
     const CSSCounterStyleRegistry& counterStyleRegistry() const;
@@ -827,7 +826,6 @@ public:
     void suspendFontLoading();
 
     RenderView* renderView() const { return m_renderView.get(); }
-    CheckedPtr<RenderView> checkedRenderView() const;
     const RenderStyle* initialContainingBlockStyle() const { return m_initialContainingBlockStyle.get(); } // This may end up differing from renderView()->style() due to adjustments.
 
     bool renderTreeBeingDestroyed() const { return m_renderTreeBeingDestroyed; }
@@ -838,7 +836,6 @@ public:
 
     inline AXObjectCache* existingAXObjectCache() const;
     WEBCORE_EXPORT AXObjectCache* axObjectCache() const;
-    WEBCORE_EXPORT CheckedPtr<AXObjectCache> checkedAXObjectCache() const;
     void clearAXObjectCache();
 
     WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
@@ -1273,8 +1270,6 @@ public:
     inline DocumentMarkerController* markersIfExists() { return m_markers.get(); }
     inline DocumentMarkerController& markers(); // Defined in DocumentMarkers.h.
     inline const DocumentMarkerController& markers() const; // Defined in DocumentMarkers.h.
-    inline CheckedRef<DocumentMarkerController> checkedMarkers(); // Defined in DocumentMarkers.h.
-    inline CheckedRef<const DocumentMarkerController> checkedMarkers() const; // Defined in DocumentMarkers.h.
 
     WEBCORE_EXPORT ExceptionOr<bool> execCommand(const String& command, bool userInterface = false, const Variant<String, Ref<TrustedHTML>>& value = String());
     WEBCORE_EXPORT ExceptionOr<bool> queryCommandEnabled(const String& command);
@@ -1343,7 +1338,6 @@ public:
     WEBCORE_EXPORT void postTask(Task&&) final; // Executes the task on context's thread asynchronously.
 
     WEBCORE_EXPORT EventLoopTaskGroup& eventLoop() final;
-    inline CheckedRef<EventLoopTaskGroup> checkedEventLoop(); // Defined in DocumentEventLoop.h
     WindowEventLoop& windowEventLoop();
 
     ScriptedAnimationController* scriptedAnimationController() { return m_scriptedAnimationController.get(); }
@@ -1421,7 +1415,6 @@ public:
 
     SVGDocumentExtensions* svgExtensionsIfExists() { return m_svgExtensions.get(); }
     WEBCORE_EXPORT SVGDocumentExtensions& svgExtensions();
-    WEBCORE_EXPORT CheckedRef<SVGDocumentExtensions> checkedSVGExtensions();
 
     void initSecurityContext();
     void initContentSecurityPolicy();
@@ -1516,7 +1509,6 @@ public:
 
 #if ENABLE(DEVICE_ORIENTATION)
     DeviceOrientationAndMotionAccessController& deviceOrientationAndMotionAccessController();
-    CheckedRef<DeviceOrientationAndMotionAccessController> checkedDeviceOrientationAndMotionAccessController();
 #endif
 
     WEBCORE_EXPORT double monotonicTimestamp() const;
@@ -1945,7 +1937,6 @@ public:
 #endif
 
     WEBCORE_EXPORT TextManipulationController& textManipulationController();
-    WEBCORE_EXPORT CheckedRef<TextManipulationController> checkedTextManipulationController();
     TextManipulationController* textManipulationControllerIfExists() { return m_textManipulationController.get(); }
 
     bool hasHighlight() const;

--- a/Source/WebCore/dom/DocumentEventLoop.h
+++ b/Source/WebCore/dom/DocumentEventLoop.h
@@ -27,12 +27,3 @@
 
 #include <WebCore/Document.h>
 #include <WebCore/EventLoop.h>
-
-namespace WebCore {
-
-inline CheckedRef<EventLoopTaskGroup> Document::checkedEventLoop()
-{
-    return eventLoop();
-}
-
-}

--- a/Source/WebCore/dom/DocumentFullscreen.cpp
+++ b/Source/WebCore/dom/DocumentFullscreen.cpp
@@ -392,7 +392,7 @@ void DocumentFullscreen::elementEnterFullscreen(Element& element)
 
     queueFullscreenChangeEventForDocument(document);
 
-    RenderElement::markRendererDirtyAfterTopLayerChange(element.checkedRenderer().get(), containingBlockBeforeStyleResolution.get());
+    RenderElement::markRendererDirtyAfterTopLayerChange(protect(element.renderer()).get(), containingBlockBeforeStyleResolution.get());
 }
 
 bool DocumentFullscreen::didEnterFullscreen()

--- a/Source/WebCore/dom/DocumentInlines.h
+++ b/Source/WebCore/dom/DocumentInlines.h
@@ -64,11 +64,6 @@ inline ExtensionStyleSheets& Document::extensionStyleSheets()
     return *m_extensionStyleSheets;
 }
 
-inline CheckedRef<ExtensionStyleSheets> Document::checkedExtensionStyleSheets()
-{
-    return extensionStyleSheets();
-}
-
 inline VisitedLinkState& Document::visitedLinkState() const
 {
     if (!m_visitedLinkState)

--- a/Source/WebCore/dom/DocumentMarkerController.cpp
+++ b/Source/WebCore/dom/DocumentMarkerController.cpp
@@ -918,17 +918,17 @@ std::tuple<float, float> DocumentMarkerController::markerYPositionAndHeightForFo
 
 void addMarker(const SimpleRange& range, DocumentMarkerType type, const DocumentMarker::Data& data)
 {
-    protect(range.start.document())->checkedMarkers()->addMarker(range, type, data);
+    protect(protect(range.start.document())->markers())->addMarker(range, type, data);
 }
 
 void addMarker(Node& node, unsigned startOffset, unsigned length, DocumentMarkerType type, DocumentMarker::Data&& data)
 {
-    protect(node.document())->checkedMarkers()->addMarker(node, startOffset, length, type, WTF::move(data));
+    protect(protect(node.document())->markers())->addMarker(node, startOffset, length, type, WTF::move(data));
 }
 
 void removeMarkers(const SimpleRange& range, OptionSet<DocumentMarkerType> types, RemovePartiallyOverlappingMarker policy)
 {
-    protect(range.start.document())->checkedMarkers()->removeMarkers(range, types, policy);
+    protect(protect(range.start.document())->markers())->removeMarkers(range, types, policy);
 }
 
 SimpleRange makeSimpleRange(Node& node, const DocumentMarker& marker)

--- a/Source/WebCore/dom/DocumentMarkers.h
+++ b/Source/WebCore/dom/DocumentMarkers.h
@@ -44,14 +44,4 @@ inline const DocumentMarkerController& Document::markers() const
     return *m_markers;
 }
 
-inline CheckedRef<DocumentMarkerController> Document::checkedMarkers()
-{
-    return markers();
-}
-
-inline CheckedRef<const DocumentMarkerController> Document::checkedMarkers() const
-{
-    return markers();
-}
-
 }

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -253,7 +253,7 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
 
         Ref document = protectedThis->m_document.get();
         if (shouldPreserveUserGesture) {
-            document->checkedEventLoop()->queueMicrotask([weakThis] {
+            protect(document->eventLoop())->queueMicrotask([weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->enableTemporaryTimeUserGesture();
             });
@@ -278,7 +278,7 @@ void DocumentStorageAccess::requestStorageAccess(Ref<DeferredPromise>&& promise)
         }
 
         if (shouldPreserveUserGesture) {
-            document->checkedEventLoop()->queueMicrotask([weakThis] {
+            protect(document->eventLoop())->queueMicrotask([weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->consumeTemporaryTimeUserGesture();
             });
@@ -358,7 +358,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         bool shouldPreserveUserGesture = result.wasGranted == StorageAccessWasGranted::Yes || result.promptWasShown == StorageAccessPromptWasShown::No;
 
         if (shouldPreserveUserGesture) {
-            protectedThis->protectedDocument()->checkedEventLoop()->queueMicrotask([weakThis] {
+            protect(protectedThis->protectedDocument()->eventLoop())->queueMicrotask([weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->enableTemporaryTimeUserGesture();
             });
@@ -376,7 +376,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
         }
 
         if (shouldPreserveUserGesture) {
-            protectedThis->protectedDocument()->checkedEventLoop()->queueMicrotask([weakThis] {
+            protect(protectedThis->protectedDocument()->eventLoop())->queueMicrotask([weakThis] {
                 if (RefPtr protectedThis = weakThis.get())
                     protectedThis->consumeTemporaryTimeUserGesture();
             });

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -418,7 +418,7 @@ void Element::hideNonceSlow()
     ASSERT(isConnected());
     ASSERT(hasAttributeWithoutSynchronization(nonceAttr));
 
-    if (!protect(document())->checkedContentSecurityPolicy()->isHeaderDelivered())
+    if (!protect(protect(document())->contentSecurityPolicy())->isHeaderDelivered())
         return;
 
     // Retain previous IDL nonce.
@@ -1838,10 +1838,10 @@ IntRect Element::boundsInRootViewSpace()
 
     if (RefPtr svgElement = elementWithSVGLayoutBox(*this)) {
         if (auto localRect = svgElement->getBoundingBox())
-            quads.append(checkedRenderer()->localToAbsoluteQuad(*localRect));
+            quads.append(protect(renderer())->localToAbsoluteQuad(*localRect));
     } else if (shouldObtainBoundsFromBoxModel(this)) {
         // Get the bounding rectangle from the box model.
-        checkedRenderer()->absoluteQuads(quads);
+        protect(renderer())->absoluteQuads(quads);
     }
 
     return view->contentsToRootView(enclosingIntRect(unitedBoundingBoxes(quads)));
@@ -1902,7 +1902,7 @@ LayoutRect Element::absoluteEventBounds(bool& boundsIncludeAllDescendantElements
     LayoutRect result;
     if (RefPtr svgElement = elementWithSVGLayoutBox(*this)) {
         if (auto localRect = svgElement->getBoundingBox())
-            result = LayoutRect(checkedRenderer()->localToAbsoluteQuad(*localRect, UseTransforms, &includesFixedPositionElements).boundingBox());
+            result = LayoutRect(protect(renderer())->localToAbsoluteQuad(*localRect, UseTransforms, &includesFixedPositionElements).boundingBox());
     } else {
         CheckedPtr renderer = this->renderer();
         if (CheckedPtr box = dynamicDowncast<RenderBox>(renderer.get())) {
@@ -3625,11 +3625,6 @@ CustomElementDefaultARIA& Element::customElementDefaultARIA()
         defaultARIA = elementRareData()->customElementDefaultARIA();
     }
     return *defaultARIA.unsafeGet();
-}
-
-CheckedRef<CustomElementDefaultARIA> Element::checkedCustomElementDefaultARIA()
-{
-    return customElementDefaultARIA();
 }
 
 CustomElementDefaultARIA* Element::customElementDefaultARIAIfExists() const

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -482,7 +482,6 @@ public:
     CustomElementRegistry* customElementRegistry() const;
 
     CustomElementDefaultARIA& customElementDefaultARIA();
-    CheckedRef<CustomElementDefaultARIA> checkedCustomElementDefaultARIA();
     CustomElementDefaultARIA* customElementDefaultARIAIfExists() const;
 
     bool isInActiveChain() const { return isUserActionElement() && isUserActionElementInActiveChain(); }

--- a/Source/WebCore/dom/ElementInternals.cpp
+++ b/Source/WebCore/dom/ElementInternals.cpp
@@ -141,7 +141,7 @@ void ElementInternals::setAttributeWithoutSynchronization(const QualifiedName& n
     RefPtr element = m_element.get();
     auto oldValue = computeValueForAttribute(*element, name);
 
-    element->checkedCustomElementDefaultARIA()->setValueForAttribute(name, value);
+    protect(element->customElementDefaultARIA())->setValueForAttribute(name, value);
 
     if (CheckedPtr cache = element->document().existingAXObjectCache())
         cache->deferAttributeChangeIfNeeded(*element, name, oldValue, computeValueForAttribute(*element, name));
@@ -166,7 +166,7 @@ void ElementInternals::setElementAttribute(const QualifiedName& name, Element* v
     RefPtr element = m_element.get();
     auto oldValue = computeValueForAttribute(*element, name);
 
-    element->checkedCustomElementDefaultARIA()->setElementForAttribute(name, value);
+    protect(element->customElementDefaultARIA())->setElementForAttribute(name, value);
 
     if (CheckedPtr cache = element->document().existingAXObjectCache())
         cache->deferAttributeChangeIfNeeded(*element, name, oldValue, computeValueForAttribute(*element, name));
@@ -186,7 +186,7 @@ void ElementInternals::setElementsArrayAttribute(const QualifiedName& name, std:
     RefPtr element = m_element.get();
     auto oldValue = computeValueForAttribute(*element, name);
 
-    element->checkedCustomElementDefaultARIA()->setElementsForAttribute(name, WTF::move(value));
+    protect(element->customElementDefaultARIA())->setElementsForAttribute(name, WTF::move(value));
 
     if (CheckedPtr cache = element->document().existingAXObjectCache())
         cache->deferAttributeChangeIfNeeded(*element, name, oldValue, computeValueForAttribute(*element, name));

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -201,7 +201,7 @@ void removeOverlaySoonIfNeeded(HTMLElement& element)
     if (!hasOverlay(element))
         return;
 
-    protect(element.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
+    protect(protect(element.document())->eventLoop())->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
         RefPtr element = weakElement.get();
         if (!element)
             return;

--- a/Source/WebCore/dom/InlineStyleSheetOwner.cpp
+++ b/Source/WebCore/dom/InlineStyleSheetOwner.cpp
@@ -147,7 +147,7 @@ void InlineStyleSheetOwner::createSheet(Element& element, const String& text)
         return;
 
     ASSERT(document->contentSecurityPolicy());
-    if (!document->checkedContentSecurityPolicy()->allowInlineStyle(document->url().string(), m_startTextPosition.m_line, text, CheckUnsafeHashes::No, element, element.nonce(), element.isInUserAgentShadowTree() || is<PluginDocument>(document))) {
+    if (!protect(document->contentSecurityPolicy())->allowInlineStyle(document->url().string(), m_startTextPosition.m_line, text, CheckUnsafeHashes::No, element, element.nonce(), element.isInUserAgentShadowTree() || is<PluginDocument>(document))) {
         element.notifyLoadedSheetAndAllCriticalSubresources(true);
         return;
     }

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -502,12 +502,10 @@ public:
     // Integration with rendering tree
 
     RenderObject* renderer() const { return m_renderer; }
-    inline CheckedPtr<RenderObject> checkedRenderer() const; // Defined in NodeInlines.h
     void setRenderer(RenderObject*); // Defined in NodeInlines.h
 
     // Use these two methods with caution.
     inline RenderBox* renderBox() const; // Defined in NodeInlines.h
-    inline CheckedPtr<RenderBox> checkedRenderBox() const; // Defined in NodeInlines.h
     inline RenderBoxModelObject* renderBoxModelObject() const; // Defined in NodeInlines.h
 
     // Wrapper for nodes that don't have a renderer, but still cache the style (like HTMLOptionElement).

--- a/Source/WebCore/dom/NodeInlines.h
+++ b/Source/WebCore/dom/NodeInlines.h
@@ -63,11 +63,6 @@ inline RenderBox* Node::renderBox() const
     return dynamicDowncast<RenderBox>(renderer());
 }
 
-inline CheckedPtr<RenderBox> Node::checkedRenderBox() const
-{
-    return renderBox();
-}
-
 inline RenderBoxModelObject* Node::renderBoxModelObject() const
 {
     return dynamicDowncast<RenderBoxModelObject>(renderer());
@@ -84,11 +79,6 @@ inline NamedNodeMap* Node::attributesMap() const
     if (auto* element = dynamicDowncast<Element>(*this))
         return &element->attributesMap();
     return nullptr;
-}
-
-CheckedPtr<RenderObject> Node::checkedRenderer() const
-{
-    return renderer();
 }
 
 inline void Node::setRenderer(RenderObject* renderer)

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -297,7 +297,7 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
     case ScriptType::SpeculationRules: {
         // If the element has a source attribute, queue a task to fire an event named error at the element, and return.
         if (hasSourceAttribute()) {
-            protect(element->document())->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [protectedThis = Ref { *this }] {
+            protect(protect(element->document())->eventLoop())->queueTask(TaskSource::DOMManipulation, [protectedThis = Ref { *this }] {
                 protectedThis->dispatchErrorEvent();
             });
             return false;
@@ -375,7 +375,7 @@ bool ScriptElement::requestClassicScript(const String& sourceURL)
         auto scriptURL = document->completeURL(sourceURL);
         document->willLoadScriptElement(scriptURL);
 
-        if (!document->checkedContentSecurityPolicy()->allowNonParserInsertedScripts(scriptURL, URL(), m_startLineNumber, element->nonce(), script->integrity(), String(), m_parserInserted))
+        if (!protect(document->contentSecurityPolicy())->allowNonParserInsertedScripts(scriptURL, URL(), m_startLineNumber, element->nonce(), script->integrity(), String(), m_parserInserted))
             return false;
 
         if (script->load(document, scriptURL)) {

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -147,7 +147,6 @@ public:
     virtual bool isJSExecutionForbidden() const = 0;
 
     virtual EventLoopTaskGroup& eventLoop() = 0;
-    inline CheckedRef<EventLoopTaskGroup> checkedEventLoop();
 
     virtual const URL& url() const = 0;
     enum class ForceUTF8 : bool { No, Yes };

--- a/Source/WebCore/dom/ScriptExecutionContextInlines.h
+++ b/Source/WebCore/dom/ScriptExecutionContextInlines.h
@@ -49,11 +49,6 @@ inline DOMTimer* ScriptExecutionContext::findTimeout(int timeoutId)
     return m_timeouts.get(timeoutId);
 }
 
-inline CheckedRef<EventLoopTaskGroup> ScriptExecutionContext::checkedEventLoop()
-{
-    return eventLoop();
-}
-
 template<typename... Arguments>
 inline void ScriptExecutionContext::postCrossThreadTask(Arguments&&... arguments)
 {

--- a/Source/WebCore/dom/SecurityContext.cpp
+++ b/Source/WebCore/dom/SecurityContext.cpp
@@ -216,16 +216,11 @@ void SecurityContext::inheritPolicyContainerFrom(const PolicyContainer& policyCo
     if (!contentSecurityPolicy())
         setContentSecurityPolicy(makeUnique<ContentSecurityPolicy>(URL { }, nullptr, nullptr));
 
-    checkedContentSecurityPolicy()->inheritHeadersFrom(policyContainer.contentSecurityPolicyResponseHeaders);
+    protect(contentSecurityPolicy())->inheritHeadersFrom(policyContainer.contentSecurityPolicyResponseHeaders);
     setCrossOriginOpenerPolicy(policyContainer.crossOriginOpenerPolicy);
     setCrossOriginEmbedderPolicy(policyContainer.crossOriginEmbedderPolicy);
     setReferrerPolicy(policyContainer.referrerPolicy);
     setIPAddressSpace(policyContainer.ipAddressSpace);
-}
-
-CheckedPtr<ContentSecurityPolicy> SecurityContext::checkedContentSecurityPolicy()
-{
-    return contentSecurityPolicy();
 }
 
 const IntegrityPolicy* SecurityContext::integrityPolicy() const

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -54,7 +54,6 @@ public:
 
     SandboxFlags sandboxFlags() const { return m_sandboxFlags; }
     WEBCORE_EXPORT ContentSecurityPolicy* contentSecurityPolicy();
-    CheckedPtr<ContentSecurityPolicy> checkedContentSecurityPolicy();
 
     bool isSecureTransitionTo(const URL&) const;
 

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -154,7 +154,7 @@ void StyledElement::styleAttributeChanged(const AtomString& newStyleString, Attr
 
     if (newStyleString.isNull())
         ensureMutableInlineStyle()->clear();
-    else if (reason == AttributeModificationReason::ByCloning || document->checkedContentSecurityPolicy()->allowInlineStyle(document->url().string(), startLineNumber, newStyleString.string(), CheckUnsafeHashes::Yes, *this, nonce(), isInUserAgentShadowTree()))
+    else if (reason == AttributeModificationReason::ByCloning || protect(document->contentSecurityPolicy())->allowInlineStyle(document->url().string(), startLineNumber, newStyleString.string(), CheckUnsafeHashes::Yes, *this, nonce(), isInUserAgentShadowTree()))
         setInlineStyleFromString(newStyleString);
 
     elementData()->setStyleAttributeIsDirty(false);

--- a/Source/WebCore/dom/Text.h
+++ b/Source/WebCore/dom/Text.h
@@ -54,7 +54,6 @@ public:
     bool canContainRangeEndPoint() const final { return true; }
 
     RenderText* renderer() const;
-    CheckedPtr<RenderText> checkedRenderer() const;
 
     void updateRendererAfterContentChange(unsigned offsetOfReplacedData, unsigned lengthOfReplacedData);
 

--- a/Source/WebCore/dom/TrustedType.cpp
+++ b/Source/WebCore/dom/TrustedType.cpp
@@ -189,7 +189,7 @@ ExceptionOr<String> trustedTypeCompliantString(TrustedType expectedType, ScriptE
     }
 
     if (std::holds_alternative<std::monostate>(convertedInput)) {
-        auto allowMissingTrustedTypes = scriptExecutionContext.checkedContentSecurityPolicy()->allowMissingTrustedTypesForSinkGroup(trustedTypeToString(expectedType), sink, "script"_s, stringValue);
+        auto allowMissingTrustedTypes = protect(scriptExecutionContext.contentSecurityPolicy())->allowMissingTrustedTypesForSinkGroup(trustedTypeToString(expectedType), sink, "script"_s, stringValue);
 
         if (!allowMissingTrustedTypes)
             return Exception { ExceptionCode::TypeError, makeString("This assignment requires a "_s, trustedTypeToString(expectedType)) };

--- a/Source/WebCore/dom/ViewTransition.cpp
+++ b/Source/WebCore/dom/ViewTransition.cpp
@@ -182,7 +182,7 @@ void ViewTransition::skipViewTransition(ExceptionOr<JSC::JSValue>&& reason)
 
     Ref document = *this->document();
     if (m_phase < ViewTransitionPhase::UpdateCallbackCalled) {
-        document->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+        protect(document->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
             RefPtr protectedThis = weakThis.get();
             if (protectedThis && protect(protectedThis->document())->globalObject())
                 protectedThis->callUpdateCallback();
@@ -297,7 +297,7 @@ void ViewTransition::callUpdateCallback()
         protectedThis->skipViewTransition(WTF::move(result));
     });
 
-    m_updateCallbackTimeout = document->checkedEventLoop()->scheduleTask(defaultTimeout, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+    m_updateCallbackTimeout = protect(document->eventLoop())->scheduleTask(defaultTimeout, TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
         RefPtr protectedThis = weakThis.get();
         LOG_WITH_STREAM(ViewTransitions, stream << "ViewTransition " << protectedThis.get() << " update callback timed out");
         if (!protectedThis)
@@ -330,7 +330,7 @@ void ViewTransition::setupViewTransition()
     else
         document->setRenderingIsSuppressedForViewTransitionAfterUpdateRendering();
 
-    document->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
+    protect(document->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }] {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -206,7 +206,7 @@ void updateImageControls(HTMLElement& element)
     if (!element.document().settings().imageControlsEnabled())
         return;
 
-    protect(element.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
+    protect(protect(element.document())->eventLoop())->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
         RefPtr protectedElement = weakElement.get();
         if (!protectedElement)
             return;

--- a/Source/WebCore/editing/AlternativeTextController.cpp
+++ b/Source/WebCore/editing/AlternativeTextController.cpp
@@ -119,7 +119,7 @@ void AlternativeTextController::startAlternativeTextUITimer(AlternativeTextType 
     if (type == AlternativeTextType::Correction)
         m_rangeWithAlternative = std::nullopt;
     m_type = type;
-    m_timer = protectedDocument()->checkedEventLoop()->scheduleTask(correctionPanelTimerInterval, TaskSource::UserInteraction, [weakThis = WeakPtr { *this }] {
+    m_timer = protect(protectedDocument()->eventLoop())->scheduleTask(correctionPanelTimerInterval, TaskSource::UserInteraction, [weakThis = WeakPtr { *this }] {
         if (CheckedPtr checkedThis = weakThis.get())
             checkedThis->timerFired();
     });
@@ -761,7 +761,7 @@ void AlternativeTextController::applyDictationAlternative(const String& alternat
     auto selection = editor->selectedRange();
     if (!selection || !editor->shouldInsertText(alternativeString, *selection, EditorInsertAction::Pasted))
         return;
-    for (auto& marker : selection->startContainer().document().checkedMarkers()->markersInRange(*selection, DocumentMarkerType::DictationAlternatives))
+    for (auto& marker : protect(selection->startContainer().document().markers())->markersInRange(*selection, DocumentMarkerType::DictationAlternatives))
         removeDictationAlternativesForMarker(*marker);
     applyAlternativeTextToRange(*selection, alternativeString, AlternativeTextType::DictationAlternatives, markerTypesForAppliedDictationAlternative());
 #else

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -474,7 +474,7 @@ void CheckboxInputType::updateIsSwitchVisuallyOnFromAbsoluteLocation(LayoutPoint
     auto isSwitchVisuallyOn = m_isSwitchVisuallyOn;
     auto isRTL = element->computedStyle()->writingMode().isBidiRTL();
     auto switchThumbIsLogicallyLeft = (!isRTL && !isSwitchVisuallyOn) || (isRTL && isSwitchVisuallyOn);
-    auto switchTrackRect = element->checkedRenderer()->absoluteBoundingBoxRect();
+    auto switchTrackRect = protect(element->renderer())->absoluteBoundingBoxRect();
     auto switchThumbLength = switchTrackRect.height();
     auto switchTrackWidth = switchTrackRect.width();
 
@@ -522,7 +522,7 @@ void CheckboxInputType::switchAnimationTimerFired()
             stopSwitchAnimation(SwitchAnimationType::Held);
     }
 
-    element->checkedRenderer()->repaint();
+    protect(element->renderer())->repaint();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -173,7 +173,7 @@ void HTMLFrameElementBase::didFinishInsertingNode()
     if (!m_openingURLAfterInserting)
         work();
     else
-        document->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, WTF::move(work));
+        protect(document->eventLoop())->queueTask(TaskSource::DOMManipulation, WTF::move(work));
 }
 
 void HTMLFrameElementBase::didAttachRenderers()

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -642,7 +642,7 @@ unsigned HTMLImageElement::naturalWidth() const
     if (!m_imageLoader->image())
         return 0;
 
-    return m_imageLoader->image()->unclampedImageSizeForRenderer(checkedRenderer().get(), effectiveImageDevicePixelRatio()).width().toUnsigned();
+    return m_imageLoader->image()->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).width().toUnsigned();
 }
 
 unsigned HTMLImageElement::naturalHeight() const
@@ -650,7 +650,7 @@ unsigned HTMLImageElement::naturalHeight() const
     if (!m_imageLoader->image())
         return 0;
 
-    return m_imageLoader->image()->unclampedImageSizeForRenderer(checkedRenderer().get(), effectiveImageDevicePixelRatio()).height().toUnsigned();
+    return m_imageLoader->image()->unclampedImageSizeForRenderer(protect(renderer()).get(), effectiveImageDevicePixelRatio()).height().toUnsigned();
 }
 
 bool HTMLImageElement::isURLAttribute(const Attribute& attribute) const

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -386,7 +386,7 @@ void HTMLLinkElement::process()
         ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
         options.nonce = nonce();
         options.sameOriginDataURLFlag = SameOriginDataURLFlag::Set;
-        if (document->checkedContentSecurityPolicy()->allowStyleWithNonce(options.nonce))
+        if (protect(document->contentSecurityPolicy())->allowStyleWithNonce(options.nonce))
             options.contentSecurityPolicyImposition = ContentSecurityPolicyImposition::SkipPolicyCheck;
         options.integrity = m_integrityMetadataForPendingSheetRequest;
         options.referrerPolicy = params.referrerPolicy;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -2789,7 +2789,7 @@ static inline bool isAllowedToLoadMediaURL(const HTMLMediaElement& element, cons
         return true;
 
     ASSERT(element.document().contentSecurityPolicy());
-    return protect(element.document())->checkedContentSecurityPolicy()->allowMediaFromSource(url);
+    return protect(protect(element.document())->contentSecurityPolicy())->allowMediaFromSource(url);
 }
 
 bool HTMLMediaElement::isSafeToLoadURL(const URL& url, InvalidURLAction actionIfInvalid, bool shouldLog) const
@@ -3887,7 +3887,7 @@ void HTMLMediaElement::setAudioOutputDevice(String&& deviceId, DOMPromiseDeferre
     if (RefPtr player = m_player)
         player->audioOutputDeviceChanged();
 
-    protect(scriptExecutionContext())->checkedEventLoop()->queueTask(TaskSource::MediaElement, [this, protectedThis = Ref { *this }, deviceId = WTF::move(deviceId), promise = WTF::move(promise)]() mutable {
+    protect(protect(scriptExecutionContext())->eventLoop())->queueTask(TaskSource::MediaElement, [this, protectedThis = Ref { *this }, deviceId = WTF::move(deviceId), promise = WTF::move(promise)]() mutable {
         m_audioOutputHashedDeviceId = WTF::move(deviceId);
         promise.resolve();
     });
@@ -9886,7 +9886,7 @@ void HTMLMediaElement::updateMediaPlayer(IntSize presentationSize, bool shouldMa
 
 void HTMLMediaElement::mediaPlayerQueueTaskOnEventLoop(Function<void()>&& task)
 {
-    protect(document())->checkedEventLoop()->queueTask(TaskSource::MediaElement, WTF::move(task));
+    protect(protect(document())->eventLoop())->queueTask(TaskSource::MediaElement, WTF::move(task));
 }
 
 template<typename T> void HTMLMediaElement::scheduleEventOn(T& target, Ref<Event>&& event)

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -463,7 +463,7 @@ bool HTMLPlugInElement::requestObject(const String& relativeURL, const String& m
     if (ScriptDisallowedScope::InMainThread::isScriptAllowed())
         return document->frame()->loader().subframeLoader().requestObject(*this, relativeURL, getNameAttribute(), mimeType, paramNames, paramValues);
 
-    document->checkedEventLoop()->queueTask(TaskSource::Networking, [this, protectedThis = Ref { *this }, relativeURL, nameAttribute = getNameAttribute(), mimeType, paramNames, paramValues, document]() mutable {
+    protect(document->eventLoop())->queueTask(TaskSource::Networking, [this, protectedThis = Ref { *this }, relativeURL, nameAttribute = getNameAttribute(), mimeType, paramNames, paramValues, document]() mutable {
         if (!this->isConnected() || &this->document() != document.ptr())
             return;
         RefPtr frame = this->document().frame();
@@ -514,7 +514,7 @@ void HTMLPlugInElement::scheduleUpdateForAfterStyleResolution()
 
     m_hasUpdateScheduledForAfterStyleResolution = true;
 
-    document->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [element = GCReachableRef { *this }] {
+    protect(document->eventLoop())->queueTask(TaskSource::DOMManipulation, [element = GCReachableRef { *this }] {
         element->updateAfterStyleResolution();
     });
 }

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -224,7 +224,7 @@ bool HTMLTrackElement::canLoadURL(const URL& url)
     Ref document = this->document();
     ASSERT(document->contentSecurityPolicy());
     // Elements in user agent show tree should load whatever the embedding document policy is.
-    if (!isInUserAgentShadowTree() && !document->checkedContentSecurityPolicy()->allowMediaFromSource(url)) {
+    if (!isInUserAgentShadowTree() && !protect(document->contentSecurityPolicy())->allowMediaFromSource(url)) {
         LOG(Media, "HTMLTrackElement::canLoadURL(%s) -> rejected by Content Security Policy", urlForLoggingTrack(url).utf8().data());
         return false;
     }

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -811,7 +811,7 @@ private:
     void createImageBitmapAndCallCompletionHandlerSoon(RefPtr<ArrayBuffer>&& arrayBuffer)
     {
         m_arrayBufferToProcess = WTF::move(arrayBuffer);
-        protect(scriptExecutionContext())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakThis = WeakPtr { *this }] {
+        protect(protect(scriptExecutionContext())->eventLoop())->queueTask(TaskSource::InternalAsyncTask, [weakThis = WeakPtr { *this }] {
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->createImageBitmapAndCallCompletionHandler();
         });

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -145,7 +145,7 @@ LayoutSize ImageDocument::imageSize()
     CachedResourceHandle cachedImage = imageElement->cachedImage();
     if (!cachedImage)
         return { };
-    return cachedImage->imageSizeForRenderer(imageElement->checkedRenderer().get(), frame() ? frame()->pageZoomFactor() : 1);
+    return cachedImage->imageSizeForRenderer(protect(imageElement->renderer()).get(), frame() ? frame()->pageZoomFactor() : 1);
 }
 
 void ImageDocument::updateDuringParsing()
@@ -190,7 +190,7 @@ void ImageDocument::finishedParsing()
         // Report the natural image size in the page title, regardless of zoom level.
         // At a zoom level of 1 the image is guaranteed to have an integer size.
         updateStyleIfNeeded();
-        IntSize size = flooredIntSize(cachedImage->imageSizeForRenderer(imageElement->checkedRenderer().get(), 1));
+        IntSize size = flooredIntSize(cachedImage->imageSizeForRenderer(protect(imageElement->renderer()).get(), 1));
         if (size.width()) {
             // Compute the title. We use the decoded filename of the resource, falling
             // back on the hostname if there is no path.

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -829,7 +829,7 @@ void TextFieldInputType::createContainer(PreserveSelectionRange preserveSelectio
     innerBlock->appendChild(Ref { *m_innerText });
 
     if (selectionState) {
-        document->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [selectionState = *selectionState, element = WeakPtr { element }] {
+        protect(document->eventLoop())->queueTask(TaskSource::DOMManipulation, [selectionState = *selectionState, element = WeakPtr { element }] {
             if (!element || !element->focused())
                 return;
 
@@ -934,7 +934,7 @@ IntRect TextFieldInputType::elementRectInRootViewCoordinates() const
     if (!element()->renderer())
         return IntRect();
     Ref element = *this->element();
-    return protect(protect(element->document())->view())->contentsToRootView(element->checkedRenderer()->absoluteBoundingBoxRect());
+    return protect(protect(element->document())->view())->contentsToRootView(protect(element->renderer())->absoluteBoundingBoxRect());
 }
 
 Vector<DataListSuggestion> TextFieldInputType::suggestions()

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -1520,12 +1520,12 @@ static LayoutSize size(CachedImage* cachedImage, RenderElement* renderer, ImageS
 
 static LayoutSize size(HTMLImageElement& element, ImageSizeType sizeType = ImageSizeType::BeforeDevicePixelRatio)
 {
-    return size(element.cachedImage(), element.checkedRenderer().get(), sizeType);
+    return size(element.cachedImage(), protect(element.renderer()).get(), sizeType);
 }
 
 static LayoutSize size(SVGImageElement& element, ImageSizeType sizeType = ImageSizeType::BeforeDevicePixelRatio)
 {
-    return size(element.cachedImage(), element.checkedRenderer().get(), sizeType);
+    return size(element.cachedImage(), protect(element.renderer()).get(), sizeType);
 }
 
 static inline FloatSize size(CanvasBase& canvas)
@@ -1632,7 +1632,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(HTMLImageElement& imag
             orientation = Style::toPlatform(computedStyle->imageOrientation()).orientation();
     }
 
-    auto result = drawImage(protect(imageElement.document()).get(), *cachedImage, imageElement.checkedRenderer().get(), imageRect, srcRect, dstRect, op, blendMode, orientation);
+    auto result = drawImage(protect(imageElement.document()).get(), *cachedImage, protect(imageElement.renderer()).get(), imageRect, srcRect, dstRect, op, blendMode, orientation);
 
     if (!result.hasException())
         checkOrigin(&imageElement);
@@ -1655,7 +1655,7 @@ ExceptionOr<void> CanvasRenderingContext2DBase::drawImage(SVGImageElement& image
 
     auto imageRect = FloatRect(FloatPoint(), size(imageElement, ImageSizeType::BeforeDevicePixelRatio));
 
-    auto result = drawImage(protect(imageElement.document()).get(), *cachedImage, imageElement.checkedRenderer().get(), imageRect, srcRect, dstRect, op, blendMode);
+    auto result = drawImage(protect(imageElement.document()).get(), *cachedImage, protect(imageElement.renderer()).get(), imageRect, srcRect, dstRect, op, blendMode);
 
     if (!result.hasException())
         checkOrigin(&imageElement);
@@ -2235,7 +2235,7 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(H
     if (intrinsicWidth == 0 || intrinsicHeight == 0)
         return nullptr;
 
-    return createPattern(*cachedImage, imageElement.checkedRenderer().get(), repeatX, repeatY);
+    return createPattern(*cachedImage, protect(imageElement.renderer()).get(), repeatX, repeatY);
 }
 
 ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(SVGImageElement& imageElement, bool repeatX, bool repeatY)
@@ -2261,7 +2261,7 @@ ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(S
     if (intrinsicWidth == 0 || intrinsicHeight == 0)
         return nullptr;
 
-    return createPattern(*cachedImage, imageElement.checkedRenderer().get(), repeatX, repeatY);
+    return createPattern(*cachedImage, protect(imageElement.renderer()).get(), repeatX, repeatY);
 }
 
 ExceptionOr<RefPtr<CanvasPattern>> CanvasRenderingContext2DBase::createPattern(CanvasBase& canvas, bool repeatX, bool repeatY)

--- a/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
+++ b/Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp
@@ -77,7 +77,7 @@ void EXTDisjointTimerQueryWebGL2::queryCounterEXT(WebGLQuery& query, GCGLenum ta
     context->graphicsContextGL()->queryCounterEXT(query.object(), target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    protect(context->scriptExecutionContext())->checkedEventLoop()->queueMicrotask([&] {
+    protect(protect(context->scriptExecutionContext())->eventLoop())->queueMicrotask([&] {
         query.makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1809,7 +1809,7 @@ void WebGL2RenderingContext::endQuery(GCGLenum target)
     graphicsContextGL()->endQuery(target);
 
     // A query's result must not be made available until control has returned to the user agent's main loop.
-    protect(scriptExecutionContext())->checkedEventLoop()->queueMicrotask([query = WTF::move(m_activeQueries[*activeQueryKey])] {
+    protect(protect(scriptExecutionContext())->eventLoop())->queueMicrotask([query = WTF::move(m_activeQueries[*activeQueryKey])] {
         query->makeResultAvailable();
     });
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -3282,7 +3282,7 @@ ExceptionOr<void> WebGLRenderingContextBase::texImageSource(TexImageFunctionID f
     if (!validationResult.returnValue())
         return { };
 
-    RefPtr imageForRender = source.cachedImage()->imageForRenderer(source.checkedRenderer().get());
+    RefPtr imageForRender = source.cachedImage()->imageForRenderer(protect(source.renderer()).get());
     if (!imageForRender)
         return { };
 
@@ -5205,7 +5205,7 @@ void WebGLRenderingContextBase::maybeRestoreContextSoon(Seconds timeout)
     if (!scriptExecutionContext)
         return;
 
-    m_restoreTimer = scriptExecutionContext->checkedEventLoop()->scheduleTask(timeout, TaskSource::WebGL, [weakThis = WeakPtr { *this }] {
+    m_restoreTimer = protect(scriptExecutionContext->eventLoop())->scheduleTask(timeout, TaskSource::WebGL, [weakThis = WeakPtr { *this }] {
         if (RefPtr protectedThis = weakThis.get()) {
             protectedThis->m_restoreTimer = nullptr;
             protectedThis->maybeRestoreContext();

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -53,9 +53,9 @@ CachedResourceRequest PreloadRequest::resourceRequest(Document& document)
 
     bool skipContentSecurityPolicyCheck = false;
     if (m_resourceType == CachedResource::Type::Script || m_resourceType == CachedResource::Type::JSON)
-        skipContentSecurityPolicyCheck = document.checkedContentSecurityPolicy()->allowScriptWithNonce(m_nonceAttribute);
+        skipContentSecurityPolicyCheck = protect(document.contentSecurityPolicy())->allowScriptWithNonce(m_nonceAttribute);
     else if (m_resourceType == CachedResource::Type::CSSStyleSheet)
-        skipContentSecurityPolicyCheck = document.checkedContentSecurityPolicy()->allowStyleWithNonce(m_nonceAttribute);
+        skipContentSecurityPolicyCheck = protect(document.contentSecurityPolicy())->allowStyleWithNonce(m_nonceAttribute);
 
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
     if (skipContentSecurityPolicyCheck)

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -461,7 +461,7 @@ void MediaControlTextTrackContainerElement::updateSizes(ForceUpdate force)
     for (auto& activeCue : currentlyActiveCues())
         activeCue.data()->recalculateStyles();
 
-    document->checkedEventLoop()->queueTask(TaskSource::MediaElement, [weakThis = WeakPtr { *this }] () {
+    protect(document->eventLoop())->queueTask(TaskSource::MediaElement, [weakThis = WeakPtr { *this }] () {
         if (weakThis)
             weakThis->updateDisplay();
     });

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -280,7 +280,7 @@ void SliderThumbElement::setPositionFromPoint(const LayoutPoint& absolutePoint)
     auto stepRange = input->createStepRange(AnyStepHandling::Reject);
     auto value = stepRange.clampValue(stepRange.valueFromProportion(fraction));
 
-    const LayoutUnit snappingThreshold = checkedRenderer()->theme().sliderTickSnappingThreshold();
+    const LayoutUnit snappingThreshold = protect(renderer())->theme().sliderTickSnappingThreshold();
     if (snappingThreshold > 0) {
         if (std::optional<Decimal> closest = input->findClosestTickMarkValue(value)) {
             double closestFraction = stepRange.proportionFromValue(*closest).toDouble();

--- a/Source/WebCore/html/shadow/SpatialImageControls.cpp
+++ b/Source/WebCore/html/shadow/SpatialImageControls.cpp
@@ -116,7 +116,7 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
     if (!shouldHaveSpatialControls(imageElement) || hasSpatialImageControls(imageElement))
         return;
 
-    protect(imageElement.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { imageElement }] {
+    protect(protect(imageElement.document())->eventLoop())->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { imageElement }] {
         RefPtr element = weakElement.get();
         if (!element)
             return;
@@ -248,7 +248,7 @@ bool handleEvent(HTMLElement& element, Event& event)
 
 void destroySpatialImageControls(HTMLElement& element)
 {
-    protect(element.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
+    protect(protect(element.document())->eventLoop())->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr { element }] {
         RefPtr protectedElement = weakElement.get();
         if (!protectedElement)
             return;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -810,7 +810,7 @@ std::optional<CrossOriginOpenerPolicyEnforcementResult> DocumentLoader::doCrossO
 
     auto currentCoopEnforcementResult = CrossOriginOpenerPolicyEnforcementResult::from(document->url(), document->securityOrigin(), document->crossOriginOpenerPolicy(), m_triggeringAction.requester(), openerURL);
 
-    auto newCoopEnforcementResult = WebCore::doCrossOriginOpenerHandlingOfResponse(*document, response, m_triggeringAction.requester(), checkedContentSecurityPolicy().get(), frame->effectiveSandboxFlags(), m_request.httpReferrer(), frameLoader()->stateMachine().isDisplayingInitialEmptyDocument(), currentCoopEnforcementResult);
+    auto newCoopEnforcementResult = WebCore::doCrossOriginOpenerHandlingOfResponse(*document, response, m_triggeringAction.requester(), protect(contentSecurityPolicy()).get(), frame->effectiveSandboxFlags(), m_request.httpReferrer(), frameLoader()->stateMachine().isDisplayingInitialEmptyDocument(), currentCoopEnforcementResult);
     if (!newCoopEnforcementResult) {
         cancelMainResourceLoad(protect(frameLoader())->cancelledError(m_request));
         return std::nullopt;
@@ -890,7 +890,7 @@ void DocumentLoader::responseReceived(const CachedResource& resource, const Reso
 
         if (!m_contentSecurityPolicy)
             m_contentSecurityPolicy = makeUnique<ContentSecurityPolicy>(URL { response.url() }, nullptr, reportingClient);
-        checkedContentSecurityPolicy()->didReceiveHeaders(ContentSecurityPolicyResponseHeaders { response }, m_request.httpReferrer(), ContentSecurityPolicy::ReportParsingErrors::No);
+        protect(contentSecurityPolicy())->didReceiveHeaders(ContentSecurityPolicyResponseHeaders { response }, m_request.httpReferrer(), ContentSecurityPolicy::ReportParsingErrors::No);
     }
     if (frame && frame->document() && frame->document()->settings().crossOriginOpenerPolicyEnabled())
         m_responseCOOP = obtainCrossOriginOpenerPolicy(response);
@@ -2744,11 +2744,6 @@ void DocumentLoader::setNewResultingClientId(ScriptExecutionContextIdentifier id
         m_resultingClientId = identifier;
         scriptExecutionContextIdentifierToLoaderMap().add(identifier, this);
     }
-}
-
-CheckedPtr<ContentSecurityPolicy> DocumentLoader::checkedContentSecurityPolicy() const
-{
-    return m_contentSecurityPolicy.get();
 }
 
 std::unique_ptr<IntegrityPolicy> DocumentLoader::integrityPolicy()

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -514,7 +514,6 @@ public:
     void setLastNavigationWasAppInitiated(bool lastNavigationWasAppInitiated) { m_lastNavigationWasAppInitiated = lastNavigationWasAppInitiated; }
 
     ContentSecurityPolicy* contentSecurityPolicy() const { return m_contentSecurityPolicy.get(); }
-    CheckedPtr<ContentSecurityPolicy> checkedContentSecurityPolicy() const;
     const std::optional<CrossOriginOpenerPolicy>& crossOriginOpenerPolicy() const { return m_responseCOOP; }
     OptionSet<ClearSiteDataValue> responseClearSiteDataValues() const { return m_responseClearSiteDataValues; }
 

--- a/Source/WebCore/loader/DocumentThreadableLoader.cpp
+++ b/Source/WebCore/loader/DocumentThreadableLoader.cpp
@@ -167,7 +167,7 @@ DocumentThreadableLoader::DocumentThreadableLoader(Document& document, Threadabl
         m_responsesCanBeOpaque = false;
     }
 
-    m_options.cspResponseHeaders = m_options.contentSecurityPolicyEnforcement != ContentSecurityPolicyEnforcement::DoNotEnforce ? checkedContentSecurityPolicy()->responseHeaders() : ContentSecurityPolicyResponseHeaders { };
+    m_options.cspResponseHeaders = m_options.contentSecurityPolicyEnforcement != ContentSecurityPolicyEnforcement::DoNotEnforce ? protect(this->contentSecurityPolicy())->responseHeaders() : ContentSecurityPolicyResponseHeaders { };
     m_options.crossOriginEmbedderPolicy = this->crossOriginEmbedderPolicy();
 
     // As per step 11 of https://fetch.spec.whatwg.org/#main-fetch, data scheme (if same-origin data-URL flag is set) and about scheme are considered same-origin.
@@ -704,11 +704,11 @@ bool DocumentThreadableLoader::isAllowedByContentSecurityPolicy(const URL& url, 
     case ContentSecurityPolicyEnforcement::DoNotEnforce:
         return true;
     case ContentSecurityPolicyEnforcement::EnforceWorkerSrcDirective:
-        return checkedContentSecurityPolicy()->allowWorkerFromSource(url, redirectResponseReceived, preRedirectURL);
+        return protect(contentSecurityPolicy())->allowWorkerFromSource(url, redirectResponseReceived, preRedirectURL);
     case ContentSecurityPolicyEnforcement::EnforceConnectSrcDirective:
-        return checkedContentSecurityPolicy()->allowConnectToSource(url, redirectResponseReceived, preRedirectURL);
+        return protect(contentSecurityPolicy())->allowConnectToSource(url, redirectResponseReceived, preRedirectURL);
     case ContentSecurityPolicyEnforcement::EnforceScriptSrcDirective:
-        return checkedContentSecurityPolicy()->allowScriptFromSource(url, redirectResponseReceived, preRedirectURL, m_options.integrity, m_options.nonce);
+        return protect(contentSecurityPolicy())->allowScriptFromSource(url, redirectResponseReceived, preRedirectURL, m_options.integrity, m_options.nonce);
     }
     ASSERT_NOT_REACHED();
     return false;
@@ -743,11 +743,6 @@ const ContentSecurityPolicy& DocumentThreadableLoader::contentSecurityPolicy() c
         return *m_contentSecurityPolicy.get();
     ASSERT(m_document->contentSecurityPolicy());
     return *m_document->contentSecurityPolicy();
-}
-
-CheckedRef<const ContentSecurityPolicy> DocumentThreadableLoader::checkedContentSecurityPolicy() const
-{
-    return contentSecurityPolicy();
 }
 
 const CrossOriginEmbedderPolicy& DocumentThreadableLoader::crossOriginEmbedderPolicy() const

--- a/Source/WebCore/loader/DocumentThreadableLoader.h
+++ b/Source/WebCore/loader/DocumentThreadableLoader.h
@@ -110,7 +110,6 @@ class CachedRawResource;
         Ref<SecurityOrigin> topOrigin() const;
         SecurityOrigin& securityOrigin() const;
         const ContentSecurityPolicy& contentSecurityPolicy() const;
-        CheckedRef<const ContentSecurityPolicy> checkedContentSecurityPolicy() const;
         const CrossOriginEmbedderPolicy& NODELETE crossOriginEmbedderPolicy() const;
 
         Document& document() { return *m_document; }

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -235,11 +235,11 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
             RefPtr parentFrame = dynamicDowncast<LocalFrame>(frame->tree().parent());
             if (parentFrame && parentFrame->document()) {
                 document->inheritPolicyContainerFrom(parentFrame->document()->policyContainer());
-                document->checkedContentSecurityPolicy()->updateSourceSelf(protect(protect(parentFrame->document())->securityOrigin()));
+                protect(document->contentSecurityPolicy())->updateSourceSelf(protect(protect(parentFrame->document())->securityOrigin()));
             }
         } else if (triggeringAction && triggeringAction->requester() && !isLoadingBrowserControlledHTML()) {
             document->inheritPolicyContainerFrom(triggeringAction->requester()->policyContainer);
-            document->checkedContentSecurityPolicy()->updateSourceSelf(triggeringAction->requester()->securityOrigin);
+            protect(document->contentSecurityPolicy())->updateSourceSelf(triggeringAction->requester()->securityOrigin);
         }
 
         // https://html.spec.whatwg.org/multipage/origin.html#requires-storing-the-policy-container-in-history
@@ -248,7 +248,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
     }
 
     if (existingDocument && existingDocument->contentSecurityPolicy() && document->contentSecurityPolicy())
-        document->checkedContentSecurityPolicy()->setInsecureNavigationRequestsToUpgrade(existingDocument->checkedContentSecurityPolicy()->takeNavigationRequestsToUpgrade());
+        protect(document->contentSecurityPolicy())->setInsecureNavigationRequestsToUpgrade(protect(existingDocument->contentSecurityPolicy())->takeNavigationRequestsToUpgrade());
 
     frameLoader->didBeginDocument(dispatch, previousWindow.get());
 

--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -201,7 +201,7 @@ Ref<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormContro
     bool isMailtoForm = actionURL.protocolIs("mailto"_s);
     bool isMultiPartForm = false;
 
-    document->checkedContentSecurityPolicy()->upgradeInsecureRequestIfNeeded(actionURL, ContentSecurityPolicy::InsecureRequestType::FormSubmission);
+    protect(document->contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(actionURL, ContentSecurityPolicy::InsecureRequestType::FormSubmission);
 
     if (copiedAttributes.method() == Method::Post) {
         isMultiPartForm = copiedAttributes.isMultiPartForm();

--- a/Source/WebCore/loader/PingLoader.cpp
+++ b/Source/WebCore/loader/PingLoader.cpp
@@ -107,7 +107,7 @@ void PingLoader::loadImage(LocalFrame& frame, URL&& url)
         return;
 #endif
 
-    document->checkedContentSecurityPolicy()->upgradeInsecureRequestIfNeeded(request, ContentSecurityPolicy::InsecureRequestType::Load);
+    protect(document->contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(request, ContentSecurityPolicy::InsecureRequestType::Load);
 
     request.setHTTPHeaderField(HTTPHeaderName::CacheControl, HTTPHeaderValues::maxAge0());
 
@@ -139,9 +139,9 @@ void PingLoader::sendPing(LocalFrame& frame, URL&& sendPingURL, const URL& desti
 #endif
 
     Ref document = *frame.document();
-    if (!document->checkedContentSecurityPolicy()->allowConnectToSource(pingURL))
+    if (!protect(document->contentSecurityPolicy())->allowConnectToSource(pingURL))
         return;
-    document->checkedContentSecurityPolicy()->upgradeInsecureRequestIfNeeded(request, ContentSecurityPolicy::InsecureRequestType::Load);
+    protect(document->contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(request, ContentSecurityPolicy::InsecureRequestType::Load);
 
     request.setHTTPMethod("POST"_s);
     request.setHTTPContentType("text/ping"_s);
@@ -181,7 +181,7 @@ void PingLoader::sendViolationReport(LocalFrame& frame, URL&& violationReportURL
 #endif
 
     Ref document = *frame.document();
-    document->checkedContentSecurityPolicy()->upgradeInsecureRequestIfNeeded(request, ContentSecurityPolicy::InsecureRequestType::Load);
+    protect(document->contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(request, ContentSecurityPolicy::InsecureRequestType::Load);
 
     request.setHTTPMethod("POST"_s);
     request.setHTTPBody(WTF::move(report));

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -88,8 +88,8 @@ static bool isAllowedByContentSecurityPolicy(const URL& url, const Element* owne
 
     ASSERT(ownerElement->document().contentSecurityPolicy());
     if (is<HTMLPlugInElement>(ownerElement))
-        return protect(ownerElement->document())->checkedContentSecurityPolicy()->allowObjectFromSource(url, redirectResponseReceived);
-    return protect(ownerElement->document())->checkedContentSecurityPolicy()->allowChildFrameFromSource(url, redirectResponseReceived);
+        return protect(protect(ownerElement->document())->contentSecurityPolicy())->allowObjectFromSource(url, redirectResponseReceived);
+    return protect(protect(ownerElement->document())->contentSecurityPolicy())->allowChildFrameFromSource(url, redirectResponseReceived);
 }
 
 static bool shouldExecuteJavaScriptURLSynchronously(const URL& url)
@@ -294,7 +294,7 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
         if (shouldExecuteJavaScriptURLSynchronously(request.url()))
             return decisionHandler(PolicyAction::Use);
 
-        document->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }, decisionHandler = WTF::move(decisionHandler), identifier = m_javaScriptURLPolicyCheckIdentifier] () mutable {
+        protect(document->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { *this }, decisionHandler = WTF::move(decisionHandler), identifier = m_javaScriptURLPolicyCheckIdentifier] () mutable {
             if (!weakThis)
                 return decisionHandler(PolicyAction::Ignore);
             // Don't proceed if PolicyChecker::stopCheck has been called between the call to queueTask and now.

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -75,7 +75,7 @@ using namespace HTMLNames;
 static bool canLoadJavaScriptURL(HTMLFrameOwnerElement& ownerElement, const URL& url)
 {
     ASSERT(url.protocolIsJavaScript());
-    if (!protect(ownerElement.document())->checkedContentSecurityPolicy()->allowJavaScriptURLs(aboutBlankURL().string(), { }, url.string(), &ownerElement))
+    if (!protect(protect(ownerElement.document())->contentSecurityPolicy())->allowJavaScriptURLs(aboutBlankURL().string(), { }, url.string(), &ownerElement))
         return false;
     if (!ownerElement.canLoadScriptURL(url))
         return false;
@@ -237,7 +237,7 @@ bool FrameLoader::SubframeLoader::requestObject(HTMLPlugInElement& ownerElement,
     if (!url.isEmpty())
         completedURL = completeURL(url);
 
-    document->checkedContentSecurityPolicy()->upgradeInsecureRequestIfNeeded(completedURL, ContentSecurityPolicy::InsecureRequestType::Load);
+    protect(document->contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(completedURL, ContentSecurityPolicy::InsecureRequestType::Load);
 
     // Historically, we haven't run javascript URLs in <embed> / <object> elements.
     if (completedURL.protocolIsJavaScript())
@@ -266,7 +266,7 @@ LocalFrame* FrameLoader::SubframeLoader::loadOrRedirectSubframe(HTMLFrameOwnerEl
     Ref initiatingDocument = ownerElement.document();
 
     URL upgradedRequestURL = requestURL;
-    initiatingDocument->checkedContentSecurityPolicy()->upgradeInsecureRequestIfNeeded(upgradedRequestURL, ContentSecurityPolicy::InsecureRequestType::Load);
+    protect(initiatingDocument->contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(upgradedRequestURL, ContentSecurityPolicy::InsecureRequestType::Load);
 
     RefPtr frame = ownerElement.contentFrame();
     if (frame) {

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -112,7 +112,7 @@ void upgradeInsecureResourceRequestIfNeeded(ResourceRequest& request, Document& 
     URL url = request.url();
 
     ASSERT(document.contentSecurityPolicy());
-    document.checkedContentSecurityPolicy()->upgradeInsecureRequestIfNeeded(url, ContentSecurityPolicy::InsecureRequestType::Load, alwaysUpgradeRequest);
+    protect(document.contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(url, ContentSecurityPolicy::InsecureRequestType::Load, alwaysUpgradeRequest);
 
     if (url == request.url())
         return;

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -346,7 +346,7 @@ std::optional<std::pair<RenderLayer&, GraphicsLayer&>> InteractionRegionOverlay:
     if (!hitNode || !hitNode->renderer())
         return std::nullopt;
 
-    CheckedPtr rendererLayer = hitNode->checkedRenderer()->enclosingLayer();
+    CheckedPtr rendererLayer = protect(hitNode->renderer())->enclosingLayer();
     if (!rendererLayer)
         return std::nullopt;
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1584,7 +1584,7 @@ void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>
 
 void DragController::finalizeDroppedImagePlaceholder(HTMLImageElement& placeholder, CompletionHandler<void()>&& completion)
 {
-    protect(placeholder.document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [completion = WTF::move(completion), placeholder = Ref { placeholder }] () mutable {
+    protect(placeholder.document().eventLoop())->queueTask(TaskSource::InternalAsyncTask, [completion = WTF::move(completion), placeholder = Ref { placeholder }] () mutable {
         if (placeholder->isDroppedImagePlaceholder()) {
             placeholder->removeAttribute(HTMLNames::heightAttr);
             placeholder->removeInlineStyleProperty(CSSPropertyBackgroundColor);

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -6695,11 +6695,6 @@ RenderView* LocalFrameView::renderView() const
     return m_frame->contentRenderer();
 }
 
-CheckedPtr<RenderView> LocalFrameView::checkedRenderView() const
-{
-    return renderView();
-}
-
 int LocalFrameView::mapFromLayoutToCSSUnits(LayoutUnit value) const
 {
     Ref frame = m_frame;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -112,7 +112,6 @@ public:
     WEBCORE_EXPORT LocalFrame& frame() const final;
 
     WEBCORE_EXPORT RenderView* renderView() const;
-    WEBCORE_EXPORT CheckedPtr<RenderView> checkedRenderView() const;
 
     int mapFromLayoutToCSSUnits(LayoutUnit) const;
     LayoutUnit mapFromCSSToLayoutUnits(int) const;

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -961,7 +961,7 @@ struct AwaitingPromiseData : public RefCounted<AwaitingPromiseData> {
 static void waitForAllPromises(Document& document, const Vector<Ref<DOMPromise>>& promises, Function<void()>&& fulfilledCallback, Function<void(JSC::JSValue)>&& rejectionCallback)
 {
     if (promises.isEmpty()) {
-        document.checkedEventLoop()->queueMicrotask(WTF::move(fulfilledCallback));
+        protect(document.eventLoop())->queueMicrotask(WTF::move(fulfilledCallback));
         return;
     }
 
@@ -1184,7 +1184,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
 
         // FIXME: this emulates the behavior of a Promise wrapped around waitForAll, but we may want the real
         // thing if the ordering-and-transition tests show timing related issues related to this.
-        scriptExecutionContext->checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { this }, promiseList, abortController, document, apiMethodTracker]() {
+        protect(scriptExecutionContext->eventLoop())->queueTask(TaskSource::DOMManipulation, [weakThis = WeakPtr { this }, promiseList, abortController, document, apiMethodTracker]() {
             waitForAllPromises(*document, promiseList, [abortController, document, apiMethodTracker, weakThis]() mutable {
                 RefPtr protectedThis = weakThis.get();
                 if (!protectedThis || abortController->signal().aborted() || !document->isFullyActive() || !protectedThis->m_ongoingNavigateEvent)

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -758,7 +758,7 @@ LayoutRect virtualRectForAreaElementAndDirection(HTMLAreaElement* area, FocusDir
     ASSERT(area->imageElement());
     // Area elements tend to overlap more than other focusable elements. We flatten the rect of the area elements
     // to minimize the effect of overlapping areas.
-    LayoutRect rect = virtualRectForDirection(direction, rectToAbsoluteCoordinates(area->document().protectedFrame().get(), area->computeRect(area->imageElement()->checkedRenderer().get())), 1);
+    LayoutRect rect = virtualRectForDirection(direction, rectToAbsoluteCoordinates(area->document().protectedFrame().get(), area->computeRect(protect(area->imageElement()->renderer()).get())), 1);
     return rect;
 }
 

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -348,11 +348,6 @@ inline RenderText* Text::renderer() const
     return downcast<RenderText>(Node::renderer());
 }
 
-inline CheckedPtr<RenderText> Text::checkedRenderer() const
-{
-    return renderer();
-}
-
 inline void RenderText::resetMinMaxWidth()
 {
     m_minWidth = { };

--- a/Source/WebCore/rendering/TextPainter.cpp
+++ b/Source/WebCore/rendering/TextPainter.cpp
@@ -264,7 +264,7 @@ String TextPainter::cachedGlyphDisplayListsForTextNodeAsText(Text& textNode, Opt
 
     StringBuilder builder;
 
-    for (auto textBox : InlineIterator::textBoxesFor(*textNode.checkedRenderer())) {
+    for (auto textBox : InlineIterator::textBoxesFor(*protect(textNode.renderer()))) {
         RefPtr<const DisplayList::DisplayList> displayList;
         if (auto* legacyInlineBox = textBox.legacyInlineBox())
             displayList = TextPainter::glyphDisplayListIfExists(*legacyInlineBox);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -210,7 +210,7 @@ bool LegacyRenderSVGModelObject::checkIntersection(RenderElement* renderer, cons
     ASSERT(svgElement->renderer());
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
-    return intersectsAllowingEmpty(rect, ctm.mapRect(svgElement->checkedRenderer()->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
+    return intersectsAllowingEmpty(rect, ctm.mapRect(protect(svgElement->renderer())->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
 }
 
 bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const FloatRect& rect)
@@ -225,7 +225,7 @@ bool LegacyRenderSVGModelObject::checkEnclosure(RenderElement* renderer, const F
     ASSERT(svgElement->renderer());
     // FIXME: [SVG] checkEnclosure implementation is inconsistent
     // https://bugs.webkit.org/show_bug.cgi?id=262709
-    return rect.contains(ctm.mapRect(svgElement->checkedRenderer()->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
+    return rect.contains(ctm.mapRect(protect(svgElement->renderer())->repaintRectInLocalCoordinates(RepaintRectCalculation::Accurate)));
 }
 
 void LegacyRenderSVGModelObject::addFocusRingRects(Vector<LayoutRect>&, const LayoutPoint&, const RenderLayerModelObject*) const

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -103,7 +103,7 @@ SVGElement::~SVGElement()
     }
 
     Ref<Document> document = this->document();
-    document->checkedSVGExtensions()->removeElementToRebuild(*this);
+    protect(document->svgExtensions())->removeElementToRebuild(*this);
 
     if (hasPendingResources()) {
         treeScopeForSVGReferences().removeElementFromPendingSVGResources(*this);
@@ -534,7 +534,7 @@ void SVGElement::attributeChanged(const QualifiedName& name, const AtomString& o
 
     switch (name.nodeName()) {
     case AttributeNames::idAttr:
-        protect(document())->checkedSVGExtensions()->rebuildAllElementReferencesForTarget(*this);
+        protect(protect(document())->svgExtensions())->rebuildAllElementReferencesForTarget(*this);
         break;
     case AttributeNames::classAttr:
         m_className->setBaseValInternal(newValue);

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -79,7 +79,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
             Ref { m_orderY }->setBaseValInternal(result->second);
 
             if (result->first < 1 || result->second < 1)
-                protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing order=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+                protect(protect(document())->svgExtensions())->reportWarning(makeString("feConvolveMatrix: problem parsing order=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         }
         break;
     }
@@ -88,7 +88,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         if (propertyValue != EdgeModeType::Unknown)
             Ref { m_edgeMode }->setBaseValInternal<EdgeModeType>(propertyValue);
         else
-            protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing edgeMode=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+            protect(protect(document())->svgExtensions())->reportWarning(makeString("feConvolveMatrix: problem parsing edgeMode=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         break;
     }
     case AttributeNames::kernelMatrixAttr:
@@ -102,7 +102,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
             Ref { m_divisor }->setBaseValInternal(*result);
 
             if (*result <= 0)
-                protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing divisor=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+                protect(protect(document())->svgExtensions())->reportWarning(makeString("feConvolveMatrix: problem parsing divisor=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         }
         break;
     }
@@ -125,7 +125,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
             Ref { m_kernelUnitLengthY }->setBaseValInternal(result->second);
 
             if (result->first < 0 || result->second < 0)
-                protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing kernelUnitLength=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+                protect(protect(document())->svgExtensions())->reportWarning(makeString("feConvolveMatrix: problem parsing kernelUnitLength=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         }
         break;
     }
@@ -135,7 +135,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         else if (newValue == falseAtom())
             Ref { m_preserveAlpha }->setBaseValInternal(false);
         else
-            protect(document())->checkedSVGExtensions()->reportWarning(makeString("feConvolveMatrix: problem parsing preserveAlphaAttr=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+            protect(protect(document())->svgExtensions())->reportWarning(makeString("feConvolveMatrix: problem parsing preserveAlphaAttr=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -80,7 +80,7 @@ void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const
         if (propertyValue != EdgeModeType::Unknown)
             Ref { m_edgeMode }->setBaseValInternal<EdgeModeType>(propertyValue);
         else
-            protect(document())->checkedSVGExtensions()->reportWarning(makeString("feGaussianBlur: problem parsing edgeMode=\""_s, newValue, "\". Filtered element will not be displayed."_s));
+            protect(protect(document())->svgExtensions())->reportWarning(makeString("feGaussianBlur: problem parsing edgeMode=\""_s, newValue, "\". Filtered element will not be displayed."_s));
         break;
     }
     default:

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -89,7 +89,7 @@ void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const A
             Ref { m_numOctaves }->setBaseValInternal(*result);
 
             if (*result <= 0)
-                protect(document())->checkedSVGExtensions()->reportWarning(makeString("feTurbulence: problem parsing numOctaves=\""_s, newValue, "\". numOctaves must be > 0. Filtered element will not be displayed."_s));
+                protect(protect(document())->svgExtensions())->reportWarning(makeString("feTurbulence: problem parsing numOctaves=\""_s, newValue, "\". numOctaves must be > 0. Filtered element will not be displayed."_s));
         }
         break;
     }

--- a/Source/WebCore/svg/SVGFitToViewBox.cpp
+++ b/Source/WebCore/svg/SVGFitToViewBox.cpp
@@ -123,26 +123,26 @@ template<typename CharacterType> std::optional<FloatRect> SVGFitToViewBox::parse
         Ref document = Ref { m_viewBox }->contextElement()->document();
 
         if (!x || !y || !width || !height) {
-            document->checkedSVGExtensions()->reportWarning(makeString("Problem parsing viewBox=\""_s, stringToParse, "\""_s));
+            protect(document->svgExtensions())->reportWarning(makeString("Problem parsing viewBox=\""_s, stringToParse, "\""_s));
             return std::nullopt;
         }
 
         // Check that width is positive.
         if (*width < 0.0) {
-            document->checkedSVGExtensions()->reportError("A negative value for ViewBox width is not allowed"_s);
+            protect(document->svgExtensions())->reportError("A negative value for ViewBox width is not allowed"_s);
             return std::nullopt;
         }
 
         // Check that height is positive.
         if (*height < 0.0) {
-            document->checkedSVGExtensions()->reportError("A negative value for ViewBox height is not allowed"_s);
+            protect(document->svgExtensions())->reportError("A negative value for ViewBox height is not allowed"_s);
             return std::nullopt;
         }
 
         // Nothing should come after the last, fourth number.
         skipOptionalSVGSpaces(buffer);
         if (buffer.hasCharactersRemaining()) {
-            document->checkedSVGExtensions()->reportWarning(makeString("Problem parsing viewBox=\""_s, stringToParse, "\""_s));
+            protect(document->svgExtensions())->reportWarning(makeString("Problem parsing viewBox=\""_s, stringToParse, "\""_s));
             return std::nullopt;
         }
     }

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -309,7 +309,7 @@ void SVGFontFaceElement::removedFromAncestor(RemovalType removalType, ContainerN
     if (removalType.disconnectedFromDocument) {
         m_fontElement = nullptr;
         Ref<Document> document = this->document();
-        document->checkedSVGExtensions()->unregisterSVGFontFaceElement(*this);
+        protect(document->svgExtensions())->unregisterSVGFontFaceElement(*this);
         Ref fontFaceSet = document->fontSelector().cssFontFaceSet();
         Ref fontFaceRule = m_fontFaceRule;
         if (RefPtr fontFace = fontFaceSet->lookUpByCSSConnection(fontFaceRule))

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -134,7 +134,7 @@ void SVGGeometryElement::attributeChanged(const QualifiedName& name, const AtomS
         Ref pathLength = m_pathLength;
         pathLength->setBaseValInternal(newValue.toFloat());
         if (pathLength->baseVal() < 0)
-            protect(document())->checkedSVGExtensions()->reportError("A negative value for path attribute <pathLength> is not allowed"_s);
+            protect(protect(document())->svgExtensions())->reportError("A negative value for path attribute <pathLength> is not allowed"_s);
     }
 
     SVGGraphicsElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -124,7 +124,7 @@ void SVGPathElement::attributeChanged(const QualifiedName& name, const AtomStrin
         else if (Ref { m_pathSegList }->baseVal()->parse(newValue))
             cache.add(newValue, m_pathSegList->baseVal()->existingPathByteStream().data());
         else
-            protect(document())->checkedSVGExtensions()->reportError(makeString("Problem parsing d=\""_s, newValue, "\""_s));
+            protect(protect(document())->svgExtensions())->reportError(makeString("Problem parsing d=\""_s, newValue, "\""_s));
     }
 
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGPolyElement.cpp
+++ b/Source/WebCore/svg/SVGPolyElement.cpp
@@ -52,7 +52,7 @@ void SVGPolyElement::attributeChanged(const QualifiedName& name, const AtomStrin
 {
     if (name == SVGNames::pointsAttr) {
         if (!m_points->baseVal()->parse(newValue))
-            protect(document())->checkedSVGExtensions()->reportError(makeString("Problem parsing points=\""_s, newValue, "\""_s));
+            protect(protect(document())->svgExtensions())->reportError(makeString("Problem parsing points=\""_s, newValue, "\""_s));
     }
 
     SVGGeometryElement::attributeChanged(name, oldValue, newValue, attributeModificationReason);

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -101,7 +101,7 @@ SVGSVGElement::~SVGSVGElement()
         viewSpec->resetContextElement();
     Ref<Document> document = this->document();
     document->unregisterForDocumentSuspensionCallbacks(*this);
-    document->checkedSVGExtensions()->removeTimeContainer(*this);
+    protect(document->svgExtensions())->removeTimeContainer(*this);
 }
 
 void SVGSVGElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)
@@ -294,15 +294,15 @@ Ref<NodeList> SVGSVGElement::collectIntersectionOrEnclosureList(SVGRect& rect, S
 static bool checkIntersectionWithoutUpdatingLayout(SVGElement& element, SVGRect& rect)
 {
     if (element.document().settings().layerBasedSVGEngineEnabled())
-        return RenderSVGModelObject::checkIntersection(element.checkedRenderer().get(), rect.value());
-    return LegacyRenderSVGModelObject::checkIntersection(element.checkedRenderer().get(), rect.value());
+        return RenderSVGModelObject::checkIntersection(protect(element.renderer()).get(), rect.value());
+    return LegacyRenderSVGModelObject::checkIntersection(protect(element.renderer()).get(), rect.value());
 }
     
 static bool checkEnclosureWithoutUpdatingLayout(SVGElement& element, SVGRect& rect)
 {
     if (element.document().settings().layerBasedSVGEngineEnabled())
-        return RenderSVGModelObject::checkEnclosure(element.checkedRenderer().get(), rect.value());
-    return LegacyRenderSVGModelObject::checkEnclosure(element.checkedRenderer().get(), rect.value());
+        return RenderSVGModelObject::checkEnclosure(protect(element.renderer()).get(), rect.value());
+    return LegacyRenderSVGModelObject::checkEnclosure(protect(element.renderer()).get(), rect.value());
 }
 
 Ref<NodeList> SVGSVGElement::getIntersectionList(SVGRect& rect, SVGElement* referenceElement)
@@ -503,7 +503,7 @@ void SVGSVGElement::removedFromAncestor(RemovalType removalType, ContainerNode& 
 {
     if (removalType.disconnectedFromDocument) {
         Ref<Document> document = this->document();
-        document->checkedSVGExtensions()->removeTimeContainer(*this);
+        protect(document->svgExtensions())->removeTimeContainer(*this);
         pauseAnimations();
     }
     SVGGraphicsElement::removedFromAncestor(removalType, oldParentOfRemovedTree);

--- a/Source/WebCore/svg/SVGTextContentElement.cpp
+++ b/Source/WebCore/svg/SVGTextContentElement.cpp
@@ -62,13 +62,13 @@ SVGTextContentElement::SVGTextContentElement(const QualifiedName& tagName, Docum
 unsigned SVGTextContentElement::getNumberOfChars()
 {
     protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
-    return SVGTextQuery(checkedRenderer().get()).numberOfCharacters();
+    return SVGTextQuery(protect(renderer()).get()).numberOfCharacters();
 }
 
 float SVGTextContentElement::getComputedTextLength()
 {
     protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
-    return SVGTextQuery(checkedRenderer().get()).textLength();
+    return SVGTextQuery(protect(renderer()).get()).textLength();
 }
 
 ExceptionOr<float> SVGTextContentElement::getSubStringLength(unsigned charnum, unsigned nchars)
@@ -78,7 +78,7 @@ ExceptionOr<float> SVGTextContentElement::getSubStringLength(unsigned charnum, u
         return Exception { ExceptionCode::IndexSizeError };
 
     nchars = std::min(nchars, numberOfChars - charnum);
-    return SVGTextQuery(checkedRenderer().get()).subStringLength(charnum, nchars);
+    return SVGTextQuery(protect(renderer()).get()).subStringLength(charnum, nchars);
 }
 
 ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getStartPositionOfChar(unsigned charnum)
@@ -86,7 +86,7 @@ ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getStartPositionOfChar(unsigne
     if (charnum >= getNumberOfChars())
         return Exception { ExceptionCode::IndexSizeError };
 
-    return SVGPoint::create(SVGTextQuery(checkedRenderer().get()).startPositionOfCharacter(charnum));
+    return SVGPoint::create(SVGTextQuery(protect(renderer()).get()).startPositionOfCharacter(charnum));
 }
 
 ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getEndPositionOfChar(unsigned charnum)
@@ -94,7 +94,7 @@ ExceptionOr<Ref<SVGPoint>> SVGTextContentElement::getEndPositionOfChar(unsigned 
     if (charnum >= getNumberOfChars())
         return Exception { ExceptionCode::IndexSizeError };
 
-    return SVGPoint::create(SVGTextQuery(checkedRenderer().get()).endPositionOfCharacter(charnum));
+    return SVGPoint::create(SVGTextQuery(protect(renderer()).get()).endPositionOfCharacter(charnum));
 }
 
 ExceptionOr<Ref<SVGRect>> SVGTextContentElement::getExtentOfChar(unsigned charnum)
@@ -102,7 +102,7 @@ ExceptionOr<Ref<SVGRect>> SVGTextContentElement::getExtentOfChar(unsigned charnu
     if (charnum >= getNumberOfChars())
         return Exception { ExceptionCode::IndexSizeError };
 
-    return SVGRect::create(SVGTextQuery(checkedRenderer().get()).extentOfCharacter(charnum));
+    return SVGRect::create(SVGTextQuery(protect(renderer()).get()).extentOfCharacter(charnum));
 }
 
 ExceptionOr<float> SVGTextContentElement::getRotationOfChar(unsigned charnum)
@@ -110,14 +110,14 @@ ExceptionOr<float> SVGTextContentElement::getRotationOfChar(unsigned charnum)
     if (charnum >= getNumberOfChars())
         return Exception { ExceptionCode::IndexSizeError };
 
-    return SVGTextQuery(checkedRenderer().get()).rotationOfCharacter(charnum);
+    return SVGTextQuery(protect(renderer()).get()).rotationOfCharacter(charnum);
 }
 
 int SVGTextContentElement::getCharNumAtPosition(DOMPointInit&& pointInit)
 {
     protect(document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, this);
     FloatPoint transformPoint {static_cast<float>(pointInit.x), static_cast<float>(pointInit.y)};
-    return SVGTextQuery(checkedRenderer().get()).characterNumberAtPosition(transformPoint);
+    return SVGTextQuery(protect(renderer()).get()).characterNumberAtPosition(transformPoint);
 }
 
 ExceptionOr<void> SVGTextContentElement::selectSubString(unsigned charnum, unsigned nchars)

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -867,7 +867,7 @@ ExceptionOr<bool> Internals::areSVGAnimationsPaused() const
     if (!document->svgExtensionsIfExists())
         return Exception { ExceptionCode::NotFoundError, "No SVG animations"_s };
 
-    return document->checkedSVGExtensions()->areAnimationsPaused();
+    return protect(document->svgExtensions())->areAnimationsPaused();
 }
 
 ExceptionOr<double> Internals::svgAnimationsInterval(SVGSVGElement& element) const

--- a/Source/WebCore/workers/AbstractWorker.cpp
+++ b/Source/WebCore/workers/AbstractWorker.cpp
@@ -76,7 +76,7 @@ std::optional<Exception> AbstractWorker::validateURL(ScriptExecutionContext& con
         return Exception { ExceptionCode::SecurityError };
 
     ASSERT(context.contentSecurityPolicy());
-    if (!context.checkedContentSecurityPolicy()->allowWorkerFromSource(scriptURL))
+    if (!protect(context.contentSecurityPolicy())->allowWorkerFromSource(scriptURL))
         return Exception { ExceptionCode::SecurityError };
 
     return { };

--- a/Source/WebCore/workers/Worker.cpp
+++ b/Source/WebCore/workers/Worker.cpp
@@ -236,7 +236,7 @@ void Worker::notifyFinished(std::optional<ScriptExecutionContextIdentifier> main
         return;
     }
 
-    const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders = m_contentSecurityPolicyResponseHeaders ? m_contentSecurityPolicyResponseHeaders.value() : context->checkedContentSecurityPolicy()->responseHeaders();
+    const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders = m_contentSecurityPolicyResponseHeaders ? m_contentSecurityPolicyResponseHeaders.value() : protect(context->contentSecurityPolicy())->responseHeaders();
     ReferrerPolicy referrerPolicy = ReferrerPolicy::EmptyString;
     if (auto policy = parseReferrerPolicy(scriptLoader->referrerPolicy(), ReferrerPolicySource::HTTPHeader))
         referrerPolicy = *policy;

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -204,7 +204,7 @@ bool WorkerGlobalScope::isSecureContext() const
 
 void WorkerGlobalScope::applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders)
 {
-    checkedContentSecurityPolicy()->didReceiveHeaders(contentSecurityPolicyResponseHeaders, String { });
+    protect(contentSecurityPolicy())->didReceiveHeaders(contentSecurityPolicyResponseHeaders, String { });
 }
 
 URL WorkerGlobalScope::completeURL(const String& url, ForceUTF8) const
@@ -340,7 +340,7 @@ ExceptionOr<int> WorkerGlobalScope::setTimeout(std::unique_ptr<ScheduledAction> 
 {
     // FIXME: Should this check really happen here? Or should it happen when code is about to eval?
     if (action->type() == ScheduledAction::Type::Code) {
-        if (!checkedContentSecurityPolicy()->allowEval(globalObject(), LogToConsole::Yes, action->code()))
+        if (!protect(contentSecurityPolicy())->allowEval(globalObject(), LogToConsole::Yes, action->code()))
             return 0;
     }
 
@@ -358,7 +358,7 @@ ExceptionOr<int> WorkerGlobalScope::setInterval(std::unique_ptr<ScheduledAction>
 {
     // FIXME: Should this check really happen here? Or should it happen when code is about to eval?
     if (action->type() == ScheduledAction::Type::Code) {
-        if (!checkedContentSecurityPolicy()->allowEval(globalObject(), LogToConsole::Yes, action->code()))
+        if (!protect(contentSecurityPolicy())->allowEval(globalObject(), LogToConsole::Yes, action->code()))
             return 0;
     }
 
@@ -421,7 +421,7 @@ ExceptionOr<void> WorkerGlobalScope::importScripts(const FixedVector<Variant<Ref
     for (auto& url : completedURLs) {
         // FIXME: Convert this to check the isolated world's Content Security Policy once webkit.org/b/104520 is solved.
         bool shouldBypassMainWorldContentSecurityPolicy = this->shouldBypassMainWorldContentSecurityPolicy();
-        if (!shouldBypassMainWorldContentSecurityPolicy && !checkedContentSecurityPolicy()->allowScriptFromSource(url))
+        if (!shouldBypassMainWorldContentSecurityPolicy && !protect(contentSecurityPolicy())->allowScriptFromSource(url))
             return Exception { ExceptionCode::NetworkError };
 
         auto scriptLoader = WorkerScriptLoader::create();

--- a/Source/WebCore/workers/service/ExtendableEvent.cpp
+++ b/Source/WebCore/workers/service/ExtendableEvent.cpp
@@ -72,7 +72,7 @@ void ExtendableEvent::addExtendLifetimePromise(Ref<DOMPromise>&& promise)
         RefPtr context = globalObject ? globalObject->scriptExecutionContext() : nullptr;
         if (!context)
             return;
-        context->checkedEventLoop()->queueMicrotask([this, protectedThis = WTF::move(protectedThis), weakContext = WeakPtr { *context }]() mutable {
+        protect(context->eventLoop())->queueMicrotask([this, protectedThis = WTF::move(protectedThis), weakContext = WeakPtr { *context }]() mutable {
             --m_pendingPromiseCount;
 
             // FIXME: Let registration be the context object's relevant global object's associated service worker's containing service worker registration.

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -193,7 +193,7 @@ void ServiceWorkerThreadProxy::notifyNetworkStateChange(bool isOnline)
     postTaskForModeToWorkerOrWorkletGlobalScope([isOnline] (ScriptExecutionContext& context) {
         auto& globalScope = downcast<WorkerGlobalScope>(context);
         globalScope.setIsOnline(isOnline);
-        globalScope.checkedEventLoop()->queueTask(TaskSource::DOMManipulation, [globalScope = Ref { globalScope }, isOnline] {
+        protect(globalScope.eventLoop())->queueTask(TaskSource::DOMManipulation, [globalScope = Ref { globalScope }, isOnline] {
             globalScope->dispatchEvent(Event::create(isOnline ? eventNames().onlineEvent : eventNames().offlineEvent, Event::CanBubble::No, Event::IsCancelable::No));
         });
     }, WorkerRunLoop::defaultMode());

--- a/Source/WebCore/worklets/Worklet.cpp
+++ b/Source/WebCore/worklets/Worklet.cpp
@@ -74,7 +74,7 @@ void Worklet::addModule(const String& moduleURLString, WorkletOptions&& options,
         return;
     }
 
-    if (!document->checkedContentSecurityPolicy()->allowScriptFromSource(moduleURL)) {
+    if (!protect(document->contentSecurityPolicy())->allowScriptFromSource(moduleURL)) {
         promise.reject(Exception { ExceptionCode::SecurityError, "Not allowed by CSP"_s });
         return;
     }

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -386,7 +386,7 @@ ExceptionOr<void> XMLHttpRequest::open(const String& method, const URL& url, boo
     clearRequest();
 
     auto newURL = url;
-    context->checkedContentSecurityPolicy()->upgradeInsecureRequestIfNeeded(newURL, ContentSecurityPolicy::InsecureRequestType::Load);
+    protect(context->contentSecurityPolicy())->upgradeInsecureRequestIfNeeded(newURL, ContentSecurityPolicy::InsecureRequestType::Load);
     m_url = { WTF::move(newURL), context->topOrigin().data() };
 
     m_async = async;
@@ -429,7 +429,7 @@ std::optional<ExceptionOr<void>> XMLHttpRequest::prepareToSend()
 
     // FIXME: Convert this to check the isolated world's Content Security Policy once webkit.org/b/104520 is solved.
     if (context->requiresScriptTrackingPrivacyProtection(ScriptTrackingPrivacyCategory::NetworkRequests)
-        || (!context->shouldBypassMainWorldContentSecurityPolicy() && !context->checkedContentSecurityPolicy()->allowConnectToSource(m_url))) {
+        || (!context->shouldBypassMainWorldContentSecurityPolicy() && !protect(context->contentSecurityPolicy())->allowConnectToSource(m_url))) {
         if (!m_async)
             return ExceptionOr<void> { Exception { ExceptionCode::NetworkError } };
         m_timeoutTimer.stop();

--- a/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
+++ b/Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp
@@ -67,7 +67,7 @@ void XMLHttpRequestProgressEventThrottle::updateProgress(bool isAsync, bool leng
         ASSERT(!m_hasPendingThrottledProgressEvent);
 
         dispatchEventWhenPossible(XMLHttpRequestProgressEvent::create(eventNames().progressEvent, lengthComputable, loaded, total));
-        m_dispatchThrottledProgressEventTimer = protect(target->scriptExecutionContext())->checkedEventLoop()->scheduleRepeatingTask(
+        m_dispatchThrottledProgressEventTimer = protect(protect(target->scriptExecutionContext())->eventLoop())->scheduleRepeatingTask(
             minimumProgressEventDispatchingInterval, minimumProgressEventDispatchingInterval, TaskSource::Networking, [weakTarget = WeakPtr { m_target.get() }] {
             if (RefPtr protectedTarget = weakTarget.get())
                 protectedTarget->dispatchThrottledProgressEventIfNeeded();

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -855,7 +855,7 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
 
     if (willConstructCustomElement) [[unlikely]] {
         markupInsertionCountIncrementer.emplace(*document);
-        document->checkedEventLoop()->performMicrotaskCheckpoint();
+        protect(document->eventLoop())->performMicrotaskCheckpoint();
         customElementReactionStack.emplace(document->globalObject());
     }
 

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1006,7 +1006,7 @@ static WebCore::IntRect snapshotElementRectForScreenshot(WebPage& page, WebCore:
             return { };
 
         WebCore::LayoutRect topLevelRect;
-        WebCore::IntRect elementRect = WebCore::snappedIntRect(element->checkedRenderer()->paintingRootRect(topLevelRect));
+        WebCore::IntRect elementRect = WebCore::snappedIntRect(protect(element->renderer())->paintingRootRect(topLevelRect));
         if (clipToViewport)
             elementRect.intersect(frameView->visibleContentRect());
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm
@@ -101,7 +101,7 @@ PDFPluginAnnotation::~PDFPluginAnnotation()
 
     m_eventListener->setAnnotation(nullptr);
 
-    protect(element->document())->checkedEventLoop()->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr<Node, WeakPtrImplWithEventTargetData> { element.get() }]() {
+    protect(protect(element->document())->eventLoop())->queueTask(TaskSource::InternalAsyncTask, [weakElement = WeakPtr<Node, WeakPtrImplWithEventTargetData> { element.get() }]() {
         if (RefPtr element = weakElement.get())
             element->remove();
     });

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -942,13 +942,13 @@ IntRect PDFPluginBase::convertFromScrollbarToContainingView(const Scrollbar& scr
     IntRect rect = scrollbarRect;
     rect.move(scrollbar.location() - view->location());
 
-    return view->frame()->protectedView()->convertFromRendererToContainingView(view->pluginElement().checkedRenderer().get(), rect);
+    return view->frame()->protectedView()->convertFromRendererToContainingView(protect(view->pluginElement().renderer()).get(), rect);
 }
 
 IntRect PDFPluginBase::convertFromContainingViewToScrollbar(const Scrollbar& scrollbar, const IntRect& parentRect) const
 {
     Ref view = *m_view;
-    IntRect rect = view->frame()->protectedView()->convertFromContainingViewToRenderer(view->pluginElement().checkedRenderer().get(), parentRect);
+    IntRect rect = view->frame()->protectedView()->convertFromContainingViewToRenderer(protect(view->pluginElement().renderer()).get(), parentRect);
     rect.move(view->location() - scrollbar.location());
 
     return rect;
@@ -960,13 +960,13 @@ IntPoint PDFPluginBase::convertFromScrollbarToContainingView(const Scrollbar& sc
     IntPoint point = scrollbarPoint;
     point.move(scrollbar.location() - view->location());
 
-    return view->frame()->protectedView()->convertFromRendererToContainingView(view->pluginElement().checkedRenderer().get(), point);
+    return view->frame()->protectedView()->convertFromRendererToContainingView(protect(view->pluginElement().renderer()).get(), point);
 }
 
 IntPoint PDFPluginBase::convertFromContainingViewToScrollbar(const Scrollbar& scrollbar, const IntPoint& parentPoint) const
 {
     Ref view = *m_view;
-    IntPoint point = view->frame()->protectedView()->convertFromContainingViewToRenderer(view->pluginElement().checkedRenderer().get(), parentPoint);
+    IntPoint point = view->frame()->protectedView()->convertFromContainingViewToRenderer(protect(view->pluginElement().renderer()).get(), parentPoint);
     point.move(view->location() - scrollbar.location());
 
     return point;
@@ -1627,7 +1627,7 @@ Color PDFPluginBase::pluginBackgroundColor() const
     RefPtr element = m_element.get();
     OptionSet<WebCore::StyleColorOptions> options;
     if (RefPtr element = m_element.get())
-        options = element->checkedRenderer()->styleColorOptions();
+        options = protect(element->renderer())->styleColorOptions();
     return WebCore::RenderTheme::singleton().systemColor(CSSValueAppleSystemBackground, WTF::move(options));
 #else
     static NeverDestroyed color = roundAndClampToSRGBALossy(RetainPtr { [CocoaColor grayColor].CGColor }.get());

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -164,7 +164,7 @@ void TextAnimationController::removeTransparentMarkersForTextAnimationID(const W
         return;
     }
 
-    document->checkedMarkers()->removeMarkers({ WebCore::DocumentMarkerType::TransparentContent }, [&](const WebCore::DocumentMarker& marker) {
+    protect(document->markers())->removeMarkers({ WebCore::DocumentMarkerType::TransparentContent }, [&](const WebCore::DocumentMarker& marker) {
         return std::get<WebCore::DocumentMarker::TransparentContentData>(marker.data()).uuid == uuid ? WebCore::FilterMarkerResult::Remove : WebCore::FilterMarkerResult::Keep;
     });
 }
@@ -340,7 +340,7 @@ void TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID(c
                 completionHandler();
             return;
         }
-        document->checkedMarkers()->addTransparentContentMarker(*animationRange, uuid);
+        protect(document->markers())->addTransparentContentMarker(*animationRange, uuid);
     }
 
     if (completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -437,7 +437,7 @@ void WebPage::addDictationAlternative(const String& text, DictationContext conte
         return;
     }
 
-    document->checkedMarkers()->addMarker(matchRange, DocumentMarkerType::DictationAlternatives, { DocumentMarker::DictationData { context, text } });
+    protect(document->markers())->addMarker(matchRange, DocumentMarkerType::DictationAlternatives, { DocumentMarker::DictationData { context, text } });
     completion(true);
 }
 
@@ -460,7 +460,7 @@ void WebPage::dictationAlternativesAtSelection(CompletionHandler<void(Vector<Dic
         return;
     }
 
-    auto markers = document->checkedMarkers()->markersInRange(*expandedSelectionRange, DocumentMarkerType::DictationAlternatives);
+    auto markers = protect(document->markers())->markersInRange(*expandedSelectionRange, DocumentMarkerType::DictationAlternatives);
     auto contexts = WTF::compactMap(markers, [](auto& marker) -> std::optional<DictationContext> {
         if (std::holds_alternative<DocumentMarker::DictationData>(marker->data()))
             return std::get<DocumentMarker::DictationData>(marker->data()).context;
@@ -485,7 +485,7 @@ void WebPage::clearDictationAlternatives(Vector<DictationContext>&& contexts)
         setOfContextsToRemove.add(context);
 
     auto documentRange = makeRangeSelectingNodeContents(*document);
-    document->checkedMarkers()->filterMarkers(documentRange, [&] (auto& marker) {
+    protect(document->markers())->filterMarkers(documentRange, [&] (auto& marker) {
         if (!std::holds_alternative<DocumentMarker::DictationData>(marker.data()))
             return FilterMarkerResult::Keep;
         return setOfContextsToRemove.contains(std::get<WebCore::DocumentMarker::DictationData>(marker.data()).context) ? FilterMarkerResult::Remove : FilterMarkerResult::Keep;

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -558,7 +558,7 @@ Vector<FloatRect> FindController::rectsForTextMatchesInRect(IntRect clipRect)
         if (!document)
             continue;
 
-        for (FloatRect rect : document->checkedMarkers()->renderedRectsForMarkers(DocumentMarkerType::TextMatch)) {
+        for (FloatRect rect : protect(document->markers())->renderedRectsForMarkers(DocumentMarkerType::TextMatch)) {
             if (!localFrame->isMainFrame())
                 rect = mainFrameView->windowToContents(localFrame->protectedView()->contentsToWindow(enclosingIntRect(rect)));
 

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -191,10 +191,10 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
     if (auto simpleRange = simpleRangeFromFoundTextRange(range)) {
         switch (style) {
         case FindDecorationStyle::Normal:
-            protect(simpleRange->start.document())->checkedMarkers()->removeMarkers(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
+            protect(protect(simpleRange->start.document())->markers())->removeMarkers(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
             break;
         case FindDecorationStyle::Found: {
-            auto addedMarker = protect(simpleRange->start.document())->checkedMarkers()->addMarker(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
+            auto addedMarker = protect(protect(simpleRange->start.document())->markers())->addMarker(*simpleRange, WebCore::DocumentMarkerType::TextMatch);
             if (!addedMarker)
                 m_unhighlightedFoundRanges.add(range);
             break;
@@ -213,7 +213,7 @@ void WebFoundTextRangeController::decorateTextRangeWithStyle(const WebFoundTextR
                 HashSet<WebFoundTextRange> rangesToRemove;
                 for (auto unhighlightedRange : m_unhighlightedFoundRanges) {
                     if (auto unhighlightedSimpleRange = simpleRangeFromFoundTextRange(unhighlightedRange)) {
-                        auto addedMarker = protect(unhighlightedSimpleRange->start.document())->checkedMarkers()->addMarker(*unhighlightedSimpleRange, WebCore::DocumentMarkerType::TextMatch);
+                        auto addedMarker = protect(protect(unhighlightedSimpleRange->start.document())->markers())->addMarker(*unhighlightedSimpleRange, WebCore::DocumentMarkerType::TextMatch);
                         if (addedMarker)
                             rangesToRemove.add(unhighlightedRange);
                     }
@@ -542,7 +542,7 @@ Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRec
         if (!document)
             continue;
 
-        for (auto rect : document->checkedMarkers()->renderedRectsForMarkers(WebCore::DocumentMarkerType::TextMatch)) {
+        for (auto rect : protect(document->markers())->renderedRectsForMarkers(WebCore::DocumentMarkerType::TextMatch)) {
             if (!localFrame->isMainFrame())
                 rect = mainFrameView->windowToContents(localFrame->protectedView()->contentsToWindow(enclosingIntRect(rect)));
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -926,7 +926,7 @@ void WebFrame::setAccessibleName(const AtomString& accessibleName)
     if (!document)
         return;
 
-    RefPtr rootObject = document->checkedAXObjectCache()->rootObjectForFrame(*localFrame);
+    RefPtr rootObject = protect(document->axObjectCache())->rootObjectForFrame(*localFrame);
     if (!rootObject)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -3326,7 +3326,7 @@ RefPtr<WebImage> WebPage::snapshotNode(WebCore::Node& node, SnapshotOptions opti
         return nullptr;
 
     LayoutRect topLevelRect;
-    IntRect snapshotRect = snappedIntRect(node.checkedRenderer()->paintingRootRect(topLevelRect));
+    IntRect snapshotRect = snappedIntRect(protect(node.renderer())->paintingRootRect(topLevelRect));
     if (snapshotRect.isEmpty())
         return nullptr;
 
@@ -6018,7 +6018,7 @@ void WebPage::unmarkAllMisspellings()
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->checkedMarkers()->removeMarkers(DocumentMarkerType::Spelling);
+            protect(document->markers())->removeMarkers(DocumentMarkerType::Spelling);
     }
 }
 
@@ -6029,7 +6029,7 @@ void WebPage::unmarkAllBadGrammar()
         if (!localFrame)
             continue;
         if (RefPtr document = localFrame->document())
-            document->checkedMarkers()->removeMarkers(DocumentMarkerType::Grammar);
+            protect(document->markers())->removeMarkers(DocumentMarkerType::Grammar);
     }
 }
 
@@ -8804,7 +8804,7 @@ void WebPage::startTextManipulationForFrame(WebCore::Frame& frame)
         return;
 
     auto exclusionRules = *m_internals->textManipulationExclusionRules;
-    document->checkedTextManipulationController()->startObservingParagraphs([webPage = WeakPtr { *this }] (Document& document, const Vector<WebCore::TextManipulationItem>& items) {
+    protect(document->textManipulationController())->startObservingParagraphs([webPage = WeakPtr { *this }] (Document& document, const Vector<WebCore::TextManipulationItem>& items) {
         RefPtr frame = document.frame();
         if (!webPage || !frame)
             return;

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -665,7 +665,7 @@ static FloatPoint shadowLayerPositionForFrame(LocalFrameView& frameView, FloatPo
 
 static FloatRect shadowLayerBoundsForFrame(LocalFrameView& frameView, float transientScale)
 {
-    FloatRect clipLayerFrame(frameView.checkedRenderView()->documentRect());
+    FloatRect clipLayerFrame(protect(frameView.renderView())->documentRect());
     FloatRect shadowLayerFrame = clipLayerFrame;
     
     shadowLayerFrame.scale(transientScale / frameView.frame().page()->pageScaleFactor());

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -677,7 +677,7 @@ void WebPage::handleImageServiceClick(WebCore::FrameIdentifier frameID, const In
         point,
         image,
         element.isContentEditable(),
-        element.checkedRenderBox()->absoluteContentQuad().enclosingBoundingBox(),
+        protect(element.renderBox())->absoluteContentQuad().enclosingBoundingBox(),
         HTMLAttachmentElement::getAttachmentIdentifier(element),
         contextForElement(element),
         image.mimeType()
@@ -693,7 +693,7 @@ void WebPage::handlePDFServiceClick(WebCore::FrameIdentifier frameID, const IntP
     send(Messages::WebPageProxy::ShowContextMenuFromFrame(webFrame->info(), ContextMenuContextData {
         point,
         element.isContentEditable(),
-        element.checkedRenderBox()->absoluteContentQuad().enclosingBoundingBox(),
+        protect(element.renderBox())->absoluteContentQuad().enclosingBoundingBox(),
         element.uniqueIdentifier(),
         "application/pdf"_s
     }, { }));


### PR DESCRIPTION
#### 59aa1f701ca79265b6a22dd2183cf739ad9ffb2f
<pre>
Reduce use of `checked*()` functions in Source/WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=307489">https://bugs.webkit.org/show_bug.cgi?id=307489</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/Modules/beacon/NavigatorBeacon.cpp:
(WebCore::NavigatorBeacon::sendBeacon):
* Source/WebCore/Modules/entriesapi/FileSystemDirectoryReader.cpp:
(WebCore::FileSystemDirectoryReader::readEntries):
* Source/WebCore/Modules/entriesapi/FileSystemEntry.cpp:
(WebCore::FileSystemEntry::getParent):
* Source/WebCore/Modules/geolocation/Geolocation.cpp:
(WebCore::Geolocation::getCurrentPosition):
(WebCore::Geolocation::watchPosition):
* Source/WebCore/Modules/indexeddb/IDBTransaction.cpp:
(WebCore::IDBTransaction::IDBTransaction):
* Source/WebCore/Modules/mediastream/RTCEncodedStreamProducer.cpp:
(WebCore::RTCEncodedStreamProducer::generateKeyFrame):
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransformer.cpp:
(WebCore::RTCRtpScriptTransformer::sendKeyFrameRequest):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::startLoadModelTimer):
* Source/WebCore/Modules/notifications/Notification.cpp:
(WebCore::Notification::requestPermission):
* Source/WebCore/Modules/screen-wake-lock/WakeLock.cpp:
(WebCore::WakeLock::request):
* Source/WebCore/Modules/streams/StreamTeeUtilities.cpp:
* Source/WebCore/Modules/webdatabase/Database.cpp:
(WebCore::Database::runTransaction):
(WebCore::Database::scheduleTransactionCallback):
* Source/WebCore/Modules/webdatabase/DatabaseManager.cpp:
(WebCore::DatabaseManager::openDatabase):
* Source/WebCore/Modules/webdatabase/SQLTransaction.cpp:
(WebCore::SQLTransaction::callErrorCallbackDueToInterruption):
(WebCore::SQLTransaction::deliverTransactionErrorCallback):
(WebCore::SQLTransaction::deliverSuccessCallback):
* Source/WebCore/animation/AnimationTimelinesController.cpp:
(WebCore::AnimationTimelinesController::updateAnimationsAndSendEvents):
(WebCore::AnimationTimelinesController::cacheCurrentTime):
* Source/WebCore/bindings/js/CachedScriptFetcher.cpp:
(WebCore::CachedScriptFetcher::requestScriptWithCache const):
* Source/WebCore/bindings/js/JSEventListener.cpp:
(WebCore::JSEventListener::handleEvent):
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
(WebCore::JSLazyEventListener::initializeJSFunction const):
* Source/WebCore/bindings/js/ScriptController.cpp:
(WebCore::ScriptController::initScriptForWindowProxy):
(WebCore::ScriptController::executeJavaScriptURL):
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::ScriptModuleLoader::notifyFinished):
* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::ActiveDOMObject::queueTaskInEventLoop):
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::rebuildSVGExtensionsElementsIfNecessary):
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/ContainerNodeInlines.h:
(WebCore::ContainerNode::checkedRenderer const): Deleted.
* Source/WebCore/dom/DeviceMotionEvent.cpp:
(WebCore::DeviceMotionEvent::requestPermission):
* Source/WebCore/dom/DeviceOrientationEvent.cpp:
(WebCore::DeviceOrientationEvent::requestPermission):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::processBaseElement):
(WebCore::Document::processMetaHttpEquiv):
(WebCore::Document::initSecurityContext):
(WebCore::Document::initContentSecurityPolicy):
(WebCore::Document::applyQuickLookSandbox):
(WebCore::Document::checkedAXObjectCache const): Deleted.
(WebCore::Document::checkedSVGExtensions): Deleted.
(WebCore::Document::checkedDeviceOrientationAndMotionAccessController): Deleted.
(WebCore::Document::checkedTextManipulationController): Deleted.
(WebCore::Document::checkedRenderView const): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::renderView const):
* Source/WebCore/dom/DocumentEventLoop.h:
(WebCore::Document::checkedEventLoop): Deleted.
* Source/WebCore/dom/DocumentFullscreen.cpp:
(WebCore::DocumentFullscreen::elementEnterFullscreen):
* Source/WebCore/dom/DocumentInlines.h:
(WebCore::Document::checkedExtensionStyleSheets): Deleted.
* Source/WebCore/dom/DocumentMarkerController.cpp:
(WebCore::addMarker):
(WebCore::removeMarkers):
* Source/WebCore/dom/DocumentMarkers.h:
(WebCore::Document::checkedMarkers): Deleted.
(WebCore::Document::checkedMarkers const): Deleted.
* Source/WebCore/dom/DocumentStorageAccess.cpp:
(WebCore::DocumentStorageAccess::requestStorageAccess):
(WebCore::DocumentStorageAccess::requestStorageAccessQuirk):
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::hideNonceSlow):
(WebCore::Element::boundsInRootViewSpace):
(WebCore::Element::absoluteEventBounds):
(WebCore::Element::checkedCustomElementDefaultARIA): Deleted.
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementInternals.cpp:
(WebCore::ElementInternals::setAttributeWithoutSynchronization):
(WebCore::ElementInternals::setElementAttribute):
(WebCore::ElementInternals::setElementsArrayAttribute):
* Source/WebCore/dom/ImageOverlay.cpp:
(WebCore::ImageOverlay::removeOverlaySoonIfNeeded):
* Source/WebCore/dom/InlineStyleSheetOwner.cpp:
(WebCore::InlineStyleSheetOwner::createSheet):
* Source/WebCore/dom/Node.h:
(WebCore::Node::renderer const):
* Source/WebCore/dom/NodeInlines.h:
(WebCore::Node::checkedRenderBox const): Deleted.
(WebCore::Node::checkedRenderer const): Deleted.
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
(WebCore::ScriptElement::requestClassicScript):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ScriptExecutionContextInlines.h:
(WebCore::ScriptExecutionContext::checkedEventLoop): Deleted.
* Source/WebCore/dom/SecurityContext.cpp:
(WebCore::SecurityContext::inheritPolicyContainerFrom):
(WebCore::SecurityContext::checkedContentSecurityPolicy): Deleted.
* Source/WebCore/dom/SecurityContext.h:
* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::styleAttributeChanged):
* Source/WebCore/dom/Text.h:
* Source/WebCore/dom/TrustedType.cpp:
(WebCore::trustedTypeCompliantString):
* Source/WebCore/dom/ViewTransition.cpp:
(WebCore::ViewTransition::skipViewTransition):
(WebCore::ViewTransition::callUpdateCallback):
(WebCore::ViewTransition::setupViewTransition):
* Source/WebCore/dom/mac/ImageControlsMac.cpp:
(WebCore::ImageControlsMac::updateImageControls):
* Source/WebCore/editing/AlternativeTextController.cpp:
(WebCore::AlternativeTextController::startAlternativeTextUITimer):
(WebCore::AlternativeTextController::applyDictationAlternative):
* Source/WebCore/html/CheckboxInputType.cpp:
(WebCore::CheckboxInputType::updateIsSwitchVisuallyOnFromAbsoluteLocation):
(WebCore::CheckboxInputType::switchAnimationTimerFired):
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::didFinishInsertingNode):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::naturalWidth const):
(WebCore::HTMLImageElement::naturalHeight const):
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::HTMLLinkElement::process):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::isAllowedToLoadMediaURL):
(WebCore::HTMLMediaElement::setAudioOutputDevice):
(WebCore::HTMLMediaElement::mediaPlayerQueueTaskOnEventLoop):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::requestObject):
(WebCore::HTMLPlugInElement::scheduleUpdateForAfterStyleResolution):
* Source/WebCore/html/HTMLTrackElement.cpp:
(WebCore::HTMLTrackElement::canLoadURL):
* Source/WebCore/html/ImageBitmap.cpp:
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocument::imageSize):
(WebCore::ImageDocument::finishedParsing):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::createContainer):
(WebCore::TextFieldInputType::elementRectInRootViewCoordinates const):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::size):
(WebCore::CanvasRenderingContext2DBase::drawImage):
(WebCore::CanvasRenderingContext2DBase::createPattern):
* Source/WebCore/html/canvas/EXTDisjointTimerQueryWebGL2.cpp:
(WebCore::EXTDisjointTimerQueryWebGL2::queryCounterEXT):
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::WebGL2RenderingContext::endQuery):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::texImageSource):
(WebCore::WebGLRenderingContextBase::maybeRestoreContextSoon):
* Source/WebCore/html/parser/HTMLResourcePreloader.cpp:
(WebCore::PreloadRequest::resourceRequest):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateSizes):
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::SliderThumbElement::setPositionFromPoint):
* Source/WebCore/html/shadow/SpatialImageControls.cpp:
(WebCore::SpatialImageControls::ensureSpatialControls):
(WebCore::SpatialImageControls::destroySpatialImageControls):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::doCrossOriginOpenerHandlingOfResponse):
(WebCore::DocumentLoader::responseReceived):
(WebCore::DocumentLoader::checkedContentSecurityPolicy const): Deleted.
* Source/WebCore/loader/DocumentLoader.h:
(WebCore::DocumentLoader::contentSecurityPolicy const):
* Source/WebCore/loader/DocumentThreadableLoader.cpp:
(WebCore::DocumentThreadableLoader::DocumentThreadableLoader):
(WebCore::DocumentThreadableLoader::isAllowedByContentSecurityPolicy):
(WebCore::DocumentThreadableLoader::checkedContentSecurityPolicy const): Deleted.
* Source/WebCore/loader/DocumentThreadableLoader.h:
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):
* Source/WebCore/loader/FormSubmission.cpp:
(WebCore::FormSubmission::create):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::changeLocation):
(WebCore::FrameLoader::submitForm):
(WebCore::FrameLoader::didBeginDocument):
(WebCore::FrameLoader::checkIfFormActionAllowedByCSP const):
(WebCore::FrameLoader::loadPostRequest):
(WebCore::FrameLoader::loadResourceSynchronously):
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
(WebCore::createWindow):
* Source/WebCore/loader/PingLoader.cpp:
(WebCore::PingLoader::loadImage):
(WebCore::PingLoader::sendPing):
(WebCore::PingLoader::sendViolationReport):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::isAllowedByContentSecurityPolicy):
(WebCore::PolicyChecker::checkNavigationPolicy):
* Source/WebCore/loader/SubframeLoader.cpp:
(WebCore::canLoadJavaScriptURL):
(WebCore::FrameLoader::SubframeLoader::requestObject):
(WebCore::FrameLoader::SubframeLoader::loadOrRedirectSubframe):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::upgradeInsecureResourceRequestIfNeeded):
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimer::fired):
(WebCore::DOMTimer::updateTimerIntervalIfNecessary):
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::InteractionRegionOverlay::activeLayer const):
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::finalizeDroppedImagePlaceholder):
* Source/WebCore/page/EventSource.cpp:
(WebCore::EventSource::create):
(WebCore::EventSource::scheduleInitialConnect):
(WebCore::EventSource::scheduleReconnect):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::processPostMessage):
(WebCore::LocalDOMWindow::closePage):
(WebCore::LocalDOMWindow::setTimeout):
(WebCore::LocalDOMWindow::setInterval):
(WebCore::LocalDOMWindow::setLocation):
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::checkedRenderView const): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::waitForAllPromises):
(WebCore::Navigation::innerDispatchNavigateEvent):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::userStyleSheetLocationChanged):
(WebCore::dispatchPrintEvent):
(WebCore::Page::didFinishLoadingImageForElement):
(WebCore::Page::injectUserStyleSheet):
(WebCore::Page::removeInjectedUserStyleSheet):
(WebCore::Page::updateElementsWithTextRecognitionResults):
(WebCore::Page::forceRepaintAllFrames):
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::virtualRectForAreaElementAndDirection):
* Source/WebCore/rendering/RenderText.h:
(WebCore::Text::checkedRenderer const): Deleted.
* Source/WebCore/rendering/TextPainter.cpp:
(WebCore::TextPainter::cachedGlyphDisplayListsForTextNodeAsText):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::checkIntersection):
(WebCore::LegacyRenderSVGModelObject::checkEnclosure):
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::~SVGElement):
(WebCore::SVGElement::attributeChanged):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::attributeChanged):
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::attributeChanged):
* Source/WebCore/svg/SVGFitToViewBox.cpp:
(WebCore::SVGFitToViewBox::parseViewBoxGeneric):
* Source/WebCore/svg/SVGFontFaceElement.cpp:
(WebCore::SVGFontFaceElement::removedFromAncestor):
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::attributeChanged):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::attributeChanged):
* Source/WebCore/svg/SVGPolyElement.cpp:
(WebCore::SVGPolyElement::attributeChanged):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::~SVGSVGElement):
(WebCore::checkIntersectionWithoutUpdatingLayout):
(WebCore::checkEnclosureWithoutUpdatingLayout):
(WebCore::SVGSVGElement::removedFromAncestor):
* Source/WebCore/svg/SVGTextContentElement.cpp:
(WebCore::SVGTextContentElement::getNumberOfChars):
(WebCore::SVGTextContentElement::getComputedTextLength):
(WebCore::SVGTextContentElement::getSubStringLength):
(WebCore::SVGTextContentElement::getStartPositionOfChar):
(WebCore::SVGTextContentElement::getEndPositionOfChar):
(WebCore::SVGTextContentElement::getExtentOfChar):
(WebCore::SVGTextContentElement::getRotationOfChar):
(WebCore::SVGTextContentElement::getCharNumAtPosition):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::areSVGAnimationsPaused const):
* Source/WebCore/workers/AbstractWorker.cpp:
(WebCore::AbstractWorker::validateURL):
* Source/WebCore/workers/Worker.cpp:
(WebCore::Worker::notifyFinished):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::applyContentSecurityPolicyResponseHeaders):
(WebCore::WorkerGlobalScope::setTimeout):
(WebCore::WorkerGlobalScope::setInterval):
(WebCore::WorkerGlobalScope::importScripts):
* Source/WebCore/workers/service/ExtendableEvent.cpp:
(WebCore::ExtendableEvent::addExtendLifetimePromise):
* Source/WebCore/workers/service/context/ServiceWorkerThread.cpp:
(WebCore::ServiceWorkerThread::queueTaskToFireFetchEvent):
(WebCore::ServiceWorkerThread::queueTaskToPostMessage):
(WebCore::ServiceWorkerThread::queueTaskToFireInstallEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireActivateEvent):
(WebCore::ServiceWorkerThread::queueTaskToFirePushEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireDeclarativePushEvent):
(WebCore::ServiceWorkerThread::queueTaskToFirePushSubscriptionChangeEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireNotificationEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchEvent):
(WebCore::ServiceWorkerThread::queueTaskToFireBackgroundFetchClickEvent):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::notifyNetworkStateChange):
* Source/WebCore/worklets/Worklet.cpp:
(WebCore::Worklet::addModule):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::open):
(WebCore::XMLHttpRequest::prepareToSend):
* Source/WebCore/xml/XMLHttpRequestProgressEventThrottle.cpp:
(WebCore::XMLHttpRequestProgressEventThrottle::updateProgress):
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::snapshotElementRectForScreenshot):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.mm:
(WebKit::PDFPluginAnnotation::~PDFPluginAnnotation):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::convertFromScrollbarToContainingView const):
(WebKit::PDFPluginBase::convertFromContainingViewToScrollbar const):
(WebKit::PDFPluginBase::pluginBackgroundColor const):
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::removeTransparentMarkersForTextAnimationID):
(WebKit::TextAnimationController::updateUnderlyingTextVisibilityForTextAnimationID):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::addDictationAlternative):
(WebKit::WebPage::dictationAlternativesAtSelection):
(WebKit::WebPage::clearDictationAlternatives):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::decorateTextRangeWithStyle):
(WebKit::WebFoundTextRangeController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::setAccessibleName):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::snapshotNode):
(WebKit::WebPage::unmarkAllMisspellings):
(WebKit::WebPage::unmarkAllBadGrammar):
(WebKit::WebPage::startTextManipulationForFrame):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::shadowLayerBoundsForFrame):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::handleImageServiceClick):
(WebKit::WebPage::handlePDFServiceClick):

Canonical link: <a href="https://commits.webkit.org/307238@main">https://commits.webkit.org/307238@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54f053e98f4b9b5740d0ae9470853ce089e020c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143782 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7965 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152450 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97019 "Build is in progress. Recent messages:") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9b499fd-ae9d-4995-9e49-c23f6001881d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145657 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16940 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16351 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110572 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/97019 "Build is in progress. Recent messages:") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8ff08c2-b8f7-4da4-9038-c742f3c310dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146745 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91489 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/601dc431-1d5f-49c9-a45b-19feb7d44644) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12479 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10206 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2452 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121937 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154762 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16311 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6854 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118579 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13728 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118936 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30481 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14874 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127020 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71724 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15932 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5532 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15666 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79703 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15731 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->