### PR TITLE
[GFC] Implement GridItemSizingFunctions for the block aixs

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -398,7 +398,6 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& pla
     const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList, const GridLayoutConstraints& layoutConstraints,
     const StyleContentAlignmentData& usedJustifyContent, const StyleContentAlignmentData& usedAlignContent) const
 {
-    auto& integrationUtils = formattingContext().integrationUtils();
     auto gridItemsCount = placedGridItems.size();
 
     Vector<WTF::Range<size_t>> columnSpanList;
@@ -447,9 +446,10 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& pla
     auto columnsGap = GridLayoutUtils::computeGapValue(formattingContextRootStyle->columnGap());
     auto rowsGap = GridLayoutUtils::computeGapValue(formattingContextRootStyle->rowGap());
 
+    auto& formattingContext = this->formattingContext();
     // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
     auto columnSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, inlineAxisComputedSizesList, inlineBorderAndPaddingList, columnSpanList,
-        columnTrackSizingFunctionsList, inlineAxisAvailableSpace, blockAxisConstraintList, GridLayoutUtils::inlineAxisGridItemSizingFunctions(integrationUtils),
+        columnTrackSizingFunctionsList, inlineAxisAvailableSpace, blockAxisConstraintList, GridLayoutUtils::inlineAxisGridItemSizingFunctions(formattingContext.integrationUtils()),
         columnFreeSpaceScenario, columnsGap, usedJustifyContent);
 
     // To find the inline-axis available space for any items whose block-axis size contributions
@@ -461,7 +461,7 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const PlacedGridItems& pla
 
     // 2. Next, the track sizing algorithm resolves the sizes of the grid rows.
     auto rowSizes = TrackSizingAlgorithm::sizeTracks(placedGridItems, blockAxisComputedSizesList, blockBorderAndPaddingList, rowSpanList,
-        rowTrackSizingFunctionsList, blockAxisAvailableSpace, inlineAxisConstraintList, GridLayoutUtils::blockAxisGridItemSizingFunctions(integrationUtils),
+        rowTrackSizingFunctionsList, blockAxisAvailableSpace, inlineAxisConstraintList, GridLayoutUtils::blockAxisGridItemSizingFunctions(formattingContext),
         rowFreeSpaceScenario, rowsGap, usedAlignContent);
 
     // 3. Then, if the min-content contribution of any grid item has changed based on the

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -414,31 +414,29 @@ GridItemSizingFunctions inlineAxisGridItemSizingFunctions(const IntegrationUtils
 
 }
 
-LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const IntegrationUtils&)
+LayoutUnit blockAxisMinContentContribution(const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint, const GridFormattingContext& formattingContext)
 {
-    UNUSED_PARAM(inlineAxisConstraint);
-    ASSERT_NOT_IMPLEMENTED_YET();
-    return { };
+    formattingContext.integrationUtils().layoutWithFormattingContextForBox(gridItem.layoutBox(), inlineAxisConstraint);
+    return formattingContext.geometryForGridItem(gridItem.layoutBox()).borderBoxHeight();
 }
 
-LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const IntegrationUtils&)
+LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint, const GridFormattingContext& formattingContext)
 {
-    UNUSED_PARAM(inlineAxisConstraint);
-    ASSERT_NOT_IMPLEMENTED_YET();
-    return { };
+    formattingContext.integrationUtils().layoutWithFormattingContextForBox(gridItem.layoutBox(), inlineAxisConstraint);
+    return formattingContext.geometryForGridItem(gridItem.layoutBox()).borderBoxHeight();
 }
 
-GridItemSizingFunctions blockAxisGridItemSizingFunctions(const IntegrationUtils& integrationUtils)
+GridItemSizingFunctions blockAxisGridItemSizingFunctions(const GridFormattingContext& formattingContext)
 {
     return {
-        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint) {
-            return blockAxisMinContentContribution(gridItem, inlineAxisConstraint, integrationUtils);
+        [&formattingContext](const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint) {
+            return blockAxisMinContentContribution(gridItem, inlineAxisConstraint, formattingContext);
         },
-        [&integrationUtils](const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint) {
-            return blockAxisMaxContentContribution(gridItem, inlineAxisConstraint, integrationUtils);
+        [&formattingContext](const PlacedGridItem& gridItem, LayoutUnit inlineAxisConstraint) {
+            return blockAxisMaxContentContribution(gridItem, inlineAxisConstraint, formattingContext);
         },
-        [&integrationUtils](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit availableSpace) {
-            return usedBlockMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, availableSpace, integrationUtils);
+        [&formattingContext](const PlacedGridItem& gridItem, const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit borderAndPadding, LayoutUnit availableSpace) {
+            return usedBlockMinimumSize(gridItem, trackSizingFunctions, borderAndPadding, availableSpace, formattingContext.integrationUtils());
         }
     };
 }

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -51,9 +51,9 @@ LayoutUnit inlineAxisMinContentContribution(const PlacedGridItem&, LayoutUnit bl
 LayoutUnit inlineAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit blockAxisConstraint, const IntegrationUtils&);
 GridItemSizingFunctions inlineAxisGridItemSizingFunctions(const IntegrationUtils&);
 
-LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const IntegrationUtils&);
-LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const IntegrationUtils&);
-GridItemSizingFunctions blockAxisGridItemSizingFunctions(const IntegrationUtils&);
+LayoutUnit blockAxisMinContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const GridFormattingContext&);
+LayoutUnit blockAxisMaxContentContribution(const PlacedGridItem&, LayoutUnit inlineAxisConstraint, const GridFormattingContext&);
+GridItemSizingFunctions blockAxisGridItemSizingFunctions(const GridFormattingContext&);
 
 bool preferredSizeBehavesAsAuto(const Style::PreferredSize&);
 bool preferredSizeDependsOnContainingBlockSize(const Style::PreferredSize&);


### PR DESCRIPTION
#### 0cef591f1e9a54b44a94fea95f123141c9a1f6e5
<pre>
[GFC] Implement GridItemSizingFunctions for the block aixs
<a href="https://bugs.webkit.org/show_bug.cgi?id=307505">https://bugs.webkit.org/show_bug.cgi?id=307505</a>
<a href="https://rdar.apple.com/170104719">rdar://170104719</a>

Reviewed by Alan Baradlay.

We have implementations for the inline axis when it comes to the
GridItemSizingFunctions API. These are used by the track sizing
algorithm to get the different types of size contributions for the grid
items in the column direction.

In order to support sizing of the rows based on the content (the grid
items), we need implementations for the block aixs. Notably, we need an
implementation for blockAxis{Min,Max}Contribution. The way render tree
accomplishes this is by performing layout on the grid item&apos;s and then
querying the renderer for the logical height (see
GridTrackSizingAlgorithmStrategy::{min,max}ContentContributionForGridItem -&gt;
logicalHeightForGridItem). So to match behavior we do the same by
calling into the equivalent integration API with the inline axis
constraints.

One small quirk of this is the fact that the block axis API will need
access to the formatting context while the inline axis one only needs
IntegrationUtils. This is because in order to return the border box size
we need to be able to get the grid item&apos;s box geometry.

Canonical link: <a href="https://commits.webkit.org/307255@main">https://commits.webkit.org/307255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c522f76b71faa7ce5714f45b4c1e921752096d5d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143788 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16269 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7971 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152456 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97025 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a8883b5-b8d2-4c95-842e-6ca49add4b9f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145663 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110575 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79535 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/381608c8-eed3-4639-b208-3e20712654f0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146751 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91492 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ac26994-9988-4773-9cd3-a7a76dea7497) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12476 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10209 "Passed tests") | [✅ 🛠 wpe-libwebrtc](https://ews-build.webkit.org/#/builders/172/builds/2458 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121933 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154768 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16317 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6853 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118581 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13731 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118938 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30495 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14868 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71730 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15938 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5531 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15672 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79709 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15737 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->