### PR TITLE
[GFC] Refactor out 'auto expandFlexibleTracks' from TrackSizingAlgorithm.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h
@@ -65,6 +65,12 @@ private:
     static bool hasFlexTracks(const UnsizedTracks&);
     static double flexFactorSum(const FlexTracks&);
     static LayoutUnit findSizeOfFr(const UnsizedTracks&, const LayoutUnit& availableSpace, const LayoutUnit& gapSize);
+
+    // Expand Flexible Tracks (spec section 11.7)
+    static void expandFlexibleTracks(UnsizedTracks&, const FreeSpaceScenario&, std::optional<LayoutUnit> availableGridSpace, const LayoutUnit& gapSize);
+    static void expandFlexibleTracksForMinContent(UnsizedTracks&);
+    static void expandFlexibleTracksForMaxContent(UnsizedTracks&, const FlexTracks&, double totalFlex);
+    static void expandFlexibleTracksForDefiniteLength(UnsizedTracks&, const FlexTracks&, std::optional<LayoutUnit> availableGridSpace, const LayoutUnit& gapSize);
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### e032afda80cc95892a0d4ddc1a704e77e5ff5511
<pre>
[GFC] Refactor out &apos;auto expandFlexibleTracks&apos; from TrackSizingAlgorithm.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307504">https://bugs.webkit.org/show_bug.cgi?id=307504</a>
&lt;<a href="https://rdar.apple.com/170104071">rdar://170104071</a>&gt;

Reviewed by Sammy Gill.

This PR extracts expandFlexibleTracks() from an inline function and breaks up the logic
for expanding under min content, max content, and definite sizing constraints.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::TrackSizingAlgorithm::sizeTracks):
(WebCore::Layout::TrackSizingAlgorithm::expandFlexibleTracksForMinContent):
(WebCore::Layout::TrackSizingAlgorithm::expandFlexibleTracksForMaxContent):
(WebCore::Layout::TrackSizingAlgorithm::expandFlexibleTracksForDefiniteLength):
(WebCore::Layout::TrackSizingAlgorithm::expandFlexibleTracks):
* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.h:

Canonical link: <a href="https://commits.webkit.org/307287@main">https://commits.webkit.org/307287@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2309ca9a71b393c83df64071f27d945b593cfa32

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16292 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/7996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152479 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97048 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e04ed06-8846-4979-b250-15f5392aa00e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145686 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/16969 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16380 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110588 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79550 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146774 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91506 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10a3921a-2c0e-4f56-9a74-25987881fbc1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12493 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10223 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121952 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5833 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154791 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16340 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118596 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16375 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118953 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14879 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127042 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71753 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22203 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/15961 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5545 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15695 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79732 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15760 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->