### PR TITLE
Drop remaining `checked*()` member functions in Source/WebKit

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -614,11 +614,6 @@ WebCore::NetworkStorageSession* NetworkProcess::storageSession(PAL::SessionID se
     return m_networkStorageSessions.get(sessionID);
 }
 
-CheckedPtr<WebCore::NetworkStorageSession> NetworkProcess::checkedStorageSession(PAL::SessionID sessionID) const
-{
-    return storageSession(sessionID);
-}
-
 void NetworkProcess::forEachNetworkStorageSession(NOESCAPE const Function<void(WebCore::NetworkStorageSession&)>& functor)
 {
     for (auto& storageSession : m_networkStorageSessions.values())
@@ -629,11 +624,6 @@ NetworkSession* NetworkProcess::networkSession(PAL::SessionID sessionID) const
 {
     ASSERT(RunLoop::isMain());
     return m_networkSessions.get(sessionID);
-}
-
-CheckedPtr<NetworkSession> NetworkProcess::checkedNetworkSession(PAL::SessionID sessionID) const
-{
-    return networkSession(sessionID);
 }
 
 void NetworkProcess::setSession(PAL::SessionID sessionID, std::unique_ptr<NetworkSession>&& session)
@@ -2356,7 +2346,7 @@ void NetworkProcess::findPendingDownloadLocation(NetworkDataTask& networkDataTas
 void NetworkProcess::dataTaskWithRequest(WebPageProxyIdentifier pageID, PAL::SessionID sessionID, WebCore::ResourceRequest&& request, const std::optional<WebCore::SecurityOriginData>& topOrigin, IPC::FormDataReference&& httpBody, CompletionHandler<void(std::optional<DataTaskIdentifier>)>&& completionHandler)
 {
     request.setHTTPBody(httpBody.takeData());
-    checkedNetworkSession(sessionID)->dataTaskWithRequest(pageID, WTF::move(request), topOrigin, [completionHandler = WTF::move(completionHandler)](auto dataTaskIdentifier) mutable {
+    protect(networkSession(sessionID))->dataTaskWithRequest(pageID, WTF::move(request), topOrigin, [completionHandler = WTF::move(completionHandler)](auto dataTaskIdentifier) mutable {
         completionHandler(dataTaskIdentifier);
     });
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -199,7 +199,6 @@ public:
 
     void setSession(PAL::SessionID, std::unique_ptr<NetworkSession>&&);
     NetworkSession* networkSession(PAL::SessionID) const final;
-    CheckedPtr<NetworkSession> checkedNetworkSession(PAL::SessionID) const;
     void destroySession(PAL::SessionID, CompletionHandler<void()>&& = [] { });
     void ensureSessionWithDataStoreIdentifierRemoved(WTF::UUID, CompletionHandler<void()>&&);
 
@@ -207,7 +206,6 @@ public:
 
     void forEachNetworkStorageSession(NOESCAPE const Function<void(WebCore::NetworkStorageSession&)>&);
     WebCore::NetworkStorageSession* storageSession(PAL::SessionID) const;
-    CheckedPtr<WebCore::NetworkStorageSession> checkedStorageSession(PAL::SessionID) const;
     std::unique_ptr<WebCore::NetworkStorageSession> newTestingSession(PAL::SessionID);
     void addStorageSession(PAL::SessionID, const WebsiteDataStoreParameters&);
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -319,7 +319,7 @@ void NetworkResourceLoader::retrieveCacheEntry(const ResourceRequest& request)
     if (isMainFrameLoad()) {
         ASSERT(m_parameters.options.mode == FetchOptions::Mode::Navigate);
         if (CheckedPtr session = protect(connectionToWebProcess())->networkProcess().networkSession(sessionID())) {
-            if (auto entry = session->checkedPrefetchCache()->take(request.url())) {
+            if (auto entry = protect(session->prefetchCache())->take(request.url())) {
                 LOADER_RELEASE_LOG("retrieveCacheEntry: retrieved an entry from the prefetch cache (isRedirect=%d)", !entry->redirectRequest.isNull());
                 if (!entry->redirectRequest.isNull()) {
                     auto cacheEntry = cache->makeRedirectEntry(request, entry->response, entry->redirectRequest);
@@ -1416,7 +1416,7 @@ void NetworkResourceLoader::didFinishWithRedirectResponse(WebCore::ResourceReque
     if (!isCrossOriginPrefetch())
         didReceiveResponse(WTF::move(redirectResponse), PrivateRelayed::No, [] (auto) { });
     else if (CheckedPtr session = protect(connectionToWebProcess())->networkProcess().networkSession(sessionID()))
-        session->checkedPrefetchCache()->storeRedirect(request.url(), WTF::move(redirectResponse), WTF::move(redirectRequest));
+        protect(session->prefetchCache())->storeRedirect(request.url(), WTF::move(redirectResponse), WTF::move(redirectRequest));
 
     WebCore::NetworkLoadMetrics networkLoadMetrics;
     networkLoadMetrics.markComplete();
@@ -1635,7 +1635,7 @@ void NetworkResourceLoader::tryStoreAsCacheEntry()
     if (isCrossOriginPrefetch()) {
         if (CheckedPtr session = protect(connectionToWebProcess())->networkProcess().networkSession(sessionID())) {
             LOADER_RELEASE_LOG("tryStoreAsCacheEntry: Storing entry in prefetch cache");
-            session->checkedPrefetchCache()->store(m_networkLoad->currentRequest().url(), WTF::move(m_response), m_privateRelayed, m_bufferedDataForCache.takeBuffer());
+            protect(session->prefetchCache())->store(m_networkLoad->currentRequest().url(), WTF::move(m_response), m_privateRelayed, m_bufferedDataForCache.takeBuffer());
         }
         return;
     }

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -936,7 +936,7 @@ void NetworkSession::setPersistedDomains(HashSet<WebCore::RegistrableDomain>&& d
         resourceLoadStatistics->setPersistedDomains(m_persistedDomains);
 }
 
-CheckedRef<PrefetchCache> NetworkSession::checkedPrefetchCache()
+PrefetchCache& NetworkSession::prefetchCache()
 {
     return m_prefetchCache.get();
 }

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -198,7 +198,7 @@ public:
 
     NetworkCache::Cache* cache() { return m_cache.get(); }
 
-    CheckedRef<PrefetchCache> checkedPrefetchCache();
+    PrefetchCache& prefetchCache();
     void clearPrefetchCache() { m_prefetchCache->clear(); }
 
     virtual RefPtr<WebSocketTask> createWebSocketTask(WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, NetworkSocketChannel&, const WebCore::ResourceRequest&, const String& protocol, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::StoredCredentialsPolicy);

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h
@@ -86,8 +86,6 @@ private:
     void setCookieTransformForFirstPartyRequest(const WebCore::ResourceRequest&);
     void setCookieTransformForThirdPartyRequest(const WebCore::ResourceRequest&, IsRedirect);
 
-    CheckedPtr<NetworkSession> checkedNetworkSession() const;
-
     WeakPtr<NetworkSession> m_networkSession;
     bool m_hasBeenSetToUseStatelessCookieStorage { false };
     Seconds m_ageCapForCNAMECloakedCookies { 24_h * 7 };

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -170,7 +170,6 @@ private:
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
     enum class ShouldWriteOriginFile : bool { No, Yes };
     OriginStorageManager& originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
-    CheckedRef<OriginStorageManager> checkedOriginStorageManager(const WebCore::ClientOrigin& origin, ShouldWriteOriginFile shouldWriteOriginFile = ShouldWriteOriginFile::Yes) { return originStorageManager(origin, shouldWriteOriginFile); }
     bool removeOriginStorageManagerIfPossible(const WebCore::ClientOrigin&);
 
     void forEachOriginDirectory(NOESCAPE const Function<void(const String&)>&);

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -732,11 +732,6 @@ IDBStorageManager& OriginStorageManager::idbStorageManager(IDBStorageRegistry& r
     });
 }
 
-CheckedRef<IDBStorageManager> OriginStorageManager::checkedIDBStorageManager(IDBStorageRegistry& registry)
-{
-    return idbStorageManager(registry);
-}
-
 IDBStorageManager* OriginStorageManager::existingIDBStorageManager()
 {
     return defaultBucket().existingIDBStorageManager();

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -77,7 +77,6 @@ public:
     SessionStorageManager& sessionStorageManager(StorageAreaRegistry&);
     SessionStorageManager* existingSessionStorageManager();
     IDBStorageManager& idbStorageManager(IDBStorageRegistry&);
-    CheckedRef<IDBStorageManager> checkedIDBStorageManager(IDBStorageRegistry&);
     IDBStorageManager* existingIDBStorageManager();
     CacheStorageManager& cacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, Ref<WorkQueue>&&);
     Ref<CacheStorageManager> protectedCacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, Ref<WorkQueue>&&);

--- a/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
+++ b/Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h
@@ -79,7 +79,6 @@ private:
     };
     ASCIILiteral statementString(StatementType) const;
     WebCore::SQLiteStatementAutoResetScope cachedStatement(StatementType);
-    CheckedPtr<WebCore::SQLiteDatabase> checkedDatabase() const;
     Expected<String, StorageError> getItem(const String& key);
     Expected<String, StorageError> getItemFromDatabase(const String& key);
     enum class IsDatabaseDeleted : bool { No, Yes };

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -133,7 +133,6 @@ public:
 private:
     explicit WebPaymentCoordinatorProxy(Client&);
     Ref<WorkQueue> protectedCanMakePaymentsQueue() const;
-    CheckedPtr<Client> checkedClient() const { return m_client.get(); }
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -85,7 +85,7 @@ void WebPaymentCoordinatorProxy::platformCanMakePaymentsWithActiveCard(const Str
         return completionHandler(false);
 #endif
 
-    PKCanMakePaymentsWithMerchantIdentifierDomainAndSourceApplication(merchantIdentifier.createNSString().get(), domainName.createNSString().get(), checkedClient()->paymentCoordinatorSourceApplicationSecondaryIdentifier(*this).createNSString().get(), makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL canMakePayments, NSError *error) mutable {
+    PKCanMakePaymentsWithMerchantIdentifierDomainAndSourceApplication(merchantIdentifier.createNSString().get(), domainName.createNSString().get(), protect(m_client)->paymentCoordinatorSourceApplicationSecondaryIdentifier(*this).createNSString().get(), makeBlockPtr([completionHandler = WTF::move(completionHandler)](BOOL canMakePayments, NSError *error) mutable {
         if (error)
             LOG_ERROR("PKCanMakePaymentsWithMerchantIdentifierAndDomain error %@", error);
 
@@ -531,7 +531,7 @@ void WebPaymentCoordinatorProxy::platformEndApplePaySetup()
 
 void WebPaymentCoordinatorProxy::platformBeginApplePaySetup(const PaymentSetupConfiguration& configuration, const PaymentSetupFeatures& features, CompletionHandler<void(bool)>&& reply)
 {
-    RetainPtr presentingViewController = checkedClient()->paymentCoordinatorPresentingViewController(*this);
+    RetainPtr presentingViewController = protect(m_client)->paymentCoordinatorPresentingViewController(*this);
     if (!presentingViewController) {
         reply(false);
         return;

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -75,7 +75,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
 #endif
         paymentRequest = platformPaymentRequest(originatingURL, linkIconURLs, request);
 
-    checkedClient()->getPaymentCoordinatorEmbeddingUserAgent(webPageProxyID, [weakThis = WeakPtr { *this }, paymentRequest, completionHandler = WTF::move(completionHandler)](const String& userAgent) mutable {
+    protect(m_client)->getPaymentCoordinatorEmbeddingUserAgent(webPageProxyID, [weakThis = WeakPtr { *this }, paymentRequest, completionHandler = WTF::move(completionHandler)](const String& userAgent) mutable {
         RefPtr paymentCoordinatorProxy = weakThis.get();
         if (!paymentCoordinatorProxy)
             return completionHandler(false);
@@ -100,7 +100,7 @@ void WebPaymentCoordinatorProxy::platformShowPaymentUI(WebPageProxyIdentifier we
             if (showPaymentUIRequestSeed != paymentCoordinatorProxy->m_showPaymentUIRequestSeed)
                 return completionHandler(false);
 
-            RetainPtr presentingWindow = paymentCoordinatorProxy->checkedClient()->paymentCoordinatorPresentingWindow(*paymentCoordinatorProxy);
+            RetainPtr presentingWindow = protect(paymentCoordinatorProxy->m_client)->paymentCoordinatorPresentingWindow(*paymentCoordinatorProxy);
             if (!presentingWindow)
                 return completionHandler(false);
 

--- a/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
+++ b/Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h
@@ -173,8 +173,6 @@ private:
     void platformRevealFileExternally(const String& path);
     void platformShowCertificate(const WebCore::CertificateInfo&);
 
-    CheckedPtr<RemoteWebInspectorUIProxyClient> checkedClient() const { return m_client.get(); }
-
     WeakPtr<RemoteWebInspectorUIProxyClient> m_client;
     WeakPtr<WebPageProxy> m_inspectorPage;
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -166,7 +166,7 @@ void WebPageInspectorController::setIndicating(bool indicating)
 
 void WebPageInspectorController::sendMessageToInspectorFrontend(const String& targetId, const String& message)
 {
-    checkedTargetAgent()->sendMessageFromTargetToFrontend(targetId, message);
+    protect(m_targetAgent)->sendMessageFromTargetToFrontend(targetId, message);
 }
 
 bool WebPageInspectorController::shouldPauseLoading(const ProvisionalPageProxy& provisionalPage) const
@@ -255,7 +255,7 @@ void WebPageInspectorController::createLazyAgents()
 
 void WebPageInspectorController::addTarget(std::unique_ptr<InspectorTargetProxy>&& target)
 {
-    checkedTargetAgent()->targetCreated(*target);
+    protect(m_targetAgent)->targetCreated(*target);
     m_targets.set(target->identifier(), WTF::move(target));
 }
 
@@ -264,7 +264,7 @@ void WebPageInspectorController::removeTarget(const String& targetId)
     auto it = m_targets.find(targetId);
     if (it == m_targets.end())
         return;
-    checkedTargetAgent()->targetDestroyed(CheckedRef { *it->value });
+    protect(m_targetAgent)->targetDestroyed(CheckedRef { *it->value });
     m_targets.remove(it);
 }
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -90,7 +90,6 @@ public:
     void browserExtensionsDisabled(HashSet<String>&&);
 
 private:
-    CheckedPtr<Inspector::InspectorTargetAgent> checkedTargetAgent() { return m_targetAgent; }
     WebPageAgentContext webPageAgentContext();
     void createLazyAgents();
 

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -117,7 +117,7 @@ WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
 {
     m_objCAdapter = adoptNS([[WKRemoteWebInspectorUIProxyObjCAdapter alloc] initWithRemoteWebInspectorUIProxy:this]);
 
-    Ref<API::InspectorConfiguration> configuration = checkedClient()->configurationForRemoteInspector(*this);
+    Ref<API::InspectorConfiguration> configuration = protect(m_client)->configurationForRemoteInspector(*this);
     m_inspectorView = adoptNS([[WKInspectorViewController alloc] initWithConfiguration:protectedWrapper(configuration.get()).get() inspectedPage:nullptr]);
     [m_inspectorView.get() setDelegate:m_objCAdapter.get()];
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -169,8 +169,6 @@ private:
 
     RefPtr<RemoteScrollingTree> scrollingTree();
 
-    CheckedPtr<RemoteLayerTreeEventDispatcherDisplayLinkClient> checkedDisplayLinkClient();
-
     Lock m_scrollingTreeLock;
     RefPtr<RemoteScrollingTree> m_scrollingTree WTF_GUARDED_BY_LOCK(m_scrollingTreeLock);
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -127,7 +127,7 @@ RemoteLayerTreeEventDispatcher::~RemoteLayerTreeEventDispatcher()
 // This must be called to break the cycle between RemoteLayerTreeEventDispatcherDisplayLinkClient and this.
 void RemoteLayerTreeEventDispatcher::invalidate()
 {
-    checkedDisplayLinkClient()->invalidate();
+    protect(m_displayLinkClient)->invalidate();
 
     removeDisplayLinkClient();
 
@@ -160,11 +160,6 @@ RefPtr<RemoteScrollingTree> RemoteLayerTreeEventDispatcher::scrollingTree()
     }
     
     return result;
-}
-
-CheckedPtr<RemoteLayerTreeEventDispatcherDisplayLinkClient> RemoteLayerTreeEventDispatcher::checkedDisplayLinkClient()
-{
-    return m_displayLinkClient.get();
 }
 
 void RemoteLayerTreeEventDispatcher::wheelEventHysteresisUpdated(PAL::HysteresisState state)
@@ -426,7 +421,7 @@ void RemoteLayerTreeEventDispatcher::startDisplayLinkObserver()
 
     m_displayRefreshObserverID = DisplayLinkObserverID::generate();
     // This display link always runs at the display update frequency (e.g. 120Hz).
-    displayLink->addObserver(*checkedDisplayLinkClient(), *m_displayRefreshObserverID, displayLink->nominalFramesPerSecond());
+    displayLink->addObserver(*protect(m_displayLinkClient), *m_displayRefreshObserverID, displayLink->nominalFramesPerSecond());
 }
 
 void RemoteLayerTreeEventDispatcher::stopDisplayLinkObserver()
@@ -440,7 +435,7 @@ void RemoteLayerTreeEventDispatcher::stopDisplayLinkObserver()
 
     LOG_WITH_STREAM(DisplayLink, stream << "[UI ] RemoteLayerTreeEventDispatcher::stopDisplayLinkObserver");
 
-    displayLink->removeObserver(*checkedDisplayLinkClient(), *m_displayRefreshObserverID);
+    displayLink->removeObserver(*protect(m_displayLinkClient), *m_displayRefreshObserverID);
     m_displayRefreshObserverID = { };
 }
 
@@ -451,7 +446,7 @@ void RemoteLayerTreeEventDispatcher::removeDisplayLinkClient()
         return;
 
     LOG_WITH_STREAM(DisplayLink, stream << "[UI ] RemoteLayerTreeEventDispatcher::removeDisplayLinkClient");
-    displayLink->removeClient(*checkedDisplayLinkClient());
+    displayLink->removeClient(*protect(m_displayLinkClient));
     m_displayRefreshObserverID = { };
 }
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.h
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.h
@@ -87,8 +87,6 @@ private:
     void sendUpdate(WebCore::SpeechRecognitionConnectionClientIdentifier, WebCore::SpeechRecognitionUpdateType, std::optional<WebCore::SpeechRecognitionError> = std::nullopt, std::optional<Vector<WebCore::SpeechRecognitionResultData>> = std::nullopt);
     void sendUpdate(const WebCore::SpeechRecognitionUpdate&);
 
-    CheckedPtr<WebCore::SpeechRecognizer> checkedRecognizer() const;
-
     // IPC::MessageReceiver.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp
@@ -81,11 +81,6 @@ static String databasePath(const String& directoryPath)
     return FileSystem::pathByAppendingComponent(directoryPath, "EnhancedSecuritySites.db"_s);
 }
 
-CheckedPtr<WebCore::SQLiteDatabase> EnhancedSecuritySitesPersistence::checkedDatabase() const
-{
-    return m_sqliteDB.get();
-}
-
 WebCore::SQLiteStatementAutoResetScope EnhancedSecuritySitesPersistence::cachedStatement(StatementType type)
 {
     ASSERT(m_sqliteDB);
@@ -196,7 +191,7 @@ void EnhancedSecuritySitesPersistence::deleteAllSites()
         return;
     }
 
-    auto deleteStatement = checkedDatabase()->prepareStatement(deleteAllSitesSQL);
+    auto deleteStatement = protect(m_sqliteDB)->prepareStatement(deleteAllSitesSQL);
     if (!deleteStatement || !deleteStatement->executeCommand())
         return reportSQLError(__FUNCTION__, "delete all sites"_s);
 }
@@ -210,7 +205,7 @@ HashSet<WebCore::RegistrableDomain> EnhancedSecuritySitesPersistence::enhancedSe
         return { };
     }
 
-    auto selectStatement = checkedDatabase()->prepareStatement(selectEnhancedSecurityOnlySitesSQL);
+    auto selectStatement = protect(m_sqliteDB)->prepareStatement(selectEnhancedSecurityOnlySitesSQL);
     if (!selectStatement) {
         reportSQLError(__FUNCTION__, "fetch enhanced security only sites"_s);
         return { };
@@ -234,7 +229,7 @@ HashSet<WebCore::RegistrableDomain> EnhancedSecuritySitesPersistence::allEnhance
         return { };
     }
 
-    auto selectStatement = checkedDatabase()->prepareStatement(selectAllSitesSQL);
+    auto selectStatement = protect(m_sqliteDB)->prepareStatement(selectAllSitesSQL);
     if (!selectStatement) {
         reportSQLError(__FUNCTION__, "fetch all sites"_s);
         return { };
@@ -289,7 +284,7 @@ void EnhancedSecuritySitesPersistence::closeDatabase()
 
     if (isDatabaseOpen()) {
         ENHANCEDSECURITY_RELEASE_LOG("%s: Closing database", __FUNCTION__);
-        checkedDatabase()->close();
+        protect(m_sqliteDB)->close();
     }
 
     m_sqliteDB = nullptr;

--- a/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.h
+++ b/Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.h
@@ -51,8 +51,6 @@ public:
     void trackEnhancedSecurityForDomain(WebCore::RegistrableDomain&&, EnhancedSecurity);
 
 private:
-    CheckedPtr<WebCore::SQLiteDatabase> checkedDatabase() const;
-
     enum class StatementType : uint8_t {
         SelectSite,
         InsertSite,

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -330,8 +330,6 @@ private:
     void showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&&) final;
 #endif
 
-    CheckedPtr<WebViewImpl> checkedImpl() const { return m_impl.get(); }
-
     bool isViewVisible(NSView *, NSWindow *);
 
     WeakObjCPtr<NSView> m_view;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -127,7 +127,7 @@ void PageClientImpl::setImpl(WebViewImpl& impl)
 
 Ref<DrawingAreaProxy> PageClientImpl::createDrawingAreaProxy(WebProcessProxy& webProcessProxy)
 {
-    return checkedImpl()->createDrawingAreaProxy(webProcessProxy);
+    return protect(m_impl)->createDrawingAreaProxy(webProcessProxy);
 }
 
 void PageClientImpl::setViewNeedsDisplay(const WebCore::Region&)
@@ -262,12 +262,12 @@ void PageClientImpl::viewWillMoveToAnotherWindow()
 
 WebCore::DestinationColorSpace PageClientImpl::colorSpace()
 {
-    return checkedImpl()->colorSpace();
+    return protect(m_impl)->colorSpace();
 }
 
 void PageClientImpl::processWillSwap()
 {
-    checkedImpl()->processWillSwap();
+    protect(m_impl)->processWillSwap();
 
 #if ENABLE(TEXT_EXTRACTION_FILTER)
     [webView() _clearTextExtractionFilterCache];
@@ -283,23 +283,23 @@ void PageClientImpl::processDidExit()
 
 void PageClientImpl::pageClosed()
 {
-    checkedImpl()->pageClosed();
+    protect(m_impl)->pageClosed();
     PageClientImplCocoa::pageClosed();
 }
 
 void PageClientImpl::didRelaunchProcess()
 {
-    checkedImpl()->didRelaunchProcess();
+    protect(m_impl)->didRelaunchProcess();
 }
 
 void PageClientImpl::preferencesDidChange()
 {
-    checkedImpl()->preferencesDidChange();
+    protect(m_impl)->preferencesDidChange();
 }
 
 void PageClientImpl::toolTipChanged(const String& oldToolTip, const String& newToolTip)
 {
-    checkedImpl()->toolTipChanged(oldToolTip, newToolTip);
+    protect(m_impl)->toolTipChanged(oldToolTip, newToolTip);
 }
 
 void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
@@ -329,7 +329,7 @@ void PageClientImpl::didFinishLoadingDataForCustomContentProvider(const String& 
 
 void PageClientImpl::didChangeContentSize(const WebCore::IntSize& newSize)
 {
-    checkedImpl()->didChangeContentSize(newSize);
+    protect(m_impl)->didChangeContentSize(newSize);
 }
 
 void PageClientImpl::setCursor(const WebCore::Cursor& cursor)
@@ -361,7 +361,7 @@ void PageClientImpl::setCursor(const WebCore::Cursor& cursor)
     if ([NSCursor currentCursor] == platformCursor.get())
         return;
 
-    if (checkedImpl()->imageAnalysisOverlayViewHasCursorAtPoint([view convertPoint:mouseLocationInScreen fromView:nil]))
+    if (protect(m_impl)->imageAnalysisOverlayViewHasCursorAtPoint([view convertPoint:mouseLocationInScreen fromView:nil]))
         return;
 
     [platformCursor set];
@@ -379,7 +379,7 @@ void PageClientImpl::setCursorHiddenUntilMouseMoves(bool hiddenUntilMouseMoves)
 
 void PageClientImpl::registerEditCommand(Ref<WebEditCommandProxy>&& command, UndoOrRedo undoOrRedo)
 {
-    checkedImpl()->registerEditCommand(WTF::move(command), undoOrRedo);
+    protect(m_impl)->registerEditCommand(WTF::move(command), undoOrRedo);
 }
 
 void PageClientImpl::registerInsertionUndoGrouping()
@@ -389,27 +389,27 @@ void PageClientImpl::registerInsertionUndoGrouping()
 
 void PageClientImpl::createPDFHUD(PDFPluginIdentifier identifier, WebCore::FrameIdentifier frameID, const WebCore::IntRect& rect)
 {
-    checkedImpl()->createPDFHUD(identifier, frameID, rect);
+    protect(m_impl)->createPDFHUD(identifier, frameID, rect);
 }
 
 void PageClientImpl::updatePDFHUDLocation(PDFPluginIdentifier identifier, const WebCore::IntRect& rect)
 {
-    checkedImpl()->updatePDFHUDLocation(identifier, rect);
+    protect(m_impl)->updatePDFHUDLocation(identifier, rect);
 }
 
 void PageClientImpl::removePDFHUD(PDFPluginIdentifier identifier)
 {
-    checkedImpl()->removePDFHUD(identifier);
+    protect(m_impl)->removePDFHUD(identifier);
 }
 
 void PageClientImpl::removeAllPDFHUDs()
 {
-    checkedImpl()->removeAllPDFHUDs();
+    protect(m_impl)->removeAllPDFHUDs();
 }
 
 void PageClientImpl::clearAllEditCommands()
 {
-    checkedImpl()->clearAllEditCommands();
+    protect(m_impl)->clearAllEditCommands();
 }
 
 bool PageClientImpl::canUndoRedo(UndoOrRedo undoOrRedo)
@@ -427,29 +427,29 @@ void PageClientImpl::executeUndoRedo(UndoOrRedo undoOrRedo)
 void PageClientImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Handle&& image, const std::optional<WebCore::NodeIdentifier>& nodeID)
 {
     UNUSED_PARAM(nodeID);
-    checkedImpl()->startDrag(item, WTF::move(image));
+    protect(m_impl)->startDrag(item, WTF::move(image));
 }
 
 void PageClientImpl::setPromisedDataForImage(const String& pasteboardName, Ref<FragmentedSharedBuffer>&& imageBuffer, const String& filename, const String& extension, const String& title, const String& url, const String& visibleURL, RefPtr<FragmentedSharedBuffer>&& archiveBuffer, const String& originIdentifier)
 {
     auto image = BitmapImage::create();
     image->setData(WTF::move(imageBuffer), true);
-    checkedImpl()->setPromisedDataForImage(image.get(), filename.createNSString().get(), extension.createNSString().get(), title.createNSString().get(), url.createNSString().get(), visibleURL.createNSString().get(), archiveBuffer.get(), pasteboardName.createNSString().get(), originIdentifier.createNSString().get());
+    protect(m_impl)->setPromisedDataForImage(image.get(), filename.createNSString().get(), extension.createNSString().get(), title.createNSString().get(), url.createNSString().get(), visibleURL.createNSString().get(), archiveBuffer.get(), pasteboardName.createNSString().get(), originIdentifier.createNSString().get());
 }
 
 void PageClientImpl::updateSecureInputState()
 {
-    checkedImpl()->updateSecureInputState();
+    protect(m_impl)->updateSecureInputState();
 }
 
 void PageClientImpl::resetSecureInputState()
 {
-    checkedImpl()->resetSecureInputState();
+    protect(m_impl)->resetSecureInputState();
 }
 
 void PageClientImpl::notifyInputContextAboutDiscardedComposition()
 {
-    checkedImpl()->notifyInputContextAboutDiscardedComposition();
+    protect(m_impl)->notifyInputContextAboutDiscardedComposition();
 }
 
 FloatRect PageClientImpl::convertToDeviceSpace(const FloatRect& rect)
@@ -518,19 +518,19 @@ IntRect PageClientImpl::rootViewToAccessibilityScreen(const IntRect& rect)
 
 void PageClientImpl::doneWithKeyEvent(const NativeWebKeyboardEvent& event, bool eventWasHandled)
 {
-    checkedImpl()->doneWithKeyEvent(RetainPtr { event.nativeEvent() }.get(), eventWasHandled);
+    protect(m_impl)->doneWithKeyEvent(RetainPtr { event.nativeEvent() }.get(), eventWasHandled);
 }
 
 #if ENABLE(IMAGE_ANALYSIS)
 
 void PageClientImpl::requestTextRecognition(const URL& imageURL, ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(TextRecognitionResult&&)>&& completion)
 {
-    checkedImpl()->requestTextRecognition(imageURL, WTF::move(imageData), sourceLanguageIdentifier, targetLanguageIdentifier, WTF::move(completion));
+    protect(m_impl)->requestTextRecognition(imageURL, WTF::move(imageData), sourceLanguageIdentifier, targetLanguageIdentifier, WTF::move(completion));
 }
 
 void PageClientImpl::computeHasVisualSearchResults(const URL& imageURL, ShareableBitmap& imageBitmap, CompletionHandler<void(bool)>&& completion)
 {
-    checkedImpl()->computeHasVisualSearchResults(imageURL, imageBitmap, WTF::move(completion));
+    protect(m_impl)->computeHasVisualSearchResults(imageURL, imageBitmap, WTF::move(completion));
 }
 
 #endif
@@ -595,22 +595,22 @@ bool PageClientImpl::hasBrowsingWarning() const
 
 void PageClientImpl::clearBrowsingWarning()
 {
-    checkedImpl()->clearWarningView();
+    protect(m_impl)->clearWarningView();
 }
 
 void PageClientImpl::clearBrowsingWarningIfForMainFrameNavigation()
 {
-    checkedImpl()->clearWarningViewIfForMainFrameNavigation();
+    protect(m_impl)->clearWarningViewIfForMainFrameNavigation();
 }
 
 CALayer* PageClientImpl::textIndicatorInstallationLayer()
 {
-    return checkedImpl()->textIndicatorInstallationLayer();
+    return protect(m_impl)->textIndicatorInstallationLayer();
 }
 
 void PageClientImpl::accessibilityWebProcessTokenReceived(std::span<const uint8_t> data, pid_t pid)
 {
-    checkedImpl()->setAccessibilityWebProcessToken(toNSData(data).get(), pid);
+    protect(m_impl)->setAccessibilityWebProcessToken(toNSData(data).get(), pid);
 }
     
 void PageClientImpl::enterAcceleratedCompositingMode(const LayerTreeContext& layerTreeContext)
@@ -618,7 +618,7 @@ void PageClientImpl::enterAcceleratedCompositingMode(const LayerTreeContext& lay
     ASSERT(!layerTreeContext.isEmpty());
 
     RetainPtr renderLayer = [CALayer _web_renderLayerWithContextID:layerTreeContext.contextID shouldPreserveFlip:NO];
-    checkedImpl()->enterAcceleratedCompositingWithRootLayer(renderLayer.get());
+    protect(m_impl)->enterAcceleratedCompositingWithRootLayer(renderLayer.get());
 }
 
 void PageClientImpl::didFirstLayerFlush(const LayerTreeContext& layerTreeContext)
@@ -626,12 +626,12 @@ void PageClientImpl::didFirstLayerFlush(const LayerTreeContext& layerTreeContext
     ASSERT(!layerTreeContext.isEmpty());
 
     RetainPtr renderLayer = [CALayer _web_renderLayerWithContextID:layerTreeContext.contextID shouldPreserveFlip:NO];
-    checkedImpl()->setAcceleratedCompositingRootLayer(renderLayer.get());
+    protect(m_impl)->setAcceleratedCompositingRootLayer(renderLayer.get());
 }
 
 void PageClientImpl::exitAcceleratedCompositingMode()
 {
-    checkedImpl()->setAcceleratedCompositingRootLayer(nil);
+    protect(m_impl)->setAcceleratedCompositingRootLayer(nil);
 }
 
 void PageClientImpl::updateAcceleratedCompositingMode(const LayerTreeContext& layerTreeContext)
@@ -639,12 +639,12 @@ void PageClientImpl::updateAcceleratedCompositingMode(const LayerTreeContext& la
     ASSERT(!layerTreeContext.isEmpty());
 
     RetainPtr renderLayer = [CALayer _web_renderLayerWithContextID:layerTreeContext.contextID shouldPreserveFlip:NO];
-    checkedImpl()->setAcceleratedCompositingRootLayer(renderLayer.get());
+    protect(m_impl)->setAcceleratedCompositingRootLayer(renderLayer.get());
 }
 
 void PageClientImpl::setRemoteLayerTreeRootNode(RemoteLayerTreeNode* rootNode)
 {
-    checkedImpl()->setAcceleratedCompositingRootLayer(rootNode ? protect(rootNode->layer()).get() : nil);
+    protect(m_impl)->setAcceleratedCompositingRootLayer(rootNode ? protect(rootNode->layer()).get() : nil);
 }
 
 CALayer *PageClientImpl::acceleratedCompositingRootLayer() const
@@ -664,34 +664,34 @@ CALayer *PageClientImpl::footerBannerLayer() const
 
 RefPtr<ViewSnapshot> PageClientImpl::takeViewSnapshot(std::optional<WebCore::IntRect>&&)
 {
-    return checkedImpl()->takeViewSnapshot();
+    return protect(m_impl)->takeViewSnapshot();
 }
 
 RefPtr<ViewSnapshot> PageClientImpl::takeViewSnapshot(std::optional<WebCore::IntRect>&&, ForceSoftwareCapturingViewportSnapshot forceSoftwareCapturing)
 {
-    return checkedImpl()->takeViewSnapshot(forceSoftwareCapturing);
+    return protect(m_impl)->takeViewSnapshot(forceSoftwareCapturing);
 }
 
 void PageClientImpl::selectionDidChange()
 {
-    checkedImpl()->selectionDidChange();
+    protect(m_impl)->selectionDidChange();
 }
 
 bool PageClientImpl::showShareSheet(ShareDataWithParsedURL&& shareData, WTF::CompletionHandler<void(bool)>&& completionHandler)
 {
-    checkedImpl()->showShareSheet(WTF::move(shareData), WTF::move(completionHandler), webView().get());
+    protect(m_impl)->showShareSheet(WTF::move(shareData), WTF::move(completionHandler), webView().get());
     return true;
 }
 
 #if ENABLE(WEB_AUTHN)
 void PageClientImpl::showDigitalCredentialsPicker(const WebCore::DigitalCredentialsRequestData& requestData, WTF::CompletionHandler<void(Expected<WebCore::DigitalCredentialsResponseData, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    checkedImpl()->showDigitalCredentialsPicker(requestData, WTF::move(completionHandler), webView().get());
+    protect(m_impl)->showDigitalCredentialsPicker(requestData, WTF::move(completionHandler), webView().get());
 }
 
 void PageClientImpl::dismissDigitalCredentialsPicker(WTF::CompletionHandler<void(bool)>&& completionHandler)
 {
-    checkedImpl()->dismissDigitalCredentialsPicker(WTF::move(completionHandler), webView().get());
+    protect(m_impl)->dismissDigitalCredentialsPicker(WTF::move(completionHandler), webView().get());
 }
 #endif
 
@@ -710,7 +710,7 @@ void PageClientImpl::gestureEventWasNotHandledByWebCore(const NativeWebGestureEv
 
 void PageClientImpl::didPerformDictionaryLookup(const DictionaryPopupInfo& dictionaryPopupInfo)
 {
-    checkedImpl()->prepareForDictionaryLookup();
+    protect(m_impl)->prepareForDictionaryLookup();
 }
 
 void PageClientImpl::showCorrectionPanel(AlternativeTextType type, const FloatRect& boundingBoxOfReplacedString, const String& replacedString, const String& replacementString, const Vector<String>& alternativeReplacementStrings)
@@ -718,7 +718,7 @@ void PageClientImpl::showCorrectionPanel(AlternativeTextType type, const FloatRe
 #if USE(AUTOCORRECTION_PANEL)
     if (!isActiveViewVisible() || !isViewInWindow())
         return;
-    m_correctionPanel.show(m_view.get().get(), *checkedImpl(), type, boundingBoxOfReplacedString, replacedString, replacementString, alternativeReplacementStrings);
+    m_correctionPanel.show(m_view.get().get(), *protect(m_impl), type, boundingBoxOfReplacedString, replacedString, replacementString, alternativeReplacementStrings);
 #endif
 }
 
@@ -768,17 +768,17 @@ void PageClientImpl::recommendedScrollbarStyleDidChange(ScrollbarStyle newStyle)
     else
         options |= NSTrackingActiveInKeyWindow;
 
-    checkedImpl()->updatePrimaryTrackingAreaOptions(options);
+    protect(m_impl)->updatePrimaryTrackingAreaOptions(options);
 }
 
 void PageClientImpl::intrinsicContentSizeDidChange(const IntSize& intrinsicContentSize)
 {
-    checkedImpl()->setIntrinsicContentSize(intrinsicContentSize);
+    protect(m_impl)->setIntrinsicContentSize(intrinsicContentSize);
 }
 
 bool PageClientImpl::executeSavedCommandBySelector(const String& selectorString)
 {
-    return checkedImpl()->executeSavedCommandBySelector(NSSelectorFromString(selectorString.createNSString().get()));
+    return protect(m_impl)->executeSavedCommandBySelector(NSSelectorFromString(selectorString.createNSString().get()));
 }
 
 void PageClientImpl::showDictationAlternativeUI(const WebCore::FloatRect& boundingBoxOfDictatedText, WebCore::DictationContext dictationContext)
@@ -786,28 +786,28 @@ void PageClientImpl::showDictationAlternativeUI(const WebCore::FloatRect& boundi
     if (!isActiveViewVisible() || !isViewInWindow())
         return;
     m_alternativeTextUIController->showAlternatives(m_view.get().get(), boundingBoxOfDictatedText, dictationContext, ^(NSString *acceptedAlternative) {
-        checkedImpl()->handleAcceptedAlternativeText(acceptedAlternative);
+        protect(m_impl)->handleAcceptedAlternativeText(acceptedAlternative);
     });
 }
 
 void PageClientImpl::setEditableElementIsFocused(bool editableElementIsFocused)
 {
-    checkedImpl()->setEditableElementIsFocused(editableElementIsFocused);
+    protect(m_impl)->setEditableElementIsFocused(editableElementIsFocused);
 }
 
 void PageClientImpl::scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID)
 {
-    checkedImpl()->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::TemporarilyRemove);
+    protect(m_impl)->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::TemporarilyRemove);
 }
 
 void PageClientImpl::willBeginViewGesture()
 {
-    checkedImpl()->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::Remove);
+    protect(m_impl)->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::Remove);
 }
 
 void PageClientImpl::didEndViewGesture()
 {
-    checkedImpl()->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::Restore);
+    protect(m_impl)->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::Restore);
 }
 
 #if ENABLE(FULLSCREEN_API)
@@ -823,7 +823,7 @@ WebFullScreenManagerProxyClient& PageClientImpl::fullScreenManagerProxyClient()
 
 void PageClientImpl::closeFullScreenManager()
 {
-    checkedImpl()->closeFullScreenWindowController();
+    protect(m_impl)->closeFullScreenWindowController();
 }
 
 bool PageClientImpl::isFullScreen()
@@ -878,7 +878,7 @@ void PageClientImpl::beganExitFullScreen(const IntRect& initialFrame, const IntR
 
 void PageClientImpl::navigationGestureDidBegin()
 {
-    checkedImpl()->dismissContentRelativeChildWindowsWithAnimation(true);
+    protect(m_impl)->dismissContentRelativeChildWindowsWithAnimation(true);
 
     if (auto webView = this->webView()) {
         if (RefPtr navigationState = NavigationState::fromWebPage(Ref { *webView->_page }))
@@ -976,18 +976,18 @@ CGRect PageClientImpl::boundsOfLayerInLayerBackedWindowCoordinates(CALayer *laye
 
 void PageClientImpl::didPerformImmediateActionHitTest(const WebHitTestResultData& result, bool contentPreventsDefault, API::Object* userData)
 {
-    checkedImpl()->didPerformImmediateActionHitTest(result, contentPreventsDefault, userData);
+    protect(m_impl)->didPerformImmediateActionHitTest(result, contentPreventsDefault, userData);
 }
 
 NSObject *PageClientImpl::immediateActionAnimationControllerForHitTestResult(RefPtr<API::HitTestResult> hitTestResult, uint64_t type, RefPtr<API::Object> userData)
 {
-    return checkedImpl()->immediateActionAnimationControllerForHitTestResult(hitTestResult.get(), type, userData.get());
+    return protect(m_impl)->immediateActionAnimationControllerForHitTestResult(hitTestResult.get(), type, userData.get());
 }
 
 void PageClientImpl::videoControlsManagerDidChange()
 {
     PageClientImplCocoa::videoControlsManagerDidChange();
-    checkedImpl()->videoControlsManagerDidChange();
+    protect(m_impl)->videoControlsManagerDidChange();
 }
 
 void PageClientImpl::showPlatformContextMenu(NSMenu *menu, IntPoint location)
@@ -1016,47 +1016,47 @@ void PageClientImpl::derefView()
 
 void PageClientImpl::startWindowDrag()
 {
-    checkedImpl()->startWindowDrag();
+    protect(m_impl)->startWindowDrag();
 }
 
 #if ENABLE(DRAG_SUPPORT)
 
 void PageClientImpl::didPerformDragOperation(bool handled)
 {
-    checkedImpl()->didPerformDragOperation(handled);
+    protect(m_impl)->didPerformDragOperation(handled);
 }
 
 #endif
 
 RetainPtr<NSView> PageClientImpl::inspectorAttachmentView()
 {
-    return checkedImpl()->inspectorAttachmentView();
+    return protect(m_impl)->inspectorAttachmentView();
 }
 
 _WKRemoteObjectRegistry *PageClientImpl::remoteObjectRegistry()
 {
-    return checkedImpl()->remoteObjectRegistry();
+    return protect(m_impl)->remoteObjectRegistry();
 }
 
 void PageClientImpl::pageDidScroll(const WebCore::IntPoint& scrollPosition)
 {
-    checkedImpl()->pageDidScroll(scrollPosition);
+    protect(m_impl)->pageDidScroll(scrollPosition);
 }
 
 void PageClientImpl::didRestoreScrollPosition()
 {
-    checkedImpl()->didRestoreScrollPosition();
+    protect(m_impl)->didRestoreScrollPosition();
 }
 
 void PageClientImpl::requestScrollToRect(const WebCore::FloatRect& targetRect, const WebCore::FloatPoint& origin)
 {
     // FIXME: Add additional logic to avoid Note Pip.
-    checkedImpl()->scrollToRect(targetRect, origin);
+    protect(m_impl)->scrollToRect(targetRect, origin);
 }
 
 bool PageClientImpl::windowIsFrontWindowUnderMouse(const NativeWebMouseEvent& event)
 {
-    return checkedImpl()->windowIsFrontWindowUnderMouse(RetainPtr { event.nativeEvent() }.get());
+    return protect(m_impl)->windowIsFrontWindowUnderMouse(RetainPtr { event.nativeEvent() }.get());
 }
 
 std::optional<float> PageClientImpl::computeAutomaticTopObscuredInset()
@@ -1082,22 +1082,22 @@ WebCore::UserInterfaceLayoutDirection PageClientImpl::userInterfaceLayoutDirecti
 
 bool PageClientImpl::effectiveAppearanceIsDark() const
 {
-    return checkedImpl()->effectiveAppearanceIsDark();
+    return protect(m_impl)->effectiveAppearanceIsDark();
 }
 
 bool PageClientImpl::effectiveUserInterfaceLevelIsElevated() const
 {
-    return checkedImpl()->effectiveUserInterfaceLevelIsElevated();
+    return protect(m_impl)->effectiveUserInterfaceLevelIsElevated();
 }
 
 bool PageClientImpl::useFormSemanticContext() const
 {
-    return checkedImpl()->useFormSemanticContext();
+    return protect(m_impl)->useFormSemanticContext();
 }
 
 void PageClientImpl::takeFocus(WebCore::FocusDirection direction)
 {
-    checkedImpl()->takeFocus(direction);
+    protect(m_impl)->takeFocus(direction);
 }
 
 void PageClientImpl::performSwitchHapticFeedback()
@@ -1107,7 +1107,7 @@ void PageClientImpl::performSwitchHapticFeedback()
 
 void PageClientImpl::requestDOMPasteAccess(WebCore::DOMPasteAccessCategory pasteAccessCategory, WebCore::DOMPasteRequiresInteraction requiresInteraction, const WebCore::IntRect& elementRect, const String& originIdentifier, CompletionHandler<void(WebCore::DOMPasteAccessResponse)>&& completion)
 {
-    checkedImpl()->requestDOMPasteAccess(pasteAccessCategory, requiresInteraction, elementRect, originIdentifier, WTF::move(completion));
+    protect(m_impl)->requestDOMPasteAccess(pasteAccessCategory, requiresInteraction, elementRect, originIdentifier, WTF::move(completion));
 }
 
 void PageClientImpl::makeViewBlank(bool makeBlank)
@@ -1144,12 +1144,12 @@ bool PageClientImpl::appUsesCustomAccentColor()
 
 bool PageClientImpl::canHandleContextMenuTranslation() const
 {
-    return checkedImpl()->canHandleContextMenuTranslation();
+    return protect(m_impl)->canHandleContextMenuTranslation();
 }
 
 void PageClientImpl::handleContextMenuTranslation(const TranslationContextMenuInfo& info)
 {
-    checkedImpl()->handleContextMenuTranslation(info);
+    protect(m_impl)->handleContextMenuTranslation(info);
 }
 
 #endif // HAVE(TRANSLATION_UI_SERVICES) && ENABLE(CONTEXT_MENUS)
@@ -1158,7 +1158,7 @@ void PageClientImpl::handleContextMenuTranslation(const TranslationContextMenuIn
 
 bool PageClientImpl::canHandleContextMenuWritingTools() const
 {
-    return checkedImpl()->canHandleContextMenuWritingTools();
+    return protect(m_impl)->canHandleContextMenuWritingTools();
 }
 
 void PageClientImpl::handleContextMenuWritingTools(WebCore::WritingTools::RequestedTool tool, WebCore::IntRect selectionRect)
@@ -1175,19 +1175,19 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 void PageClientImpl::handleClickForDataDetectionResult(const DataDetectorElementInfo& info, const IntPoint& clickLocation)
 {
-    checkedImpl()->handleClickForDataDetectionResult(info, clickLocation);
+    protect(m_impl)->handleClickForDataDetectionResult(info, clickLocation);
 }
 
 #endif
 
 void PageClientImpl::beginTextRecognitionForVideoInElementFullscreen(ShareableBitmap::Handle&& bitmapHandle, FloatRect bounds)
 {
-    checkedImpl()->beginTextRecognitionForVideoInElementFullscreen(WTF::move(bitmapHandle), bounds);
+    protect(m_impl)->beginTextRecognitionForVideoInElementFullscreen(WTF::move(bitmapHandle), bounds);
 }
 
 void PageClientImpl::cancelTextRecognitionForVideoInElementFullscreen()
 {
-    checkedImpl()->cancelTextRecognitionForVideoInElementFullscreen();
+    protect(m_impl)->cancelTextRecognitionForVideoInElementFullscreen();
 }
 
 void PageClientImpl::didChangeLocalInspectorAttachment()
@@ -1199,7 +1199,7 @@ void PageClientImpl::didChangeLocalInspectorAttachment()
 
 void PageClientImpl::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier identifier, const WebCore::ResolvedCaptionDisplaySettingsOptions& options, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&& completionHandler)
 {
-    checkedImpl()->showCaptionDisplaySettings(identifier, options, WTF::move(completionHandler));
+    protect(m_impl)->showCaptionDisplaySettings(identifier, options, WTF::move(completionHandler));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -1048,7 +1048,7 @@ void MediaPlayerPrivateRemote::load(const URL& url, const LoadOptions& options, 
             // MediaSource can only be re-opened after RemoteMediaPlayerProxy::LoadMediaSource has been called.
             client.reOpen();
         } else
-            m_mediaSourcePrivate = MediaSourcePrivateRemote::create(protect(manager()->gpuProcessConnection()), identifier, manager()->checkedTypeCache(m_remoteEngineIdentifier), *this, client);
+            m_mediaSourcePrivate = MediaSourcePrivateRemote::create(protect(manager()->gpuProcessConnection()), identifier, protect(manager()->typeCache(m_remoteEngineIdentifier)), *this, client);
         return;
     }
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp
@@ -134,11 +134,6 @@ RemoteMediaPlayerMIMETypeCache& RemoteMediaPlayerManager::typeCache(MediaPlayerE
     return *cachePtr;
 }
 
-CheckedRef<RemoteMediaPlayerMIMETypeCache> RemoteMediaPlayerManager::checkedTypeCache(MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier)
-{
-    return typeCache(remoteEngineIdentifier);
-}
-
 void RemoteMediaPlayerManager::initialize(const WebProcessCreationParameters& parameters)
 {
 #if PLATFORM(COCOA)
@@ -226,7 +221,7 @@ std::optional<MediaPlayerIdentifier> RemoteMediaPlayerManager::findRemotePlayerI
 
 void RemoteMediaPlayerManager::getSupportedTypes(MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier, HashSet<String>& result)
 {
-    result = checkedTypeCache(remoteEngineIdentifier)->supportedTypes();
+    result = protect(typeCache(remoteEngineIdentifier))->supportedTypes();
 }
 
 MediaPlayer::SupportsType RemoteMediaPlayerManager::supportsTypeAndCodecs(MediaPlayerEnums::MediaEngineIdentifier remoteEngineIdentifier, const MediaEngineSupportParameters& parameters)
@@ -239,7 +234,7 @@ MediaPlayer::SupportsType RemoteMediaPlayerManager::supportsTypeAndCodecs(MediaP
     if (!contentTypeMeetsContainerAndCodecTypeRequirements(parameters.type, parameters.allowedMediaContainerTypes, parameters.allowedMediaCodecTypes))
         return MediaPlayer::SupportsType::IsNotSupported;
 
-    return checkedTypeCache(remoteEngineIdentifier)->supportsTypeAndCodecs(parameters);
+    return protect(typeCache(remoteEngineIdentifier))->supportsTypeAndCodecs(parameters);
 }
 
 bool RemoteMediaPlayerManager::supportsKeySystem(MediaPlayerEnums::MediaEngineIdentifier, const String& keySystem, const String& mimeType)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h
@@ -65,7 +65,6 @@ public:
     std::optional<WebCore::MediaPlayerIdentifier> findRemotePlayerId(const WebCore::MediaPlayerPrivateInterface*);
 
     RemoteMediaPlayerMIMETypeCache& typeCache(WebCore::MediaPlayerEnums::MediaEngineIdentifier);
-    CheckedRef<RemoteMediaPlayerMIMETypeCache> checkedTypeCache(WebCore::MediaPlayerEnums::MediaEngineIdentifier);
 
     WTF_ABSTRACT_THREAD_SAFE_REF_COUNTED_AND_CAN_MAKE_WEAK_PTR_IMPL;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -71,7 +71,6 @@ private:
     bool handleKeyboardEvent(const WebKeyboardEvent&) override;
 #if PLATFORM(MAC)
     bool handleKeyboardCommand(const WebKeyboardEvent&);
-    CheckedPtr<WebCore::KeyboardScrollingAnimator> checkedKeyboardScrollingAnimator() const;
 #endif
 
     std::optional<PDFDocumentLayout::PageIndex> pageIndexForCurrentView(AnchorPoint) const override;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -80,11 +80,6 @@ bool PDFScrollingPresentationController::handleKeyboardEvent(const WebKeyboardEv
 }
 
 #if PLATFORM(MAC)
-CheckedPtr<WebCore::KeyboardScrollingAnimator> PDFScrollingPresentationController::checkedKeyboardScrollingAnimator() const
-{
-    return m_plugin->scrollAnimator().keyboardScrollingAnimator();
-}
-
 bool PDFScrollingPresentationController::handleKeyboardCommand(const WebKeyboardEvent& event)
 {
     auto& commands = event.commands();
@@ -93,10 +88,10 @@ bool PDFScrollingPresentationController::handleKeyboardCommand(const WebKeyboard
 
     auto commandName = commands[0].commandName;
     if (commandName == "scrollToBeginningOfDocument:"_s)
-        return checkedKeyboardScrollingAnimator()->beginKeyboardScrollGesture(ScrollDirection::ScrollUp, ScrollGranularity::Document, false);
+        return protect(m_plugin->scrollAnimator().keyboardScrollingAnimator())->beginKeyboardScrollGesture(ScrollDirection::ScrollUp, ScrollGranularity::Document, false);
 
     if (commandName == "scrollToEndOfDocument:"_s)
-        return checkedKeyboardScrollingAnimator()->beginKeyboardScrollGesture(ScrollDirection::ScrollDown, ScrollGranularity::Document, false);
+        return protect(m_plugin->scrollAnimator().keyboardScrollingAnimator())->beginKeyboardScrollGesture(ScrollDirection::ScrollDown, ScrollGranularity::Document, false);
 
     return false;
 }


### PR DESCRIPTION
#### 121c09c9c8f30b7a66c03356dd9dfad92c82740d
<pre>
Drop remaining `checked*()` member functions in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307513">https://bugs.webkit.org/show_bug.cgi?id=307513</a>

Reviewed by Anne van Kesteren.

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::dataTaskWithRequest):
(WebKit::NetworkProcess::checkedStorageSession const): Deleted.
(WebKit::NetworkProcess::checkedNetworkSession const): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::retrieveCacheEntry):
(WebKit::NetworkResourceLoader::didFinishWithRedirectResponse):
(WebKit::NetworkResourceLoader::tryStoreAsCacheEntry):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::prefetchCache):
(WebKit::NetworkSession::checkedPrefetchCache): Deleted.
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::makeUseDecision):
(WebKit::NetworkCache::Cache::retrieve):
(WebKit::NetworkCache::Cache::makeEntry):
(WebKit::NetworkCache::Cache::makeRedirectEntry):
(WebKit::NetworkCache::Cache::update):
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkTaskCocoa.mm:
(WebKit::NetworkTaskCocoa::shouldApplyCookiePolicyForThirdPartyCloaking const):
(WebKit::NetworkTaskCocoa::unblockCookies):
(WebKit::NetworkTaskCocoa::requestThirdPartyCookieBlockingDecision const):
(WebKit::NetworkTaskCocoa::willPerformHTTPRedirection):
(WebKit::NetworkTaskCocoa::shouldRelaxThirdPartyCookieBlocking const):
(WebKit::NetworkTaskCocoa::checkedNetworkSession const): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::donePrepareForEviction):
(WebKit::NetworkStorageManager::performEviction):
(WebKit::NetworkStorageManager::estimate):
(WebKit::NetworkStorageManager::restoreSessionStorageForWebPage):
(WebKit::NetworkStorageManager::fileSystemGetDirectory):
(WebKit::NetworkStorageManager::fetchDataFromDisk):
(WebKit::NetworkStorageManager::moveData):
(WebKit::NetworkStorageManager::getOriginDirectory):
(WebKit::NetworkStorageManager::fetchLocalStorage):
(WebKit::NetworkStorageManager::restoreLocalStorage):
(WebKit::NetworkStorageManager::requestSpace):
(WebKit::NetworkStorageManager::openDatabase):
(WebKit::NetworkStorageManager::openDBRequestCancelled):
(WebKit::NetworkStorageManager::deleteDatabase):
(WebKit::NetworkStorageManager::databaseConnectionClosed):
(WebKit::NetworkStorageManager::getAllDatabaseNamesAndVersions):
(WebKit::NetworkStorageManager::cacheStorageOpenCache):
(WebKit::NetworkStorageManager::cacheStorageAllCaches):
(WebKit::NetworkStorageManager::lockCacheStorage):
(WebKit::NetworkStorageManager::unlockCacheStorage):
(WebKit::NetworkStorageManager::dispatchTaskToBackgroundFetchManager):
(WebKit::NetworkStorageManager::clearServiceWorkerRegistrations):
(WebKit::NetworkStorageManager::importServiceWorkerRegistrations):
(WebKit::NetworkStorageManager::updateServiceWorkerRegistrationsByOrigin):
(WebKit::NetworkStorageManager::queryCacheStorage):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::checkedIDBStorageManager): Deleted.
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.cpp:
(WebKit::SQLiteStorageArea::prepareDatabase):
(WebKit::SQLiteStorageArea::startTransactionIfNecessary):
(WebKit::SQLiteStorageArea::cachedStatement):
(WebKit::SQLiteStorageArea::clear):
(WebKit::SQLiteStorageArea::checkedDatabase const): Deleted.
* Source/WebKit/NetworkProcess/storage/SQLiteStorageArea.h:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformCanMakePaymentsWithActiveCard):
(WebKit::WebPaymentCoordinatorProxy::platformBeginApplePaySetup):
* Source/WebKit/Shared/ApplePay/ios/WebPaymentCoordinatorProxyIOS.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformShowPaymentUI):
* Source/WebKit/UIProcess/Inspector/RemoteWebInspectorUIProxy.h:
(WebKit::RemoteWebInspectorUIProxy::checkedClient const): Deleted.
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::sendMessageToInspectorFrontend):
(WebKit::WebPageInspectorController::addTarget):
(WebKit::WebPageInspectorController::removeTarget):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
(WebKit::WebPageInspectorController::checkedTargetAgent): Deleted.
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::invalidate):
(WebKit::RemoteLayerTreeEventDispatcher::startDisplayLinkObserver):
(WebKit::RemoteLayerTreeEventDispatcher::stopDisplayLinkObserver):
(WebKit::RemoteLayerTreeEventDispatcher::removeDisplayLinkClient):
(WebKit::RemoteLayerTreeEventDispatcher::checkedDisplayLinkClient): Deleted.
* Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
(WebKit::SpeechRecognitionServer::handleRequest):
(WebKit::SpeechRecognitionServer::checkedRecognizer const): Deleted.
* Source/WebKit/UIProcess/SpeechRecognitionServer.h:
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.cpp:
(WebKit::EnhancedSecuritySitesPersistence::deleteAllSites):
(WebKit::EnhancedSecuritySitesPersistence::enhancedSecurityOnlyDomains):
(WebKit::EnhancedSecuritySitesPersistence::allEnhancedSecuritySites):
(WebKit::EnhancedSecuritySitesPersistence::closeDatabase):
(WebKit::EnhancedSecuritySitesPersistence::checkedDatabase const): Deleted.
* Source/WebKit/UIProcess/WebsiteData/EnhancedSecuritySitesPersistence.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::createDrawingAreaProxy):
(WebKit::PageClientImpl::colorSpace):
(WebKit::PageClientImpl::processWillSwap):
(WebKit::PageClientImpl::pageClosed):
(WebKit::PageClientImpl::didRelaunchProcess):
(WebKit::PageClientImpl::preferencesDidChange):
(WebKit::PageClientImpl::toolTipChanged):
(WebKit::PageClientImpl::didChangeContentSize):
(WebKit::PageClientImpl::setCursor):
(WebKit::PageClientImpl::registerEditCommand):
(WebKit::PageClientImpl::createPDFHUD):
(WebKit::PageClientImpl::updatePDFHUDLocation):
(WebKit::PageClientImpl::removePDFHUD):
(WebKit::PageClientImpl::removeAllPDFHUDs):
(WebKit::PageClientImpl::clearAllEditCommands):
(WebKit::PageClientImpl::startDrag):
(WebKit::PageClientImpl::setPromisedDataForImage):
(WebKit::PageClientImpl::updateSecureInputState):
(WebKit::PageClientImpl::resetSecureInputState):
(WebKit::PageClientImpl::notifyInputContextAboutDiscardedComposition):
(WebKit::PageClientImpl::doneWithKeyEvent):
(WebKit::PageClientImpl::requestTextRecognition):
(WebKit::PageClientImpl::computeHasVisualSearchResults):
(WebKit::PageClientImpl::clearBrowsingWarning):
(WebKit::PageClientImpl::clearBrowsingWarningIfForMainFrameNavigation):
(WebKit::PageClientImpl::textIndicatorInstallationLayer):
(WebKit::PageClientImpl::accessibilityWebProcessTokenReceived):
(WebKit::PageClientImpl::enterAcceleratedCompositingMode):
(WebKit::PageClientImpl::didFirstLayerFlush):
(WebKit::PageClientImpl::exitAcceleratedCompositingMode):
(WebKit::PageClientImpl::updateAcceleratedCompositingMode):
(WebKit::PageClientImpl::setRemoteLayerTreeRootNode):
(WebKit::PageClientImpl::takeViewSnapshot):
(WebKit::PageClientImpl::selectionDidChange):
(WebKit::PageClientImpl::showShareSheet):
(WebKit::PageClientImpl::showDigitalCredentialsPicker):
(WebKit::PageClientImpl::dismissDigitalCredentialsPicker):
(WebKit::PageClientImpl::didPerformDictionaryLookup):
(WebKit::PageClientImpl::showCorrectionPanel):
(WebKit::PageClientImpl::recommendedScrollbarStyleDidChange):
(WebKit::PageClientImpl::intrinsicContentSizeDidChange):
(WebKit::PageClientImpl::executeSavedCommandBySelector):
(WebKit::PageClientImpl::showDictationAlternativeUI):
(WebKit::PageClientImpl::setEditableElementIsFocused):
(WebKit::PageClientImpl::scrollingNodeScrollViewDidScroll):
(WebKit::PageClientImpl::willBeginViewGesture):
(WebKit::PageClientImpl::didEndViewGesture):
(WebKit::PageClientImpl::closeFullScreenManager):
(WebKit::PageClientImpl::navigationGestureDidBegin):
(WebKit::PageClientImpl::didPerformImmediateActionHitTest):
(WebKit::PageClientImpl::immediateActionAnimationControllerForHitTestResult):
(WebKit::PageClientImpl::videoControlsManagerDidChange):
(WebKit::PageClientImpl::startWindowDrag):
(WebKit::PageClientImpl::didPerformDragOperation):
(WebKit::PageClientImpl::inspectorAttachmentView):
(WebKit::PageClientImpl::remoteObjectRegistry):
(WebKit::PageClientImpl::pageDidScroll):
(WebKit::PageClientImpl::didRestoreScrollPosition):
(WebKit::PageClientImpl::requestScrollToRect):
(WebKit::PageClientImpl::windowIsFrontWindowUnderMouse):
(WebKit::PageClientImpl::effectiveAppearanceIsDark const):
(WebKit::PageClientImpl::effectiveUserInterfaceLevelIsElevated const):
(WebKit::PageClientImpl::useFormSemanticContext const):
(WebKit::PageClientImpl::takeFocus):
(WebKit::PageClientImpl::requestDOMPasteAccess):
(WebKit::PageClientImpl::canHandleContextMenuTranslation const):
(WebKit::PageClientImpl::handleContextMenuTranslation):
(WebKit::PageClientImpl::canHandleContextMenuWritingTools const):
(WebKit::PageClientImpl::handleClickForDataDetectionResult):
(WebKit::PageClientImpl::beginTextRecognitionForVideoInElementFullscreen):
(WebKit::PageClientImpl::cancelTextRecognitionForVideoInElementFullscreen):
(WebKit::PageClientImpl::showCaptionDisplaySettings):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::load):
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.cpp:
(WebKit::RemoteMediaPlayerManager::getSupportedTypes):
(WebKit::RemoteMediaPlayerManager::supportsTypeAndCodecs):
(WebKit::RemoteMediaPlayerManager::checkedTypeCache): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteMediaPlayerManager.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::handleKeyboardCommand):
(WebKit::PDFScrollingPresentationController::checkedKeyboardScrollingAnimator const): Deleted.

Canonical link: <a href="https://commits.webkit.org/307247@main">https://commits.webkit.org/307247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e0c6d789cbf068bae36e7c1b92b45b6d813ba19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143874 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152542 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79185239-da8a-4258-be4b-fe76ffc17d3d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17032 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16443 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110634 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97113 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ef1cf50-c30d-46d0-8cfa-936ded9ae2f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129268 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91552 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12526 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10258 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121988 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154854 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6942 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118643 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16438 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118997 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30490 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14915 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71816 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16024 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5583 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15758 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/15970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15823 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->