### PR TITLE
Clean-up <select> UA styles

### DIFF
--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1055,47 +1055,46 @@ input[type="color"]::-webkit-color-swatch {
 select {
     box-sizing: border-box;
     appearance: auto;
+    border: 1px solid;
+    -webkit-rtl-ordering: logical;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
-    letter-spacing: normal;
-    word-spacing: normal;
-    line-height: normal;
     padding-block: 0;
     padding-inline: 0.4em;
     color: -apple-system-blue;
     font: 11px system-ui;
-    border: 1px solid -webkit-control-background;
-    border-radius: initial;
+    border-color: -webkit-control-background;
 #if defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION
     background-color: rgba(0, 0, 0, 0.04);
 #else
     background-color: -apple-system-opaque-secondary-fill;
 #endif /* defined(WTF_PLATFORM_VISION) && WTF_PLATFORM_VISION */
 #else
-    border-radius: 5px;
-    border: 1px solid;
     color: CanvasText;
     background-color: Canvas;
 #endif
+}
+
+/* FIXME: Replace with select:-internal-uses-menulist */
+#if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
+select:not([size], [multiple]),
+select:is([size=""], [size="0"], [size="1"]):not([multiple]) {
+#else
+select {
+#endif
+#if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
+    border-radius: 5px;
+#endif
     align-items: center;
     white-space: pre;
-    -webkit-rtl-ordering: logical;
     cursor: default;
 }
 
+/* FIXME: Replace with select:not(:-internal-uses-menulist) */
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
-select:is([size], [multiple]), select[size][multiple] {
-    align-items: normal;
-    cursor: auto;
-    border: 1px inset gray;
-    border-radius: initial;
-    white-space: initial;
-}
-
-select:is([size=""], [size="0"], [size="1"]) {
-    align-items: center;
-    border: 1px solid;
-    border-radius: 5px;
-    white-space: pre;
+select[size][multiple],
+select:is([size], [multiple]):not([size=""], [size="0"], [size="1"]) {
+    border-style: inset;
+    border-color: gray;
 }
 #endif
 


### PR DESCRIPTION
#### 01bebeb407f96c47e911edb2013435fead32a2fa
<pre>
Clean-up &lt;select&gt; UA styles
<a href="https://bugs.webkit.org/show_bug.cgi?id=307511">https://bugs.webkit.org/show_bug.cgi?id=307511</a>
<a href="https://rdar.apple.com/170112281">rdar://170112281</a>

Reviewed by Aditya Keerthi.

The following clean-ups were made:

- Remove declarations redundant with the `input, textarea, select, button` rule at the beginning of the file:
    letter-spacing: normal;
    word-spacing: normal;
    line-height: normal;

- Clarify which rules are for menulists vs listboxes

- Avoid the pattern where we set a property to reset it to initial under a different selector by making good use of the selectors.

No expected behavior changes.

* Source/WebCore/css/html.css:
(select):
(#if !(defined(WTF_PLATFORM_IOS_FAMILY) &amp;&amp; WTF_PLATFORM_IOS_FAMILY)):
(select:is([size=&quot;&quot;], [size=&quot;0&quot;], [size=&quot;1&quot;])): Deleted.

Canonical link: <a href="https://commits.webkit.org/307311@main">https://commits.webkit.org/307311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/576ae38fd3274b44a61ff9ca4a779d7f2b192911

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143870 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152538 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97109 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa87022e-7c0a-4c52-8e51-5dd6460563bc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145745 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17028 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16439 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110631 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79566 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13d52e80-dc8c-4362-ab5a-4e2621172eb8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13064 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129261 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91549 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b5696e8-e7ce-45be-8527-88e9065e83a1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12528 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10255 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121990 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5888 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154850 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16399 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118640 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13786 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118994 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30526 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14907 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71812 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16020 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15754 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79815 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15966 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15819 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->