### PR TITLE
[Site Isolation] Implement UIProcess-driven back/forward navigation for child frames.

### DIFF
--- a/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
@@ -13,6 +13,7 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
         'navigate-to-page2': () => navigateIframeTo("back-iframe-2.html"),
+        'navigate-to-page2-cross-site-iframe': () => navigateIframeTo(crossSiteUrl("back-iframe-2.html")),
         'navigate-to-other': () => navigateTo("back-iframe-other.html"),
         back2: () => history.back(),
     },

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
@@ -4,7 +4,7 @@
 <script src="navigation-utils.js"></script>
 <script>
 
-const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+const page = location.hostname === loopbackAddress ? "samesite" : "crosssite";
 
 window.onload = () => sendMessageToTop("load");
 window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
@@ -13,8 +13,5 @@ window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persist
 </head>
 <body>
 <h1>Iframe Page</h1>
-<script>
-document.getElementById("host").textContent = location.hostname + ":" + location.port;
-</script>
 </body>
 </html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
@@ -12,7 +12,7 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
-        'navigate-to-cross-site': () => navigateIframeTo(`http://${crossSiteHostname}:8000/navigation/resources/cross-site-iframe-nav-page.html`),
+        'navigate-to-cross-site': () => navigateIframeTo(crossSiteUrl('cross-site-iframe-nav-page.html')),
         'navigate-to-other': () => navigateTo("cross-site-iframe-nav-other.html"),
         back2: () => history.back(),
     },

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
@@ -4,7 +4,7 @@
 <script src="navigation-utils.js"></script>
 <script>
 
-const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+const page = location.hostname === loopbackAddress ? "samesite" : "crosssite";
 
 window.onload = () => sendMessageToTop("load");
 window.onpageshow = () => sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
@@ -13,9 +13,5 @@ window.onpageshow = () => sendMessageToTop("pageshow", event.persisted ? "persis
 </head>
 <body>
 <h1>Iframe Page</h1>
-<p id="host"></p>
-<script>
-document.getElementById("host").textContent = location.hostname + ":" + location.port;
-</script>
 </body>
 </html>

--- a/LayoutTests/http/tests/navigation/resources/navigation-utils.js
+++ b/LayoutTests/http/tests/navigation/resources/navigation-utils.js
@@ -1,5 +1,10 @@
-const sameSiteHostname = "127.0.0.1";
-const crossSiteHostname = "localhost";
+const hostname = location.hostname;
+
+const localhost = "localhost";
+const loopbackAddress = "127.0.0.1";
+
+const sameSiteHostname = hostname;
+const crossSiteHostname = hostname === localhost ? loopbackAddress : localhost;
 
 /* `page` must be defined in embedding HTML files */
 function makeMessage(action, arg = "") {
@@ -90,4 +95,10 @@ function navigateTo(url) {
 
 function navigateIframeTo(url) {
     iframeContentWindow().location.href = url;
+}
+
+function crossSiteUrl(path) {
+    const url = new URL(path, location.href);
+    url.hostname = crossSiteHostname;
+    return url.href;
 }

--- a/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache-expected.txt
@@ -1,0 +1,21 @@
+Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Page1 loaded
+Page1 displayed first time.
+Page2 loaded
+Page2 displayed first time.
+Other page loaded
+Other page displayed.
+Page2 loaded
+PASS Page2 displayed twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with back-iframe-popup.html. It has an same-site iframe with page1 loaded initially.
+Navigate iframe to cross-site page2.
+Navigate main frame to other (same-site).
+Go back. (back-iframe-popup.html with iframe showing cross-site page2)
+... and ensures the nested iframe content is correctly restored to page2.

--- a/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html
+++ b/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html
@@ -1,0 +1,93 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false UseUIProcessForBackForwardItemLoading=true dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/navigation/resources/navigation-utils.js"></script>
+<script>
+
+description("Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.");
+jsTestIsAsync = true;
+
+const page = "opener";
+var popup = null;
+
+window.onload = function() {
+    popup = window.open("/navigation/resources/back-iframe-popup.html");
+}
+
+var page1ShowCount = 0;
+var page2ShowCount = 0;
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    popup: {
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Popup should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+        },
+    },
+    page1: {
+        load: () => debug("Page1 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page1 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page1ShowCount++;
+            if (page1ShowCount == 1) {
+                debug("Page1 displayed first time.");
+                sendMessageToPopup("navigate-to-page2-cross-site-iframe");
+            } else {
+                testFailed("Page1 should be displayed only once.");
+                finishJSTest();
+            }
+        }
+    },
+    page2: {
+        load: () => debug("Page2 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page2 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page2ShowCount++;
+            if (page2ShowCount == 1) {
+                debug("Page2 displayed first time.");
+                sendMessageToPopup("navigate-to-other");
+            } else if (page2ShowCount == 2) {
+                testPassed("Page2 displayed twice.");
+                finishJSTest();
+            } else {
+                testFailed("Page2 should be displayed only twice.");
+                finishJSTest();
+            }
+        }
+    },
+    other: {
+        load: () => debug("Other page loaded"),
+        pageshow: ({arg}) => {
+            debug("Other page displayed.");
+            sendMessageToPopup("back1");
+        }
+    },
+});
+
+</script>
+</head>
+<body>
+<ul>
+    <li>Open a new window with back-iframe-popup.html. It has an same-site iframe with page1 loaded initially.</li>
+    <li>Navigate iframe to cross-site page2.</li>
+    <li>Navigate main frame to other (same-site).</li>
+    <li>Go back. (back-iframe-popup.html with iframe showing cross-site page2)</li>
+</ul>
+<p>... and ensures the nested iframe content is correctly restored to page2.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/navigation/back-iframe-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/navigation/back-iframe-no-bf-cache-expected.txt
@@ -1,0 +1,21 @@
+Nested iframe history navigation works correctly with same-site iframe when back/forward cache is disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Page1 loaded
+Page1 displayed first time.
+Page2 loaded
+Page2 displayed first time.
+Other page loaded
+Other page displayed.
+Page2 loaded
+PASS Page2 displayed twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with back-iframe-popup.html. It has an iframe with page1 loaded initially.
+Navigate iframe to page2.
+Navigate main frame to other.
+Go back. (back-iframe-popup.html with iframe showing page2)
+... and ensures the nested iframe content is correctly restored to page2.

--- a/LayoutTests/http/tests/site-isolation/navigation/back-iframe-no-bf-cache.html
+++ b/LayoutTests/http/tests/site-isolation/navigation/back-iframe-no-bf-cache.html
@@ -1,0 +1,93 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false UseUIProcessForBackForwardItemLoading=true dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/navigation/resources/navigation-utils.js"></script>
+<script>
+
+description("Nested iframe history navigation works correctly with same-site iframe when back/forward cache is disabled.");
+jsTestIsAsync = true;
+
+const page = "opener";
+var popup = null;
+
+window.onload = function() {
+    popup = window.open("/navigation/resources/back-iframe-popup.html");
+}
+
+var page1ShowCount = 0;
+var page2ShowCount = 0;
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    popup: {
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Popup should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+        },
+    },
+    page1: {
+        load: () => debug("Page1 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page1 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page1ShowCount++;
+            if (page1ShowCount == 1) {
+                debug("Page1 displayed first time.");
+                sendMessageToPopup("navigate-to-page2");
+            } else if (page1ShowCount == 2) {
+                testFailed("Page1 should be displayed only once.");
+                finishJSTest();
+            }
+        }
+    },
+    page2: {
+        load: () => debug("Page2 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page2 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page2ShowCount++;
+            if (page2ShowCount == 1) {
+                debug("Page2 displayed first time.");
+                sendMessageToPopup("navigate-to-other");
+            } else if (page2ShowCount == 2) {
+                testPassed("Page2 displayed twice.");
+                finishJSTest();
+            } else {
+                testFailed("Page2 should be displayed only twice.");
+                finishJSTest();
+            }
+        }
+    },
+    other: {
+        load: () => debug("Other page loaded"),
+        pageshow: ({arg}) => {
+            debug("Other page displayed.");
+            sendMessageToPopup("back1");
+        }
+    },
+});
+
+</script>
+</head>
+<body>
+<ul>
+    <li>Open a new window with back-iframe-popup.html. It has an iframe with page1 loaded initially.</li>
+    <li>Navigate iframe to page2.</li>
+    <li>Navigate main frame to other.</li>
+    <li>Go back. (back-iframe-popup.html with iframe showing page2)</li>
+</ul>
+<p>... and ensures the nested iframe content is correctly restored to page2.</p>
+</body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -8795,6 +8795,20 @@ UseSystemAppearance:
     WebCore:
       default: false
 
+UseUIProcessForBackForwardItemLoading:
+  type: bool
+  status: unstable
+  exposed: [ WebKit ]
+  humanReadableName: "Use UIProcess for Back/Forward Item Loading"
+  humanReadableDescription: "Enable UIProcess-side BackForwardListFrameItem lookup for child frames during Back/Forward navigation"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 UserActivationAPIEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/history/BackForwardFrameItemIdentifier.h
+++ b/Source/WebCore/history/BackForwardFrameItemIdentifier.h
@@ -32,4 +32,9 @@ namespace WebCore {
 struct BackForwardFrameItemIdentifierType;
 using BackForwardFrameItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardFrameItemIdentifierType>>;
 
+struct BackForwardChildFrameItemIndex {
+    BackForwardFrameItemIdentifier parentFrameItemID;
+    unsigned childIndex { 0 };
+};
+
 } // namespace WebCore

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/AdvancedPrivacyProtections.h>
+#include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/Element.h>
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/ReferrerPolicy.h>
@@ -79,6 +80,12 @@ public:
     bool isFromNavigationAPI() const { return m_isFromNavigationAPI; }
     void setIsFromNavigationAPI(bool isFromNavigationAPI) { m_isFromNavigationAPI = isFromNavigationAPI; }
 
+    // For Back/Forward child frame navigation: identifies which child frame item
+    // to load from the parent frame's BackForwardList entry.
+    // Contains the parent frame's item ID and the child's index in the children array.
+    const std::optional<BackForwardChildFrameItemIndex>& backForwardChildFrameIndex() const { return m_backForwardChildFrameIndex; }
+    void setBackForwardChildFrameIndex(std::optional<BackForwardChildFrameItemIndex> index) { m_backForwardChildFrameIndex = index; }
+
 protected:
     FrameLoadRequestBase() = default;
     FrameLoadRequestBase(const FrameLoadRequestBase&) = default;
@@ -103,6 +110,7 @@ private:
     bool m_isInitialFrameSrcLoad { false };
     bool m_isContentRuleListRedirect { false };
     bool m_isFromNavigationAPI { false };
+    std::optional<BackForwardChildFrameItemIndex> m_backForwardChildFrameIndex;
 };
 
 class FrameLoadRequest : public FrameLoadRequestBase {

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -497,14 +497,24 @@ void FrameLoader::checkContentPolicy(const ResourceResponse& response, ContentPo
     protect(client())->dispatchDecidePolicyForResponse(response, activeDocumentLoader()->request(), activeDocumentLoader()->downloadAttribute(), WTF::move(function));
 }
 
-void FrameLoader::changeLocation(const URL& url, const AtomString& passedTarget, Event* triggeringEvent, const ReferrerPolicy& referrerPolicy, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, std::optional<NewFrameOpenerPolicy> openerPolicy, const AtomString& downloadAttribute, std::optional<PrivateClickMeasurement>&& privateClickMeasurement, NavigationHistoryBehavior historyBehavior, Element* sourceElement)
+FrameLoadRequest FrameLoader::createFrameLoadRequest(URL&& url)
+{
+    return createFrameLoadRequest(WTF::move(url), selfTargetFrameName());
+}
+
+FrameLoadRequest FrameLoader::createFrameLoadRequest(URL&& url, const AtomString& frameName, const AtomString& downloadAttribute)
 {
     RefPtr frame = lexicalFrameFromCommonVM();
     auto initiatedByMainFrame = frame && frame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
 
     Ref document = *m_frame->document();
+    return FrameLoadRequest(document.copyRef(), document->securityOrigin(), { WTF::move(url) }, frameName, initiatedByMainFrame, downloadAttribute);
+}
+
+void FrameLoader::changeLocation(const URL& url, const AtomString& passedTarget, Event* triggeringEvent, const ReferrerPolicy& referrerPolicy, ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy, std::optional<NewFrameOpenerPolicy> openerPolicy, const AtomString& downloadAttribute, std::optional<PrivateClickMeasurement>&& privateClickMeasurement, NavigationHistoryBehavior historyBehavior, Element* sourceElement)
+{
     NewFrameOpenerPolicy newFrameOpenerPolicy = openerPolicy.value_or(referrerPolicy == ReferrerPolicy::NoReferrer ? NewFrameOpenerPolicy::Suppress : NewFrameOpenerPolicy::Allow);
-    FrameLoadRequest frameLoadRequest(document.copyRef(), document->securityOrigin(), { URL { url } }, passedTarget, initiatedByMainFrame, downloadAttribute);
+    auto frameLoadRequest = createFrameLoadRequest(URL { url }, passedTarget, downloadAttribute);
     frameLoadRequest.setNewFrameOpenerPolicy(newFrameOpenerPolicy);
     frameLoadRequest.setReferrerPolicy(referrerPolicy);
     frameLoadRequest.setShouldOpenExternalURLsPolicy(shouldOpenExternalURLsPolicy);
@@ -1074,6 +1084,13 @@ void FrameLoader::loadURLIntoChildFrame(const URL& url, const String& referer, L
     }
 #endif
 
+    URL childURL { url };
+
+    if (m_frame->page() && m_frame->page()->settings().useUIProcessForBackForwardItemLoading()) {
+        m_client->dispatchLoadURLIntoChildFrame(WTF::move(childURL), referer, childFrame);
+        return;
+    }
+
     // If we're moving in the back/forward list, we might want to replace the content
     // of this child frame with whatever was there at that point.
     RefPtr parentItem = history().currentItem();
@@ -1087,11 +1104,12 @@ void FrameLoader::loadURLIntoChildFrame(const URL& url, const String& referer, L
         }
     }
 
-    RefPtr lexicalFrame = lexicalFrameFromCommonVM();
-    auto initiatedByMainFrame = lexicalFrame && lexicalFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
+    continueLoadURLIntoChildFrame(WTF::move(childURL), referer, childFrame);
+}
 
-    RefPtr document = m_frame->document();
-    FrameLoadRequest frameLoadRequest { *document, document->securityOrigin(), { URL { url } }, selfTargetFrameName(), initiatedByMainFrame };
+void FrameLoader::continueLoadURLIntoChildFrame(URL&& url, const String& referer, LocalFrame& childFrame)
+{
+    auto frameLoadRequest = createFrameLoadRequest(WTF::move(url));
     frameLoadRequest.setNewFrameOpenerPolicy(NewFrameOpenerPolicy::Suppress);
     frameLoadRequest.setLockBackForwardList(LockBackForwardList::Yes);
     frameLoadRequest.setIsInitialFrameSrcLoad(true);
@@ -4453,7 +4471,7 @@ void FrameLoader::loadSameDocumentItem(HistoryItem& item)
 // FIXME: This function should really be split into a couple pieces, some of
 // which should be methods of HistoryController and some of which should be
 // methods of FrameLoader.
-void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType loadType, FormSubmissionCacheLoadPolicy cacheLoadPolicy, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad)
+void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadType loadType, FormSubmissionCacheLoadPolicy cacheLoadPolicy, ShouldTreatAsContinuingLoad shouldTreatAsContinuingLoad, PolicyAlreadyDecided policyAlreadyDecided)
 {
     FRAMELOADER_RELEASE_LOG(ResourceLoading, "loadDifferentDocumentItem: frame load started");
 
@@ -4477,6 +4495,7 @@ void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* from
         action.setTargetBackForwardItem(item);
         action.setSourceBackForwardItem(fromItem);
         action.setNavigationAPIType(determineNavigationType(loadType, NavigationHistoryBehavior::Auto));
+        action.setPolicyAlreadyDecided(policyAlreadyDecided);
         documentLoader->setTriggeringAction(WTF::move(action));
 
         documentLoader->setLastCheckedRequest(ResourceRequest());
@@ -4570,6 +4589,7 @@ void FrameLoader::loadDifferentDocumentItem(HistoryItem& item, HistoryItem* from
     action.setTargetBackForwardItem(item);
     action.setSourceBackForwardItem(fromItem);
     action.setNavigationAPIType(determineNavigationType(loadType, NavigationHistoryBehavior::Auto));
+    action.setPolicyAlreadyDecided(policyAlreadyDecided);
 
     loadWithNavigationAction(WTF::move(request), WTF::move(action), loadType, { }, AllowNavigationToInvalidURL::Yes, shouldTreatAsContinuingLoad);
 }
@@ -4620,6 +4640,26 @@ void FrameLoader::loadItem(HistoryItem& item, HistoryItem* fromItem, FrameLoadTy
         loadSameDocumentItem(item);
     } else
         loadDifferentDocumentItem(item, fromItem, loadType, MayAttemptCacheOnlyLoadForFormSubmissionItem, shouldTreatAsContinuingLoad);
+}
+
+void FrameLoader::setRequestedHistoryItem(HistoryItem& item)
+{
+    Ref frame = m_frame.get();
+
+    item.setFrameID(frame->frameID());
+    m_requestedHistoryItem = item;
+}
+
+void FrameLoader::loadRequestedHistoryItem(FrameLoadType loadType, PolicyAlreadyDecided policyAlreadyDecided)
+{
+    ASSERT(m_requestedHistoryItem);
+    loadDifferentDocumentItem(protect(*m_requestedHistoryItem), nullptr, loadType, MayAttemptCacheOnlyLoadForFormSubmissionItem, ShouldTreatAsContinuingLoad::No, policyAlreadyDecided);
+}
+
+void FrameLoader::loadItem(HistoryItem& item, FrameLoadType loadType, PolicyAlreadyDecided policyAlreadyDecided)
+{
+    setRequestedHistoryItem(item);
+    loadRequestedHistoryItem(loadType, policyAlreadyDecided);
 }
 
 void FrameLoader::retryAfterFailedCacheOnlyMainResourceLoad()

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -36,6 +36,7 @@
 #include <WebCore/FrameLoaderTypes.h>
 #include <WebCore/LayoutMilestone.h>
 #include <WebCore/LoaderMalloc.h>
+#include <WebCore/NavigationAction.h>
 #include <WebCore/NavigationRequester.h>
 #include <WebCore/PageIdentifier.h>
 #include <WebCore/PrivateClickMeasurement.h>
@@ -79,7 +80,6 @@ class HistoryController;
 class HistoryItem;
 class LocalDOMWindow;
 class LocalFrameLoaderClient;
-class NavigationAction;
 class NetworkingContext;
 class Node;
 class Page;
@@ -354,7 +354,10 @@ public:
 
     // HistoryController specific.
     void loadItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, ShouldTreatAsContinuingLoad);
+    WEBCORE_EXPORT void loadItem(HistoryItem&, FrameLoadType, PolicyAlreadyDecided = PolicyAlreadyDecided::No);
     HistoryItem* requestedHistoryItem() const { return m_requestedHistoryItem.get(); }
+    WEBCORE_EXPORT void setRequestedHistoryItem(HistoryItem&);
+    WEBCORE_EXPORT void loadRequestedHistoryItem(FrameLoadType, PolicyAlreadyDecided = PolicyAlreadyDecided::No);
 
     void updateURLAndHistory(const URL&, RefPtr<SerializedScriptValue>&& stateObject, NavigationHistoryBehavior = NavigationHistoryBehavior::Replace);
 
@@ -365,6 +368,9 @@ public:
 
     void prefetch(const URL&, const Vector<String>&, std::optional<ReferrerPolicy>, bool lowPriority = false);
     DocumentPrefetcher& documentPrefetcher() { return m_documentPrefetcher.get(); }
+
+    WEBCORE_EXPORT void continueLoadURLIntoChildFrame(URL&&, const String& referer, LocalFrame&);
+    WEBCORE_EXPORT FrameLoadRequest createFrameLoadRequest(URL&&);
 
 private:
     enum FormSubmissionCacheLoadPolicy {
@@ -383,7 +389,7 @@ private:
     void checkCompletenessNow();
 
     void loadSameDocumentItem(HistoryItem&);
-    void loadDifferentDocumentItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, FormSubmissionCacheLoadPolicy, ShouldTreatAsContinuingLoad);
+    void loadDifferentDocumentItem(HistoryItem&, HistoryItem* fromItem, FrameLoadType, FormSubmissionCacheLoadPolicy, ShouldTreatAsContinuingLoad, PolicyAlreadyDecided = PolicyAlreadyDecided::No);
 
     void loadProvisionalItemFromCachedPage();
 
@@ -464,6 +470,7 @@ private:
     // SubframeLoader specific.
     void loadURLIntoChildFrame(const URL&, const String& referer, LocalFrame&);
     void started();
+    FrameLoadRequest createFrameLoadRequest(URL&&, const AtomString& frameName, const AtomString& downloadAttribute = { });
 
     // PolicyChecker specific.
     void clearProvisionalLoadForPolicyCheck();

--- a/Source/WebCore/loader/LocalFrameLoaderClient.cpp
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.cpp
@@ -27,6 +27,7 @@
 #include "LocalFrameLoaderClient.h"
 
 #include "FrameLoader.h"
+#include "LocalFrame.h"
 
 namespace WebCore {
 
@@ -55,6 +56,11 @@ void LocalFrameLoaderClient::didExceedNetworkUsageThreshold()
 RefPtr<Frame> LocalFrameLoaderClient::provisionalParentFrame() const
 {
     return nullptr;
+}
+
+void LocalFrameLoaderClient::dispatchLoadURLIntoChildFrame(URL&& url, const String& referer, LocalFrame& childFrame)
+{
+    protect(m_loader)->continueLoadURLIntoChildFrame(WTF::move(url), referer, childFrame);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -206,6 +206,8 @@ public:
     virtual void dispatchWillSendSubmitEvent(Ref<FormState>&&) = 0;
     virtual void dispatchWillSubmitForm(FormState&, URL&& requestURL, String&& method, CompletionHandler<void()>&&) = 0;
 
+    virtual void dispatchLoadURLIntoChildFrame(URL&&, const String& referer, LocalFrame& childFrame);
+
     virtual void revertToProvisionalState(DocumentLoader*) = 0;
     virtual void setMainDocumentError(DocumentLoader*, const ResourceError&) = 0;
 

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/CrossOriginOpenerPolicy.h>
 #include <WebCore/FrameLoadRequest.h>
@@ -52,6 +53,7 @@ class UIEventWithKeyState;
 enum class SyntheticClickType : uint8_t;
 enum class MouseButton : int8_t;
 enum class NavigationNavigationType : uint8_t;
+enum class PolicyAlreadyDecided : bool { No, Yes };
 
 // NavigationAction should never hold a strong reference to the originating document either directly
 // or indirectly as doing so prevents its destruction even after navigating away from it because
@@ -132,6 +134,16 @@ public:
     void setPendingDispatchNavigateEvent(std::function<bool()>&& function) { m_pendingDispatchNavigateEvent = WTF::move(function); }
     std::function<bool()> takePendingDispatchNavigateEvent() { return std::exchange(m_pendingDispatchNavigateEvent, nullptr); }
 
+    // Whether UIProcess has already made the policy decision for this navigation.
+    // When Yes, PolicyChecker will skip the IPC to UIProcess and proceed with PolicyAction::Use.
+    // This is used for Back/Forward child frame navigation where UIProcess has already:
+    //   1. Retrieved the FrameState from BackForwardList
+    //   2. Performed all necessary policy checks (Safe Browsing, CSP, etc.)
+    //   3. Sent the FrameState back to WebProcess
+    // WebProcess still performs local security checks (CSP, etc.) but skips the IPC roundtrip.
+    PolicyAlreadyDecided policyAlreadyDecided() const { return m_policyAlreadyDecided; }
+    void setPolicyAlreadyDecided(PolicyAlreadyDecided value) { m_policyAlreadyDecided = value; }
+
 private:
     // Do not add a strong reference to the originating document or a subobject that holds the
     // originating document. See comment above the class for more details.
@@ -151,6 +163,7 @@ private:
     bool m_treatAsSameOriginNavigation { false };
     bool m_hasOpenedFrames { false };
     bool m_openedByDOMWithOpener { false };
+    PolicyAlreadyDecided m_policyAlreadyDecided { PolicyAlreadyDecided::No };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/loader/PolicyChecker.cpp
+++ b/Source/WebCore/loader/PolicyChecker.cpp
@@ -335,6 +335,15 @@ void PolicyChecker::checkNavigationPolicy(ResourceRequest&& request, const Resou
         // We ignore the response from the client for initial empty document loads and proceed with the load synchronously.
         frameLoader->client().dispatchDecidePolicyForNavigationAction(action, request, redirectResponse, formState.get(), clientRedirectSourceForHistory, navigationID, hitTestResult(action), hasOpener, frameLoader->navigationUpgradeToHTTPSBehavior(), sandboxFlags, policyDecisionMode, [](PolicyAction) { });
         decisionHandler(PolicyAction::Use);
+    } else if (action.policyAlreadyDecided() == PolicyAlreadyDecided::Yes) {
+        // UIProcess already made the policy decision, skip IPC.
+        // This happens for Back/Forward child frame navigation when:
+        //   - UIProcess retrieved FrameState from BackForwardList
+        //   - UIProcess performed all policy checks
+        //   - WebProcess received FrameState via PolicyDecision or LoadParameters
+        // We still run local security checks (CSP, etc.) above, but skip the IPC roundtrip.
+        POLICYCHECKER_RELEASE_LOG("checkNavigationPolicy: skipping UIProcess IPC (already decided)");
+        decisionHandler(PolicyAction::Use);
     } else
         frameLoader->client().dispatchDecidePolicyForNavigationAction(action, request, redirectResponse, formState.get(), clientRedirectSourceForHistory, navigationID, hitTestResult(action), hasOpener, frameLoader->navigationUpgradeToHTTPSBehavior(), sandboxFlags, policyDecisionMode, WTF::move(decisionHandler));
 }

--- a/Source/WebKit/Shared/LoadParameters.h
+++ b/Source/WebKit/Shared/LoadParameters.h
@@ -97,6 +97,7 @@ struct LoadParameters {
     uint64_t requiredCookiesVersion { 0 };
     std::optional<WebCore::NavigationRequester> requester;
     std::optional<WebCore::ResourceRequest> originalRequest;
+    RefPtr<FrameState> backForwardChildFrameState;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/LoadParameters.serialization.in
+++ b/Source/WebKit/Shared/LoadParameters.serialization.in
@@ -63,4 +63,5 @@ enum class WebCore::LockBackForwardList : bool;
     uint64_t requiredCookiesVersion;
     std::optional<WebCore::NavigationRequester> requester;
     std::optional<WebCore::ResourceRequest> originalRequest;
+    RefPtr<WebKit::FrameState> backForwardChildFrameState;
 };

--- a/Source/WebKit/Shared/NavigationActionData.h
+++ b/Source/WebKit/Shared/NavigationActionData.h
@@ -30,6 +30,7 @@
 #include "WebMouseEvent.h"
 #include "WebPageProxyIdentifier.h"
 #include <WebCore/AdvancedPrivacyProtections.h>
+#include <WebCore/BackForwardFrameItemIdentifier.h>
 #include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/FloatPoint.h>
 #include <WebCore/FrameLoaderTypes.h>
@@ -91,6 +92,7 @@ struct NavigationActionData {
     WebCore::ResourceRequest request;
     String invalidURLString;
     std::optional<WebCore::NavigationRequester> requester;
+    std::optional<WebCore::BackForwardChildFrameItemIndex> backForwardChildFrameIndex;
 };
 
 }

--- a/Source/WebKit/Shared/NavigationActionData.serialization.in
+++ b/Source/WebKit/Shared/NavigationActionData.serialization.in
@@ -63,4 +63,5 @@ struct WebKit::NavigationActionData {
     [EncodeRequestBody] WebCore::ResourceRequest request;
     String invalidURLString;
     std::optional<WebCore::NavigationRequester> requester;
+    std::optional<WebCore::BackForwardChildFrameItemIndex> backForwardChildFrameIndex;
 };

--- a/Source/WebKit/Shared/PolicyDecision.h
+++ b/Source/WebKit/Shared/PolicyDecision.h
@@ -29,6 +29,7 @@
 #include "NavigatingToAppBoundDomain.h"
 #include "SafeBrowsingCheckOngoing.h"
 #include "SandboxExtension.h"
+#include "SessionState.h"
 #include "WebsitePoliciesData.h"
 #include <WebCore/NavigationIdentifier.h>
 
@@ -54,6 +55,7 @@ struct PolicyDecision {
     std::optional<SandboxExtension::Handle> sandboxExtensionHandle { std::nullopt };
     std::optional<PolicyDecisionConsoleMessage> consoleMessage { std::nullopt };
     SafeBrowsingCheckOngoing isSafeBrowsingCheckOngoing { SafeBrowsingCheckOngoing::No };
+    RefPtr<FrameState> backForwardChildFrameState { nullptr };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/PolicyDecision.serialization.in
+++ b/Source/WebKit/Shared/PolicyDecision.serialization.in
@@ -31,6 +31,7 @@ enum class WebKit::SafeBrowsingCheckOngoing : bool;
     std::optional<WebKit::SandboxExtensionHandle> sandboxExtensionHandle;
     std::optional<WebKit::PolicyDecisionConsoleMessage> consoleMessage;
     WebKit::SafeBrowsingCheckOngoing isSafeBrowsingCheckOngoing;
+    RefPtr<WebKit::FrameState> backForwardChildFrameState;
 }
 
 [CustomHeader] struct WebKit::PolicyDecisionConsoleMessage {

--- a/Source/WebKit/Shared/SessionState.serialization.in
+++ b/Source/WebKit/Shared/SessionState.serialization.in
@@ -82,3 +82,9 @@ header: "SessionState.h"
     Vector<Ref<WebKit::FrameState>> items;
     std::optional<uint32_t> currentIndex;
 };
+
+header: <WebCore/BackForwardFrameItemIdentifier.h>
+[CustomHeader] struct WebCore::BackForwardChildFrameItemIndex {
+    WebCore::BackForwardFrameItemIdentifier parentFrameItemID;
+    unsigned childIndex;
+};

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -96,6 +96,22 @@ RefPtr<WebBackForwardListFrameItem> WebBackForwardListFrameItem::protectedChildI
     return childItemForFrameID(frameID);
 }
 
+WebBackForwardListFrameItem* WebBackForwardListFrameItem::childItemForFrameItemID(BackForwardFrameItemIdentifier frameItemID)
+{
+    if (m_frameState->frameItemID == frameItemID)
+        return this;
+    for (auto& child : m_children) {
+        if (auto* childFrameItem = child->childItemForFrameItemID(frameItemID))
+            return childFrameItem;
+    }
+    return nullptr;
+}
+
+WebBackForwardListFrameItem* WebBackForwardListFrameItem::childItemAtIndex(size_t index)
+{
+    return index < m_children.size() ? m_children[index].ptr() : nullptr;
+}
+
 WebBackForwardListItem* WebBackForwardListFrameItem::backForwardListItem() const
 {
     return m_backForwardListItem.get();

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -60,6 +60,8 @@ public:
     Ref<WebBackForwardListFrameItem> mainFrame();
     WebBackForwardListFrameItem* childItemForFrameID(WebCore::FrameIdentifier);
     RefPtr<WebBackForwardListFrameItem> protectedChildItemForFrameID(WebCore::FrameIdentifier);
+    WebBackForwardListFrameItem* childItemForFrameItemID(WebCore::BackForwardFrameItemIdentifier);
+    WebBackForwardListFrameItem* childItemAtIndex(size_t);
 
     WebBackForwardListItem* backForwardListItem() const;
 

--- a/Source/WebKit/Shared/WebBackForwardListItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListItem.cpp
@@ -219,4 +219,9 @@ void WebBackForwardListItem::updateFrameID(FrameIdentifier oldFrameID, FrameIden
         m_navigatedFrameID = newFrameID;
 }
 
+WebBackForwardListFrameItem* WebBackForwardListItem::findFrameItem(BackForwardFrameItemIdentifier frameItemID)
+{
+    return m_mainFrameItem->childItemForFrameItemID(frameItemID);
+}
+
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -105,6 +105,8 @@ public:
 
     void updateFrameID(WebCore::FrameIdentifier oldFrameID, WebCore::FrameIdentifier newFrameID);
 
+    WebBackForwardListFrameItem* findFrameItem(WebCore::BackForwardFrameItemIdentifier);
+
 private:
     WebBackForwardListItem(Ref<FrameState>&&, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, BrowsingContextGroup*);
 

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -203,6 +203,9 @@ public:
     void setIsEnhancedSecurityLinkForCurrentSite(bool isEnhancedSecurityLink) { m_isEnhancedSecurityLinkForCurrentSite = isEnhancedSecurityLink; }
     bool isEnhancedSecurityLinkForCurrentSite() const { return m_isEnhancedSecurityLinkForCurrentSite; }
 
+    WebKit::FrameState* backForwardChildFrameState() const { return m_backForwardChildFrameState.get(); }
+    void setBackForwardChildFrameState(RefPtr<WebKit::FrameState>&& frameState) { m_backForwardChildFrameState = WTF::move(frameState); }
+
 private:
     Navigation(WebCore::ProcessIdentifier);
     Navigation(WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
@@ -241,6 +244,7 @@ private:
     RefPtr<WebKit::BrowsingWarning> m_safeBrowsingWarning;
     ListHashSet<size_t> m_ongoingSafeBrowsingChecks;
     RefPtr<WebKit::FrameProcess> m_pendingSharedProcess;
+    RefPtr<WebKit::FrameState> m_backForwardChildFrameState;
 };
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -167,6 +167,9 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)setSiteSpecificQuirksModeEnabled:(BOOL)enabled
 {
     protect(*_preferences)->setNeedsSiteSpecificQuirks(enabled);
+
+    // Enable UIProcess-driven BackForward item loading with Site Isolation.
+    protect(*_preferences)->setUseUIProcessForBackForwardItemLoading(enabled);
 }
 
 - (BOOL)isElementFullscreenEnabled
@@ -446,6 +449,16 @@ static _WKStorageBlockingPolicy toAPI(WebCore::StorageBlockingPolicy policy)
 - (void)_setTextAutosizingEnabled:(BOOL)enabled
 {
     protect(*_preferences)->setTextAutosizingEnabled(enabled);
+}
+
+- (BOOL)_useUIProcessForBackForwardItemLoading
+{
+    return protect(*_preferences)->useUIProcessForBackForwardItemLoading();
+}
+
+- (void)_setUseUIProcessForBackForwardItemLoading:(BOOL)flag
+{
+    protect(*_preferences)->setUseUIProcessForBackForwardItemLoading(flag);
 }
 
 - (BOOL)_developerExtrasEnabled

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -87,6 +87,8 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 @property (nonatomic, setter=_setAnimatedImageAsyncDecodingEnabled:) BOOL _animatedImageAsyncDecodingEnabled WK_API_AVAILABLE(macos(10.12.4), ios(10.3));
 @property (nonatomic, setter=_setTextAutosizingEnabled:) BOOL _textAutosizingEnabled WK_API_AVAILABLE(macos(10.12), ios(10.0));
 
+@property (nonatomic, setter=_setUseUIProcessForBackForwardItemLoading:) BOOL _useUIProcessForBackForwardItemLoading WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 @property (nonatomic, setter=_setDeveloperExtrasEnabled:) BOOL _developerExtrasEnabled WK_API_AVAILABLE(macos(10.11), ios(9.0));
 
 @property (nonatomic, setter=_setLogsPageMessagesToSystemConsoleEnabled:) BOOL _logsPageMessagesToSystemConsoleEnabled WK_API_AVAILABLE(macos(10.11), ios(9.0));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5598,6 +5598,16 @@ void WebPageProxy::continueNavigationInNewProcess(API::Navigation& navigation, W
         if (auto& action = navigation.lastNavigationAction())
             loadParameters.requester = action->requester;
 
+        // Pass FrameState for Back/Forward child frame navigation.
+        // When Site Isolation causes a process swap for a child frame's Back/Forward navigation,
+        // the FrameState was stored on the Navigation object during policy decision.
+        // We pass it to the new process so it can restore the historical state without
+        // making another IPC roundtrip to look up the FrameState.
+        if (RefPtr frameState = navigation.backForwardChildFrameState()) {
+            WEBPAGEPROXY_RELEASE_LOG(Loading, "continueNavigationInNewProcess: Passing FrameState for child frame to new process, URL=%s", frameState->urlString.utf8().data());
+            loadParameters.backForwardChildFrameState = frameState;
+        }
+
         if (navigation.isInitialFrameSrcLoad())
             frame.setIsPendingInitialHistoryItem(true);
 
@@ -8432,8 +8442,52 @@ static bool frameSandboxAllowsOpeningExternalCustomProtocols(SandboxFlags sandbo
 }
 #endif
 
-void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& process, WebFrameProxy& frame, NavigationActionData&& navigationActionData, CompletionHandler<void(PolicyDecision&&)>&& completionHandler)
+void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& process, WebFrameProxy& frame, NavigationActionData&& navigationActionData, CompletionHandler<void(PolicyDecision&&)>&& originalCompletionHandler)
 {
+    // Handle Back/Forward child frame navigation:
+    // For child frames navigating via Back/Forward, we look up the FrameState from the
+    // BackForwardList and rewrite the request URL to match the historical URL.
+    // This ensures:
+    //   1. Policy checks use the correct historical URL (not the potentially stale iframe src)
+    //   2. The FrameState is passed to WebProcess to avoid duplicate IPC
+    //   3. Site Isolation is supported (FrameState is stored on Navigation for process swap)
+    RefPtr<FrameState> frameStateForChildFrame;
+    if (auto& backForwardChildFrameIndex = navigationActionData.backForwardChildFrameIndex) {
+        if (RefPtr currentItem = backForwardList().currentItem()) {
+            if (RefPtr parentFrameItem = currentItem->findFrameItem(backForwardChildFrameIndex->parentFrameItemID)) {
+                if (RefPtr childFrameItem = parentFrameItem->childItemAtIndex(backForwardChildFrameIndex->childIndex)) {
+                    frameStateForChildFrame = childFrameItem->frameState();
+                    if (frameStateForChildFrame) {
+                        WEBPAGEPROXY_RELEASE_LOG(Loading, "decidePolicyForNavigationAction: Back/Forward child frame, rewriting URL to %s",
+                            frameStateForChildFrame->urlString.utf8().data());
+                        navigationActionData.request.setURL(URL { frameStateForChildFrame->urlString });
+                    }
+                }
+            }
+        }
+
+        if (!frameStateForChildFrame)
+            WEBPAGEPROXY_RELEASE_LOG(Loading, "decidePolicyForNavigationAction: Back/Forward child frame, FrameState not found, using fallback");
+    }
+
+    // Keep a copy for navigation (before it's moved into completionHandler)
+    // This is needed for Site Isolation: if the navigation causes a process swap,
+    // the new process needs the FrameState to restore the historical state.
+    RefPtr<FrameState> frameStateForNavigation = frameStateForChildFrame;
+
+    // Wrap completionHandler to include FrameState in response
+    auto completionHandler = [
+        originalCompletionHandler = WTF::move(originalCompletionHandler),
+        frameStateForChildFrame = WTF::move(frameStateForChildFrame)
+    ](PolicyDecision&& policyDecision) mutable {
+        // Include FrameState for both Use and LoadWillContinueInAnotherProcess.
+        // For LoadWillContinueInAnotherProcess, the FrameState will be passed via
+        // LoadParameters to the new process (see continueNavigationInNewProcess).
+        if (frameStateForChildFrame && (policyDecision.policyAction == PolicyAction::Use || policyDecision.policyAction == PolicyAction::LoadWillContinueInAnotherProcess))
+            policyDecision.backForwardChildFrameState = WTF::move(frameStateForChildFrame);
+        originalCompletionHandler(WTF::move(policyDecision));
+    };
+
     auto frameInfo = navigationActionData.frameInfo;
     auto navigationID = navigationActionData.navigationID;
     auto originatingFrameInfoData = navigationActionData.originatingFrameInfoData;
@@ -8486,6 +8540,10 @@ void WebPageProxy::decidePolicyForNavigationAction(Ref<WebProcessProxy>&& proces
         if (!navigation)
             navigation = m_navigationState->createLoadRequestNavigation(process->coreProcessIdentifier(), ResourceRequest(request), protect(backForwardList().currentItem()));
     }
+
+    // Store frameState on navigation for Site Isolation process swap
+    if (frameStateForNavigation && navigation)
+        navigation->setBackForwardChildFrameState(WTF::move(frameStateForNavigation));
 
     if (!checkURLReceivedFromCurrentOrPreviousWebProcess(process, request.url())) {
         WEBPAGEPROXY_RELEASE_LOG_ERROR(Process, "Ignoring request to load this main resource because it is outside the sandbox");

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -427,6 +427,7 @@ RefPtr<Page> WebChromeClient::createWindow(LocalFrame& frame, const String& open
         originalRequest, /* request */
         originalRequest.url().isValid() ? String() : originalRequest.url().string(), /* invalidURLString */
         navigationAction.requester(), /* requester */
+        std::nullopt, /* backForwardChildFrameIndex */
     };
 
     auto sendResult = protect(webProcess.parentProcessConnection())->sendSync(Messages::WebPageProxy::CreateNewPage(windowFeatures, navigationActionData), page->identifier(), IPC::Timeout::infinity(), { IPC::SendSyncOption::MaintainOrderingWithAsyncMessages });

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -32,6 +32,7 @@
 #include "MessageSenderInlines.h"
 #include "NavigationActionData.h"
 #include "WebFrame.h"
+#include "WebLocalFrameLoaderClient.h"
 #include "WebMouseEvent.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
@@ -177,6 +178,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         request,
         request.url().isValid() ? String() : request.url().string(),
         requester,
+        navigationAction.backForwardChildFrameIndex(),
     };
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -44,6 +44,8 @@
 #include "NetworkProcessConnection.h"
 #include "NetworkResourceLoadParameters.h"
 #include "PluginView.h"
+#include "SessionState.h"
+#include "SessionStateConversion.h"
 #include "UserData.h"
 #include "WKBundleAPICast.h"
 #include "WebAutomationSessionProxy.h"
@@ -76,6 +78,7 @@
 #include <WebCore/EventHandler.h>
 #include <WebCore/FormState.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
+#include <WebCore/FrameLoadRequest.h>
 #include <WebCore/FrameLoader.h>
 #include <WebCore/HTMLFormControlElement.h>
 #include <WebCore/HTMLFormElement.h>
@@ -87,6 +90,7 @@
 #include <WebCore/MIMETypeRegistry.h>
 #include <WebCore/MediaDocument.h>
 #include <WebCore/MouseEvent.h>
+#include <WebCore/NavigationAction.h>
 #include <WebCore/NodeDocument.h>
 #include <WebCore/NotImplemented.h>
 #include <WebCore/PluginData.h>
@@ -518,6 +522,7 @@ void WebLocalFrameLoaderClient::didSameDocumentNavigationForFrameViaJS(SameDocum
         { }, /* request */
         { }, /* invalidURLString */
         std::nullopt, /* requester */
+        std::nullopt, /* backForwardChildFrameIndex */
     };
 
     // Notify the UIProcess.
@@ -1027,6 +1032,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const Nav
         request,
         request.url().isValid() ? String() : request.url().string(), /* invalidURLString */
         std::nullopt, /* requester */
+        std::nullopt, /* backForwardChildFrameIndex */
     };
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForNewWindowAction(navigationActionData, frameName), [frame = m_frame, listenerID] (PolicyDecision&& policyDecision) {
@@ -1140,6 +1146,84 @@ void WebLocalFrameLoaderClient::dispatchWillSubmitForm(FormState& formState, URL
     }
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::WillSubmitForm { m_frame->info(), sourceFrame->info(), values, UserData { WebProcess::singleton().transformObjectsToHandles(userData.get()).get() }, requestURL, method }, WTF::move(completionHandler));
+}
+
+void WebLocalFrameLoaderClient::dispatchLoadURLIntoChildFrame(URL&& url, const String& referer, LocalFrame& childFrame)
+{
+    RefPtr localFrame = m_localFrame.ptr();
+    if (!localFrame)
+        return;
+
+    Ref loader = localFrame->loader();
+
+    // Check Back/Forward conditions
+    if (isBackForwardLoadType(loader->loadType()) && !localFrame->document()->loadEventFinished()) {
+        if (RefPtr parentItem = loader->history().currentItem()) {
+            if (auto index = childFrame.indexInFrameTreeSiblings()) {
+                if (auto* childClient = dynamicDowncast<WebLocalFrameLoaderClient>(childFrame.loader().client())) {
+                    WebLocalFrameLoaderClient_RELEASE_LOG(Loading, "dispatchLoadURLIntoChildFrame: Back/Forward child frame detected, parentFrameItemID=%" PRIu64 ", childIndex=%" PRIu64,
+                        parentItem->frameItemID().object().toUInt64(), *index);
+
+                    auto frameLoadRequest = loader->createFrameLoadRequest(WTF::move(url));
+                    BackForwardChildFrameItemIndex frameItemIndex { parentItem->frameItemID(), static_cast<unsigned>(*index) };
+                    frameLoadRequest.setBackForwardChildFrameIndex(frameItemIndex);
+
+                    childClient->dispatchDecidePolicyForBackForwardNavigationAction(WTF::move(frameLoadRequest), referer, loader->loadType());
+                    return;
+                }
+            }
+        }
+    }
+
+    loader->continueLoadURLIntoChildFrame(WTF::move(url), referer, childFrame);
+}
+
+void WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationAction(WebCore::FrameLoadRequest&& frameLoadRequest, const String& referer, WebCore::FrameLoadType loadType)
+{
+    RefPtr localFrame = m_localFrame.ptr();
+    if (!localFrame)
+        return;
+
+    NavigationAction navigationAction { frameLoadRequest, NavigationType::BackForward, nullptr };
+    navigationAction.setBackForwardChildFrameIndex(frameLoadRequest.backForwardChildFrameIndex());
+
+    auto request = frameLoadRequest.resourceRequest();
+
+    // Call dispatchDecidePolicyForNavigationAction on this (child) frame's client
+    // Response will be handled in the callback below
+    dispatchDecidePolicyForNavigationAction(
+        navigationAction,
+        request,
+        ResourceResponse { },
+        nullptr, // formState
+        { }, // clientRedirectSourceForHistory
+        std::nullopt, // navigationID
+        std::nullopt, // hitTestResult
+        false, // hasOpener
+        NavigationUpgradeToHTTPSBehavior::BasedOnPolicy,
+        localFrame->effectiveSandboxFlags(),
+        PolicyDecisionMode::Asynchronous,
+        [weakLocalFrame = WeakPtr { *localFrame }, url = request.url(), referer, loadType](PolicyAction action) {
+            if (action != PolicyAction::Use)
+                return;
+
+            RefPtr localFrame = weakLocalFrame.get();
+            if (!localFrame)
+                return;
+
+            RefPtr historyItem = localFrame->loader().requestedHistoryItem();
+            if (!historyItem) {
+                // Fallback: FrameState not found, use normal load path
+                RELEASE_LOG(Loading, "dispatchDecidePolicyForBackForwardNavigationAction: FrameState not found, using fallback normal load path");
+
+                if (RefPtr parent = dynamicDowncast<LocalFrame>(localFrame->tree().parent()))
+                    parent->loader().continueLoadURLIntoChildFrame(URL { url }, referer, *localFrame);
+                return;
+            }
+
+            localFrame->loader().loadRequestedHistoryItem(loadType, PolicyAlreadyDecided::Yes);
+        }
+    );
 }
 
 void WebLocalFrameLoaderClient::revertToProvisionalState(DocumentLoader*)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -34,12 +34,13 @@
 #include <pal/SessionID.h>
 
 namespace WebCore {
+class FrameLoadRequest;
 struct BackForwardItemIdentifierType;
 using BackForwardItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardItemIdentifierType>>;
 }
 
 namespace WebKit {
-
+class FrameState;
 class PluginView;
 class WebFrame;
 struct WebsitePoliciesData;
@@ -150,7 +151,9 @@ private:
     
     void dispatchWillSendSubmitEvent(Ref<WebCore::FormState>&&) final;
     void dispatchWillSubmitForm(WebCore::FormState&, URL&& requestURL, String&& method, CompletionHandler<void()>&&) final;
-    
+
+    void dispatchLoadURLIntoChildFrame(URL&&, const String& referer, WebCore::LocalFrame& childFrame) final;
+
     void revertToProvisionalState(WebCore::DocumentLoader*) final;
     void setMainDocumentError(WebCore::DocumentLoader*, const WebCore::ResourceError&) final;
     
@@ -285,6 +288,8 @@ private:
 
     void broadcastAllFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncData&) final;
     void broadcastFrameTreeSyncDataToOtherProcesses(const WebCore::FrameTreeSyncSerializationData&) final;
+
+    void dispatchDecidePolicyForBackForwardNavigationAction(WebCore::FrameLoadRequest&&, const String& referer, WebCore::FrameLoadType);
 
 #if ENABLE(CONTENT_EXTENSIONS)
     void didExceedNetworkUsageThreshold();

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -44,6 +44,7 @@
 #include "NetworkProcessConnection.h"
 #include "PluginView.h"
 #include "ProvisionalFrameCreationParameters.h"
+#include "SessionStateConversion.h"
 #include "WKAPICast.h"
 #include "WKBundleAPICast.h"
 #include "WebChromeClient.h"
@@ -54,6 +55,7 @@
 #include "WebFrameProxyMessages.h"
 #include "WebImage.h"
 #include "WebKeyboardEvent.h"
+#include "WebLocalFrameLoaderClient.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
 #include "WebProcess.h"
@@ -611,6 +613,26 @@ void WebFrame::didReceivePolicyDecision(uint64_t listenerID, PolicyDecision&& po
         RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
         if (RefPtr documentLoader = localFrame ? localFrame->loader().policyDocumentLoader() : nullptr)
             documentLoader->setNavigationID(*policyDecision.navigationID);
+    }
+
+    // Handle Back/Forward child frame FrameState
+    // Save frameState to client for callback processing
+    if (policyDecision.backForwardChildFrameState) {
+        RELEASE_LOG(Loading, "didReceivePolicyDecision: Received FrameState for child frame, URL=%s", policyDecision.backForwardChildFrameState->urlString.utf8().data());
+
+        if (RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get())) {
+            if (RefPtr page = m_page.get()) {
+                // Build HistoryItem from FrameState
+                Ref historyItemClient = page->historyItemClient();
+                auto ignoreHistoryItemChangesForScope = historyItemClient->ignoreChangesForScope();
+                Ref historyItem = toHistoryItem(historyItemClient, Ref { *policyDecision.backForwardChildFrameState });
+
+                Ref frameLoader = localFrame->loader();
+                frameLoader->setRequestedHistoryItem(historyItem);
+
+                RELEASE_LOG(Loading, "didReceivePolicyDecision: HistoryItem created from FrameState, will load in callback");
+            }
+        }
     }
 
     if (policyDecision.policyAction == PolicyAction::Use && policyDecision.sandboxExtensionHandle) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2217,6 +2217,25 @@ void WebPage::loadRequest(LoadParameters&& loadParameters)
         return;
     }
 
+    // Handle Back/Forward child frame navigation with Site Isolation.
+    // When a child frame's Back/Forward navigation triggers a process swap (Site Isolation),
+    // UIProcess sends the FrameState directly via LoadParameters instead of PolicyDecision.
+    // This allows the new process to restore the historical state without knowing about
+    // the previous process or making additional IPC calls.
+    if (loadParameters.backForwardChildFrameState) {
+        WEBPAGE_RELEASE_LOG(Loading, "loadRequest: Handling Back/Forward child frame with Site Isolation, URL=%s", loadParameters.backForwardChildFrameState->urlString.utf8().data());
+
+        // Build HistoryItem from FrameState
+        Ref historyItemClient = this->historyItemClient();
+        auto ignoreHistoryItemChangesForScope = historyItemClient->ignoreChangesForScope();
+        Ref historyItem = toHistoryItem(historyItemClient, Ref { *loadParameters.backForwardChildFrameState });
+
+        // Set the history item and do a back/forward navigation.
+        // PolicyAlreadyDecided::Yes because UIProcess already performed all policy checks.
+        localFrame->loader().loadItem(historyItem, FrameLoadType::IndexedBackForward, PolicyAlreadyDecided::Yes);
+        return;
+    }
+
     setLastNavigationWasAppInitiated(loadParameters.request.isAppInitiated());
 
 #if ENABLE(APP_BOUND_DOMAINS)


### PR DESCRIPTION
#### f1aaffe50f1a41a4fc293c168aca6b90f8514f2f
<pre>
[Site Isolation] Implement UIProcess-driven back/forward navigation for child frames.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307518">https://bugs.webkit.org/show_bug.cgi?id=307518</a>
<a href="https://rdar.apple.com/170106309">rdar://170106309</a>

Reviewed by NOBODY (OOPS!).

This patch implements UIProcess-driven back/forward navigation for child frames to address
security/privacy concerns with Site Isolation.

WebKit&apos;s traditional back/forward navigation has a security/privacy issue when navigating
pages with iframes: the complete state of all frames (including cross-site iframes) is sent
to the main frame&apos;s process, violating site isolation principles.

The solution is to have each child frame query the UIProcess directly for its own FrameState
during back/forward navigation. The UIProcess provides each frame with only its own
historical state, without exposing cross-site information to other frames.

Core Mechanism:
- When a child frame navigation is triggered during back/forward navigation, WebProcess sends
  DecidePolicyForNavigationAction to UIProcess with the parent frame item ID and child index.
- UIProcess looks up the FrameState from BackForwardList using the parent frame item ID and
  child index.
- UIProcess rewrites the navigation URL to match the historical URL and performs policy checks.
- FrameState is returned to WebProcess via PolicyDecision (same-process) or LoadParameters
  (cross-process for Site Isolation).
- WebProcess restores historical state using the FrameState and skips duplicate policy check
  with PolicyAlreadyDecided::Yes.

Site Isolation Support:
- When process swap occurs, FrameState is stored on Navigation object and passed to new process
  via LoadParameters
- New process can restore child frame state without knowing about the previous process

Gated behind UseUIProcessForBackForwardItemLoading preference (status: unstable) and off
by default (opt-in)

Combined changes:
Tests: http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html
       http/tests/site-isolation/navigation/back-iframe-no-bf-cache.html
* LayoutTests/http/tests/navigation/resources/back-iframe-popup.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html:
* LayoutTests/http/tests/navigation/resources/navigation-utils.js:
(crossSiteUrl):
* LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html: Added.
* LayoutTests/http/tests/site-isolation/navigation/back-iframe-no-bf-cache-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/navigation/back-iframe-no-bf-cache.html: Added.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/history/BackForwardFrameItemIdentifier.h:
* Source/WebCore/loader/FrameLoadRequest.h:
(WebCore::FrameLoadRequestBase::backForwardChildFrameIndex const):
(WebCore::FrameLoadRequestBase::setBackForwardChildFrameIndex):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::createFrameLoadRequest):
(WebCore::FrameLoader::changeLocation):
(WebCore::FrameLoader::loadURLIntoChildFrame):
(WebCore::FrameLoader::continueLoadURLIntoChildFrame):
(WebCore::FrameLoader::loadDifferentDocumentItem):
(WebCore::FrameLoader::setRequestedHistoryItem):
(WebCore::FrameLoader::loadRequestedHistoryItem):
(WebCore::FrameLoader::loadItem):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/LocalFrameLoaderClient.cpp:
(WebCore::LocalFrameLoaderClient::dispatchLoadURLIntoChildFrame):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/NavigationAction.h:
(WebCore::NavigationAction::policyAlreadyDecided const):
(WebCore::NavigationAction::setPolicyAlreadyDecided):
* Source/WebCore/loader/PolicyChecker.cpp:
(WebCore::PolicyChecker::checkNavigationPolicy):
* Source/WebKit/Shared/LoadParameters.h:
* Source/WebKit/Shared/LoadParameters.serialization.in:
* Source/WebKit/Shared/NavigationActionData.h:
* Source/WebKit/Shared/NavigationActionData.serialization.in:
* Source/WebKit/Shared/PolicyDecision.h:
* Source/WebKit/Shared/PolicyDecision.serialization.in:
* Source/WebKit/Shared/SessionState.serialization.in:
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::childItemForFrameItemID):
(WebKit::WebBackForwardListFrameItem::childItemAtIndex):
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebBackForwardListItem.cpp:
(WebKit::WebBackForwardListItem::findFrameItem):
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/UIProcess/API/APINavigation.h:
(API::Navigation::backForwardChildFrameState const):
(API::Navigation::setBackForwardChildFrameState):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences setSiteSpecificQuirksModeEnabled:]):
(-[WKPreferences _useUIProcessForBackForwardItemLoading]):
(-[WKPreferences _setUseUIProcessForBackForwardItemLoading:]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
(WebKit::WebPageProxy::decidePolicyForNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchLoadURLIntoChildFrame):
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForBackForwardNavigationAction):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::didReceivePolicyDecision):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::loadRequest):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1aaffe50f1a41a4fc293c168aca6b90f8514f2f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145760 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18451 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10416 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154439 "Hash f1aaffe5 for PR 58382 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99373 "Hash f1aaffe5 for PR 58382 does not build (failure)") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7ece249-1c78-4f12-8fa2-b166cd88bfe9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147635 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18340 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/154439 "Hash f1aaffe5 for PR 58382 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/99373 "Hash f1aaffe5 for PR 58382 does not build (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148723 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130940 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/154439 "Hash f1aaffe5 for PR 58382 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c4eb2fc-0d83-4722-9248-074f93706088) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11551 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1886 "Hash f1aaffe5 for PR 58382 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137754 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123347 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7797 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156752 "Hash f1aaffe5 for PR 58382 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6568 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27 "Found 167 new failures in JSWebExtensionAPIWebPageRuntime.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm, JSWebExtensionAPILocalization.mm, JSWebExtensionAPIStorage.mm, JSWebExtensionAPIWindowsEvent.mm, JSWebExtensionAPIWebNavigationEvent.mm, JSWebExtensionAPIPermissions.mm, JSWebExtensionAPICommands.mm, JSWebExtensionAPIMenus.mm, JSWebExtensionAPIExtension.mm ...") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8964 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/156752 "Hash f1aaffe5 for PR 58382 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18298 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15286 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/156752 "Hash f1aaffe5 for PR 58382 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129128 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74042 "Hash f1aaffe5 for PR 58382 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7202 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177063 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17919 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81708 "Found 188 new failures in JSWebExtensionAPIWebPageRuntime.mm, WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm, JSWebExtensionAPIDevToolsNetwork.mm, JSWebExtensionAPILocalization.mm, JSWebExtensionAPIStorage.mm, JSWebExtensionAPIWindowsEvent.mm, JSWebExtensionAPIDevToolsInspectedWindow.mm, JSWebExtensionAPIWebNavigationEvent.mm, JSWebExtensionAPIPermissions.mm, JSWebExtensionAPIMenus.mm ...") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45471 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17656 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17865 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17717 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->