### PR TITLE
Drop more `checked*()` member functions in Source/WebCore/page

### DIFF
--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -156,7 +156,7 @@ Vector<Ref<TextTrack>> MediaControlsHost::sortedTrackListForMenu(TextTrackList& 
     if (!page)
         return { };
 
-    return page->checkedGroup()->ensureProtectedCaptionPreferences()->sortedTrackListForMenu(&trackList, { TextTrack::Kind::Subtitles, TextTrack::Kind::Captions, TextTrack::Kind::Descriptions });
+    return protect(page->group())->ensureProtectedCaptionPreferences()->sortedTrackListForMenu(&trackList, { TextTrack::Kind::Subtitles, TextTrack::Kind::Captions, TextTrack::Kind::Descriptions });
 }
 
 Vector<Ref<AudioTrack>> MediaControlsHost::sortedTrackListForMenu(AudioTrackList& trackList)
@@ -165,7 +165,7 @@ Vector<Ref<AudioTrack>> MediaControlsHost::sortedTrackListForMenu(AudioTrackList
     if (!page)
         return { };
 
-    return page->checkedGroup()->ensureProtectedCaptionPreferences()->sortedTrackListForMenu(&trackList);
+    return protect(page->group())->ensureProtectedCaptionPreferences()->sortedTrackListForMenu(&trackList);
 }
 
 String MediaControlsHost::displayNameForTrack(const std::optional<TextOrAudioTrack>& track)
@@ -178,7 +178,7 @@ String MediaControlsHost::displayNameForTrack(const std::optional<TextOrAudioTra
         return emptyString();
 
     return WTF::visit([page](auto& track) {
-        return page->checkedGroup()->ensureCaptionPreferences().displayNameForTrack(track);
+        return protect(page->group())->ensureCaptionPreferences().displayNameForTrack(track);
     }, track.value());
 }
 
@@ -203,7 +203,7 @@ AtomString MediaControlsHost::captionDisplayMode() const
     if (!page)
         return emptyAtom();
 
-    switch (page->checkedGroup()->ensureProtectedCaptionPreferences()->captionDisplayMode()) {
+    switch (protect(page->group())->ensureProtectedCaptionPreferences()->captionDisplayMode()) {
     case CaptionUserPreferences::CaptionDisplayMode::Automatic:
         return automaticKeyword();
     case CaptionUserPreferences::CaptionDisplayMode::ForcedOnly:
@@ -594,7 +594,7 @@ auto MediaControlsHost::mediaControlsContextMenuItems(String&& optionsJSONString
 
     if (optionsJSONObject->getBoolean("includeLanguages"_s).value_or(false)) {
         if (RefPtr audioTracks = mediaElement->audioTracks(); audioTracks && audioTracks->length() > 1) {
-            Ref captionPreferences = page->checkedGroup()->ensureCaptionPreferences();
+            Ref captionPreferences = protect(page->group())->ensureCaptionPreferences();
             auto languageMenuItems = captionPreferences->sortedTrackListForMenu(audioTracks.get()).map([&createMenuItem, captionPreferences](auto& audioTrack) {
                 return createMenuItem(audioTrack, captionPreferences->displayNameForTrack(audioTrack.get()), audioTrack->enabled());
             });
@@ -606,7 +606,7 @@ auto MediaControlsHost::mediaControlsContextMenuItems(String&& optionsJSONString
 
     if (optionsJSONObject->getBoolean("includeSubtitles"_s).value_or(false)) {
         if (RefPtr textTracks = mediaElement->textTracks(); textTracks && textTracks->length()) {
-            Ref captionPreferences = page->checkedGroup()->ensureCaptionPreferences();
+            Ref captionPreferences = protect(page->group())->ensureCaptionPreferences();
             auto sortedTextTracks = captionPreferences->sortedTrackListForMenu(textTracks.get(), { TextTrack::Kind::Subtitles, TextTrack::Kind::Captions, TextTrack::Kind::Descriptions });
             bool allTracksDisabled = notFound == sortedTextTracks.findIf([] (const auto& textTrack) {
                 return textTrack->mode() == TextTrack::Mode::Showing;
@@ -678,7 +678,7 @@ auto MediaControlsHost::mediaControlsContextMenuItems(String&& optionsJSONString
 
     if (optionsJSONObject->getBoolean("includeChapters"_s).value_or(false)) {
         if (RefPtr textTracks = mediaElement->textTracks(); textTracks && textTracks->length()) {
-            Ref captionPreferences = page->checkedGroup()->ensureCaptionPreferences();
+            Ref captionPreferences = protect(page->group())->ensureCaptionPreferences();
 
             for (auto& textTrack : captionPreferences->sortedTrackListForMenu(textTracks.get(), { TextTrack::Kind::Chapters })) {
                 Vector<MenuItem> chapterMenuItems;
@@ -950,7 +950,7 @@ void MediaControlsHost::savePreviouslySelectedTextTrackIfNecessary()
         }
     }
 
-    switch (page->checkedGroup()->ensureProtectedCaptionPreferences()->captionDisplayMode()) {
+    switch (protect(page->group())->ensureProtectedCaptionPreferences()->captionDisplayMode()) {
     case CaptionUserPreferences::CaptionDisplayMode::Automatic:
         m_previouslySelectedTextTrack = TextTrack::captionMenuAutomaticItemSingleton();
         return;

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -1226,7 +1226,7 @@ bool HTMLModelElement::shouldDeferLoading() const
     if (!frame)
         return false;
 
-    if (!frame->checkedScript()->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
+    if (!protect(frame->script())->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
         return false;
 
     return !isVisible() && isModelDeferred() && !document().page()->shouldDisableModelLoadDelaysForTesting();

--- a/Source/WebCore/accessibility/AXUtilities.cpp
+++ b/Source/WebCore/accessibility/AXUtilities.cpp
@@ -474,7 +474,7 @@ String roleToString(AccessibilityRole role)
 bool needsLayoutOrStyleRecalc(const Document& document)
 {
     if (RefPtr frameView = document.view()) {
-        if (frameView->needsLayout() || frameView->checkedLayoutContext()->isLayoutPending())
+        if (frameView->needsLayout() || protect(frameView->layoutContext())->isLayoutPending())
             return true;
     }
     return document.hasPendingStyleRecalc();

--- a/Source/WebCore/bindings/js/WindowProxy.cpp
+++ b/Source/WebCore/bindings/js/WindowProxy.cpp
@@ -144,7 +144,7 @@ JSWindowProxy& WindowProxy::createJSWindowProxyWithInitializedScript(DOMWrapperW
     JSLockHolder lock(world.vm());
     auto& windowProxy = createJSWindowProxy(world);
     if (RefPtr localFrame = dynamicDowncast<LocalFrame>(*m_frame))
-        localFrame->checkedScript()->initScriptForWindowProxy(windowProxy);
+        protect(localFrame->script())->initScriptForWindowProxy(windowProxy);
     return windowProxy;
 }
 

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -641,7 +641,7 @@ static const IdentifierSchema& scriptingFeatureSchema()
         OptionSet<MediaQueryDynamicDependency>(),
         [](auto& context) {
             Ref frame = *context.document->frame();
-            if (!frame->checkedScript()->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
+            if (!protect(frame->script())->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
                 return MatchingIdentifiers { CSSValueNone };
             return MatchingIdentifiers { CSSValueEnabled };
         }

--- a/Source/WebCore/dom/CharacterData.cpp
+++ b/Source/WebCore/dom/CharacterData.cpp
@@ -65,7 +65,7 @@ void CharacterData::setData(const String& data)
         Ref document = this->document();
         document->textRemoved(*this, 0, oldLength);
         if (RefPtr frame = document->frame())
-            frame->checkedSelection()->textWasReplaced(*this, 0, oldLength, oldLength);
+            protect(frame->selection())->textWasReplaced(*this, 0, oldLength, oldLength);
         return;
     }
 
@@ -205,7 +205,7 @@ void CharacterData::setDataAndUpdate(const String& newData, unsigned offsetOfRep
         processingIntruction->checkStyleSheet();
 
     if (RefPtr frame = document->frame())
-        frame->checkedSelection()->textWasReplaced(*this, offsetOfReplacedData, oldLength, newLength);
+        protect(frame->selection())->textWasReplaced(*this, offsetOfReplacedData, oldLength, newLength);
 
     notifyParentAfterChange(childChange);
 

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -3466,7 +3466,7 @@ void Document::createRenderTree()
 
 void Document::didBecomeCurrentDocumentInFrame()
 {
-    protectedFrame()->checkedScript()->updateDocument();
+    protect(protectedFrame()->script())->updateDocument();
 
     // Many of these functions have event handlers which can detach the frame synchronously, so we must check repeatedly in this function.
     if (!m_frame)
@@ -4974,7 +4974,7 @@ void Document::disableEval(const String& errorMessage)
     if (!frame)
         return;
 
-    frame->checkedScript()->setEvalEnabled(false, errorMessage);
+    protect(frame->script())->setEvalEnabled(false, errorMessage);
 }
 
 void Document::disableWebAssembly(const String& errorMessage)
@@ -4983,7 +4983,7 @@ void Document::disableWebAssembly(const String& errorMessage)
     if (!frame)
         return;
 
-    frame->checkedScript()->setWebAssemblyEnabled(false, errorMessage);
+    protect(frame->script())->setWebAssemblyEnabled(false, errorMessage);
 }
 
 void Document::setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement enforcement)
@@ -4995,7 +4995,7 @@ void Document::setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement enforceme
     if (!frame)
         return;
 
-    frame->checkedScript()->setTrustedTypesEnforcement(enforcement);
+    protect(frame->script())->setTrustedTypesEnforcement(enforcement);
     m_requiresTrustedTypes = enforcement != JSC::TrustedTypesEnforcement::None;
 }
 

--- a/Source/WebCore/dom/LoadableSpeculationRules.cpp
+++ b/Source/WebCore/dom/LoadableSpeculationRules.cpp
@@ -133,7 +133,7 @@ void LoadableSpeculationRules::notifyFinished(CachedResource& resource, const Ne
         // 5. Let ruleSet be the result of parsing a speculation rule set string given bodyText, document, and response's URL. If this throws an exception, then abort these steps.
         // 6. Append ruleSet to document's speculation rule sets.
         // Header-based rules use the Document as the source node.
-        if (frame->checkedScript()->registerSpeculationRules(*document, sourceCode, m_url)) {
+        if (protect(frame->script())->registerSpeculationRules(*document, sourceCode, m_url)) {
             // 7. Consider speculative loads for document.
             document->considerSpeculationRules();
         }

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -646,7 +646,7 @@ JSC::JSGlobalObject* ScriptExecutionContext::globalObject() const
 {
     if (auto* document = dynamicDowncast<Document>(*this)) {
         RefPtr frame = document->frame();
-        return frame ? frame->checkedScript()->globalObject(mainThreadNormalWorldSingleton()) : nullptr;
+        return frame ? protect(frame->script())->globalObject(mainThreadNormalWorldSingleton()) : nullptr;
     }
 
     if (auto* globalScope = dynamicDowncast<WorkerOrWorkletGlobalScope>(*this)) {

--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -78,7 +78,7 @@ static inline void logBackForwardCacheFailureDiagnosticMessage(Page* page, const
     if (!page)
         return;
 
-    logBackForwardCacheFailureDiagnosticMessage(page->checkedDiagnosticLoggingClient(), reason);
+    logBackForwardCacheFailureDiagnosticMessage(protect(page->diagnosticLoggingClient()), reason);
 }
 
 static bool canCacheFrame(LocalFrame& frame, DiagnosticLoggingClient& diagnosticLoggingClient, unsigned indentLevel)

--- a/Source/WebCore/history/CachedFrame.cpp
+++ b/Source/WebCore/history/CachedFrame.cpp
@@ -119,7 +119,7 @@ void CachedFrameBase::restore()
         // It is necessary to update any platform script objects after restoring the
         // cached page.
         if (localFrame) {
-            localFrame->checkedScript()->updatePlatformScriptObjects();
+            protect(localFrame->script())->updatePlatformScriptObjects();
             localFrame->loader().client().didRestoreFromBackForwardCache();
         }
 

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -157,7 +157,7 @@ void CachedPage::restore(Page& page)
         if (frameView)
             frameView->setProhibitsScrolling(hadProhibitsScrolling);
         if (localMainFrame)
-            localMainFrame->checkedSelection()->restoreScrolling();
+            protect(localMainFrame->selection())->restoreScrolling();
 #endif
     }
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -183,7 +183,7 @@ void HTMLCanvasElement::attributeChanged(const QualifiedName& name, const AtomSt
 RenderPtr<RenderElement> HTMLCanvasElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& insertionPosition)
 {
     RefPtr frame = document().frame();
-    if (frame && frame->checkedScript()->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
+    if (frame && protect(frame->script())->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
         return createRenderer<RenderHTMLCanvas>(*this, WTF::move(style));
     return HTMLElement::createElementRenderer(WTF::move(style), insertionPosition);
 }
@@ -191,7 +191,7 @@ RenderPtr<RenderElement> HTMLCanvasElement::createElementRenderer(RenderStyle&& 
 bool HTMLCanvasElement::isReplaced(const RenderStyle*) const
 {
     RefPtr frame = document().frame();
-    return frame && frame->checkedScript()->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript);
+    return frame && protect(frame->script())->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript);
 }
 
 bool HTMLCanvasElement::canContainRangeEndPoint() const

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -206,7 +206,7 @@ static bool isFrameLazyLoadable(const Document& document, const URL& url, const 
     if (!url.isValid() || url.isAboutBlank())
         return false;
 
-    if (RefPtr frame = document.frame(); !frame || !frame->checkedScript()->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
+    if (RefPtr frame = document.frame(); !frame || !protect(frame->script())->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
         return false;
 
     return equalLettersIgnoringASCIICase(loadingAttributeValue, "lazy"_s);

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -989,7 +989,7 @@ bool HTMLImageElement::isDeferred() const
 
 bool HTMLImageElement::isLazyLoadable() const
 {
-    if (!document().frame() || !document().frame()->checkedScript()->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
+    if (!document().frame() || !protect(document().frame()->script())->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript))
         return false;
     return hasLazyLoadableAttributeValue(attributeWithoutSynchronization(HTMLNames::loadingAttr));
 }

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -157,7 +157,7 @@ JSC::Bindings::Instance* HTMLPlugInElement::bindingsInstance()
 
     if (!m_instance) {
         if (RefPtr widget = pluginWidget())
-            m_instance = frame->checkedScript()->createScriptInstanceForWidget(widget.get());
+            m_instance = protect(frame->script())->createScriptInstanceForWidget(widget.get());
     }
     return m_instance.get();
 }

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -765,7 +765,7 @@ bool TextFieldInputType::shouldDrawCapsLockIndicator() const
     if (!frame)
         return false;
 
-    if (!frame->checkedSelection()->isFocusedAndActive())
+    if (!protect(frame->selection())->isFocusedAndActive())
         return false;
 
     return PlatformKeyboardEvent::currentCapsLockState();

--- a/Source/WebCore/html/parser/HTMLParserOptions.cpp
+++ b/Source/WebCore/html/parser/HTMLParserOptions.cpp
@@ -47,7 +47,7 @@ HTMLParserOptions::HTMLParserOptions(Document& document)
     if (document.settings().htmlParserScriptingFlagPolicy() == HTMLParserScriptingFlagPolicy::Enabled)
         scriptingFlag = true;
     else
-        scriptingFlag = frame && frame->checkedScript()->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript) && document.allowsContentJavaScript();
+        scriptingFlag = frame && protect(frame->script())->canExecuteScripts(ReasonForCallingCanExecuteScripts::NotAboutToExecuteScript) && document.allowsContentJavaScript();
 
     usePreHTML5ParserQuirks = document.settings().usePreHTML5ParserQuirks();
     enhancedSelect = document.settings().htmlEnhancedSelectParsingEnabled();

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -259,7 +259,7 @@ void MediaControlTextTrackContainerElement::updateActiveCuesFontSize()
     if (!mediaElement)
         return;
 
-    float fontScale = document().page()->checkedGroup()->ensureProtectedCaptionPreferences()->captionFontSizeScaleAndImportance(m_fontSizeIsImportant);
+    float fontScale = protect(document().page()->group())->ensureProtectedCaptionPreferences()->captionFontSizeScaleAndImportance(m_fontSizeIsImportant);
 
     // Caption fonts are defined as |size vh| units, so there's no need to
     // scale by display size. Since |vh| is a decimal percentage, multiply
@@ -295,7 +295,7 @@ void MediaControlTextTrackContainerElement::updateTextStrokeStyle()
     bool important;
 
     // FIXME: find a way to set this property in the stylesheet like the other user style preferences, see <https://bugs.webkit.org/show_bug.cgi?id=169874>.
-    if (document().page()->checkedGroup()->ensureProtectedCaptionPreferences()->captionStrokeWidthForFont(m_fontSize, language, strokeWidth, important))
+    if (protect(document().page()->group())->ensureProtectedCaptionPreferences()->captionStrokeWidthForFont(m_fontSize, language, strokeWidth, important))
         setInlineStyleProperty(CSSPropertyStrokeWidth, strokeWidth, CSSUnitType::CSS_PX, important ? IsImportant::Yes : IsImportant::No);
 }
 
@@ -434,7 +434,7 @@ void MediaControlTextTrackContainerElement::captionPreferencesChanged()
 {
     if (RefPtr page = document().page()) {
         if (RefPtr previewCue = m_previewCue) {
-            previewCue->setText(page->checkedGroup()->ensureProtectedCaptionPreferences()->captionPreviewTitle());
+            previewCue->setText(protect(page->group())->ensureProtectedCaptionPreferences()->captionPreviewTitle());
             previewCue->updateDisplayTree(MediaTime::zeroTime());
         }
     }
@@ -561,7 +561,7 @@ VTTCue& MediaControlTextTrackContainerElement::ensurePreviewCue() const
         m_previewCue->setIsActive(true);
 
         if (RefPtr page = document().page())
-            m_previewCue->setText(page->checkedGroup()->ensureProtectedCaptionPreferences()->captionPreviewTitle());
+            m_previewCue->setText(protect(page->group())->ensureProtectedCaptionPreferences()->captionPreviewTitle());
 
         m_previewTrack->addCue(*m_previewCue);
     }

--- a/Source/WebCore/loader/DocumentWriter.cpp
+++ b/Source/WebCore/loader/DocumentWriter.cpp
@@ -201,7 +201,7 @@ bool DocumentWriter::begin(const URL& urlReference, bool dispatch, Document* own
         return false;
 
     if (!shouldReuseDefaultView)
-        frame->checkedScript()->updatePlatformScriptObjects();
+        protect(frame->script())->updatePlatformScriptObjects();
 
     frameLoader->setOutgoingReferrer(url);
     frame->setDocument(document.copyRef());

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -613,7 +613,7 @@ void HistoryController::updateForRedirectWithLockedBackForwardList()
             if (RefPtr parentCurrentItem = parentFrame->loader().history().currentItem()) {
                 Ref item = createItem(page->historyItemClient(), parentCurrentItem->itemID());
                 parentCurrentItem->setChildItem(item.copyRef());
-                page->checkedBackForward()->setChildItem(parentCurrentItem->frameItemID(), WTF::move(item));
+                protect(page->backForward())->setChildItem(parentCurrentItem->frameItemID(), WTF::move(item));
             }
         }
     }
@@ -1008,7 +1008,7 @@ void HistoryController::updateBackForwardListClippedAtTarget(bool doClip)
     if (!item)
         return;
     LOG(History, "HistoryController %p updateBackForwardListClippedAtTarget: Adding backforward item %p in frame %p (main frame %d) %s", this, item.get(), m_frame.ptr(), m_frame->isMainFrame(), m_frame->loader().documentLoader()->url().string().utf8().data());
-    page->checkedBackForward()->addItem(item.releaseNonNull());
+    protect(page->backForward())->addItem(item.releaseNonNull());
 }
 
 void HistoryController::updateCurrentItem()
@@ -1071,7 +1071,7 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
 
     LOG(History, "HistoryController %p pushState: Adding top item %p, setting url of current item %p to %s, scrollRestoration is %s", this, topItem.ptr(), m_currentItem.get(), urlString.ascii().data(), topItem->shouldRestoreScrollPosition() ? "auto" : "manual");
 
-    page->checkedBackForward()->addItem(WTF::move(topItem));
+    protect(page->backForward())->addItem(WTF::move(topItem));
 
     if (!canRecordHistoryForFrame(frame))
         return;

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -303,12 +303,12 @@ public:
             return;
 
         RefPtr page { localFrame->page() };
-        if (!page || !page->checkedBackForward()->containsItem(m_historyItem))
+        if (!page || !protect(page->backForward())->containsItem(m_historyItem))
             return;
 
         UserGestureIndicator gestureIndicator(userGestureToForward());
 
-        if (RefPtr currentItem = page->checkedBackForward()->currentItem(); currentItem && currentItem->itemID() == m_historyItem->itemID()) {
+        if (RefPtr currentItem = protect(page->backForward())->currentItem(); currentItem && currentItem->itemID() == m_historyItem->itemID()) {
             localFrame->loader().changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
             return;
         }
@@ -324,7 +324,7 @@ public:
             return false;
 
         RefPtr page { localFrame->page() };
-        if (!page || !page->checkedBackForward()->containsItem(m_historyItem))
+        if (!page || !protect(page->backForward())->containsItem(m_historyItem))
             return false;
 
         URL url { m_historyItem->url() };
@@ -368,7 +368,7 @@ public:
         bool backwards = entry->index() < localFrame.window()->navigation().currentEntry()->index();
 
         RefPtr page { localFrame.page() };
-        auto items = page->checkedBackForward()->allItems();
+        auto items = protect(page->backForward())->allItems();
         for (size_t i = 0 ; i < items.size(); i++) {
             Ref item = items[backwards ? items.size() - 1 - i: i];
             auto index = item->children().findIf([&historyItem](const auto& child) {
@@ -399,7 +399,7 @@ public:
 
         UserGestureIndicator gestureIndicator(userGestureToForward());
 
-        if (RefPtr currentItem = page->checkedBackForward()->currentItem(); currentItem && currentItem->itemID() == (*historyItem)->itemID()) {
+        if (RefPtr currentItem = protect(page->backForward())->currentItem(); currentItem && currentItem->itemID() == (*historyItem)->itemID()) {
             if (RefPtr localFrame = dynamicDowncast<LocalFrame>(frame))
                 localFrame->loader().changeLocation(localFrame->document()->url(), selfTargetFrameName(), 0, ReferrerPolicy::EmptyString, shouldOpenExternalURLs(), std::nullopt, nullAtom(), std::nullopt, NavigationHistoryBehavior::Reload);
             return;

--- a/Source/WebCore/loader/ResourceLoadNotifier.cpp
+++ b/Source/WebCore/loader/ResourceLoadNotifier.cpp
@@ -71,7 +71,7 @@ void ResourceLoadNotifier::didReceiveResponse(ResourceLoader& loader, ResourceLo
     loader.documentLoader()->addResponse(r);
 
     if (RefPtr page = m_frame->page())
-        page->checkedProgress()->incrementProgress(identifier, r);
+        protect(page->progress())->incrementProgress(identifier, r);
 
     dispatchDidReceiveResponse(protect(loader.documentLoader()), identifier, r, &loader);
 }
@@ -79,7 +79,7 @@ void ResourceLoadNotifier::didReceiveResponse(ResourceLoader& loader, ResourceLo
 void ResourceLoadNotifier::didReceiveData(ResourceLoader& loader, ResourceLoaderIdentifier identifier, const SharedBuffer& buffer, int encodedDataLength)
 {
     if (RefPtr page = m_frame->page())
-        page->checkedProgress()->incrementProgress(identifier, buffer.size());
+        protect(page->progress())->incrementProgress(identifier, buffer.size());
 
     dispatchDidReceiveData(protect(loader.documentLoader()), identifier, &buffer, buffer.size(), encodedDataLength);
 }
@@ -87,7 +87,7 @@ void ResourceLoadNotifier::didReceiveData(ResourceLoader& loader, ResourceLoader
 void ResourceLoadNotifier::didFinishLoad(ResourceLoader& loader, ResourceLoaderIdentifier identifier, const NetworkLoadMetrics& networkLoadMetrics)
 {    
     if (RefPtr page = m_frame->page())
-        page->checkedProgress()->completeProgress(identifier);
+        protect(page->progress())->completeProgress(identifier);
 
     dispatchDidFinishLoading(protect(loader.documentLoader()), identifier, networkLoadMetrics, &loader);
 }
@@ -98,7 +98,7 @@ void ResourceLoadNotifier::didFailToLoad(ResourceLoader& loader, ResourceLoaderI
     if (!page) // This may be called during the frame's destruction after detaching from parent page.
         return;
 
-    page->checkedProgress()->completeProgress(identifier);
+    protect(page->progress())->completeProgress(identifier);
 
     // Notifying the LocalFrameLoaderClient may cause the frame to be destroyed.
     Ref frame = m_frame.get();

--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -427,11 +427,11 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
         break;
     case ContextMenuItemTagGoBack:
         if (RefPtr page = frame->page())
-            page->checkedBackForward()->goBackOrForward(-1);
+            protect(page->backForward())->goBackOrForward(-1);
         break;
     case ContextMenuItemTagGoForward:
         if (RefPtr page = frame->page())
-            page->checkedBackForward()->goBackOrForward(1);
+            protect(page->backForward())->goBackOrForward(1);
         break;
     case ContextMenuItemTagStop:
         frame->loader().stop();
@@ -498,7 +498,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
                 ASSERT(selection.isCaretOrRange());
                 VisibleSelection wordSelection(selection.base());
                 wordSelection.expandUsingGranularity(TextGranularity::WordGranularity);
-                frame->checkedSelection()->setSelection(wordSelection);
+                protect(frame->selection())->setSelection(wordSelection);
             } else {
                 ASSERT(frame->editor().selectedText().length());
                 replaceOptions.add(ReplaceSelectionCommand::SelectReplacement);
@@ -508,7 +508,7 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
             ASSERT(document);
             Ref command = ReplaceSelectionCommand::create(*document, createFragmentFromMarkup(*document, title, emptyString()), replaceOptions);
             command->apply();
-            frame->checkedSelection()->revealSelection({ SelectionRevealMode::Reveal, ScrollAlignment::alignToEdgeIfNeeded });
+            protect(frame->selection())->revealSelection({ SelectionRevealMode::Reveal, ScrollAlignment::alignToEdgeIfNeeded });
         }
         break;
     }
@@ -1270,10 +1270,10 @@ void ContextMenuController::populate()
 #else
 
                 if (isMainFrame) {
-                    if (page && page->checkedBackForward()->canGoBackOrForward(-1))
+                    if (page && protect(page->backForward())->canGoBackOrForward(-1))
                         appendItem(BackItem, m_contextMenu.get());
 
-                    if (page && page->checkedBackForward()->canGoBackOrForward(1))
+                    if (page && protect(page->backForward())->canGoBackOrForward(1))
                         appendItem(ForwardItem, m_contextMenu.get());
 
                     // Here we use isLoadingInAPISense rather than isLoading because Stop/Reload are
@@ -1740,10 +1740,10 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
 #endif
 #if PLATFORM(GTK) || PLATFORM(WPE)
         case ContextMenuItemTagGoBack:
-            shouldEnable = frame->page() && frame->page()->checkedBackForward()->canGoBackOrForward(-1);
+            shouldEnable = frame->page() && protect(frame->page()->backForward())->canGoBackOrForward(-1);
             break;
         case ContextMenuItemTagGoForward:
-            shouldEnable = frame->page() && frame->page()->checkedBackForward()->canGoBackOrForward(1);
+            shouldEnable = frame->page() && protect(frame->page()->backForward())->canGoBackOrForward(1);
             break;
         case ContextMenuItemTagStop:
             shouldEnable = frame->loader().documentLoader()->isLoadingInAPISense();

--- a/Source/WebCore/page/DOMSelection.cpp
+++ b/Source/WebCore/page/DOMSelection.cpp
@@ -155,7 +155,7 @@ unsigned DOMSelection::rangeCount() const
     RefPtr frame = this->frame();
     if (!frame)
         return 0;
-    if (frame->checkedSelection()->associatedLiveRange())
+    if (protect(frame->selection())->associatedLiveRange())
         return 1;
     if (selectionShadowAncestor(*frame))
         return 1;
@@ -280,7 +280,7 @@ void DOMSelection::modify(const String& alterString, const String& directionStri
         return;
 
     if (RefPtr frame = this->frame())
-        frame->checkedSelection()->modify(alter, direction, granularity);
+        protect(frame->selection())->modify(alter, direction, granularity);
 }
 
 ExceptionOr<void> DOMSelection::extend(Node& node, unsigned offset)
@@ -317,7 +317,7 @@ ExceptionOr<Ref<Range>> DOMSelection::getRangeAt(unsigned index)
     if (index >= rangeCount())
         return Exception { ExceptionCode::IndexSizeError };
     Ref frame = this->frame().releaseNonNull();
-    if (RefPtr liveRange = frame->checkedSelection()->associatedLiveRange())
+    if (RefPtr liveRange = protect(frame->selection())->associatedLiveRange())
         return liveRange.releaseNonNull();
     return createLiveRangeBeforeShadowHostWithSelection(frame.get()).releaseNonNull();
 }
@@ -327,7 +327,7 @@ void DOMSelection::removeAllRanges()
     RefPtr frame = this->frame();
     if (!frame)
         return;
-    frame->checkedSelection()->clear();
+    protect(frame->selection())->clear();
 }
 
 void DOMSelection::addRange(Range& liveRange)
@@ -345,7 +345,7 @@ ExceptionOr<void> DOMSelection::removeRange(Range& liveRange)
     RefPtr frame = this->frame();
     if (!frame)
         return { };
-    if (&liveRange != frame->checkedSelection()->associatedLiveRange())
+    if (&liveRange != protect(frame->selection())->associatedLiveRange())
         return Exception { ExceptionCode::NotFoundError };
     removeAllRanges();
     return { };
@@ -400,7 +400,7 @@ void DOMSelection::deleteFromDocument()
     RefPtr frame = this->frame();
     if (!frame)
         return;
-    if (RefPtr range = frame->checkedSelection()->associatedLiveRange())
+    if (RefPtr range = protect(frame->selection())->associatedLiveRange())
         range->deleteContents();
 }
 

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -130,8 +130,8 @@ void DOMWindow::close()
     if (!frame->isMainFrame())
         return;
 
-    if (!(page->openedByDOM() || page->checkedBackForward()->count() <= 1)) {
-        checkedConsole()->addMessage(MessageSource::JS, MessageLevel::Warning, "Can't close the window since it was not opened by JavaScript"_s);
+    if (!(page->openedByDOM() || protect(page->backForward())->count() <= 1)) {
+        protect(console())->addMessage(MessageSource::JS, MessageLevel::Warning, "Can't close the window since it was not opened by JavaScript"_s);
         return;
     }
 
@@ -149,11 +149,6 @@ FrameConsoleClient* DOMWindow::console() const
 {
     RefPtr frame = dynamicDowncast<LocalFrame>(this->frame());
     return frame ? &frame->console() : nullptr;
-}
-
-CheckedPtr<FrameConsoleClient> DOMWindow::checkedConsole() const
-{
-    return console();
 }
 
 RefPtr<Frame> DOMWindow::protectedFrame() const

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -123,7 +123,6 @@ public:
     virtual void closePage() = 0;
 
     FrameConsoleClient* console() const;
-    CheckedPtr<FrameConsoleClient> checkedConsole() const;
 
     WindowProxy* opener() const;
     WEBCORE_EXPORT Document* documentIfLocal();

--- a/Source/WebCore/page/DeviceController.cpp
+++ b/Source/WebCore/page/DeviceController.cpp
@@ -56,7 +56,7 @@ void DeviceController::addDeviceEventListener(LocalDOMWindow& window)
     }
 
     if (wasEmpty)
-        checkedClient()->startUpdating();
+        protect(client())->startUpdating();
 }
 
 void DeviceController::removeDeviceEventListener(LocalDOMWindow& window)
@@ -64,7 +64,7 @@ void DeviceController::removeDeviceEventListener(LocalDOMWindow& window)
     m_listeners.remove(&window);
     m_lastEventListeners.remove(&window);
     if (m_listeners.isEmpty())
-        checkedClient()->stopUpdating();
+        protect(client())->stopUpdating();
 }
 
 void DeviceController::removeAllDeviceEventListeners(LocalDOMWindow& window)
@@ -72,7 +72,7 @@ void DeviceController::removeAllDeviceEventListeners(LocalDOMWindow& window)
     m_listeners.removeAll(&window);
     m_lastEventListeners.removeAll(&window);
     if (m_listeners.isEmpty())
-        checkedClient()->stopUpdating();
+        protect(client())->stopUpdating();
 }
 
 bool DeviceController::hasDeviceEventListener(LocalDOMWindow& window) const
@@ -103,11 +103,6 @@ void DeviceController::fireDeviceEvent()
                 listener->dispatchEvent(*lastEvent);
         }
     }
-}
-
-CheckedRef<DeviceClient> DeviceController::checkedClient()
-{
-    return client();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/DeviceController.h
+++ b/Source/WebCore/page/DeviceController.h
@@ -61,7 +61,6 @@ public:
 
 private:
     void fireDeviceEvent();
-    CheckedRef<DeviceClient> checkedClient();
 
     HashCountedSet<RefPtr<LocalDOMWindow>> m_listeners;
     HashCountedSet<RefPtr<LocalDOMWindow>> m_lastEventListeners;

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -487,7 +487,7 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
             clearDragCaret();
 
         RefPtr innerFrame = element->document().frame();
-        dragOperation = dragIsMove(innerFrame->checkedSelection().get(), dragData) ? DragOperation::Move : DragOperation::Copy;
+        dragOperation = dragIsMove(protect(innerFrame->selection()), dragData) ? DragOperation::Move : DragOperation::Copy;
 
         unsigned numberOfFiles = dragData.numberOfFiles();
         if (RefPtr fileInput = m_fileInputElementUnderMouse) {
@@ -555,7 +555,7 @@ static bool setSelectionToDragCaret(LocalFrame* frame, VisibleSelection& dragCar
     frame->selection().setSelection(dragCaret);
     if (frame->selection().selection().isNone()) {
         dragCaret = frame->visiblePositionForPoint(point);
-        frame->checkedSelection()->setSelection(dragCaret);
+        protect(frame->selection())->setSelection(dragCaret);
     }
     return !frame->selection().isNone() && frame->selection().selection().isContentEditable();
 }
@@ -905,7 +905,7 @@ static void selectElement(Element& element)
 {
     if (RefPtr frame = element.document().frame()) {
         if (auto range = makeRangeSelectingNode(element))
-            frame->checkedSelection()->setSelection(*range);
+            protect(frame->selection())->setSelection(*range);
     }
 }
 
@@ -1199,7 +1199,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
             // the enclosing anchor element
             Position pos = sourceSelection.base();
             if (RefPtr node = enclosingAnchorElement(pos))
-                src.checkedSelection()->setSelection(VisibleSelection::selectionFromContentsOfNode(node.get()));
+                protect(src.selection())->setSelection(VisibleSelection::selectionFromContentsOfNode(node.get()));
         }
 
         client().willPerformDragSourceAction(DragSourceAction::Link, dragOrigin, dataTransfer);
@@ -1268,7 +1268,7 @@ bool DragController::startDrag(LocalFrame& src, const DragState& state, OptionSe
         }
         doSystemDrag(WTF::move(dragImage), dragLoc, dragOrigin, src, state, WTF::move(promisedAttachment), rootFrameID);
         if (!element->isContentRichlyEditable())
-            src.checkedSelection()->setSelection(previousSelection);
+            protect(src.selection())->setSelection(previousSelection);
         protect(src.editor())->setIgnoreSelectionChanges(false);
         return true;
     }
@@ -1537,7 +1537,7 @@ void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>
         fragment->appendChild(WTF::move(image));
     }
 
-    frame->checkedSelection()->setSelection(dropCaret);
+    protect(frame->selection())->setSelection(dropCaret);
 
     Ref command = ReplaceSelectionCommand::create(*document, WTF::move(fragment), { ReplaceSelectionCommand::PreventNesting, ReplaceSelectionCommand::SmartReplace }, EditAction::InsertFromDrop);
     command->apply();
@@ -1578,7 +1578,7 @@ void DragController::insertDroppedImagePlaceholdersAtCaret(const Vector<IntSize>
     m_droppedImagePlaceholders = WTF::move(placeholders);
     m_droppedImagePlaceholderRange = WTF::move(insertedContentRange);
 
-    frame->checkedSelection()->clear();
+    protect(frame->selection())->clear();
     caretController.setCaretPosition(makeDeprecatedLegacyPosition(m_droppedImagePlaceholderRange->start));
 }
 

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -5052,9 +5052,9 @@ void EventHandler::defaultBackspaceEventHandler(KeyboardEvent& event)
     bool handledEvent = false;
 
     if (event.shiftKey())
-        handledEvent = page->checkedBackForward()->goForward();
+        handledEvent = protect(page->backForward())->goForward();
     else
-        handledEvent = page->checkedBackForward()->goBack();
+        handledEvent = protect(page->backForward())->goBack();
 
     if (handledEvent)
         event.setDefaultHandled();

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -543,7 +543,7 @@ void FocusController::setFocusedInternal(bool focused)
 
     RefPtr focusedFrame = focusedLocalFrame();
     if (focusedFrame && focusedFrame->view()) {
-        focusedFrame->checkedSelection()->setFocused(focused);
+        protect(focusedFrame->selection())->setFocused(focused);
         dispatchEventsOnWindowAndFocusedElement(protect(focusedFrame->document()).get(), focused);
     }
 }

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -82,7 +82,7 @@ ExceptionOr<unsigned> History::length() const
     RefPtr page = frame->page();
     if (!page)
         return 0;
-    return page->checkedBackForward()->count();
+    return protect(page->backForward())->count();
 }
 
 ExceptionOr<History::ScrollRestoration> History::scrollRestoration() const

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -173,11 +173,8 @@ public:
 
     inline FrameSelection& selection(); // Defined in LocalFrameInlines.h
     inline const FrameSelection& selection() const; // Defined in LocalFrameInlines.h
-    CheckedRef<FrameSelection> checkedSelection() const; // Defined in LocalFrameInlines.h
     ScriptController& script() { return m_script; }
     const ScriptController& script() const { return m_script; }
-    WEBCORE_EXPORT CheckedRef<ScriptController> checkedScript();
-    WEBCORE_EXPORT CheckedRef<const ScriptController> checkedScript() const;
     void resetScript();
 
     bool isRootFrame() const final { return m_rootFrame.get() == this; }
@@ -185,7 +182,6 @@ public:
     LocalFrame& rootFrame() { return *m_rootFrame; }
 
     WEBCORE_EXPORT RenderView* contentRenderer() const; // Root of the render tree for the document contained in this frame.
-    WEBCORE_EXPORT CheckedPtr<RenderView> checkedContentRenderer() const;
 
     bool documentIsBeingReplaced() const { return m_documentIsBeingReplaced; }
 

--- a/Source/WebCore/page/LocalFrameInlines.h
+++ b/Source/WebCore/page/LocalFrameInlines.h
@@ -64,9 +64,4 @@ inline const FrameSelection& LocalFrame::selection() const
     return document()->selection();
 }
 
-inline CheckedRef<FrameSelection> LocalFrame::checkedSelection() const
-{
-    return document()->selection();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4665,16 +4665,6 @@ void LocalFrameView::flushAnyPendingPostLayoutTasks()
         updateEmbeddedObjectsTimerFired();
 }
 
-CheckedRef<const LocalFrameViewLayoutContext> LocalFrameView::checkedLayoutContext() const
-{
-    return m_layoutContext;
-}
-
-CheckedRef<LocalFrameViewLayoutContext> LocalFrameView::checkedLayoutContext()
-{
-    return m_layoutContext;
-}
-
 void LocalFrameView::performPostLayoutTasks()
 {
     ScriptDisallowedScope::InMainThread scriptDisallowedScope;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -128,8 +128,6 @@ public:
 
     const LocalFrameViewLayoutContext& layoutContext() const { return m_layoutContext; }
     LocalFrameViewLayoutContext& layoutContext() { return m_layoutContext; }
-    CheckedRef<const LocalFrameViewLayoutContext> checkedLayoutContext() const;
-    CheckedRef<LocalFrameViewLayoutContext> checkedLayoutContext();
 
     WEBCORE_EXPORT bool didFirstLayout() const;
 

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -465,7 +465,6 @@ public:
     WEBCORE_EXPORT const String& groupName() const;
 
     WEBCORE_EXPORT PageGroup& group();
-    WEBCORE_EXPORT CheckedRef<PageGroup> checkedGroup();
 
     BroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry; }
     WEBCORE_EXPORT void setBroadcastChannelRegistry(Ref<BroadcastChannelRegistry>&&); // Only used by WebKitLegacy.
@@ -512,8 +511,6 @@ public:
     WEBCORE_EXPORT void enableICECandidateFiltering();
     bool shouldEnableICECandidateFilteringByDefault() const { return m_shouldEnableICECandidateFilteringByDefault; }
 
-    WEBCORE_EXPORT CheckedRef<ElementTargetingController> checkedElementTargetingController();
-
     void didChangeMainDocument(Document* newDocument);
     void mainFrameDidChangeToNonInitialEmptyDocument();
 
@@ -542,15 +539,13 @@ public:
 
     ProgressTracker& progress() { return m_progress.get(); }
     const ProgressTracker& progress() const { return m_progress.get(); }
-    CheckedRef<ProgressTracker> checkedProgress();
-    CheckedRef<const ProgressTracker> checkedProgress() const;
 
     WEBCORE_EXPORT void applyWindowFeatures(const WindowFeatures&);
 
     void progressEstimateChanged(LocalFrame&) const;
     void progressFinished(LocalFrame&) const;
     BackForwardController& backForward() { return m_backForwardController.get(); }
-    WEBCORE_EXPORT CheckedRef<BackForwardController> checkedBackForward();
+    ElementTargetingController& elementTargetingController() { return m_elementTargetingController.get(); }
 
     Seconds domTimerAlignmentInterval() const { return m_domTimerAlignmentInterval; }
 
@@ -729,7 +724,6 @@ public:
     WEBCORE_EXPORT unsigned pageCountAssumingLayoutIsUpToDate() const;
 
     WEBCORE_EXPORT DiagnosticLoggingClient& diagnosticLoggingClient() const;
-    WEBCORE_EXPORT CheckedRef<DiagnosticLoggingClient> checkedDiagnosticLoggingClient() const;
 
     WEBCORE_EXPORT void logMediaDiagnosticMessage(const RefPtr<FormData>&) const;
 
@@ -1448,7 +1442,6 @@ private:
     void prioritizeVisibleResources();
 
     RenderingUpdateScheduler& renderingUpdateScheduler();
-    CheckedRef<RenderingUpdateScheduler> checkedRenderingUpdateScheduler();
     RenderingUpdateScheduler* NODELETE existingRenderingUpdateScheduler();
 
     WheelEventTestMonitor& ensureWheelEventTestMonitor();

--- a/Source/WebCore/page/TextIndicator.cpp
+++ b/Source/WebCore/page/TextIndicator.cpp
@@ -403,7 +403,7 @@ static bool initializeIndicator(TextIndicatorData& data, LocalFrame& frame, cons
 
     // Store the selection rect in window coordinates, to be used subsequently
     // to determine if the indicator and selection still precisely overlap.
-    data.selectionRectInRootViewCoordinates = protect(frame.view())->contentsToRootView(enclosingIntRect(frame.checkedSelection()->selectionBounds(FrameSelection::ClipToVisibleContent::No)));
+    data.selectionRectInRootViewCoordinates = protect(frame.view())->contentsToRootView(enclosingIntRect(protect(frame.selection())->selectionBounds(FrameSelection::ClipToVisibleContent::No)));
     data.textBoundingRectInRootViewCoordinates = textBoundingRectInRootViewCoordinates;
     data.textRectsInBoundingRectCoordinates = WTF::move(textRectsInBoundingRectCoordinates);
 

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -92,7 +92,7 @@ JSC::JSValue WebKitNamespace::evaluateScript(JSC::JSGlobalObject& globalObject, 
     if (!frame)
         return JSC::jsNull();
     WTFBeginSignpost(this, EvaluateJavaScriptFromBuffer, "evaluateScript(url: %" PRIVATE_LOG_STRING ")", url.ascii().data());
-    auto result = frame->checkedScript()->evaluateInWorldIgnoringException(ScriptSourceCode { source, JSC::SourceTaintedOrigin::Untainted, URL { url } }, world);
+    auto result = protect(frame->script())->evaluateInWorldIgnoringException(ScriptSourceCode { source, JSC::SourceTaintedOrigin::Untainted, URL { url } }, world);
     WTFEndSignpost(this, EvaluateJavaScriptFromBuffer);
     return result;
 }

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -2184,7 +2184,7 @@ void applyRules(const String& input, std::optional<NodeIdentifier>&& containerNo
                 return jsNull();
 
             JSLockHolder lock { &lexicalGlobalObject };
-            return toJS(&lexicalGlobalObject, mainFrame->checkedScript()->globalObject(world), *containerNode);
+            return toJS(&lexicalGlobalObject, protect(mainFrame->script())->globalObject(world), *containerNode);
         });
         return std::make_optional(WTF::move(argumentMap));
     };
@@ -2222,7 +2222,7 @@ void applyRules(const String& input, std::optional<NodeIdentifier>&& containerNo
         };
 
         JSLockHolder lock(commonVM());
-        mainFrame->checkedScript()->executeAsynchronousUserAgentScriptInWorld(world, WTF::move(parameters), [document, aggregator, filteredStrings](auto valueOrException) {
+        protect(mainFrame->script())->executeAsynchronousUserAgentScriptInWorld(world, WTF::move(parameters), [document, aggregator, filteredStrings](auto valueOrException) {
             if (!valueOrException)
                 return;
 

--- a/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
+++ b/Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm
@@ -508,7 +508,7 @@ void PlaybackSessionModelMediaElement::updateMediaSelectionOptions()
     if (!mediaElement->document().page())
         return;
 
-    Ref captionPreferences = mediaElement->document().page()->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = protect(mediaElement->document().page()->group())->ensureCaptionPreferences();
     auto* textTracks = mediaElement->textTracks();
     if (textTracks && textTracks->length())
         m_legibleTracksForMenu = captionPreferences->sortedTrackListForMenu(textTracks, { TextTrack::Kind::Subtitles, TextTrack::Kind::Captions, TextTrack::Kind::Descriptions });
@@ -710,7 +710,7 @@ Vector<MediaSelectionOption> PlaybackSessionModelMediaElement::audioMediaSelecti
     if (!mediaElement || !mediaElement->document().page())
         return { };
 
-    Ref captionPreferences = mediaElement->document().page()->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = protect(mediaElement->document().page()->group())->ensureCaptionPreferences();
     return m_audioTracksForMenu.map([&](auto& audioTrack) {
         return captionPreferences->mediaSelectionOptionForTrack(audioTrack.get());
     });
@@ -733,7 +733,7 @@ Vector<MediaSelectionOption> PlaybackSessionModelMediaElement::legibleMediaSelec
     if (!mediaElement || !mediaElement->document().page())
         return { };
 
-    Ref captionPreferences = mediaElement->document().page()->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = protect(mediaElement->document().page()->group())->ensureCaptionPreferences();
     return m_legibleTracksForMenu.map([&](auto& track) {
         return captionPreferences->mediaSelectionOptionForTrack(track.get());
     });

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -591,10 +591,10 @@ void RenderObject::clearNeedsLayout(HadSkippedLayout hadSkippedLayout)
 void RenderObject::scheduleLayout(RenderElement* layoutRoot)
 {
     if (auto* renderView = dynamicDowncast<RenderView>(layoutRoot))
-        return renderView->frameView().checkedLayoutContext()->scheduleLayout();
+        return protect(renderView->frameView().layoutContext())->scheduleLayout();
 
     if (layoutRoot && layoutRoot->isRooted())
-        layoutRoot->view().frameView().checkedLayoutContext()->scheduleSubtreeLayout(*layoutRoot);
+        protect(layoutRoot->view().frameView().layoutContext())->scheduleSubtreeLayout(*layoutRoot);
 }
 
 RenderElement* RenderObject::markContainingBlocksForLayout(RenderElement* layoutRoot)

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1264,7 +1264,7 @@ bool RenderTheme::isFocused(const RenderElement& renderer) const
 
     Ref document = delegate->document();
     RefPtr frame = document->frame();
-    return delegate == document->focusedElement() && frame && frame->checkedSelection()->isFocusedAndActive();
+    return delegate == document->focusedElement() && frame && protect(frame->selection())->isFocusedAndActive();
 }
 
 bool RenderTheme::isPressed(const RenderElement& renderer) const

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -1917,7 +1917,7 @@ static void paintAttachmentTitleBackground(const RenderAttachment& attachment, G
         return line.backgroundRect;
     });
 
-    auto backgroundColor = colorFromCocoaColor(attachment.frame().checkedSelection()->isFocusedAndActive() ? [NSColor selectedContentBackgroundColor] : [NSColor unemphasizedSelectedContentBackgroundColor]);
+    auto backgroundColor = colorFromCocoaColor(protect(attachment.frame().selection())->isFocusedAndActive() ? [NSColor selectedContentBackgroundColor] : [NSColor unemphasizedSelectedContentBackgroundColor]);
 
     Style::ColorResolver colorResolver { attachment.style() };
 

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -332,7 +332,7 @@ bool SVGSVGElement::checkEnclosure(Ref<SVGElement>&& element, SVGRect& rect)
 void SVGSVGElement::deselectAll()
 {
     if (RefPtr frame = document().frame())
-        frame->checkedSelection()->clear();
+        protect(frame->selection())->clear();
 }
 
 Ref<SVGNumber> SVGSVGElement::createSVGNumber()

--- a/Source/WebCore/testing/InternalSettings.cpp
+++ b/Source/WebCore/testing/InternalSettings.cpp
@@ -447,7 +447,7 @@ ExceptionOr<void> InternalSettings::setShouldDisplayTrackKind(TrackKind kind, bo
     if (!m_page)
         return Exception { ExceptionCode::InvalidAccessError };
 #if ENABLE(VIDEO)
-    Ref captionPreferences = m_page->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = protect(m_page->group())->ensureCaptionPreferences();
     switch (kind) {
     case TrackKind::Subtitles:
         captionPreferences->setUserPrefersSubtitles(enabled);
@@ -471,7 +471,7 @@ ExceptionOr<bool> InternalSettings::shouldDisplayTrackKind(TrackKind kind)
     if (!m_page)
         return Exception { ExceptionCode::InvalidAccessError };
 #if ENABLE(VIDEO)
-    Ref captionPreferences = m_page->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = protect(m_page->group())->ensureCaptionPreferences();
     switch (kind) {
     case TrackKind::Subtitles:
         return captionPreferences->userPrefersSubtitles();

--- a/Source/WebCore/xml/XMLTreeViewer.cpp
+++ b/Source/WebCore/xml/XMLTreeViewer.cpp
@@ -59,8 +59,8 @@ void XMLTreeViewer::transformDocumentToTreeView()
     String scriptString = StringImpl::createWithoutCopying(XMLViewer_js);
     Ref document = m_document.get();
     RefPtr frame = document->frame();
-    frame->checkedScript()->evaluateIgnoringException(ScriptSourceCode(scriptString, JSC::SourceTaintedOrigin::Untainted));
-    frame->checkedScript()->evaluateIgnoringException(ScriptSourceCode(AtomString("prepareWebKitXMLViewer('This XML file does not appear to have any style information associated with it. The document tree is shown below.');"_s), JSC::SourceTaintedOrigin::Untainted));
+    protect(frame->script())->evaluateIgnoringException(ScriptSourceCode(scriptString, JSC::SourceTaintedOrigin::Untainted));
+    protect(frame->script())->evaluateIgnoringException(ScriptSourceCode(AtomString("prepareWebKitXMLViewer('This XML file does not appear to have any style information associated with it. The document tree is shown below.');"_s), JSC::SourceTaintedOrigin::Untainted));
 
     String cssString = StringImpl::createWithoutCopying(XMLViewer_css);
     Ref text = document->createTextNode(WTF::move(cssString));

--- a/Source/WebKit/Shared/EditingRange.cpp
+++ b/Source/WebKit/Shared/EditingRange.cpp
@@ -46,7 +46,7 @@ std::optional<WebCore::SimpleRange> EditingRange::toRange(WebCore::LocalFrame& f
         // directly in the document DOM, so serialization is problematic. Our solution is
         // to use the root editable element of the selection start as the positional base.
         // That fits with AppKit's idea of an input context.
-        RefPtr element = frame.checkedSelection()->rootEditableElementOrDocumentElement();
+        RefPtr element = protect(frame.selection())->rootEditableElementOrDocumentElement();
         if (!element)
             return std::nullopt;
         return resolveCharacterRange(makeRangeSelectingNodeContents(*element), range);
@@ -69,7 +69,7 @@ EditingRange EditingRange::fromRange(WebCore::LocalFrame& frame, const std::opti
     if (!range)
         return { };
 
-    RefPtr element = frame.checkedSelection()->rootEditableElementOrDocumentElement();
+    RefPtr element = protect(frame.selection())->rootEditableElementOrDocumentElement();
     if (!element)
         return { };
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -722,7 +722,7 @@ void WKBundlePageSetCaptionDisplayMode(WKBundlePageRef pageRef, WKStringRef mode
     RefPtr page = WebKit::toImpl(pageRef)->corePage();
     if (!page)
         return;
-    Ref captionPreferences = page->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = protect(page->group())->ensureCaptionPreferences();
     auto displayMode = WTF::EnumTraits<WebCore::CaptionUserPreferences::CaptionDisplayMode>::fromString(WebKit::toWTFString(mode));
     if (displayMode.has_value())
         captionPreferences->setCaptionDisplayMode(displayMode.value());
@@ -738,7 +738,7 @@ WKCaptionUserPreferencesTestingModeTokenRef WKBundlePageCreateCaptionUserPrefere
     RefPtr page = WebKit::toImpl(pageRef)->corePage();
     if (!page)
         return { };
-    Ref captionPreferences = page->checkedGroup()->ensureCaptionPreferences();
+    Ref captionPreferences = protect(page->group())->ensureCaptionPreferences();
     return WebKit::toAPILeakingRef(API::CaptionUserPreferencesTestingModeToken::create(captionPreferences.get()));
 #else
     UNUSED_PARAM(page);

--- a/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp
@@ -134,7 +134,7 @@ RefPtr<WebImage> InjectedBundleRangeHandle::renderedImage(SnapshotOptions option
 #endif
 
     VisibleSelection oldSelection = frame->selection().selection();
-    frame->checkedSelection()->setSelection(range);
+    protect(frame->selection())->setSelection(range);
 
     float scaleFactor = options.contains(SnapshotOption::ExcludeDeviceScaleFactor) ? 1 : frame->page()->deviceScaleFactor();
     IntRect paintRect = enclosingIntRect(unionRectIgnoringZeroRects(RenderObject::absoluteBorderAndTextRects(range)));
@@ -167,7 +167,7 @@ RefPtr<WebImage> InjectedBundleRangeHandle::renderedImage(SnapshotOptions option
     frameView->paint(graphicsContext, paintRect);
     frameView->setPaintBehavior(oldPaintBehavior);
 
-    frame->checkedSelection()->setSelection(oldSelection);
+    protect(frame->selection())->setSelection(oldSelection);
 
     return snapshot;
 }

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
@@ -286,7 +286,7 @@ bool RemoteWebInspectorUI::supportsDiagnosticLogging()
 
 void RemoteWebInspectorUI::logDiagnosticEvent(const String& eventName,  const DiagnosticLoggingClient::ValueDictionary& dictionary)
 {
-    protect(protectedWebPage()->corePage())->checkedDiagnosticLoggingClient()->logDiagnosticMessageWithValueDictionary(eventName, "Remote Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
+    protect(protect(protectedWebPage()->corePage())->diagnosticLoggingClient())->logDiagnosticMessageWithValueDictionary(eventName, "Remote Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
 }
 
 void RemoteWebInspectorUI::setDiagnosticLoggingAvailable(bool available)

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp
@@ -343,7 +343,7 @@ bool WebInspectorUI::supportsDiagnosticLogging()
 
 void WebInspectorUI::logDiagnosticEvent(const String& eventName, const DiagnosticLoggingClient::ValueDictionary& dictionary)
 {
-    protect(RefPtr { m_page.get() }->corePage())->checkedDiagnosticLoggingClient()->logDiagnosticMessageWithValueDictionary(eventName, "Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
+    protect(protect(RefPtr { m_page.get() }->corePage())->diagnosticLoggingClient())->logDiagnosticMessageWithValueDictionary(eventName, "Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
 }
 
 void WebInspectorUI::setDiagnosticLoggingAvailable(bool available)

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -886,7 +886,7 @@ void WebLoaderStrategy::loadResourceSynchronously(FrameLoader& frameLoader, WebC
     if (!sendResult.succeeded()) {
         WEBLOADERSTRATEGY_WITH_FRAMELOADER_RELEASE_LOG_ERROR("loadResourceSynchronously: failed sending synchronous network process message %" PUBLIC_LOG_STRING, IPC::errorAsString(sendResult.error()).characters());
         if (page)
-            page->checkedDiagnosticLoggingClient()->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::synchronousMessageFailedKey(), WebCore::ShouldSample::No);
+            protect(page->diagnosticLoggingClient())->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::synchronousMessageFailedKey(), WebCore::ShouldSample::No);
         response = ResourceResponse();
         error = internalError(request.url());
     } else

--- a/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
+++ b/Source/WebKit/WebProcess/Network/WebResourceLoader.cpp
@@ -418,7 +418,7 @@ void WebResourceLoader::didReceiveResource(ShareableResource::Handle&& handle)
         WEBRESOURCELOADER_RELEASE_LOG(WEBRESOURCELOADER_DIDRECEIVERESOURCE_UNABLE_TO_CREATE_FRAGMENTEDSHAREDBUFFER);
         if (RefPtr frame = coreLoader->frame()) {
             if (RefPtr page = frame->page())
-                page->checkedDiagnosticLoggingClient()->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::createSharedBufferFailedKey(), WebCore::ShouldSample::No);
+                protect(page->diagnosticLoggingClient())->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::createSharedBufferFailedKey(), WebCore::ShouldSample::No);
         }
         coreLoader->didFail(internalError(coreLoader->request().url()));
         return;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -381,7 +381,7 @@ void WebPage::insertDictatedTextAsync(const String& text, const EditingRange& re
     if (replacementEditingRange.location != notFound) {
         auto replacementRange = EditingRange::toRange(*frame, replacementEditingRange);
         if (replacementRange)
-            frame->checkedSelection()->setSelection(VisibleSelection { *replacementRange });
+            protect(frame->selection())->setSelection(VisibleSelection { *replacementRange });
     }
 
     if (options.registerUndoGroup)
@@ -910,7 +910,7 @@ void WebPage::replaceImageForRemoveBackground(const ElementContext& elementConte
 
     constexpr auto restoreSelectionOptions = FrameSelection::defaultSetSelectionOptions(UserTriggered::Yes);
     if (!originalSelection.isNoneOrOrphaned()) {
-        frame->checkedSelection()->setSelection(originalSelection, restoreSelectionOptions);
+        protect(frame->selection())->setSelection(originalSelection, restoreSelectionOptions);
         return;
     }
 
@@ -929,7 +929,7 @@ void WebPage::replaceImageForRemoveBackground(const ElementContext& elementConte
     // The node replacement may have orphaned the original selection range; in this case, try to restore
     // the original selected character range.
     auto newSelectionRange = resolveCharacterRange(selectionHostRange, *rangeToRestore, iteratorOptions);
-    frame->checkedSelection()->setSelection(newSelectionRange, restoreSelectionOptions);
+    protect(frame->selection())->setSelection(newSelectionRange, restoreSelectionOptions);
 }
 
 #endif // ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
@@ -1766,7 +1766,7 @@ void WebPage::setTextAsync(const String& text)
 
     if (frame->selection().selection().isContentEditable()) {
         UserTypingGestureIndicator indicator(*frame);
-        frame->checkedSelection()->selectAll();
+        protect(frame->selection())->selectAll();
         if (text.isEmpty())
             protect(frame->editor())->deleteSelectionWithSmartDelete(false);
         else
@@ -1799,7 +1799,7 @@ void WebPage::insertTextAsync(const String& text, const EditingRange& replacemen
     if (replacementEditingRange.location != notFound) {
         if (auto replacementRange = EditingRange::toRange(*frame, replacementEditingRange, options.editingRangeIsRelativeTo)) {
             SetForScope isSelectingTextWhileInsertingAsynchronously(m_isSelectingTextWhileInsertingAsynchronously, options.suppressSelectionUpdate);
-            frame->checkedSelection()->setSelection(VisibleSelection(*replacementRange));
+            protect(frame->selection())->setSelection(VisibleSelection(*replacementRange));
             replacesText = replacementEditingRange.length;
         }
     }
@@ -1943,7 +1943,7 @@ void WebPage::setCompositionAsync(const String& text, const Vector<CompositionUn
     if (frame->selection().selection().isContentEditable()) {
         if (replacementEditingRange.location != notFound) {
             if (auto replacementRange = EditingRange::toRange(*frame, replacementEditingRange))
-                frame->checkedSelection()->setSelection(VisibleSelection(*replacementRange));
+                protect(frame->selection())->setSelection(VisibleSelection(*replacementRange));
         }
         protect(frame->editor())->setComposition(text, underlines, highlights, annotations, selection.location, selection.location + selection.length);
     }

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -165,7 +165,7 @@ void FindController::updateFindUIAfterPageScroll(bool found, const String& strin
             protect(webPage->corePage())->unmarkAllTextMatches();
 
         if (selectedFrame && shouldSetSelection)
-            selectedFrame->checkedSelection()->clear();
+            protect(selectedFrame->selection())->clear();
 
         hideFindIndicator();
         resetMatchIndex();
@@ -291,7 +291,7 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
 #endif
     {
         if (RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get())) {
-            if (selectedFrame->checkedSelection()->selectionBounds().isEmpty()) {
+            if (protect(selectedFrame->selection())->selectionBounds().isEmpty()) {
                 auto result = protect(webPage->corePage())->findTextMatches(string, coreOptions, maxMatchCount);
                 m_foundStringMatchIndex = result.indexForSelection;
                 foundStringStartsAfterSelection = true;
@@ -321,7 +321,7 @@ void FindController::findString(const String& string, OptionSet<FindOptions> opt
         RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get());
         if (foundRange && selectedFrame) {
             m_lastFoundRange = foundRange;
-            m_lastSelection = selectedFrame->checkedSelection()->selection().toNormalizedRange();
+            m_lastSelection = protect(selectedFrame->selection())->selection().toNormalizedRange();
         }
     }
 
@@ -394,7 +394,7 @@ void FindController::selectFindMatch(uint32_t matchIndex)
     RefPtr frame = m_findMatches[matchIndex].start.document().frame();
     if (!frame)
         return;
-    frame->checkedSelection()->setSelection(m_findMatches[matchIndex]);
+    protect(frame->selection())->setSelection(m_findMatches[matchIndex]);
 }
 
 void FindController::indicateFindMatch(uint32_t matchIndex)
@@ -450,7 +450,7 @@ bool FindController::updateFindIndicator(bool isShowingOverlay, bool shouldAnima
             return { webPage->mainFrame(), pluginView->textIndicatorForCurrentSelection(textIndicatorOptions, presentationTransition) };
 #endif
         if (RefPtr selectedFrame = frameWithSelection(protect(webPage->corePage()).get())) {
-            auto selectedRange = selectedFrame->checkedSelection()->selection().toNormalizedRange();
+            auto selectedRange = protect(selectedFrame->selection())->selection().toNormalizedRange();
             if (selectedRange && ImageOverlay::isInsideOverlay(*selectedRange))
                 textIndicatorOptions.add({ TextIndicatorOption::PaintAllContent, TextIndicatorOption::PaintBackgrounds });
 
@@ -626,7 +626,7 @@ void FindController::drawRect(PageOverlay&, GraphicsContext& graphicsContext, co
         return;
 
     if (RefPtr selectedFrame = frameWithSelection(protect(protectedWebPage()->corePage()).get())) {
-        auto findIndicatorRect = selectedFrame->protectedView()->contentsToRootView(enclosingIntRect(selectedFrame->checkedSelection()->selectionBounds(FrameSelection::ClipToVisibleContent::No)));
+        auto findIndicatorRect = selectedFrame->protectedView()->contentsToRootView(enclosingIntRect(protect(selectedFrame->selection())->selectionBounds(FrameSelection::ClipToVisibleContent::No)));
 
         if (findIndicatorRect != m_findIndicatorRect) {
             // We are underneath painting, so it's not safe to mutate the layer tree synchronously.

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -856,7 +856,7 @@ String WebFrame::layerTreeAsText() const
     if (!localFrame)
         return emptyString();
 
-    return localFrame->checkedContentRenderer()->checkedCompositor()->layerTreeAsText();
+    return protect(protect(localFrame->contentRenderer())->compositor())->layerTreeAsText();
 }
 
 unsigned WebFrame::pendingUnloadCount() const
@@ -883,7 +883,7 @@ JSGlobalContextRef WebFrame::jsContext()
     if (!localFrame)
         return nullptr;
 
-    return toGlobalRef(localFrame->checkedScript()->globalObject(mainThreadNormalWorldSingleton()));
+    return toGlobalRef(protect(localFrame->script())->globalObject(mainThreadNormalWorldSingleton()));
 }
 
 JSGlobalContextRef WebFrame::jsContextForWorld(DOMWrapperWorld& world)
@@ -892,7 +892,7 @@ JSGlobalContextRef WebFrame::jsContextForWorld(DOMWrapperWorld& world)
     if (!localFrame)
         return nullptr;
 
-    return toGlobalRef(localFrame->checkedScript()->globalObject(world));
+    return toGlobalRef(protect(localFrame->script())->globalObject(world));
 }
 
 JSGlobalContextRef WebFrame::jsContextForWorld(InjectedBundleScriptWorld* world)
@@ -1098,7 +1098,7 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleCSSStyleDeclarationHandle* 
     if (!localFrame)
         return nullptr;
 
-    auto* globalObject = localFrame->checkedScript()->globalObject(protect(world->coreWorld()));
+    auto* globalObject = protect(localFrame->script())->globalObject(protect(world->coreWorld()));
 
     JSLockHolder lock(globalObject);
     return toRef(globalObject, toJS(globalObject, globalObject, cssStyleDeclarationHandle->coreCSSStyleDeclaration()));
@@ -1110,7 +1110,7 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleNodeHandle* nodeHandle, Inj
     if (!localFrame)
         return nullptr;
 
-    auto* globalObject = localFrame->checkedScript()->globalObject(protect(world->coreWorld()));
+    auto* globalObject = protect(localFrame->script())->globalObject(protect(world->coreWorld()));
 
     JSLockHolder lock(globalObject);
     RefPtr coreNode = nodeHandle->coreNode();
@@ -1123,7 +1123,7 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleRangeHandle* rangeHandle, I
     if (!localFrame)
         return nullptr;
 
-    auto* globalObject = localFrame->checkedScript()->globalObject(protect(world->coreWorld()));
+    auto* globalObject = protect(localFrame->script())->globalObject(protect(world->coreWorld()));
 
     JSLockHolder lock(globalObject);
     return toRef(globalObject, toJS(globalObject, globalObject, Ref { rangeHandle->coreRange() }.get()));

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -215,7 +215,7 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
         postLayoutData.selectionBoundingRect = frame.protectedView()->contentsToWindow(enclosingIntRect(unitedBoundingBoxes(quads)));
     else if (selection.isCaret()) {
         // Quads will be empty at the start of a paragraph.
-        postLayoutData.selectionBoundingRect = frame.protectedView()->contentsToWindow(frame.checkedSelection()->absoluteCaretBounds());
+        postLayoutData.selectionBoundingRect = frame.protectedView()->contentsToWindow(protect(frame.selection())->absoluteCaretBounds());
     }
 }
 
@@ -426,9 +426,9 @@ bool WebPage::performNonEditingBehaviorForSelector(const String& selector, Keybo
     }
 
     if (selector == "moveToLeftEndOfLine:"_s)
-        didPerformAction = m_userInterfaceLayoutDirection == WebCore::UserInterfaceLayoutDirection::LTR ? page->checkedBackForward()->goBack() : page->checkedBackForward()->goForward();
+        didPerformAction = m_userInterfaceLayoutDirection == WebCore::UserInterfaceLayoutDirection::LTR ? protect(page->backForward())->goBack() : protect(page->backForward())->goForward();
     else if (selector == "moveToRightEndOfLine:"_s)
-        didPerformAction = m_userInterfaceLayoutDirection == WebCore::UserInterfaceLayoutDirection::LTR ? page->checkedBackForward()->goForward() : page->checkedBackForward()->goBack();
+        didPerformAction = m_userInterfaceLayoutDirection == WebCore::UserInterfaceLayoutDirection::LTR ? protect(page->backForward())->goForward() : protect(page->backForward())->goBack();
 
     return didPerformAction;
 }

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1417,7 +1417,7 @@ void WebProcess::logDiagnosticMessageForNetworkProcessCrash()
     }
 
     if (page)
-        page->checkedDiagnosticLoggingClient()->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::networkProcessCrashedKey(), WebCore::ShouldSample::No);
+        protect(page->diagnosticLoggingClient())->logDiagnosticMessage(WebCore::DiagnosticLoggingKeys::internalErrorKey(), WebCore::DiagnosticLoggingKeys::networkProcessCrashedKey(), WebCore::ShouldSample::No);
 }
 
 void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connection)


### PR DESCRIPTION
#### 0de5508244331b7f9d6d6c958b42040e94332b01
<pre>
Drop more `checked*()` member functions in Source/WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=307523">https://bugs.webkit.org/show_bug.cgi?id=307523</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::sortedTrackListForMenu):
(WebCore::MediaControlsHost::displayNameForTrack):
(WebCore::MediaControlsHost::captionDisplayMode const):
(WebCore::MediaControlsHost::mediaControlsContextMenuItems):
(WebCore::MediaControlsHost::savePreviouslySelectedTextTrackIfNecessary):
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::shouldDeferLoading const):
* Source/WebCore/accessibility/AXUtilities.cpp:
(WebCore::needsLayoutOrStyleRecalc):
* Source/WebCore/bindings/js/WindowProxy.cpp:
(WebCore::WindowProxy::createJSWindowProxyWithInitializedScript):
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::scriptingFeatureSchema):
* Source/WebCore/dom/CharacterData.cpp:
(WebCore::CharacterData::setData):
(WebCore::CharacterData::setDataAndUpdate):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::didBecomeCurrentDocumentInFrame):
(WebCore::Document::disableEval):
(WebCore::Document::disableWebAssembly):
(WebCore::Document::setTrustedTypesEnforcement):
* Source/WebCore/dom/LoadableSpeculationRules.cpp:
(WebCore::LoadableSpeculationRules::notifyFinished):
* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::reportSpeculationRulesError):
(WebCore::ScriptElement::requestModuleScript):
(WebCore::ScriptElement::executeClassicScript):
(WebCore::ScriptElement::registerImportMap):
(WebCore::ScriptElement::executeScriptAndDispatchEvent):
(WebCore::ScriptElement::registerSpeculationRules):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::globalObject const):
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::logBackForwardCacheFailureDiagnosticMessage):
* Source/WebCore/history/CachedFrame.cpp:
(WebCore::CachedFrameBase::restore):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::createElementRenderer):
(WebCore::HTMLCanvasElement::isReplaced const):
* Source/WebCore/html/HTMLIFrameElement.cpp:
(WebCore::isFrameLazyLoadable):
* Source/WebCore/html/HTMLImageElement.cpp:
(WebCore::HTMLImageElement::isLazyLoadable const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::loadResource):
(WebCore::HTMLMediaElement::controls const):
(WebCore::HTMLMediaElement::addTextTrack):
(WebCore::HTMLMediaElement::configureTextTrackGroup):
(WebCore::HTMLMediaElement::setSelectedTextTrack):
(WebCore::HTMLMediaElement::updatePlayState):
(WebCore::HTMLMediaElement::captionPreferencesChanged):
(WebCore::HTMLMediaElement::captionDisplayMode):
(WebCore::HTMLMediaElement::mediaPlayerPreferredAudioCharacteristics const):
(WebCore::HTMLMediaElement::mediaPlayerEngineFailedToLoad):
(WebCore::HTMLMediaElement::logTextTrackDiagnostics):
(WebCore::HTMLMediaElement::watchtimeTimerFired):
(WebCore::HTMLMediaElement::invalidateBufferingStopwatch):
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::bindingsInstance):
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::shouldDrawCapsLockIndicator const):
* Source/WebCore/html/parser/HTMLParserOptions.cpp:
(WebCore::HTMLParserOptions::HTMLParserOptions):
* Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp:
(WebCore::MediaControlTextTrackContainerElement::updateActiveCuesFontSize):
(WebCore::MediaControlTextTrackContainerElement::updateTextStrokeStyle):
(WebCore::MediaControlTextTrackContainerElement::captionPreferencesChanged):
(WebCore::MediaControlTextTrackContainerElement::ensurePreviewCue const):
* Source/WebCore/loader/DocumentWriter.cpp:
(WebCore::DocumentWriter::begin):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::clear):
(WebCore::FrameLoader::checkLoadCompleteForThisFrame):
(WebCore::FrameLoader::executeJavaScriptURL):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::dispatchDidClearWindowObjectsInAllWorlds):
(WebCore::FrameLoader::dispatchDidClearWindowObjectInWorld):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateForRedirectWithLockedBackForwardList):
(WebCore::HistoryController::updateBackForwardListClippedAtTarget):
(WebCore::HistoryController::pushState):
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledHistoryNavigationByKey::findBackForwardItemByKey const):
* Source/WebCore/loader/ResourceLoadNotifier.cpp:
(WebCore::ResourceLoadNotifier::didReceiveResponse):
(WebCore::ResourceLoadNotifier::didReceiveData):
(WebCore::ResourceLoadNotifier::didFinishLoad):
(WebCore::ResourceLoadNotifier::didFailToLoad):
* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/page/DOMSelection.cpp:
(WebCore::DOMSelection::rangeCount const):
(WebCore::DOMSelection::modify):
(WebCore::DOMSelection::getRangeAt):
(WebCore::DOMSelection::removeAllRanges):
(WebCore::DOMSelection::removeRange):
(WebCore::DOMSelection::deleteFromDocument):
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::close):
(WebCore::DOMWindow::checkedConsole const): Deleted.
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/DeviceController.cpp:
(WebCore::DeviceController::addDeviceEventListener):
(WebCore::DeviceController::removeDeviceEventListener):
(WebCore::DeviceController::removeAllDeviceEventListeners):
(WebCore::DeviceController::checkedClient): Deleted.
* Source/WebCore/page/DeviceController.h:
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::tryDocumentDrag):
(WebCore::setSelectionToDragCaret):
(WebCore::selectElement):
(WebCore::DragController::startDrag):
(WebCore::DragController::insertDroppedImagePlaceholdersAtCaret):
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::defaultBackspaceEventHandler):
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedInternal):
* Source/WebCore/page/History.cpp:
(WebCore::History::length const):
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::~LocalFrame):
(WebCore::LocalFrame::setView):
(WebCore::LocalFrame::injectUserScriptImmediately):
(WebCore::LocalFrame::clearTimers):
(WebCore::LocalFrame::willDetachPage):
(WebCore::LocalFrame::setPageAndTextZoomFactors):
(WebCore::LocalFrame::resumeActiveDOMObjectsAndAnimations):
(WebCore::LocalFrame::checkedContentRenderer const): Deleted.
(WebCore::LocalFrame::checkedScript): Deleted.
(WebCore::LocalFrame::checkedScript const): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameInlines.h:
(WebCore::LocalFrame::checkedSelection const): Deleted.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::checkedLayoutContext const): Deleted.
(WebCore::LocalFrameView::checkedLayoutContext): Deleted.
(WebCore::LocalFrameView::checkedRenderView const): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::~Page):
(WebCore::Page::findString):
(WebCore::replaceRanges):
(WebCore::Page::logMediaDiagnosticMessage const):
(WebCore::Page::scheduleRenderingUpdateInternal):
(WebCore::Page::logNavigation):
(WebCore::Page::didChangeMainDocument):
(WebCore::Page::revealCurrentSelection):
(WebCore::Page::forceRepaintAllFrames):
(WebCore::Page::deleteRemovedNodesAndDetachedRenderers):
(WebCore::Page::checkedBackForward): Deleted.
(WebCore::Page::checkedDiagnosticLoggingClient const): Deleted.
(WebCore::Page::checkedGroup): Deleted.
(WebCore::Page::checkedRenderingUpdateScheduler): Deleted.
(WebCore::Page::checkedProgress): Deleted.
(WebCore::Page::checkedProgress const): Deleted.
(WebCore::Page::checkedElementTargetingController): Deleted.
* Source/WebCore/page/Page.h:
(WebCore::Page::progress const):
(WebCore::Page::elementTargetingController):
* Source/WebCore/page/TextIndicator.cpp:
(WebCore::initializeIndicator):
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::evaluateScript):
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::applyRules):
* Source/WebCore/platform/cocoa/PlaybackSessionModelMediaElement.mm:
(WebCore::PlaybackSessionModelMediaElement::updateMediaSelectionOptions):
(WebCore::PlaybackSessionModelMediaElement::audioMediaSelectionOptions const):
(WebCore::PlaybackSessionModelMediaElement::legibleMediaSelectionOptions const):
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::RenderObject::scheduleLayout):
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::RenderTheme::isFocused const):
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::paintAttachmentTitleBackground):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::deselectAll):
* Source/WebCore/testing/InternalSettings.cpp:
(WebCore::InternalSettings::setShouldDisplayTrackKind):
(WebCore::InternalSettings::shouldDisplayTrackKind):
* Source/WebCore/xml/XMLTreeViewer.cpp:
(WebCore::XMLTreeViewer::transformDocumentToTreeView):
* Source/WebKit/Shared/EditingRange.cpp:
(WebKit::EditingRange::toRange):
(WebKit::EditingRange::fromRange):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKBundlePageSetCaptionDisplayMode):
(WKBundlePageCreateCaptionUserPreferencesTestingModeToken):
* Source/WebKit/WebProcess/InjectedBundle/DOM/InjectedBundleRangeHandle.cpp:
(WebKit::InjectedBundleRangeHandle::renderedImage):
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp:
(WebKit::RemoteWebInspectorUI::logDiagnosticEvent):
* Source/WebKit/WebProcess/Inspector/WebInspectorUI.cpp:
(WebKit::WebInspectorUI::logDiagnosticEvent):
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::WebLoaderStrategy::loadResourceSynchronously):
* Source/WebKit/WebProcess/Network/WebResourceLoader.cpp:
(WebKit::WebResourceLoader::didReceiveResource):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::insertDictatedTextAsync):
(WebKit::WebPage::replaceImageForRemoveBackground):
(WebKit::WebPage::setTextAsync):
(WebKit::WebPage::insertTextAsync):
(WebKit::WebPage::setCompositionAsync):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::updateFindUIAfterPageScroll):
(WebKit::FindController::findString):
(WebKit::FindController::selectFindMatch):
(WebKit::FindController::updateFindIndicator):
(WebKit::FindController::drawRect):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::layerTreeAsText const):
(WebKit::WebFrame::jsContext):
(WebKit::WebFrame::jsContextForWorld):
(WebKit::WebFrame::jsWrapperForWorld):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::setEditable):
(WebKit::WebPage::paintSnapshotAtSize):
(WebKit::WebPage::centerSelectionInVisibleArea):
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::clearSelection):
(WebKit::WebPage::setCaretAnimatorType):
(WebKit::WebPage::setCaretBlinkingSuspended):
(WebKit::WebPage::deleteSurrounding):
(WebKit::WebPage::layerTreeAsTextForTesting):
(WebKit::WebPage::requestTargetedElement):
(WebKit::WebPage::requestAllTargetableElements):
(WebKit::WebPage::adjustVisibilityForTargetedElements):
(WebKit::WebPage::resetVisibilityAdjustmentsForTargetedElements):
(WebKit::WebPage::takeSnapshotForTargetedElement):
(WebKit::WebPage::numberOfVisibilityAdjustmentRects):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::getPlatformEditorState const):
(WebKit::WebPage::performNonEditingBehaviorForSelector):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::logDiagnosticMessageForNetworkProcessCrash):

Canonical link: <a href="https://commits.webkit.org/307248@main">https://commits.webkit.org/307248@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eecb381c4cdc5f513ca2e70d7449cfc1ebab778d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143863 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152531 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a39d47b2-ff2c-465e-b6a2-f12b963e74fe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145738 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16432 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110627 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6656e4f4-5c1b-4acf-ad77-7462a1573dca) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146826 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13053 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129263 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91545 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3463de31-3f3a-476d-8706-fcce6b0113c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12517 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10254 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121979 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5890 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154843 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16392 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118638 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118992 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30492 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14910 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127100 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71805 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16013 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5579 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15747 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15959 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15812 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->