### PR TITLE
[Site Isolation] Fix cross-origin window enumeration missing child frame indices

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowCustom.cpp
@@ -396,22 +396,21 @@ template void addCrossOriginOwnPropertyNames<CrossOriginObject::Location>(JSC::J
 
 static void addScopedChildrenIndexes(JSGlobalObject& lexicalGlobalObject, DOMWindow& window, PropertyNameArrayBuilder& propertyNames)
 {
-    RefPtr localDOMWindow = dynamicDowncast<LocalDOMWindow>(window);
-    if (!localDOMWindow)
-        return;
-
-    CheckedPtr document = localDOMWindow->document();
-    if (!document)
-        return;
-
-    auto* frame = document->frame();
+    RefPtr frame = window.frame();
     if (!frame)
         return;
 
     VM& vm = lexicalGlobalObject.vm();
-    unsigned scopedChildCount = frame->tree().scopedChildCount();
-    for (unsigned i = 0; i < scopedChildCount; ++i)
-        propertyNames.add(Identifier::from(vm, i));
+    // FIXME: scopedChild/scopedChildCount and RemoteFrame need to work together well. We're using child/childCount until then.
+    if (window.documentIfLocal()) {
+        unsigned scopedChildCount = frame->tree().scopedChildCount();
+        for (unsigned i = 0; i < scopedChildCount; ++i)
+            propertyNames.add(Identifier::from(vm, i));
+    } else {
+        unsigned childCount = frame->tree().childCount();
+        for (unsigned i = 0; i < childCount; ++i)
+            propertyNames.add(Identifier::from(vm, i));
+    }
 }
 
 // https://html.spec.whatwg.org/#windowproxy-ownpropertykeys


### PR DESCRIPTION
#### 29daa35f0a26eec9333a8bc1089974bc64a5858e
<pre>
[Site Isolation] Fix cross-origin window enumeration missing child frame indices
<a href="https://bugs.webkit.org/show_bug.cgi?id=307524">https://bugs.webkit.org/show_bug.cgi?id=307524</a>
<a href="https://rdar.apple.com/170123897">rdar://170123897</a>

Reviewed by Sihui Liu.

Object.getOwnPropertyNames() on a cross-origin window should return the child frame indices
(e.g., &apos;0&apos;, &apos;1&apos;, &apos;2&apos;) . With site isolation enabled, the cross-origin
window is a RemoteDOMWindow, but addScopedChildrenIndexes() only handled LocalDOMWindow,
causing it to return early without adding the indices.

Update addScopedChildrenIndexes() to use documentIfLocal() to distinguish between
LocalDOMWindow and RemoteDOMWindow, using childCount() for the latter since scoped child
enumeration isn&apos;t yet supported by RemoteFrame. This follows the same pattern already used
in getOwnPropertySlotByIndex().

* Source/WebCore/bindings/js/JSDOMWindowCustom.cpp:
(WebCore::addScopedChildrenIndexes):

Canonical link: <a href="https://commits.webkit.org/307319@main">https://commits.webkit.org/307319@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97811c13df0d67bbc92b92fd9c73d73ddc85c8c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16685 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8238 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152676 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a38fe09-efbe-43b8-a59d-b2992711877a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17167 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110732 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13155 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129398 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91651 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/557cb08c-9faa-40ea-b376-c1b51503cd7e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12621 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10355 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/122 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154988 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16537 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7098 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118746 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16573 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119101 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30532 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15005 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127254 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71958 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16159 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5701 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15893 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15959 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->