### PR TITLE
Adopt `NODELETE` annotation in more places in WebCore/

### DIFF
--- a/Source/WebCore/Modules/WebGPU/GPUDevice.h
+++ b/Source/WebCore/Modules/WebGPU/GPUDevice.h
@@ -107,10 +107,10 @@ public:
     String label() const;
     void setLabel(String&&);
 
-    Ref<GPUSupportedFeatures> features() const;
-    Ref<GPUSupportedLimits> limits() const;
+    Ref<GPUSupportedFeatures> NODELETE features() const;
+    Ref<GPUSupportedLimits> NODELETE limits() const;
 
-    Ref<GPUQueue> queue() const;
+    Ref<GPUQueue> NODELETE queue() const;
 
     void destroy(ScriptExecutionContext&);
 
@@ -152,7 +152,7 @@ public:
     const WebGPU::Device& backing() const { return m_backing; }
     void removeBufferToUnmap(GPUBuffer&);
     void addBufferToUnmap(GPUBuffer&);
-    Ref<GPUAdapterInfo> adapterInfo() const;
+    Ref<GPUAdapterInfo> NODELETE adapterInfo() const;
 
 #if ENABLE(VIDEO)
     WeakPtr<GPUExternalTexture> takeExternalTextureForVideoElement(const HTMLVideoElement&);

--- a/Source/WebCore/Modules/applepay/ApplePaySession.cpp
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.cpp
@@ -840,11 +840,6 @@ ExceptionOr<void> ApplePaySession::completePayment(unsigned short status)
     return completePayment(WTF::move(result));
 }
 
-unsigned ApplePaySession::version() const
-{
-    return m_version;
-}
-
 void ApplePaySession::validateMerchant(URL&& validationURL)
 {
     if (m_state == State::Aborted) {

--- a/Source/WebCore/Modules/applepay/ApplePaySession.h
+++ b/Source/WebCore/Modules/applepay/ApplePaySession.h
@@ -118,7 +118,7 @@ private:
     void derefEventTarget() override { deref(); }
 
     // PaymentSession
-    unsigned version() const override;
+    unsigned version() const override { return m_version; }
     void validateMerchant(URL&&) override;
     void didAuthorizePayment(const Payment&) override;
     void didSelectShippingMethod(const ApplePayShippingMethod&) override;

--- a/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
+++ b/Source/WebCore/Modules/mediarecorder/MediaRecorder.h
@@ -127,7 +127,7 @@ private:
     void computeBitRates(const MediaStreamPrivate*);
     void timeSlicerTimerFired();
 
-    CheckedPtr<MediaRecorderPrivate> checkedPrivate();
+    CheckedPtr<MediaRecorderPrivate> NODELETE checkedPrivate();
 
     static CreatorFunction m_customCreator;
 

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp
@@ -143,16 +143,6 @@ unsigned AudioNodeOutput::paramFanOutCount()
     return m_params.size();
 }
 
-unsigned AudioNodeOutput::renderingFanOutCount() const
-{
-    return m_renderingFanOutCount;
-}
-
-unsigned AudioNodeOutput::renderingParamFanOutCount() const
-{
-    return m_renderingParamFanOutCount;
-}
-
 void AudioNodeOutput::addInput(AudioNodeInput* input)
 {
     ASSERT(context().isGraphOwner());

--- a/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
+++ b/Source/WebCore/Modules/webaudio/AudioNodeOutput.h
@@ -65,11 +65,11 @@ public:
 
     // renderingFanOutCount() is the number of AudioNodeInputs that we're connected to during rendering.
     // Unlike fanOutCount() it will not change during the course of a render quantum.
-    unsigned renderingFanOutCount() const;
+    unsigned renderingFanOutCount() const { return m_renderingFanOutCount; }
 
     // renderingParamFanOutCount() is the number of AudioParams that we're connected to during rendering.
     // Unlike paramFanOutCount() it will not change during the course of a render quantum.
-    unsigned renderingParamFanOutCount() const;
+    unsigned renderingParamFanOutCount() const { return m_renderingParamFanOutCount; }
 
     // Must be called with the context's graph lock.
     void disconnectAll();

--- a/Source/WebCore/Modules/webaudio/AudioParam.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioParam.cpp
@@ -121,11 +121,6 @@ ExceptionOr<void> AudioParam::setAutomationRate(AutomationRate automationRate)
     return { };
 }
 
-float AudioParam::smoothedValue()
-{
-    return m_smoothedValue;
-}
-
 bool AudioParam::smooth()
 {
     if (!context())

--- a/Source/WebCore/Modules/webaudio/AudioParam.h
+++ b/Source/WebCore/Modules/webaudio/AudioParam.h
@@ -90,7 +90,7 @@ public:
 
     // When a new value is set with setValue(), in our internal use of the parameter we don't immediately jump to it.
     // Instead we smoothly approach this value to avoid glitching.
-    float smoothedValue();
+    float smoothedValue() const { return m_smoothedValue; }
 
     // Smoothly exponentially approaches to (de-zippers) the desired value.
     // Returns true if smoothed value has already snapped exactly to value.

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
@@ -55,7 +55,7 @@ public:
     AudioWorkletThread& workletThread() { return m_workletThread.get(); }
 
     void postTaskToAudioWorklet(Function<void(AudioWorklet&)>&&);
-    ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
+    ScriptExecutionContextIdentifier NODELETE loaderContextIdentifier() const final;
 
     uint32_t checkedPtrCount() const final { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::checkedPtrCount(); }
     uint32_t checkedPtrCountWithoutThreadCheck() const final { return CanMakeThreadSafeCheckedPtr<AudioWorkletMessagingProxy>::checkedPtrCountWithoutThreadCheck(); }

--- a/Source/WebCore/Modules/webaudio/AudioWorkletThread.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletThread.h
@@ -50,7 +50,7 @@ public:
     void clearProxies() final;
 
     // WorkerOrWorkletThread.
-    WorkerLoaderProxy* workerLoaderProxy() const final;
+    WorkerLoaderProxy* NODELETE workerLoaderProxy() const final;
     WorkerDebuggerProxy* workerDebuggerProxy() const final;
 
     AudioWorkletMessagingProxy* messagingProxy() { return m_messagingProxy.get(); }

--- a/Source/WebCore/animation/BlendingKeyframes.cpp
+++ b/Source/WebCore/animation/BlendingKeyframes.cpp
@@ -292,16 +292,6 @@ bool BlendingKeyframes::containsProperty(const AnimatableCSSProperty& property) 
     return m_properties.contains(property);
 }
 
-bool BlendingKeyframes::usesRelativeFontWeight() const
-{
-    return m_usesRelativeFontWeight;
-}
-
-bool BlendingKeyframes::hasCSSVariableReferences() const
-{
-    return m_containsCSSVariableReferences;
-}
-
 bool BlendingKeyframes::hasColorSetToCurrentColor() const
 {
     return m_propertiesSetToCurrentColor.contains(CSSPropertyColor);

--- a/Source/WebCore/animation/BlendingKeyframes.h
+++ b/Source/WebCore/animation/BlendingKeyframes.h
@@ -146,8 +146,8 @@ public:
     auto end() const LIFETIME_BOUND { return m_keyframes.end(); }
 
     bool usesContainerUnits() const;
-    bool usesRelativeFontWeight() const;
-    bool hasCSSVariableReferences() const;
+    bool usesRelativeFontWeight() const { return m_usesRelativeFontWeight; }
+    bool hasCSSVariableReferences() const { return m_containsCSSVariableReferences; }
     bool hasColorSetToCurrentColor() const;
     bool hasPropertySetToCurrentColor() const;
     const HashSet<AnimatableCSSProperty>& propertiesSetToInherit() const;

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -131,7 +131,7 @@ struct CSSCounterStyleDescriptors {
     void setSymbols(Vector<Symbol>);
     void setAdditiveSymbols(AdditiveSymbols);
 
-    String nameCSSText() const;
+    String NODELETE nameCSSText() const;
     String systemCSSText() const;
     String negativeCSSText() const;
     String prefixCSSText() const;

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -105,7 +105,7 @@ public:
 
     std::span<const UnicodeRange> ranges() const LIFETIME_BOUND { ASSERT(m_status != Status::Failure); return m_ranges.span(); }
 
-    RefPtr<CSSValue> familyCSSValue() const;
+    RefPtr<CSSValue> NODELETE familyCSSValue() const;
 
     void setFontSelectionCapabilities(FontSelectionCapabilities capabilities) { m_fontSelectionCapabilities = capabilities; }
     FontSelectionCapabilities fontSelectionCapabilities() const { ASSERT(m_status != Status::Failure); return m_fontSelectionCapabilities.computeFontSelectionCapabilities(); }

--- a/Source/WebCore/css/MutableStyleProperties.h
+++ b/Source/WebCore/css/MutableStyleProperties.h
@@ -57,7 +57,7 @@ public:
     static constexpr std::nullptr_t end() { return nullptr; }
     unsigned size() const { return propertyCount(); }
 
-    CSSStyleProperties* cssStyleProperties();
+    CSSStyleProperties* NODELETE cssStyleProperties();
 
     bool addParsedProperties(const ParsedPropertyVector&);
     bool addParsedProperty(const CSSProperty&);

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -421,7 +421,7 @@ public:
     const CSSSelectorList& originalScopeEnd() const { return m_originalScopeEnd; }
     void setScopeStart(CSSSelectorList&& scopeStart) { m_scopeStart = WTF::move(scopeStart); }
     void setScopeEnd(CSSSelectorList&& scopeEnd) { m_scopeEnd = WTF::move(scopeEnd); }
-    WeakPtr<const StyleSheetContents> styleSheetContents() const;
+    WeakPtr<const StyleSheetContents> NODELETE styleSheetContents() const;
     void setStyleSheetContents(const StyleSheetContents&);
 
 private:

--- a/Source/WebCore/dom/ConstantPropertyMap.h
+++ b/Source/WebCore/dom/ConstantPropertyMap.h
@@ -77,7 +77,7 @@ private:
     void updateConstantsForSafeAreaInsets();
     void updateConstantsForFullscreen();
 
-    Ref<Document> protectedDocument() const;
+    Ref<Document> NODELETE protectedDocument() const;
 
     std::optional<Values> m_values;
 

--- a/Source/WebCore/dom/CustomElementReactionQueue.cpp
+++ b/Source/WebCore/dom/CustomElementReactionQueue.cpp
@@ -301,11 +301,6 @@ bool CustomElementReactionQueue::hasFormStateRestoreCallback() const
     return m_interface->hasFormStateRestoreCallback();
 }
 
-bool CustomElementReactionQueue::isElementInternalsAttached() const
-{
-    return m_elementInternalsAttached;
-}
-
 void CustomElementReactionQueue::setElementInternalsAttached()
 {
     m_elementInternalsAttached = true;

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -139,7 +139,7 @@ public:
 
     bool observesStyleAttribute() const;
     bool isElementInternalsDisabled() const;
-    bool isElementInternalsAttached() const;
+    bool isElementInternalsAttached() const { return m_elementInternalsAttached; }
     void setElementInternalsAttached();
     bool isFormAssociated() const;
     bool hasFormStateRestoreCallback() const;

--- a/Source/WebCore/dom/DOMImplementation.h
+++ b/Source/WebCore/dom/DOMImplementation.h
@@ -47,7 +47,7 @@ public:
     static Ref<Document> createDocument(const String& contentType, LocalFrame*, const Settings&, const URL&, std::optional<ScriptExecutionContextIdentifier> = std::nullopt);
 
 private:
-    Ref<Document> protectedDocument();
+    Ref<Document> NODELETE protectedDocument();
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 };

--- a/Source/WebCore/dom/DeviceMotionController.h
+++ b/Source/WebCore/dom/DeviceMotionController.h
@@ -54,7 +54,7 @@ public:
 
     bool hasLastData() override;
     RefPtr<Event> getLastEvent() override;
-    DeviceClient& client() final;
+    DeviceClient& NODELETE client() final;
 
     static DeviceMotionController* from(Page*);
     static bool isActiveAt(Page*);
@@ -63,7 +63,7 @@ private:
     static ASCIILiteral supplementName() { return "DeviceMotionController"_s; }
     bool isDeviceMotionController() const final { return true; }
 
-    CheckedRef<DeviceMotionClient> checkedClient();
+    CheckedRef<DeviceMotionClient> NODELETE checkedClient();
 
     WeakRef<DeviceMotionClient> m_client;
 };

--- a/Source/WebCore/dom/DeviceOrientationController.h
+++ b/Source/WebCore/dom/DeviceOrientationController.h
@@ -55,7 +55,7 @@ public:
     bool hasLastData() override;
     RefPtr<Event> getLastEvent() override;
 #endif
-    DeviceClient& client() final;
+    DeviceClient& NODELETE client() final;
 
     static DeviceOrientationController* from(Page*);
     static bool isActiveAt(Page*);
@@ -64,7 +64,7 @@ private:
     static ASCIILiteral supplementName() { return "DeviceOrientationController"_s; }
     bool isDeviceOrientationController() const final { return true; }
 
-    CheckedRef<DeviceOrientationClient> checkedClient();
+    CheckedRef<DeviceOrientationClient> NODELETE checkedClient();
 
     WeakRef<DeviceOrientationClient> m_client;
 };

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -7909,11 +7909,6 @@ void Document::setShouldCreateRenderers(bool f)
     m_createRenderers = f;
 }
 
-bool Document::shouldCreateRenderers()
-{
-    return m_createRenderers;
-}
-
 // Support for Javascript execCommand, and related methods
 
 static Editor::Command command(Document* document, const String& commandName, bool userInterface = false)
@@ -8377,11 +8372,6 @@ void Document::clearSharedObjectPool()
 bool Document::isTelephoneNumberParsingEnabled() const
 {
     return settings().telephoneNumberParsingEnabled() && m_isTelephoneNumberParsingAllowed;
-}
-
-bool Document::isTelephoneNumberParsingAllowed() const
-{
-    return m_isTelephoneNumberParsingAllowed;
 }
 
 #endif
@@ -9625,11 +9615,6 @@ bool Document::hasRecentUserInteractionForNavigationFromJS() const
 void Document::startTrackingStyleRecalcs()
 {
     m_styleRecalcCount = 0;
-}
-
-unsigned Document::styleRecalcCount() const
-{
-    return m_styleRecalcCount;
 }
 
 #if ENABLE(TOUCH_EVENTS)
@@ -11928,19 +11913,9 @@ void Document::setActiveViewTransition(RefPtr<ViewTransition>&& viewTransition)
     }
 }
 
-bool Document::hasViewTransitionPseudoElementTree() const
-{
-    return m_hasViewTransitionPseudoElementTree;
-}
-
 void Document::setHasViewTransitionPseudoElementTree(bool value)
 {
     m_hasViewTransitionPseudoElementTree = value;
-}
-
-bool Document::renderingIsSuppressedForViewTransition() const
-{
-    return m_renderingIsSuppressedForViewTransition;
 }
 
 void Document::setRenderingIsSuppressedForViewTransitionAfterUpdateRendering()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -896,8 +896,8 @@ public:
     // https://wicg.github.io/nav-speculation/speculation-rules.html#consider-speculation
     void considerSpeculationRules();
     void processSpeculationRules();
-    Ref<const SpeculationRules> speculationRules() const;
-    Ref<SpeculationRules> speculationRules();
+    Ref<const SpeculationRules> NODELETE speculationRules() const;
+    Ref<SpeculationRules> NODELETE speculationRules();
 
     URL baseURLForComplete(const URL& baseURLOverride) const;
     WEBCORE_EXPORT URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
@@ -918,7 +918,7 @@ public:
 
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final;
     StorageConnection* storageConnection();
-    SocketProvider* socketProvider() final;
+    SocketProvider* NODELETE socketProvider() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
 
 #if ENABLE(WEB_RTC)
@@ -1393,7 +1393,7 @@ public:
     void unregisterForVisibilityStateChangedCallbacks(VisibilityChangeClient&);
 
     WEBCORE_EXPORT void setShouldCreateRenderers(bool);
-    bool shouldCreateRenderers();
+    bool shouldCreateRenderers() const { return m_createRenderers; }
 
     void setDecoder(RefPtr<TextResourceDecoder>&&);
     TextResourceDecoder* decoder() const { return m_decoder.get(); }
@@ -1527,7 +1527,7 @@ public:
     bool hasPendingIdleCallback() const;
     IdleCallbackController* idleCallbackController() const { return m_idleCallbackController.get(); }
 
-    EventTarget* errorEventTarget() final;
+    EventTarget* NODELETE errorEventTarget() final;
     void logExceptionToConsole(const String& errorMessage, const String& sourceURL, int lineNumber, int columnNumber, RefPtr<Inspector::ScriptCallStack>&&) final;
 
     WEBCORE_EXPORT void didAddWheelEventHandler(Node&);
@@ -1547,7 +1547,7 @@ public:
     WEBCORE_EXPORT unsigned touchEventHandlerCount() const;
 
     WEBCORE_EXPORT void startTrackingStyleRecalcs();
-    WEBCORE_EXPORT unsigned styleRecalcCount() const;
+    WEBCORE_EXPORT unsigned styleRecalcCount() const { return m_styleRecalcCount; }
 
 #if ENABLE(TOUCH_EVENTS)
     bool hasTouchEventHandlers() const;
@@ -1773,12 +1773,12 @@ public:
     bool activeViewTransitionCapturedDocumentElement() const;
     void setActiveViewTransition(RefPtr<ViewTransition>&&);
 
-    bool hasViewTransitionPseudoElementTree() const;
+    bool hasViewTransitionPseudoElementTree() const { return m_hasViewTransitionPseudoElementTree; }
     void setHasViewTransitionPseudoElementTree(bool);
 
     void performPendingViewTransitions();
 
-    bool renderingIsSuppressedForViewTransition() const;
+    bool renderingIsSuppressedForViewTransition() const { return m_renderingIsSuppressedForViewTransition; }
     void setRenderingIsSuppressedForViewTransitionAfterUpdateRendering();
     void setRenderingIsSuppressedForViewTransitionImmediately();
     void clearRenderingIsSuppressedForViewTransition();
@@ -1801,7 +1801,7 @@ public:
     //    - A read-only telephoneNumberParsingAllowed which is set by the
     //      document if it has the appropriate meta tag.
     //    - isTelephoneNumberParsingEnabled() == isTelephoneNumberParsingAllowed() && page()->settings()->isTelephoneNumberParsingEnabled()
-    WEBCORE_EXPORT bool isTelephoneNumberParsingAllowed() const;
+    WEBCORE_EXPORT bool isTelephoneNumberParsingAllowed() const { return m_isTelephoneNumberParsingAllowed; }
     WEBCORE_EXPORT bool isTelephoneNumberParsingEnabled() const;
 #endif
 
@@ -1989,7 +1989,7 @@ public:
     void setFragmentDirective(const String& fragmentDirective) { m_fragmentDirective = fragmentDirective; }
     const String& fragmentDirective() const { return m_fragmentDirective; }
 
-    FragmentDirective& fragmentDirectiveForBindings();
+    FragmentDirective& NODELETE fragmentDirectiveForBindings();
 
     void prepareCanvasesForDisplayOrFlushIfNeeded();
     void addCanvasNeedingPreparationForDisplayOrFlush(CanvasRenderingContext&);

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -130,7 +130,7 @@ private:
     void fadeAnimationTimerFired();
     void writingToolsTextSuggestionAnimationTimerFired();
 
-    Ref<Document> protectedDocument() const;
+    Ref<Document> NODELETE protectedDocument() const;
 
     MarkerMap m_markers;
     // Provide a quick way to determine whether a particular marker type is absent without going through the map.

--- a/Source/WebCore/dom/DocumentStorageAccess.h
+++ b/Source/WebCore/dom/DocumentStorageAccess.h
@@ -99,7 +99,7 @@ private:
     void enableTemporaryTimeUserGesture();
     void consumeTemporaryTimeUserGesture();
 
-    Ref<Document> protectedDocument() const;
+    Ref<Document> NODELETE protectedDocument() const;
 
     std::unique_ptr<UserGestureIndicator> m_temporaryUserGesture;
     

--- a/Source/WebCore/dom/EventLoop.h
+++ b/Source/WebCore/dom/EventLoop.h
@@ -237,7 +237,7 @@ public:
 private:
     enum class State : uint8_t { Running, Suspended, ReadyToStop, Stopped };
 
-    RefPtr<EventLoop> protectedEventLoop() const;
+    RefPtr<EventLoop> NODELETE protectedEventLoop() const;
 
     WeakPtr<EventLoop> m_eventLoop;
     WeakHashSet<EventLoopTimer> m_timers;

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -88,7 +88,7 @@ public:
     void detachFromDocument();
 
 private:
-    Ref<Document> protectedDocument() const;
+    Ref<Document> NODELETE protectedDocument() const;
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
 

--- a/Source/WebCore/dom/LoadableModuleScript.cpp
+++ b/Source/WebCore/dom/LoadableModuleScript.cpp
@@ -49,11 +49,6 @@ LoadableModuleScript::LoadableModuleScript(IsInline isInline, const AtomString& 
 
 LoadableModuleScript::~LoadableModuleScript() = default;
 
-bool LoadableModuleScript::isLoaded() const
-{
-    return m_isLoaded;
-}
-
 bool LoadableModuleScript::hasError() const
 {
     return !!m_error;
@@ -62,11 +57,6 @@ bool LoadableModuleScript::hasError() const
 std::optional<LoadableScript::Error> LoadableModuleScript::takeError()
 {
     return std::exchange(m_error, std::nullopt);
-}
-
-bool LoadableModuleScript::wasCanceled() const
-{
-    return m_wasCanceled;
 }
 
 void LoadableModuleScript::notifyLoadCompleted(UniquedStringImpl& moduleKey)

--- a/Source/WebCore/dom/LoadableModuleScript.h
+++ b/Source/WebCore/dom/LoadableModuleScript.h
@@ -41,10 +41,10 @@ public:
     enum class IsInline : bool { No, Yes };
     static Ref<LoadableModuleScript> create(IsInline, const AtomString& nonce, const AtomString& integrity, ReferrerPolicy, RequestPriority, const AtomString& crossOriginMode, const AtomString& charset, const AtomString& initiatorType, bool isInUserAgentShadowTree);
 
-    bool isLoaded() const final;
+    bool isLoaded() const final { return m_isLoaded; }
     bool hasError() const final;
     std::optional<Error> takeError() final;
-    bool wasCanceled() const final;
+    bool wasCanceled() const final { return m_wasCanceled; }
     bool isInlineModule() const final { return m_isInline; }
 
     ScriptType scriptType() const final { return ScriptType::Module; }

--- a/Source/WebCore/dom/NamedNodeMap.h
+++ b/Source/WebCore/dom/NamedNodeMap.h
@@ -56,7 +56,7 @@ public:
 
     Vector<String> supportedPropertyNames() const;
 
-    Element& element() const;
+    Element& NODELETE element() const;
 
 private:
     WeakRef<Element, WeakPtrImplWithEventTargetData> m_element;

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -60,7 +60,7 @@ private:
     friend class CharacterData;
     ProcessingInstruction(Document&, String&& target, String&& data);
 
-    String nodeName() const override;
+    String NODELETE nodeName() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const override;
     SerializedNode serializeNode(CloningOperation) const override;
 

--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -76,7 +76,7 @@ private:
     bool isThrottledRelativeToPage() const;
     bool shouldRescheduleRequestAnimationFrame(ReducedResolutionSeconds) const;
     void scheduleAnimation();
-    RefPtr<Document> protectedDocument();
+    RefPtr<Document> NODELETE protectedDocument();
 
     struct CallbackData {
         Ref<RequestAnimationFrameCallback> callback;

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -68,7 +68,7 @@ public:
 private:
     MessagePortChannel(MessagePortChannelRegistry&, const MessagePortIdentifier& port1, const MessagePortIdentifier& port2);
 
-    CheckedRef<MessagePortChannelRegistry> checkedRegistry() const;
+    CheckedRef<MessagePortChannelRegistry> NODELETE checkedRegistry() const;
 
     std::array<MessagePortIdentifier, 2> m_ports;
     std::array<bool, 2> m_isClosed { false, false };

--- a/Source/WebCore/editing/FrameSelection.h
+++ b/Source/WebCore/editing/FrameSelection.h
@@ -353,7 +353,7 @@ private:
 
     void caretAnimationDidUpdate(CaretAnimator&) final;
 
-    Document* document() final;
+    Document* NODELETE document() final;
     inline RefPtr<Document> protectedDocument() const; // Defined in DocumentInlines.h
 
     Node* caretNode() final;

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -93,19 +93,19 @@ public:
 
     bool operator==(const HistoryItem& other) const { return itemID() == other.itemID(); }
 
-    WEBCORE_EXPORT const String& originalURLString() const;
-    WEBCORE_EXPORT const String& urlString() const;
-    WEBCORE_EXPORT const String& title() const;
+    WEBCORE_EXPORT const String& NODELETE originalURLString() const;
+    WEBCORE_EXPORT const String& NODELETE urlString() const;
+    WEBCORE_EXPORT const String& NODELETE title() const;
     
     WEBCORE_EXPORT bool isInBackForwardCache() const;
     WEBCORE_EXPORT bool hasCachedPageExpired() const;
 
     WEBCORE_EXPORT void setAlternateTitle(const String&);
-    WEBCORE_EXPORT const String& alternateTitle() const;
+    WEBCORE_EXPORT const String& NODELETE alternateTitle() const;
     
     WEBCORE_EXPORT URL url() const;
     WEBCORE_EXPORT URL originalURL() const;
-    WEBCORE_EXPORT const String& referrer() const;
+    WEBCORE_EXPORT const String& NODELETE referrer() const;
     WEBCORE_EXPORT const AtomString& target() const;
     std::optional<FrameIdentifier> frameID() const { return m_frameID; }
     bool isTargetItem() const { return m_isTargetItem; }

--- a/Source/WebCore/html/FileInputType.h
+++ b/Source/WebCore/html/FileInputType.h
@@ -75,7 +75,7 @@ private:
     RenderPtr<RenderElement> createInputRenderer(RenderStyle&&) final;
     enum class RequestIcon : bool { No, Yes };
     void setFiles(RefPtr<FileList>&&, RequestIcon, WasSetByJavaScript);
-    String displayString() const final;
+    String NODELETE displayString() const final;
     void setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection) final;
     void showPicker() final;
     bool allowsShowPickerAcrossFrames() final;

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -325,9 +325,4 @@ void HTMLDialogElement::queueDialogToggleEventTask(ToggleState oldState, ToggleS
     RefPtr { m_toggleEventTask }->queue(oldState, newState, source);
 }
 
-bool HTMLDialogElement::isOpen() const
-{
-    return m_isOpen;
-}
-
 }

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -36,7 +36,7 @@ class HTMLDialogElement final : public HTMLElement {
 public:
     template<typename... Args> static Ref<HTMLDialogElement> create(Args&&... args) { return adoptRef(*new HTMLDialogElement(std::forward<Args>(args)...)); }
 
-    bool isOpen() const;
+    bool isOpen() const { return m_isOpen; }
 
     const String& returnValue() const { return m_returnValue; }
     void setReturnValue(String&& value) { m_returnValue = WTF::move(value); }

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -151,11 +151,6 @@ bool HTMLOptionElement::isFocusable() const
     return HTMLElement::isFocusable();
 }
 
-bool HTMLOptionElement::matchesDefaultPseudoClass() const
-{
-    return m_isDefault;
-}
-
 String HTMLOptionElement::text() const
 {
     String text = collectOptionInnerText();

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -79,7 +79,7 @@ private:
 
     bool isFocusable() const final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
-    bool matchesDefaultPseudoClass() const final;
+    bool matchesDefaultPseudoClass() const final { return m_isDefault; }
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -444,11 +444,6 @@ bool HTMLSelectElement::isMouseFocusable() const
     return HTMLFormControlElement::isMouseFocusable();
 }
 
-bool HTMLSelectElement::canSelectAll() const
-{
-    return m_multiple;
-}
-
 RenderPtr<RenderElement> HTMLSelectElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
 {
     if (usesMenuList()) {

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -156,7 +156,7 @@ public:
 
     void scrollToSelection();
 
-    bool canSelectAll() const;
+    bool canSelectAll() const { return m_multiple; }
     void selectAll();
     int listToOptionIndex(int listIndex) const;
     void listBoxOnChange();

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.h
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.h
@@ -107,7 +107,7 @@ public:
     String backendCommandsURL() const final { return String(); };
 
     InspectorFrontendAPIDispatcher& frontendAPIDispatcher() final { return m_frontendAPIDispatcher; }
-    WEBCORE_EXPORT Page* frontendPage() final;
+    WEBCORE_EXPORT Page* NODELETE frontendPage() final;
     
     WEBCORE_EXPORT bool canAttachWindow();
     WEBCORE_EXPORT void setDockingUnavailable(bool);

--- a/Source/WebCore/inspector/PageInspectorController.h
+++ b/Source/WebCore/inspector/PageInspectorController.h
@@ -86,7 +86,7 @@ public:
     void inspectedPageDestroyed();
 
     WEBCORE_EXPORT bool enabled() const;
-    Page& inspectedPage() const;
+    Page& NODELETE inspectedPage() const;
 
     WEBCORE_EXPORT void show();
 
@@ -140,7 +140,7 @@ public:
     Inspector::InspectorFunctionCallHandler functionCallHandler() const override;
     Inspector::InspectorEvaluateHandler evaluateHandler() const override;
     void frontendInitialized() override;
-    WTF::Stopwatch& executionStopwatch() const final;
+    WTF::Stopwatch& NODELETE executionStopwatch() const final;
     JSC::Debugger* debugger() override;
     JSC::VM& vm() override;
 

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp
@@ -110,11 +110,6 @@ Inspector::Protocol::ErrorStringOr<void> InspectorWorkerAgent::sendMessageToWork
     return { };
 }
 
-bool InspectorWorkerAgent::shouldWaitForDebuggerOnStart() const
-{
-    return m_enabled;
-}
-
 void InspectorWorkerAgent::workerStarted(WorkerInspectorProxy& proxy)
 {
     if (!m_enabled)

--- a/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
+++ b/Source/WebCore/inspector/agents/InspectorWorkerAgent.h
@@ -62,7 +62,7 @@ public:
     Inspector::Protocol::ErrorStringOr<void> sendMessageToWorker(const String& workerId, const String& message);
 
     // InspectorInstrumentation
-    bool shouldWaitForDebuggerOnStart() const;
+    bool shouldWaitForDebuggerOnStart() const { return m_enabled; }
     void workerStarted(WorkerInspectorProxy&);
     void workerTerminated(WorkerInspectorProxy&);
 

--- a/Source/WebCore/layout/LayoutContext.h
+++ b/Source/WebCore/layout/LayoutContext.h
@@ -60,7 +60,7 @@ public:
 
 private:
     void layoutFormattingContextSubtree(const ElementBox&);
-    LayoutState& layoutState();
+    LayoutState& NODELETE layoutState();
 
     const CheckedRef<LayoutState> m_layoutState;
 };

--- a/Source/WebCore/layout/floats/FloatingContext.h
+++ b/Source/WebCore/layout/floats/FloatingContext.h
@@ -75,7 +75,7 @@ private:
 
     const ElementBox& root() const { return m_formattingContextRoot; }
     // FIXME: Turn this into an actual geometry cache.
-    const LayoutState& containingBlockGeometries() const;
+    const LayoutState& NODELETE containingBlockGeometries() const;
 
     void findPositionForFormattingContextRoot(FloatAvoider&, BoxGeometry::HorizontalEdges containingBlockContentBoxEdges) const;
 

--- a/Source/WebCore/layout/formattingContexts/FormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/FormattingContext.h
@@ -56,7 +56,7 @@ public:
 
     const ElementBox& root() const { return m_root; }
 
-    LayoutState& layoutState();
+    LayoutState& NODELETE layoutState();
     const LayoutState& layoutState() const { return const_cast<FormattingContext&>(*this).layoutState(); }
 
     enum class EscapeReason {

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h
@@ -96,7 +96,7 @@ public:
 
     template<typename Function> void traverseNonRootInlineBoxes(const Layout::Box&, Function&&);
 
-    const RenderBlockFlow& formattingContextRoot() const;
+    const RenderBlockFlow& NODELETE formattingContextRoot() const;
 
     const Vector<SVGTextFragment>& svgTextFragments(size_t boxIndex) const;
     Vector<Vector<SVGTextFragment>>& svgTextFragmentsForBoxes() { return m_svgTextFragmentsForBoxes; }

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h
@@ -61,7 +61,7 @@ private:
     void paintDisplayBox(const InlineDisplay::Box&);
     void paintEllipsis(size_t lineIndex);
     LayoutPoint flippedContentOffsetIfNeeded(const RenderBox&) const;
-    const RenderBlock& root() const;
+    const RenderBlock& NODELETE root() const;
 
     PaintInfo& m_paintInfo;
     const LayoutPoint m_paintOffset;

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -275,7 +275,7 @@ public:
     WEBCORE_EXPORT void addAllArchiveResources(Archive&);
     WEBCORE_EXPORT void addArchiveResource(Ref<ArchiveResource>&&);
     RefPtr<Archive> popArchiveForSubframe(const String& frameName, const URL&);
-    WEBCORE_EXPORT SharedBuffer* parsedArchiveData() const;
+    WEBCORE_EXPORT SharedBuffer* NODELETE parsedArchiveData() const;
 
     bool hasArchiveResourceCollection() const { return !!m_archiveResourceCollection; }
     WEBCORE_EXPORT bool scheduleArchiveLoad(ResourceLoader&, const ResourceRequest&);
@@ -408,7 +408,7 @@ public:
     void setModalContainerObservationPolicy(ModalContainerObservationPolicy policy) { m_modalContainerObservationPolicy = policy; }
 
     // FIXME: Why is this in a Loader?
-    WEBCORE_EXPORT ColorSchemePreference colorSchemePreference() const;
+    WEBCORE_EXPORT ColorSchemePreference NODELETE colorSchemePreference() const;
     void setColorSchemePreference(ColorSchemePreference preference) { m_colorSchemePreference = preference; }
 
     HTTPSByDefaultMode httpsByDefaultMode() { return m_httpsByDefaultMode; }
@@ -455,7 +455,7 @@ public:
 
 #if USE(QUICK_LOOK)
     void setPreviewConverter(RefPtr<PreviewConverter>&&);
-    PreviewConverter* previewConverter() const;
+    PreviewConverter* NODELETE previewConverter() const;
 #endif
 
 #if ENABLE(CONTENT_EXTENSIONS)

--- a/Source/WebCore/loader/FrameLoadRequest.h
+++ b/Source/WebCore/loader/FrameLoadRequest.h
@@ -119,8 +119,8 @@ public:
 
     bool isEmpty() const { return m_resourceRequest.isEmpty(); }
 
-    WEBCORE_EXPORT Document& requester() const;
-    const SecurityOrigin& requesterSecurityOrigin() const;
+    WEBCORE_EXPORT Document& NODELETE requester() const;
+    const SecurityOrigin& NODELETE requesterSecurityOrigin() const;
 
     ResourceRequest& resourceRequest() { return m_resourceRequest; }
     const ResourceRequest& resourceRequest() const { return m_resourceRequest; }

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1374,11 +1374,6 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
     m_client->didFinishLoad();
 }
 
-bool FrameLoader::isComplete() const
-{
-    return m_isComplete;
-}
-
 void FrameLoader::completed()
 {
     Ref frame = m_frame.get();

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -121,7 +121,7 @@ public:
     WEBCORE_EXPORT void init();
     void initForSynthesizedDocument(const URL&);
 
-    WEBCORE_EXPORT LocalFrame& frame() const;
+    WEBCORE_EXPORT LocalFrame& NODELETE frame() const;
 
     PolicyChecker& policyChecker() const { return m_policyChecker; }
 
@@ -213,7 +213,7 @@ public:
 
     bool shouldTreatURLAsSrcdocDocument(const URL&) const;
 
-    WEBCORE_EXPORT FrameLoadType loadType() const;
+    WEBCORE_EXPORT FrameLoadType NODELETE loadType() const;
 
     CachePolicy subresourceCachePolicy(const URL&) const;
 
@@ -271,7 +271,7 @@ public:
     void finishedParsing();
     void checkCompleted();
 
-    WEBCORE_EXPORT bool isComplete() const;
+    bool isComplete() const { return m_isComplete; }
 
     void commitProvisionalLoad();
     void provisionalLoadFailedInAnotherProcess();
@@ -304,7 +304,7 @@ public:
     enum class PageDismissalType { None, BeforeUnload, PageHide, Unload };
     PageDismissalType pageDismissalEventBeingDispatched() const { return m_pageDismissalEventBeingDispatched; }
 
-    WEBCORE_EXPORT NetworkingContext* networkingContext() const;
+    WEBCORE_EXPORT NetworkingContext* NODELETE networkingContext() const;
 
     void loadProgressingStatusChanged();
 

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -115,7 +115,7 @@ public:
 
     virtual String captionPreviewTitle() const;
 
-    PageGroup& pageGroup() const;
+    PageGroup& NODELETE pageGroup() const;
 
 protected:
     explicit CaptionUserPreferences(PageGroup&);

--- a/Source/WebCore/page/ContextMenuController.h
+++ b/Source/WebCore/page/ContextMenuController.h
@@ -50,7 +50,7 @@ public:
     ContextMenuController(Page&, UniqueRef<ContextMenuClient>&&);
     ~ContextMenuController();
 
-    Page& page();
+    Page& NODELETE page();
     ContextMenuClient& client() { return m_client.get(); }
 
     ContextMenu* contextMenu() const { return m_contextMenu.get(); }

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -657,7 +657,7 @@ private:
     bool isCapturingMouseEventsElement() const { return m_capturingMouseEventsElement || m_isCapturingRootElementForMouseEvents; }
     void resetCapturingMouseEventsElement();
 
-    Ref<LocalFrame> protectedFrame() const;
+    Ref<LocalFrame> NODELETE protectedFrame() const;
 
     WeakRef<LocalFrame> m_frame;
     RefPtr<Node> m_mousePressNode;

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -130,7 +130,7 @@ private:
     void findFocusCandidateInContainer(const ContainerNode&, const LayoutRect& startingRect, FocusDirection, const FocusEventData&, FocusCandidate& closest);
 
     void focusRepaintTimerFired();
-    Ref<Page> protectedPage() const;
+    Ref<Page> NODELETE protectedPage() const;
 
     WeakRef<Page> m_page;
     WeakPtr<Frame> m_focusedFrame;

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -111,7 +111,7 @@ private:
     void platformUpdateElementUnderMouse(LocalFrame&, Element* elementUnderMouse);
     bool platformHandleMouseEvent(const PlatformMouseEvent&);
 
-    Ref<Page> protectedPage() const;
+    Ref<Page> NODELETE protectedPage() const;
     RefPtr<PageOverlay> protectedOverlay() const { return m_overlay; }
 
     WeakRef<Page> m_page;

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -391,7 +391,7 @@ private:
     std::optional<DocumentSecurityPolicy> frameDocumentSecurityPolicy() const final;
     String frameURLProtocol() const final;
 
-    FrameView* virtualView() const final;
+    FrameView* NODELETE virtualView() const final;
     void disconnectView() final;
     DOMWindow* virtualWindow() const final;
     void reinitializeDocumentSecurityContext() final;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -230,10 +230,10 @@ private:
 
     LocalFrame& frame() const;
     Ref<LocalFrame> protectedFrame();
-    LocalFrameView& view() const;
+    LocalFrameView& NODELETE view() const;
     RenderView* renderView() const;
     Document* document() const;
-    RefPtr<Document> protectedDocument() const;
+    RefPtr<Document> NODELETE protectedDocument() const;
 
     SingleThreadWeakRef<LocalFrameView> m_frameView;
     Timer m_layoutTimer;

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1194,7 +1194,7 @@ public:
 
     WEBCORE_EXPORT StorageConnection& storageConnection();
 
-    ModelPlayerProvider& modelPlayerProvider();
+    ModelPlayerProvider& NODELETE modelPlayerProvider();
 
     void updateScreenSupportedContentsFormats();
 

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -105,7 +105,7 @@ private:
     bool shouldDumpPropertyForLayer(const GraphicsLayer*, ASCIILiteral propertyName, OptionSet<LayerTreeAsTextOptions>) const override;
     void tiledBackingUsageChanged(const GraphicsLayer*, bool) override;
 
-    Ref<Page> protectedPage() const;
+    Ref<Page> NODELETE protectedPage() const;
 
     WeakRef<Page> m_page;
     RefPtr<GraphicsLayer> m_documentOverlayRootLayer;

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -333,7 +333,7 @@ private:
     static bool domainShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk(const URL&, QuirksData&);
 #endif
 
-    RefPtr<Document> protectedDocument() const;
+    RefPtr<Document> NODELETE protectedDocument() const;
 
     URL topDocumentURL() const;
 

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -57,7 +57,7 @@ public:
     WEBCORE_EXPORT static Ref<RemoteFrame> createSubframeWithContentsInAnotherProcess(Page&, ClientCreator&&, FrameIdentifier, HTMLFrameOwnerElement&, std::optional<LayerHostingContextIdentifier>, Ref<FrameTreeSyncData>&&);
     ~RemoteFrame();
 
-    RemoteDOMWindow& window() const;
+    RemoteDOMWindow& NODELETE window() const;
 
     const RemoteFrameClient& client() const { return m_client.get(); }
     RemoteFrameClient& client() { return m_client.get(); }
@@ -109,10 +109,10 @@ private:
     std::optional<DocumentSecurityPolicy> frameDocumentSecurityPolicy() const final;
     String frameURLProtocol() const final;
 
-    FrameView* virtualView() const final;
+    FrameView* NODELETE virtualView() const final;
     void disconnectView() final;
     DOMWindow* virtualWindow() const final;
-    FrameLoaderClient& loaderClient() final;
+    FrameLoaderClient& NODELETE loaderClient() final;
     void reinitializeDocumentSecurityContext() final { }
 
     const Ref<RemoteDOMWindow> m_window;

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -65,7 +65,7 @@ public:
     FloatSize snappedContentBoxSize() const;
 
     Element* target() const { return m_target.get(); }
-    RefPtr<Element> protectedTarget() const;
+    RefPtr<Element> NODELETE protectedTarget() const;
     ResizeObserverBoxOptions observedBox() const { return m_observedBox; }
     size_t targetElementDepth() const;
 

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -135,7 +135,7 @@ public:
 
     WEBCORE_EXPORT void resetToConsistentState();
 
-    WEBCORE_EXPORT RefPtr<Page> protectedPage() const;
+    WEBCORE_EXPORT RefPtr<Page> NODELETE protectedPage() const;
     WeakPtr<Page> page() const { return m_page; }
 
 protected:

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -191,7 +191,7 @@ public:
     GstElement* pipeline() const { return m_pipeline.get(); }
 
 #if USE(COORDINATED_GRAPHICS)
-    PlatformLayer* platformLayer() const override;
+    PlatformLayer* NODELETE platformLayer() const override;
     bool supportsAcceleratedRendering() const override { return true; }
 #endif
 

--- a/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
+++ b/Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h
@@ -64,7 +64,7 @@ public:
     void pause() final { };
 
 #if USE(COORDINATED_GRAPHICS)
-    PlatformLayer* platformLayer() const final;
+    PlatformLayer* NODELETE platformLayer() const final;
 #endif
 
     FloatSize naturalSize() const final;

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -70,8 +70,8 @@ public:
     // Takes `closedEdges` into account.
     const RectEdges<LayoutUnit>& borderWidths() const { return m_borderWidths; }
 
-    LayoutRoundedRect deprecatedRoundedRect() const;
-    LayoutRoundedRect deprecatedInnerRoundedRect() const;
+    LayoutRoundedRect NODELETE deprecatedRoundedRect() const;
+    LayoutRoundedRect NODELETE deprecatedInnerRoundedRect() const;
     FloatRoundedRect deprecatedPixelSnappedRoundedRect(float deviceScaleFactor) const;
     FloatRoundedRect deprecatedPixelSnappedInnerRoundedRect(float deviceScaleFactor) const;
 

--- a/Source/WebCore/rendering/LegacyInlineTextBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.cpp
@@ -101,11 +101,6 @@ const RenderStyle& LegacyInlineTextBox::lineStyle() const
     return isFirstLine() ? renderer().firstLineStyle() : renderer().style();
 }
 
-bool LegacyInlineTextBox::hasTextContent() const
-{
-    return m_len;
-}
-
 void LegacyInlineTextBox::markDirty(bool dirty)
 {
     if (dirty) {
@@ -224,11 +219,6 @@ std::pair<unsigned, unsigned> LegacyInlineTextBox::selectionStartEnd() const
 bool LegacyInlineTextBox::hasMarkers() const
 {
     return MarkedText::collectForDocumentMarkers(renderer(), selectableRange(), MarkedText::PaintPhase::Decoration).size();
-}
-
-int LegacyInlineTextBox::caretMinOffset() const
-{
-    return m_start;
 }
 
 int LegacyInlineTextBox::caretMaxOffset() const

--- a/Source/WebCore/rendering/LegacyInlineTextBox.h
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.h
@@ -49,7 +49,7 @@ public:
     void setNextTextBox(LegacyInlineTextBox* n) { m_nextTextBox = n; }
     void setPreviousTextBox(LegacyInlineTextBox* p) { m_prevTextBox = p; }
 
-    bool hasTextContent() const;
+    bool hasTextContent() const { return m_len; }
 
     unsigned start() const { return m_start; }
     unsigned end() const { return m_start + m_len; }
@@ -99,7 +99,7 @@ private:
     bool isInlineTextBox() const final { return true; }
 
 public:
-    int caretMinOffset() const final;
+    int caretMinOffset() const final { return m_start; }
     int caretMaxOffset() const final;
 
 private:

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -129,7 +129,7 @@ private:
 
     void setScrollOffset(const ScrollOffset&) final;
 
-    ScrollPosition scrollPosition() const final;
+    ScrollPosition NODELETE scrollPosition() const final;
     ScrollPosition minimumScrollPosition() const final;
     ScrollPosition maximumScrollPosition() const final;
 

--- a/Source/WebCore/rendering/style/StyleCachedImage.h
+++ b/Source/WebCore/rendering/style/StyleCachedImage.h
@@ -50,7 +50,7 @@ public:
     bool operator==(const StyleImage&) const final;
     bool equals(const StyleCachedImage&) const;
 
-    CachedImage* cachedImage() const final;
+    CachedImage* NODELETE cachedImage() const final;
 
     WrappedImagePtr data() const final { return m_cachedImage.get(); }
 

--- a/Source/WebCore/rendering/style/StyleMultiImage.cpp
+++ b/Source/WebCore/rendering/style/StyleMultiImage.cpp
@@ -108,11 +108,6 @@ bool StyleMultiImage::canRender(const RenderElement* renderer, float multiplier)
     return m_selectedImage && m_selectedImage->canRender(renderer, multiplier);
 }
 
-bool StyleMultiImage::isPending() const
-{
-    return m_isPending;
-}
-
 bool StyleMultiImage::isLoaded(const RenderElement* renderer) const
 {
     return m_selectedImage && m_selectedImage->isLoaded(renderer);

--- a/Source/WebCore/rendering/style/StyleMultiImage.h
+++ b/Source/WebCore/rendering/style/StyleMultiImage.h
@@ -60,7 +60,7 @@ private:
     WrappedImagePtr data() const final;
 
     bool canRender(const RenderElement*, float multiplier) const final;
-    bool isPending() const final;
+    bool isPending() const final { return m_isPending; }
     void load(CachedResourceLoader&, const ResourceLoaderOptions&) final;
     bool isLoaded(const RenderElement*) const final;
     bool errorOccurred() const final;

--- a/Source/WebCore/svg/SVGDocumentExtensions.h
+++ b/Source/WebCore/svg/SVGDocumentExtensions.h
@@ -73,7 +73,7 @@ public:
     void unregisterSVGFontFaceElement(SVGFontFaceElement&);
 
 private:
-    Ref<Document> protectedDocument() const;
+    Ref<Document> NODELETE protectedDocument() const;
 
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_timeContainers; // For SVG 1.2 support this will need to be made more general.

--- a/Source/WebCore/svg/SVGLengthContext.h
+++ b/Source/WebCore/svg/SVGLengthContext.h
@@ -93,7 +93,7 @@ private:
     float removeZoomFromFontOrRootFontRelativeLength(float value, CSS::LengthUnit) const;
 
     std::optional<CSSToLengthConversionData> cssConversionData() const;
-    RefPtr<const SVGElement> protectedContext() const;
+    RefPtr<const SVGElement> NODELETE protectedContext() const;
 
     template<typename SizeType> float valueForSizeType(const SizeType&, Style::ZoomFactor usedZoom, SVGLengthMode = SVGLengthMode::Other) requires (SizeType::Fixed::zoomOptions == CSS::RangeZoomOptions::Unzoomed || SizeType::Calc::range.zoomOptions == CSS::RangeZoomOptions::Unzoomed);
     template<typename SizeType> float valueForSizeType(const SizeType&, Style::ZoomNeeded, SVGLengthMode = SVGLengthMode::Other);

--- a/Source/WebCore/svg/properties/SVGAnimatedPropertyBase.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPropertyBase.h
@@ -64,7 +64,7 @@ public:
 
 protected:
     explicit SVGAnimatedPropertyBase(SVGElement*);
-    SVGPropertyOwner* owner() const override;
+    SVGPropertyOwner* NODELETE owner() const override;
     void commitPropertyChange(SVGProperty*) override;
 
     WeakPtr<SVGElement, WeakPtrImplWithEventTargetData> m_contextElement;

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -96,7 +96,7 @@ public:
     String origin() const;
     const String& inspectorIdentifier() const { return m_inspectorIdentifier; }
 
-    IDBClient::IDBConnectionProxy* idbConnectionProxy() final;
+    IDBClient::IDBConnectionProxy* NODELETE idbConnectionProxy() final;
     void suspend() final;
     void resume() final;
     GraphicsClient* graphicsClient() final;
@@ -202,7 +202,7 @@ private:
 
     EventTarget* errorEventTarget() final;
     String resourceRequestIdentifier() const final { return m_inspectorIdentifier; }
-    SocketProvider* socketProvider() final;
+    SocketProvider* NODELETE socketProvider() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
 
     bool shouldBypassMainWorldContentSecurityPolicy() const final { return m_shouldBypassMainWorldContentSecurityPolicy; }


### PR DESCRIPTION
#### f5944683e6f092204486863d67d310aec899d7eb
<pre>
Adopt `NODELETE` annotation in more places in WebCore/
<a href="https://bugs.webkit.org/show_bug.cgi?id=307527">https://bugs.webkit.org/show_bug.cgi?id=307527</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/Modules/WebGPU/GPUDevice.h:
* Source/WebCore/Modules/applepay/ApplePaySession.cpp:
(WebCore::ApplePaySession::version const): Deleted.
* Source/WebCore/Modules/applepay/ApplePaySession.h:
* Source/WebCore/Modules/mediarecorder/MediaRecorder.h:
* Source/WebCore/Modules/webaudio/AudioNodeOutput.cpp:
(WebCore::AudioNodeOutput::renderingFanOutCount const): Deleted.
(WebCore::AudioNodeOutput::renderingParamFanOutCount const): Deleted.
* Source/WebCore/Modules/webaudio/AudioNodeOutput.h:
* Source/WebCore/Modules/webaudio/AudioParam.cpp:
(WebCore::AudioParam::smoothedValue): Deleted.
* Source/WebCore/Modules/webaudio/AudioParam.h:
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h:
* Source/WebCore/Modules/webaudio/AudioWorkletThread.h:
* Source/WebCore/animation/BlendingKeyframes.cpp:
(WebCore::BlendingKeyframes::usesRelativeFontWeight const): Deleted.
(WebCore::BlendingKeyframes::hasCSSVariableReferences const): Deleted.
* Source/WebCore/animation/BlendingKeyframes.h:
(WebCore::BlendingKeyframes::usesRelativeFontWeight const):
(WebCore::BlendingKeyframes::hasCSSVariableReferences const):
* Source/WebCore/css/CSSCounterStyleDescriptors.h:
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/MutableStyleProperties.h:
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/dom/ConstantPropertyMap.h:
* Source/WebCore/dom/CustomElementReactionQueue.cpp:
(WebCore::CustomElementReactionQueue::isElementInternalsAttached const): Deleted.
* Source/WebCore/dom/CustomElementReactionQueue.h:
* Source/WebCore/dom/DOMImplementation.h:
* Source/WebCore/dom/DeviceMotionController.h:
* Source/WebCore/dom/DeviceOrientationController.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::shouldCreateRenderers): Deleted.
(WebCore::Document::isTelephoneNumberParsingAllowed const): Deleted.
(WebCore::Document::styleRecalcCount const): Deleted.
(WebCore::Document::hasViewTransitionPseudoElementTree const): Deleted.
(WebCore::Document::renderingIsSuppressedForViewTransition const): Deleted.
* Source/WebCore/dom/Document.h:
(WebCore::Document::shouldCreateRenderers const):
(WebCore::Document::styleRecalcCount const):
(WebCore::Document::hasViewTransitionPseudoElementTree const):
(WebCore::Document::renderingIsSuppressedForViewTransition const):
(WebCore::Document::isTelephoneNumberParsingAllowed const):
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/DocumentStorageAccess.h:
* Source/WebCore/dom/EventLoop.h:
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/LoadableModuleScript.cpp:
(WebCore::LoadableModuleScript::isLoaded const): Deleted.
(WebCore::LoadableModuleScript::wasCanceled const): Deleted.
* Source/WebCore/dom/LoadableModuleScript.h:
* Source/WebCore/dom/NamedNodeMap.h:
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/dom/ScriptedAnimationController.h:
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/editing/FrameSelection.h:
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/html/FileInputType.h:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::isOpen const): Deleted.
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::matchesDefaultPseudoClass const): Deleted.
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::canSelectAll const): Deleted.
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/inspector/InspectorFrontendClientLocal.h:
* Source/WebCore/inspector/PageInspectorController.h:
* Source/WebCore/inspector/agents/InspectorWorkerAgent.cpp:
(WebCore::InspectorWorkerAgent::shouldWaitForDebuggerOnStart const): Deleted.
* Source/WebCore/inspector/agents/InspectorWorkerAgent.h:
(WebCore::InspectorWorkerAgent::shouldWaitForDebuggerOnStart const):
* Source/WebCore/layout/LayoutContext.h:
* Source/WebCore/layout/floats/FloatingContext.h:
* Source/WebCore/layout/formattingContexts/FormattingContext.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContent.h:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentPainter.h:
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/FrameLoadRequest.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::isComplete const): Deleted.
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/CaptionUserPreferences.h:
* Source/WebCore/page/ContextMenuController.h:
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/FocusController.h:
* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/ResizeObservation.h:
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/holepunch/MediaPlayerPrivateHolePunch.h:
* Source/WebCore/rendering/BorderShape.h:
* Source/WebCore/rendering/LegacyInlineTextBox.cpp:
(WebCore::LegacyInlineTextBox::hasTextContent const): Deleted.
(WebCore::LegacyInlineTextBox::caretMinOffset const): Deleted.
* Source/WebCore/rendering/LegacyInlineTextBox.h:
(WebCore::LegacyInlineTextBox::hasTextContent const):
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/style/StyleCachedImage.h:
* Source/WebCore/rendering/style/StyleMultiImage.cpp:
(WebCore::StyleMultiImage::isPending const): Deleted.
* Source/WebCore/rendering/style/StyleMultiImage.h:
* Source/WebCore/svg/SVGDocumentExtensions.h:
* Source/WebCore/svg/SVGLengthContext.h:
* Source/WebCore/svg/properties/SVGAnimatedPropertyBase.h:
* Source/WebCore/workers/WorkerGlobalScope.h:

Canonical link: <a href="https://commits.webkit.org/307353@main">https://commits.webkit.org/307353@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ad2915a0bcabdccf3a194e3b14c9d7d993d163a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144158 "23 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16837 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8393 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152828 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2c5a2b55-2797-4f4a-bbbf-b2bae58d441a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146033 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17319 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16731 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110851 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147121 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13264 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91769 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/274 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155140 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16689 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118867 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16726 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14014 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119225 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30551 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15109 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127383 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16311 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5820 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16045 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16256 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16111 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->