### PR TITLE
Adopt `NODELETE` annotation in more places in WebKit/

### DIFF
--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -154,7 +154,7 @@ public:
 #endif
 
 #if ENABLE(WEBXR)
-    std::optional<WebCore::ProcessIdentity> immersiveModeProcessIdentity() const;
+    std::optional<WebCore::ProcessIdentity> NODELETE immersiveModeProcessIdentity() const;
 #endif
 
 #if HAVE(AUDIT_TOKEN)

--- a/Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.h
@@ -43,7 +43,7 @@ public:
     static Ref<RemoteSnapshotRecorder> create(RemoteSnapshotRecorderIdentifier, RemoteSnapshot&, RemoteRenderingBackend&);
     ~RemoteSnapshotRecorder();
     void stopListeningForIPC();
-    Ref<RemoteSnapshot> snapshot() const;
+    Ref<RemoteSnapshot> NODELETE snapshot() const;
     Ref<const WebCore::DisplayList::DisplayList> takeDisplayList() { return m_recorder->takeDisplayList(); }
 
 private:

--- a/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.h
@@ -38,7 +38,7 @@ public:
     static RefPtr<ShareablePixelBuffer> tryCreate(const WebCore::PixelBufferFormat&, const WebCore::IntSize&);
 
     WebCore::SharedMemory& data() const { return m_data.get(); }
-    Ref<WebCore::SharedMemory> protectedData() const;
+    Ref<WebCore::SharedMemory> NODELETE protectedData() const;
 
     RefPtr<WebCore::PixelBuffer> createScratchPixelBuffer(const WebCore::IntSize&) const override;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -74,10 +74,10 @@ private:
     RemoteBindGroup& operator=(RemoteBindGroup&&) = delete;
 
     WebCore::WebGPU::BindGroup& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::BindGroup> protectedBacking();
+    Ref<WebCore::WebGPU::BindGroup> NODELETE protectedBacking();
 
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
@@ -75,7 +75,7 @@ private:
 
     WebCore::WebGPU::BindGroupLayout& backing() { return m_backing; }
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -83,9 +83,9 @@ private:
     RemoteBuffer& operator=(RemoteBuffer&&) = delete;
 
     WebCore::WebGPU::Buffer& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::Buffer> protectedBacking();
+    Ref<WebCore::WebGPU::Buffer> NODELETE protectedBacking();
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
@@ -74,7 +74,7 @@ private:
     RemoteCommandBuffer& operator=(RemoteCommandBuffer&&) = delete;
 
     WebCore::WebGPU::CommandBuffer& backing() { return m_backing; }
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -84,7 +84,7 @@ private:
     RemoteCommandEncoder& operator=(RemoteCommandEncoder&&) = delete;
 
     WebCore::WebGPU::CommandEncoder& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::CommandEncoder> protectedBacking();
+    Ref<WebCore::WebGPU::CommandEncoder> NODELETE protectedBacking();
 
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu; }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -90,9 +90,9 @@ private:
     RemoteCompositorIntegration& operator=(RemoteCompositorIntegration&&) = delete;
 
     WebCore::WebGPU::CompositorIntegration& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::CompositorIntegration> protectedBacking();
+    Ref<WebCore::WebGPU::CompositorIntegration> NODELETE protectedBacking();
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu; }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
@@ -75,10 +75,10 @@ private:
     RemoteComputePassEncoder& operator=(RemoteComputePassEncoder&&) = delete;
 
     WebCore::WebGPU::ComputePassEncoder& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::ComputePassEncoder> protectedBacking();
+    Ref<WebCore::WebGPU::ComputePassEncoder> NODELETE protectedBacking();
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
+    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -74,9 +74,9 @@ private:
     RemoteComputePipeline& operator=(RemoteComputePipeline&&) = delete;
 
     WebCore::WebGPU::ComputePipeline& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::ComputePipeline> protectedBacking();
+    Ref<WebCore::WebGPU::ComputePipeline> NODELETE protectedBacking();
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu; }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -115,7 +115,7 @@ private:
     RemoteDevice& operator=(RemoteDevice&&) = delete;
 
     WebCore::WebGPU::Device& backing() { return m_backing; }
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
+    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
     Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
@@ -74,9 +74,9 @@ private:
     RemoteExternalTexture& operator=(RemoteExternalTexture&&) = delete;
 
     WebCore::WebGPU::ExternalTexture& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::ExternalTexture> protectedBacking();
+    Ref<WebCore::WebGPU::ExternalTexture> NODELETE protectedBacking();
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
@@ -74,7 +74,7 @@ private:
     RemotePipelineLayout& operator=(RemotePipelineLayout&&) = delete;
 
     WebCore::WebGPU::PipelineLayout& backing() { return m_backing; }
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -77,9 +77,9 @@ private:
     RemotePresentationContext& operator=(RemotePresentationContext&&) = delete;
 
     WebCore::WebGPU::PresentationContext& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::PresentationContext> protectedBacking();
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
+    Ref<WebCore::WebGPU::PresentationContext> NODELETE protectedBacking();
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
+    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
     Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
@@ -74,9 +74,9 @@ private:
     RemoteQuerySet& operator=(RemoteQuerySet&&) = delete;
 
     WebCore::WebGPU::QuerySet& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::QuerySet> protectedBacking();
+    Ref<WebCore::WebGPU::QuerySet> NODELETE protectedBacking();
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -87,9 +87,9 @@ private:
     RemoteQueue& operator=(RemoteQueue&&) = delete;
 
     WebCore::WebGPU::Queue& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::Queue> protectedBacking();
+    Ref<WebCore::WebGPU::Queue> NODELETE protectedBacking();
 
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
+    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -75,7 +75,7 @@ private:
 
     WebCore::WebGPU::RenderBundle& backing() { return m_backing; }
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -80,9 +80,9 @@ private:
     RemoteRenderBundleEncoder& operator=(RemoteRenderBundleEncoder&&) = delete;
 
     WebCore::WebGPU::RenderBundleEncoder& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::RenderBundleEncoder> protectedBacking() const;
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
+    Ref<WebCore::WebGPU::RenderBundleEncoder> NODELETE protectedBacking() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
+    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
     Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -77,9 +77,9 @@ private:
     RemoteRenderPassEncoder& operator=(RemoteRenderPassEncoder&&) = delete;
 
     WebCore::WebGPU::RenderPassEncoder& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::RenderPassEncoder> protectedBacking();
+    Ref<WebCore::WebGPU::RenderPassEncoder> NODELETE protectedBacking();
 
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const;
+    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
     Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -74,9 +74,9 @@ private:
     RemoteRenderPipeline& operator=(RemoteRenderPipeline&&) = delete;
 
     WebCore::WebGPU::RenderPipeline& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::RenderPipeline> protectedBacking();
+    Ref<WebCore::WebGPU::RenderPipeline> NODELETE protectedBacking();
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu; }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
@@ -74,7 +74,7 @@ private:
     RemoteSampler& operator=(RemoteSampler&&) = delete;
 
     WebCore::WebGPU::Sampler& backing() { return m_backing; }
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -77,8 +77,8 @@ private:
     RemoteShaderModule& operator=(RemoteShaderModule&&) = delete;
 
     WebCore::WebGPU::ShaderModule& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::ShaderModule> protectedBacking();
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<WebCore::WebGPU::ShaderModule> NODELETE protectedBacking();
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
     Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
     Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -78,7 +78,7 @@ private:
     RemoteTexture& operator=(RemoteTexture&&) = delete;
 
     WebCore::WebGPU::Texture& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::Texture> protectedBacking();
+    Ref<WebCore::WebGPU::Texture> NODELETE protectedBacking();
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
@@ -74,7 +74,7 @@ private:
     RemoteTextureView& operator=(RemoteTextureView&&) = delete;
 
     WebCore::WebGPU::TextureView& backing() { return m_backing; }
-    Ref<IPC::StreamServerConnection> protectedStreamConnection() const;
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
@@ -78,10 +78,10 @@ private:
     RemoteXRBinding& operator=(const RemoteXRBinding&) = delete;
     RemoteXRBinding& operator=(RemoteXRBinding&&) = delete;
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection();
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection();
 
     WebCore::WebGPU::XRBinding& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::XRBinding> protectedBacking();
+    Ref<WebCore::WebGPU::XRBinding> NODELETE protectedBacking();
 
     Ref<RemoteGPU> protectedGPU();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
@@ -95,8 +95,8 @@ private:
     RemoteXRProjectionLayer& operator=(const RemoteXRProjectionLayer&) = delete;
     RemoteXRProjectionLayer& operator=(RemoteXRProjectionLayer&&) = delete;
 
-    Ref<WebCore::WebGPU::XRProjectionLayer> protectedBacking();
-    Ref<IPC::StreamServerConnection> protectedStreamConnection();
+    Ref<WebCore::WebGPU::XRProjectionLayer> NODELETE protectedBacking();
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection();
     Ref<RemoteGPU> protectedGPU() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
@@ -89,9 +89,9 @@ private:
     RemoteXRSubImage& operator=(RemoteXRSubImage&&) = delete;
 
     WebCore::WebGPU::XRSubImage& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::XRSubImage> protectedBacking();
+    Ref<WebCore::WebGPU::XRSubImage> NODELETE protectedBacking();
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection();
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection();
     Ref<RemoteGPU> protectedGPU() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
@@ -87,7 +87,7 @@ private:
     RemoteXRView& operator=(const RemoteXRView&) = delete;
     RemoteXRView& operator=(RemoteXRView&&) = delete;
 
-    Ref<IPC::StreamServerConnection> protectedStreamConnection();
+    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection();
 
     WebCore::WebGPU::XRView& backing() { return m_backing; }
 

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -411,7 +411,7 @@ private:
 #endif
 
     Ref<IPC::Connection> protectedConnection() const { return m_webProcessConnection; }
-    Ref<RemoteVideoFrameObjectHeap> protectedVideoFrameObjectHeap() const;
+    Ref<RemoteVideoFrameObjectHeap> NODELETE protectedVideoFrameObjectHeap() const;
 
     Vector<Ref<RemoteAudioTrackProxy>> m_audioTracks;
     Vector<Ref<RemoteVideoTrackProxy>> m_videoTracks;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResource.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResource.cpp
@@ -79,11 +79,6 @@ void RemoteMediaResource::shutdown()
     });
 }
 
-bool RemoteMediaResource::didPassAccessControlCheck() const
-{
-    return m_didPassAccessControlCheck;
-}
-
 void RemoteMediaResource::responseReceived(const ResourceResponse& response, bool didPassAccessControlCheck, CompletionHandler<void(ShouldContinuePolicyCheck)>&& completionHandler)
 {
     assertIsCurrent(RemoteMediaResourceLoader::defaultQueue());

--- a/Source/WebKit/GPUProcess/media/RemoteMediaResource.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaResource.h
@@ -56,7 +56,7 @@ public:
     void shutdown() final;
 
     // PlatformMediaResource, called on the main thread.
-    bool didPassAccessControlCheck() const final;
+    bool didPassAccessControlCheck() const final { return m_didPassAccessControlCheck; }
 
     // Called on MediaResourceLoader's WorkQueue.
     void responseReceived(const WebCore::ResourceResponse&, bool, CompletionHandler<void(WebCore::ShouldContinuePolicyCheck)>&&);

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -132,7 +132,7 @@ public:
 
 private:
     explicit WebPaymentCoordinatorProxy(Client&);
-    Ref<WorkQueue> protectedCanMakePaymentsQueue() const;
+    Ref<WorkQueue> NODELETE protectedCanMakePaymentsQueue() const;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/Shared/WebBackForwardListItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListItem.h
@@ -92,7 +92,7 @@ public:
 
     WebBackForwardListFrameItem& navigatedFrameItem() const SWIFT_RETURNS_INDEPENDENT_VALUE;
 
-    WebBackForwardListFrameItem& mainFrameItem() const SWIFT_RETURNS_INDEPENDENT_VALUE;
+    WebBackForwardListFrameItem& NODELETE mainFrameItem() const SWIFT_RETURNS_INDEPENDENT_VALUE;
 
     void setWasRestoredFromSession();
 

--- a/Source/WebKit/Shared/WebMemorySampler.cpp
+++ b/Source/WebKit/Shared/WebMemorySampler.cpp
@@ -119,11 +119,6 @@ void WebMemorySampler::stop()
     if (RefPtr extension = std::exchange(m_sampleLogSandboxExtension, nullptr))
         extension->revoke();
 }
-
-bool WebMemorySampler::isRunning() const
-{
-    return m_isRunning;
-}
     
 void WebMemorySampler::initializeTempLogFile()
 {

--- a/Source/WebKit/Shared/WebMemorySampler.h
+++ b/Source/WebKit/Shared/WebMemorySampler.h
@@ -79,7 +79,7 @@ public:
     void start(const double interval = 0);
     void start(SandboxExtension::Handle&&, const String&, const double interval = 0);
     void stop();
-    bool isRunning() const;
+    bool isRunning() const { return m_isRunning; }
     
     // Do nothing since this is a singleton.
     void ref() const { }

--- a/Source/WebKit/UIProcess/API/APIJSBuffer.h
+++ b/Source/WebKit/UIProcess/API/APIJSBuffer.h
@@ -38,7 +38,7 @@ public:
     explicit JSBuffer(Ref<WebCore::SharedMemory>&&);
     virtual ~JSBuffer();
 
-    Ref<WebCore::SharedMemory> sharedMemory();
+    Ref<WebCore::SharedMemory> NODELETE sharedMemory();
 
 private:
     Ref<WebCore::SharedMemory> m_sharedMemory;

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -186,7 +186,7 @@ public:
     bool safeBrowsingCheckOngoing(size_t);
     bool safeBrowsingCheckOngoing();
     void setSafeBrowsingWarning(RefPtr<WebKit::BrowsingWarning>&&);
-    RefPtr<WebKit::BrowsingWarning> safeBrowsingWarning();
+    RefPtr<WebKit::BrowsingWarning> NODELETE safeBrowsingWarning();
     void setSafeBrowsingCheckTimedOut() { m_safeBrowsingCheckTimedOut = true; }
     bool safeBrowsingCheckTimedOut() { return m_safeBrowsingCheckTimedOut; }
     MonotonicTime requestStart() const { return m_requestStart; }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2906,7 +2906,7 @@ public:
 #endif
 
 #if ENABLE(POINTER_LOCK)
-    RefPtr<WebProcessProxy> webContentPointerLockProcess();
+    RefPtr<WebProcessProxy> NODELETE webContentPointerLockProcess();
     void clearWebContentPointerLockProcess();
     void resetPointerLockState(void);
 #endif
@@ -2929,7 +2929,7 @@ public:
     void takeActivitiesOnRemotePage(RemotePageProxy&);
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
-    RefPtr<WebDeviceOrientationUpdateProviderProxy> webDeviceOrientationUpdateProviderProxy();
+    RefPtr<WebDeviceOrientationUpdateProviderProxy> NODELETE webDeviceOrientationUpdateProviderProxy();
 #endif
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -410,7 +410,6 @@ private:
     void abandonGpuProcess();
     uint32_t createObjectName();
 
-
     WeakPtr<GPUProcessConnection> m_gpuProcessConnection; // Only main thread use.
     RefPtr<IPC::StreamClientConnection> m_streamConnection;
     bool m_didInitialize { false };

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -78,7 +78,7 @@ private:
         return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }
 
-    Ref<WebCore::WebGPU::Queue> queue() final;
+    Ref<WebCore::WebGPU::Queue> NODELETE queue() final;
 
     void destroy() final;
 
@@ -115,12 +115,12 @@ private:
     void setLabelInternal(const String&) final;
     void resolveDeviceLostPromise(CompletionHandler<void(WebCore::WebGPU::DeviceLostReason)>&&) final;
 
-    Ref<WebCore::WebGPU::BindGroupLayout> emptyBindGroupLayout() const final;
+    Ref<WebCore::WebGPU::BindGroupLayout> NODELETE emptyBindGroupLayout() const final;
 
-    Ref<WebCore::WebGPU::CommandEncoder> invalidCommandEncoder() final;
-    Ref<WebCore::WebGPU::CommandBuffer> invalidCommandBuffer() final;
-    Ref<WebCore::WebGPU::RenderPassEncoder> invalidRenderPassEncoder() final;
-    Ref<WebCore::WebGPU::ComputePassEncoder> invalidComputePassEncoder() final;
+    Ref<WebCore::WebGPU::CommandEncoder> NODELETE invalidCommandEncoder() final;
+    Ref<WebCore::WebGPU::CommandBuffer> NODELETE invalidCommandBuffer() final;
+    Ref<WebCore::WebGPU::RenderPassEncoder> NODELETE invalidRenderPassEncoder() final;
+    Ref<WebCore::WebGPU::ComputePassEncoder> NODELETE invalidComputePassEncoder() final;
     void pauseAllErrorReporting(bool pause) final;
 
     bool isRemoteDeviceProxy() const final { return true; }


### PR DESCRIPTION
#### 43740686537f60db466be13580cb17873f5b7c3d
<pre>
Adopt `NODELETE` annotation in more places in WebKit/
<a href="https://bugs.webkit.org/show_bug.cgi?id=307528">https://bugs.webkit.org/show_bug.cgi?id=307528</a>

Reviewed by Ryosuke Niwa and Mike Wyrzykowski.

* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/graphics/RemoteSnapshotRecorder.h:
* Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaResource.cpp:
(WebKit::RemoteMediaResource::didPassAccessControlCheck const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaResource.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/WebBackForwardListItem.h:
* Source/WebKit/Shared/WebMemorySampler.cpp:
(WebKit::WebMemorySampler::stop):
(WebKit::WebMemorySampler::isRunning const): Deleted.
* Source/WebKit/Shared/WebMemorySampler.h:
* Source/WebKit/UIProcess/API/APIJSBuffer.h:
* Source/WebKit/UIProcess/API/APINavigation.h:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.h:

Canonical link: <a href="https://commits.webkit.org/307397@main">https://commits.webkit.org/307397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29452c86400642cb7b018973fb24e1a36bdb127e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144185 "48 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152855 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97424 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ba2c25a-5861-44f4-b4f4-a2c1332064f8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17346 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16758 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110872 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79668 "Exiting early after 60 failures. 15291 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bbbc2f6-ab10-41e4-8478-4ab85482e87d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147148 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13285 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129536 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91790 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4b06ce5-cb75-4177-875b-ae43dc980524) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12723 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10471 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/301 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122215 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155167 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16716 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118891 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16753 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14036 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119249 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30587 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15124 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127402 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72137 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16338 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5838 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16072 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80117 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16138 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->