### PR TITLE
Adopt `NODELETE` annotation in more places in WebKitLegacy/

### DIFF
--- a/Source/WebKitLegacy/Storage/StorageAreaImpl.cpp
+++ b/Source/WebKitLegacy/Storage/StorageAreaImpl.cpp
@@ -97,11 +97,6 @@ StorageAreaImpl::StorageAreaImpl(const StorageAreaImpl& area)
     ASSERT(!m_isShutdown);
 }
 
-StorageType StorageAreaImpl::storageType() const
-{
-    return m_storageType;
-}
-
 unsigned StorageAreaImpl::length()
 {
     ASSERT(!m_isShutdown);

--- a/Source/WebKitLegacy/Storage/StorageAreaImpl.h
+++ b/Source/WebKitLegacy/Storage/StorageAreaImpl.h
@@ -54,7 +54,7 @@ public:
     void clear(WebCore::LocalFrame& sourceFrame) override;
     bool contains(const String& key) override;
 
-    WebCore::StorageType storageType() const override;
+    WebCore::StorageType storageType() const override { return m_storageType; }
 
     size_t memoryBytesUsedByCache() override;
 

--- a/Source/WebKitLegacy/Storage/StorageTracker.cpp
+++ b/Source/WebKitLegacy/Storage/StorageTracker.cpp
@@ -596,11 +596,6 @@ void StorageTracker::cancelDeletingOrigin(const String& originIdentifier)
     }
 }
 
-bool StorageTracker::isActive()
-{
-    return m_isActive;
-}
-
 void StorageTracker::setIsActive(bool flag)
 {
     m_isActive = flag;

--- a/Source/WebKitLegacy/Storage/StorageTracker.h
+++ b/Source/WebKitLegacy/Storage/StorageTracker.h
@@ -60,7 +60,7 @@ public:
     
     void cancelDeletingOrigin(const String& originIdentifier);
     
-    bool isActive();
+    bool isActive() const { return m_isActive; }
 
     Seconds storageDatabaseIdleInterval() { return m_StorageDatabaseIdleInterval; }
     void setStorageDatabaseIdleInterval(Seconds interval) { m_StorageDatabaseIdleInterval = interval; }

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp
@@ -44,11 +44,6 @@ SocketStreamHandle::SocketStreamHandle(const URL& url, SocketStreamHandleClient&
     ASSERT(isMainThread());
 }
 
-SocketStreamHandle::SocketStreamState SocketStreamHandle::state() const
-{
-    return m_state;
-}
-
 void SocketStreamHandle::sendData(std::span<const uint8_t> data, Function<void(bool)> completionHandler)
 {
     if (m_state == Connecting || m_state == Closing)

--- a/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.h
+++ b/Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.h
@@ -51,7 +51,7 @@ class SocketStreamHandle : public ThreadSafeRefCounted<SocketStreamHandle, WTF::
 public:
     enum SocketStreamState { Connecting, Open, Closing, Closed };
     virtual ~SocketStreamHandle() = default;
-    SocketStreamState state() const;
+    SocketStreamState state() const { return m_state; }
 
     void sendData(std::span<const uint8_t> data, Function<void(bool)>);
     void sendHandshake(CString&& handshake, std::optional<CookieRequestHeaderFieldProxy>&&, Function<void(bool, bool)>);

--- a/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
+++ b/Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h
@@ -109,7 +109,7 @@ public:
     ResourceRequest clientHandshakeRequest(const CookieGetter&) const final;
     const ResourceResponse& serverHandshakeResponse() const final;
 
-    Document* document();
+    Document* NODELETE document();
     
 private:
     WEBCORE_EXPORT WebSocketChannel(Document&, WebSocketChannelClient&, SocketProvider&);


### PR DESCRIPTION
#### 2941f680e35b0be8a05beefc792ca9d8a213c619
<pre>
Adopt `NODELETE` annotation in more places in WebKitLegacy/
<a href="https://bugs.webkit.org/show_bug.cgi?id=307530">https://bugs.webkit.org/show_bug.cgi?id=307530</a>

Reviewed by Darin Adler.

* Source/WebKitLegacy/Storage/StorageAreaImpl.cpp:
(WebKit::StorageAreaImpl::storageType const): Deleted.
* Source/WebKitLegacy/Storage/StorageAreaImpl.h:
* Source/WebKitLegacy/Storage/StorageTracker.cpp:
(WebKit::StorageTracker::isActive): Deleted.
* Source/WebKitLegacy/Storage/StorageTracker.h:
(WebKit::StorageTracker::isActive const):
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.cpp:
(WebCore::SocketStreamHandle::state const): Deleted.
* Source/WebKitLegacy/WebCoreSupport/SocketStreamHandle.h:
(WebCore::SocketStreamHandle::state const):
* Source/WebKitLegacy/WebCoreSupport/WebSocketChannel.h:

Canonical link: <a href="https://commits.webkit.org/307329@main">https://commits.webkit.org/307329@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ca10007b3ffce7df99b412901f76d97abbba39e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143867 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16539 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8062 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97106 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f7ffc614-bd45-4166-8c27-f91f4d5ace10) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16436 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110629 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79565 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a26af63e-62eb-485f-a921-62899ac4c216) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91547 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/534b6da9-a2bc-48c0-99bf-06f4c1dcc595) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12520 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10256 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5886 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154847 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16396 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118639 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13787 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118993 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30538 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14911 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127095 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71809 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16017 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5577 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79814 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15963 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15816 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->