### PR TITLE
[YARR] Need to use stored backtracking address from NestedAlternativeEnd

### DIFF
--- a/JSTests/stress/regexp-fixed-count-multi-alt-backtracking.js
+++ b/JSTests/stress/regexp-fixed-count-multi-alt-backtracking.js
@@ -1,0 +1,309 @@
+// Regression test for FixedCount multi-alternative backtracking bug.
+// The bug was that when backtracking to try a different alternative within
+// an iteration, the index was incorrectly set to endOffset (where iteration ended)
+// instead of beginOffset (where iteration started), causing alternatives to be
+// tested at the wrong position.
+//
+// This test specifically focuses on cases where beginIndex restoration matters:
+// 1. Alternatives of different lengths
+// 2. Multiple alternatives with various orderings
+// 3. Nested patterns
+// 4. Multiple iterations with backtracking
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + JSON.stringify(actual) + ' expected: ' + JSON.stringify(expected));
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(JSON.stringify(actual), JSON.stringify(expected));
+}
+
+// =============================================================================
+// SECTION 1: Alternatives of different lengths
+// When first (longer) alternative fails, second (shorter) must be tried at
+// the SAME start position, not at the end of where the longer one partially matched.
+// =============================================================================
+
+// (ab|a){2} - 'ab' is longer than 'a'
+function testDiffLen1(s) { return s.match(/(ab|a){2}c/); }
+noInline(testDiffLen1);
+
+// (abc|ab|a){2} - three alternatives of decreasing length
+function testDiffLen2(s) { return s.match(/(abc|ab|a){2}d/); }
+noInline(testDiffLen2);
+
+// (abcd|abc|ab|a){2} - four alternatives
+function testDiffLen3(s) { return s.match(/(abcd|abc|ab|a){2}e/); }
+noInline(testDiffLen3);
+
+// (a|ab){2} - shorter alternative first (different backtrack pattern)
+function testDiffLen4(s) { return s.match(/(a|ab){2}c/); }
+noInline(testDiffLen4);
+
+// (a|ab|abc){2} - increasing length order
+function testDiffLen5(s) { return s.match(/(a|ab|abc){2}d/); }
+noInline(testDiffLen5);
+
+// =============================================================================
+// SECTION 2: Three or more alternatives - ensure all are tried at correct position
+// =============================================================================
+
+// (a|b|c){2} - three single-char alternatives
+function testThreeAlt1(s) { return s.match(/(a|b|c){2}$/); }
+noInline(testThreeAlt1);
+
+// (a|b|c|d){2} - four single-char alternatives
+function testFourAlt1(s) { return s.match(/(a|b|c|d){2}$/); }
+noInline(testFourAlt1);
+
+// (aa|bb|cc){2} - three two-char alternatives
+function testThreeAlt2(s) { return s.match(/(aa|bb|cc){2}$/); }
+noInline(testThreeAlt2);
+
+// (a|bb|ccc){2} - three alternatives of different lengths
+function testThreeAlt3(s) { return s.match(/(a|bb|ccc){2}d/); }
+noInline(testThreeAlt3);
+
+// =============================================================================
+// SECTION 3: Multiple iterations ({3}, {4}, etc.) - beginIndex must be correct
+// for each iteration's backtracking
+// =============================================================================
+
+// (a|b){3} - three iterations
+function testThreeIter1(s) { return s.match(/(a|b){3}$/); }
+noInline(testThreeIter1);
+
+// (ab|a){3} - three iterations with different length alternatives
+function testThreeIter2(s) { return s.match(/(ab|a){3}c/); }
+noInline(testThreeIter2);
+
+// (a|b|c){4} - four iterations
+function testFourIter1(s) { return s.match(/(a|b|c){4}$/); }
+noInline(testFourIter1);
+
+// (a|b){5} - five iterations
+function testFiveIter1(s) { return s.match(/(a|b){5}$/); }
+noInline(testFiveIter1);
+
+// =============================================================================
+// SECTION 4: Combinations requiring inter-iteration backtracking
+// After exhausting all alternatives in iteration N, must correctly backtrack
+// to iteration N-1 and try its remaining alternatives at N-1's beginIndex
+// =============================================================================
+
+// Test where iter2 fails completely, forcing iter1 to try different alternatives
+function testInterIter1(s) { return s.match(/(ab|a){2}x/); }
+noInline(testInterIter1);
+
+// Test chain: iter3 fails -> iter2 backtracks -> iter1 backtracks
+function testInterIter2(s) { return s.match(/(ab|a){3}x/); }
+noInline(testInterIter2);
+
+// =============================================================================
+// SECTION 5: Patterns with content that can partially match
+// The first alternative may consume input before failing, and the second
+// must start from the original position
+// =============================================================================
+
+// (xy|x){2} - 'xy' consumes 'x' before failing on 'y'
+function testPartial1(s) { return s.match(/(xy|x){2}z/); }
+noInline(testPartial1);
+
+// (xyz|xy|x){2} - multiple levels of partial consumption
+function testPartial2(s) { return s.match(/(xyz|xy|x){2}w/); }
+noInline(testPartial2);
+
+// =============================================================================
+// SECTION 6: Backtrackable content within alternatives
+// Combines content backtracking with alternative switching
+// =============================================================================
+
+// (a+|b){2} - first alt is greedy, second is fixed
+function testGreedy1(s) { return s.match(/(a+|b){2}c/); }
+noInline(testGreedy1);
+
+// (a+|b+){2} - both alts are greedy
+function testGreedy2(s) { return s.match(/(a+|b+){2}c/); }
+noInline(testGreedy2);
+
+// (a+|b+|c+){2} - three greedy alternatives
+function testGreedy3(s) { return s.match(/(a+|b+|c+){2}d/); }
+noInline(testGreedy3);
+
+// (a*|b){2} - first alt can match empty
+function testStar1(s) { return s.match(/(a*x|b){2}c/); }
+noInline(testStar1);
+
+// =============================================================================
+// SECTION 7: Nested parentheses - beginIndex handling with nesting
+// =============================================================================
+
+// ((a|b){2}){2} - nested FixedCount
+function testNested1(s) { return s.match(/((a|b){2}){2}$/); }
+noInline(testNested1);
+
+// (a|(bc){2}){2} - alternative contains FixedCount
+function testNested2(s) { return s.match(/(a|(bc){2}){2}$/); }
+noInline(testNested2);
+
+// =============================================================================
+// SECTION 8: Edge cases
+// =============================================================================
+
+// Single iteration (boundary case)
+function testSingleIter(s) { return s.match(/(ab|a){1}c/); }
+noInline(testSingleIter);
+
+// Two-char vs one-char where input has exact match for longer
+function testExactLong(s) { return s.match(/(ab|a){2}c/); }
+noInline(testExactLong);
+
+// Pattern at different positions in string
+function testPosition(s) { return s.match(/(ab|a){2}c/); }
+noInline(testPosition);
+
+for (var i = 0; i < 1e4; ++i) {
+    // SECTION 1: Different length alternatives
+    shouldBeArray(testDiffLen1('aac'), ['aac', 'a']);
+    shouldBeArray(testDiffLen1('abc'), null);  // 'ab' + ? can't make {2}c
+    shouldBeArray(testDiffLen1('aabc'), ['aabc', 'ab']);  // 'a' + 'ab'
+    shouldBeArray(testDiffLen1('abac'), ['abac', 'a']);   // 'ab' + 'a'
+    shouldBeArray(testDiffLen1('ababc'), ['ababc', 'ab']); // 'ab' + 'ab'
+
+    shouldBeArray(testDiffLen2('aad'), ['aad', 'a']);
+    shouldBeArray(testDiffLen2('aabd'), ['aabd', 'ab']);
+    shouldBeArray(testDiffLen2('aabcd'), ['aabcd', 'abc']);
+    shouldBeArray(testDiffLen2('abcd'), null);  // 'abc' alone can't make {2}
+    shouldBeArray(testDiffLen2('abcad'), ['abcad', 'a']);
+
+    shouldBeArray(testDiffLen3('aae'), ['aae', 'a']);
+    shouldBeArray(testDiffLen3('aabe'), ['aabe', 'ab']);
+    shouldBeArray(testDiffLen3('aabce'), ['aabce', 'abc']);
+    shouldBeArray(testDiffLen3('aabcde'), ['aabcde', 'abcd']);
+    shouldBeArray(testDiffLen3('abcdae'), ['abcdae', 'a']);
+
+    shouldBeArray(testDiffLen4('aac'), ['aac', 'a']);  // 'a' + 'a'
+    shouldBeArray(testDiffLen4('aabc'), ['aabc', 'ab']); // 'a' + 'ab'
+    shouldBeArray(testDiffLen4('abac'), ['abac', 'a']);  // 'ab' + 'a'
+    shouldBeArray(testDiffLen4('ababc'), ['ababc', 'ab']);
+
+    shouldBeArray(testDiffLen5('aad'), ['aad', 'a']);
+    shouldBeArray(testDiffLen5('aabd'), ['aabd', 'ab']);
+    shouldBeArray(testDiffLen5('aabcd'), ['aabcd', 'abc']);
+
+    // SECTION 2: Three or more alternatives
+    shouldBeArray(testThreeAlt1('aa'), ['aa', 'a']);
+    shouldBeArray(testThreeAlt1('ab'), ['ab', 'b']);
+    shouldBeArray(testThreeAlt1('ac'), ['ac', 'c']);
+    shouldBeArray(testThreeAlt1('ba'), ['ba', 'a']);
+    shouldBeArray(testThreeAlt1('bb'), ['bb', 'b']);
+    shouldBeArray(testThreeAlt1('bc'), ['bc', 'c']);
+    shouldBeArray(testThreeAlt1('ca'), ['ca', 'a']);
+    shouldBeArray(testThreeAlt1('cb'), ['cb', 'b']);
+    shouldBeArray(testThreeAlt1('cc'), ['cc', 'c']);
+
+    shouldBeArray(testFourAlt1('ad'), ['ad', 'd']);
+    shouldBeArray(testFourAlt1('da'), ['da', 'a']);
+    shouldBeArray(testFourAlt1('bd'), ['bd', 'd']);
+    shouldBeArray(testFourAlt1('cd'), ['cd', 'd']);
+
+    shouldBeArray(testThreeAlt2('aaaa'), ['aaaa', 'aa']);
+    shouldBeArray(testThreeAlt2('aabb'), ['aabb', 'bb']);
+    shouldBeArray(testThreeAlt2('bbcc'), ['bbcc', 'cc']);
+    shouldBeArray(testThreeAlt2('ccaa'), ['ccaa', 'aa']);
+
+    shouldBeArray(testThreeAlt3('aad'), ['aad', 'a']);      // 'a' + 'a'
+    shouldBeArray(testThreeAlt3('abbd'), ['abbd', 'bb']);   // 'a' + 'bb'
+    shouldBeArray(testThreeAlt3('acccd'), ['acccd', 'ccc']); // 'a' + 'ccc'
+    shouldBeArray(testThreeAlt3('bbad'), ['bbad', 'a']);    // 'bb' + 'a'
+    shouldBeArray(testThreeAlt3('cccad'), ['cccad', 'a']);  // 'ccc' + 'a'
+
+    // SECTION 3: Multiple iterations
+    shouldBeArray(testThreeIter1('aaa'), ['aaa', 'a']);
+    shouldBeArray(testThreeIter1('aab'), ['aab', 'b']);
+    shouldBeArray(testThreeIter1('aba'), ['aba', 'a']);
+    shouldBeArray(testThreeIter1('baa'), ['baa', 'a']);
+    shouldBeArray(testThreeIter1('bbb'), ['bbb', 'b']);
+
+    shouldBeArray(testThreeIter2('aaac'), ['aaac', 'a']);
+    shouldBeArray(testThreeIter2('aaabc'), ['aaabc', 'ab']);
+    shouldBeArray(testThreeIter2('aababc'), ['aababc', 'ab']);
+    shouldBeArray(testThreeIter2('ababac'), ['ababac', 'a']);
+
+    shouldBeArray(testFourIter1('aaaa'), ['aaaa', 'a']);
+    shouldBeArray(testFourIter1('abca'), ['abca', 'a']);
+    shouldBeArray(testFourIter1('abcd'), null);  // 'd' not in [abc]
+    shouldBeArray(testFourIter1('abcb'), ['abcb', 'b']);
+
+    shouldBeArray(testFiveIter1('aaaaa'), ['aaaaa', 'a']);
+    shouldBeArray(testFiveIter1('ababa'), ['ababa', 'a']);
+    shouldBeArray(testFiveIter1('bbbbb'), ['bbbbb', 'b']);
+
+    // SECTION 4: Inter-iteration backtracking
+    shouldBeArray(testInterIter1('aax'), ['aax', 'a']);
+    shouldBeArray(testInterIter1('abx'), null);  // 'ab' leaves no room
+    shouldBeArray(testInterIter1('aabx'), ['aabx', 'ab']);
+
+    shouldBeArray(testInterIter2('aaax'), ['aaax', 'a']);
+    shouldBeArray(testInterIter2('aaabx'), ['aaabx', 'ab']);
+    shouldBeArray(testInterIter2('aababx'), ['aababx', 'ab']);
+
+    // SECTION 5: Partial matching
+    shouldBeArray(testPartial1('xxz'), ['xxz', 'x']);
+    shouldBeArray(testPartial1('xyz'), null);  // 'xy' leaves no room for {2}
+    shouldBeArray(testPartial1('xxyz'), ['xxyz', 'xy']);
+    shouldBeArray(testPartial1('xyxz'), ['xyxz', 'x']);
+
+    shouldBeArray(testPartial2('xxw'), ['xxw', 'x']);
+    shouldBeArray(testPartial2('xxyw'), ['xxyw', 'xy']);
+    shouldBeArray(testPartial2('xxyzw'), ['xxyzw', 'xyz']);
+    shouldBeArray(testPartial2('xyzxw'), ['xyzxw', 'x']);
+
+    // SECTION 6: Greedy content
+    shouldBeArray(testGreedy1('aac'), ['aac', 'a']);
+    shouldBeArray(testGreedy1('abc'), ['abc', 'b']);
+    shouldBeArray(testGreedy1('aabc'), ['aabc', 'b']);
+    shouldBeArray(testGreedy1('aaabc'), ['aaabc', 'b']);
+    shouldBeArray(testGreedy1('bbc'), ['bbc', 'b']);
+    shouldBeArray(testGreedy1('bac'), ['bac', 'a']);
+
+    shouldBeArray(testGreedy2('aac'), ['aac', 'a']);
+    shouldBeArray(testGreedy2('abc'), ['abc', 'b']);
+    shouldBeArray(testGreedy2('aabc'), ['aabc', 'b']);
+    shouldBeArray(testGreedy2('abbc'), ['abbc', 'bb']);
+    shouldBeArray(testGreedy2('aabbc'), ['aabbc', 'bb']);
+
+    shouldBeArray(testGreedy3('aad'), ['aad', 'a']);
+    shouldBeArray(testGreedy3('abd'), ['abd', 'b']);
+    shouldBeArray(testGreedy3('acd'), ['acd', 'c']);
+    shouldBeArray(testGreedy3('aabd'), ['aabd', 'b']);
+    shouldBeArray(testGreedy3('abcd'), ['bcd', 'c']);  // matches 'b'+'c' starting at pos 1
+    shouldBeArray(testGreedy3('aabcd'), ['bcd', 'c']); // matches 'b'+'c' starting at pos 2
+
+    shouldBeArray(testStar1('xxbc'), ['xbc', 'b']);  // 'x' + 'b' starting at pos 1
+    shouldBeArray(testStar1('axbc'), ['axbc', 'b']);
+    shouldBeArray(testStar1('bbc'), ['bbc', 'b']);
+    shouldBeArray(testStar1('baxc'), ['baxc', 'ax']);
+
+    // SECTION 7: Nested patterns
+    shouldBeArray(testNested1('aabb'), ['aabb', 'bb', 'b']);
+    shouldBeArray(testNested1('abab'), ['abab', 'ab', 'b']);
+    shouldBeArray(testNested1('abba'), ['abba', 'ba', 'a']);
+    shouldBeArray(testNested1('baab'), ['baab', 'ab', 'b']);
+
+    shouldBeArray(testNested2('aa'), ['aa', 'a', null]);
+    shouldBeArray(testNested2('abcbc'), ['abcbc', 'bcbc', 'bc']);
+    shouldBeArray(testNested2('bcbca'), ['bcbca', 'a', null]);
+
+    // SECTION 8: Edge cases
+    shouldBeArray(testSingleIter('ac'), ['ac', 'a']);
+    shouldBeArray(testSingleIter('abc'), ['abc', 'ab']);
+
+    shouldBeArray(testExactLong('ababc'), ['ababc', 'ab']);  // exactly two 'ab'
+    shouldBeArray(testExactLong('abac'), ['abac', 'a']);     // 'ab' + 'a'
+
+    shouldBeArray(testPosition('xaacy'), ['aac', 'a']);   // middle of string
+    shouldBeArray(testPosition('aac'), ['aac', 'a']);     // start of string
+    shouldBeArray(testPosition('xyzaac'), ['aac', 'a']);  // end of string
+}

--- a/JSTests/stress/regexp-nested-quantified-parens-backtrack.js
+++ b/JSTests/stress/regexp-nested-quantified-parens-backtrack.js
@@ -1,0 +1,43 @@
+// Regression test for nested quantified parentheses crash.
+// The bug occurred when:
+// 1. An outer quantified parentheses group with multiple alternatives
+// 2. One alternative contains a nested quantified parentheses group
+// 3. Other alternatives don't contain the nested group
+// 4. The nested group's frame slots (parenContextHead) were uninitialized
+//    when the alternative containing it was entered after other alternatives failed.
+
+// The pattern that triggered the crash:
+// (a|b|c(){2}$){2}$ - outer group {2} with alternatives a, b, and c(){2}$
+// The inner (){2} is only in the 'c' alternative.
+
+var r = new RegExp('(a|b|c(){2}$){2}$');
+
+function test(input, expected) {
+    var result = input.match(r);
+    if (expected === null) {
+        if (result !== null)
+            throw new Error("Expected null for input '" + input + "', got: " + JSON.stringify(result));
+    } else {
+        if (result === null)
+            throw new Error("Expected match for input '" + input + "', got null");
+        if (JSON.stringify(result) !== JSON.stringify(expected))
+            throw new Error("Expected " + JSON.stringify(expected) + " for input '" + input + "', got: " + JSON.stringify(result));
+    }
+}
+
+// Cases that match (alternative a or b taken, no nested group execution)
+test("aa", ["aa", "a", null]);
+test("ab", ["ab", "b", null]);
+test("ba", ["ba", "a", null]);
+test("bb", ["bb", "b", null]);
+
+// Cases where alternative c is taken (nested group executes)
+test("ac", ["ac", "c", ""]);
+test("bc", ["bc", "c", ""]);
+
+// The original crash case - enters 'c' alternative after 'a' and 'b' fail
+test("abc", ["bc", "c", ""]);
+
+// Cases that don't match
+test("cc", null);
+test("aabbbccc", null);

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -139,6 +139,7 @@ bool hasCapacityToUseLargeGigacage();
     v(Bool, dumpDFGDisassembly, false, Normal, "dumps disassembly of DFG function upon compilation"_s) \
     v(Bool, dumpFTLDisassembly, false, Normal, "dumps disassembly of FTL function upon compilation"_s) \
     v(Bool, dumpRegExpDisassembly, false, Normal, "dumps disassembly of RegExp upon compilation"_s) \
+    v(Bool, traceRegExpJITExecution, false, Normal, "traces RegExp JIT execution at reentry points"_s) \
     v(Bool, dumpWasmDisassembly, false, Normal, "dumps disassembly of all wasm code upon compilation"_s) \
     v(OptionString, dumpWasmSourceFileName, nullptr, Normal, "log every wasm module validation, and dump source bytes to <filename>.0.wasm, <filename>.1.wasm, etc..."_s) \
     v(OptionString, wasmOMGFunctionsToDump, nullptr, Normal, "file with newline separated list of function indices to dump IR/disassembly for, if no such file exists, the function index itself"_s) \


### PR DESCRIPTION
#### d4f884d21c0e96b8ec7d1eb289343cf221cbd016
<pre>
[YARR] Need to use stored backtracking address from NestedAlternativeEnd
<a href="https://rdar.apple.com/170038644">rdar://170038644</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307532">https://bugs.webkit.org/show_bug.cgi?id=307532</a>

Reviewed by Yijia Huang.

Let&apos;s have Pattern: (a|b|c(){2}$){2}$ with input &apos;aabbbccc&apos;

When the first iteration of `(a|b|c(){2}$)` can run successfully with
&apos;a&apos;. And the second iteration works well too with &apos;a&apos;. But after that, $
fails because there is &apos;bbbccc&apos; after &apos;aa&apos;.

So, we backtrack to the second iteration. Since &apos;a&apos; is just a character
and no way to backtrack again, we need to go to the next alternative
&apos;b&apos;. And this fails too, and next alternative &apos;c&apos; fails too.

At this point, we go back to the previous first iteration. And we go to
NestedAlternativeEnd with the previous iteration&apos;s context (via
restoring of paren context).

To make it easily debuggable, we added trace logging via
Options::traceRegExpJITExecution. This dumps the execution log of the
above like this. Previously, we are wrongly jumping to ParenthesesSubpatternBegin.bt
from NestedAlternativeEnd.bt because we were not using stored
returnAddress jump. But this is fixed in this patch.

      === TRY MATCH AT POSITION 0 ===

      RegExpJIT [0] BodyAlternativeBegin index=0          # Start matching at pos 0
      RegExpJIT [1] ParenthesesSubpatternBegin index=0    # Outer paren iter1: try at pos 0
      RegExpJIT [1] ParenthesesSubpatternBegin index=1    # Outer paren iter2: try at pos 1 (&apos;a&apos; matched iter1)
      RegExpJIT [14] ParenthesesSubpatternEnd index=2     # iter2 completed, now at pos 2 (&apos;a&apos; matched iter2)
      RegExpJIT [14] ParenthesesSubpatternEnd.bt index=2  # &apos;$&apos; at pos 2 failed (&apos;b&apos; != end), backtrack
      RegExpJIT [13] NestedAlternativeEnd.bt index=2      # Jump via returnAddress to content backtrack
      RegExpJIT [2] NestedAlternativeBegin.bt index=2     # &apos;a&apos; content backtrack fails (nothing to give up)
      RegExpJIT [4] NestedAlternativeNext index=1         # Try &apos;b&apos; at pos 1 (with my fix: beginIndex restored)
      RegExpJIT [4] NestedAlternativeNext.bt index=2      # &apos;b&apos; at pos 1 fails (&apos;a&apos; != &apos;b&apos;), backtrack
      RegExpJIT [6] NestedAlternativeNext index=1         # Try &apos;c(){2}$&apos; at pos 1
      RegExpJIT [6] NestedAlternativeNext.bt index=2      # &apos;c&apos; at pos 1 fails (&apos;a&apos; != &apos;c&apos;), backtrack
      RegExpJIT [1] ParenthesesSubpatternBegin.bt index=1 # All iter2 alts exhausted, try iter1

      # Now backtracking into iter1 (which matched &apos;a&apos; at pos 0)
      RegExpJIT [2] NestedAlternativeBegin.bt index=2     # &apos;a&apos; content backtrack at iter1&apos;s end (pos 1) - fails
      RegExpJIT [4] NestedAlternativeNext index=1         # Try &apos;b&apos; at iter1&apos;s begin (pos 0)
      RegExpJIT [4] NestedAlternativeNext.bt index=2      # &apos;b&apos; at pos 0 fails (&apos;a&apos; != &apos;b&apos;)
      RegExpJIT [6] NestedAlternativeNext index=1         # Try &apos;c(){2}$&apos; at pos 0
      RegExpJIT [6] NestedAlternativeNext.bt index=2      # &apos;c&apos; at pos 0 fails (&apos;a&apos; != &apos;c&apos;)
      RegExpJIT [1] ParenthesesSubpatternBegin.bt index=1 # All iter1 alts exhausted, no more contexts
      RegExpJIT [0] BodyAlternativeBegin.bt index=0       # Propagate failure, try next start position

      === TRY MATCH AT POSITION 1 ===

      RegExpJIT [0] BodyAlternativeBegin index=1          # Start matching at pos 1
      RegExpJIT [1] ParenthesesSubpatternBegin index=1    # Outer paren iter1: try at pos 1
      RegExpJIT [1] ParenthesesSubpatternBegin index=2    # iter2: try at pos 2 (&apos;a&apos; matched at 1)
      RegExpJIT [2] NestedAlternativeBegin.bt index=3     # &apos;a&apos; at pos 2 fails (&apos;b&apos; != &apos;a&apos;)
      RegExpJIT [4] NestedAlternativeNext index=2         # Try &apos;b&apos; at pos 2
      RegExpJIT [14] ParenthesesSubpatternEnd index=3     # iter2 completed with &apos;b&apos;, now at pos 3
      RegExpJIT [14] ParenthesesSubpatternEnd.bt index=3  # &apos;$&apos; at pos 3 fails, backtrack
      RegExpJIT [13] NestedAlternativeEnd.bt index=3      # Jump to content backtrack
      RegExpJIT [4] NestedAlternativeNext.bt index=3      # &apos;b&apos; content backtrack fails
      RegExpJIT [6] NestedAlternativeNext index=2         # Try &apos;c(){2}$&apos; at pos 2
      RegExpJIT [6] NestedAlternativeNext.bt index=3      # &apos;c&apos; at pos 2 fails (&apos;b&apos; != &apos;c&apos;)
      RegExpJIT [1] ParenthesesSubpatternBegin.bt index=2 # All iter2 alts exhausted, try iter1

      # Backtrack iter1
      RegExpJIT [4] NestedAlternativeNext.bt index=3      # iter1 took &apos;a&apos;, content backtrack fails
      RegExpJIT [6] NestedAlternativeNext index=2         # Try &apos;c(){2}$&apos; at iter1&apos;s begin (pos 1)
      RegExpJIT [6] NestedAlternativeNext.bt index=3      # &apos;c&apos; at pos 1 fails (&apos;a&apos; != &apos;c&apos;)
      RegExpJIT [1] ParenthesesSubpatternBegin.bt index=2 # Incomplete context skipped

      # Now at iter1&apos;s context from when it matched &apos;a&apos; at pos 1
      RegExpJIT [2] NestedAlternativeBegin.bt index=2     # &apos;a&apos; content backtrack at pos 2 fails
      RegExpJIT [4] NestedAlternativeNext index=1         # Try &apos;b&apos; at pos 1
      RegExpJIT [4] NestedAlternativeNext.bt index=2      # &apos;b&apos; at pos 1 fails (&apos;a&apos; != &apos;b&apos;)
      RegExpJIT [6] NestedAlternativeNext index=1         # Try &apos;c&apos; at pos 1
      RegExpJIT [6] NestedAlternativeNext.bt index=2      # &apos;c&apos; at pos 1 fails
      RegExpJIT [1] ParenthesesSubpatternBegin.bt index=1 # All exhausted
      RegExpJIT [0] BodyAlternativeBegin.bt index=1       # Try next position

      === TRY MATCH AT POSITION 2 ===

      RegExpJIT [0] BodyAlternativeBegin index=2          # Start at pos 2 (&apos;b&apos;)
      RegExpJIT [1] ParenthesesSubpatternBegin index=2    # iter1 at pos 2
      RegExpJIT [2] NestedAlternativeBegin.bt index=3     # &apos;a&apos; fails at pos 2
      RegExpJIT [4] NestedAlternativeNext index=2         # Try &apos;b&apos; at pos 2
      RegExpJIT [1] ParenthesesSubpatternBegin index=3    # iter1=&apos;b&apos;, iter2 at pos 3
      RegExpJIT [2] NestedAlternativeBegin.bt index=4     # &apos;a&apos; fails at pos 3
      RegExpJIT [4] NestedAlternativeNext index=3         # Try &apos;b&apos; at pos 3
      RegExpJIT [14] ParenthesesSubpatternEnd index=4     # iter2=&apos;b&apos;, completed at pos 4
      RegExpJIT [14] ParenthesesSubpatternEnd.bt index=4  # &apos;$&apos; fails at pos 4
      RegExpJIT [13] NestedAlternativeEnd.bt index=4
      RegExpJIT [4] NestedAlternativeNext.bt index=4
      RegExpJIT [6] NestedAlternativeNext index=3         # Try &apos;c&apos; at pos 3
      RegExpJIT [6] NestedAlternativeNext.bt index=4      # &apos;c&apos; fails (&apos;b&apos; != &apos;c&apos;)
      RegExpJIT [1] ParenthesesSubpatternBegin.bt index=3 # iter2 exhausted
      RegExpJIT [4] NestedAlternativeNext.bt index=4      # iter1 backtrack
      RegExpJIT [6] NestedAlternativeNext index=3         # Try &apos;c&apos; at iter1 pos 2
      RegExpJIT [6] NestedAlternativeNext.bt index=4      # &apos;c&apos; fails
      RegExpJIT [1] ParenthesesSubpatternBegin.bt index=3 # Skip incomplete
      RegExpJIT [4] NestedAlternativeNext.bt index=3      # iter1 &apos;b&apos; content backtrack
      RegExpJIT [6] NestedAlternativeNext index=2         # Try &apos;c&apos; at pos 2
      RegExpJIT [6] NestedAlternativeNext.bt index=3      # &apos;c&apos; fails
      RegExpJIT [1] ParenthesesSubpatternBegin.bt index=2 # All exhausted
      RegExpJIT [0] BodyAlternativeBegin.bt index=2

      === TRY MATCH AT POSITION 3 ===

      RegExpJIT [0] BodyAlternativeBegin index=3          # Start at pos 3 (&apos;b&apos;)
      # ... similar pattern, eventually fails ...
      RegExpJIT [0] BodyAlternativeBegin.bt index=3

      === TRY MATCH AT POSITION 4 ===

      RegExpJIT [0] BodyAlternativeBegin index=4          # Start at pos 4 (&apos;b&apos;)
      RegExpJIT [1] ParenthesesSubpatternBegin index=4
      RegExpJIT [2] NestedAlternativeBegin.bt index=5     # &apos;a&apos; fails
      RegExpJIT [4] NestedAlternativeNext index=4         # Try &apos;b&apos;
      RegExpJIT [1] ParenthesesSubpatternBegin index=5    # iter1=&apos;b&apos;, iter2 at pos 5
      RegExpJIT [2] NestedAlternativeBegin.bt index=6     # &apos;a&apos; fails at pos 5
      RegExpJIT [4] NestedAlternativeNext index=5         # Try &apos;b&apos; at pos 5
      RegExpJIT [4] NestedAlternativeNext.bt index=6      # &apos;b&apos; fails (&apos;c&apos; != &apos;b&apos;)
      RegExpJIT [6] NestedAlternativeNext index=5         # Try &apos;c(){2}$&apos; at pos 5
      RegExpJIT [8] ParenthesesSubpatternBegin index=6    # Enter inner (){2} at pos 6...

Test: JSTests/stress/regexp-nested-quantified-parens-backtrack.js

* JSTests/stress/regexp-fixed-count-multi-alt-backtracking.js: Added.
(shouldBe):
(shouldBeArray):
(testDiffLen1):
(testDiffLen2):
(testDiffLen3):
(testDiffLen4):
(testDiffLen5):
(testThreeAlt1):
(testFourAlt1):
(testThreeAlt2):
(testThreeAlt3):
(testThreeIter1):
(testThreeIter2):
(testFourIter1):
(testFiveIter1):
(testInterIter1):
(testInterIter2):
(testPartial1):
(testPartial2):
(testGreedy1):
(testGreedy2):
(testGreedy3):
(testStar1):
(testNested1):
(testNested2):
(testSingleIter):
(testExactLong):
(testPosition):
* JSTests/stress/regexp-nested-quantified-parens-backtrack.js: Added.
(test):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307293@main">https://commits.webkit.org/307293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ae96614943493c93ecb6cadadd461920b66d7b1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143976 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152646 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3b823ab-63c4-4920-a9f5-f8ae357b494a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17137 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16548 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/110719 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f17573c1-1748-4ef3-b66f-46238ff2051f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146939 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13136 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91637 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5367c41d-52cf-4e56-abbd-7184bcc3e3c1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/92 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135967 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122073 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154958 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4784 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7071 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16543 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/13877 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119087 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/14990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127227 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22206 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16129 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5674 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175263 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/15863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45196 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15929 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->