### PR TITLE
[YARR] Fix infinite loop in JIT for non-greedy backreference with insufficient input

### DIFF
--- a/JSTests/stress/regexp-nongreedy-backref-insufficient-input.js
+++ b/JSTests/stress/regexp-nongreedy-backref-insufficient-input.js
@@ -1,0 +1,78 @@
+// Regression test for non-greedy backreference infinite loop when the
+// capture is non-zero-width but there is not enough remaining input to
+// match another repetition.
+//
+// In the JIT, the NonGreedy reentry code stored beginIndex AFTER
+// checkNotEnoughInput. When checkNotEnoughInput failed (not enough
+// input), beginIndex kept its stale value from a previous successful
+// iteration. The backtrack code's zero-width progress check then saw
+// index != beginIndex (stale) and allowed retry, looping forever.
+//
+// These patterns must all terminate promptly.
+
+function shouldBe(actual, expected, description) {
+    let actualStr = JSON.stringify(actual);
+    let expectedStr = JSON.stringify(expected);
+    if (actualStr !== expectedStr)
+        throw new Error(description + ": expected " + expectedStr + ", got " + actualStr);
+}
+
+// ---- Core bug pattern: one successful match then insufficient input ----
+
+// \1*? matches "ab" once (index 2→4), then can't match again (need 2
+// chars but only 1 left). Without the fix the JIT loops forever here.
+shouldBe(/(ab)\1*?X/.exec("ababY"), null,
+    "one match then insufficient input, no X");
+
+shouldBe(/(ab)\1*?X/.exec("abab"), null,
+    "one match then insufficient input, string ends");
+
+// ---- Longer capture ----
+
+shouldBe(/(abc)\1*?X/.exec("abcabcY"), null,
+    "longer capture, one match then insufficient input");
+
+shouldBe(/(abcde)\1*?X/.exec("abcdeabcdeYY"), null,
+    "5-char capture, one match then insufficient input");
+
+// ---- Multiple successful matches before running out ----
+
+shouldBe(/(ab)\1*?X/.exec("ababababY"), null,
+    "three matches possible, then insufficient input");
+
+// ---- Finite max count (should still terminate) ----
+
+shouldBe(/(ab)\1{0,100}?X/.exec("ababY"), null,
+    "finite max count, one match then insufficient input");
+
+// ---- Case-insensitive ----
+
+shouldBe(/(ab)\1*?X/i.exec("ababY"), null,
+    "case-insensitive, one match then insufficient input");
+
+shouldBe(/(AB)\1*?x/i.exec("ABABZ"), null,
+    "case-insensitive upper, one match then insufficient input");
+
+// ---- Named backreference ----
+
+shouldBe(/(?<cap>ab)\k<cap>*?X/.exec("ababY"), null,
+    "named backref, one match then insufficient input");
+
+// ---- Correct matches still work ----
+
+shouldBe(/(ab)\1*?X/.exec("ababX"), ["ababX", "ab"],
+    "correct: one backref match then X");
+
+shouldBe(/(ab)\1*?X/.exec("abX"), ["abX", "ab"],
+    "correct: zero backref matches then X");
+
+shouldBe(/(ab)\1*?X/.exec("abababX"), ["abababX", "ab"],
+    "correct: two backref matches then X");
+
+// ---- Zero-width captures still handled (original fix) ----
+
+shouldBe(/()\1*?X/.exec("Y"), null,
+    "empty capture, no match");
+
+shouldBe(/(a)|\1*?X/.exec("Y"), null,
+    "undefined capture in other alternative, no match");

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2240,11 +2240,13 @@ class YarrGenerator final : public YarrJITInfo {
             matches.append(m_jit.jump());
             tryNonZeroMatch.link(&m_jit);
 
-            // Check if we have input remaining to match
+            // Check if we have input remaining to match.
+            // Update beginIndex before the check so the backtrack code's
+            // zero-width progress guard sees the current position even
+            // when checkNotEnoughInput bails out early.
+            storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoBackReference::beginIndex());
             m_jit.sub32(patternIndex, patternTemp);
             matches.append(checkNotEnoughInput(patternTemp));
-
-            storeToFrame(m_regs.index, parenthesesFrameLocation + BackTrackInfoBackReference::beginIndex());
 
             matchBackreference(opIndex, incompleteMatches, characterOrTemp, patternIndex, patternTemp, subpatternIdReg == m_regs.unicodeAndSubpatternIdTemp ? subpatternIdReg : InvalidGPRReg);
 


### PR DESCRIPTION
#### b3fe79f2afa557818e77f6772816ab8bbec66eb3
<pre>
[YARR] Fix infinite loop in JIT for non-greedy backreference with insufficient input
<a href="https://bugs.webkit.org/show_bug.cgi?id=307533">https://bugs.webkit.org/show_bug.cgi?id=307533</a>

Reviewed by Yusuke Suzuki.

Move the beginIndex store before checkNotEnoughInput in the NonGreedy
backreference reentry path. Without this, when checkNotEnoughInput
bails out, beginIndex stays stale and the backtrack zero-width progress
check never fires.

Test: JSTests/stress/regexp-nongreedy-backref-insufficient-input.js

* JSTests/stress/regexp-nongreedy-backref-insufficient-input.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307323@main">https://commits.webkit.org/307323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fe451271ee5bac8b39dcc5444872257042508dd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16547 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8070 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97114 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17033 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110635 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79567 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146838 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13063 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129266 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12527 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10257 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135863 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/121989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5894 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154855 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4681 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118644 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/118998 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30534 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14916 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127105 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71817 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16025 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5581 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175161 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79816 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45177 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/15971 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15824 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->