### PR TITLE
[GTK][WPE] Use run loop observer to schedule rendering updates in non-composited mode

### DIFF
--- a/Source/WTF/wtf/glib/RunLoopSourcePriority.h
+++ b/Source/WTF/wtf/glib/RunLoopSourcePriority.h
@@ -57,9 +57,6 @@ enum RunLoopSourcePriority {
     // Used for timers that discard resources like backing store, buffers, etc.
     ReleaseUnusedResourcesTimer = 200,
 
-    // Rendering timer in the main thread when accelerated compositing is not used.
-    NonAcceleratedDrawingTimer = 100,
-
     // Async IO network callbacks.
     AsyncIONetwork = 100,
 };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
@@ -33,12 +33,12 @@
 
 namespace WebCore {
 class GraphicsContext;
+class RunLoopObserver;
 }
 
 namespace WebKit {
 class NonCompositedFrameRenderer;
 struct RenderProcessInfo;
-struct UpdateInfo;
 
 class DrawingAreaCoordinatedGraphics final : public DrawingArea {
 public:
@@ -108,9 +108,11 @@ private:
     void suspendPainting();
     void resumePainting();
 
-    void scheduleDisplay();
-    void displayTimerFired();
-    void display();
+    void scheduleUpdate();
+    void scheduleRenderingUpdateRunLoopObserver();
+    void invalidateRenderingUpdateRunLoopObserver();
+    void renderingUpdateRunLoopObserverFired();
+    void updateRendering();
 
     // Whether we're currently processing an UpdateGeometry message.
     bool m_inUpdateGeometry { false };
@@ -134,7 +136,7 @@ private:
 
     bool m_supportsAsyncScrolling { true };
 
-    RunLoop::Timer m_displayTimer;
+    std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
 
 #if PLATFORM(GTK)
     bool m_transientZoom { false };


### PR DESCRIPTION
#### 579fb57124129114b1c07791b5fa48cb5003bbdc
<pre>
[GTK][WPE] Use run loop observer to schedule rendering updates in non-composited mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=307541">https://bugs.webkit.org/show_bug.cgi?id=307541</a>

Reviewed by Nikolas Zimmermann.

* Source/WTF/wtf/glib/RunLoopSourcePriority.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics):
(WebKit::DrawingAreaCoordinatedGraphics::~DrawingAreaCoordinatedGraphics):
(WebKit::DrawingAreaCoordinatedGraphics::setNeedsDisplayInRect):
(WebKit::DrawingAreaCoordinatedGraphics::scroll):
(WebKit::DrawingAreaCoordinatedGraphics::setLayerTreeStateIsFrozen):
(WebKit::DrawingAreaCoordinatedGraphics::triggerRenderingUpdate):
(WebKit::DrawingAreaCoordinatedGraphics::dispatchAfterEnsuringDrawing):
(WebKit::DrawingAreaCoordinatedGraphics::suspendPainting):
(WebKit::DrawingAreaCoordinatedGraphics::resumePainting):
(WebKit::DrawingAreaCoordinatedGraphics::scheduleUpdate):
(WebKit::DrawingAreaCoordinatedGraphics::scheduleRenderingUpdateRunLoopObserver):
(WebKit::DrawingAreaCoordinatedGraphics::invalidateRenderingUpdateRunLoopObserver):
(WebKit::DrawingAreaCoordinatedGraphics::renderingUpdateRunLoopObserverFired):
(WebKit::DrawingAreaCoordinatedGraphics::updateRendering):
(WebKit::DrawingAreaCoordinatedGraphics::scheduleDisplay): Deleted.
(WebKit::DrawingAreaCoordinatedGraphics::displayTimerFired): Deleted.
(WebKit::DrawingAreaCoordinatedGraphics::display): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h:

Canonical link: <a href="https://commits.webkit.org/307354@main">https://commits.webkit.org/307354@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a445164b886942dd23203f4acdbce2b0c058bb19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16848 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152839 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16742 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110859 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97408 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13275 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91777 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12717 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/285 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136160 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155151 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4977 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16700 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7235 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16737 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/14021 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119234 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15110 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127391 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22233 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16322 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175456 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16056 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45220 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16122 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->