### PR TITLE
[visionOS] Opt into the alternate scrolling indicator rendering

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -607,3 +607,10 @@ symbols = [
 ]
 requires = ["ENABLE_GPU_PROCESS_MODEL"]
 
+[[temporary-usage]]
+request = "rdar://170141943"
+cleanup = "rdar://170141943"
+selectors = [
+    { name = "_setUseVisionAlternateScrollIndicatorRendering:", class = "UIScrollView" },
+]
+requires = ["PLATFORM_VISION"]

--- a/Source/WebKit/Platform/spi/ios/UIKitSPI.h
+++ b/Source/WebKit/Platform/spi/ios/UIKitSPI.h
@@ -1402,6 +1402,14 @@ typedef NS_ENUM(NSUInteger, _UIScrollDeviceCategory) {
 
 #endif // HAVE(LIQUID_GLASS)
 
+#if PLATFORM(VISION)
+
+@interface UIScrollView ()
+@property (nonatomic, setter=_setUseVisionAlternateScrollIndicatorRendering:) BOOL _useVisionAlternateScrollIndicatorRendering;
+@end
+
+#endif // PLATFORM(VISION)
+
 WTF_EXTERN_C_BEGIN
 
 BOOL UIKeyboardEnabledInputModesAllowOneToManyShortcuts(void);

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -1909,6 +1909,12 @@ static WebCore::FloatPoint constrainContentOffset(WebCore::FloatPoint contentOff
 
     [_contentView setOpaque:opaque];
 
+#if PLATFORM(VISION)
+    static BOOL alternateRenderingAvailable = [UIScrollView instancesRespondToSelector:@selector(_setUseVisionAlternateScrollIndicatorRendering:)];
+    if (alternateRenderingAvailable)
+        [_scrollView _setUseVisionAlternateScrollIndicatorRendering:opaque];
+#endif
+
     if (!_page)
         return;
 

--- a/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
+++ b/Source/WebKit/UIProcess/ios/WKBaseScrollView.mm
@@ -139,6 +139,12 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     self.allowsKeyboardScrolling = YES;
 #endif
 
+#if PLATFORM(VISION)
+    static BOOL alternateRenderingAvailable = [UIScrollView instancesRespondToSelector:@selector(_setUseVisionAlternateScrollIndicatorRendering:)];
+    if (alternateRenderingAvailable)
+        [self _setUseVisionAlternateScrollIndicatorRendering:YES];
+#endif
+
     _axesToPreventMomentumScrolling = UIAxisNeither;
     [self.panGestureRecognizer addTarget:self action:@selector(_updatePanGestureToPreventScrolling)];
     return self;


### PR DESCRIPTION
#### cc9c1ba1bb8b3c60c6e3789d94a6e1bacd74ae4f
<pre>
[visionOS] Opt into the alternate scrolling indicator rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=307544">https://bugs.webkit.org/show_bug.cgi?id=307544</a>
&lt;<a href="https://rdar.apple.com/169644435">rdar://169644435</a>&gt;

Reviewed by Mike Wyrzykowski and Abrar Rahman Protyasha.

The new rendering temporarily needs a hint about the opacity of the
ScrollView.
When available, opt into the new rendering by default, except for cases
where the WebView is set as non-opaque.

* Source/WebKit/Configurations/AllowedSPI.toml:
Document the temporary SPI use.

* Source/WebKit/Platform/spi/ios/UIKitSPI.h:
Add the SPI stub.

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _setOpaqueInternal:]):
Opt the top level WebView in based on the `isOpaque` flag.

* Source/WebKit/UIProcess/ios/WKBaseScrollView.mm:
(-[WKBaseScrollView initWithFrame:]):
Opt ScrollViews in.

Canonical link: <a href="https://commits.webkit.org/307363@main">https://commits.webkit.org/307363@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c42c90171db6e4efef6d0f3ca7a6bb365395927a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143906 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16585 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8120 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152574 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97145 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46cd247a-0d8e-4519-b699-d89a73172c7b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16475 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110659 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79576 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a2afc93b-9a6f-460c-93b7-83533bcc666f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146869 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13084 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129309 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91577 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f98acd7-51fe-4377-bd0e-a42afbbdc7ae) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12545 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10289 "Passed tests") | [⏳ 🛠 gtk3-libwebrtc ](https://ews-build.webkit.org/#/builders/GTK-GTK3-LibWebRTC-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122023 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154886 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16435 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/6991 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118668 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16470 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119022 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30563 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14941 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127157 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71848 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16056 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5616 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15790 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79838 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16002 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->