### PR TITLE
Plumb WebView configuration signal to allow immersive elements

### DIFF
--- a/LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions-expected.txt
+++ b/LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions-expected.txt
@@ -1,5 +1,5 @@
 
-FAIL document.immersiveEnabled is true on top-level document assert_true: document.immersiveEnabled should be true on top-level document expected true got false
+PASS document.immersiveEnabled is true on top-level document
 PASS document.immersiveEnabled is false on iframe document
 PASS requestImmersive rejects with InvalidAccessError in iframe
 PASS requestImmersive error message is correct for iframe

--- a/LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions.html
+++ b/LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ ModelElementEnabled=true ModelProcessEnabled=true ModelElementImmersiveEnabled=true shouldAcceptImmersiveEnvironmentRequests=false ] -->
 <meta charset="utf-8">
 <title>&lt;model> immersive iframe restrictions</title>
 <script src="../../imported/w3c/web-platform-tests/resources/testdriver.js"></script>
@@ -66,7 +66,7 @@ promise_test(async t => {
         errorMessage = e.message;
     }
 
-    assert_equals(errorMessage, 'Immersive API is only available in top-level frames.',
+    assert_equals(errorMessage, 'Immersive API is only available in a top-level frame.',
         'Error message should indicate iframe restriction');
 }, 'requestImmersive error message is correct for iframe');
 

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -344,6 +344,7 @@ public:
     virtual void allowImmersiveElement(CompletionHandler<void(bool)>&& completion) const { completion(false); }
     virtual void presentImmersiveElement(const LayerHostingContextIdentifier, CompletionHandler<void(bool)>&& completion) const { completion(false); }
     virtual void dismissImmersiveElement(CompletionHandler<void()>&& completion) const { completion(); }
+    virtual bool supportsImmersiveElement() const { return false; }
 #endif
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -361,6 +361,10 @@ struct WebPageCreationParameters {
     WebCore::ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent { WebCore::ShouldRequireExplicitConsentForGamepadAccess::No };
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    bool allowsImmersiveEnvironments { false };
+#endif
+
 #if HAVE(AUDIT_TOKEN)
     std::optional<CoreIPCAuditToken> presentingApplicationAuditToken;
 #endif

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -276,6 +276,10 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     WebCore::ShouldRequireExplicitConsentForGamepadAccess gamepadAccessRequiresExplicitConsent;
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    bool allowsImmersiveEnvironments;
+#endif
+
 #if HAVE(AUDIT_TOKEN)
     std::optional<WebKit::CoreIPCAuditToken> presentingApplicationAuditToken;
 #endif

--- a/Source/WebKit/UIProcess/API/APIPageConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIPageConfiguration.h
@@ -483,6 +483,11 @@ public:
     void setCSSTransformStyleSeparatedEnabled(bool value) { m_data.cssTransformStyleSeparatedEnabled = value; }
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    bool allowsImmersiveEnvironments() const { return m_data.allowsImmersiveEnvironments; }
+    void setAllowsImmersiveEnvironments(bool allows) { m_data.allowsImmersiveEnvironments = allows; }
+#endif
+
 #endif // PLATFORM(VISION)
 
 private:
@@ -663,6 +668,10 @@ private:
 
 #if HAVE(CORE_ANIMATION_SEPARATED_LAYERS)
         bool cssTransformStyleSeparatedEnabled { false };
+#endif
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+        bool allowsImmersiveEnvironments { false };
 #endif
 
 #endif // PLATFORM(VISION)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm
@@ -1640,6 +1640,22 @@ static WebKit::AttributionOverrideTesting toAttributionOverrideTesting(_WKAttrib
 #endif
 }
 
+- (void)_setAllowsImmersiveEnvironments:(BOOL)allows
+{
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    _pageConfiguration->setAllowsImmersiveEnvironments(allows);
+#endif
+}
+
+- (BOOL)_allowsImmersiveEnvironments
+{
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    return _pageConfiguration->allowsImmersiveEnvironments();
+#else
+    return false;
+#endif
+}
+
 #endif // PLATFORM(VISION)
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h
@@ -179,6 +179,7 @@ typedef NS_ENUM(NSUInteger, _WKContentSecurityPolicyModeForExtension) {
 #if defined(TARGET_OS_VISION) && TARGET_OS_VISION
 @property (nonatomic, setter=_setGamepadAccessRequiresExplicitConsent:) BOOL _gamepadAccessRequiresExplicitConsent WK_API_AVAILABLE(visionos(2.0));
 @property (nonatomic, setter=_setCSSTransformStyleSeparatedEnabled:) BOOL _cssTransformStyleSeparatedEnabled WK_API_AVAILABLE(visionos(2.4));
+@property (nonatomic, setter=_setAllowsImmersiveEnvironments:) BOOL _allowsImmersiveEnvironments WK_API_AVAILABLE(visionos(WK_XROS_TBA));
 #endif
 
 @property (nonatomic, setter=_setSystemTextExtractionEnabled:) BOOL _systemTextExtractionEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12565,6 +12565,10 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
     parameters.gamepadAccessRequiresExplicitConsent = m_configuration->gamepadAccessRequiresExplicitConsent();
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    parameters.allowsImmersiveEnvironments = m_configuration->allowsImmersiveEnvironments();
+#endif
+
     Ref preferences = m_preferences;
 #if PLATFORM(COCOA)
     parameters.smartInsertDeleteEnabled = m_isSmartInsertDeleteEnabled;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -1690,6 +1690,12 @@ void WebChromeClient::dismissImmersiveElement(CompletionHandler<void()>&& comple
     else
         completion();
 }
+
+bool WebChromeClient::supportsImmersiveElement() const
+{
+    RefPtr page = m_page.get();
+    return page && page->allowsImmersiveEnvironments();
+}
 #endif
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -385,6 +385,7 @@ private:
     void allowImmersiveElement(CompletionHandler<void(bool)>&&) const final;
     void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&&) const final;
     void dismissImmersiveElement(CompletionHandler<void()>&&) const final;
+    bool supportsImmersiveElement() const final;
 #endif
 
 #if ENABLE(APP_HIGHLIGHTS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -716,6 +716,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
 #endif
     , m_backgroundTextExtractionEnabled(parameters.backgroundTextExtractionEnabled)
     , m_isPopup(parameters.isPopup)
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    , m_allowsImmersiveEnvironments(parameters.allowsImmersiveEnvironments)
+#endif
 {
     WEBPAGE_RELEASE_LOG(Loading, "constructor:");
 
@@ -8041,6 +8044,11 @@ void WebPage::exitImmersive() const
 {
     if (RefPtr localTopDocument = this->localTopDocument(); RefPtr protectedImmersive = localTopDocument->immersiveIfExists())
         protectedImmersive->exitImmersive();
+}
+
+bool WebPage::allowsImmersiveEnvironments() const
+{
+    return m_allowsImmersiveEnvironments;
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1728,6 +1728,7 @@ public:
     void presentImmersiveElement(const WebCore::LayerHostingContextIdentifier, CompletionHandler<void(bool)>&&);
     void dismissImmersiveElement(CompletionHandler<void()>&&);
     void exitImmersive() const;
+    bool allowsImmersiveEnvironments() const;
 #endif
 
     void flushPendingEditorStateUpdate();
@@ -3290,6 +3291,10 @@ private:
 
     bool m_backgroundTextExtractionEnabled { false };
     bool m_isPopup { false };
+
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    bool m_allowsImmersiveEnvironments { false };
+#endif
 };
 
 #if !PLATFORM(IOS_FAMILY)

--- a/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm
@@ -317,6 +317,10 @@ void TestController::platformCreateWebView(WKPageConfigurationRef configuration,
     [cocoaConfiguration _setLongPressActionsEnabled:options.longPressActionsEnabled()];
 #endif
 
+#if ENABLE(MODEL_ELEMENT_IMMERSIVE)
+    [cocoaConfiguration _setAllowsImmersiveEnvironments:YES];
+#endif
+
     if (options.enableAttachmentElement())
         [cocoaConfiguration _setAttachmentElementEnabled:YES];
     if (options.enableAttachmentWideLayout())


### PR DESCRIPTION
#### 3a36d0249db3a536284e31496c9e88c6b0ef43ac
<pre>
Plumb WebView configuration signal to allow immersive elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=307550">https://bugs.webkit.org/show_bug.cgi?id=307550</a>
<a href="https://rdar.apple.com/168579137">rdar://168579137</a>

Reviewed by Etienne Segonzac.

Add a configuration parameter on WKWebViewConfiguration so that clients
can let webpages know that the immersive element feature is supported.
This enables websites to adapt their UI depending on the support of the feature.

* LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions-expected.txt:
* LayoutTests/model-element/immersive/model-element-immersive-iframe-restrictions.html:
Test is now passing!

* Source/WebCore/dom/DocumentImmersive.cpp:
(WebCore::immersiveAvailabilityError):
(WebCore::DocumentImmersive::immersiveEnabled):
(WebCore::DocumentImmersive::requestImmersive):
(WebCore::DocumentImmersive::beginImmersiveRequest):
(WebCore::DocumentImmersive::createModelPlayerForImmersive):
(WebCore::DocumentImmersive::presentImmersiveElement):
Refactor the error handling to avoid duplicate code.

* Source/WebCore/page/ChromeClient.h:
(WebCore::ChromeClient::supportsImmersiveElement const):
* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/API/APIPageConfiguration.h:
(API::PageConfiguration::allowsImmersiveEnvironments const):
(API::PageConfiguration::setAllowsImmersiveEnvironments):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm:
(-[WKWebViewConfiguration _setAllowsImmersiveEnvironments:]):
(-[WKWebViewConfiguration _allowsImmersiveEnvironments]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfigurationPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::supportsImmersiveElement const):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::m_allowsImmersiveEnvironments):
(WebKit::WebPage::allowsImmersiveEnvironments const):
(WebKit::m_isPopup): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.h:
Plumb the configuration from the UI Process to the web process.

* Tools/WebKitTestRunner/cocoa/TestControllerCocoa.mm:
(WTR::TestController::platformCreateWebView):
Add the configuration boolean in the test controller that runs
the Layout Tests since this one supports immersive elements.

Canonical link: <a href="https://commits.webkit.org/307482@main">https://commits.webkit.org/307482@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/756e695315607731fddf8a4d1734691210a6a644

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144524 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17203 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153194 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17685 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17097 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111136 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147487 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92045 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12907 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10661 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/640 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155507 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17055 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7531 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119138 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17093 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14277 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119491 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30636 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15317 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127688 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16677 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6091 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16413 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16622 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16477 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->