### PR TITLE
[JSC] Simplify the greedy register allocator state machine

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -1591,22 +1591,23 @@ private:
                 Tmp tmp = entry.tmp();
                 ASSERT(tmp && tmp.bank() == bank);
                 TmpData& tmpData = m_map.get<bank>(tmp);
+                Stage stage = tmpData.stage;
                 if (verbose()) {
                     StringPrintStream out;
                     out.println("Pop: ", entry, " tmp: ", tmpData);
                     dumpRegRanges<bank>(out);
                     dataLog(out.toCString());
                 }
-                if (tmpData.stage == Stage::Replaced)
-                    continue; // Tmp no longer relevant
-                if (tryAllocate<bank>(tmp, tmpData))
-                    continue;
-                if (tmpData.stage != Stage::TrySplit && tryEvict<bank>(tmp, tmpData))
-                    continue;
 
                 ASSERT(&tmpData == &m_map.get<bank>(tmp)); // Verify m_map hasn't been resized on this path
-                switch (tmpData.stage) {
+                switch (stage) {
+                case Stage::Unspillable:
                 case Stage::TryAllocate: {
+                    if (tryAllocate<bank>(tmp, tmpData))
+                        continue;
+                    if (tryEvict<bank>(tmp, tmpData))
+                        continue;
+                    RELEASE_ASSERT(stage != Stage::Unspillable);
                     // If we couldn't allocate tmp, allow it to split next time.
                     Stage nextStage = Stage::TrySplit;
                     // If we already know splitting won't be profitable, skip it.
@@ -1623,8 +1624,6 @@ private:
                     ASSERT(queueContainsOnlySpills()); // FIXME: remove
                     spill(tmp, tmpData);
                     continue;
-                case Stage::Unspillable:
-                    // Unspillables must have been allocated during tryAllocate or tryEvict.
                 default:
                     dataLogLn("Invalid stage tmp = ", tmp, " tmpData = ", tmpData);
                     // Tmps in these stages should not have been enqueued.


### PR DESCRIPTION
#### 2af576675b08735893a7702c1586ca2268382871
<pre>
[JSC] Simplify the greedy register allocator state machine
<a href="https://bugs.webkit.org/show_bug.cgi?id=307551">https://bugs.webkit.org/show_bug.cgi?id=307551</a>
<a href="https://rdar.apple.com/170151533">rdar://170151533</a>

Reviewed by NOBODY (OOPS!).

WIP

No new tests (OOPS!).
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::allocateRegisters):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2af576675b08735893a7702c1586ca2268382871

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16624 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8177 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97184 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/086a7054-2c14-4eea-a576-7dccad6ebd94) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17106 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110687 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79585 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bebf314-670f-4d60-b40e-0cc39ee70c92) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13110 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129345 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91605 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/438fed19-7219-442e-844e-fae34d72b9ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12578 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10316 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/61 "Built successfully") | | 
| [❌ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/135936 "Found 1 new JSC binary failure: testb3 (failure)") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122047 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/5987 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154927 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4753 "Found 1 new JSC binary failure: testb3 (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118697 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13852 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119049 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14966 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127198 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71897 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16098 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5648 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175232 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15832 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79877 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45193 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16043 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->