### PR TITLE
[threaded-animations] only opt animations affecting transform into high frame rate on iOS

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -49,6 +49,7 @@ ipc/mac [ Pass ]
 ipc/restrictedendpoints/mac [ Pass ]
 fast/page-color-sampling [ Pass ]
 [ Sequoia+ ] webanimations/threaded-animations [ Pass ]
+[ Sequoia+ ] webanimations/threaded-animations/ios [ Skip ]
 
 editing/pasteboard/data-transfer-get-data-on-drop-custom.html [ Pass ]
 editing/pasteboard/data-transfer-get-data-on-drop-plain-text.html [ Pass ]

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -2078,6 +2078,15 @@ window.UIHelper = class UIHelper {
         }
     }
 
+    static async displayLinkWantsHighFrameRate()
+    {
+        if (!this.isWebKit2() || !this.isIOSFamily())
+            return Promise.resolve(false);
+
+        const script = `uiController.displayLinkWantsHighFrameRate()`;
+        return new Promise(resolve => testRunner.runUIScript(script, result => resolve(result === "true")));
+    }
+
     static dragFromPointToPoint(fromX, fromY, toX, toY, duration)
     {
         if (!this.isWebKit2() || !this.isIOSFamily()) {

--- a/LayoutTests/webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations-expected.txt
+++ b/LayoutTests/webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Display link opts into high frame rate updates only when high-impact animations are running
+

--- a/LayoutTests/webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations.html
+++ b/LayoutTests/webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ThreadedTimeBasedAnimationsEnabled=true ThreadedTimeBasedAnimationsAtHighFrameRateEnabled=true ] -->
+<body>
+<style>
+
+#target {
+    width: 100px;
+    height: 100px;
+    background-color: black;
+}
+
+</style>
+
+<div id="target"></div>
+
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../imported/w3c/web-platform-tests/web-animations/testcommon.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../threaded-animations-utils.js"></script>
+
+<script>
+
+const assertLowImpactOpacityAnimation = async () => {
+    const acceleratedAnimations = internals.acceleratedAnimationsForElement(target);
+    assert_equals(acceleratedAnimations.length, 1);
+    assert_equals(acceleratedAnimations[0].property, "opacity");
+    assert_false(acceleratedAnimations[0].hasHighImpact, "Animating 'opacity' does not have a high impact");
+    assert_false(await UIHelper.displayLinkWantsHighFrameRate(), "Animating 'opacity' does not yield high frame rate display link updates");
+};
+
+promise_test(async t => {
+    const duration = 1000 * 1000;
+
+    // First, start an opacity animation, which is not considered high-impact and
+    // should not result in high frame rate display link updates.
+    const opacityAnimation = target.animate({ opacity: 0.5 }, duration);
+    await animationAcceleration(opacityAnimation);
+    await assertLowImpactOpacityAnimation();
+
+    // Now, add a translate animation, which is considered high-impact and should
+    // result in high frame rate display link updates.
+    const translateAnimation = target.animate({ translate: "1000px" }, duration);
+    await animationAcceleration(translateAnimation);
+    const acceleratedAnimations = internals.acceleratedAnimationsForElement(target);
+    assert_equals(acceleratedAnimations.length, 2);
+    assert_equals(acceleratedAnimations[1].property, "translate");
+    assert_true(acceleratedAnimations[1].hasHighImpact, "Animating 'translate' has a high impact");
+    assert_true(await UIHelper.displayLinkWantsHighFrameRate(), "Animating 'translate' yields high frame rate display link updates");
+
+    // Finally, terminate that translate animation, which means only the opacity
+    // animation is running in the remote layer tree, which should result in the
+    // display link updates to return to a non-high frame rate.
+    translateAnimation.finish();
+    await threadedAnimationsCommit();
+    await assertLowImpactOpacityAnimation();
+}, "Display link opts into high frame rate updates only when high-impact animations are running");
+
+</script>
+</body>

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -565,6 +565,14 @@ bool AcceleratedEffect::animatesTransformRelatedProperty() const
     return m_animatedProperties.containsAny(transformRelatedAcceleratedProperties);
 }
 
+bool AcceleratedEffect::hasHighImpact() const
+{
+    // FIXME: This is just an initial implementation. A logical next step would be to
+    // compute the distance traveled over time and only mark effects with distance traveled
+    // over a certain threshold (over 60px, 90px, 120px per second?) as high impact.
+    return animatesTransformRelatedProperty();
+}
+
 const KeyframeInterpolation::Keyframe& AcceleratedEffect::keyframeAtIndex(size_t index) const
 {
     ASSERT(index < m_keyframes.size());

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -105,6 +105,7 @@ public:
     const OptionSet<AcceleratedEffectProperty>& replacedProperties() const { return m_replacedProperties; }
 
     bool animatesTransformRelatedProperty() const;
+    WEBCORE_EXPORT bool hasHighImpact() const;
 
 private:
     AcceleratedEffect(const KeyframeEffect&, const IntRect&, const OptionSet<AcceleratedEffectProperty>&);

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -377,6 +377,7 @@ public:
         String property;
         double speed;
         bool isThreaded;
+        bool hasHighImpact;
     };
     virtual Vector<AcceleratedAnimationForTesting> acceleratedAnimationsForTesting() const { return { }; }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -666,7 +666,7 @@ Vector<GraphicsLayer::AcceleratedAnimationForTesting> GraphicsLayerCoordinated::
 {
     Vector<GraphicsLayer::AcceleratedAnimationForTesting> animations;
     for (auto& animation : m_animations.animations())
-        animations.append({ animatedPropertyIDAsString(animation.keyframes().property()), animation.state() == TextureMapperAnimation::State::Playing ? 1.0 : 0.0, false });
+        animations.append({ animatedPropertyIDAsString(animation.keyframes().property()), animation.state() == TextureMapperAnimation::State::Playing ? 1.0 : 0.0, false, false });
     return animations;
 }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1484,7 +1484,7 @@ Vector<Internals::AcceleratedAnimation> Internals::acceleratedAnimationsForEleme
 
     Vector<Internals::AcceleratedAnimation> animations;
     for (const auto& acceleratedAnimation : timelinesController->acceleratedAnimationsForElement(element))
-        animations.append({ acceleratedAnimation.property, acceleratedAnimation.speed, acceleratedAnimation.isThreaded });
+        animations.append({ acceleratedAnimation.property, acceleratedAnimation.speed, acceleratedAnimation.isThreaded, acceleratedAnimation.hasHighImpact });
     return animations;
 }
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -336,6 +336,7 @@ public:
         String property;
         double speed;
         bool isThreaded;
+        bool hasHighImpact;
     };
     struct ScrollingNodeID {
         uint64_t nodeIdentifier;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -337,6 +337,7 @@ enum AV1ConfigurationRange {
     required DOMString property;
     required double speed;
     required boolean isThreaded;
+    required boolean hasHighImpact;
 };
 
 [

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h
@@ -187,6 +187,7 @@ struct WKAppPrivacyReportTestingData {
 - (NSString *)_animationStackForLayerWithID:(unsigned long long)layerID;
 - (NSString *)_progressBasedTimelinesForScrollingNodeID:(uint64_t)scrollingNodeID processID:(uint64_t)processID;
 #endif
+- (bool)_displayLinkWantsHighFrameRate;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm
@@ -1265,6 +1265,11 @@ static void dumpCALayer(TextStream& ts, CALayer *layer, bool traverse)
 }
 #endif
 
+- (bool)_displayLinkWantsHighFrameRate
+{
+    return downcast<WebKit::RemoteLayerTreeDrawingAreaProxy>(protect(_page->drawingArea()))->displayLinkWantsHighFrameRateForTesting();
+}
+
 @end
 
 #if ENABLE(MEDIA_SESSION_COORDINATOR)

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h
@@ -129,6 +129,7 @@ public:
 
     virtual void didRefreshDisplay();
     virtual void setDisplayLinkWantsFullSpeedUpdates(bool) { }
+    virtual bool displayLinkWantsHighFrameRateForTesting() const { return false; };
 
     bool hasDebugIndicator() const { return !!m_debugIndicatorLayerTreeHost; }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -157,6 +157,7 @@ public:
     void setAcceleratedEffectsAndBaseValues(const WebCore::AcceleratedEffects&, const WebCore::AcceleratedEffectValues&, RemoteLayerTreeHost&);
     const RemoteAnimationStack* animationStack() const { return m_animationStack.get(); }
     RefPtr<RemoteAnimationStack> takeAnimationStack() { return std::exchange(m_animationStack, nullptr); }
+    bool hasHighImpactMonotonicAnimations() const { return m_hasHighImpactMonotonicAnimations; }
 #endif
 
     bool backdropRootIsOpaque() const { return m_backdropRootIsOpaque; }
@@ -222,6 +223,7 @@ private:
 
 #if ENABLE(THREADED_ANIMATIONS)
     RefPtr<RemoteAnimationStack> m_animationStack;
+    bool m_hasHighImpactMonotonicAnimations { false };
 #endif
     bool m_backdropRootIsOpaque { false };
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -423,6 +423,8 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
         animationStack->clear(layer.get());
     host.animationsWereRemovedFromNode(*this);
 
+    m_hasHighImpactMonotonicAnimations = false;
+
     if (effects.isEmpty())
         return;
 
@@ -430,6 +432,8 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
         TimelineID timelineID { effect->timelineIdentifier(), m_layerID.processIdentifier() };
         RefPtr timeline = host.timeline(timelineID);
         ASSERT(timeline);
+        if (!m_hasHighImpactMonotonicAnimations && timeline->isMonotonic())
+            m_hasHighImpactMonotonicAnimations = effect->hasHighImpact();
         return RemoteAnimation::create(Ref { effect }.get(), *timeline);
     }), baseValues.clone(), layer.get().bounds);
     m_animationStack = animationStack.copyRef();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -159,6 +159,7 @@ public:
     virtual void progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode&) { }
     virtual RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const { return nullptr; }
     virtual HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const { return { }; }
+    virtual bool hasHighImpactMonotonicAnimations() const { return false; }
 #endif
 
     String scrollingTreeAsText() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -45,6 +45,7 @@ public:
 
     void scheduleDisplayRefreshCallbacksForMonotonicAnimations();
     void pauseDisplayRefreshCallbacksForMonotonicAnimations();
+    void highImpactMonotonicAnimationsWereRemoved();
 
     UIView *viewWithLayerIDForTesting(WebCore::PlatformLayerIdentifier) const;
 
@@ -66,12 +67,14 @@ private:
     void windowScreenDidChange(WebCore::PlatformDisplayID) override;
 
     std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() override;
+    bool displayLinkWantsHighFrameRateForTesting() const override;
 
     WKDisplayLinkHandler *displayLinkHandler();
 
     RetainPtr<WKDisplayLinkHandler> m_displayLinkHandler;
 
     bool m_needsDisplayRefreshCallbacksForMonotonicAnimations { false };
+    bool m_hasHighImpactMonotonicAnimations { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -77,6 +77,7 @@ public:
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&) const override;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID) const override;
     void progressBasedTimelinesWereUpdatedForNode(const WebCore::ScrollingTreeScrollingNode&) override;
+    bool hasHighImpactMonotonicAnimations() const override;
 #endif
 
     void displayDidRefresh(WebCore::PlatformDisplayID) override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -819,6 +819,8 @@ void RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode(RemoteLay
     m_animatedNodeLayerIDs.remove(node.layerID());
     if (m_animatedNodeLayerIDs.isEmpty() || !m_monotonicTimelineRegistry || m_monotonicTimelineRegistry->isEmpty())
         protect(drawingAreaIOS())->pauseDisplayRefreshCallbacksForMonotonicAnimations();
+    else if (node.hasHighImpactMonotonicAnimations())
+        protect(drawingAreaIOS())->highImpactMonotonicAnimationsWereRemoved();
 }
 
 void RemoteScrollingCoordinatorProxyIOS::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate, MonotonicTime now)
@@ -886,6 +888,17 @@ void RemoteScrollingCoordinatorProxyIOS::updateAnimationStacks(NOESCAPE const Fu
         if (!animationStack->isEmpty())
             m_animatedNodeLayerIDs.add(animatedNodeLayerID);
     }
+}
+
+bool RemoteScrollingCoordinatorProxyIOS::hasHighImpactMonotonicAnimations() const
+{
+    auto& layerTreeHost = drawingAreaIOS().remoteLayerTreeHost();
+    for (auto animatedNodeLayerID : m_animatedNodeLayerIDs) {
+        RefPtr animatedNode = layerTreeHost.nodeForID(animatedNodeLayerID);
+        if (animatedNode->hasHighImpactMonotonicAnimations())
+            return true;
+    }
+    return false;
 }
 #endif
 

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -472,4 +472,5 @@ interface UIScriptController {
     DOMString animationStackForLayerWithID(unsigned long long layerID);
     DOMString progressBasedTimelinesForScrollingNodeID(unsigned long long scrollingNodeID, unsigned long long processID);
 #endif
+    boolean displayLinkWantsHighFrameRate();
 };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -482,6 +482,7 @@ public:
     virtual JSRetainPtr<JSStringRef> animationStackForLayerWithID(uint64_t) const { notImplemented(); return nullptr; }
     virtual JSRetainPtr<JSStringRef> progressBasedTimelinesForScrollingNodeID(unsigned long long, unsigned long long) const { notImplemented(); return nullptr; }
 #endif
+    virtual bool displayLinkWantsHighFrameRate() const { notImplemented(); return false; };
 
 protected:
     explicit UIScriptController(UIScriptContext&);

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h
@@ -109,6 +109,7 @@ private:
     JSRetainPtr<JSStringRef> animationStackForLayerWithID(uint64_t layerID) const final;
     JSRetainPtr<JSStringRef> progressBasedTimelinesForScrollingNodeID(unsigned long long scrollingNodeID, unsigned long long processID) const final;
 #endif
+    bool displayLinkWantsHighFrameRate() const final;
 };
 
 } // namespace WTR

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -645,4 +645,9 @@ JSRetainPtr<JSStringRef> UIScriptControllerCocoa::progressBasedTimelinesForScrol
 }
 #endif
 
+bool UIScriptControllerCocoa::displayLinkWantsHighFrameRate() const
+{
+    return [webView() _displayLinkWantsHighFrameRate];
+}
+
 } // namespace WTR


### PR DESCRIPTION
#### de8c3e0c5b1569b54b671df962fb811deda134b8
<pre>
[threaded-animations] only opt animations affecting transform into high frame rate on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=307554">https://bugs.webkit.org/show_bug.cgi?id=307554</a>
<a href="https://rdar.apple.com/problem/170153252">rdar://problem/170153252</a>

Reviewed by Simon Fraser.

In 307177@main we added a dedicated setting to control whether high frame rate can be used to update animations at all.
But even if this setting is enabled, we need to be smart about what animations will be updated at a high frame rate.
An obvious first step is to only include animations targeting a transform-related property.

To support this, we add a new `AcceleratedEffect::hasHighImpact()` method which we&apos;ll use on the remote side to keep
a per-node flag as `RemoteLayerTreeNode::m_hasHighImpactMonotonicAnimations` that we update when a node&apos;s animation
stack is updated from the web side (ie. as animations start and end).

Then `RemoteScrollingCoordinatorProxyIOS`, which is notified as animations are added and removed, can notify
`RemoteLayerTreeDrawingAreaProxyIOS` of such updates such that its new `m_hasHighImpactMonotonicAnimations`
flag can be updated.

Finally, we account for this flag in `RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayLinkAndSetFrameRate()`
to determine whether to request high frame rate updates for the display link.

In order to test this, we add a new bit indicating whether an accelerated effect has high impact on the web side
when calling `internals.acceleratedAnimationsForElement()`, as well as a new `UIScriptController.displayLinkWantsHighFrameRate()`
method to indicate whether the display link has been asked to update at a high frame rate. Combining those two
testing abilities, we write a new test that checks that animations marked as high impact indeed end up causing
the display link to request high frame rate updates.

Test: webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations.html

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async displayLinkWantsHighFrameRate):
* LayoutTests/webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations-expected.txt: Added.
* LayoutTests/webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations.html: Added.
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::hasHighImpact const):
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
(WebCore::GraphicsLayerCoordinated::acceleratedAnimationsForTesting const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::acceleratedAnimationsForElement):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewPrivateForTesting.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewTesting.mm:
(-[WKWebView _displayLinkWantsHighFrameRate]):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeDrawingAreaProxy.h:
(WebKit::RemoteLayerTreeDrawingAreaProxy::displayLinkWantsHighFrameRateForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
(WebKit::RemoteScrollingCoordinatorProxy::hasHighImpactMonotonicAnimations const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler wantsHighFrameRate]):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacksForMonotonicAnimations):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::highImpactMonotonicAnimationsWereRemoved):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacksForMonotonicAnimations):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayLinkAndSetFrameRate):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::displayLinkWantsHighFrameRateForTesting const):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode):
(WebKit::RemoteScrollingCoordinatorProxyIOS::hasHighImpactMonotonicAnimations const):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::displayLinkWantsHighFrameRate const):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::displayLinkWantsHighFrameRate const):

Canonical link: <a href="https://commits.webkit.org/307339@main">https://commits.webkit.org/307339@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2cc0764a88bd91311812cff4e56e70a0d93fbbad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144122 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16801 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/8356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/152792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145997 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16695 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/152792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147085 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/152792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/238 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/6141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155104 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16653 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/7196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/16689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/13984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/119196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/127352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22227 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/16275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16075 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->