### PR TITLE
[AutoFill Debugging] Miscellaneous refinements when extracting DOM attributes

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
@@ -8,6 +8,8 @@ root,scrollPosition=(0,0),contentSize=[…]
             'This is some article content with highlighted text.'
         form,autocomplete='on',name='signup'
             'Sign up for our newsletter'
+            input,'checkbox',label='Remember me'
+            'Remember me'
             input,'text',placeholder='Username',name='username',minlength=3,maxlength=20,required
             input,'password',placeholder='Password',name='password',minlength=3,maxlength=20,required,secure
             input,'text',placeholder='Email',pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$',name='email',required
@@ -24,6 +26,8 @@ root,scrollPosition=(0,0),contentSize=[…]
         </article>
         <form autocomplete='on' name='signup'>
             Sign up for our newsletter
+            <input type='checkbox' label='Remember me'>
+            Remember me
             <input type='text' placeholder='Username' name='username' minlength=3 maxlength=20 required>
             <input type='password' placeholder='Password' name='password' minlength=3 maxlength=20 required>
             <input type='text' placeholder='Email' pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$' name='email' required>

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html
@@ -48,6 +48,10 @@ h4 {
         <div class="tall"></div>
         <form name="signup" autocomplete="on">
             <h4>Sign up for our newsletter</h4>
+            <label>
+                <input type="checkbox" name="4dbbd829694147d79fecb2e70f3109db">
+                Remember me
+            </label>
             <div class="form-container">
                 <input name="username" placeholder="Username" minlength="3" maxlength="20" required />
                 <input name="password" placeholder="Password" minlength="3" maxlength="20" type="password" required />

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -18,7 +18,7 @@ root
 		link,url='example.com','Plain link'
 		link,url='example.com/2','Plain link (2)'
 		link,url='example.com/3','Plain link (3)'
-		link,url='/Users/test/cat.png','Local file'
+		link,url='/test/cat.png','Local file'
 	section
 		image,src='image',alt='SVG data URL'
 		image,src='image2',alt='PNG data URL'
@@ -47,7 +47,7 @@ root
 [Plain link](example.com)
 [Plain link \(2\)](example.com/2)
 [Plain link \(3\)](example.com/3)
-[Local file](/Users/test/cat.png)
+[Local file](/test/cat.png)
 ![SVG data URL](image)
 ![PNG data URL](image2)
 ![Long image path](vacation-2024-summer-beach.jpg)

--- a/Source/WebCore/platform/StringEntropyHelpers.cpp
+++ b/Source/WebCore/platform/StringEntropyHelpers.cpp
@@ -128,7 +128,7 @@ static double entropyScore(StringView text)
     return totalWeight / textLength;
 }
 
-static bool isProbablyHumanReadable(StringView text, double entropyThreshold = 0)
+bool isProbablyHumanReadable(StringView text)
 {
     static constexpr auto highEntropyThreshold = 40;
     static constexpr auto lowEntropyThreshold = 5;
@@ -139,7 +139,7 @@ static bool isProbablyHumanReadable(StringView text, double entropyThreshold = 0
     if (text.length() <= lowEntropyThreshold)
         return true;
 
-    return entropyScore(text) >= entropyThreshold;
+    return entropyScore(text) >= 0;
 }
 
 String lowEntropyLastPathComponent(const URL& url, const String& fallbackName)

--- a/Source/WebCore/platform/StringEntropyHelpers.h
+++ b/Source/WebCore/platform/StringEntropyHelpers.h
@@ -29,6 +29,7 @@
 
 namespace WebCore::StringEntropyHelpers {
 
+bool isProbablyHumanReadable(StringView);
 String lowEntropyLastPathComponent(const URL&, const String& fallbackName);
 URL removeHighEntropyComponents(const URL&);
 


### PR DESCRIPTION
#### e3364ca09bc891ff61bbdeb9431ca5c72eb0a5c8
<pre>
[AutoFill Debugging] Miscellaneous refinements when extracting DOM attributes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307568">https://bugs.webkit.org/show_bug.cgi?id=307568</a>
<a href="https://rdar.apple.com/170157790">rdar://170157790</a>

Reviewed by Abrar Rahman Protyasha.

Make several small refinements to text extraction:

-   Limit file URLs to the last 2 path components.
-   Only extract the `name` attribute if it&apos;s &quot;probably human-readable&quot; (based on the same heuristic
    used to shorten URLs).
-   Simplify whitespace when extracting label text.

* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html:

Augment an existing layout test to contain a label and input with high-entropy `name`.

* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt:

Rebaseline an existing layout test.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::stringOnlyIfHumanReadable):
(WebCore::TextExtraction::labelText):
(WebCore::TextExtraction::extractItemData):
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::handleInteraction):

Also fix this error detail to reflect the fact that node and/or search text is preferred over
location.

* Source/WebCore/platform/StringEntropyHelpers.cpp:
(WebCore::StringEntropyHelpers::isProbablyHumanReadable):
* Source/WebCore/platform/StringEntropyHelpers.h:

Canonical link: <a href="https://commits.webkit.org/307314@main">https://commits.webkit.org/307314@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a1d62cd4553d5a5b67ac47cedac253859a919c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143999 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16678 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8231 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152669 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8a0fd817-abee-40f8-aaf9-4086441297ce) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110728 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3eb9071d-eff6-4292-9537-df749fbb370d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146962 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129390 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91647 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ee7298e-2016-42a4-a7f0-b481f6d60b34) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12624 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10352 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/115 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154981 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7090 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118741 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16566 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13892 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119095 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30527 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15001 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127246 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71951 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16152 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5694 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15886 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79931 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16097 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15952 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->