### PR TITLE
Web Inspector: Remove obsolete WI.NavigationSidebarPanel.suppressFilteringOnTreeElements

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.js
+++ b/Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.js
@@ -158,16 +158,6 @@ WI.NavigationSidebarPanel = class NavigationSidebarPanel extends WI.SidebarPanel
         return contentTreeOutline;
     }
 
-    suppressFilteringOnTreeElements(treeElements)
-    {
-        console.assert(Array.isArray(treeElements), "TreeElements should be an array.");
-
-        for (let treeElement of treeElements)
-            treeElement[WI.NavigationSidebarPanel.SuppressFilteringSymbol] = true;
-
-        this.updateFilter();
-    }
-
     treeElementForRepresentedObject(representedObject)
     {
         let treeElement = null;


### PR DESCRIPTION
#### 329adc7bd2301e81678ffa013b7040b3fdd0bb74
<pre>
Web Inspector: Remove obsolete WI.NavigationSidebarPanel.suppressFilteringOnTreeElements
<a href="https://bugs.webkit.org/show_bug.cgi?id=307574">https://bugs.webkit.org/show_bug.cgi?id=307574</a>
<a href="https://rdar.apple.com/170160245">rdar://170160245</a>

Reviewed by Brandon Stewart.

The method was introduced in <a href="https://commits.webkit.org/170154@main">https://commits.webkit.org/170154@main</a>
and used to prevent hiding some tree outlines in the Debugger tab (now Sources Tab).

The method is no longer used. Tree outline are explicitly marked as non-filterable by applying
the `WI.NavigationSidebarPanel.SuppressFilteringSymbol` at creation time in
`WI.NavigationSidebarPanel.prototype.createContentTreeOutline()`.

There&apos;s no use case where this status needs to change during runtime. The unused method can be removed.

* Source/WebInspectorUI/UserInterface/Views/NavigationSidebarPanel.js:
(WI.NavigationSidebarPanel.prototype.suppressFilteringOnTreeElements): Deleted.

Canonical link: <a href="https://commits.webkit.org/307296@main">https://commits.webkit.org/307296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58a48bf227f6801fa25900aa38c8d98081d1b28d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143969 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16648 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8201 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152639 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a1341ea-c0d9-4faf-8620-00fc8453b74a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16541 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110707 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146932 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129365 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91625 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12598 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10331 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/85 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122068 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6010 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154951 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16500 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118717 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16536 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119069 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30520 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14985 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127221 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16122 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5668 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/15856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79901 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16067 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15922 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->