### PR TITLE
[iOS] Rename MediaDeviceRoute::currentValue() to MediaDeviceRoute::currentPlaybackPosition()

### DIFF
--- a/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
+++ b/Source/WebCore/platform/audio/ios/MediaDeviceRoute.h
@@ -104,7 +104,7 @@ public:
     virtual void bufferingDidChange(MediaDeviceRoute&) { }
     virtual void playbackErrorDidChange(MediaDeviceRoute&) { }
     virtual void hasAudioDidChange(MediaDeviceRoute&) { }
-    virtual void currentValueDidChange(MediaDeviceRoute&) { }
+    virtual void currentPlaybackPositionDidChange(MediaDeviceRoute&) { }
     virtual void playingDidChange(MediaDeviceRoute&) { }
     virtual void playbackSpeedDidChange(MediaDeviceRoute&) { }
     virtual void scanSpeedDidChange(MediaDeviceRoute&) { }
@@ -133,14 +133,14 @@ public:
     bool buffering() const;
     std::optional<MediaPlaybackSourceError> playbackError() const;
     bool hasAudio() const;
-    MediaTime currentValue() const;
+    MediaTime currentPlaybackPosition() const;
     bool playing() const;
     float playbackSpeed() const;
     float scanSpeed() const;
     bool muted() const;
     float volume() const;
 
-    void setCurrentValue(MediaTime);
+    void setCurrentPlaybackPosition(MediaTime);
     void setPlaying(bool);
     void setPlaybackSpeed(float);
     void setScanSpeed(float);


### PR DESCRIPTION
#### 58bf77b4dc4bbe74a622a16a17781fa12d2cb965
<pre>
[iOS] Rename MediaDeviceRoute::currentValue() to MediaDeviceRoute::currentPlaybackPosition()
<a href="https://bugs.webkit.org/show_bug.cgi?id=307576">https://bugs.webkit.org/show_bug.cgi?id=307576</a>
<a href="https://rdar.apple.com/170161647">rdar://170161647</a>

Reviewed by Jer Noble.

* Source/WebCore/platform/audio/ios/MediaDeviceRoute.h:
(WebCore::MediaDeviceRouteClient::currentPlaybackPositionDidChange):
(WebCore::MediaDeviceRouteClient::currentValueDidChange): Deleted.
* Source/WebCore/platform/audio/ios/MediaDeviceRoute.mm:
(-[WebMediaSourceObserver observeValueForKeyPath:ofObject:change:context:]):
(WebCore::MediaDeviceRoute::currentPlaybackPosition const):
(WebCore::MediaDeviceRoute::setCurrentPlaybackPosition):

Canonical link: <a href="https://commits.webkit.org/307440@main">https://commits.webkit.org/307440@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/130b001c2be5bea4cfac8293137241e30d6ebcfd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143975 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16654 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8207 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97214 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f944a5a-5f96-433d-8dec-691613a7ccb0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145850 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17136 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110712 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79587 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d3c4195a-029f-46d4-8233-09b8f0c3a882) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146938 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13145 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129372 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91630 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b49ea36-4d60-4194-afe6-8072c1176005) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10333 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/91 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122082 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6017 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154957 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16506 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118718 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16542 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13871 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119070 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30612 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14986 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71927 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16128 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5675 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15862 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79907 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15928 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->