### PR TITLE
[macOS] imported/w3c/web-platform-tests/workers/SharedWorkerPerformanceNow.html is a flaky text failure

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/workers/SharedWorkerPerformanceNow.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/workers/SharedWorkerPerformanceNow.html
@@ -16,7 +16,7 @@ async_test(function(t) {
           'workerStart not defined on the Worker object');
         assert_equals(results[1], 'object', 'self.performance is defined');
         assert_equals(results[2], 'function', 'self.performance.now is defined');
-        assert_greater_than(results[3], 0, 'Time in the worker should be positive');
+        assert_greater_than_equal(results[3], 0, 'Time in the worker should be non-negative');
         assert_greater_than(window.performance.now(), results[3], 'Time in the worker should be before the current time in the main document');
         setupIframe();
     });


### PR DESCRIPTION
#### 30d1ac0d9651dfdd5dcf37f7c8265400b5c97d09
<pre>
[macOS] imported/w3c/web-platform-tests/workers/SharedWorkerPerformanceNow.html is a flaky text failure
<a href="https://rdar.apple.com/170159172">rdar://170159172</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307571">https://bugs.webkit.org/show_bug.cgi?id=307571</a>

Reviewed by Sam Sneddon.

The test imported/w3c/web-platform-tests/workers/SharedWorkerPerformanceNow.html
is flaky because it asserts that performance.now() must be strictly greater than 0.
However, due to WebKit&apos;s 1ms timer precision (Performance.cpp:72), if the SharedWorker
calls performance.now() within ~0.5ms of creation, the time rounds down to 0ms.

Performance.now() returning 0 is valid when called at or very
close to the time origin. The test should accept 0 as a valid value.

Changed assertion from assert_greater_than(results[3], 0, ...) to
assert_greater_than_equal(results[3], 0, ...) on line 19.

* LayoutTests/imported/w3c/web-platform-tests/workers/SharedWorkerPerformanceNow.html:

Canonical link: <a href="https://commits.webkit.org/307405@main">https://commits.webkit.org/307405@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c5e3d5aac4d9cadbf51951f4583957e04da615b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16656 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8209 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97216 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17138 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16549 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110710 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79590 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129373 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91628 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12602 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10335 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/93 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6018 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154959 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16508 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118722 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16544 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119075 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30589 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14988 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127229 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71929 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16130 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5676 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15864 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15930 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->