### PR TITLE
AX: Expose the IntersectTextMarkerRanges API to macOS clients.

### DIFF
--- a/LayoutTests/accessibility/mac/text-marker-ranges-intersect-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-ranges-intersect-expected.txt
@@ -1,0 +1,49 @@
+Tests the intersectTextMarkerRanges method.
+
+text, AXRole: AXGroup
+elementRange: text: 'abcdefghij', start: {{ID 74, role StaticText, offset 0}}, end: {{ID 74, role StaticText, offset 10}}
+range1: text: 'abc', start: {{ID 74, role StaticText, offset 0}}, end: {{ID 74, role StaticText, offset 3}}
+range2: text: 'hij', start: {{ID 74, role StaticText, offset 7}}, end: {{ID 74, role StaticText, offset 10}}
+elementRange range1 intersection: text: 'abc', start: {{ID 74, role StaticText, offset 0}}, end: {{ID 74, role StaticText, offset 3}}
+elementRange range2 intersection: text: 'hij', start: {{ID 74, role StaticText, offset 7}}, end: {{ID 74, role StaticText, offset 10}}
+range1 range2 intersection: null
+
+text, AXRole: AXGroup
+elementRange: text: 'abcdefghij', start: {{ID 74, role StaticText, offset 0}}, end: {{ID 74, role StaticText, offset 10}}
+range1: text: 'def', start: {{ID 74, role StaticText, offset 3}}, end: {{ID 74, role StaticText, offset 6}}
+range2: text: 'efghij', start: {{ID 74, role StaticText, offset 4}}, end: {{ID 74, role StaticText, offset 10}}
+elementRange range1 intersection: text: 'def', start: {{ID 74, role StaticText, offset 3}}, end: {{ID 74, role StaticText, offset 6}}
+elementRange range2 intersection: text: 'efghij', start: {{ID 74, role StaticText, offset 4}}, end: {{ID 74, role StaticText, offset 10}}
+range1 range2 intersection: text: 'ef', start: {{ID 74, role StaticText, offset 4}}, end: {{ID 74, role StaticText, offset 6}}
+
+textarea, AXRole: AXTextArea
+elementRange: text: 'Write something here.', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 21}}
+range1: text: 'Write some', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 10}}
+range2: text: 'thing here.', start: {{ID 76, role StaticText, offset 10}}, end: {{ID 76, role StaticText, offset 21}}
+elementRange range1 intersection: text: 'Write some', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 10}}
+elementRange range2 intersection: text: 'thing here.', start: {{ID 76, role StaticText, offset 10}}, end: {{ID 76, role StaticText, offset 21}}
+range1 range2 intersection: text: '', start: {{ID 76, role StaticText, offset 10}}, end: {{ID 76, role StaticText, offset 10}}
+
+textarea, AXRole: AXTextArea
+elementRange: text: 'Write something here.', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 21}}
+range1: text: 'Write some', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 10}}
+range2: text: 'something here.', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 21}}
+elementRange range1 intersection: text: 'Write some', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 10}}
+elementRange range2 intersection: text: 'something here.', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 21}}
+range1 range2 intersection: text: 'some', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 10}}
+
+textarea, AXRole: AXTextArea
+elementRange: text: 'Write something here.', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 21}}
+range1: text: 'te something h', start: {{ID 76, role StaticText, offset 3}}, end: {{ID 76, role StaticText, offset 17}}
+range2: text: 'something here.', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 21}}
+elementRange range1 intersection: text: 'te something h', start: {{ID 76, role StaticText, offset 3}}, end: {{ID 76, role StaticText, offset 17}}
+elementRange range2 intersection: text: 'something here.', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 21}}
+range1 range2 intersection: text: 'something h', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 17}}
+
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+abcdefghij
+
+

--- a/LayoutTests/accessibility/mac/text-marker-ranges-intersect.html
+++ b/LayoutTests/accessibility/mac/text-marker-ranges-intersect.html
@@ -1,0 +1,80 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ IsAccessibilityIsolatedTreeEnabled=true ] -->
+<!-- FIXME: make it work for ITM off. -->
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="text">abcdefghij</p>
+
+<textarea id="textarea" rows="10" cols="50">Write something here.</textarea>
+
+<script>
+let output = "Tests the intersectTextMarkerRanges method.\n\n";
+
+function moveTextMarker(axElement, marker, number) {
+    for (i = 0; i < Math.abs(number); ++i) {
+        if (number > 0)
+            marker = axElement.nextTextMarker(marker);
+        else
+            marker = axElement.previousTextMarker(marker);
+    }
+    return marker;
+}
+
+function testIntersectRanges(axElement, elementRange, range1, range2) {
+    output += `${axElement.domIdentifier}, ${axElement.role}\n`;
+    output += `elementRange: ${axElement.textMarkerRangeDebugDescription(elementRange)}\n`;
+    output += `range1: ${axElement.textMarkerRangeDebugDescription(range1)}\n`;
+    output += `range2: ${axElement.textMarkerRangeDebugDescription(range2)}\n`;
+
+    intersection = axElement.intersectTextMarkerRanges(elementRange, range1);
+    output += `elementRange range1 intersection: ${axElement.textMarkerRangeDebugDescription(intersection)}\n`;
+
+    intersection = axElement.intersectTextMarkerRanges(elementRange, range2);
+    output += `elementRange range2 intersection: ${axElement.textMarkerRangeDebugDescription(intersection)}\n`;
+
+    intersection = axElement.intersectTextMarkerRanges(range1, range2);
+    output += `range1 range2 intersection: ${axElement.textMarkerRangeDebugDescription(intersection)}\n\n`;
+}
+
+if (window.accessibilityController) {
+    axElement = accessibilityController.accessibleElementById("text");
+    range = axElement.textMarkerRangeForElement(axElement);
+    start = axElement.startTextMarkerForTextMarkerRange(range);
+    end = axElement.endTextMarkerForTextMarkerRange(range);
+    range1 = axElement.textMarkerRangeForMarkers(start, moveTextMarker(axElement, start, 3));
+    range2 = axElement.textMarkerRangeForMarkers(moveTextMarker(axElement, end, -3), end);
+    testIntersectRanges(axElement, range, range1, range2);
+
+    range1 = axElement.textMarkerRangeForMarkers(moveTextMarker(axElement, start, 3), moveTextMarker(axElement, start, 6));
+    range2 = axElement.textMarkerRangeForMarkers(moveTextMarker(axElement, end, -6), end);
+    testIntersectRanges(axElement, range, range1, range2);
+
+    axElement = accessibilityController.accessibleElementById("textarea");
+    range = axElement.textMarkerRangeForElement(axElement);
+    start = axElement.startTextMarkerForTextMarkerRange(range);
+    end = axElement.endTextMarkerForTextMarkerRange(range);
+    range1 = axElement.textMarkerRangeForMarkers(start, moveTextMarker(axElement, start, 10));
+    range2 = axElement.textMarkerRangeForMarkers(moveTextMarker(axElement, end, -11), end);
+    testIntersectRanges(axElement, range, range1, range2);
+
+    start = axElement.startTextMarkerForTextMarkerRange(range2);
+    start = moveTextMarker(axElement, start, -4);
+    range2 = axElement.textMarkerRangeForMarkers(start, end);
+    testIntersectRanges(axElement, range, range1, range2);
+
+    start = axElement.startTextMarkerForTextMarkerRange(range1);
+    start = moveTextMarker(axElement, start, 3);
+    end = axElement.endTextMarkerForTextMarkerRange(range1);
+    end = moveTextMarker(axElement, end, 7);
+    range1 = axElement.textMarkerRangeForMarkers(start, end);
+    testIntersectRanges(axElement, range, range1, range2);
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
+++ b/Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h
@@ -243,6 +243,7 @@
 #define NSAccessibilityConvertRelativeFrameParameterizedAttribute @"AXConvertRelativeFrame"
 #define NSAccessibilityEndTextMarkerForBoundsAttribute @"AXEndTextMarkerForBounds"
 #define NSAccessibilityIndexForTextMarkerAttribute @"AXIndexForTextMarker"
+#define NSAccessibilityIntersectTextMarkerRangesAttribute @"AXIntersectTextMarkerRanges"
 #define NSAccessibilityLeftLineTextMarkerRangeForTextMarkerAttribute @"AXLeftLineTextMarkerRangeForTextMarker"
 #define NSAccessibilityLeftWordTextMarkerRangeForTextMarkerAttribute @"AXLeftWordTextMarkerRangeForTextMarker"
 #define NSAccessibilityLengthForTextMarkerRangeAttribute @"AXLengthForTextMarkerRange"

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -3455,6 +3455,18 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         return @(range ? AXObjectCache::lengthForRange(*range) : 0);
     }
 
+    if ([attribute isEqualToString:NSAccessibilityIntersectTextMarkerRangesAttribute]) {
+        if (array.count < 2
+            || !AXObjectIsTextMarkerRange([array objectAtIndex:0])
+            || !AXObjectIsTextMarkerRange([array objectAtIndex:1]))
+            return nil;
+
+        auto range1 = AXTextMarkerRange { (AXTextMarkerRangeRef)[array objectAtIndex:0] };
+        auto range2 = AXTextMarkerRange { (AXTextMarkerRangeRef)[array objectAtIndex:1] };
+        auto intersection = range1.intersectionWith(range2);
+        return intersection ? (*intersection).platformData().bridgingAutorelease() : nil;
+    }
+
     if (backingObject->isExposableTable()) {
         if ([attribute isEqualToString:NSAccessibilityCellForColumnAndRowParameterizedAttribute]) {
             if (array == nil || [array count] != 2)

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -1399,6 +1399,11 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForM
     return nullptr;
 }
 
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::intersectTextMarkerRanges(WTR::AccessibilityTextMarkerRange*, WTR::AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElement::textMarkerRangeForRange(unsigned, unsigned)
 {
     return nullptr;

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -317,6 +317,7 @@ public:
     virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*);
     virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*);
     virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForUnorderedMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*);
+    virtual RefPtr<AccessibilityTextMarkerRange> intersectTextMarkerRanges(AccessibilityTextMarkerRange*, AccessibilityTextMarkerRange*);
     virtual RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForRange(unsigned location, unsigned length);
     virtual RefPtr<AccessibilityTextMarkerRange> selectedTextMarkerRange();
     virtual void resetSelectedTextMarkerRange();

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -259,6 +259,7 @@ interface AccessibilityUIElement {
     AccessibilityTextMarkerRange textMarkerRangeForElement(AccessibilityUIElement element);
     AccessibilityTextMarkerRange textMarkerRangeForMarkers(AccessibilityTextMarker startMarker, AccessibilityTextMarker endMarker);
     AccessibilityTextMarkerRange textMarkerRangeForUnorderedMarkers(AccessibilityTextMarker startMarker, AccessibilityTextMarker endMarker);
+    AccessibilityTextMarkerRange intersectTextMarkerRanges(AccessibilityTextMarkerRange range1, AccessibilityTextMarkerRange range2);
     AccessibilityTextMarkerRange textMarkerRangeForRange(unsigned long location, unsigned long length);
     AccessibilityTextMarkerRange selectedTextMarkerRange();
     undefined resetSelectedTextMarkerRange();

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
@@ -328,6 +328,7 @@ public:
     RefPtr<AccessibilityUIElement> accessibilityElementForTextMarker(AccessibilityTextMarker*) override;
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*) override;
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> intersectTextMarkerRanges(AccessibilityTextMarkerRange*, AccessibilityTextMarkerRange*) override;
     int indexForTextMarker(AccessibilityTextMarker*) override;
     JSRetainPtr<JSStringRef> rectsForTextMarkerRange(AccessibilityTextMarkerRange*, JSStringRef) override;
     JSRetainPtr<JSStringRef> attributedStringForTextMarkerRange(AccessibilityTextMarkerRange*) override;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -1398,6 +1398,11 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementIOS::textMarkerRangeF
     return AccessibilityTextMarkerRange::create(textMarkerRange);
 }
 
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementIOS::intersectTextMarkerRanges(AccessibilityTextMarkerRange*, AccessibilityTextMarkerRange*)
+{
+    return nullptr;
+}
+
 RefPtr<AccessibilityTextMarker> AccessibilityUIElementIOS::startTextMarkerForTextMarkerRange(AccessibilityTextMarkerRange* range)
 {
     id textMarkers = range->platformTextMarkerRange();

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
@@ -269,6 +269,7 @@ public:
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForElement(AccessibilityUIElement*) override;
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) override;
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForUnorderedMarkers(AccessibilityTextMarker*, AccessibilityTextMarker*) override;
+    RefPtr<AccessibilityTextMarkerRange> intersectTextMarkerRanges(AccessibilityTextMarkerRange*, AccessibilityTextMarkerRange*) override;
     RefPtr<AccessibilityTextMarkerRange> textMarkerRangeForRange(unsigned location, unsigned length) override;
     RefPtr<AccessibilityTextMarkerRange> selectedTextMarkerRange() override;
     void resetSelectedTextMarkerRange() override;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -2438,6 +2438,19 @@ RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementMac::textMarkerRangeF
     return nullptr;
 }
 
+RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementMac::intersectTextMarkerRanges(AccessibilityTextMarkerRange* range1, AccessibilityTextMarkerRange* range2)
+{
+    BEGIN_AX_OBJC_EXCEPTIONS
+    if (!range1->platformTextMarkerRange() || !range2->platformTextMarkerRange())
+        return nullptr;
+    NSArray *textMarkerRanges = @[range1->platformTextMarkerRange(), range2->platformTextMarkerRange()];
+    auto intersection = attributeValueForParameter(@"AXIntersectTextMarkerRanges", textMarkerRanges);
+    return AccessibilityTextMarkerRange::create(intersection.get());
+    END_AX_OBJC_EXCEPTIONS
+
+    return nullptr;
+}
+
 RefPtr<AccessibilityTextMarkerRange> AccessibilityUIElementMac::textMarkerRangeForRange(unsigned location, unsigned length)
 {
     BEGIN_AX_OBJC_EXCEPTIONS


### PR DESCRIPTION
#### cd47ffff2464757df28031da4b2a267a648b4eab
<pre>
AX: Expose the IntersectTextMarkerRanges API to macOS clients.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307573">https://bugs.webkit.org/show_bug.cgi?id=307573</a>
&lt;<a href="https://rdar.apple.com/problem/170160233">rdar://problem/170160233</a>&gt;

Reviewed by Tyler Wilcock.

This change exposes the AXIntersectTextMarkerRanges parameterized attribute to AX macOS clients. , It enables layout tests to verify the
Proper Behavior of the API. The intersection operation
returns a new text marker range representing the overlapping text
of the two input ranges, or null if there is no overlap. This is
useful for accessibility clients that need to determine the common
text region shared by two selections or ranges.

Test: accessibility/mac/text-marker-ranges-intersect.html
* LayoutTests/accessibility/mac/text-marker-ranges-intersect-expected.txt: Added.
* LayoutTests/accessibility/mac/text-marker-ranges-intersect.html: Added.
* Source/WebCore/accessibility/mac/CocoaAccessibilityConstants.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::intersectTextMarkerRanges):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElementIOS::intersectTextMarkerRanges):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElementMac::intersectTextMarkerRanges):

Canonical link: <a href="https://commits.webkit.org/307362@main">https://commits.webkit.org/307362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1527d51db2df2e43341016e5c33559aae9b99b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/143981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152651 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97220 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17142 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110713 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79589 "1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/428f9d67-ac9a-4093-8c5d-07e33c22ba35) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146944 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91631 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b7af04c-3055-4ae5-9428-300d8f7625fa) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12605 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10338 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/97 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154963 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16512 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7075 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118723 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16548 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13876 "8 flakes 1 failures") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119076 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30561 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/14991 "Passed tests") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127231 "Exiting early after 10 failures. 10 tests run. 1 flakes") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71933 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16134 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5678 "Exiting early after 10 failures. 10 tests run. 1 flakes") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15868 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79913 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16079 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15934 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->