### PR TITLE
REGRESSION(Xcode 26): Broke WebPushD tests (ASSERTION FAILED: m_shouldIncrementProtocolVersionForTesting)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm
@@ -505,7 +505,10 @@ static NSDictionary<NSString *, id> *testDaemonPList(NSURL *storageLocation)
         @"Label" : @"org.webkit.pcmtestdaemon",
         @"LaunchOnlyOnce" : @YES,
         @"StandardErrorPath" : [storageLocation URLByAppendingPathComponent:@"daemon_stderr"].path,
-        @"EnvironmentVariables" : @{ @"DYLD_FRAMEWORK_PATH" : currentExecutableDirectory().get().path },
+        @"EnvironmentVariables" : @{
+            @"DYLD_FRAMEWORK_PATH" : currentExecutableDirectory().get().path,
+            @"DYLD_LIBRARY_PATH"   : currentExecutableDirectory().get().path
+        },
         @"MachServices" : @{ @"org.webkit.pcmtestdaemon.service" : @YES },
         @"ProgramArguments" : @[
             testPCMDaemonLocation().get().path,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm
@@ -160,7 +160,10 @@ static NSDictionary<NSString *, id> *testWebPushDaemonPList(NSURL *storageLocati
         @"LaunchOnlyOnce" : @(static_cast<BOOL>(launchOnlyOnce)),
         @"ThrottleInterval" : @(1),
         @"StandardErrorPath" : [storageLocation URLByAppendingPathComponent:@"daemon_stderr"].path,
-        @"EnvironmentVariables" : @{ @"DYLD_FRAMEWORK_PATH" : currentExecutableDirectory().get().path },
+        @"EnvironmentVariables" : @{
+            @"DYLD_FRAMEWORK_PATH" : currentExecutableDirectory().get().path,
+            @"DYLD_LIBRARY_PATH"   : currentExecutableDirectory().get().path
+        },
         @"MachServices" : @{ @"org.webkit.webpushtestdaemon.service" : @YES },
         @"ProgramArguments" : @[
             testWebPushDaemonLocation().get().path,


### PR DESCRIPTION
#### ce27b7cfad2d3183419286d634d9c12bf50bd1e7
<pre>
REGRESSION(Xcode 26): Broke WebPushD tests (ASSERTION FAILED: m_shouldIncrementProtocolVersionForTesting)
<a href="https://bugs.webkit.org/show_bug.cgi?id=307362">https://bugs.webkit.org/show_bug.cgi?id=307362</a>
<a href="https://rdar.apple.com/169991396">rdar://169991396</a>

Reviewed by Mike Wyrzykowski.

At-desk-style builds produce a flat build directory structure and
require setting both DYLD_FRAMEWORK_PATH and DYLD_LIBRARY_PATH in all
the executables we spawn. Test code for webpushd was only setting the
former. Now that webpushd can pull in strictly safe Swift code, on older
platforms it requires loading the libswiftCompatibilitySpan.dylib
compatibility runtime. So, it needs DYLD_LIBRARY_PATH set too.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/EventAttribution.mm:
(TestWebKitAPI::testDaemonPList): While we do not observe the same crash
in adattributiond, this is the same loading logic, so add
DYLD_LIBRARY_PATH here too for correctness.
* Tools/TestWebKitAPI/Tests/WebKitCocoa/WebPushDaemon.mm:
(TestWebKitAPI::testWebPushDaemonPList):

Canonical link: <a href="https://commits.webkit.org/307416@main">https://commits.webkit.org/307416@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d93e9f71362f3c7b13d32c2f74fa5c2fd2a6a6ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8288 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152726 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97295 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85b1c790-288b-43ad-ab9c-03dc38908fed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16629 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110772 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79613 "Exiting early after 60 failures. 15448 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147019 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13189 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129434 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91691 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/feae9731-aec9-4535-8ee5-98cd03d34de7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12650 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10383 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/172 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122123 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6081 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155038 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16587 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118786 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13930 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119141 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30595 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15031 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127292 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72008 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16209 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5735 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15943 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16154 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16009 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->