### PR TITLE
[grid-lanes] display:grid subgrid should contribute item sizes to correct tracks

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing-expected.html
@@ -42,7 +42,7 @@
   <item style="width: 1ch">1</item>
   <subgrid>
     <item style="width: 2ch">2</item>
-    <item style="width: 2ch">3</item>
+    <item>3</item>
     <item>4</item>
   </subgrid>
   <item>5</item>
@@ -51,7 +51,7 @@
 <grid>
   <item>1</item>
   <subgrid>
-    <item style="width: 3ch">2</item>
+    <item>2</item>
     <item style="width: 3ch">3</item>
     <item>4</item>
   </subgrid>
@@ -62,11 +62,10 @@
   <item style="width: 1ch">1</item>
   <subgrid>
     <item>2</item>
-    <item style="width: 4ch">3</item>
+    <item>3</item>
     <item style="width: 4ch">4</item>
   </subgrid>
   <item>5</item>
 </grid>
-
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing-ref.html
@@ -42,7 +42,7 @@
   <item style="width: 1ch">1</item>
   <subgrid>
     <item style="width: 2ch">2</item>
-    <item style="width: 2ch">3</item>
+    <item>3</item>
     <item>4</item>
   </subgrid>
   <item>5</item>
@@ -51,7 +51,7 @@
 <grid>
   <item>1</item>
   <subgrid>
-    <item style="width: 3ch">2</item>
+    <item>2</item>
     <item style="width: 3ch">3</item>
     <item>4</item>
   </subgrid>
@@ -62,7 +62,7 @@
   <item style="width: 1ch">1</item>
   <subgrid>
     <item>2</item>
-    <item style="width: 4ch">3</item>
+    <item>3</item>
     <item style="width: 4ch">4</item>
   </subgrid>
   <item>5</item>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing.html
@@ -1,0 +1,78 @@
+<!DOCTYPE HTML>
+<!--
+     Any copyright is dedicated to the Public Domain.
+     http://creativecommons.org/publicdomain/zero/1.0/
+-->
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Verify correct sizing of intrinsically sized tracks when using subgrid in CSS Grid Lanes</title>
+  <link rel="author" title="Brandon Stewart" href="mailto:brandonstewart@apple.com">
+  <link rel="help" href="https://drafts.csswg.org/css-grid-3/#subgrids">
+  <link rel="match" href="grid-lanes-subgrid-intrinsic-sizing-ref.html">
+  <style>
+    grid {
+      display: inline-grid-lanes;
+      grid-template-columns: auto min-content max-content;
+      border: 1px solid;
+      background: lightgrey;
+    }
+
+    subgrid {
+      display: grid;
+      grid-template-columns: subgrid;
+      grid-column: 2 / span 2;
+      background: lightblue;
+    }
+  </style>
+</head>
+
+<body>
+  <!-- Verify basic subgrid -->
+  <grid>
+    <item>1</item>
+    <subgrid>
+      <item>2</item>
+      <item>3</item>
+      <item>4</item>
+    </subgrid>
+    <item>5</item>
+  </grid>
+
+  <!-- Verify subgrid with first item in subgrid set to 2ch -->
+  <grid>
+    <item>1</item>
+    <subgrid>
+      <item style="width: 2ch">2</item>
+      <item>3</item>
+      <item>4</item>
+    </subgrid>
+    <item>5</item>
+  </grid>
+
+  <!-- Verify subgrid with second item in subgrid set to 3ch -->
+  <grid>
+    <item>1</item>
+    <subgrid>
+      <item>2</item>
+      <item style="width: 3ch">3</item>
+      <item>4</item>
+    </subgrid>
+    <item>5</item>
+  </grid>
+
+  <!-- Verify subgrid with final item in subgrid set to 4ch -->
+  <grid>
+    <item>1</item>
+    <subgrid>
+      <item>2</item>
+      <item>3</item>
+      <item style="width: 4ch">4</item>
+    </subgrid>
+    <item>5</item>
+  </grid>
+
+</body>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-ref.html
@@ -68,14 +68,5 @@
   <item>5</item>
 </grid>
 
-<grid>
-  <item style="width: 1ch">1</item>
-  <subgrid>
-    <item style="width: 3ch">2</item>
-    <item style="width: 3ch">3</item>
-    <item>4</item>
-  </subgrid>
-  <item>5</item>
-</grid>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html
@@ -72,15 +72,5 @@
   <item>5</item>
 </grid>
 
-<!-- Verify behavior when subgrid is set to grid-lanes too -->
-<grid>
-  <item>1</item>
-  <subgrid style="display: grid-lanes;">
-    <item>2</item>
-    <item style="width: 3ch">3</item>
-    <item>4</item>
-  </subgrid>
-  <item>5</item>
-</grid>
 </body>
 </html>


### PR DESCRIPTION
#### e63622220d8afb3b32fe321feb489fed73b941b9
<pre>
[grid-lanes] display:grid subgrid should contribute item sizes to correct tracks
<a href="https://bugs.webkit.org/show_bug.cgi?id=307587">https://bugs.webkit.org/show_bug.cgi?id=307587</a>
<a href="https://rdar.apple.com/170168798">rdar://170168798</a>

Reviewed by Sammy Gill.

When an explicitly placed subgrid uses display:grid (instead of
display:grid-lanes) inside a grid-lanes container, the subgrid&apos;s items
should contribute their intrinsic sizes only to the specific tracks
where they are placed, not to all tracks in the subgrid&apos;s span.

The issue was in computeDefiniteAndIndefiniteItemsForMasonry, which
determines whether items have indefinite positions based on their CSS
style (via resolveGridPositionsFromStyle). For auto-placed items inside
the subgrid, this returns indefinite even though a display:grid subgrid
has already placed them to specific tracks via its grid auto-placement
algorithm.

The fix checks whether the item&apos;s parent is a regular grid (not
grid-lanes) using isMasonry(). If so, we treat items as having definite
positions since the grid has placed them, and they contribute only to
their actual tracks rather than all tracks in the subgrid span.

Tests: imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing-ref.html
       imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing-expected.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-expected.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing-ref.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-expected.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-display-grid-intrinsic-sizing.html: Copied from LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::GridTrackSizingAlgorithm::computeDefiniteAndIndefiniteItemsForMasonry):

Canonical link: <a href="https://commits.webkit.org/308253@main">https://commits.webkit.org/308253@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/748a8da0b3255e60fee9247075680c0c188d250a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19519 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13183 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100227 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ca604ddf-c605-4496-8c64-1aa052588e80) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113148 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80765 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73a2ac1f-af35-40bb-9961-ed4ca7164741) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15393 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93944 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9eed0fe-dc3d-4fe9-9daf-55adfb80719f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14627 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12401 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2962 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124213 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9910 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157838 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/983 "Found 2 new failures in UIProcess/API/ios/WKWebViewIOS.mm, UIProcess/ios/WKContentViewInteraction.mm") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/11349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121182 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19321 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121360 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31108 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19330 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131666 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16964 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18936 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82691 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18666 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18817 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18725 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->