### PR TITLE
Allow the api test parallel allowlist to accept test names individually

### DIFF
--- a/Tools/Scripts/webkitpy/api_tests/allowlist.txt
+++ b/Tools/Scripts/webkitpy/api_tests/allowlist.txt
@@ -1,9 +1,18 @@
-# API Test Suite Allowlist
-# 
-# This file contains test suites that are allowed to run in regular shards.
-# Test suites NOT listed here will be placed in the system shard.
-# 
-# Format: One suite name per line (BINARY.SUITE format, where SUITE can contain slashes)
+# API Test Allowlist
+#
+# Tests listed here are allowed to run in parallel (non-system shard).
+# Tests NOT listed here will be placed in the system shard and run sequentially.
+#
+# Format: Both suite-level and test-level entries are supported:
+#   - BINARY.SUITE - allowlists all tests in the suite
+#   - BINARY.SUITE.TESTCASE - allowlists a specific test
+#
+# A test is allowlisted if either:
+#   1. Its full name (BINARY.SUITE.TESTCASE) is in this list, OR
+#   2. Its suite prefix (BINARY.SUITE) is in this list
+#
+# SUITE can contain slashes for parametrized tests (e.g., WTF_Int128IntegerConversionTest/0)
+#
 TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/Encoder
 TestIPC.ArgumentCoderTest/ArgumentCoderDecodingMoveCounterTest/StreamConnectionEncoder
 TestIPC.ArgumentCoderTest/ArgumentCoderEncodingCounterTest
@@ -140,6 +149,8 @@ TestWTF.WTF_IteratorRange
 TestWTF.WTF_LazyRef
 TestWTF.WTF_LazyUniqueRef
 TestWTF.WTF_ListHashSet
+TestWTF.WTF_Lock.Basic
+TestWTF.WTF_Lock.ContendedShortSection
 TestWTF.WTF_Logger
 TestWTF.WTF_Markable
 TestWTF.WTF_NakedPtr

--- a/Tools/Scripts/webkitpy/api_tests/runner.py
+++ b/Tools/Scripts/webkitpy/api_tests/runner.py
@@ -169,8 +169,16 @@ class Runner(object):
         if self.port.get_option('fully_parallel') and self.port.get_option('test_parallel_safety'):
             raise RuntimeError(f'Running api tests fully parallel is not compatible with test_parallel_safety')
 
+        self.printer.write_update('Filtering tests by allowlist ...')
+        # Split tests by allowlist BEFORE sharding
+        allowlisted_tests, non_allowlisted_tests = self.port.filter_api_tests_by_allowlist(tests)
+
+        if non_allowlisted_tests:
+            _log.info(f'{len(non_allowlisted_tests)} tests not in allowlist will run in system shard')
+
         self.printer.write_update('Sharding tests ...')
-        shards = Runner._shard_tests(tests, self.port.get_option('fully_parallel'))
+        # Only shard allowlisted tests for parallel execution
+        shards = Runner._shard_tests(allowlisted_tests, self.port.get_option('fully_parallel'))
 
         original_level = server_process_logger.level
         server_process_logger.setLevel(logging.CRITICAL)
@@ -213,20 +221,10 @@ class Runner(object):
             # For minimum worker calculation, use current batch size (first batch or all if unbatched)
             self._num_workers = min(workers, max(len(shards) + (len(test_parallel_safety_batches[0]) if test_parallel_safety_batches else 0), 1))
 
-            system_shards = {}
-            non_system_shards = {}
-
-            for name, tests in iteritems(shards):
-                group = self.port.group_for_shard(type('Shard', (), {'name': name})(), suite='api-tests')
-                if group == 'system' and not self.port.get_option('fully_parallel'):
-                    system_shards[name] = tests
-                else:
-                    non_system_shards[name] = tests
-
             # Process test-parallel-safety batches sequentially
             for batch_index, test_parallel_safety_batch in enumerate(test_parallel_safety_batches if test_parallel_safety_batches else [[]]):
                 if test_parallel_safety_batch:
-                    _log.info(f'Running batch {batch_index + 1}/{len(test_parallel_safety_batches)}: {len(non_system_shards)} regular shards with {len(test_parallel_safety_batch)} test-parallel-safety repeat tasks')
+                    _log.info(f'Running batch {batch_index + 1}/{len(test_parallel_safety_batches)}: {len(shards)} regular shards with {len(test_parallel_safety_batch)} test-parallel-safety repeat tasks')
 
                 non_system_groups = [group for group in mutually_exclusive_groups if group != 'system']
                 test_parallel_safety_groups = []
@@ -237,7 +235,7 @@ class Runner(object):
                         test_parallel_safety_groups.append(test_parallel_safety_group)
                         non_system_groups.append(test_parallel_safety_group)
                     batch_test_parallel_safety_count = len(test_parallel_safety_batch)
-                    batch_effective_work_count = len(non_system_shards) + batch_test_parallel_safety_count
+                    batch_effective_work_count = len(shards) + batch_test_parallel_safety_count
                     batch_workers = min(workers, max(batch_effective_work_count, 1))
                 else:
                     batch_workers = self._num_workers
@@ -254,31 +252,27 @@ class Runner(object):
                             _log.info(f'Dispatching repeat test-parallel-safety task for {test_name} to group {test_parallel_safety_group} (batch {batch_index + 1}/{len(test_parallel_safety_batches)})')
                             pool.do(run_test_parallel_safety_single_iteration, test_name, repeat=True, group=test_parallel_safety_group)
 
-                    # Run regular shards with each batch - this is the whole point of test-parallel-safety testing
-                    for name, tests in iteritems(non_system_shards):
+                    # Run regular shards
+                    for name, shard_tests in iteritems(shards):
                         if name.startswith('test-parallel-safety.'):
                             continue
 
-                        group = self.port.group_for_shard(type('Shard', (), {'name': name})(), suite='api-tests')
-                        if test_parallel_safety_batches and group == 'system':
-                            continue
-
-                        if group and group != 'system' and not self.port.get_option('fully_parallel'):
-                            pool.do(run_shard, name, *tests, group=group)
-                        else:
-                            pool.do(run_shard, name, *tests)
+                        pool.do(run_shard, name, *shard_tests)
 
                     pool.wait()
 
-            # Run system tests after all non-system tests complete (unless in test-parallel-safety mode)
-            if system_shards and not self.port.get_option('test_parallel_safety'):
+            # Run system shard tests after all parallel tests complete (unless in test-parallel-safety mode)
+            if non_allowlisted_tests and not self.port.get_option('test_parallel_safety'):
+                _log.info(f'Running {len(non_allowlisted_tests)} system shard tests sequentially')
                 with TaskPool(
-                    workers=1,  # System tests run with single worker to avoid conflicts
+                    workers=1,  # System shard tests run with single worker to avoid conflicts
                     mutually_exclusive_groups=[],
                     setup=setup_shard, setupkwargs=dict(port=self.port, devices=devices, log_limit=self.log_limit), teardown=teardown_shard,
                 ) as pool:
-                    for name, tests in iteritems(system_shards):
-                        pool.do(run_shard, name, *tests)
+                    # Group system shard tests by suite for efficiency
+                    non_allowlisted_shards = Runner._shard_tests(non_allowlisted_tests, False)
+                    for name, shard_tests in iteritems(non_allowlisted_shards):
+                        pool.do(run_shard, name, *shard_tests)
 
                     pool.wait()
             elif self.port.get_option('test_parallel_safety'):

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -305,6 +305,14 @@ class Port(object):
                 return group
         return None
 
+    def filter_api_tests_by_allowlist(self, tests):
+        """Split API tests into allowlisted (parallel) and non-allowlisted (system) groups.
+
+        Default implementation: all tests are allowlisted (no system shard).
+        Override in platform-specific ports to implement allowlist filtering.
+        """
+        return tests, []
+
     def check_build(self):
         """This routine is used to ensure that the build is up to date
         and all the needed binaries are present."""

--- a/Tools/Scripts/webkitpy/port/darwin.py
+++ b/Tools/Scripts/webkitpy/port/darwin.py
@@ -70,19 +70,38 @@ class DarwinPort(ApplePort):
             pass
         return sorted(list(allowlist))
 
-    def _should_use_system_shard(self, shard_name):
-        """Check if a shard should be placed in the system shard based on the allowlist."""
-        allowlist = self._load_api_test_suite_allowlist()
-        return shard_name not in allowlist
+    @memoized
+    def _allowlist_as_set(self):
+        """Return the allowlist as a set for efficient lookups."""
+        return set(self._load_api_test_suite_allowlist())
+
+    def is_test_allowlisted(self, test_name):
+        """Check if a test is allowlisted (exact match or suite match).
+
+        A test is allowlisted if:
+        1. Its full name (BINARY.SUITE.TESTCASE) is in the allowlist, OR
+        2. Its suite prefix (BINARY.SUITE) is in the allowlist
+        """
+        allowlist = self._allowlist_as_set()
+        # Check exact match (test name in allowlist)
+        if test_name in allowlist:
+            return True
+        # Check suite match (BINARY.SUITE prefix in allowlist)
+        suite_prefix = '.'.join(test_name.split('.')[:-1])
+        return suite_prefix in allowlist
+
+    def filter_api_tests_by_allowlist(self, tests):
+        """Split API tests into allowlisted (parallel) and non-allowlisted (system) groups."""
+        allowlisted = []
+        non_allowlisted = []
+        for t in tests:
+            if self.is_test_allowlisted(t):
+                allowlisted.append(t)
+            else:
+                non_allowlisted.append(t)
+        return allowlisted, non_allowlisted
 
     def sharding_groups(self, suite=None):
-        if suite == 'api-tests':
-            groups = {}
-
-            # Add system group - test-parallel-safety groups will be created dynamically in runner.py
-            groups['system'] = lambda shard: '__WEBKIT_TEST_PARALLEL_SAFETY_SHARD_' not in shard.name and self._should_use_system_shard(shard.name)
-
-            return groups
         return {
             'media': lambda shard: 'media' in shard.name or 'webaudio' in shard.name,
         }

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -57,6 +57,7 @@ from webkitpy.style.checkers.messagesin import MessagesInChecker
 from webkitpy.style.checkers.png import PNGChecker
 from webkitpy.style.checkers.python import PythonChecker, Python3Checker
 from webkitpy.style.checkers.spi_allowlist import SPIAllowlistChecker
+from webkitpy.style.checkers.api_test_allowlist import APITestAllowlistChecker
 from webkitpy.style.checkers.swift import SwiftChecker
 from webkitpy.style.checkers.test_expectations import TestExpectationsChecker
 from webkitpy.style.checkers.text import TextChecker
@@ -793,6 +794,7 @@ class FileType:
     XCSCHEME = 14
     SWIFT = 15
     SPI_ALLOWLIST = 16
+    API_TEST_ALLOWLIST = 17
 
 
 class ANSIColor:
@@ -908,6 +910,8 @@ class CheckerDispatcher(object):
             return FileType.BASE_XCCONFIG
         elif os.path.basename(file_path).startswith('AllowedSPI') and file_extension == 'toml':
             return FileType.SPI_ALLOWLIST
+        elif 'api_tests' in file_path and os.path.basename(file_path) == 'allowlist.txt':
+            return FileType.API_TEST_ALLOWLIST
         else:
             return FileType.NONE
 
@@ -989,6 +993,8 @@ class CheckerDispatcher(object):
             checker = BaseXcconfigChecker(file_path, handle_style_error)
         elif file_type == FileType.SPI_ALLOWLIST:
             checker = SPIAllowlistChecker(file_path, handle_style_error)
+        elif file_type == FileType.API_TEST_ALLOWLIST:
+            checker = APITestAllowlistChecker(file_path, handle_style_error)
         else:
             raise ValueError('Invalid file type "%(file_type)s": the only valid file types '
                              "are %(NONE)s, %(CPP)s, and %(TEXT)s."

--- a/Tools/Scripts/webkitpy/style/checkers/api_test_allowlist.py
+++ b/Tools/Scripts/webkitpy/style/checkers/api_test_allowlist.py
@@ -1,0 +1,77 @@
+# Copyright (C) 2024 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import re
+
+# Valid entry format: BINARY.SUITE or BINARY.SUITE.TESTCASE
+# BINARY is like TestWTF, TestWebKitAPI, TestIPC, TestWGSL
+# SUITE can contain slashes for parametrized tests
+# TESTCASE is the individual test name
+_ENTRY_PATTERN = re.compile(r'^(Test\w+)\.([^.]+(?:/[^.]+)*)(?:\.(.+))?$')
+
+
+class APITestAllowlistChecker(object):
+    """Processes api_tests/allowlist.txt to enforce allowlist conventions."""
+
+    def __init__(self, file_path, handle_style_error):
+        self.file_path = file_path
+        self.handle_style_error = handle_style_error
+
+    def check(self, lines):
+        seen = set()
+        suites = set()
+        prev_entry = ""
+
+        for line_number, line in enumerate(lines, 1):
+            line = line.rstrip('\n\r')
+            stripped = line.strip()
+
+            # Skip empty lines and comments
+            if not stripped or stripped.startswith('#'):
+                continue
+
+            # Check for valid format
+            match = _ENTRY_PATTERN.match(stripped)
+            if not match:
+                self.handle_style_error(line_number, 'api-test-allowlist/format', 5, f"Invalid entry format: '{stripped}' (expected BINARY.SUITE or BINARY.SUITE.TESTCASE)")
+                continue
+
+            binary, suite, testcase = match.groups()
+            suite_key = f'{binary}.{suite}'
+
+            # Check for duplicates
+            if stripped in seen:
+                self.handle_style_error(line_number, 'api-test-allowlist/duplicate', 5, f"Duplicate entry: '{stripped}'")
+            seen.add(stripped)
+
+            # Track suites (entries without testcase)
+            if testcase is None:
+                suites.add(suite_key)
+            else:
+                # Check if suite is already listed (redundant entry)
+                if suite_key in suites:
+                    self.handle_style_error(line_number, 'api-test-allowlist/redundant', 5, f"Redundant entry: '{stripped}' (suite '{suite_key}' already listed)")
+
+            # Check alphabetical order
+            if stripped < prev_entry:
+                self.handle_style_error(line_number, 'api-test-allowlist/order', 5, f"Entry not in alphabetical order: '{stripped}' should come before '{prev_entry}'")
+            prev_entry = stripped


### PR DESCRIPTION
#### 1689358a9eb9e78de43befd3a8a1773965b1f0af
<pre>
Allow the api test parallel allowlist to accept test names individually
<a href="https://bugs.webkit.org/show_bug.cgi?id=307590">https://bugs.webkit.org/show_bug.cgi?id=307590</a>
<a href="https://rdar.apple.com/170169417">rdar://170169417</a>

Reviewed by Jonathan Bedard.

More granular allowlist will speed up api test runs by increasing our parallel test and reducing the long unparallel thread.

* Tools/Scripts/webkitpy/api_tests/allowlist.txt:
* Tools/Scripts/webkitpy/api_tests/runner.py:
(Runner.run):
* Tools/Scripts/webkitpy/port/base.py:
(Port.filter_tests_by_allowlist):
* Tools/Scripts/webkitpy/port/darwin.py:
(DarwinPort):
(DarwinPort._allowlist_as_set):
(DarwinPort.is_test_allowlisted):
(DarwinPort.filter_tests_by_allowlist):
(DarwinPort.sharding_groups):
(DarwinPort._should_use_system_shard): Deleted.
* Tools/Scripts/webkitpy/style/checker.py:
(FileType):
(CheckerDispatcher._file_type):
(CheckerDispatcher._create_checker):

Canonical link: <a href="https://commits.webkit.org/312125@main">https://commits.webkit.org/312125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc4eaa019eed1a8db928a84949fb023ef8364c1e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/158384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/31810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/24917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/167213 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/112467 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/160254 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/31878 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/31797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/122668 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/86097 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/161342 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/24920 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/142265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/103338 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/157705 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/23976 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/22361 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/14985 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/133664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/20045 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/169704 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/21669 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/130853 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/31500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/26425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/130967 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/35557 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/31446 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/141838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/89321 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/25658 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/18644 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/30957 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/30477 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/30750 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/30631 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->