### PR TITLE
REGRESSION(307285@main): Broke internal iOS builds

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
@@ -135,9 +135,10 @@ typedef NS_ENUM(NSInteger, WTSessionType) {
 typedef NS_ENUM(NSInteger, WTTextSuggestionState) {
     WTTextSuggestionStatePending = 0,
     WTTextSuggestionStateReviewing = 1,
-    WTTextSuggestionStateAccepted = 2,
     WTTextSuggestionStateRejected = 3,
     WTTextSuggestionStateInvalid = 4,
+
+    WTTextSuggestionStateAccepted = 2,
 };
 
 @interface WTTextSuggestion : NSObject<BSXPCCoding, NSSecureCoding>


### PR DESCRIPTION
#### a1dc8a3ac9007a02678094b84dd828ac89831b3d
<pre>
REGRESSION(307285@main): Broke internal iOS builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=307591">https://bugs.webkit.org/show_bug.cgi?id=307591</a>
<a href="https://rdar.apple.com/170170052">rdar://170170052</a>

Unreviewed build fix.

```
Source/WebKit/UIProcess/ios/WKBrowserEngineDefinitions.h:29:2: note: in module &apos;pal&apos; imported from Source/WebKit/UIProcess/ios/WKBrowserEngineDefinitions.h:29:
 ^
pal/spi/cocoa/WritingToolsSPI.h:138:5: error: &apos;WTTextSuggestionState&apos; has different definitions in different modules; definition in module &apos;pal.spi.cocoa.WritingToolsSPI&apos; first difference is 3rd element has name &apos;WTTextSuggestionStateAccepted&apos;
  ¦ WTTextSuggestionStateAccepted = 2,
WritingTools.framework/Headers/WTTextSuggestion.h:16:5: note: but in &apos;WritingTools.WTTextSuggestion&apos; found 3rd element has name &apos;WTTextSuggestionStateRejected&apos;
  ¦ WTTextSuggestionStateRejected = 3,
```

307285@main modified the order of the WTTextSuggestionState enum
declaration by putting them in ascending order. This should have been a
harmless change, but supposedly it could pass as a different definition
of the same type, since it does not agree exactly with what exists in
the SDK&apos;s framework header.

We fix the error by partially reverting the WritingToolsSPI.h changes
made in 307285@main.

* Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h:

Canonical link: <a href="https://commits.webkit.org/307302@main">https://commits.webkit.org/307302@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5af2e5b7776eacf5a12d163b97cc284ab396cd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144004 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/8236 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152674 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b062b57-52fc-4e39-b50f-72fc515cd87c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145879 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16576 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/110734 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5698226-8ff8-4ba6-9883-b961b9c31b2f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146967 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129394 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91653 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12623 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/6039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/154986 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/7094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118745 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/16571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/13895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119100 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/127250 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/71956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22212 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/16157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/15891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/15957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->