### PR TITLE
[iOS] [Scroll anchoring] Scroll anchoring in overflow scroll double-adjusts

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-scroll-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-scroll-expected.txt
@@ -1,0 +1,7 @@
+PASS scroller.scrollTop is 310
+PASS scroller.scrollTop is 410
+PASS scroller.scrollTop is 310
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-scroll.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-scroll.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html><!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] --> 
+<html>
+<head>
+    <style>
+        .scroller {
+            width: 300px;
+            height: 400px;
+            border: 1px solid black;
+            overflow-y: scroll;
+        }
+        
+        .changing {
+            height: 300px;
+            background-color: orange;
+        }
+
+        body.changed .changing {
+            height: 400px;
+        }
+
+        .anchor {
+            height: 300px;
+            background-color: limegreen;
+        }
+        
+        .spacer {
+            height: 500px;
+        }
+        
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        jsTestIsAsync = true;
+
+        let scroller;
+        window.addEventListener('load', async () => {
+            scroller = document.querySelector('.scroller');
+            scroller.scrollTo(0, 310);
+            // should anchor to 'anchor'
+
+            shouldBe('scroller.scrollTop', '310');
+            document.body.classList.toggle('changed');
+
+            await UIHelper.renderingUpdate();
+
+            shouldBe('scroller.scrollTop', '410');
+
+            document.body.classList.toggle('changed');
+
+            await UIHelper.ensurePresentationUpdate();
+
+            shouldBe('scroller.scrollTop', '310');
+
+            finishJSTest();
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="changing"></div>
+        <div class="anchor"></div>
+        <div class="spacer"></div>
+    </div>
+<div id="console"></div>
+</body>
+</html>

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -84,7 +84,10 @@ bool ScrollAnchoringController::shouldMaintainScrollAnchor() const
 
 void ScrollAnchoringController::scrollPositionDidChange()
 {
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollableArea::scrollPositionChanged() to " << m_owningScrollableArea->scrollPosition() << " - clearing scroll anchor");
+    if (m_isUpdatingScrollPositionForAnchoring)
+        return;
+
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController::scrollPositionChanged() to " << m_owningScrollableArea->scrollPosition() << " - clearing scroll anchor");
     clearAnchor();
     updateScrollableAreaRegistration();
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm
@@ -395,11 +395,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         END_BLOCK_OBJC_EXCEPTIONS
     }
 
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RequestedScrollPosition)) {
-        scrollingNode->handleScrollPositionRequest(scrollingStateNode.requestedScrollData());
-        scrollingTree()->setNeedsApplyLayerPositionsAfterCommit();
-    }
-
     if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ScrollbarWidth)) {
         auto scrollbarWidth = scrollingStateNode.scrollbarWidth();
 


### PR DESCRIPTION
#### 08e8584f2a997d928ced65716a03e9e4bd19a320
<pre>
[iOS] [Scroll anchoring] Scroll anchoring in overflow scroll double-adjusts
<a href="https://bugs.webkit.org/show_bug.cgi?id=307600">https://bugs.webkit.org/show_bug.cgi?id=307600</a>
<a href="https://rdar.apple.com/170178709">rdar://170178709</a>

Reviewed by Abrar Rahman Protyasha.

Scroll anchoring inside overflow:scroll on iOS was janky, because it double-applied
the scroll delta. This happened because both `ScrollingTreeScrollingNodeDelegateIOS`
and `ScrollingTreeScrollingNode` called `handleScrollPositionRequest()`.

Fix by removing the call in `ScrollingTreeScrollingNodeDelegateIOS`. I verified
that `setNeedsApplyLayerPositionsAfterCommit()` is always called already.

Test: fast/scrolling/scroll-anchoring-in-overflow-scroll.html

* LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-scroll-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-scroll.html: Added.
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::scrollPositionDidChange): Early return to make logging clearer.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/ScrollingTreeScrollingNodeDelegateIOS.mm:
(WebKit::ScrollingTreeScrollingNodeDelegateIOS::commitStateAfterChildren):

Canonical link: <a href="https://commits.webkit.org/307434@main">https://commits.webkit.org/307434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38c913f68b0c3188e7da0232b4150987cba72331

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8265 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152703 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97272 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145908 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17194 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110754 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79605 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/146996 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13169 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129420 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91673 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12633 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-initial-focus-display-animation.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10370 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecords (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/149 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122104 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6067 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155015 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16564 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118767 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16600 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119122 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30608 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15011 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127278 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71985 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16186 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5721 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15920 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79965 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16131 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15986 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->