### PR TITLE
Adopt `:-internal-uses-menulist` in UA stylesheet

### DIFF
--- a/LayoutTests/fast/forms/select-size-expected.html
+++ b/LayoutTests/fast/forms/select-size-expected.html
@@ -1,14 +1,2 @@
-<html>
-<head>
-<style>
-.listBox {
-    -webkit-appearance: listbox;
-    border-radius: initial;
-    border: 1px solid gray;
-}
-</style>
-</head>
-<body>
 This tests an HTMLSelectElement with a malformed size attribute<br>
-<select size="1" class="listbox"><option>test</select>
-</body>
+<select size="1"><option>test</select>

--- a/LayoutTests/fast/forms/select-size.html
+++ b/LayoutTests/fast/forms/select-size.html
@@ -1,2 +1,2 @@
 This tests an HTMLSelectElement with a malformed size attribute<br>
-<select style="border: 1px solid gray;" size= 1"><option>test</select>
+<select size= 1"><option>test</select>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1074,13 +1074,7 @@ select {
 #endif
 }
 
-/* FIXME: Replace with select:-internal-uses-menulist */
-#if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
-select:not([size], [multiple]),
-select:is([size=""], [size="0"], [size="1"]):not([multiple]) {
-#else
-select {
-#endif
+select:-internal-uses-menulist {
 #if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
     border-radius: 5px;
 #endif
@@ -1089,14 +1083,10 @@ select {
     cursor: default;
 }
 
-/* FIXME: Replace with select:not(:-internal-uses-menulist) */
-#if !(defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY)
-select[size][multiple],
-select:is([size], [multiple]):not([size=""], [size="0"], [size="1"]) {
+select:not(:-internal-uses-menulist) {
     border-style: inset;
     border-color: gray;
 }
-#endif
 
 select:not([multiple]):-internal-uses-menulist > button:first-child {
     all: unset;


### PR DESCRIPTION
#### 2b0ddc4d60d3932500171cfecd8656f30c380067
<pre>
Adopt `:-internal-uses-menulist` in UA stylesheet
<a href="https://bugs.webkit.org/show_bug.cgi?id=307525">https://bugs.webkit.org/show_bug.cgi?id=307525</a>
<a href="https://rdar.apple.com/170124020">rdar://170124020</a>

Reviewed by Simon Fraser.

This selector is equivalent, minus for cases where the size attribute is malformed, where we now more accurately select whether the element is rendered as a menulist or a listbox.

* LayoutTests/fast/forms/select-size-expected.html:
* LayoutTests/fast/forms/select-size.html:
* Source/WebCore/css/html.css:
(select:-internal-uses-menulist):
(select:not(:-internal-uses-menulist)):
(#if !(defined(WTF_PLATFORM_IOS_FAMILY) &amp;&amp; WTF_PLATFORM_IOS_FAMILY)): Deleted.

Canonical link: <a href="https://commits.webkit.org/307338@main">https://commits.webkit.org/307338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e64cb8c85784139c3f4454d41ddcd697574eebb2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144047 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8279 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152717 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1a71282-89e2-452f-9b5a-de0f9f35b145) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145922 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16619 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110764 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147010 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129422 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91683 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5780969-e963-4d08-b643-f25fcd0146a7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12643 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10377 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/163 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122116 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155029 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16578 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118777 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16614 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13923 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119132 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15025 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127280 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71999 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22226 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16200 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5723 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175334 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/79979 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/175334 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16145 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->