### PR TITLE
[macOS] Call -[NSTextInputContext textInputClientDidUpdateSelection] when the non-editable ranged selection changes

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -658,6 +658,7 @@ public:
     void insertText(id string);
     void insertText(id string, NSRange replacementRange);
     NSTextInputContext *inputContext();
+    NSTextInputContext *inputContextIncludingNonEditable();
     void unmarkText();
     void setMarkedText(id string, NSRange selectedRange, NSRange replacementRange);
     NSRange selectedRange();


### PR DESCRIPTION
#### 3d10598b567ea12426cb75f2a27af7296aaa1b84
<pre>
[macOS] Call -[NSTextInputContext textInputClientDidUpdateSelection] when the non-editable ranged selection changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307603">https://bugs.webkit.org/show_bug.cgi?id=307603</a>
<a href="https://rdar.apple.com/169743663">rdar://169743663</a>

Reviewed by Abrar Rahman Protyasha.

When the selection changes, notify AppKit by way of `-textInputClientDidUpdateSelection`, even if
the selection is non-editable (as long as it&apos;s ranged). See below for more details.

Test:   EditorStateTests.UnionRectInVisibleSelectedRangeForNonEditableRangeSelection
        EditorStateTests.UnionRectInVisibleSelectedRangeForEditableCaretSelection

* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::selectionDidChange):
(WebKit::WebViewImpl::unionRectInVisibleSelectedRangeInScreen const):

Drive-by fix: also include caret rects in the selection union rect (with a zero width).

(WebKit::WebViewImpl::inputContext):
(WebKit::WebViewImpl::inputContextIncludingNonEditable):

Split `inputContext` out into `inputContextIncludingNonEditable`, which (when the feature flag is
enabled) returns a non-null context as long as the selection is visible. This means either:
- Caret selection in an editable context, or
- Ranged selection, in either non-editable or editable contexts.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/EditorStateTests.mm:
(TestWebKitAPI::configurationWithTextInputClientSelectionUpdatesEnabled):
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeAndDocumentVisibleRect)):
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForEditableCaretSelection)):
(TestWebKitAPI::TEST(EditorStateTests, UnionRectInVisibleSelectedRangeForNonEditableRangeSelection)):

Canonical link: <a href="https://commits.webkit.org/307333@main">https://commits.webkit.org/307333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/acf26f8efa40e73331a59250845f5f2bd2b21947

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8278 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152716 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa8fe5ec-8d41-417b-bd74-adbdcac4e4e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145921 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110762 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97285 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7998916-ee7d-4404-97b6-0b3b040bc73d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147009 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13180 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129423 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecordsForMultipleContexts (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91681 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12642 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10379 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/162 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122115 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6070 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155028 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16577 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7125 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118776 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16613 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119131 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30542 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15024 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127281 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/71998 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16199 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5724 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15933 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/79978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16144 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/15999 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->