### PR TITLE
Correct <model> entity transform calculations

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -1279,18 +1279,11 @@ extension WKBridgeReceiver {
             let originalTransforms = meshTransforms[identifier]
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
             // swift-format-ignore: NeverForceUnwrap
-            let angle: Float = 0.707
-            let rotationY90 = simd_float4x4(
-                simd_float4(angle, 0, angle, 0), // column 0
-                simd_float4(0, 1, 0, 0), // column 1
-                simd_float4(-angle, 0, angle, 0), // column 2
-                simd_float4(0, 0, 0, 1) // column 3
-            )
 
             for (index, meshInstance) in meshes.enumerated() {
                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                 // swift-format-ignore: NeverForceUnwrap
-                let computedTransform = modelTransform * rotationY90 * originalTransforms![index]
+                let computedTransform = modelTransform * originalTransforms![index]
                 meshInstance.setTransform(.single(computedTransform))
             }
         }

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp
@@ -72,31 +72,30 @@ static WebModel::Float4x4 makeTransformMatrix(
 
 static std::pair<simd_float4, simd_float4> computeMinAndMaxCorners(const Vector<WebModel::MeshPart>& parts, const Vector<WebModel::Float4x4>& instanceTransforms)
 {
-    simd_float3 minCorner = simd_make_float3(FLT_MAX, FLT_MAX, FLT_MAX);
-    simd_float3 maxCorner = simd_make_float3(-FLT_MAX, -FLT_MAX, -FLT_MAX);
-    for (const WebModel::MeshPart& part : parts) {
-        minCorner = simd_min(part.boundsMin, minCorner);
-        maxCorner = simd_max(part.boundsMax, maxCorner);
-    }
+    simd_float4 minCorner4 = simd_make_float4(FLT_MAX, FLT_MAX, FLT_MAX, 1.f);
+    simd_float4 maxCorner4 = simd_make_float4(-FLT_MAX, -FLT_MAX, -FLT_MAX, 1.f);
 
-    if (!instanceTransforms.size())
-        return std::make_pair(simd_make_float4(minCorner), simd_make_float4(maxCorner));
+    for (auto& part : parts) {
+        // Get the 8 corners of the axis-aligned bounding box
+        std::array<simd_float3, 8> corners;
+        corners[0] = simd_make_float3(part.boundsMin.x, part.boundsMin.y, part.boundsMin.z);
+        corners[1] = simd_make_float3(part.boundsMax.x, part.boundsMin.y, part.boundsMin.z);
+        corners[2] = simd_make_float3(part.boundsMin.x, part.boundsMax.y, part.boundsMin.z);
+        corners[3] = simd_make_float3(part.boundsMax.x, part.boundsMax.y, part.boundsMin.z);
+        corners[4] = simd_make_float3(part.boundsMin.x, part.boundsMin.y, part.boundsMax.z);
+        corners[5] = simd_make_float3(part.boundsMax.x, part.boundsMin.y, part.boundsMax.z);
+        corners[6] = simd_make_float3(part.boundsMin.x, part.boundsMax.y, part.boundsMax.z);
+        corners[7] = simd_make_float3(part.boundsMax.x, part.boundsMax.y, part.boundsMax.z);
 
-    simd_float3 simdCenter = .5f * (minCorner + maxCorner);
-    simd_float3 simdExtent = 2.f * (maxCorner - simdCenter);
+        for (auto& transform : instanceTransforms) {
+            for (int j = 0; j < 8; ++j) {
+                simd_float4 corner4 = simd_make_float4(corners[j].x, corners[j].y, corners[j].z, 1.f);
+                simd_float4 transformedCorner = simd_mul(transform, corner4);
 
-    simd_float4 simdCenter4 = simd::make_float4(simdCenter.x, simdCenter.y, simdCenter.z, 1.f);
-    simd_float4 simdExtent4 = simd::make_float4(simdExtent.x, simdExtent.y, simdExtent.z, 0.f);
-
-    simd_float4 minCorner4 = simd::make_float4(FLT_MAX, FLT_MAX, FLT_MAX, 1.f);
-    simd_float4 maxCorner4 = simd::make_float4(-FLT_MAX, -FLT_MAX, -FLT_MAX, 1.f);
-
-    for (auto& transform : instanceTransforms) {
-        simd_float4 transformedCenter = simd_mul(transform, simdCenter4);
-        simd_float4 transformedExtent = simd_mul(transform, simdExtent4);
-
-        minCorner4 = simd_min(transformedCenter - transformedExtent, minCorner4);
-        maxCorner4 = simd_max(transformedCenter + transformedExtent, maxCorner4);
+                minCorner4 = simd_min(transformedCorner, minCorner4);
+                maxCorner4 = simd_max(transformedCorner, maxCorner4);
+            }
+        }
     }
 
     return std::make_pair(minCorner4, maxCorner4);
@@ -136,6 +135,7 @@ void RemoteMeshProxy::update(const WebModel::UpdateMeshDescriptor& descriptor)
 #if ENABLE(GPU_PROCESS_MODEL)
     auto [minCorner, maxCorner] = computeMinAndMaxCorners(descriptor.parts, descriptor.instanceTransforms);
     auto boundingBoxChanged = minCorner.x <= maxCorner.x && minCorner.y <= maxCorner.y && minCorner.z <= maxCorner.z;
+    boundingBoxChanged = boundingBoxChanged && (!simd_equal(m_minCorner, minCorner) || !simd_equal(m_maxCorner, maxCorner));
     if (boundingBoxChanged) {
         m_minCorner = simd_min(m_minCorner, minCorner);
         m_maxCorner = simd_max(m_maxCorner, maxCorner);
@@ -148,7 +148,8 @@ void RemoteMeshProxy::update(const WebModel::UpdateMeshDescriptor& descriptor)
     auto sendResult = send(Messages::RemoteMesh::Update(descriptor));
     UNUSED_PARAM(sendResult);
     if (boundingBoxChanged)
-        setEntityTransform(buildTranslation(-center.x, -center.y, -center.z));
+        setStageMode(m_stageMode);
+
 #else
     UNUSED_PARAM(descriptor);
 #endif
@@ -196,7 +197,7 @@ void RemoteMeshProxy::updateMaterial(const WebModel::UpdateMaterialDescriptor& d
 std::pair<simd_float4, simd_float4> RemoteMeshProxy::getCenterAndExtents() const
 {
     auto center = .5f * (m_minCorner + m_maxCorner);
-    auto extents = 2.f * (m_maxCorner - center);
+    auto extents = m_maxCorner - m_minCorner;
     return std::make_pair(center, extents);
 }
 #endif
@@ -204,10 +205,16 @@ std::pair<simd_float4, simd_float4> RemoteMeshProxy::getCenterAndExtents() const
 void RemoteMeshProxy::setEntityTransform(const WebModel::Float4x4& transform)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    if (m_transform && *m_transform == transform)
-        return;
-
     m_transform = transform;
+    setStageMode(m_stageMode);
+#else
+    UNUSED_PARAM(transform);
+#endif
+}
+
+void RemoteMeshProxy::setEntityTransformInternal(const WebModel::Float4x4& transform)
+{
+#if ENABLE(GPU_PROCESS_MODEL)
     auto sendResult = send(Messages::RemoteMesh::UpdateTransform(transform));
     UNUSED_PARAM(sendResult);
 #else
@@ -288,14 +295,13 @@ void RemoteMeshProxy::setScale(float scale)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
     if (!m_transform)
-        return;
+        m_transform = matrix_identity_float4x4;
     WebModel::Float4x4 transform = *m_transform;
     transform.column0 = simd_normalize(transform.column0) * scale;
     transform.column1 = simd_normalize(transform.column1) * scale;
     transform.column2 = simd_normalize(transform.column2) * scale;
 
-    if (!simd_almost_equal_elements(transform, *m_transform, tolerance))
-        setEntityTransform(transform);
+    setEntityTransform(transform);
 #else
     UNUSED_PARAM(scale);
 #endif
@@ -304,16 +310,20 @@ void RemoteMeshProxy::setScale(float scale)
 void RemoteMeshProxy::setStageMode(WebCore::StageModeOperation stageMode)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
-    if (stageMode == WebCore::StageModeOperation::None || !m_transform)
-        return;
-
     m_stageMode = stageMode;
     auto [center, extents] = getCenterAndExtents();
+    if (stageMode == WebCore::StageModeOperation::None) {
+        setEntityTransformInternal(buildTranslation(-center.x, -center.y, -center.z - .5f * extents.z));
+        return;
+    }
+
     WebModel::Float4x4 result = matrix_identity_float4x4;
     if (auto existingTransform = entityTransform())
         result = *existingTransform;
 
-    float scale = (2.f * m_cameraDistance) / std::max(simd_length(extents.xy), simd_length(extents.yz));
+    float maxExtent = simd_reduce_max(extents.xyz);
+    float scale = m_cameraDistance / maxExtent;
+
     result.column0 = scale * simd_normalize(result.column0);
     result.column1 = scale * simd_normalize(result.column1);
     result.column2 = scale * simd_normalize(result.column2);
@@ -323,7 +333,7 @@ void RemoteMeshProxy::setStageMode(WebCore::StageModeOperation stageMode)
         -simd_dot(center.xyz, simd_make_float3(result.column0.z, result.column1.z, result.column2.z)),
         1.f);
 
-    setEntityTransform(result);
+    setEntityTransformInternal(result);
 #else
     UNUSED_PARAM(stageMode);
 #endif
@@ -348,9 +358,6 @@ static simd_float4x4 buildRotation(float azimuth, float elevation)
 
 void RemoteMeshProxy::setRotation(float yaw, float pitch, float roll)
 {
-    if (!m_transform)
-        return;
-
     UNUSED_PARAM(roll);
     m_transform = buildRotation(yaw, pitch);
     setStageMode(m_stageMode);

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -94,6 +94,7 @@ private:
     void render() final;
     void setLabelInternal(const String&) final;
     void setEntityTransform(const WebModel::Float4x4&) final;
+    void setEntityTransformInternal(const WebModel::Float4x4&);
 #if PLATFORM(COCOA)
     std::optional<WebModel::Float4x4> entityTransform() const final;
 #endif

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -497,18 +497,20 @@ void WebModelPlayer::simulate(float elapsedTime)
     m_yawAcceleration *= 0.95f;
     m_pitchAcceleration *= 0.95f;
 
+    const float simulationEpsilon = 0.01f;
     m_yawAcceleration = std::clamp(m_yawAcceleration, -5.f, 5.f);
     m_pitchAcceleration = std::clamp(m_pitchAcceleration, -5.f, 5.f);
-    if (fabs(m_yawAcceleration) < 0.01f)
+    if (fabs(m_yawAcceleration) < simulationEpsilon)
         m_yawAcceleration = 0.f;
-    if (fabs(m_pitchAcceleration) < 0.01f)
+    if (fabs(m_pitchAcceleration) < simulationEpsilon)
         m_pitchAcceleration = 0.f;
 
     m_yaw += m_yawAcceleration * elapsedTime;
     m_pitch += m_pitchAcceleration * elapsedTime;
     m_pitch *= (1.f - elapsedTime);
 
-    model->setRotation(m_yaw, m_pitch);
+    if (m_yawAcceleration || m_pitchAcceleration)
+        model->setRotation(m_yaw, m_pitch);
 }
 
 void WebModelPlayer::setPlaybackRate(double newRate, CompletionHandler<void(double effectivePlaybackRate)>&& completion)
@@ -602,9 +604,6 @@ std::optional<WebCore::TransformationMatrix> WebModelPlayer::entityTransform() c
 void WebModelPlayer::setStageMode(WebCore::StageModeOperation stageMode)
 {
     m_stageMode = stageMode;
-    if (m_stageMode == WebCore::StageModeOperation::None)
-        return;
-
     if (RefPtr model = m_currentModel) {
         model->setStageMode(m_stageMode);
         notifyEntityTransformUpdated();


### PR DESCRIPTION
#### 53d16cd0ae3c6269c89aa36e242e6318efeb7002
<pre>
Correct &lt;model&gt; entity transform calculations
<a href="https://bugs.webkit.org/show_bug.cgi?id=307575">https://bugs.webkit.org/show_bug.cgi?id=307575</a>
<a href="https://rdar.apple.com/170160478">rdar://170160478</a>

Reviewed by Etienne Segonzac.

Correct some bounding box math during rotations which was
resulting in some inconsistencies between macOS/iOS and visionOS.

* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(Material.render(with:)):
Remove temporary 90 degree rotation which was added for testing purposes.

* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.cpp:
(WebKit::computeMinAndMaxCorners):
In order to correctly compute a tight fitting AABB, it is necessary to
rotate the 8 points which define the AABB instead of rotating the center + extents
which is effectively the representation of the bounding sphere.

(WebKit::RemoteMeshProxy::update):
The bounding box only changes if its corners change. Also instead of calling
setEntityTransform directly, go through setStageMode which correctly handles
any scale needed for orbiting.

(WebKit::RemoteMeshProxy::getCenterAndExtents const):
2.f * (m_maxCorner - center) is equivalent to  m_maxCorner - m_minCorner, there
is no function change here but the latter is more readable.

(WebKit::RemoteMeshProxy::setEntityTransform):
The entity transform is not necessarily the transform we use to render on screen
due to scaling or potential precision issues, so call setStageMode similar to
RemoteMeshProxy::update

(WebKit::RemoteMeshProxy::setEntityTransformInternal):
Refactor out of a member function which calls the actual IPC message

(WebKit::RemoteMeshProxy::setScale):
Setting the scale is equivalent to setting a transform, call setTransform
to simplify logic

(WebKit::RemoteMeshProxy::setStageMode):
For stage mode == none, we want to center the mesh in its center and moved
backward by half its extent. The extent is the entire lengh of the bounding box,
so half is half the length.

To tightly fit the model in the viewport during rotations, take the max extent
of its transform to scale the model up or down during orbit mode.

(WebKit::RemoteMeshProxy::setRotation):
Set rotation should be allowed before the entity has a transform set, in case
it is set before the model is loaded.

* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
Add member function declaration.

* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::simulate):
Only update the rotation when it actually changes.

(WebKit::WebModelPlayer::setStageMode):
If set don&apos;t call setStageMode when it is == none then after setting to orbit
and back to none, orbit will persist in RemoteMeshProxy which is wrong.

Canonical link: <a href="https://commits.webkit.org/307847@main">https://commits.webkit.org/307847@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9946d47d2a329fa40020da3f1bdbc2af7f962a5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145705 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18387 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10299 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154377 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45a72779-be37-475a-b4a1-74aa8698784a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18280 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112054 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34c9eb4b-ab32-4ced-b16e-072afd931e1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14427 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130868 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92960 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f650b50-9d3f-46e8-a5d4-9d37ae034df1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13748 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11512 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1824 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123278 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156690 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120057 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18237 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15218 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120408 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30866 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18283 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129014 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73978 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7123 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17859 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81638 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17595 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17803 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17658 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->