### PR TITLE
[CoreIPC] Fix RetainPtr serialization by aliasing bare refs instead of RetainPtr<T>

### DIFF
--- a/LayoutTests/ipc/convert-to-luminance-mask-float16.html
+++ b/LayoutTests/ipc/convert-to-luminance-mask-float16.html
@@ -27,7 +27,7 @@ window.setTimeout(async () => {
         renderingMode : 0,
         renderingPurpose : 7,
         resolutionScale : 3.650556716916852e+32,
-        colorSpace : { serializableColorSpace : { alias : { m_cgColorSpace : { alias : { variantType : 'WebCore::ColorSpace', variant : 17 } } } } },
+        colorSpace : { serializableColorSpace : { alias : { optionalValue : { m_cgColorSpace : { alias : { variantType : 'WebCore::ColorSpace', variant : 17 } } } } } },
         bufferFormat : { pixelFormat : 3, useLosslessCompression : 0 },
         identifier: imageBufferIdentifier,
         contextIdentifier: contextIdentifier

--- a/LayoutTests/ipc/coreipc.js
+++ b/LayoutTests/ipc/coreipc.js
@@ -224,27 +224,25 @@ const aliases = {
     'GCGLenum': 'uint32_t',
     'GCGLint': 'int32_t',
     'GCGLErrorCodeSet': 'OptionSet<GCGLErrorCode>',
-    // these RetainPtr<T> should not be treated as optionnal because
-    // of the 'Ref wrapped by' in Source/WebKit/Shared/cf/CFTypes.serialization.in
-    // see generated code in WebKitBuild/Debug/DerivedSources/WebKit/WebKitPlatformGeneratedSerializers.mm
-    'RetainPtr<CFTypeRef>': 'WebKit::CoreIPCCFType',
-    'RetainPtr<CFDataRef>': 'WebKit::CoreIPCData',
-    'RetainPtr<CFStringRef>': 'String',
-    'RetainPtr<CFArrayRef>': 'WebKit::CoreIPCCFArray',
-    'RetainPtr<CFDictionaryRef>': 'WebKit::CoreIPCCFDictionary',
-    'RetainPtr<CFBooleanRef>': 'WebKit::CoreIPCBoolean',
-    'RetainPtr<CFNumberRef>': 'WebKit::CoreIPCNumber',
-    'RetainPtr<CFDateRef>': 'WebKit::CoreIPCDate',
-    'RetainPtr<CFURLRef>': 'WebKit::CoreIPCCFURL',
-    'RetainPtr<CFNullRef>': 'WebKit::CoreIPCNull',
-    'RetainPtr<SecAccessControlRef>': 'WebKit::CoreIPCSecAccessControl',
-    'RetainPtr<SecCertificateRef>': 'WebKit::CoreIPCSecCertificate',
-    'RetainPtr<SecKeychainItemRef>': 'WebKit::CoreIPCSecKeychainItem',
-    'RetainPtr<CVPixelBufferRef>': 'WebKit::CoreIPCCVPixelBufferRef',
-    'RetainPtr<SecTrustRef>': 'WebKit::CoreIPCSecTrust',
-    'RetainPtr<CFCharacterSetRef>': 'WebKit::CoreIPCCFCharacterSet',
-    'RetainPtr<CGColorRef>': 'WebCore::Color',
-    'RetainPtr<CGColorSpaceRef>': 'WebKit::CoreIPCCGColorSpace'
+    // Encoder serializes bare CF/CG/CV/Sec refs as their CoreIPC wrapper types
+    'CFTypeRef': 'WebKit::CoreIPCCFType',
+    'CFDataRef': 'WebKit::CoreIPCData',
+    'CFStringRef': 'String',
+    'CFArrayRef': 'WebKit::CoreIPCCFArray',
+    'CFDictionaryRef': 'WebKit::CoreIPCCFDictionary',
+    'CFBooleanRef': 'WebKit::CoreIPCBoolean',
+    'CFNumberRef': 'WebKit::CoreIPCNumber',
+    'CFDateRef': 'WebKit::CoreIPCDate',
+    'CFURLRef': 'WebKit::CoreIPCCFURL',
+    'CFNullRef': 'WebKit::CoreIPCNull',
+    'SecAccessControlRef': 'WebKit::CoreIPCSecAccessControl',
+    'SecCertificateRef': 'WebKit::CoreIPCSecCertificate',
+    'SecKeychainItemRef': 'WebKit::CoreIPCSecKeychainItem',
+    'CVPixelBufferRef': 'WebKit::CoreIPCCVPixelBufferRef',
+    'SecTrustRef': 'WebKit::CoreIPCSecTrust',
+    'CFCharacterSetRef': 'WebKit::CoreIPCCFCharacterSet',
+    'CGColorRef': 'WebCore::Color',
+    'CGColorSpaceRef': 'WebKit::CoreIPCCGColorSpace'
 }
 
 export function resolveAlias(argumentType) {

--- a/LayoutTests/ipc/create-image-buffer-crash.html
+++ b/LayoutTests/ipc/create-image-buffer-crash.html
@@ -42,10 +42,12 @@
           colorSpace: {
             serializableColorSpace: {
               alias: {
-                m_cgColorSpace: {
-                  alias: {
-                    variantType: 'RetainPtr<CFStringRef>',
-                    variant: 'A'
+                optionalValue: {
+                  m_cgColorSpace: {
+                    alias: {
+                      variantType: 'RetainPtr<CFStringRef>',
+                      variant: 'A'
+                    }
                   }
                 }
               }

--- a/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
+++ b/LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html
@@ -39,12 +39,14 @@ setTimeout(async () => {
                         operatingColorSpace : {
                             serializableColorSpace: {
                                 alias: {
-                                    m_cgColorSpace: {
-                                        alias: {
-                                            variantType: "WebKit::ICCData",
-                                            variant: {
-                                                data: [],
-                                                derivative: 0
+                                    optionalValue: {
+                                        m_cgColorSpace: {
+                                            alias: {
+                                                variantType: "WebKit::ICCData",
+                                                variant: {
+                                                    data: [],
+                                                    derivative: 0
+                                                },
                                             },
                                         },
                                     },
@@ -61,12 +63,14 @@ setTimeout(async () => {
                         operatingColorSpace : {
                             serializableColorSpace: {
                                 alias: {
-                                    m_cgColorSpace: {
-                                        alias: {
-                                            variantType: "WebKit::ICCData",
-                                            variant: {
-                                                data: [],
-                                                derivative: 0
+                                    optionalValue: {
+                                        m_cgColorSpace: {
+                                            alias: {
+                                                variantType: "WebKit::ICCData",
+                                                variant: {
+                                                    data: [],
+                                                    derivative: 0
+                                                },
                                             },
                                         },
                                     },
@@ -85,12 +89,14 @@ setTimeout(async () => {
                         operatingColorSpace : {
                             serializableColorSpace: {
                                 alias: {
-                                    m_cgColorSpace: {
-                                        alias: {
-                                            variantType: "WebKit::ICCData",
-                                            variant: {
-                                                data: [],
-                                                derivative: 0
+                                    optionalValue: {
+                                        m_cgColorSpace: {
+                                            alias: {
+                                                variantType: "WebKit::ICCData",
+                                                variant: {
+                                                    data: [],
+                                                    derivative: 0
+                                                },
                                             },
                                         },
                                     },
@@ -112,12 +118,14 @@ setTimeout(async () => {
                         operatingColorSpace : {
                             serializableColorSpace: {
                                 alias: {
-                                    m_cgColorSpace: {
-                                        alias: {
-                                            variantType: "WebKit::ICCData",
-                                            variant: {
-                                                data: [],
-                                                derivative: 0
+                                    optionalValue: {
+                                        m_cgColorSpace: {
+                                            alias: {
+                                                variantType: "WebKit::ICCData",
+                                                variant: {
+                                                    data: [],
+                                                    derivative: 0
+                                                },
                                             },
                                         },
                                     },
@@ -135,12 +143,14 @@ setTimeout(async () => {
                         operatingColorSpace : {
                             serializableColorSpace: {
                                 alias: {
-                                    m_cgColorSpace: {
-                                        alias: {
-                                            variantType: "WebKit::ICCData",
-                                            variant: {
-                                                data: [],
-                                                derivative: 0
+                                    optionalValue: {
+                                        m_cgColorSpace: {
+                                            alias: {
+                                                variantType: "WebKit::ICCData",
+                                                variant: {
+                                                    data: [],
+                                                    derivative: 0
+                                                },
                                             },
                                         },
                                     },
@@ -157,12 +167,14 @@ setTimeout(async () => {
                         operatingColorSpace : {
                             serializableColorSpace: {
                                 alias: {
-                                    m_cgColorSpace: {
-                                        alias: {
-                                            variantType: "WebKit::ICCData",
-                                            variant: {
-                                                data: [],
-                                                derivative: 0
+                                    optionalValue: {
+                                        m_cgColorSpace: {
+                                            alias: {
+                                                variantType: "WebKit::ICCData",
+                                                variant: {
+                                                    data: [],
+                                                    derivative: 0
+                                                },
                                             },
                                         },
                                     },
@@ -190,12 +202,14 @@ setTimeout(async () => {
                         operatingColorSpace : {
                             serializableColorSpace: {
                                 alias: {
-                                    m_cgColorSpace: {
-                                        alias: {
-                                            variantType: "WebKit::ICCData",
-                                            variant: {
-                                                data: [],
-                                                derivative: 0
+                                    optionalValue: {
+                                        m_cgColorSpace: {
+                                            alias: {
+                                                variantType: "WebKit::ICCData",
+                                                variant: {
+                                                    data: [],
+                                                    derivative: 0
+                                                },
                                             },
                                         },
                                     },

--- a/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
+++ b/LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html
@@ -30,12 +30,14 @@
             colorSpace: {
                 serializableColorSpace: {
                     alias: {
-                        m_cgColorSpace: {
-                            alias: {
-                                variantType: "WebKit::ICCData",
-                                variant: {
-                                    data: [],
-                                    derivative: 0
+                        optionalValue: {
+                            m_cgColorSpace: {
+                                alias: {
+                                    variantType: "WebKit::ICCData",
+                                    variant: {
+                                        data: [],
+                                        derivative: 0
+                                    },
                                 },
                             },
                         },
@@ -80,11 +82,13 @@
                                             operatingColorSpace: {
                                                 serializableColorSpace: {
                                                     alias: {
-                                                        m_cgColorSpace: {
-                                                            alias: {
-                                                                variantType:
-                                                                    "WebCore::ColorSpace",
-                                                                variant: 17,
+                                                        optionalValue: {
+                                                            m_cgColorSpace: {
+                                                                alias: {
+                                                                    variantType:
+                                                                        "WebCore::ColorSpace",
+                                                                    variant: 17,
+                                                                },
                                                             },
                                                         },
                                                     },

--- a/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
+++ b/LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html
@@ -30,7 +30,7 @@
             renderingMode: 0,
             renderingPurpose: 0,
             resolutionScale: 1.0,
-            colorSpace: {serializableColorSpace: {alias: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}},
+            colorSpace: {serializableColorSpace: {alias: {optionalValue: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}},
             bufferFormat: { pixelFormat: 1, useLosslessCompression: 0 },
             identifier: imageBufferIdentifier,
             contextIdentifier: contextIdentifier,
@@ -60,7 +60,7 @@
                                     variantType: 'WebCore::FEBlend',
                                     variant: {
                                         blendMode: 8,
-                                        operatingColorSpace: {serializableColorSpace: {alias: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}
+                                        operatingColorSpace: {serializableColorSpace: {alias: {optionalValue: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}}
                                     }
                                 }
                             }

--- a/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
+++ b/LayoutTests/ipc/invalid-feConvolveMatrix-crash.html
@@ -33,10 +33,12 @@
                 colorSpace: {
                     serializableColorSpace: {
                         alias: {
-                            m_cgColorSpace: {
-                                alias: {
-                                    variantType: 'WebCore::ColorSpace',
-                                    variant: 1
+                            optionalValue: {
+                                m_cgColorSpace: {
+                                    alias: {
+                                        variantType: 'WebCore::ColorSpace',
+                                        variant: 1
+                                    }
                                 }
                             }
                         }
@@ -79,10 +81,12 @@
                                             operatingColorSpace: {
                                                 serializableColorSpace: {
                                                     alias: {
-                                                        m_cgColorSpace: {
-                                                            alias: {
-                                                                variantType: 'WebCore::ColorSpace',
-                                                                variant: 1
+                                                        optionalValue: {
+                                                            m_cgColorSpace: {
+                                                                alias: {
+                                                                    variantType: 'WebCore::ColorSpace',
+                                                                    variant: 1
+                                                                }
                                                             }
                                                         }
                                                     }

--- a/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
+++ b/LayoutTests/ipc/invalid-svgfilter-expression-crash.html
@@ -30,7 +30,7 @@ window.setTimeout(async () => {
         renderingMode: 0,
         renderingPurpose: 0,
         resolutionScale: 1.0,
-        colorSpace: {serializableColorSpace: {alias: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}},
+        colorSpace: {serializableColorSpace: {alias: {optionalValue: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}},
         bufferFormat: { pixelFormat: 1, useLosslessCompression: 0 },
         identifier: imageBufferIdentifier,
         contextIdentifier: contextIdentifier
@@ -57,7 +57,7 @@ window.setTimeout(async () => {
                                     variantType: 'WebCore::FEBlend',
                                     variant: {
                                         blendMode: 8,
-                                        operatingColorSpace: {serializableColorSpace: {alias: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}
+                                        operatingColorSpace: {serializableColorSpace: {alias: {optionalValue: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}}
                                     }
                                 }
                             }

--- a/LayoutTests/ipc/restore-empty-stack-crash.html
+++ b/LayoutTests/ipc/restore-empty-stack-crash.html
@@ -10,7 +10,7 @@
             CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0,{renderingBackendIdentifier:393219,connectionHandle:o10});
             o12=o10.newInterface("RemoteRenderingBackend", 393219);
             o10.connection.waitForMessage(393219, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1);
-            o12.CreateImageBuffer({logicalSize:{width:32,height:18},renderingMode:3,renderingPurpose:1,resolutionScale:489626271805,colorSpace:{serializableColorSpace:{alias:{m_cgColorSpace:{alias:{variantType:'WebCore::ColorSpace',variant:5}}}}},pixelFormat:1,bufferFormat:{pixelFormat:1,useLosslessCompression:0},identifier:393225,contextIdentifier:393226});
+            o12.CreateImageBuffer({logicalSize:{width:32,height:18},renderingMode:3,renderingPurpose:1,resolutionScale:489626271805,colorSpace:{serializableColorSpace:{alias:{optionalValue:{m_cgColorSpace:{alias:{variantType:'WebCore::ColorSpace',variant:5}}}}}},pixelFormat:1,bufferFormat:{pixelFormat:1,useLosslessCompression:0},identifier:393225,contextIdentifier:393226});
             o10.connection.waitForMessage(393225, IPC.messages.RemoteImageBufferProxy_DidCreateBackend.name, 1);
             o31=o10.newInterface("RemoteGraphicsContext", 393226);
             o31.Restore({});


### PR DESCRIPTION
#### 41779952ad0ea0d839a11c6f0b4857479d41c37c
<pre>
[CoreIPC] Fix RetainPtr serialization by aliasing bare refs instead of RetainPtr&lt;T&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=307605">https://bugs.webkit.org/show_bug.cgi?id=307605</a>
<a href="https://rdar.apple.com/170186377">rdar://170186377</a>

Reviewed by Simon Fraser.

The aliases dictionary previously mapped RetainPtr directly to CoreIPC wrapper types (e.g. RetainPtr -&gt; WebKit::CoreIPCCGColorSpace).
Because resolveAlias() runs before serializeTemplate(), this resolved the entire template type before serializeOptional
could process RetainPtr, so the bool presence prefix was never emitted. The C++ decoder always expects
this prefix. This led to decoding failures for these types.

So alias the bare refs (e.g. CGColorSpaceRef -&gt; WebKit::CoreIPCCGColorSpace) so that RetainPtr flows through
serializeOptional naturally. This also means tests using these types need optionalValue wrappers to match the wire format.

* LayoutTests/ipc/convert-to-luminance-mask-float16.html:
* LayoutTests/ipc/coreipc.js:
* LayoutTests/ipc/create-image-buffer-crash.html:
* LayoutTests/ipc/decode-feConvolveMatrix-kernelSize-overflow.html:
* LayoutTests/ipc/empty-svgfilterrenderer-expression-crash.html:
* LayoutTests/ipc/insufficient-svgfilter-inputs-crash.html:
* LayoutTests/ipc/invalid-feConvolveMatrix-crash.html:
* LayoutTests/ipc/invalid-svgfilter-expression-crash.html:
* LayoutTests/ipc/restore-empty-stack-crash.html:

Canonical link: <a href="https://commits.webkit.org/307502@main">https://commits.webkit.org/307502@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b643a71d498fd2d3e60608f9e7c498f725ba54d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16732 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8285 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152723 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97292 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17214 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110771 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79611 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/deeb59f9-8ff8-4343-813e-be47dab03ac3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147016 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129433 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91690 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12648 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10385 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/169 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122121 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6080 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155035 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16584 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7135 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118784 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16620 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13932 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119139 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30647 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15028 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127291 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72005 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16206 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5734 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15940 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16151 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16006 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->