### PR TITLE
[YARR] Implement BitInTable SIMD search in RegExp

### DIFF
--- a/JSTests/stress/regexp-boyer-moore-simd-begin-index.js
+++ b/JSTests/stress/regexp-boyer-moore-simd-begin-index.js
@@ -1,0 +1,63 @@
+// This test verifies that Boyer-Moore SIMD search correctly handles
+// cases where beginIndex > 0. When the BM algorithm selects a range
+// starting at a non-zero position (e.g., position 1 or 2), the SIMD
+// path must read from the correct character position.
+//
+// The bug scenario:
+// - Pattern like /[a-z][x].../ where position 0 has 26 candidates
+// - BM algorithm selects beginIndex=1, endIndex=2 (single position 'x')
+// - SIMD must check position 1 (the 'x'), not position 0
+
+function testBoyerMooreSIMDBeginIndex() {
+    // Test patterns that should trigger non-zero beginIndex selection
+    // [a-z] has 26 candidates, so BM should skip it and select 'x' position
+
+    // Pattern 1: beginIndex=1 case
+    (function() {
+        var re = /[a-z]x123456/;
+        var tests = [
+            { input: "m".repeat(50) + "bx123456" + "m".repeat(50), expected: true },
+            { input: "m".repeat(50) + "ay123456" + "m".repeat(50), expected: false },
+            { input: "bx123456", expected: true },
+            { input: "ax12345", expected: false },
+        ];
+        for (var i = 0; i < tests.length; i++) {
+            var result = re.test(tests[i].input);
+            if (result !== tests[i].expected) {
+                throw new Error("Pattern 1 test " + i + " failed: expected " + tests[i].expected + ", got " + result);
+            }
+        }
+    })();
+
+    // Pattern 2: Test near 16-byte boundaries (SIMD vector size)
+    (function() {
+        var re = /[0-9]xhello/;
+        for (var offset = 0; offset < 32; offset++) {
+            var shouldMatch = "a".repeat(offset) + "5xhello" + "a".repeat(50);
+            var shouldNotMatch = "a".repeat(offset) + "5yhello" + "a".repeat(50);
+            if (!re.test(shouldMatch)) {
+                throw new Error("Pattern 2 should match at offset " + offset);
+            }
+            if (re.test(shouldNotMatch)) {
+                throw new Error("Pattern 2 should not match at offset " + offset);
+            }
+        }
+    })();
+
+    // Pattern 3: beginIndex=2 case (two wide positions before narrow)
+    (function() {
+        var re = /[a-z][0-9]xworld/;
+        var tests = [
+            { input: "m".repeat(50) + "a5xworld" + "m".repeat(50), expected: true },
+            { input: "m".repeat(50) + "b6yworld" + "m".repeat(50), expected: false },
+        ];
+        for (var i = 0; i < tests.length; i++) {
+            var result = re.test(tests[i].input);
+            if (result !== tests[i].expected) {
+                throw new Error("Pattern 3 test " + i + " failed: expected " + tests[i].expected + ", got " + result);
+            }
+        }
+    })();
+}
+
+testBoyerMooreSIMDBeginIndex();

--- a/JSTests/stress/regexp-skip-until-bit-in-table-edge-cases.js
+++ b/JSTests/stress/regexp-skip-until-bit-in-table-edge-cases.js
@@ -1,0 +1,144 @@
+// Edge cases for nibble table SIMD optimization
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error((msg || '') + ': expected ' + expected + ', got ' + actual);
+}
+
+// Case-insensitive patterns with character classes
+function testCaseInsensitive() {
+    var prefix = 'x'.repeat(50);
+
+    shouldBe(/[ABC]/i.test(prefix + 'a'), true, 'case-insensitive lowercase a');
+    shouldBe(/[ABC]/i.test(prefix + 'A'), true, 'case-insensitive uppercase A');
+    shouldBe(/[ABC]/i.test(prefix + 'b'), true, 'case-insensitive lowercase b');
+    shouldBe(/[ABC]/i.test(prefix + 'B'), true, 'case-insensitive uppercase B');
+    shouldBe(/[ABC]/i.test(prefix + 'd'), false, 'case-insensitive no match d');
+
+    shouldBe(/HELLO/i.test(prefix + 'hello'), true, 'case-insensitive literal hello');
+    shouldBe(/HELLO/i.test(prefix + 'HELLO'), true, 'case-insensitive literal HELLO');
+    shouldBe(/HELLO/i.test(prefix + 'HeLLo'), true, 'case-insensitive literal mixed');
+}
+
+// Characters at nibble boundaries
+function testNibbleBoundaries() {
+    var prefix = 'w'.repeat(100);
+
+    // Test characters at different nibble positions
+    // Low nibble 0: 0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70
+    // Testing some ASCII printable chars at these positions
+    shouldBe(/[@P`p]/.test(prefix + '@'), true, 'nibble boundary @');
+    shouldBe(/[@P`p]/.test(prefix + 'P'), true, 'nibble boundary P');
+    shouldBe(/[@P`p]/.test(prefix + '`'), true, 'nibble boundary `');
+    shouldBe(/[@P`p]/.test(prefix + 'p'), true, 'nibble boundary p');
+
+    // Characters with same low nibble but different high nibble
+    // 0x31='1', 0x41='A', 0x61='a' all have low nibble 1
+    shouldBe(/[1Aa]/.test(prefix + '1'), true, 'same low nibble 1');
+    shouldBe(/[1Aa]/.test(prefix + 'A'), true, 'same low nibble A');
+    shouldBe(/[1Aa]/.test(prefix + 'a'), true, 'same low nibble a');
+    shouldBe(/[1Aa]/.test(prefix + 'Q'), false, 'same low nibble no match Q');
+}
+
+// Edge case: very long strings
+function testLongStrings() {
+    var veryLong = 'n'.repeat(10000);
+
+    shouldBe(/[abc]/.test(veryLong + 'a'), true, 'very long string match at end');
+    shouldBe(/[abc]/.test('a' + veryLong), true, 'very long string match at start');
+    shouldBe(/[abc]/.test(veryLong.slice(0, 5000) + 'b' + veryLong.slice(5000)), true, 'very long string match in middle');
+    shouldBe(/[abc]/.test(veryLong), false, 'very long string no match');
+}
+
+// Multiple character classes in pattern
+function testMultipleCharClasses() {
+    var prefix = 'z'.repeat(100);
+
+    shouldBe(/[abc][def][ghi]/.test(prefix + 'adg'), true, 'three char classes adg');
+    shouldBe(/[abc][def][ghi]/.test(prefix + 'beh'), true, 'three char classes beh');
+    shouldBe(/[abc][def][ghi]/.test(prefix + 'cfi'), true, 'three char classes cfi');
+    shouldBe(/[abc][def][ghi]/.test(prefix + 'aaa'), false, 'three char classes no match aaa');
+
+    // With quantifiers
+    shouldBe(/[aeiou]+[0-9]+/.test(prefix + 'aei123'), true, 'char classes with quantifiers');
+}
+
+// Test with special regex characters in the string (not pattern)
+function testSpecialCharsInString() {
+    var prefix = 'm'.repeat(50);
+
+    shouldBe(/[abc]/.test(prefix + '.a'), true, 'dot before match');
+    shouldBe(/[abc]/.test(prefix + '*b'), true, 'star before match');
+    shouldBe(/[abc]/.test(prefix + '+c'), true, 'plus before match');
+    shouldBe(/[abc]/.test(prefix + '?a'), true, 'question before match');
+    shouldBe(/[abc]/.test(prefix + '[b'), true, 'bracket before match');
+}
+
+// Test exec() results
+function testExec() {
+    var prefix = 'q'.repeat(100);
+    var str = prefix + 'abc';
+
+    var match = /[abc]/.exec(str);
+    shouldBe(match !== null, true, 'exec found match');
+    shouldBe(match[0], 'a', 'exec match value');
+    shouldBe(match.index, 100, 'exec match index');
+
+    // Multiple calls to exec with global flag
+    var re = /[abc]/g;
+    var str2 = prefix + 'a' + 'x'.repeat(10) + 'b' + 'y'.repeat(10) + 'c';
+    var m1 = re.exec(str2);
+    var m2 = re.exec(str2);
+    var m3 = re.exec(str2);
+    var m4 = re.exec(str2);
+
+    shouldBe(m1[0], 'a', 'global exec 1');
+    shouldBe(m2[0], 'b', 'global exec 2');
+    shouldBe(m3[0], 'c', 'global exec 3');
+    shouldBe(m4, null, 'global exec 4 null');
+}
+
+// Test match() results
+function testMatch() {
+    var prefix = 'r'.repeat(50);
+    var str = prefix + 'a' + prefix + 'b' + prefix + 'c';
+
+    var matches = str.match(/[abc]/g);
+    shouldBe(matches.length, 3, 'match count');
+    shouldBe(matches[0], 'a', 'match 0');
+    shouldBe(matches[1], 'b', 'match 1');
+    shouldBe(matches[2], 'c', 'match 2');
+}
+
+// Test replace() with character classes
+function testReplace() {
+    var prefix = 's'.repeat(30);
+    var str = prefix + 'aXbXc';
+
+    var result = str.replace(/[abc]/g, 'Z');
+    shouldBe(result, prefix + 'ZXZXZ', 'replace result');
+}
+
+// Ensure no false positives (characters that shouldn't match)
+function testNoFalsePositives() {
+    var prefix = 't'.repeat(100);
+
+    // Test with a 5-character class
+    var pattern = /[vwxyz]/;
+    for (var c = 32; c < 127; c++) {
+        var char = String.fromCharCode(c);
+        var str = prefix + char;
+        var expected = (char === 'v' || char === 'w' || char === 'x' || char === 'y' || char === 'z');
+        shouldBe(pattern.test(str), expected, 'no false positive for char code ' + c);
+    }
+}
+
+testCaseInsensitive();
+testNibbleBoundaries();
+testLongStrings();
+testMultipleCharClasses();
+testSpecialCharsInString();
+testExec();
+testMatch();
+testReplace();
+testNoFalsePositives();

--- a/JSTests/stress/regexp-skip-until-bit-in-table-simd.js
+++ b/JSTests/stress/regexp-skip-until-bit-in-table-simd.js
@@ -1,0 +1,154 @@
+// Tests for SIMD nibble table optimization in Boyer-Moore character class search
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(msg + ': expected ' + expected + ', got ' + actual);
+}
+
+// Test character class patterns (triggers SIMD path with >2 candidates)
+function testCharacterClass() {
+    var longPrefix = 'x'.repeat(100);
+
+    // Basic character class with 4 candidates
+    shouldBe(/[abcd]/.test(longPrefix + 'a'), true, 'char class at end - a');
+    shouldBe(/[abcd]/.test(longPrefix + 'b'), true, 'char class at end - b');
+    shouldBe(/[abcd]/.test(longPrefix + 'c'), true, 'char class at end - c');
+    shouldBe(/[abcd]/.test(longPrefix + 'd'), true, 'char class at end - d');
+    shouldBe(/[abcd]/.test(longPrefix), false, 'char class no match');
+
+    // Vowels (5 candidates)
+    shouldBe(/[aeiou]+/.test(longPrefix + 'aeiou'), true, 'vowels');
+    shouldBe(/[aeiou]+/.test(longPrefix), false, 'vowels no match');
+
+    // Digits (10 candidates)
+    shouldBe(/[0-9]+/.test(longPrefix + '12345'), true, 'digits');
+    shouldBe(/[0-9]+/.test(longPrefix), false, 'digits no match');
+
+    // Letters (26 candidates)
+    shouldBe(/[a-z]+end/.test(longPrefix + 'abcend'), true, 'lowercase letters');
+
+    // Hex digits (22 candidates: 0-9, a-f, A-F)
+    shouldBe(/[0-9a-fA-F]+/.test(longPrefix + 'deadBEEF'), true, 'hex digits');
+}
+
+// Test boundary conditions
+function testBoundaries() {
+    // Match at various positions relative to SIMD boundaries (16 bytes)
+    for (var i = 0; i < 64; i++) {
+        var str = 'x'.repeat(i) + 'a';
+        shouldBe(/[abc]/.test(str), true, 'boundary ' + i);
+    }
+
+    // Empty string
+    shouldBe(/[abc]/.test(''), false, 'empty string');
+
+    // Match at start
+    shouldBe(/[abc]/.test('abc'), true, 'match at start');
+
+    // Match exactly at position 15 (end of first SIMD chunk)
+    shouldBe(/[abc]/.test('x'.repeat(15) + 'a'), true, 'position 15');
+
+    // Match exactly at position 16 (start of second SIMD chunk)
+    shouldBe(/[abc]/.test('x'.repeat(16) + 'a'), true, 'position 16');
+
+    // Match exactly at position 31 (end of second SIMD chunk)
+    shouldBe(/[abc]/.test('x'.repeat(31) + 'a'), true, 'position 31');
+}
+
+// Test all ASCII characters in the set
+function testAllCandidates() {
+    var longPrefix = 'z'.repeat(100);
+
+    // Test each candidate character individually
+    var candidates = 'abcdefghij';
+    for (var i = 0; i < candidates.length; i++) {
+        var pattern = new RegExp('[' + candidates + ']');
+        shouldBe(pattern.test(longPrefix + candidates[i]), true, 'candidate ' + candidates[i]);
+    }
+
+    // Test non-matching characters
+    shouldBe(/[abcdefghij]/.test(longPrefix + 'k'), false, 'non-match k');
+    shouldBe(/[abcdefghij]/.test(longPrefix + 'z'), false, 'non-match z');
+}
+
+// Test patterns with longer context
+function testLongerPatterns() {
+    var longPrefix = 'y'.repeat(200);
+
+    // Character class followed by literal
+    shouldBe(/[aeiou]bc/.test(longPrefix + 'abc'), true, 'vowel + bc');
+    shouldBe(/[aeiou]bc/.test(longPrefix + 'ebc'), true, 'vowel e + bc');
+    shouldBe(/[aeiou]bc/.test(longPrefix + 'xbc'), false, 'consonant + bc');
+
+    // Literal followed by character class
+    shouldBe(/ab[cdef]/.test(longPrefix + 'abc'), true, 'ab + char class c');
+    shouldBe(/ab[cdef]/.test(longPrefix + 'abf'), true, 'ab + char class f');
+    shouldBe(/ab[cdef]/.test(longPrefix + 'abg'), false, 'ab + non-match g');
+}
+
+// Stress test for JIT compilation
+function stressTest() {
+    var pattern = /[abcdefgh]+test/;
+    var matchStr = 'xyz'.repeat(500) + 'abctest';
+    var noMatchStr = 'xyz'.repeat(500);
+
+    for (var i = 0; i < 1e4; i++) {
+        shouldBe(pattern.test(matchStr), true, 'stress match ' + i);
+        shouldBe(pattern.test(noMatchStr), false, 'stress no match ' + i);
+    }
+}
+
+// Test regex-dna style patterns (the target benchmark)
+function testRegexDnaPatterns() {
+    var dna = 'acgt'.repeat(500) + 'cgggtaaa';
+
+    // Pattern similar to regex-dna
+    shouldBe(/[cgt]gggtaaa/i.test(dna), true, 'dna pattern 1');
+    shouldBe(/tttaccc[acg]/i.test('acgt'.repeat(500) + 'tttaccca'), true, 'dna pattern 2');
+
+    // Multiple character classes
+    shouldBe(/[ag][ct][gt]/.test(dna), true, 'multiple char classes');
+}
+
+// Test exact SIMD chunk boundaries with NO match (exercises line 6240 bounds check in YarrJIT.cpp)
+// This tests the case where SIMD exhausts all input and index exceeds length
+function testExactChunkSizes() {
+    // For /[abc]/ with minimumSize=1:
+    // - baseOffset = -checkedOffset + endIndex - 1 = -1 + 1 - 1 = -1
+    // - totalOffset = 16 + baseOffset = 15
+    // - SIMD can run when length >= totalOffset + 1 = 16
+    // When length=16, SIMD processes all 16 chars, then index becomes 17 > 16, scalar loop skipped
+
+    // Exact chunk boundaries (SIMD exhausts all input, line 6240 triggers)
+    shouldBe(/[abc]/.test('x'.repeat(16)), false, 'exactly 16 chars no match');
+    shouldBe(/[abc]/.test('x'.repeat(32)), false, 'exactly 32 chars no match');
+    shouldBe(/[abc]/.test('x'.repeat(48)), false, 'exactly 48 chars no match');
+
+    // Slightly over chunk boundary (scalar loop processes remainder)
+    shouldBe(/[abc]/.test('x'.repeat(17)), false, '17 chars no match');
+    shouldBe(/[abc]/.test('x'.repeat(33)), false, '33 chars no match');
+
+    // Match in scalar loop region (after SIMD chunk boundary)
+    shouldBe(/[abc]/.test('x'.repeat(17) + 'a'), true, 'match at position 17');
+    shouldBe(/[abc]/.test('x'.repeat(33) + 'b'), true, 'match at position 33');
+
+    // Match exactly at SIMD boundary
+    shouldBe(/[abc]/.test('x'.repeat(15) + 'c'), true, 'match at position 15');
+    shouldBe(/[abc]/.test('x'.repeat(31) + 'a'), true, 'match at position 31');
+
+    // Additional edge cases around chunk boundaries
+    shouldBe(/[abc]/.test('x'.repeat(14) + 'a' + 'x'), true, 'match at 14 with trailing');
+    shouldBe(/[abc]/.test('x'.repeat(30) + 'b' + 'x'), true, 'match at 30 with trailing');
+
+    // Very short strings (below SIMD threshold, scalar-only path)
+    shouldBe(/[abc]/.test('x'.repeat(10)), false, '10 chars no match');
+    shouldBe(/[abc]/.test('x'.repeat(15)), false, '15 chars no match');
+}
+
+testCharacterClass();
+testBoundaries();
+testAllCandidates();
+testLongerPatterns();
+stressTest();
+testRegexDnaPatterns();
+testExactChunkSizes();

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARM64.h
@@ -7054,6 +7054,21 @@ public:
         m_assembler.tbl2(dest, a, b, control);
     }
 
+    void vectorUshrInt8(FPRegisterID src, uint8_t shift, FPRegisterID dest)
+    {
+        m_assembler.ushr_vi(dest, src, shift, SIMDLane::i8x16);
+    }
+
+    void vectorTest(SIMDInfo simdInfo, FPRegisterID a, FPRegisterID b, FPRegisterID dest)
+    {
+        m_assembler.cmtst(dest, a, b, simdInfo.lane);
+    }
+
+    void vectorShrnInt8(FPRegisterID src, uint8_t shift, FPRegisterID dest)
+    {
+        m_assembler.template shrn<SIMDLane::i8x16>(dest, src, shift);
+    }
+
     // Misc helper functions.
 
     // Invert a relational condition, e.g. == becomes !=, < becomes >=, etc.

--- a/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
+++ b/Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp
@@ -196,7 +196,7 @@ void A64DOpcode::maybeAnnotateBuiltConstant()
         return;
 
     if (Integrity::isSanePointer(ptr)) {
-        bufferPrintf(" -> %p", ptr);
+        bufferPrintf(" -> %p", std::bit_cast<void*>(constant));
         if (const char* label = labelFor(ptr)) {
             bufferPrintf(" %s", label);
             return;
@@ -221,7 +221,7 @@ void A64DOpcode::maybeAnnotateBuiltConstant()
     if (constant < 0x10000)
         bufferPrintf(" -> %u", static_cast<unsigned>(constant));
     else
-        bufferPrintf(" -> %p", reinterpret_cast<void*>(constant));
+        bufferPrintf(" -> %p", std::bit_cast<void*>(constant));
 }
 
 bool A64DOpcode::handlePotentialDataPointer(void* ptr)


### PR DESCRIPTION
#### 1def424e4f3b3df95e4e2c3dfcecbbe3531ae06e
<pre>
[YARR] Implement BitInTable SIMD search in RegExp
<a href="https://bugs.webkit.org/show_bug.cgi?id=307604">https://bugs.webkit.org/show_bug.cgi?id=307604</a>
<a href="https://rdar.apple.com/170186063">rdar://170186063</a>

Reviewed by Keith Miller.

This patch implements V8&apos;s SkipUntilBitInTable optimization in YarrJIT
as well. Basically what it is doing is pretty much SIMD version of
BoyerMoore search which we already have as a scalar version. We
spread BoyerMoore Bitmap into a vector register and bulk compare (for
each 16 characters) to detect potential matching candidate so we can
walk the characters with 16 characters stride.

Currently, it is enabled only when Char8 size, and only when stride is 1.
This *stride* means that BM search&apos;s stride we already have (we are
collecting pattern information, and we can say &quot;when this bitmap does
not match, we can skip N characters&quot;). Because this larger stride can be
really efficient, we are currently using our SIMD search only when
stride is 1.

We also fixed a bug in A64DOpcode, we strip the upper bits for dump when
the value looks like a pointer (because of PAC tag). But this makes it
hard to read. So let&apos;s just dump the full content regardless.

Tests: JSTests/stress/regexp-skip-until-bit-in-table-edge-cases.js
       JSTests/stress/regexp-skip-until-bit-in-table-simd.js

* JSTests/stress/regexp-boyer-moore-simd-begin-index.js: Added.
(testBoyerMooreSIMDBeginIndex):
* JSTests/stress/regexp-skip-until-bit-in-table-edge-cases.js: Added.
(shouldBe):
(testCaseInsensitive):
(testNibbleBoundaries):
(testLongStrings):
(testMultipleCharClasses):
(testSpecialCharsInString):
(testExec):
(testMatch):
(testReplace):
(testNoFalsePositives):
* JSTests/stress/regexp-skip-until-bit-in-table-simd.js: Added.
(shouldBe):
(testCharacterClass):
(testBoundaries):
(testAllCandidates):
(testLongerPatterns):
(stressTest):
(testRegexDnaPatterns):
* Source/JavaScriptCore/assembler/ARM64Assembler.h:
* Source/JavaScriptCore/assembler/MacroAssemblerARM64.h:
(JSC::MacroAssemblerARM64::vectorUshrInt8):
(JSC::MacroAssemblerARM64::vectorTest):
(JSC::MacroAssemblerARM64::vectorShrnInt8):
* Source/JavaScriptCore/disassembler/ARM64/A64DOpcode.cpp:
(JSC::ARM64Disassembler::A64DOpcode::maybeAnnotateBuiltConstant):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307409@main">https://commits.webkit.org/307409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c0dd6a66f11c6c7a3c92b56dfb5fe8dee7c39d82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144334 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/17013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/8571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/153004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/17495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/16907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/153004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147297 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/17495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/8571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/153004 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/17495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/8571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/450 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/136325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/17495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/8571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155316 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/5143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16865 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/8571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/16903 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/16907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/119357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/8571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22261 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/16487 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/8571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/175621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/175621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/16287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->