### PR TITLE
[SaferCPP] Fixed misc. remaining [iOS] issues in Source/WebKit

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -281,7 +281,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     _screenForDisplayLink = [self _screenForDisplayLink];
 
     if (_screenForDisplayLink)
-        _displayLink = [_screenForDisplayLink displayLinkWithTarget:self selector:@selector(displayLinkFired:)];
+        _displayLink = [protect(_screenForDisplayLink) displayLinkWithTarget:self selector:@selector(displayLinkFired:)];
     else {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         // FIXME: CoreAnimation version deprecated rdar://164090713

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -674,7 +674,7 @@ void RemoteScrollingCoordinatorProxyIOS::establishLayerTreeScrollingRelations(co
         MESSAGE_CHECK(overflowNode);
 
         if (RefPtr layerNode = RemoteLayerTreeNode::forCALayer(protect(scrollProxyNode->layer()))) {
-            layerNode->setActingScrollContainerID(RemoteLayerTreeNode::layerID(static_cast<CALayer*>(overflowNode->scrollContainerLayer())));
+            layerNode->setActingScrollContainerID(RemoteLayerTreeNode::layerID(protect(static_cast<CALayer*>(overflowNode->scrollContainerLayer()))));
             m_layersWithScrollingRelations.add(layerNode->layerID());
         }
     }

--- a/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
+++ b/Source/WebKit/UIProcess/ios/WKKeyboardScrollingAnimator.mm
@@ -481,7 +481,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (void)stopScrollingImmediately
 {
     [self resetViewForScrollToExtentAnimation];
-    [_scrollable didFinishScrolling];
+    [protect(_scrollable) didFinishScrolling];
     [self stopDisplayLink];
     _velocity = { };
 }

--- a/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
+++ b/Source/WebKit/UIProcess/ios/WKSyntheticTapGestureRecognizer.mm
@@ -84,7 +84,7 @@
     if (!_supportingTouchEventsGestureRecognizer)
         return;
 
-    RetainPtr activeTouches = [_supportingTouchEventsGestureRecognizer activeTouchesByIdentifier];
+    RetainPtr activeTouches = [protect(_supportingTouchEventsGestureRecognizer) activeTouchesByIdentifier];
     for (NSNumber *touchIdentifier in activeTouches.get()) {
         UITouch *touch = [activeTouches objectForKey:touchIdentifier];
         if ([touch.gestureRecognizers containsObject:self]) {

--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -1307,7 +1307,7 @@ void WebPageProxy::setIsScrollingOrZooming(bool isScrollingOrZooming)
     // We finished doing the scrolling / zoom animation so we can now show the validation
     // bubble if we're supposed to.
     if (!m_isScrollingOrZooming && m_validationBubble)
-        m_validationBubble->show();
+        protect(m_validationBubble)->show();
 }
 
 void WebPageProxy::hardwareKeyboardAvailabilityChanged(HardwareKeyboardState hardwareKeyboardState)

--- a/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFileUploadPanel.mm
@@ -815,7 +815,7 @@ static NSSet<NSString *> *UTIsForMIMETypes(NSArray *mimeTypes)
     if (!_menuPresenter)
         return;
 
-    auto *webView = [_view.get() webView];
+    RetainPtr webView = [_view.get() webView];
     if (!webView)
         return;
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -976,7 +976,7 @@ static NSString *optionCellReuseIdentifier = @"WKSelectPickerTableViewCell";
     _collapsedSections = adoptNS([[NSMutableSet alloc] init]);
 
     _numberOfSections = 1;
-    for (auto& option : _contentView.focusedSelectElementOptions) {
+    for (auto& option : protect(_contentView).get().focusedSelectElementOptions) {
         if (option.isGroup)
             _numberOfSections++;
     }

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3196,7 +3196,7 @@ void WebPage::performActionOnElement(uint32_t action, const String& authorizatio
         return;
 
     if (static_cast<SheetAction>(action) == SheetAction::Copy) {
-        Ref interactionNodeEditor = m_interactionNode->document().editor();
+        Ref interactionNodeEditor = protect(m_interactionNode->document())->editor();
         Ref elementDocument = element->document();
         if (is<RenderImage>(*element->renderer())) {
             URL urlToCopy;
@@ -5274,7 +5274,7 @@ void WebPage::setInsertionPointColor(WebCore::Color color)
 
 void WebPage::textInputContextsInRect(FloatRect searchRect, CompletionHandler<void(const Vector<ElementContext>&)>&& completionHandler)
 {
-    auto contexts = m_page->editableElementsInRect(searchRect).map([&] (const auto& element) {
+    auto contexts = protect(m_page)->editableElementsInRect(searchRect).map([&] (const auto& element) {
         Ref document = element->document();
 
         ElementContext context;


### PR DESCRIPTION
#### 3fdbb7698ab689d74dc1b76f1741362a2ede8e0b
<pre>
[SaferCPP] Fixed misc. remaining [iOS] issues in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307615">https://bugs.webkit.org/show_bug.cgi?id=307615</a>
<a href="https://rdar.apple.com/170189857">rdar://170189857</a>

Reviewed by Ryosuke Niwa.

As dictated by the SaferCPP bot.

Canonical link: <a href="https://commits.webkit.org/307334@main">https://commits.webkit.org/307334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/043ddffb1a3360bcde9f27cb22e3418acd504e67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144074 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16753 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8306 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152744 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17235 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16647 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110781 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147037 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129450 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91700 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10394 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/190 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122150 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155056 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16605 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7154 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118800 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16641 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13942 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119156 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15037 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127310 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72026 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22224 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16227 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5751 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15961 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16027 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->