### PR TITLE
exp: canvas drawtext cached gb

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -55,7 +55,9 @@
 #include "DOMMatrix.h"
 #include "DOMMatrix2DInit.h"
 #include "FloatQuad.h"
+#include "FontCascadeFonts.h"
 #include "GeometryUtilities.h"
+#include "GlyphBuffer.h"
 #include "Gradient.h"
 #include "HTMLCanvasElement.h"
 #include "HTMLImageElement.h"
@@ -81,6 +83,7 @@
 #include "StyleResolver.h"
 #include "TextMetrics.h"
 #include "TextRun.h"
+#include "TextUtil.h"
 #include "WebCodecsVideoFrame.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/CheckedArithmetic.h>
@@ -2851,14 +2854,21 @@ String CanvasRenderingContext2DBase::normalizeSpaces(const String& text)
 
 void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, double x, double y, bool fill, std::optional<double> maxWidth)
 {
-    auto measureTextRun = [&](const TextRun& textRun) -> std::tuple<float, FontMetrics>  {
-        auto& fontProxy = *this->fontProxy();
+    auto& fontCascade = this->fontProxy()->fontCascade();
+    auto& fontMetrics = fontProxy()->metricsOfPrimaryFont();
 
-        // FIXME: Need to turn off font smoothing.
-        return { fontProxy.width(textRun), fontProxy.metricsOfPrimaryFont() };
-    };
+    // Determine if we can use simple path (single bidi run) and try to get cached shaped glyphs
+    bool canUseSimplePath = textRun.ltr() && !Layout::TextUtil::containsStrongDirectionalityText(textRun.text());
+    RefPtr<SharedGlyphBuffer> cachedShapedGlyphs;
+    if (canUseSimplePath) {
+        auto* fonts = fontCascade.fonts();
+        ASSERT(fonts);
+        cachedShapedGlyphs = fonts->getOrCreateShapedGlyphs(textRun, fontCascade);
+    }
 
-    auto [fontWidth, fontMetrics] = measureTextRun(textRun);
+    // Get width: from cached glyphs if available, otherwise measure normally
+    float fontWidth = cachedShapedGlyphs ? cachedShapedGlyphs->width() : fontCascade.width(textRun);
+
     bool useMaxWidth = maxWidth && maxWidth.value() < fontWidth;
     float width = useMaxWidth ? maxWidth.value() : fontWidth;
     FloatPoint location(x, y);
@@ -2876,6 +2886,21 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     // https://bugs.webkit.org/show_bug.cgi?id=193077.
     auto* c = effectiveDrawingContext();
     auto& fontProxy = *this->fontProxy();
+
+    // Lambda to draw text - uses cached glyphs when available
+    auto drawText = [&](GraphicsContext& context, const FloatPoint& point) {
+        if (cachedShapedGlyphs) {
+            // Use cached shaped glyphs
+            const auto& glyphBuffer = cachedShapedGlyphs->glyphBuffer();
+            if (!glyphBuffer.isEmpty()) {
+                FloatPoint startPoint = point + WebCore::size(glyphBuffer.initialAdvance());
+                fontCascade.drawGlyphBuffer(context, glyphBuffer, startPoint, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+            }
+        } else {
+            // Complex text or caching not allowed - use standard path
+            fontProxy.drawBidiText(context, textRun, point, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+        }
+    };
 
 #if USE(CG)
     const CanvasStyle& drawStyle = fill ? state().fillStyle : state().strokeStyle;
@@ -2905,7 +2930,7 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
             else
                 c->setStrokeColor(Color::black);
 
-            fontProxy.drawBidiText(*c, textRun, location + offset, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+            drawText(*c, location + offset);
         }
 
         auto maskImage = c->createAlignedImageBuffer(maskRect.size());
@@ -2927,10 +2952,10 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
             maskImageContext.translate(location - maskRect.location());
             // We draw when fontWidth is 0 so compositing operations (eg, a "copy" op) still work.
             maskImageContext.scale(FloatSize((fontWidth > 0 ? (width / fontWidth) : 0), 1));
-            fontProxy.drawBidiText(maskImageContext, textRun, FloatPoint(0, 0), FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+            drawText(maskImageContext, FloatPoint(0, 0));
         } else {
             maskImageContext.translate(-maskRect.location());
-            fontProxy.drawBidiText(maskImageContext, textRun, location, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+            drawText(maskImageContext, location);
         }
 
         GraphicsContextStateSaver stateSaver(*c);
@@ -2958,18 +2983,18 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     bool repaintEntireCanvas = false;
     if (isFullCanvasCompositeMode(state().globalComposite)) {
         beginCompositeLayer();
-        fontProxy.drawBidiText(*c, textRun, location, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+        drawText(*c, location);
         endCompositeLayer();
         repaintEntireCanvas = true;
     } else if (state().globalComposite == CompositeOperator::Copy) {
         clearCanvas();
-        fontProxy.drawBidiText(*c, textRun, location, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+        drawText(*c, location);
         repaintEntireCanvas = true;
     } else {
         auto clipBounds = c->clipBounds();
         if ((clipBounds.isEmpty() || !clipBounds.intersects(enclosingIntRect(textRect))) && !shouldDrawShadows())
             return;
-        fontProxy.drawBidiText(*c, textRun, location, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);
+        drawText(*c, location);
     }
 
     didDraw(repaintEntireCanvas, targetSwitcher ? targetSwitcher->expandedBounds() : textRect);

--- a/Source/WebCore/html/parser/HTMLParserOptions.cpp
+++ b/Source/WebCore/html/parser/HTMLParserOptions.cpp
@@ -27,6 +27,7 @@
 #include "HTMLParserOptions.h"
 
 #include "Document.h"
+#include "FrameDestructionObserverInlines.h"
 #include "LocalFrame.h"
 #include "ScriptController.h"
 #include "Settings.h"

--- a/Source/WebCore/html/shadow/DataListButtonElement.cpp
+++ b/Source/WebCore/html/shadow/DataListButtonElement.cpp
@@ -30,6 +30,7 @@
 #include "EventNames.h"
 #include "HTMLNames.h"
 #include "MouseEvent.h"
+#include "RenderStyleBase+GettersInlines.h"
 #include "StyleAppearance.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -29,6 +29,7 @@
 
 #include "Chrome.h"
 #include "ContainerNodeInlines.h"
+#include "DocumentPage.h"
 #include "EventHandler.h"
 #include "EventNames.h"
 #include "FrameDestructionObserverInlines.h"

--- a/Source/WebCore/html/track/DataCue.cpp
+++ b/Source/WebCore/html/track/DataCue.cpp
@@ -31,6 +31,8 @@
 #include "DataCue.h"
 
 #include "Document.h"
+#include "Exception.h"
+#include "ExceptionOr.h"
 #include "Logging.h"
 #include "TextTrack.h"
 #include "TextTrackCueList.h"

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -107,6 +107,7 @@ public:
     unsigned fontSelectorVersion() const;
 
     enum class CustomFontNotReadyAction : bool { DoNotPaintIfFontNotReady, UseFallbackIfFontNotReady };
+    enum class ForTextEmphasisOrNot : bool { NotForTextEmphasis, ForTextEmphasis };
     WEBCORE_EXPORT FloatSize drawText(GraphicsContext&, const TextRun&, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt, CustomFontNotReadyAction = CustomFontNotReadyAction::DoNotPaintIfFontNotReady) const;
     static void drawGlyphs(GraphicsContext&, const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode);
     void drawEmphasisMarks(GraphicsContext&, const TextRun&, const AtomString& mark, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) const;
@@ -205,12 +206,13 @@ public:
 
     unsigned generation() const { return m_generation; }
 
-private:
-    enum class ForTextEmphasisOrNot : bool { NotForTextEmphasis, ForTextEmphasis };
-
+    // Exposed for Canvas text shape caching
     GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
-    GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
     void drawGlyphBuffer(GraphicsContext&, const GlyphBuffer&, FloatPoint&, CustomFontNotReadyAction) const;
+
+private:
+
+    GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
     void drawEmphasisMarks(GraphicsContext&, const GlyphBuffer&, const AtomString&, const FloatPoint&) const;
     int offsetForPositionForSimpleText(const TextRun&, float position, bool includePartialGlyphs) const;
     void adjustSelectionRectForSimpleText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -33,6 +33,7 @@
 #include "FontCache.h"
 #include "FontCascade.h"
 #include "GlyphPage.h"
+#include <wtf/Assertions.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -568,6 +569,60 @@ void FontCascadeFonts::pruneSystemFallbacks()
         });
     }
     m_systemFallbackFontSet.clear();
+}
+
+RefPtr<SharedGlyphBuffer> FontCascadeFonts::getOrCreateShapedGlyphs(const TextRun& run, const FontCascade& fontCascade)
+{
+    // Apply same caching conditions as TextMeasurementCache (WidthCache)
+    // The cache is not profitable unless we're doing expensive glyph transformations
+    bool hasKerningOrLigatures = fontCascade.enableKerning() || fontCascade.requiresShaping();
+    if (!hasKerningOrLigatures)
+        return nullptr;
+
+    // Word spacing and letter spacing change the width of a word
+    bool hasWordSpacingOrLetterSpacing = fontCascade.wordSpacing() || fontCascade.letterSpacing();
+    if (hasWordSpacingOrLetterSpacing)
+        return nullptr;
+
+    // If we allow tabs, tab width varies based on position on the line
+    if (run.allowTabs())
+        return nullptr;
+
+    // Text spacing depends on context of adjacent characters
+    bool hasTextSpacing = !fontCascade.textAutospace().isNoAutospace();
+    if (hasTextSpacing)
+        return nullptr;
+
+    // Build cache key
+    GlyphBufferCacheKey key {
+        run.text().toString(),
+        run.direction(),
+        run.directionalOverride()
+    };
+
+    // Check cache
+    auto it = m_glyphBufferCache.find(key);
+    if (it != m_glyphBufferCache.end())
+        return it->value.ptr();
+
+    // Shape the text
+    auto codePath = fontCascade.codePath(run);
+    auto glyphBuffer = fontCascade.layoutText(codePath, run, 0, run.length(), FontCascade::ForTextEmphasisOrNot::NotForTextEmphasis);
+    glyphBuffer.flatten();
+
+    if (glyphBuffer.isEmpty())
+        return nullptr;
+
+    // Calculate width by summing advances
+    float totalWidth = 0;
+    for (unsigned i = 0; i < glyphBuffer.size(); ++i)
+        totalWidth += width(glyphBuffer.advanceAt(i));
+
+    // Create SharedGlyphBuffer and cache it
+    auto sharedBuffer = SharedGlyphBuffer::create(WTF::move(glyphBuffer), totalWidth);
+    m_glyphBufferCache.set(key, sharedBuffer.copyRef());
+
+    return sharedBuffer;
 }
 
 TextStream& operator<<(TextStream& ts, const FontCascadeFonts& fontCascadeFonts)

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -24,11 +24,14 @@
 #include <WebCore/FontCascadeDescription.h>
 #include <WebCore/FontRanges.h>
 #include <WebCore/FontSelector.h>
+#include <WebCore/GlyphBuffer.h>
 #include <WebCore/GlyphPage.h>
 #include <WebCore/TextMeasurementCache.h>
+#include <WebCore/TextRun.h>
 #include <wtf/EnumeratedArray.h>
 #include <wtf/Forward.h>
 #include <wtf/HashFunctions.h>
+#include <wtf/HashMap.h>
 #include <wtf/HashTraits.h>
 #include <wtf/MainThread.h>
 #include <wtf/Platform.h>
@@ -59,6 +62,35 @@ struct GlyphOverflow {
     bool computeBounds { false };
 };
 
+// Key for caching shaped glyph buffers
+// Uses just text + direction (no font generation needed - cache lives per FontCascadeFonts)
+struct GlyphBufferCacheKey {
+    String text;
+    TextDirection direction;
+    bool directionalOverride;
+
+    bool operator==(const GlyphBufferCacheKey& other) const
+    {
+        return text == other.text
+            && direction == other.direction
+            && directionalOverride == other.directionalOverride;
+    }
+};
+
+struct GlyphBufferCacheKeyHash {
+    static unsigned hash(const GlyphBufferCacheKey& key)
+    {
+        return computeHash(key.text, key.direction, key.directionalOverride);
+    }
+
+    static bool equal(const GlyphBufferCacheKey& a, const GlyphBufferCacheKey& b)
+    {
+        return a == b;
+    }
+
+    static const bool safeToCompareToEmptyOrDeleted = false;
+};
+
 } // namespace WebCore
 
 namespace WTF {
@@ -76,6 +108,13 @@ struct MarkableTraits<WebCore::GlyphOverflow> {
     }
 };
 
+template<> struct HashTraits<WebCore::GlyphBufferCacheKey> : GenericHashTraits<WebCore::GlyphBufferCacheKey> {
+    static constexpr bool emptyValueIsZero = false;
+    static void constructDeletedValue(WebCore::GlyphBufferCacheKey& slot) { new (NotNull, &slot.text) String(WTF::HashTableDeletedValue); }
+    static bool isDeletedValue(const WebCore::GlyphBufferCacheKey& value) { return value.text.isHashTableDeletedValue(); }
+};
+
+template<> struct DefaultHash<WebCore::GlyphBufferCacheKey> : WebCore::GlyphBufferCacheKeyHash { };
 } // namespace WTF
 
 namespace WebCore {
@@ -110,6 +149,12 @@ public:
     using GlyphGeometryCache = TextMeasurementCache<GlyphGeometryCacheEntry>;
     GlyphGeometryCache& glyphGeometryCache() { return m_glyphGeometryCache; }
     const GlyphGeometryCache& glyphGeometryCache() const { return m_glyphGeometryCache; }
+
+    using GlyphBufferCache = HashMap<GlyphBufferCacheKey, Ref<SharedGlyphBuffer>>;
+    GlyphBufferCache& glyphBufferCache() { return m_glyphBufferCache; }
+    const GlyphBufferCache& glyphBufferCache() const { return m_glyphBufferCache; }
+
+    RefPtr<SharedGlyphBuffer> getOrCreateShapedGlyphs(const TextRun&, const FontCascade&);
 
     const Font& primaryFont(const FontCascadeDescription&, FontSelector*);
     WEBCORE_EXPORT const FontRanges& realizeFallbackRangesAt(const FontCascadeDescription&, FontSelector*, unsigned fallbackIndex);
@@ -155,6 +200,7 @@ private:
     SingleThreadWeakPtr<const Font> m_cachedPrimaryFont;
 
     GlyphGeometryCache m_glyphGeometryCache;
+    GlyphBufferCache m_glyphBufferCache;
 
     unsigned short m_generation { 0 };
     Pitch m_pitch { UnknownPitch };

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -36,6 +36,7 @@
 #include <climits>
 #include <limits>
 #include <wtf/CheckedRef.h>
+#include <wtf/RefCounted.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 
@@ -267,6 +268,27 @@ private:
     Vector<GlyphBufferOrigin, 1024> m_origins;
     Vector<GlyphBufferStringOffset, 1024> m_offsetsInString;
     GlyphBufferAdvance m_initialAdvance { makeGlyphBufferAdvance() };
+};
+
+class SharedGlyphBuffer : public RefCounted<SharedGlyphBuffer> {
+public:
+    static Ref<SharedGlyphBuffer> create(GlyphBuffer&& buffer, float width)
+    {
+        return adoptRef(*new SharedGlyphBuffer(WTF::move(buffer), width));
+    }
+
+    const GlyphBuffer& glyphBuffer() const { return m_glyphBuffer; }
+    float width() const { return m_width; }
+
+private:
+    SharedGlyphBuffer(GlyphBuffer&& buffer, float width)
+        : m_glyphBuffer(WTF::move(buffer))
+        , m_width(width)
+    {
+    }
+
+    GlyphBuffer m_glyphBuffer;
+    float m_width;
 };
 
 }


### PR DESCRIPTION
#### 9e84b0833410c409a272146268cff4857d12ca34
<pre>
exp: canvas drawtext cached gb
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
* Source/WebCore/html/parser/HTMLParserOptions.cpp:
* Source/WebCore/html/shadow/DataListButtonElement.cpp:
* Source/WebCore/html/shadow/SpinButtonElement.cpp:
* Source/WebCore/html/track/DataCue.cpp:
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::getOrCreateShapedGlyphs):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::GlyphBufferCacheKey::operator== const):
(WebCore::GlyphBufferCacheKeyHash::hash):
(WebCore::GlyphBufferCacheKeyHash::equal):
(WTF::HashTraits&lt;WebCore::GlyphBufferCacheKey&gt;::constructDeletedValue):
(WTF::HashTraits&lt;WebCore::GlyphBufferCacheKey&gt;::isDeletedValue):
(WebCore::FontCascadeFonts::glyphBufferCache):
(WebCore::FontCascadeFonts::glyphBufferCache const):
* Source/WebCore/platform/graphics/GlyphBuffer.h:
(WebCore::SharedGlyphBuffer::create):
(WebCore::SharedGlyphBuffer::glyphBuffer const):
(WebCore::SharedGlyphBuffer::width const):
(WebCore::SharedGlyphBuffer::SharedGlyphBuffer):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e84b0833410c409a272146268cff4857d12ca34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144135 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16814 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8369 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152805 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97374 "Hash 9e84b083 for PR 58460 does not build (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84fa0fb7-b200-4788-ba2c-d7fba0e22954) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146010 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17296 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16708 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/152805 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/97374 "Hash 9e84b083 for PR 58460 does not build (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1e38dda-a63a-4fb2-8908-448587715ace) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147098 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/17296 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/8369 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/152805 "Hash 9e84b083 for PR 58460 does not build (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c6bce15-f8b5-429e-b7c8-ad330527655a) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/17296 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/168/builds/8369 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/251 "Hash 9e84b083 for PR 58460 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/17296 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/8369 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155117 "Hash 9e84b083 for PR 58460 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16666 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/8369 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/155117 "Hash 9e84b083 for PR 58460 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16703 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/16708 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/155117 "Hash 9e84b083 for PR 58460 does not build (failure)") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/8369 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72087 "Hash 9e84b083 for PR 58460 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16288 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/8369 "Hash 9e84b083 for PR 58460 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16022 "Hash 9e84b083 for PR 58460 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80067 "Failed to build and analyze WebKit") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16233 "Hash 9e84b083 for PR 58460 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16088 "Hash 9e84b083 for PR 58460 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->