### PR TITLE
[JSC] Use `UFormattedValue` API in `IntlRelativeTimeFormat::formatToParts`

### DIFF
--- a/JSTests/microbenchmarks/intl-relative-time-format-to-parts-auto.js
+++ b/JSTests/microbenchmarks/intl-relative-time-format-to-parts-auto.js
@@ -1,0 +1,19 @@
+// This benchmark tests IntlRelativeTimeFormat.formatToParts with numeric:"auto"
+// which can produce literal-only output (e.g. "today", "yesterday")
+function test() {
+    const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+    let count = 0;
+    for (let i = 0; i < 1e4; i++) {
+        count += rtf.formatToParts(0, 'day').length;
+        count += rtf.formatToParts(-1, 'week').length;
+        count += rtf.formatToParts(1, 'month').length;
+        count += rtf.formatToParts(-1, 'day').length;
+        count += rtf.formatToParts(1, 'day').length;
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 50000)
+    throw new Error("Bad result: " + result);

--- a/JSTests/microbenchmarks/intl-relative-time-format-to-parts.js
+++ b/JSTests/microbenchmarks/intl-relative-time-format-to-parts.js
@@ -1,0 +1,19 @@
+// This benchmark tests IntlRelativeTimeFormat.formatToParts with numeric:"always"
+// which produces {type, value, unit} objects with numeric sub-parts
+function test() {
+    const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'always' });
+
+    let count = 0;
+    for (let i = 0; i < 1e4; i++) {
+        count += rtf.formatToParts(10000.5, 'day').length;
+        count += rtf.formatToParts(-3, 'hour').length;
+        count += rtf.formatToParts(1, 'year').length;
+        count += rtf.formatToParts(-100, 'second').length;
+        count += rtf.formatToParts(0, 'week').length;
+    }
+    return count;
+}
+
+const result = test();
+if (result !== 170000)
+    throw new Error("Bad result: " + result);

--- a/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
+++ b/Source/JavaScriptCore/runtime/IntlNumberFormat.cpp
@@ -663,10 +663,6 @@ JSValue IntlNumberFormat::formatRange(JSGlobalObject* globalObject, IntlMathemat
 }
 
 static constexpr int32_t literalField = -1;
-struct IntlNumberFormatField {
-    int32_t m_field;
-    WTF::Range<int32_t> m_range;
-};
 
 static Vector<IntlNumberFormatField> flattenFields(Vector<IntlNumberFormatField>&& fields, int32_t formattedStringLength)
 {

--- a/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h
+++ b/Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "JSObject.h"
+#include <unicode/uformattedvalue.h>
 #include <unicode/ureldatefmt.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
@@ -74,12 +75,12 @@ private:
     enum class Style : uint8_t { Long, Short, Narrow };
 
     using URelativeDateTimeFormatterDeleter = ICUDeleter<ureldatefmt_close>;
-    using UNumberFormatDeleter = ICUDeleter<unum_close>;
 
     static ASCIILiteral styleString(Style);
 
     std::unique_ptr<URelativeDateTimeFormatter, URelativeDateTimeFormatterDeleter> m_relativeDateTimeFormatter;
-    std::unique_ptr<UNumberFormat, UNumberFormatDeleter> m_numberFormat;
+    mutable std::unique_ptr<UFormattedRelativeDateTime, ICUDeleter<ureldatefmt_closeResult>> m_formattedResult;
+    mutable std::unique_ptr<UConstrainedFieldPosition, ICUDeleter<ucfpos_close>> m_cfpos;
 
     String m_locale;
     String m_numberingSystem;


### PR DESCRIPTION
#### 21bc1e34f9398ac93d49cb9118f022f801275684
<pre>
[JSC] Use `UFormattedValue` API in `IntlRelativeTimeFormat::formatToParts`
<a href="https://bugs.webkit.org/show_bug.cgi?id=307623">https://bugs.webkit.org/show_bug.cgi?id=307623</a>

Reviewed by Yusuke Suzuki.

Use ureldatefmt_formatNumericToResult / ureldatefmt_formatToResult to
obtain both the formatted string and field position metadata in a single
ICU call.

Read UFIELD_CATEGORY_NUMBER fields directly from the UFormattedValue to
build number sub-parts, eliminating the separate unum_formatDoubleForFields
call and String::find lookup.

Pre-allocate UFormattedRelativeDateTime and UConstrainedFieldPosition
during initialization and reuse them across calls.

Extend IntlFieldIterator to support construction from a Vector of
pre-collected fields, so number fields from UFormattedValue can be
passed to IntlNumberFormat::formatToPartsInternal.

                                                 TipOfTree                  Patched

intl-relative-time-format-to-parts-auto       14.3070+-0.6379     ^      6.7217+-0.3445        ^ definitely 2.1285x faster
intl-relative-time-format-to-parts            30.4560+-0.2629     ^     26.3840+-0.0927        ^ definitely 1.1543x faster

* JSTests/microbenchmarks/intl-relative-time-format-to-parts-auto.js: Added.
(test):
* JSTests/microbenchmarks/intl-relative-time-format-to-parts.js: Added.
(test):
* Source/JavaScriptCore/runtime/IntlNumberFormat.cpp:
* Source/JavaScriptCore/runtime/IntlNumberFormatInlines.h:
(JSC::IntlFieldIterator::IntlFieldIterator):
(JSC::IntlFieldIterator::next):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.cpp:
(JSC::IntlRelativeTimeFormat::initializeRelativeTimeFormat):
(JSC::IntlRelativeTimeFormat::formatInternal const):
(JSC::IntlRelativeTimeFormat::formatToParts const):
* Source/JavaScriptCore/runtime/IntlRelativeTimeFormat.h:

Canonical link: <a href="https://commits.webkit.org/307449@main">https://commits.webkit.org/307449@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53c467b04bd570c8bfa089ed40f107df2f271858

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144087 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16766 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152757 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97326 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17248 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110792 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79629 "Exiting early after 60 failures. 15347 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13206 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12663 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10407 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/203 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136078 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122142 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6100 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155069 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4895 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16618 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118807 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16654 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119165 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30617 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15052 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127311 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72039 "Hash 53c467b0 for PR 58462 does not build (failure)") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16240 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5752 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175374 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15974 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80019 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45210 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16185 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16040 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->