### PR TITLE
[WebGL] Remove redundant m_filteredDrawBuffers code

### DIFF
--- a/LayoutTests/webgl/drawbuffers-before-attachment-expected.txt
+++ b/LayoutTests/webgl/drawbuffers-before-attachment-expected.txt
@@ -1,0 +1,16 @@
+Test that framebuffer rendering works correctly when drawBuffersWEBGL is called before texture attachment.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 7 PASS, 0 FAIL
+
+PASS WEBGL_draw_buffers extension enabled
+PASS getError was expected value: NO_ERROR : drawBuffersWEBGL should succeed
+PASS drawBuffersWEBGL called BEFORE texture attachment
+PASS Texture attached AFTER drawBuffersWEBGL
+PASS getError was expected value: NO_ERROR : draw should succeed
+PASS framebuffer should contain red pixels after draw
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/drawbuffers-before-attachment.html
+++ b/LayoutTests/webgl/drawbuffers-before-attachment.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test that draw buffers work when drawBuffersWEBGL is called before texture attachment</title>
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body onload="runTest()">
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Test that framebuffer rendering works correctly when drawBuffersWEBGL is called before texture attachment.");
+
+var wtu = WebGLTestUtils;
+
+function runTest()
+{
+    var canvas = document.createElement("canvas");
+    canvas.width = 16;
+    canvas.height = 16;
+    document.body.appendChild(canvas);
+
+    var gl = wtu.create3DContext(canvas, undefined, 1);
+
+    if (!gl) {
+        testFailed("WebGL1 context does not exist");
+        finishTest();
+        return;
+    }
+
+    // Enable extension first
+    var ext = gl.getExtension("WEBGL_draw_buffers");
+    if (!ext) {
+        testPassed("WEBGL_draw_buffers extension not available - skipping test");
+        finishTest();
+        return;
+    }
+    testPassed("WEBGL_draw_buffers extension enabled");
+
+    var vertexShaderSource = `
+        attribute vec4 vPosition;
+        void main() {
+            gl_Position = vPosition;
+        }`;
+
+    var fragmentShaderSource = `
+        #extension GL_EXT_draw_buffers : require
+        precision mediump float;
+        void main() {
+            gl_FragData[0] = vec4(1.0, 0.0, 0.0, 1.0);
+        }`;
+
+    var program = wtu.setupProgram(gl, [vertexShaderSource, fragmentShaderSource], ["vPosition"]);
+    if (!program) {
+        testFailed("Failed to create program");
+        finishTest();
+        return;
+    }
+    wtu.setupUnitQuad(gl);
+
+    // Create framebuffer and call drawBuffersWEBGL BEFORE attaching texture
+    var fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    ext.drawBuffersWEBGL([ext.COLOR_ATTACHMENT0_WEBGL]);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawBuffersWEBGL should succeed");
+    testPassed("drawBuffersWEBGL called BEFORE texture attachment");
+
+    // Attach texture after drawBuffersWEBGL
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 16, 16, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("Framebuffer is not complete");
+        finishTest();
+        return;
+    }
+    testPassed("Texture attached AFTER drawBuffersWEBGL");
+
+    // Draw and verify red pixels
+    gl.viewport(0, 0, 16, 16);
+    gl.clearColor(0, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    wtu.drawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "draw should succeed");
+    wtu.checkCanvas(gl, [255, 0, 0, 255], "framebuffer should contain red pixels after draw", 1);
+
+    // Cleanup
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(texture);
+    gl.deleteProgram(program);
+    finishTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/webgl/drawbuffers-extension-after-setup-expected.txt
+++ b/LayoutTests/webgl/drawbuffers-extension-after-setup-expected.txt
@@ -1,0 +1,15 @@
+Test that framebuffer rendering works correctly when WEBGL_draw_buffers extension is enabled after framebuffer setup.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 6 PASS, 0 FAIL
+
+PASS WebGL1 context created
+PASS Framebuffer created and texture attached BEFORE extension enabled
+PASS WEBGL_draw_buffers extension enabled AFTER framebuffer setup
+PASS getError was expected value: NO_ERROR : draw should succeed
+PASS framebuffer should contain red pixels after draw
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/drawbuffers-extension-after-setup.html
+++ b/LayoutTests/webgl/drawbuffers-extension-after-setup.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test that draw buffers work when extension is enabled after framebuffer setup</title>
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body onload="runTest()">
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Test that framebuffer rendering works correctly when WEBGL_draw_buffers extension is enabled after framebuffer setup.");
+
+var wtu = WebGLTestUtils;
+
+function runTest()
+{
+    var canvas = document.createElement("canvas");
+    canvas.width = 16;
+    canvas.height = 16;
+    document.body.appendChild(canvas);
+
+    var gl = wtu.create3DContext(canvas, undefined, 1);
+
+    if (!gl) {
+        testFailed("WebGL1 context does not exist");
+        finishTest();
+        return;
+    }
+    testPassed("WebGL1 context created");
+
+    var vertexShaderSource = `
+        attribute vec4 vPosition;
+        void main() {
+            gl_Position = vPosition;
+        }`;
+
+    var fragmentShaderSource = `
+        precision mediump float;
+        void main() {
+            gl_FragColor = vec4(1.0, 0.0, 0.0, 1.0);
+        }`;
+
+    var program = wtu.setupProgram(gl, [vertexShaderSource, fragmentShaderSource], ["vPosition"]);
+    if (!program) {
+        testFailed("Failed to create program");
+        finishTest();
+        return;
+    }
+    wtu.setupUnitQuad(gl);
+
+    // Create framebuffer and attach texture BEFORE enabling extension
+    var fb = gl.createFramebuffer();
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, 16, 16, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("Framebuffer is not complete");
+        finishTest();
+        return;
+    }
+    testPassed("Framebuffer created and texture attached BEFORE extension enabled");
+
+    // Enable WEBGL_draw_buffers extension
+    var ext = gl.getExtension("WEBGL_draw_buffers");
+    if (!ext) {
+        testPassed("WEBGL_draw_buffers extension not available - skipping test");
+        gl.deleteFramebuffer(fb);
+        gl.deleteTexture(texture);
+        gl.deleteProgram(program);
+        finishTest();
+        return;
+    }
+    testPassed("WEBGL_draw_buffers extension enabled AFTER framebuffer setup");
+
+    // Draw to the framebuffer without calling drawBuffersWEBGL
+    gl.viewport(0, 0, 16, 16);
+    gl.clearColor(0, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    wtu.drawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "draw should succeed");
+
+    // Verify the draw rendered red pixels
+    wtu.checkCanvas(gl, [255, 0, 0, 255], "framebuffer should contain red pixels after draw", 1);
+
+    // Cleanup
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(texture);
+    gl.deleteProgram(program);
+    finishTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/webgl/webgl2-drawbuffers-before-attachment-expected.txt
+++ b/LayoutTests/webgl/webgl2-drawbuffers-before-attachment-expected.txt
@@ -1,0 +1,16 @@
+Test that WebGL2 framebuffer rendering works correctly when drawBuffers is called before texture attachment.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 7 PASS, 0 FAIL
+
+PASS WebGL2 context created
+PASS getError was expected value: NO_ERROR : drawBuffers should succeed
+PASS drawBuffers called BEFORE texture attachment
+PASS Texture attached AFTER drawBuffers
+PASS getError was expected value: NO_ERROR : draw should succeed
+PASS framebuffer should contain red pixels after draw
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/webgl2-drawbuffers-before-attachment.html
+++ b/LayoutTests/webgl/webgl2-drawbuffers-before-attachment.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test WebGL2 draw buffers work when drawBuffers is called before texture attachment</title>
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body onload="runTest()">
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Test that WebGL2 framebuffer rendering works correctly when drawBuffers is called before texture attachment.");
+
+var wtu = WebGLTestUtils;
+
+function runTest()
+{
+    var canvas = document.createElement("canvas");
+    canvas.width = 16;
+    canvas.height = 16;
+    document.body.appendChild(canvas);
+
+    var gl = wtu.create3DContext(canvas, undefined, 2);
+
+    if (!gl) {
+        testFailed("WebGL2 context does not exist");
+        finishTest();
+        return;
+    }
+    testPassed("WebGL2 context created");
+
+    var vertexShaderSource = `#version 300 es
+        in vec4 vPosition;
+        void main() {
+            gl_Position = vPosition;
+        }`;
+
+    var fragmentShaderSource = `#version 300 es
+        precision mediump float;
+        layout(location = 0) out vec4 fragColor;
+        void main() {
+            fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+        }`;
+
+    var program = wtu.setupProgram(gl, [vertexShaderSource, fragmentShaderSource], ["vPosition"]);
+    if (!program) {
+        testFailed("Failed to create program");
+        finishTest();
+        return;
+    }
+    wtu.setupUnitQuad(gl);
+
+    // Create framebuffer and call drawBuffers BEFORE attaching texture
+    var fb = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.drawBuffers([gl.COLOR_ATTACHMENT0]);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "drawBuffers should succeed");
+    testPassed("drawBuffers called BEFORE texture attachment");
+
+    // Attach texture after drawBuffers
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 16, 16, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("Framebuffer is not complete");
+        finishTest();
+        return;
+    }
+    testPassed("Texture attached AFTER drawBuffers");
+
+    // Draw and verify red pixels
+    gl.viewport(0, 0, 16, 16);
+    gl.clearColor(0, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    wtu.drawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "draw should succeed");
+    wtu.checkCanvas(gl, [255, 0, 0, 255], "framebuffer should contain red pixels after draw", 1);
+
+    // Cleanup
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(texture);
+    gl.deleteProgram(program);
+    finishTest();
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/webgl/webgl2-drawbuffers-default-expected.txt
+++ b/LayoutTests/webgl/webgl2-drawbuffers-default-expected.txt
@@ -1,0 +1,14 @@
+Test that WebGL2 framebuffer rendering works correctly without an explicit drawBuffers call.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+TEST COMPLETE: 5 PASS, 0 FAIL
+
+PASS WebGL2 context created
+PASS WebGL2 framebuffer created WITHOUT calling drawBuffers()
+PASS getError was expected value: NO_ERROR : draw should succeed
+PASS framebuffer should contain red pixels after draw
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/webgl/webgl2-drawbuffers-default.html
+++ b/LayoutTests/webgl/webgl2-drawbuffers-default.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Test WebGL2 default draw buffer behavior without explicit drawBuffers call</title>
+<link rel="stylesheet" href="resources/webgl_test_files/resources/js-test-style.css"/>
+<script src="resources/webgl_test_files/js/js-test-pre.js"></script>
+<script src="resources/webgl_test_files/js/webgl-test-utils.js"></script>
+</head>
+<body onload="runTest()">
+<div id="description"></div>
+<div id="console"></div>
+<script>
+"use strict";
+description("Test that WebGL2 framebuffer rendering works correctly without an explicit drawBuffers call.");
+
+var wtu = WebGLTestUtils;
+
+function runTest()
+{
+    var canvas = document.createElement("canvas");
+    canvas.width = 16;
+    canvas.height = 16;
+    document.body.appendChild(canvas);
+
+    var gl = wtu.create3DContext(canvas, undefined, 2);
+
+    if (!gl) {
+        testFailed("WebGL2 context does not exist");
+        finishTest();
+        return;
+    }
+    testPassed("WebGL2 context created");
+
+    var vertexShaderSource = `#version 300 es
+        in vec4 vPosition;
+        void main() {
+            gl_Position = vPosition;
+        }`;
+
+    var fragmentShaderSource = `#version 300 es
+        precision mediump float;
+        out vec4 fragColor;
+        void main() {
+            fragColor = vec4(1.0, 0.0, 0.0, 1.0);
+        }`;
+
+    var program = wtu.setupProgram(gl, [vertexShaderSource, fragmentShaderSource], ["vPosition"]);
+    if (!program) {
+        testFailed("Failed to create program");
+        finishTest();
+        return;
+    }
+    wtu.setupUnitQuad(gl);
+
+    // Create framebuffer and attach texture without calling drawBuffers()
+    var fb = gl.createFramebuffer();
+    var texture = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA8, 16, 16, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fb);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
+
+    if (gl.checkFramebufferStatus(gl.FRAMEBUFFER) != gl.FRAMEBUFFER_COMPLETE) {
+        testFailed("Framebuffer is not complete");
+        finishTest();
+        return;
+    }
+    testPassed("WebGL2 framebuffer created WITHOUT calling drawBuffers()");
+
+    // Draw and verify red pixels
+    gl.viewport(0, 0, 16, 16);
+    gl.clearColor(0, 0, 0, 1);
+    gl.clear(gl.COLOR_BUFFER_BIT);
+    wtu.drawUnitQuad(gl);
+    wtu.glErrorShouldBe(gl, gl.NO_ERROR, "draw should succeed");
+    wtu.checkCanvas(gl, [255, 0, 0, 255], "framebuffer should contain red pixels after draw", 1);
+
+    // Cleanup
+    gl.deleteFramebuffer(fb);
+    gl.deleteTexture(texture);
+    gl.deleteProgram(program);
+    finishTest();
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.h
@@ -84,11 +84,8 @@ public:
 
     void didBind() { m_hasEverBeenBound = true; }
 
-    // Wrapper for drawBuffersEXT/drawBuffersARB to work around a driver bug.
+    // Set draw buffers for this framebuffer. ANGLE handles filtering internally.
     void drawBuffers(const Vector<GCGLenum>& bufs);
-
-    // Apply m_filteredDrawBuffers to GL state if pending sync is needed.
-    void applyFilteredDrawBuffers();
 
     GCGLenum NODELETE getDrawBuffer(GCGLenum);
 
@@ -123,9 +120,6 @@ private:
     // Check if the framebuffer is currently bound to the given target.
     bool isBound(GCGLenum target) const;
 
-    // Update m_filteredDrawBuffers based on current attachments. Returns true if changed.
-    bool updateFilteredDrawBuffers(bool force);
-
     void setAttachmentInternal(GCGLenum attachment, AttachmentEntry);
     // If a given attachment point for the currently bound framebuffer is not
     // null, remove the attached object.
@@ -139,8 +133,6 @@ private:
     HashMap<GCGLenum, AttachmentEntry> m_attachments;
     bool m_hasEverBeenBound { false };
     Vector<GCGLenum> m_drawBuffers;
-    Vector<GCGLenum> m_filteredDrawBuffers;
-    bool m_drawBufferStatePendingSync { false };
 #if ENABLE(WEBXR)
     const bool m_isOpaque;
     bool m_insideWebXRRAF { false };

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -5393,10 +5393,6 @@ void WebGLRenderingContextBase::setFramebuffer(const AbstractLocker&, GCGLenum t
         m_framebufferBinding = buffer;
     auto fbo = buffer ? buffer->object() : m_defaultFramebuffer->object();
     graphicsContextGL()->bindFramebuffer(target, fbo);
-
-    // Apply deferred draw buffer state when binding for drawing.
-    if (buffer && (target == GraphicsContextGL::FRAMEBUFFER || target == GraphicsContextGL::DRAW_FRAMEBUFFER))
-        buffer->applyFilteredDrawBuffers();
 }
 
 bool WebGLRenderingContextBase::supportsDrawBuffers()


### PR DESCRIPTION
#### 763e36f74c98805f14a6a5d5a33fbe3cec115d16
<pre>
[WebGL] Remove redundant m_filteredDrawBuffers code
<a href="https://bugs.webkit.org/show_bug.cgi?id=307622">https://bugs.webkit.org/show_bug.cgi?id=307622</a>
<a href="https://rdar.apple.com/170192162">rdar://170192162</a>

Reviewed by Dan Glastonbury.

The m_filteredDrawBuffers mechanism was added to work around a macOS native OpenGL
driver bug. Since WebKit uses ANGLE exclusively for its implementation since 2022, this filtering is
redundant - ANGLE handles unattached draw buffer filtering internally during rendering.

This simplifies the code by removing:
- m_filteredDrawBuffers and m_drawBufferStatePendingSync members
- updateFilteredDrawBuffers() method
- applyFilteredDrawBuffers() method and its call site in setFramebuffer()
- Draw buffer handling in setAttachmentForBoundFramebuffer() and removeAttachmentFromBoundFramebuffer()

Tests: webgl/drawbuffers-before-attachment.html
       webgl/drawbuffers-extension-after-setup.html
       webgl/webgl2-drawbuffers-before-attachment.html
       webgl/webgl2-drawbuffers-default.html

* LayoutTests/webgl/drawbuffers-before-attachment-expected.txt: Added.
* LayoutTests/webgl/drawbuffers-before-attachment.html: Added.
* LayoutTests/webgl/drawbuffers-extension-after-setup-expected.txt: Added.
* LayoutTests/webgl/drawbuffers-extension-after-setup.html: Added.
* LayoutTests/webgl/webgl2-drawbuffers-before-attachment-expected.txt: Added.
* LayoutTests/webgl/webgl2-drawbuffers-before-attachment.html: Added.
* LayoutTests/webgl/webgl2-drawbuffers-default-expected.txt: Added.
* LayoutTests/webgl/webgl2-drawbuffers-default.html: Added.
* Source/WebCore/html/canvas/WebGLFramebuffer.cpp:
(WebCore::WebGLFramebuffer::setAttachmentForBoundFramebuffer):
(WebCore::WebGLFramebuffer::removeAttachmentFromBoundFramebuffer):
(WebCore::WebGLFramebuffer::drawBuffers):
(WebCore::WebGLFramebuffer::applyFilteredDrawBuffers): Deleted.
(WebCore::WebGLFramebuffer::updateFilteredDrawBuffers): Deleted.
* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::WebGLRenderingContextBase::setFramebuffer):

Canonical link: <a href="https://commits.webkit.org/308079@main">https://commits.webkit.org/308079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4382b5f047734926b80677006cd09cee63f730c2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19013 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155003 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99781 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59a0797f-1e63-4861-aab5-38c5f79783a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18908 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112618 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80537 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4ddf489-8f42-4200-9de5-40cb67e7c87d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93487 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84bba4d8-5c1a-4a06-b658-fb4f91e8094a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14241 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12048 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2449 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157324 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/495 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/10733 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120648 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15781 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120946 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30992 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131053 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74627 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16620 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8012 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82203 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18180 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18345 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18238 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->