### PR TITLE
[GFC] TrackSizingAlgorithm needs to know if the max track sizing function is auto

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -315,16 +315,9 @@ TrackSizingFunctions GridLayout::convertGridTrackSizeToTrackSizingFunctions(cons
         if (gridTrackSize.isMinMax())
             return gridTrackSize.maxTrackBreadth();
 
-        // Otherwise, the track's sizing function. In all cases, treat auto and fit-content() as max-content,
+        // Otherwise, the track’s sizing function. In all cases, treat auto and fit-content() as max-content,
         // except where specified otherwise for fit-content().
-        if (gridTrackSize.maxTrackBreadth().isAuto())
-            return Style::GridTrackBreadth { CSS::Keyword::MaxContent { } };
-
-        if (gridTrackSize.isFitContent()) {
-            ASSERT_NOT_IMPLEMENTED_YET();
-            return Style::GridTrackBreadth { CSS::Keyword::MaxContent { } };
-        }
-
+        // Note: This special treatment is handled inside of TrackSizingAlgorithm.
         return gridTrackSize.maxTrackBreadth();
     };
 

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -265,22 +265,15 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
                 // limit to the maximum of the items’ max-content contributions.
                 auto itemContributions = maxContentContributions(gridItems, singleSpanningItemsIndexes, oppositeAxisConstraints, gridItemSizingFunctions);
                 auto maximumMaxContentContribution = itemContributions.isEmpty() ? 0_lu : std::ranges::max(itemContributions);
-
-                auto hasFitContentMaximum = [] {
-                    notImplemented();
-                    return false;
-                };
-                // For fit-content() maximums, furthermore clamp this growth limit by the
-                // fit-content() argument.
-                if (hasFitContentMaximum())  {
-                    ASSERT_NOT_IMPLEMENTED_YET();
-                    return { };
-                }
                 return maximumMaxContentContribution;
             },
             [&](const CSS::Keyword::Auto&) -> LayoutUnit {
-                ASSERT_NOT_IMPLEMENTED_YET();
-                return { };
+                // Since it is not explicitly stated otherwise in the spec, auto is treated as max-content:
+                // If the track has a max-content max track sizing function, set its growth
+                // limit to the maximum of the items’ max-content contributions.
+                auto itemContributions = maxContentContributions(gridItems, singleSpanningItemsIndexes, oppositeAxisConstraints, gridItemSizingFunctions);
+                auto maximumMaxContentContribution = itemContributions.isEmpty() ? 0_lu : std::ranges::max(itemContributions);
+                return maximumMaxContentContribution;
             },
             [&](const auto&) -> LayoutUnit {
                 ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 7dcc86a73bc796460a0cf714450999166d7c24ea
<pre>
[GFC] TrackSizingAlgorithm needs to know if the max track sizing function is auto
<a href="https://bugs.webkit.org/show_bug.cgi?id=307624">https://bugs.webkit.org/show_bug.cgi?id=307624</a>
<a href="https://rdar.apple.com/170192225">rdar://170192225</a>

Reviewed by Alan Baradlay.

Currently TrackSizingAlgorithm is unable to know if the max track sizing
function is auto. This causes us to skip over the &quot;stretch auto tracks,&quot;
portion of the algorithm because we fail to see these tracks. This
happens because in GridLayout::trackSizingFunctions we transform the
auto and fit-content max track sizing functions to max-content since the
spec says &quot;in all cases, treat auto and fit-content() as max-content,
except where specified otherwise for fit-content().&quot;
<a href="https://drafts.csswg.org/css-grid-1/#algo-terms">https://drafts.csswg.org/css-grid-1/#algo-terms</a>

For now let&apos;s stop doing this transformation, watch out for auto and
fit-content in TrackSizingAlgorithm, and either match the max-content
behavior or other behavior as called out by the spec.

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::sizeTracksToFitNonSpanningItems):
I removed the fit-content stub logic here since we&apos;ll probably just
detect this in another case for the switchOn (or some other way if we
decide to try a different approach again).

Canonical link: <a href="https://commits.webkit.org/307392@main">https://commits.webkit.org/307392@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b4d73ec89feaee08f5742ab5476d3c984aa15332

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144246 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16925 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8481 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152916 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146121 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110923 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/085aa3d1-f05e-47b6-8c02-87277a022eeb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147209 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13341 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91840 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12768 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10516 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/362 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155228 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16777 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118941 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16814 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119299 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30582 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15165 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72198 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16399 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5894 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16134 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80178 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16344 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16199 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->