### PR TITLE
[GFC] Enable non-fixed

### DIFF
--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -45,7 +45,6 @@ enum class ReasonCollectionMode : bool {
 };
 
 enum class GridAvoidanceReason : uint8_t {
-    GridHasNonFixedWidth,
     GridHasNonFixedHeight,
     GridHasVerticalWritingMode,
     GridHasMarginTrim,
@@ -233,9 +232,6 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         ADD_REASON_AND_RETURN_IF_NEEDED(GridFormattingContextIntegrationDisabled, reasons, reasonCollectionMode);
 
     CheckedRef renderGridStyle = renderGrid.style();
-
-    if (!renderGridStyle->width().isFixed())
-        ADD_REASON_AND_RETURN_IF_NEEDED(GridHasNonFixedWidth, reasons, reasonCollectionMode);
 
     if (!renderGridStyle->height().isFixed())
         ADD_REASON_AND_RETURN_IF_NEEDED(GridHasNonFixedHeight, reasons, reasonCollectionMode);
@@ -586,9 +582,6 @@ static void printReason(GridAvoidanceReason reason, TextStream& stream)
     switch (reason) {
     case GridAvoidanceReason::GridFormattingContextIntegrationDisabled:
         stream << "grid formatting context integration is disabled";
-        break;
-    case GridAvoidanceReason::GridHasNonFixedWidth:
-        stream << "grid has non-fixed width";
         break;
     case GridAvoidanceReason::GridHasNonFixedHeight:
         stream << "grid has non-fixed height";

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -233,8 +233,10 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
 
     CheckedRef renderGridStyle = renderGrid.style();
 
-    if (!renderGridStyle->height().isFixed())
-        ADD_REASON_AND_RETURN_IF_NEEDED(GridHasNonFixedHeight, reasons, reasonCollectionMode);
+    // [GFC] Support non-fixed container heights - use max-content constraint
+    // See: LayoutIntegrationGridLayout.cpp:121-133 (creates AxisConstraint::maxContent for indefinite heights)
+    // if (!renderGridStyle->height().isFixed())
+    //     ADD_REASON_AND_RETURN_IF_NEEDED(GridHasNonFixedHeight, reasons, reasonCollectionMode);
 
     if (renderGridStyle->display() == DisplayType::InlineGrid)
         ADD_REASON_AND_RETURN_IF_NEEDED(GridNeedsBaseline, reasons, reasonCollectionMode);

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.cpp
@@ -174,6 +174,19 @@ std::pair<LayoutUnit, LayoutUnit> GridLayout::computeIntrinsicWidths()
     return { intrinsicWidths.minimum, intrinsicWidths.maximum };
 }
 
+LayoutUnit GridLayout::contentBoxLogicalHeight() const
+{
+    // Compute the grid container's content height from the positioned grid items.
+    // For grids with height: auto, this determines the grid's final height.
+    // For grids with explicit height, this is computed but the explicit height takes precedence.
+    auto contentLogicalBottom = LayoutUnit { };
+    for (auto& layoutBox : Layout::formattingContextBoxes(gridBox())) {
+        auto marginBoxRect = Layout::BoxGeometry::marginBoxRect(layoutState().geometryForBox(layoutBox));
+        contentLogicalBottom = std::max(contentLogicalBottom, marginBoxRect.bottom());
+    }
+    return contentLogicalBottom;
+}
+
 void GridLayout::layout()
 {
     Layout::GridFormattingContext { gridBox(), layoutState() }.layout(constraintsForGridContent(gridBox()));

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -51,6 +51,7 @@ public:
     void layout();
 
     std::pair<LayoutUnit, LayoutUnit> computeIntrinsicWidths();
+    LayoutUnit contentBoxLogicalHeight() const;
 
     friend WTF::TextStream& operator<<(WTF::TextStream&, const GridLayout&);
 

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -578,6 +578,8 @@ bool RenderGrid::layoutUsingGridFormattingContext()
     gridLayout.updateFormattingContextGeometries();
 
     gridLayout.layout();
+    // Set the grid container's height to include content height (for height: auto grids)
+    setLogicalHeight(std::max(logicalHeight(), borderAndPaddingLogicalHeight() + gridLayout.contentBoxLogicalHeight()));
     updateLogicalHeight();
     return true;
 }


### PR DESCRIPTION
#### 7550604418076ccc586520a778a4c7d48aaf8d02
<pre>
[GFC] Enable non-fixed heights.
</pre>
----------------------------------------------------------------------
#### 02a4d29e03764a8106d166ae20b2f50c691584c2
<pre>
[GFC] Enable non-fixed widths.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307618">https://bugs.webkit.org/show_bug.cgi?id=307618</a>
&lt;<a href="https://rdar.apple.com/170191154">rdar://170191154</a>&gt;

Reviewed by NOBODY (OOPS!).

This PR loosens the restriction to allow GFC to handle grids with auto width.

* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
(WebCore::LayoutIntegration::printReason):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7550604418076ccc586520a778a4c7d48aaf8d02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144086 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97325 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145961 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17247 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16659 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110799 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/whitespace-reattach.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79623 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13207 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91710 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12664 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/whitespace-reattach.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10404 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/202 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122143 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6095 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155068 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16617 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7150 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118806 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/whitespace-reattach.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16653 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13952 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-grid/whitespace-reattach.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119164 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15048 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127306 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72038 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16239 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5747 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15973 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80018 "Found 2 new failures in layout/integration/grid/LayoutIntegrationGridLayout.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16184 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16039 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->