### PR TITLE
[GFC][Integration] Allow max-content as track sizing function for columns

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -269,7 +269,7 @@ static void sizeTracksToFitNonSpanningItems(UnsizedTracks& unsizedTracks, const 
                 auto maximumMaxContentContribution = itemContributions.isEmpty() ? 0_lu : std::ranges::max(itemContributions);
 
                 auto hasFitContentMaximum = [] {
-                    ASSERT_NOT_IMPLEMENTED_YET();
+                    notImplemented();
                     return false;
                 };
                 // For fit-content() maximums, furthermore clamp this growth limit by the

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -298,8 +298,8 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
 
                 if (minBreadth.isLength()) {
                     auto& gridTrackBreadthLength = minBreadth.length();
-                    // Length types like auto, min-content, max-content, etc. not yet supported
-                    if (!gridTrackBreadthLength.isFixed())
+                    // Length types like auto, min-content, etc. not yet supported
+                    if (!gridTrackBreadthLength.isFixed() && !gridTrackBreadthLength.isMaxContent())
                         return GridAvoidanceReason::GridHasUnsupportedGridTemplateColumns;
                     return std::nullopt;
                 }


### PR DESCRIPTION
#### 6b34ac51510516bd6a3ec2f5edc97413758d3ab1
<pre>
[GFC][Integration] Allow max-content as track sizing function for columns
<a href="https://bugs.webkit.org/show_bug.cgi?id=307629">https://bugs.webkit.org/show_bug.cgi?id=307629</a>
<a href="https://rdar.apple.com/170193665">rdar://170193665</a>

Reviewed by Vitor Roriz.

TrackSizingAlgorithm should be able to perform track sizing with
max-content as the track sizing function. We can ease the GFC
restrictions a bit by allowing content that has this as part of its
columns track sizing functions list.

This allows content like the following to run through GFC:
&lt;div style=&quot;display: grid; width: 100px; height: 100px; grid-template-columns: max-content max-content; grid-template-rows: 20px; min-width: 0; min-height: 0; outline: 1px solid green;&quot;&gt;
  &lt;div style=&quot;outline: 1px solid red; grid-column: 1/2; grid-row: 1/2; min-width: 0; min-height: 0;&quot;&gt;x x x x&lt;/div&gt;
  &lt;div style=&quot;outline: 1px solid red; grid-column: 2/3; grid-row: 1/2; min-width: 0; min-height: 0;&quot;&gt;xxxxxxxxx&lt;/div&gt;
&lt;/div&gt;

* Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp:
(WebCore::Layout::sizeTracksToFitNonSpanningItems):
Needed to change this ASSERT_NOT_IMPLEMENTED_YET() to notImplemented()
to avoid debug crashes since we called it unconditionally.

Canonical link: <a href="https://commits.webkit.org/307372@main">https://commits.webkit.org/307372@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b3e2a22f849557415217637dbbf9158da0606da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144092 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152762 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97331 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6143630-9766-4f00-9ffd-691aa8b4442d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145967 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17253 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110797 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79626 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13212 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129454 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91716 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c931b1e-2969-48cd-8639-0bb8e3aaef8d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12669 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10410 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/208 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122149 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6103 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155074 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16623 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7158 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118812 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16659 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13958 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119170 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30577 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15051 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127314 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72044 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16245 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5755 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80024 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16190 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->