### PR TITLE
[JSC] Use `tryFindOneChar` for `String#includes`

### DIFF
--- a/JSTests/microbenchmarks/rope-includes-one-char.js
+++ b/JSTests/microbenchmarks/rope-includes-one-char.js
@@ -1,0 +1,21 @@
+// Benchmark: String.prototype.includes with single char on a fresh rope each iteration.
+// This tests the target use case: (a + b + c).includes("x") where the rope is temporary.
+// The base string is pre-resolved so that (base + "z") creates a shallow depth-1 rope.
+
+let base = (-1).toLocaleString().padEnd(315241, "hello ");
+base.charCodeAt(0); // Force resolve so (base + suffix) creates a shallow rope
+
+function testFoundEarly(a, b) {
+    return (a + b).includes("h");
+}
+noInline(testFoundEarly);
+
+function testNotFound(a, b) {
+    return (a + b).includes("Q");
+}
+noInline(testNotFound);
+
+for (let i = 0; i < 1e2; i++) {
+    testFoundEarly(base, "z");
+    testNotFound(base, "z");
+}

--- a/JSTests/stress/rope-string-includes.js
+++ b/JSTests/stress/rope-string-includes.js
@@ -1,0 +1,130 @@
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message || "Assertion failed");
+}
+
+// Build a rope string that exceeds the 0x128 (296) length threshold.
+function makeLongRope() {
+    let a = "a".repeat(200);
+    let b = "b".repeat(200);
+    return a + b;
+}
+
+// Basic: rope includes with single character.
+function testBasicRopeIncludes() {
+    let rope = makeLongRope();
+    assert(rope.includes("a") === true, "'a' should be found");
+    assert(rope.includes("b") === true, "'b' should be found");
+    assert(rope.includes("z") === false, "'z' should not be found");
+}
+
+// startPosition argument.
+function testRopeIncludesWithPosition() {
+    let rope = makeLongRope();
+    assert(rope.includes("a", 100) === true, "'a' from 100 should be found");
+    assert(rope.includes("a", 200) === false, "'a' from 200 should not be found");
+    assert(rope.includes("b", 300) === true, "'b' from 300 should be found");
+    assert(rope.includes("b", 400) === false, "'b' from 400 should not be found");
+}
+
+// Deep rope (multi-level concatenation).
+function testDeepRope() {
+    let s = "x".repeat(100);
+    for (let i = 0; i < 10; i++)
+        s = s + "y".repeat(30);
+    // s is "x"*100 + "y"*300 = 400 chars, exceeds threshold
+    assert(s.includes("x") === true, "'x' should be found");
+    assert(s.includes("y") === true, "'y' should be found");
+    assert(s.includes("z") === false, "'z' should not be found");
+}
+
+// Edge: character at fiber boundary.
+function testFiberBoundary() {
+    let a = "a".repeat(150);
+    let b = "b" + "a".repeat(149);
+    let rope = a + b; // 300 chars, 'b' is at position 150
+    assert(rope.includes("b") === true, "'b' at fiber boundary should be found");
+}
+
+// Three-fiber rope.
+function testThreeFiberRope() {
+    let a = "a".repeat(100);
+    let b = "b".repeat(100);
+    let c = "c".repeat(100);
+    let rope = a + b + c; // JSC may create a 3-fiber rope
+    assert(rope.includes("a") === true);
+    assert(rope.includes("b") === true);
+    assert(rope.includes("c") === true);
+    assert(rope.includes("c", 250) === true);
+    assert(rope.includes("z") === false);
+}
+
+// Last character.
+function testLastChar() {
+    let a = "a".repeat(299);
+    let rope = a + "z"; // 300 chars
+    assert(rope.includes("z") === true);
+}
+
+// Ensure short ropes still work (they take the normal path).
+function testShortRope() {
+    let rope = "hello" + " world";
+    assert(rope.includes("w") === true);
+    assert(rope.includes("z") === false);
+}
+
+// Substring rope as root: slice() creates a substring rope.
+function testSubstringRopeRoot() {
+    let base = "a".repeat(200) + "b".repeat(200);
+    // Force resolve so slice() creates a substring rope over a resolved base.
+    base.charCodeAt(0);
+    let sub = base.slice(100, 350); // 250 chars, substring rope
+    assert(sub.includes("a") === true, "sub: 'a' should be found");
+    assert(sub.includes("b") === true, "sub: 'b' should be found");
+    assert(sub.includes("z") === false, "sub: 'z' should not be found");
+    assert(sub.includes("b", 150) === true, "sub: 'b' from 150 should be found");
+}
+
+// Substring rope as fiber: concat a substring with another string.
+function testSubstringRopeFiber() {
+    let base = "x".repeat(400);
+    base.charCodeAt(0);
+    let sub = base.slice(0, 200); // substring rope, 200 chars of 'x'
+    let rope = sub + "y".repeat(200); // fiber0=substring rope, fiber1=resolved
+    assert(rope.includes("x") === true, "fiber sub: 'x' should be found");
+    assert(rope.includes("y") === true, "fiber sub: 'y' should be found");
+    assert(rope.includes("z") === false, "fiber sub: 'z' should not be found");
+    assert(rope.includes("x", 199) === true, "fiber sub: 'x' at 199 should be found");
+    assert(rope.includes("x", 200) === false, "fiber sub: no 'x' from 200");
+}
+
+// Nested rope with startPosition: ensure startPosition is not regressed
+// when tryFindOneChar bails out on a non-substring rope fiber.
+function makeNestedRope() {
+    let partA = "a".repeat(50) + "z" + "a".repeat(449); // 500 chars, 'z' at index 50
+    let partB = "a".repeat(500);                          // 500 chars
+    let inner = partA + partB;                             // 1000 chars, rope
+    let partC = "b".repeat(200);                           // 200 chars
+    return inner + partC;                                  // 1200 chars, fiber0 = inner (rope)
+}
+function testNestedRopeStartPosition() {
+    // Each assertion uses a fresh rope because the first includes call
+    // resolves the rope, hiding the bug for subsequent calls.
+    assert(makeNestedRope().includes("z", 100) === false, "nested rope: includes('z', 100) should be false");
+    assert(makeNestedRope().includes("z", 51) === false, "nested rope: includes('z', 51) should be false");
+    assert(makeNestedRope().includes("z", 50) === true, "nested rope: includes('z', 50) should be true");
+    assert(makeNestedRope().includes("z") === true, "nested rope: includes('z') should be true");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testBasicRopeIncludes();
+    testRopeIncludesWithPosition();
+    testDeepRope();
+    testFiberBoundary();
+    testThreeFiberRope();
+    testLastChar();
+    testShortRope();
+    testSubstringRopeRoot();
+    testSubstringRopeFiber();
+    testNestedRopeStartPosition();
+}

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1416,10 +1416,10 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
     return JSValue::encode(jsBoolean(stringToSearchIn->hasInfixEndingAt(searchString, end)));
 }
 
-static EncodedJSValue stringIncludesImpl(JSGlobalObject* globalObject, VM& vm, StringView stringToSearchIn, StringView searchString, JSValue positionArg)
+static EncodedJSValue stringIncludesImpl(JSGlobalObject* globalObject, VM& vm, JSString* string, JSString* search, JSValue positionArg)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-    auto length = stringToSearchIn.length();
+    auto length = string->length();
     unsigned start;
     if (positionArg.isInt32())
         start = std::min(clampTo<unsigned>(positionArg.asInt32()), length);
@@ -1428,7 +1428,20 @@ static EncodedJSValue stringIncludesImpl(JSGlobalObject* globalObject, VM& vm, S
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
 
-    return JSValue::encode(jsBoolean(stringToSearchIn.find(vm.adaptiveStringSearcherTables(), searchString, start) != notFound));
+    if (search->length() == 1 && string->isRope() && string->length() >= JSString::minLengthForRopeWalk) {
+        auto searchView = search->view(globalObject);
+        RETURN_IF_EXCEPTION(scope, encodedJSValue());
+
+        if (auto result = string->tryFindOneChar(globalObject, searchView[0], start))
+            return JSValue::encode(jsBoolean(*result != notFound));
+    }
+
+    auto stringToSearchIn = string->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    auto searchString = search->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, encodedJSValue());
+
+    return JSValue::encode(jsBoolean(stringToSearchIn->find(vm.adaptiveStringSearcherTables(), searchString, start) != notFound));
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIncludes, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1443,9 +1456,6 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIncludes, (JSGlobalObject* globalObject,
     auto* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto stringToSearchIn = string->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue a0 = callFrame->argument(0);
     bool isRegularExpression = isRegExp(vm, globalObject, a0);
     RETURN_IF_EXCEPTION(scope, { });
@@ -1455,12 +1465,9 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIncludes, (JSGlobalObject* globalObject,
     auto* search = a0.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto searchString = search->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue positionArg = callFrame->argument(1);
 
-    RELEASE_AND_RETURN(scope, stringIncludesImpl(globalObject, vm, stringToSearchIn, searchString, positionArg));
+    RELEASE_AND_RETURN(scope, stringIncludesImpl(globalObject, vm, string, search, positionArg));
 }
 
 JSC_DEFINE_HOST_FUNCTION(builtinStringIncludesInternal, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1474,20 +1481,14 @@ JSC_DEFINE_HOST_FUNCTION(builtinStringIncludesInternal, (JSGlobalObject* globalO
     auto* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto stringToSearchIn = string->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue a0 = callFrame->uncheckedArgument(0);
 
     auto* search = a0.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto searchString = search->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue positionArg = callFrame->argument(1);
 
-    RELEASE_AND_RETURN(scope, stringIncludesImpl(globalObject, vm, stringToSearchIn, searchString, positionArg));
+    RELEASE_AND_RETURN(scope, stringIncludesImpl(globalObject, vm, string, search, positionArg));
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncIterator, (JSGlobalObject* globalObject, CallFrame* callFrame))


### PR DESCRIPTION
#### dbe0b0a08f9a72c3ac2c35da4e7033a02d6fc1c5
<pre>
[JSC] Use `tryFindOneChar` for `String#includes`
<a href="https://bugs.webkit.org/show_bug.cgi?id=307633">https://bugs.webkit.org/show_bug.cgi?id=307633</a>

Reviewed by Yusuke Suzuki.

This patch changes to use tryFindOneChar added in 307324@main for String#includes.

String#includes is handled as StringIndexOf node in DFG, it alreadly uses tryFindOneChar.
So this PR does not change DFG/FTL.

                                TipOfTree                  Patched

rope-includes-one-char        3.4551+-0.0917     ^      1.2645+-0.0909        ^ definitely 2.7325x faster

Tests: JSTests/microbenchmarks/rope-includes-one-char.js
       JSTests/stress/rope-string-includes.js

* JSTests/microbenchmarks/rope-includes-one-char.js: Added.
(testFoundEarly):
(testNotFound):
* JSTests/stress/rope-string-includes.js: Added.
(assert):
(makeLongRope):
(testBasicRopeIncludes):
(testNestedRopeStartPosition):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::stringIncludesImpl):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/308713@main">https://commits.webkit.org/308713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a34d9aa716bc6eac8285b69b82e4609021b2cb6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144095 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16774 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8328 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97334 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16668 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110802 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79632 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13220 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129463 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91720 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12677 "Found 2 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-home-end-pagedown-pageup.optional.html imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-initial-focus-display-animation.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10413 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/211 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136086 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122157 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155077 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4903 "Built successfully and passed tests") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7169 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118816 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16626 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13961 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119174 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33318 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16662 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127325 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72047 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15058 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5765 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175382 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16248 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80027 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45211 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15982 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16193 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->