### PR TITLE
Further reduce use of protected functions in Source/WebKit

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp
@@ -180,7 +180,7 @@ void RemoteGraphicsContextGL::reshape(int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
     if (width && height)
-        protectedContext()->reshape(width, height);
+        protect(m_context)->reshape(width, height);
     else
         forceContextLost();
 }
@@ -197,20 +197,20 @@ void RemoteGraphicsContextGL::prepareForDisplay(CompletionHandler<void()>&& comp
 void RemoteGraphicsContextGL::getErrors(CompletionHandler<void(GCGLErrorCodeSet)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
-    completionHandler(protectedContext()->getErrors());
+    completionHandler(protect(m_context)->getErrors());
 }
 
 void RemoteGraphicsContextGL::ensureExtensionEnabled(GCGLExtension extension)
 {
     assertIsCurrent(workQueue());
-    bool success = protectedContext()->enableExtension(extension);
+    bool success = protect(m_context)->enableExtension(extension);
     MESSAGE_CHECK(success);
 }
 
 void RemoteGraphicsContextGL::copyNativeImageYFlipped(WebCore::GraphicsContextGL::SurfaceBuffer buffer, WebCore::RenderingResourceIdentifier nativeImageIdentifier)
 {
     assertIsCurrent(workQueue());
-    RefPtr image = protectedContext()->copyNativeImageYFlipped(buffer);
+    RefPtr image = protect(m_context)->copyNativeImageYFlipped(buffer);
     // FIXME: Handle OOM.
     MESSAGE_CHECK(image);
     bool success = m_sharedResourceCache->addNativeImage(nativeImageIdentifier, image.releaseNonNull());
@@ -222,7 +222,7 @@ void RemoteGraphicsContextGL::surfaceBufferToVideoFrame(WebCore::GraphicsContext
 {
     assertIsCurrent(workQueue());
     std::optional<WebKit::RemoteVideoFrameProxy::Properties> result;
-    if (auto videoFrame = protectedContext()->surfaceBufferToVideoFrame(buffer))
+    if (auto videoFrame = protect(m_context)->surfaceBufferToVideoFrame(buffer))
         result = m_videoFrameObjectHeap->add(videoFrame.releaseNonNull());
     completionHandler(WTF::move(result));
 }
@@ -259,7 +259,7 @@ void RemoteGraphicsContextGL::simulateEventForTesting(WebCore::GraphicsContextGL
         });
         return;
     }
-    protectedContext()->simulateEventForTesting(event);
+    protect(m_context)->simulateEventForTesting(event);
 }
 
 void RemoteGraphicsContextGL::getBufferSubDataInline(uint32_t target, uint64_t offset, uint64_t dataSize, CompletionHandler<void(std::span<const uint8_t>)>&& completionHandler)
@@ -364,7 +364,7 @@ void RemoteGraphicsContextGL::multiDrawArraysANGLE(uint32_t mode, IPC::ArrayRefe
     // Copy the arrays. The contents are to be verified. The data might be in memory region shared by the caller.
     Vector<GCGLint> firsts = vectorCopyCast<GCGLint, 0>(firstsAndCounts);
     Vector<GCGLsizei> counts = vectorCopyCast<GCGLsizei, 1>(firstsAndCounts);
-    protectedContext()->multiDrawArraysANGLE(mode, GCGLSpanTuple { firsts, counts });
+    protect(m_context)->multiDrawArraysANGLE(mode, GCGLSpanTuple { firsts, counts });
 }
 
 void RemoteGraphicsContextGL::multiDrawArraysInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t>&& firstsCountsAndInstanceCounts)
@@ -374,7 +374,7 @@ void RemoteGraphicsContextGL::multiDrawArraysInstancedANGLE(uint32_t mode, IPC::
     Vector<GCGLint> firsts = vectorCopyCast<GCGLint, 0>(firstsCountsAndInstanceCounts);
     Vector<GCGLsizei> counts = vectorCopyCast<GCGLsizei, 1>(firstsCountsAndInstanceCounts);
     Vector<GCGLsizei> instanceCounts = vectorCopyCast<GCGLsizei, 2>(firstsCountsAndInstanceCounts);
-    protectedContext()->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firsts, counts, instanceCounts });
+    protect(m_context)->multiDrawArraysInstancedANGLE(mode, GCGLSpanTuple { firsts, counts, instanceCounts });
 }
 
 void RemoteGraphicsContextGL::multiDrawElementsANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t>&& countsAndOffsets, uint32_t type)
@@ -384,7 +384,7 @@ void RemoteGraphicsContextGL::multiDrawElementsANGLE(uint32_t mode, IPC::ArrayRe
     const Vector<GCGLsizei> counts = vectorCopyCast<GCGLsizei, 0>(countsAndOffsets);
     // Currently offsets are copied in the m_context.
     const GCGLsizei* offsets = reinterpret_cast<const GCGLsizei*>(countsAndOffsets.data<1>());
-    protectedContext()->multiDrawElementsANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, counts.size() }, type);
+    protect(m_context)->multiDrawElementsANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, counts.size() }, type);
 }
 
 void RemoteGraphicsContextGL::multiDrawElementsInstancedANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t>&& countsOffsetsAndInstanceCounts, uint32_t type)
@@ -395,7 +395,7 @@ void RemoteGraphicsContextGL::multiDrawElementsInstancedANGLE(uint32_t mode, IPC
     // Currently offsets are copied in the m_context.
     const GCGLsizei* offsets = reinterpret_cast<const GCGLsizei*>(countsOffsetsAndInstanceCounts.data<1>());
     const Vector<GCGLsizei> instanceCounts = vectorCopyCast<GCGLsizei, 2>(countsOffsetsAndInstanceCounts);
-    protectedContext()->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, instanceCounts.span().data(), counts.size() }, type);
+    protect(m_context)->multiDrawElementsInstancedANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, instanceCounts.span().data(), counts.size() }, type);
 }
 
 void RemoteGraphicsContextGL::multiDrawArraysInstancedBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, uint32_t>&& firstsCountsInstanceCountsAndBaseInstances)
@@ -406,7 +406,7 @@ void RemoteGraphicsContextGL::multiDrawArraysInstancedBaseInstanceANGLE(uint32_t
     Vector<GCGLsizei> counts = vectorCopyCast<GCGLsizei, 1>(firstsCountsInstanceCountsAndBaseInstances);
     Vector<GCGLsizei> instanceCounts = vectorCopyCast<GCGLsizei, 2>(firstsCountsInstanceCountsAndBaseInstances);
     Vector<GCGLuint> baseInstances = vectorCopyCast<GCGLuint, 3>(firstsCountsInstanceCountsAndBaseInstances);
-    protectedContext()->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firsts, counts, instanceCounts, baseInstances });
+    protect(m_context)->multiDrawArraysInstancedBaseInstanceANGLE(mode, GCGLSpanTuple { firsts, counts, instanceCounts, baseInstances });
 }
 
 void RemoteGraphicsContextGL::multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, IPC::ArrayReferenceTuple<int32_t, int32_t, int32_t, int32_t, uint32_t>&& countsOffsetsInstanceCountsBaseVerticesAndBaseInstances, uint32_t type)
@@ -419,31 +419,31 @@ void RemoteGraphicsContextGL::multiDrawElementsInstancedBaseVertexBaseInstanceAN
     const Vector<GCGLsizei> instanceCounts = vectorCopyCast<GCGLsizei, 2>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances);
     const Vector<GCGLint> baseVertices = vectorCopyCast<GCGLint, 3>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances);
     const Vector<GCGLuint> baseInstances = vectorCopyCast<GCGLuint, 4>(countsOffsetsInstanceCountsBaseVerticesAndBaseInstances);
-    protectedContext()->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, instanceCounts.span().data(), baseVertices.span().data(), baseInstances.span().data(), counts.size() }, type);
+    protect(m_context)->multiDrawElementsInstancedBaseVertexBaseInstanceANGLE(mode, GCGLSpanTuple { counts.span().data(), offsets, instanceCounts.span().data(), baseVertices.span().data(), baseInstances.span().data(), counts.size() }, type);
 }
 
 void RemoteGraphicsContextGL::drawBuffers(std::span<const uint32_t> bufs)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->drawBuffers(Vector(bufs));
+    protect(m_context)->drawBuffers(Vector(bufs));
 }
 
 void RemoteGraphicsContextGL::drawBuffersEXT(std::span<const uint32_t> bufs)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->drawBuffersEXT(Vector(bufs));
+    protect(m_context)->drawBuffersEXT(Vector(bufs));
 }
 
 void RemoteGraphicsContextGL::invalidateFramebuffer(uint32_t target, std::span<const uint32_t> attachments)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->invalidateFramebuffer(target, Vector(attachments));
+    protect(m_context)->invalidateFramebuffer(target, Vector(attachments));
 }
 
 void RemoteGraphicsContextGL::invalidateSubFramebuffer(uint32_t target, std::span<const uint32_t> attachments, int32_t x, int32_t y, int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->invalidateSubFramebuffer(target, Vector(attachments), x, y, width, height);
+    protect(m_context)->invalidateSubFramebuffer(target, Vector(attachments), x, y, width, height);
 }
 
 #if ENABLE(WEBXR)
@@ -452,7 +452,7 @@ void RemoteGraphicsContextGL::framebufferDiscard(uint32_t target, std::span<cons
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(webXRPromptAccepted());
-    protectedContext()->framebufferDiscard(target, Vector(attachments));
+    protect(m_context)->framebufferDiscard(target, Vector(attachments));
 }
 
 #endif
@@ -460,13 +460,7 @@ void RemoteGraphicsContextGL::framebufferDiscard(uint32_t target, std::span<cons
 void RemoteGraphicsContextGL::setDrawingBufferColorSpace(WebCore::DestinationColorSpace&& colorSpace)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->setDrawingBufferColorSpace(colorSpace);
-}
-
-RefPtr<RemoteGraphicsContextGL::GCGLContext> RemoteGraphicsContextGL::protectedContext()
-{
-    assertIsCurrent(workQueue());
-    return m_context;
+    protect(m_context)->setDrawingBufferColorSpace(colorSpace);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h
@@ -170,7 +170,6 @@ protected:
 private:
     bool webXREnabled() const;
     bool webXRPromptAccepted() const;
-    RefPtr<GCGLContext> protectedContext();
 
 protected:
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp
@@ -60,7 +60,7 @@ void RemoteGraphicsContextGL::copyTextureFromVideoFrame(WebKit::SharedVideoFrame
         return;
     }
     texture = m_objectNames.get(texture);
-    bool result = protectedContext()->copyTextureFromVideoFrame(*videoFrame, texture, target, level, internalFormat, format, type, premultiplyAlpha, flipY);
+    bool result = protect(m_context)->copyTextureFromVideoFrame(*videoFrame, texture, target, level, internalFormat, format, type, premultiplyAlpha, flipY);
     completionHandler(result);
 }
 

--- a/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp
@@ -39,7 +39,7 @@ using namespace WebCore;
 void RemoteGraphicsContextGL::activeTexture(uint32_t texture)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->activeTexture(texture);
+    protect(m_context)->activeTexture(texture);
 }
 
 void RemoteGraphicsContextGL::attachShader(uint32_t program, uint32_t shader)
@@ -51,7 +51,7 @@ void RemoteGraphicsContextGL::attachShader(uint32_t program, uint32_t shader)
     MESSAGE_CHECK(m_objectNames.isValidKey(shader));
     if (shader)
         shader = m_objectNames.get(shader);
-    protectedContext()->attachShader(program, shader);
+    protect(m_context)->attachShader(program, shader);
 }
 
 void RemoteGraphicsContextGL::bindAttribLocation(uint32_t arg0, uint32_t index, CString&& name)
@@ -60,7 +60,7 @@ void RemoteGraphicsContextGL::bindAttribLocation(uint32_t arg0, uint32_t index, 
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    protectedContext()->bindAttribLocation(arg0, index, name);
+    protect(m_context)->bindAttribLocation(arg0, index, name);
 }
 
 void RemoteGraphicsContextGL::bindBuffer(uint32_t target, uint32_t arg1)
@@ -69,7 +69,7 @@ void RemoteGraphicsContextGL::bindBuffer(uint32_t target, uint32_t arg1)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg1));
     if (arg1)
         arg1 = m_objectNames.get(arg1);
-    protectedContext()->bindBuffer(target, arg1);
+    protect(m_context)->bindBuffer(target, arg1);
 }
 
 void RemoteGraphicsContextGL::bindFramebuffer(uint32_t target, uint32_t arg1)
@@ -78,7 +78,7 @@ void RemoteGraphicsContextGL::bindFramebuffer(uint32_t target, uint32_t arg1)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg1));
     if (arg1)
         arg1 = m_objectNames.get(arg1);
-    protectedContext()->bindFramebuffer(target, arg1);
+    protect(m_context)->bindFramebuffer(target, arg1);
 }
 
 void RemoteGraphicsContextGL::bindRenderbuffer(uint32_t target, uint32_t arg1)
@@ -87,7 +87,7 @@ void RemoteGraphicsContextGL::bindRenderbuffer(uint32_t target, uint32_t arg1)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg1));
     if (arg1)
         arg1 = m_objectNames.get(arg1);
-    protectedContext()->bindRenderbuffer(target, arg1);
+    protect(m_context)->bindRenderbuffer(target, arg1);
 }
 
 void RemoteGraphicsContextGL::bindTexture(uint32_t target, uint32_t arg1)
@@ -96,75 +96,75 @@ void RemoteGraphicsContextGL::bindTexture(uint32_t target, uint32_t arg1)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg1));
     if (arg1)
         arg1 = m_objectNames.get(arg1);
-    protectedContext()->bindTexture(target, arg1);
+    protect(m_context)->bindTexture(target, arg1);
 }
 
 void RemoteGraphicsContextGL::blendColor(float red, float green, float blue, float alpha)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blendColor(red, green, blue, alpha);
+    protect(m_context)->blendColor(red, green, blue, alpha);
 }
 
 void RemoteGraphicsContextGL::blendEquation(uint32_t mode)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blendEquation(mode);
+    protect(m_context)->blendEquation(mode);
 }
 
 void RemoteGraphicsContextGL::blendEquationSeparate(uint32_t modeRGB, uint32_t modeAlpha)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blendEquationSeparate(modeRGB, modeAlpha);
+    protect(m_context)->blendEquationSeparate(modeRGB, modeAlpha);
 }
 
 void RemoteGraphicsContextGL::blendFunc(uint32_t sfactor, uint32_t dfactor)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blendFunc(sfactor, dfactor);
+    protect(m_context)->blendFunc(sfactor, dfactor);
 }
 
 void RemoteGraphicsContextGL::blendFuncSeparate(uint32_t srcRGB, uint32_t dstRGB, uint32_t srcAlpha, uint32_t dstAlpha)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
+    protect(m_context)->blendFuncSeparate(srcRGB, dstRGB, srcAlpha, dstAlpha);
 }
 
 void RemoteGraphicsContextGL::checkFramebufferStatus(uint32_t target, CompletionHandler<void(uint32_t)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     GCGLenum returnValue = { };
-    returnValue = protectedContext()->checkFramebufferStatus(target);
+    returnValue = protect(m_context)->checkFramebufferStatus(target);
     completionHandler(returnValue);
 }
 
 void RemoteGraphicsContextGL::clear(uint32_t mask)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->clear(mask);
+    protect(m_context)->clear(mask);
 }
 
 void RemoteGraphicsContextGL::clearColor(float red, float green, float blue, float alpha)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->clearColor(red, green, blue, alpha);
+    protect(m_context)->clearColor(red, green, blue, alpha);
 }
 
 void RemoteGraphicsContextGL::clearDepth(float depth)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->clearDepth(depth);
+    protect(m_context)->clearDepth(depth);
 }
 
 void RemoteGraphicsContextGL::clearStencil(int32_t s)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->clearStencil(s);
+    protect(m_context)->clearStencil(s);
 }
 
 void RemoteGraphicsContextGL::colorMask(bool red, bool green, bool blue, bool alpha)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->colorMask(static_cast<GCGLboolean>(red), static_cast<GCGLboolean>(green), static_cast<GCGLboolean>(blue), static_cast<GCGLboolean>(alpha));
+    protect(m_context)->colorMask(static_cast<GCGLboolean>(red), static_cast<GCGLboolean>(green), static_cast<GCGLboolean>(blue), static_cast<GCGLboolean>(alpha));
 }
 
 void RemoteGraphicsContextGL::compileShader(uint32_t arg0)
@@ -173,26 +173,26 @@ void RemoteGraphicsContextGL::compileShader(uint32_t arg0)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    protectedContext()->compileShader(arg0);
+    protect(m_context)->compileShader(arg0);
 }
 
 void RemoteGraphicsContextGL::copyTexImage2D(uint32_t target, int32_t level, uint32_t internalformat, int32_t x, int32_t y, int32_t width, int32_t height, int32_t border)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->copyTexImage2D(target, level, internalformat, x, y, width, height, border);
+    protect(m_context)->copyTexImage2D(target, level, internalformat, x, y, width, height, border);
 }
 
 void RemoteGraphicsContextGL::copyTexSubImage2D(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t x, int32_t y, int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->copyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
+    protect(m_context)->copyTexSubImage2D(target, level, xoffset, yoffset, x, y, width, height);
 }
 
 void RemoteGraphicsContextGL::createBuffer(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createBuffer();
+    auto result = protect(m_context)->createBuffer();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -201,7 +201,7 @@ void RemoteGraphicsContextGL::createFramebuffer(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createFramebuffer();
+    auto result = protect(m_context)->createFramebuffer();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -210,7 +210,7 @@ void RemoteGraphicsContextGL::createProgram(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createProgram();
+    auto result = protect(m_context)->createProgram();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -219,7 +219,7 @@ void RemoteGraphicsContextGL::createRenderbuffer(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createRenderbuffer();
+    auto result = protect(m_context)->createRenderbuffer();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -228,7 +228,7 @@ void RemoteGraphicsContextGL::createShader(uint32_t name, uint32_t arg0)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createShader(arg0);
+    auto result = protect(m_context)->createShader(arg0);
     if (result)
         m_objectNames.add(name, result);
 }
@@ -237,7 +237,7 @@ void RemoteGraphicsContextGL::createTexture(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createTexture();
+    auto result = protect(m_context)->createTexture();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -245,7 +245,7 @@ void RemoteGraphicsContextGL::createTexture(uint32_t name)
 void RemoteGraphicsContextGL::cullFace(uint32_t mode)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->cullFace(mode);
+    protect(m_context)->cullFace(mode);
 }
 
 void RemoteGraphicsContextGL::deleteBuffer(uint32_t arg0)
@@ -255,7 +255,7 @@ void RemoteGraphicsContextGL::deleteBuffer(uint32_t arg0)
     if (!arg0) [[unlikely]]
         return;
     arg0 = m_objectNames.take(arg0);
-    protectedContext()->deleteBuffer(arg0);
+    protect(m_context)->deleteBuffer(arg0);
 }
 
 void RemoteGraphicsContextGL::deleteFramebuffer(uint32_t arg0)
@@ -265,7 +265,7 @@ void RemoteGraphicsContextGL::deleteFramebuffer(uint32_t arg0)
     if (!arg0) [[unlikely]]
         return;
     arg0 = m_objectNames.take(arg0);
-    protectedContext()->deleteFramebuffer(arg0);
+    protect(m_context)->deleteFramebuffer(arg0);
 }
 
 void RemoteGraphicsContextGL::deleteProgram(uint32_t arg0)
@@ -275,7 +275,7 @@ void RemoteGraphicsContextGL::deleteProgram(uint32_t arg0)
     if (!arg0) [[unlikely]]
         return;
     arg0 = m_objectNames.take(arg0);
-    protectedContext()->deleteProgram(arg0);
+    protect(m_context)->deleteProgram(arg0);
 }
 
 void RemoteGraphicsContextGL::deleteRenderbuffer(uint32_t arg0)
@@ -285,7 +285,7 @@ void RemoteGraphicsContextGL::deleteRenderbuffer(uint32_t arg0)
     if (!arg0) [[unlikely]]
         return;
     arg0 = m_objectNames.take(arg0);
-    protectedContext()->deleteRenderbuffer(arg0);
+    protect(m_context)->deleteRenderbuffer(arg0);
 }
 
 void RemoteGraphicsContextGL::deleteShader(uint32_t arg0)
@@ -295,7 +295,7 @@ void RemoteGraphicsContextGL::deleteShader(uint32_t arg0)
     if (!arg0) [[unlikely]]
         return;
     arg0 = m_objectNames.take(arg0);
-    protectedContext()->deleteShader(arg0);
+    protect(m_context)->deleteShader(arg0);
 }
 
 void RemoteGraphicsContextGL::deleteTexture(uint32_t arg0)
@@ -305,25 +305,25 @@ void RemoteGraphicsContextGL::deleteTexture(uint32_t arg0)
     if (!arg0) [[unlikely]]
         return;
     arg0 = m_objectNames.take(arg0);
-    protectedContext()->deleteTexture(arg0);
+    protect(m_context)->deleteTexture(arg0);
 }
 
 void RemoteGraphicsContextGL::depthFunc(uint32_t func)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->depthFunc(func);
+    protect(m_context)->depthFunc(func);
 }
 
 void RemoteGraphicsContextGL::depthMask(bool flag)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->depthMask(static_cast<GCGLboolean>(flag));
+    protect(m_context)->depthMask(static_cast<GCGLboolean>(flag));
 }
 
 void RemoteGraphicsContextGL::depthRange(float zNear, float zFar)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->depthRange(zNear, zFar);
+    protect(m_context)->depthRange(zNear, zFar);
 }
 
 void RemoteGraphicsContextGL::detachShader(uint32_t arg0, uint32_t arg1)
@@ -335,55 +335,55 @@ void RemoteGraphicsContextGL::detachShader(uint32_t arg0, uint32_t arg1)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg1));
     if (arg1)
         arg1 = m_objectNames.get(arg1);
-    protectedContext()->detachShader(arg0, arg1);
+    protect(m_context)->detachShader(arg0, arg1);
 }
 
 void RemoteGraphicsContextGL::disable(uint32_t cap)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->disable(cap);
+    protect(m_context)->disable(cap);
 }
 
 void RemoteGraphicsContextGL::disableVertexAttribArray(uint32_t index)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->disableVertexAttribArray(index);
+    protect(m_context)->disableVertexAttribArray(index);
 }
 
 void RemoteGraphicsContextGL::drawArrays(uint32_t mode, int32_t first, int32_t count)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->drawArrays(mode, first, count);
+    protect(m_context)->drawArrays(mode, first, count);
 }
 
 void RemoteGraphicsContextGL::drawElements(uint32_t mode, int32_t count, uint32_t type, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->drawElements(mode, count, type, static_cast<GCGLintptr>(offset));
+    protect(m_context)->drawElements(mode, count, type, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::enable(uint32_t cap)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->enable(cap);
+    protect(m_context)->enable(cap);
 }
 
 void RemoteGraphicsContextGL::enableVertexAttribArray(uint32_t index)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->enableVertexAttribArray(index);
+    protect(m_context)->enableVertexAttribArray(index);
 }
 
 void RemoteGraphicsContextGL::finish()
 {
     assertIsCurrent(workQueue());
-    protectedContext()->finish();
+    protect(m_context)->finish();
 }
 
 void RemoteGraphicsContextGL::flush()
 {
     assertIsCurrent(workQueue());
-    protectedContext()->flush();
+    protect(m_context)->flush();
 }
 
 void RemoteGraphicsContextGL::framebufferRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
@@ -392,7 +392,7 @@ void RemoteGraphicsContextGL::framebufferRenderbuffer(uint32_t target, uint32_t 
     MESSAGE_CHECK(m_objectNames.isValidKey(arg3));
     if (arg3)
         arg3 = m_objectNames.get(arg3);
-    protectedContext()->framebufferRenderbuffer(target, attachment, renderbuffertarget, arg3);
+    protect(m_context)->framebufferRenderbuffer(target, attachment, renderbuffertarget, arg3);
 }
 
 void RemoteGraphicsContextGL::framebufferTexture2D(uint32_t target, uint32_t attachment, uint32_t textarget, uint32_t arg3, int32_t level)
@@ -401,19 +401,19 @@ void RemoteGraphicsContextGL::framebufferTexture2D(uint32_t target, uint32_t att
     MESSAGE_CHECK(m_objectNames.isValidKey(arg3));
     if (arg3)
         arg3 = m_objectNames.get(arg3);
-    protectedContext()->framebufferTexture2D(target, attachment, textarget, arg3, level);
+    protect(m_context)->framebufferTexture2D(target, attachment, textarget, arg3, level);
 }
 
 void RemoteGraphicsContextGL::frontFace(uint32_t mode)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->frontFace(mode);
+    protect(m_context)->frontFace(mode);
 }
 
 void RemoteGraphicsContextGL::generateMipmap(uint32_t target)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->generateMipmap(target);
+    protect(m_context)->generateMipmap(target);
 }
 
 void RemoteGraphicsContextGL::activeAttribs(uint32_t program, CompletionHandler<void(Vector<WebCore::GCGLAttribActiveInfo>&&)>&& completionHandler)
@@ -423,7 +423,7 @@ void RemoteGraphicsContextGL::activeAttribs(uint32_t program, CompletionHandler<
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
-    returnValue = protectedContext()->activeAttribs(program);
+    returnValue = protect(m_context)->activeAttribs(program);
     completionHandler(WTF::move(returnValue));
 }
 
@@ -434,7 +434,7 @@ void RemoteGraphicsContextGL::activeUniforms(uint32_t program, CompletionHandler
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
-    returnValue = protectedContext()->activeUniforms(program);
+    returnValue = protect(m_context)->activeUniforms(program);
     completionHandler(WTF::move(returnValue));
 }
 
@@ -442,7 +442,7 @@ void RemoteGraphicsContextGL::getBufferParameteri(uint32_t target, uint32_t pnam
 {
     assertIsCurrent(workQueue());
     GCGLint returnValue = { };
-    returnValue = protectedContext()->getBufferParameteri(target, pname);
+    returnValue = protect(m_context)->getBufferParameteri(target, pname);
     completionHandler(returnValue);
 }
 
@@ -450,7 +450,7 @@ void RemoteGraphicsContextGL::getString(uint32_t name, CompletionHandler<void(CS
 {
     assertIsCurrent(workQueue());
     CString returnValue = { };
-    returnValue = protectedContext()->getString(name);
+    returnValue = protect(m_context)->getString(name);
     completionHandler(WTF::move(returnValue));
 }
 
@@ -460,7 +460,7 @@ void RemoteGraphicsContextGL::getFloatv(uint32_t pname, uint64_t valueSize, Comp
     if (!WTF::isValidCapacityForVector<GCGLfloat>(valueSize))
         valueSize = 16;
     Vector<GCGLfloat, 16> value(valueSize, 0);
-    protectedContext()->getFloatv(pname, value);
+    protect(m_context)->getFloatv(pname, value);
     completionHandler(spanReinterpretCast<const float>(value.span()));
 }
 
@@ -470,7 +470,7 @@ void RemoteGraphicsContextGL::getIntegerv(uint32_t pname, uint64_t valueSize, Co
     if (!WTF::isValidCapacityForVector<GCGLint>(valueSize))
         valueSize = 4;
     Vector<GCGLint, 4> value(valueSize, 0);
-    protectedContext()->getIntegerv(pname, value);
+    protect(m_context)->getIntegerv(pname, value);
     completionHandler(spanReinterpretCast<const int32_t>(value.span()));
 }
 
@@ -478,7 +478,7 @@ void RemoteGraphicsContextGL::getIntegeri_v(uint32_t pname, uint32_t index, Comp
 {
     assertIsCurrent(workQueue());
     std::array<GCGLint, 4> value { };
-    protectedContext()->getIntegeri_v(pname, index, value);
+    protect(m_context)->getIntegeri_v(pname, index, value);
     completionHandler(spanReinterpretCast<const int32_t, 4>(std::span<const GCGLint, 4>(value)));
 }
 
@@ -486,7 +486,7 @@ void RemoteGraphicsContextGL::getInteger64(uint32_t pname, CompletionHandler<voi
 {
     assertIsCurrent(workQueue());
     GCGLint64 returnValue = { };
-    returnValue = protectedContext()->getInteger64(pname);
+    returnValue = protect(m_context)->getInteger64(pname);
     completionHandler(static_cast<int64_t>(returnValue));
 }
 
@@ -494,7 +494,7 @@ void RemoteGraphicsContextGL::getInteger64i(uint32_t pname, uint32_t index, Comp
 {
     assertIsCurrent(workQueue());
     GCGLint64 returnValue = { };
-    returnValue = protectedContext()->getInteger64i(pname, index);
+    returnValue = protect(m_context)->getInteger64i(pname, index);
     completionHandler(static_cast<int64_t>(returnValue));
 }
 
@@ -505,7 +505,7 @@ void RemoteGraphicsContextGL::getProgrami(uint32_t program, uint32_t pname, Comp
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
-    returnValue = protectedContext()->getProgrami(program, pname);
+    returnValue = protect(m_context)->getProgrami(program, pname);
     completionHandler(returnValue);
 }
 
@@ -515,7 +515,7 @@ void RemoteGraphicsContextGL::getBooleanv(uint32_t pname, uint64_t valueSize, Co
     if (!WTF::isValidCapacityForVector<GCGLboolean>(valueSize))
         valueSize = 4;
     Vector<GCGLboolean, 4> value(valueSize, 0);
-    protectedContext()->getBooleanv(pname, value);
+    protect(m_context)->getBooleanv(pname, value);
     completionHandler(spanReinterpretCast<const bool>(value.span()));
 }
 
@@ -523,7 +523,7 @@ void RemoteGraphicsContextGL::getFramebufferAttachmentParameteri(uint32_t target
 {
     assertIsCurrent(workQueue());
     GCGLint returnValue = { };
-    returnValue = protectedContext()->getFramebufferAttachmentParameteri(target, attachment, pname);
+    returnValue = protect(m_context)->getFramebufferAttachmentParameteri(target, attachment, pname);
     completionHandler(returnValue);
 }
 
@@ -534,7 +534,7 @@ void RemoteGraphicsContextGL::getProgramInfoLog(uint32_t arg0, CompletionHandler
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->getProgramInfoLog(arg0);
+    returnValue = protect(m_context)->getProgramInfoLog(arg0);
     completionHandler(WTF::move(returnValue));
 }
 
@@ -542,7 +542,7 @@ void RemoteGraphicsContextGL::getRenderbufferParameteri(uint32_t target, uint32_
 {
     assertIsCurrent(workQueue());
     GCGLint returnValue = { };
-    returnValue = protectedContext()->getRenderbufferParameteri(target, pname);
+    returnValue = protect(m_context)->getRenderbufferParameteri(target, pname);
     completionHandler(returnValue);
 }
 
@@ -553,7 +553,7 @@ void RemoteGraphicsContextGL::getShaderi(uint32_t arg0, uint32_t pname, Completi
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->getShaderi(arg0, pname);
+    returnValue = protect(m_context)->getShaderi(arg0, pname);
     completionHandler(returnValue);
 }
 
@@ -564,7 +564,7 @@ void RemoteGraphicsContextGL::getShaderInfoLog(uint32_t arg0, CompletionHandler<
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->getShaderInfoLog(arg0);
+    returnValue = protect(m_context)->getShaderInfoLog(arg0);
     completionHandler(WTF::move(returnValue));
 }
 
@@ -573,7 +573,7 @@ void RemoteGraphicsContextGL::getShaderPrecisionFormat(uint32_t shaderType, uint
     assertIsCurrent(workQueue());
     std::array<GCGLint, 2> range { };
     GCGLint precision = { };
-    protectedContext()->getShaderPrecisionFormat(shaderType, precisionType, range, &precision);
+    protect(m_context)->getShaderPrecisionFormat(shaderType, precisionType, range, &precision);
     completionHandler(spanReinterpretCast<const int32_t, 2>(std::span<const GCGLint, 2>(range)), precision);
 }
 
@@ -581,7 +581,7 @@ void RemoteGraphicsContextGL::getTexParameterf(uint32_t target, uint32_t pname, 
 {
     assertIsCurrent(workQueue());
     GCGLfloat returnValue = { };
-    returnValue = protectedContext()->getTexParameterf(target, pname);
+    returnValue = protect(m_context)->getTexParameterf(target, pname);
     completionHandler(returnValue);
 }
 
@@ -589,7 +589,7 @@ void RemoteGraphicsContextGL::getTexParameteri(uint32_t target, uint32_t pname, 
 {
     assertIsCurrent(workQueue());
     GCGLint returnValue = { };
-    returnValue = protectedContext()->getTexParameteri(target, pname);
+    returnValue = protect(m_context)->getTexParameteri(target, pname);
     completionHandler(returnValue);
 }
 
@@ -602,7 +602,7 @@ void RemoteGraphicsContextGL::getUniformfv(uint32_t program, int32_t location, u
     if (!WTF::isValidCapacityForVector<GCGLfloat>(valueSize))
         valueSize = 16;
     Vector<GCGLfloat, 16> value(valueSize, 0);
-    protectedContext()->getUniformfv(program, location, value);
+    protect(m_context)->getUniformfv(program, location, value);
     completionHandler(spanReinterpretCast<const float>(value.span()));
 }
 
@@ -615,7 +615,7 @@ void RemoteGraphicsContextGL::getUniformiv(uint32_t program, int32_t location, u
     if (!WTF::isValidCapacityForVector<GCGLint>(valueSize))
         valueSize = 4;
     Vector<GCGLint, 4> value(valueSize, 0);
-    protectedContext()->getUniformiv(program, location, value);
+    protect(m_context)->getUniformiv(program, location, value);
     completionHandler(spanReinterpretCast<const int32_t>(value.span()));
 }
 
@@ -628,7 +628,7 @@ void RemoteGraphicsContextGL::getUniformuiv(uint32_t program, int32_t location, 
     if (!WTF::isValidCapacityForVector<GCGLuint>(valueSize))
         valueSize = 4;
     Vector<GCGLuint, 4> value(valueSize, 0);
-    protectedContext()->getUniformuiv(program, location, value);
+    protect(m_context)->getUniformuiv(program, location, value);
     completionHandler(spanReinterpretCast<const uint32_t>(value.span()));
 }
 
@@ -636,14 +636,14 @@ void RemoteGraphicsContextGL::getVertexAttribOffset(uint32_t index, uint32_t pna
 {
     assertIsCurrent(workQueue());
     GCGLsizeiptr returnValue = { };
-    returnValue = protectedContext()->getVertexAttribOffset(index, pname);
+    returnValue = protect(m_context)->getVertexAttribOffset(index, pname);
     completionHandler(static_cast<uint64_t>(returnValue));
 }
 
 void RemoteGraphicsContextGL::hint(uint32_t target, uint32_t mode)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->hint(target, mode);
+    protect(m_context)->hint(target, mode);
 }
 
 void RemoteGraphicsContextGL::isBuffer(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
@@ -653,7 +653,7 @@ void RemoteGraphicsContextGL::isBuffer(uint32_t arg0, CompletionHandler<void(boo
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->isBuffer(arg0);
+    returnValue = protect(m_context)->isBuffer(arg0);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -661,7 +661,7 @@ void RemoteGraphicsContextGL::isEnabled(uint32_t cap, CompletionHandler<void(boo
 {
     assertIsCurrent(workQueue());
     GCGLboolean returnValue = { };
-    returnValue = protectedContext()->isEnabled(cap);
+    returnValue = protect(m_context)->isEnabled(cap);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -672,7 +672,7 @@ void RemoteGraphicsContextGL::isFramebuffer(uint32_t arg0, CompletionHandler<voi
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->isFramebuffer(arg0);
+    returnValue = protect(m_context)->isFramebuffer(arg0);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -683,7 +683,7 @@ void RemoteGraphicsContextGL::isProgram(uint32_t arg0, CompletionHandler<void(bo
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->isProgram(arg0);
+    returnValue = protect(m_context)->isProgram(arg0);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -694,7 +694,7 @@ void RemoteGraphicsContextGL::isRenderbuffer(uint32_t arg0, CompletionHandler<vo
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->isRenderbuffer(arg0);
+    returnValue = protect(m_context)->isRenderbuffer(arg0);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -705,7 +705,7 @@ void RemoteGraphicsContextGL::isShader(uint32_t arg0, CompletionHandler<void(boo
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->isShader(arg0);
+    returnValue = protect(m_context)->isShader(arg0);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -716,14 +716,14 @@ void RemoteGraphicsContextGL::isTexture(uint32_t arg0, CompletionHandler<void(bo
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->isTexture(arg0);
+    returnValue = protect(m_context)->isTexture(arg0);
     completionHandler(static_cast<bool>(returnValue));
 }
 
 void RemoteGraphicsContextGL::lineWidth(float arg0)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->lineWidth(arg0);
+    protect(m_context)->lineWidth(arg0);
 }
 
 void RemoteGraphicsContextGL::linkProgram(uint32_t arg0)
@@ -732,37 +732,37 @@ void RemoteGraphicsContextGL::linkProgram(uint32_t arg0)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    protectedContext()->linkProgram(arg0);
+    protect(m_context)->linkProgram(arg0);
 }
 
 void RemoteGraphicsContextGL::pixelStorei(uint32_t pname, int32_t param)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->pixelStorei(pname, param);
+    protect(m_context)->pixelStorei(pname, param);
 }
 
 void RemoteGraphicsContextGL::polygonOffset(float factor, float units)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->polygonOffset(factor, units);
+    protect(m_context)->polygonOffset(factor, units);
 }
 
 void RemoteGraphicsContextGL::renderbufferStorage(uint32_t target, uint32_t internalformat, int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->renderbufferStorage(target, internalformat, width, height);
+    protect(m_context)->renderbufferStorage(target, internalformat, width, height);
 }
 
 void RemoteGraphicsContextGL::sampleCoverage(float value, bool invert)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->sampleCoverage(value, static_cast<GCGLboolean>(invert));
+    protect(m_context)->sampleCoverage(value, static_cast<GCGLboolean>(invert));
 }
 
 void RemoteGraphicsContextGL::scissor(int32_t x, int32_t y, int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->scissor(x, y, width, height);
+    protect(m_context)->scissor(x, y, width, height);
 }
 
 void RemoteGraphicsContextGL::shaderSource(uint32_t arg0, CString&& arg1)
@@ -771,169 +771,169 @@ void RemoteGraphicsContextGL::shaderSource(uint32_t arg0, CString&& arg1)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    protectedContext()->shaderSource(arg0, arg1);
+    protect(m_context)->shaderSource(arg0, arg1);
 }
 
 void RemoteGraphicsContextGL::stencilFunc(uint32_t func, int32_t ref, uint32_t mask)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->stencilFunc(func, ref, mask);
+    protect(m_context)->stencilFunc(func, ref, mask);
 }
 
 void RemoteGraphicsContextGL::stencilFuncSeparate(uint32_t face, uint32_t func, int32_t ref, uint32_t mask)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->stencilFuncSeparate(face, func, ref, mask);
+    protect(m_context)->stencilFuncSeparate(face, func, ref, mask);
 }
 
 void RemoteGraphicsContextGL::stencilMask(uint32_t mask)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->stencilMask(mask);
+    protect(m_context)->stencilMask(mask);
 }
 
 void RemoteGraphicsContextGL::stencilMaskSeparate(uint32_t face, uint32_t mask)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->stencilMaskSeparate(face, mask);
+    protect(m_context)->stencilMaskSeparate(face, mask);
 }
 
 void RemoteGraphicsContextGL::stencilOp(uint32_t fail, uint32_t zfail, uint32_t zpass)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->stencilOp(fail, zfail, zpass);
+    protect(m_context)->stencilOp(fail, zfail, zpass);
 }
 
 void RemoteGraphicsContextGL::stencilOpSeparate(uint32_t face, uint32_t fail, uint32_t zfail, uint32_t zpass)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->stencilOpSeparate(face, fail, zfail, zpass);
+    protect(m_context)->stencilOpSeparate(face, fail, zfail, zpass);
 }
 
 void RemoteGraphicsContextGL::texParameterf(uint32_t target, uint32_t pname, float param)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texParameterf(target, pname, param);
+    protect(m_context)->texParameterf(target, pname, param);
 }
 
 void RemoteGraphicsContextGL::texParameteri(uint32_t target, uint32_t pname, int32_t param)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texParameteri(target, pname, param);
+    protect(m_context)->texParameteri(target, pname, param);
 }
 
 void RemoteGraphicsContextGL::uniform1f(int32_t location, float x)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform1f(location, x);
+    protect(m_context)->uniform1f(location, x);
 }
 
 void RemoteGraphicsContextGL::uniform1fv(int32_t location, std::span<const float>&& v)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform1fv(location, v);
+    protect(m_context)->uniform1fv(location, v);
 }
 
 void RemoteGraphicsContextGL::uniform1i(int32_t location, int32_t x)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform1i(location, x);
+    protect(m_context)->uniform1i(location, x);
 }
 
 void RemoteGraphicsContextGL::uniform1iv(int32_t location, std::span<const int32_t>&& v)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform1iv(location, v);
+    protect(m_context)->uniform1iv(location, v);
 }
 
 void RemoteGraphicsContextGL::uniform2f(int32_t location, float x, float y)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform2f(location, x, y);
+    protect(m_context)->uniform2f(location, x, y);
 }
 
 void RemoteGraphicsContextGL::uniform2fv(int32_t location, std::span<const float>&& v)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform2fv(location, v);
+    protect(m_context)->uniform2fv(location, v);
 }
 
 void RemoteGraphicsContextGL::uniform2i(int32_t location, int32_t x, int32_t y)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform2i(location, x, y);
+    protect(m_context)->uniform2i(location, x, y);
 }
 
 void RemoteGraphicsContextGL::uniform2iv(int32_t location, std::span<const int32_t>&& v)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform2iv(location, v);
+    protect(m_context)->uniform2iv(location, v);
 }
 
 void RemoteGraphicsContextGL::uniform3f(int32_t location, float x, float y, float z)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform3f(location, x, y, z);
+    protect(m_context)->uniform3f(location, x, y, z);
 }
 
 void RemoteGraphicsContextGL::uniform3fv(int32_t location, std::span<const float>&& v)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform3fv(location, v);
+    protect(m_context)->uniform3fv(location, v);
 }
 
 void RemoteGraphicsContextGL::uniform3i(int32_t location, int32_t x, int32_t y, int32_t z)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform3i(location, x, y, z);
+    protect(m_context)->uniform3i(location, x, y, z);
 }
 
 void RemoteGraphicsContextGL::uniform3iv(int32_t location, std::span<const int32_t>&& v)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform3iv(location, v);
+    protect(m_context)->uniform3iv(location, v);
 }
 
 void RemoteGraphicsContextGL::uniform4f(int32_t location, float x, float y, float z, float w)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform4f(location, x, y, z, w);
+    protect(m_context)->uniform4f(location, x, y, z, w);
 }
 
 void RemoteGraphicsContextGL::uniform4fv(int32_t location, std::span<const float>&& v)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform4fv(location, v);
+    protect(m_context)->uniform4fv(location, v);
 }
 
 void RemoteGraphicsContextGL::uniform4i(int32_t location, int32_t x, int32_t y, int32_t z, int32_t w)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform4i(location, x, y, z, w);
+    protect(m_context)->uniform4i(location, x, y, z, w);
 }
 
 void RemoteGraphicsContextGL::uniform4iv(int32_t location, std::span<const int32_t>&& v)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform4iv(location, v);
+    protect(m_context)->uniform4iv(location, v);
 }
 
 void RemoteGraphicsContextGL::uniformMatrix2fv(int32_t location, bool transpose, std::span<const float>&& value)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniformMatrix2fv(location, static_cast<GCGLboolean>(transpose), value);
+    protect(m_context)->uniformMatrix2fv(location, static_cast<GCGLboolean>(transpose), value);
 }
 
 void RemoteGraphicsContextGL::uniformMatrix3fv(int32_t location, bool transpose, std::span<const float>&& value)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniformMatrix3fv(location, static_cast<GCGLboolean>(transpose), value);
+    protect(m_context)->uniformMatrix3fv(location, static_cast<GCGLboolean>(transpose), value);
 }
 
 void RemoteGraphicsContextGL::uniformMatrix4fv(int32_t location, bool transpose, std::span<const float>&& value)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniformMatrix4fv(location, static_cast<GCGLboolean>(transpose), value);
+    protect(m_context)->uniformMatrix4fv(location, static_cast<GCGLboolean>(transpose), value);
 }
 
 void RemoteGraphicsContextGL::useProgram(uint32_t arg0)
@@ -942,7 +942,7 @@ void RemoteGraphicsContextGL::useProgram(uint32_t arg0)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    protectedContext()->useProgram(arg0);
+    protect(m_context)->useProgram(arg0);
 }
 
 void RemoteGraphicsContextGL::validateProgram(uint32_t arg0)
@@ -951,164 +951,164 @@ void RemoteGraphicsContextGL::validateProgram(uint32_t arg0)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    protectedContext()->validateProgram(arg0);
+    protect(m_context)->validateProgram(arg0);
 }
 
 void RemoteGraphicsContextGL::vertexAttrib1f(uint32_t index, float x)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttrib1f(index, x);
+    protect(m_context)->vertexAttrib1f(index, x);
 }
 
 void RemoteGraphicsContextGL::vertexAttrib1fv(uint32_t index, std::span<const float, 1>&& values)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttrib1fv(index, values);
+    protect(m_context)->vertexAttrib1fv(index, values);
 }
 
 void RemoteGraphicsContextGL::vertexAttrib2f(uint32_t index, float x, float y)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttrib2f(index, x, y);
+    protect(m_context)->vertexAttrib2f(index, x, y);
 }
 
 void RemoteGraphicsContextGL::vertexAttrib2fv(uint32_t index, std::span<const float, 2>&& values)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttrib2fv(index, values);
+    protect(m_context)->vertexAttrib2fv(index, values);
 }
 
 void RemoteGraphicsContextGL::vertexAttrib3f(uint32_t index, float x, float y, float z)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttrib3f(index, x, y, z);
+    protect(m_context)->vertexAttrib3f(index, x, y, z);
 }
 
 void RemoteGraphicsContextGL::vertexAttrib3fv(uint32_t index, std::span<const float, 3>&& values)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttrib3fv(index, values);
+    protect(m_context)->vertexAttrib3fv(index, values);
 }
 
 void RemoteGraphicsContextGL::vertexAttrib4f(uint32_t index, float x, float y, float z, float w)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttrib4f(index, x, y, z, w);
+    protect(m_context)->vertexAttrib4f(index, x, y, z, w);
 }
 
 void RemoteGraphicsContextGL::vertexAttrib4fv(uint32_t index, std::span<const float, 4>&& values)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttrib4fv(index, values);
+    protect(m_context)->vertexAttrib4fv(index, values);
 }
 
 void RemoteGraphicsContextGL::vertexAttribPointer(uint32_t index, int32_t size, uint32_t type, bool normalized, int32_t stride, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttribPointer(index, size, type, static_cast<GCGLboolean>(normalized), stride, static_cast<GCGLintptr>(offset));
+    protect(m_context)->vertexAttribPointer(index, size, type, static_cast<GCGLboolean>(normalized), stride, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::viewport(int32_t x, int32_t y, int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->viewport(x, y, width, height);
+    protect(m_context)->viewport(x, y, width, height);
 }
 
 void RemoteGraphicsContextGL::bufferData0(uint32_t target, uint64_t arg1, uint32_t usage)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->bufferData(target, static_cast<GCGLsizeiptr>(arg1), usage);
+    protect(m_context)->bufferData(target, static_cast<GCGLsizeiptr>(arg1), usage);
 }
 
 void RemoteGraphicsContextGL::bufferData1(uint32_t target, std::span<const uint8_t>&& data, uint32_t usage)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->bufferData(target, data, usage);
+    protect(m_context)->bufferData(target, data, usage);
 }
 
 void RemoteGraphicsContextGL::bufferSubData(uint32_t target, uint64_t offset, std::span<const uint8_t>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->bufferSubData(target, static_cast<GCGLintptr>(offset), data);
+    protect(m_context)->bufferSubData(target, static_cast<GCGLintptr>(offset), data);
 }
 
 void RemoteGraphicsContextGL::readPixelsBufferObject(WebCore::IntRect&& arg0, uint32_t format, uint32_t type, uint64_t offset, int32_t alignment, int32_t rowLength)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->readPixelsBufferObject(arg0, format, type, static_cast<GCGLintptr>(offset), alignment, rowLength);
+    protect(m_context)->readPixelsBufferObject(arg0, format, type, static_cast<GCGLintptr>(offset), alignment, rowLength);
 }
 
 void RemoteGraphicsContextGL::texImage2D0(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
+    protect(m_context)->texImage2D(target, level, internalformat, width, height, border, format, type, pixels);
 }
 
 void RemoteGraphicsContextGL::texImage2D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, uint32_t format, uint32_t type, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texImage2D(target, level, internalformat, width, height, border, format, type, static_cast<GCGLintptr>(offset));
+    protect(m_context)->texImage2D(target, level, internalformat, width, height, border, format, type, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::texSubImage2D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+    protect(m_context)->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
 }
 
 void RemoteGraphicsContextGL::texSubImage2D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, uint32_t type, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, static_cast<GCGLintptr>(offset));
+    protect(m_context)->texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::compressedTexImage2D0(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, int32_t imageSize, std::span<const uint8_t>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, data);
+    protect(m_context)->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, data);
 }
 
 void RemoteGraphicsContextGL::compressedTexImage2D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t border, int32_t imageSize, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, static_cast<GCGLintptr>(offset));
+    protect(m_context)->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::compressedTexSubImage2D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, int32_t imageSize, std::span<const uint8_t>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, data);
+    protect(m_context)->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, data);
 }
 
 void RemoteGraphicsContextGL::compressedTexSubImage2D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t width, int32_t height, uint32_t format, int32_t imageSize, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<GCGLintptr>(offset));
+    protect(m_context)->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::drawArraysInstanced(uint32_t mode, int32_t first, int32_t count, int32_t primcount)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->drawArraysInstanced(mode, first, count, primcount);
+    protect(m_context)->drawArraysInstanced(mode, first, count, primcount);
 }
 
 void RemoteGraphicsContextGL::drawElementsInstanced(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t primcount)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->drawElementsInstanced(mode, count, type, static_cast<GCGLintptr>(offset), primcount);
+    protect(m_context)->drawElementsInstanced(mode, count, type, static_cast<GCGLintptr>(offset), primcount);
 }
 
 void RemoteGraphicsContextGL::vertexAttribDivisor(uint32_t index, uint32_t divisor)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttribDivisor(index, divisor);
+    protect(m_context)->vertexAttribDivisor(index, divisor);
 }
 
 void RemoteGraphicsContextGL::createVertexArray(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createVertexArray();
+    auto result = protect(m_context)->createVertexArray();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -1120,7 +1120,7 @@ void RemoteGraphicsContextGL::deleteVertexArray(uint32_t arg0)
     if (!arg0) [[unlikely]]
         return;
     arg0 = m_objectNames.take(arg0);
-    protectedContext()->deleteVertexArray(arg0);
+    protect(m_context)->deleteVertexArray(arg0);
 }
 
 void RemoteGraphicsContextGL::isVertexArray(uint32_t arg0, CompletionHandler<void(bool)>&& completionHandler)
@@ -1130,7 +1130,7 @@ void RemoteGraphicsContextGL::isVertexArray(uint32_t arg0, CompletionHandler<voi
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->isVertexArray(arg0);
+    returnValue = protect(m_context)->isVertexArray(arg0);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -1140,19 +1140,19 @@ void RemoteGraphicsContextGL::bindVertexArray(uint32_t arg0)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    protectedContext()->bindVertexArray(arg0);
+    protect(m_context)->bindVertexArray(arg0);
 }
 
 void RemoteGraphicsContextGL::copyBufferSubData(uint32_t readTarget, uint32_t writeTarget, uint64_t readOffset, uint64_t writeOffset, uint64_t arg4)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->copyBufferSubData(readTarget, writeTarget, static_cast<GCGLintptr>(readOffset), static_cast<GCGLintptr>(writeOffset), static_cast<GCGLsizeiptr>(arg4));
+    protect(m_context)->copyBufferSubData(readTarget, writeTarget, static_cast<GCGLintptr>(readOffset), static_cast<GCGLintptr>(writeOffset), static_cast<GCGLsizeiptr>(arg4));
 }
 
 void RemoteGraphicsContextGL::blitFramebuffer(int32_t srcX0, int32_t srcY0, int32_t srcX1, int32_t srcY1, int32_t dstX0, int32_t dstY0, int32_t dstX1, int32_t dstY1, uint32_t mask, uint32_t filter)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    protect(m_context)->blitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
 }
 
 void RemoteGraphicsContextGL::framebufferTextureLayer(uint32_t target, uint32_t attachment, uint32_t texture, int32_t level, int32_t layer)
@@ -1161,85 +1161,85 @@ void RemoteGraphicsContextGL::framebufferTextureLayer(uint32_t target, uint32_t 
     MESSAGE_CHECK(m_objectNames.isValidKey(texture));
     if (texture)
         texture = m_objectNames.get(texture);
-    protectedContext()->framebufferTextureLayer(target, attachment, texture, level, layer);
+    protect(m_context)->framebufferTextureLayer(target, attachment, texture, level, layer);
 }
 
 void RemoteGraphicsContextGL::readBuffer(uint32_t src)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->readBuffer(src);
+    protect(m_context)->readBuffer(src);
 }
 
 void RemoteGraphicsContextGL::renderbufferStorageMultisample(uint32_t target, int32_t samples, uint32_t internalformat, int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->renderbufferStorageMultisample(target, samples, internalformat, width, height);
+    protect(m_context)->renderbufferStorageMultisample(target, samples, internalformat, width, height);
 }
 
 void RemoteGraphicsContextGL::texStorage2D(uint32_t target, int32_t levels, uint32_t internalformat, int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texStorage2D(target, levels, internalformat, width, height);
+    protect(m_context)->texStorage2D(target, levels, internalformat, width, height);
 }
 
 void RemoteGraphicsContextGL::texStorage3D(uint32_t target, int32_t levels, uint32_t internalformat, int32_t width, int32_t height, int32_t depth)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texStorage3D(target, levels, internalformat, width, height, depth);
+    protect(m_context)->texStorage3D(target, levels, internalformat, width, height, depth);
 }
 
 void RemoteGraphicsContextGL::texImage3D0(uint32_t target, int32_t level, int32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texImage3D(target, level, internalformat, width, height, depth, border, format, type, pixels);
+    protect(m_context)->texImage3D(target, level, internalformat, width, height, depth, border, format, type, pixels);
 }
 
 void RemoteGraphicsContextGL::texImage3D1(uint32_t target, int32_t level, int32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, uint32_t format, uint32_t type, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texImage3D(target, level, internalformat, width, height, depth, border, format, type, static_cast<GCGLintptr>(offset));
+    protect(m_context)->texImage3D(target, level, internalformat, width, height, depth, border, format, type, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::texSubImage3D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, uint32_t type, std::span<const uint8_t>&& pixels)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+    protect(m_context)->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
 }
 
 void RemoteGraphicsContextGL::texSubImage3D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, uint32_t type, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<GCGLintptr>(offset));
+    protect(m_context)->texSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::copyTexSubImage3D(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t x, int32_t y, int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->copyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
+    protect(m_context)->copyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
 }
 
 void RemoteGraphicsContextGL::compressedTexImage3D0(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, int32_t imageSize, std::span<const uint8_t>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, data);
+    protect(m_context)->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, data);
 }
 
 void RemoteGraphicsContextGL::compressedTexImage3D1(uint32_t target, int32_t level, uint32_t internalformat, int32_t width, int32_t height, int32_t depth, int32_t border, int32_t imageSize, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, static_cast<GCGLintptr>(offset));
+    protect(m_context)->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::compressedTexSubImage3D0(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, int32_t imageSize, std::span<const uint8_t>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+    protect(m_context)->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
 }
 
 void RemoteGraphicsContextGL::compressedTexSubImage3D1(uint32_t target, int32_t level, int32_t xoffset, int32_t yoffset, int32_t zoffset, int32_t width, int32_t height, int32_t depth, uint32_t format, int32_t imageSize, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<GCGLintptr>(offset));
+    protect(m_context)->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::getFragDataLocation(uint32_t program, CString&& name, CompletionHandler<void(int32_t)>&& completionHandler)
@@ -1249,159 +1249,159 @@ void RemoteGraphicsContextGL::getFragDataLocation(uint32_t program, CString&& na
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
-    returnValue = protectedContext()->getFragDataLocation(program, name);
+    returnValue = protect(m_context)->getFragDataLocation(program, name);
     completionHandler(returnValue);
 }
 
 void RemoteGraphicsContextGL::uniform1ui(int32_t location, uint32_t v0)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform1ui(location, v0);
+    protect(m_context)->uniform1ui(location, v0);
 }
 
 void RemoteGraphicsContextGL::uniform2ui(int32_t location, uint32_t v0, uint32_t v1)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform2ui(location, v0, v1);
+    protect(m_context)->uniform2ui(location, v0, v1);
 }
 
 void RemoteGraphicsContextGL::uniform3ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform3ui(location, v0, v1, v2);
+    protect(m_context)->uniform3ui(location, v0, v1, v2);
 }
 
 void RemoteGraphicsContextGL::uniform4ui(int32_t location, uint32_t v0, uint32_t v1, uint32_t v2, uint32_t v3)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform4ui(location, v0, v1, v2, v3);
+    protect(m_context)->uniform4ui(location, v0, v1, v2, v3);
 }
 
 void RemoteGraphicsContextGL::uniform1uiv(int32_t location, std::span<const uint32_t>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform1uiv(location, data);
+    protect(m_context)->uniform1uiv(location, data);
 }
 
 void RemoteGraphicsContextGL::uniform2uiv(int32_t location, std::span<const uint32_t>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform2uiv(location, data);
+    protect(m_context)->uniform2uiv(location, data);
 }
 
 void RemoteGraphicsContextGL::uniform3uiv(int32_t location, std::span<const uint32_t>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform3uiv(location, data);
+    protect(m_context)->uniform3uiv(location, data);
 }
 
 void RemoteGraphicsContextGL::uniform4uiv(int32_t location, std::span<const uint32_t>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniform4uiv(location, data);
+    protect(m_context)->uniform4uiv(location, data);
 }
 
 void RemoteGraphicsContextGL::uniformMatrix2x3fv(int32_t location, bool transpose, std::span<const float>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniformMatrix2x3fv(location, static_cast<GCGLboolean>(transpose), data);
+    protect(m_context)->uniformMatrix2x3fv(location, static_cast<GCGLboolean>(transpose), data);
 }
 
 void RemoteGraphicsContextGL::uniformMatrix3x2fv(int32_t location, bool transpose, std::span<const float>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniformMatrix3x2fv(location, static_cast<GCGLboolean>(transpose), data);
+    protect(m_context)->uniformMatrix3x2fv(location, static_cast<GCGLboolean>(transpose), data);
 }
 
 void RemoteGraphicsContextGL::uniformMatrix2x4fv(int32_t location, bool transpose, std::span<const float>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniformMatrix2x4fv(location, static_cast<GCGLboolean>(transpose), data);
+    protect(m_context)->uniformMatrix2x4fv(location, static_cast<GCGLboolean>(transpose), data);
 }
 
 void RemoteGraphicsContextGL::uniformMatrix4x2fv(int32_t location, bool transpose, std::span<const float>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniformMatrix4x2fv(location, static_cast<GCGLboolean>(transpose), data);
+    protect(m_context)->uniformMatrix4x2fv(location, static_cast<GCGLboolean>(transpose), data);
 }
 
 void RemoteGraphicsContextGL::uniformMatrix3x4fv(int32_t location, bool transpose, std::span<const float>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniformMatrix3x4fv(location, static_cast<GCGLboolean>(transpose), data);
+    protect(m_context)->uniformMatrix3x4fv(location, static_cast<GCGLboolean>(transpose), data);
 }
 
 void RemoteGraphicsContextGL::uniformMatrix4x3fv(int32_t location, bool transpose, std::span<const float>&& data)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->uniformMatrix4x3fv(location, static_cast<GCGLboolean>(transpose), data);
+    protect(m_context)->uniformMatrix4x3fv(location, static_cast<GCGLboolean>(transpose), data);
 }
 
 void RemoteGraphicsContextGL::vertexAttribI4i(uint32_t index, int32_t x, int32_t y, int32_t z, int32_t w)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttribI4i(index, x, y, z, w);
+    protect(m_context)->vertexAttribI4i(index, x, y, z, w);
 }
 
 void RemoteGraphicsContextGL::vertexAttribI4iv(uint32_t index, std::span<const int32_t, 4>&& values)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttribI4iv(index, values);
+    protect(m_context)->vertexAttribI4iv(index, values);
 }
 
 void RemoteGraphicsContextGL::vertexAttribI4ui(uint32_t index, uint32_t x, uint32_t y, uint32_t z, uint32_t w)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttribI4ui(index, x, y, z, w);
+    protect(m_context)->vertexAttribI4ui(index, x, y, z, w);
 }
 
 void RemoteGraphicsContextGL::vertexAttribI4uiv(uint32_t index, std::span<const uint32_t, 4>&& values)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttribI4uiv(index, values);
+    protect(m_context)->vertexAttribI4uiv(index, values);
 }
 
 void RemoteGraphicsContextGL::vertexAttribIPointer(uint32_t index, int32_t size, uint32_t type, int32_t stride, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->vertexAttribIPointer(index, size, type, stride, static_cast<GCGLintptr>(offset));
+    protect(m_context)->vertexAttribIPointer(index, size, type, stride, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::drawRangeElements(uint32_t mode, uint32_t start, uint32_t end, int32_t count, uint32_t type, uint64_t offset)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->drawRangeElements(mode, start, end, count, type, static_cast<GCGLintptr>(offset));
+    protect(m_context)->drawRangeElements(mode, start, end, count, type, static_cast<GCGLintptr>(offset));
 }
 
 void RemoteGraphicsContextGL::clearBufferiv(uint32_t buffer, int32_t drawbuffer, std::span<const int32_t>&& values)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->clearBufferiv(buffer, drawbuffer, values);
+    protect(m_context)->clearBufferiv(buffer, drawbuffer, values);
 }
 
 void RemoteGraphicsContextGL::clearBufferuiv(uint32_t buffer, int32_t drawbuffer, std::span<const uint32_t>&& values)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->clearBufferuiv(buffer, drawbuffer, values);
+    protect(m_context)->clearBufferuiv(buffer, drawbuffer, values);
 }
 
 void RemoteGraphicsContextGL::clearBufferfv(uint32_t buffer, int32_t drawbuffer, std::span<const float>&& values)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->clearBufferfv(buffer, drawbuffer, values);
+    protect(m_context)->clearBufferfv(buffer, drawbuffer, values);
 }
 
 void RemoteGraphicsContextGL::clearBufferfi(uint32_t buffer, int32_t drawbuffer, float depth, int32_t stencil)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->clearBufferfi(buffer, drawbuffer, depth, stencil);
+    protect(m_context)->clearBufferfi(buffer, drawbuffer, depth, stencil);
 }
 
 void RemoteGraphicsContextGL::createQuery(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createQuery();
+    auto result = protect(m_context)->createQuery();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -1413,7 +1413,7 @@ void RemoteGraphicsContextGL::deleteQuery(uint32_t query)
     if (!query) [[unlikely]]
         return;
     query = m_objectNames.take(query);
-    protectedContext()->deleteQuery(query);
+    protect(m_context)->deleteQuery(query);
 }
 
 void RemoteGraphicsContextGL::isQuery(uint32_t query, CompletionHandler<void(bool)>&& completionHandler)
@@ -1423,7 +1423,7 @@ void RemoteGraphicsContextGL::isQuery(uint32_t query, CompletionHandler<void(boo
     MESSAGE_CHECK(m_objectNames.isValidKey(query));
     if (query)
         query = m_objectNames.get(query);
-    returnValue = protectedContext()->isQuery(query);
+    returnValue = protect(m_context)->isQuery(query);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -1433,20 +1433,20 @@ void RemoteGraphicsContextGL::beginQuery(uint32_t target, uint32_t query)
     MESSAGE_CHECK(m_objectNames.isValidKey(query));
     if (query)
         query = m_objectNames.get(query);
-    protectedContext()->beginQuery(target, query);
+    protect(m_context)->beginQuery(target, query);
 }
 
 void RemoteGraphicsContextGL::endQuery(uint32_t target)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->endQuery(target);
+    protect(m_context)->endQuery(target);
 }
 
 void RemoteGraphicsContextGL::getQuery(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     GCGLint returnValue = { };
-    returnValue = protectedContext()->getQuery(target, pname);
+    returnValue = protect(m_context)->getQuery(target, pname);
     completionHandler(returnValue);
 }
 
@@ -1457,7 +1457,7 @@ void RemoteGraphicsContextGL::getQueryObjectui(uint32_t query, uint32_t pname, C
     MESSAGE_CHECK(m_objectNames.isValidKey(query));
     if (query)
         query = m_objectNames.get(query);
-    returnValue = protectedContext()->getQueryObjectui(query, pname);
+    returnValue = protect(m_context)->getQueryObjectui(query, pname);
     completionHandler(returnValue);
 }
 
@@ -1465,7 +1465,7 @@ void RemoteGraphicsContextGL::createSampler(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createSampler();
+    auto result = protect(m_context)->createSampler();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -1477,7 +1477,7 @@ void RemoteGraphicsContextGL::deleteSampler(uint32_t sampler)
     if (!sampler) [[unlikely]]
         return;
     sampler = m_objectNames.take(sampler);
-    protectedContext()->deleteSampler(sampler);
+    protect(m_context)->deleteSampler(sampler);
 }
 
 void RemoteGraphicsContextGL::isSampler(uint32_t sampler, CompletionHandler<void(bool)>&& completionHandler)
@@ -1487,7 +1487,7 @@ void RemoteGraphicsContextGL::isSampler(uint32_t sampler, CompletionHandler<void
     MESSAGE_CHECK(m_objectNames.isValidKey(sampler));
     if (sampler)
         sampler = m_objectNames.get(sampler);
-    returnValue = protectedContext()->isSampler(sampler);
+    returnValue = protect(m_context)->isSampler(sampler);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -1497,7 +1497,7 @@ void RemoteGraphicsContextGL::bindSampler(uint32_t unit, uint32_t sampler)
     MESSAGE_CHECK(m_objectNames.isValidKey(sampler));
     if (sampler)
         sampler = m_objectNames.get(sampler);
-    protectedContext()->bindSampler(unit, sampler);
+    protect(m_context)->bindSampler(unit, sampler);
 }
 
 void RemoteGraphicsContextGL::samplerParameteri(uint32_t sampler, uint32_t pname, int32_t param)
@@ -1506,7 +1506,7 @@ void RemoteGraphicsContextGL::samplerParameteri(uint32_t sampler, uint32_t pname
     MESSAGE_CHECK(m_objectNames.isValidKey(sampler));
     if (sampler)
         sampler = m_objectNames.get(sampler);
-    protectedContext()->samplerParameteri(sampler, pname, param);
+    protect(m_context)->samplerParameteri(sampler, pname, param);
 }
 
 void RemoteGraphicsContextGL::samplerParameterf(uint32_t sampler, uint32_t pname, float param)
@@ -1515,7 +1515,7 @@ void RemoteGraphicsContextGL::samplerParameterf(uint32_t sampler, uint32_t pname
     MESSAGE_CHECK(m_objectNames.isValidKey(sampler));
     if (sampler)
         sampler = m_objectNames.get(sampler);
-    protectedContext()->samplerParameterf(sampler, pname, param);
+    protect(m_context)->samplerParameterf(sampler, pname, param);
 }
 
 void RemoteGraphicsContextGL::getSamplerParameterf(uint32_t sampler, uint32_t pname, CompletionHandler<void(float)>&& completionHandler)
@@ -1525,7 +1525,7 @@ void RemoteGraphicsContextGL::getSamplerParameterf(uint32_t sampler, uint32_t pn
     MESSAGE_CHECK(m_objectNames.isValidKey(sampler));
     if (sampler)
         sampler = m_objectNames.get(sampler);
-    returnValue = protectedContext()->getSamplerParameterf(sampler, pname);
+    returnValue = protect(m_context)->getSamplerParameterf(sampler, pname);
     completionHandler(returnValue);
 }
 
@@ -1536,7 +1536,7 @@ void RemoteGraphicsContextGL::getSamplerParameteri(uint32_t sampler, uint32_t pn
     MESSAGE_CHECK(m_objectNames.isValidKey(sampler));
     if (sampler)
         sampler = m_objectNames.get(sampler);
-    returnValue = protectedContext()->getSamplerParameteri(sampler, pname);
+    returnValue = protect(m_context)->getSamplerParameteri(sampler, pname);
     completionHandler(returnValue);
 }
 
@@ -1544,7 +1544,7 @@ void RemoteGraphicsContextGL::fenceSync(uint32_t condition, uint32_t flags, Comp
 {
     assertIsCurrent(workQueue());
     GCGLsync returnValue = { };
-    returnValue = protectedContext()->fenceSync(condition, flags);
+    returnValue = protect(m_context)->fenceSync(condition, flags);
     completionHandler(static_cast<uint64_t>(reinterpret_cast<intptr_t>(returnValue)));
 }
 
@@ -1552,35 +1552,35 @@ void RemoteGraphicsContextGL::isSync(uint64_t arg0, CompletionHandler<void(bool)
 {
     assertIsCurrent(workQueue());
     GCGLboolean returnValue = { };
-    returnValue = protectedContext()->isSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)));
+    returnValue = protect(m_context)->isSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)));
     completionHandler(static_cast<bool>(returnValue));
 }
 
 void RemoteGraphicsContextGL::deleteSync(uint64_t arg0)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->deleteSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)));
+    protect(m_context)->deleteSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)));
 }
 
 void RemoteGraphicsContextGL::clientWaitSync(uint64_t arg0, uint32_t flags, uint64_t timeout, CompletionHandler<void(uint32_t)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     GCGLenum returnValue = { };
-    returnValue = protectedContext()->clientWaitSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), flags, static_cast<GCGLuint64>(timeout));
+    returnValue = protect(m_context)->clientWaitSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), flags, static_cast<GCGLuint64>(timeout));
     completionHandler(returnValue);
 }
 
 void RemoteGraphicsContextGL::waitSync(uint64_t arg0, uint32_t flags, int64_t timeout)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->waitSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), flags, static_cast<GCGLint64>(timeout));
+    protect(m_context)->waitSync(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), flags, static_cast<GCGLint64>(timeout));
 }
 
 void RemoteGraphicsContextGL::getSynci(uint64_t arg0, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     GCGLint returnValue = { };
-    returnValue = protectedContext()->getSynci(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), pname);
+    returnValue = protect(m_context)->getSynci(reinterpret_cast<GCGLsync>(static_cast<intptr_t>(arg0)), pname);
     completionHandler(returnValue);
 }
 
@@ -1588,7 +1588,7 @@ void RemoteGraphicsContextGL::createTransformFeedback(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createTransformFeedback();
+    auto result = protect(m_context)->createTransformFeedback();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -1600,7 +1600,7 @@ void RemoteGraphicsContextGL::deleteTransformFeedback(uint32_t id)
     if (!id) [[unlikely]]
         return;
     id = m_objectNames.take(id);
-    protectedContext()->deleteTransformFeedback(id);
+    protect(m_context)->deleteTransformFeedback(id);
 }
 
 void RemoteGraphicsContextGL::isTransformFeedback(uint32_t id, CompletionHandler<void(bool)>&& completionHandler)
@@ -1610,7 +1610,7 @@ void RemoteGraphicsContextGL::isTransformFeedback(uint32_t id, CompletionHandler
     MESSAGE_CHECK(m_objectNames.isValidKey(id));
     if (id)
         id = m_objectNames.get(id);
-    returnValue = protectedContext()->isTransformFeedback(id);
+    returnValue = protect(m_context)->isTransformFeedback(id);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -1620,19 +1620,19 @@ void RemoteGraphicsContextGL::bindTransformFeedback(uint32_t target, uint32_t id
     MESSAGE_CHECK(m_objectNames.isValidKey(id));
     if (id)
         id = m_objectNames.get(id);
-    protectedContext()->bindTransformFeedback(target, id);
+    protect(m_context)->bindTransformFeedback(target, id);
 }
 
 void RemoteGraphicsContextGL::beginTransformFeedback(uint32_t primitiveMode)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->beginTransformFeedback(primitiveMode);
+    protect(m_context)->beginTransformFeedback(primitiveMode);
 }
 
 void RemoteGraphicsContextGL::endTransformFeedback()
 {
     assertIsCurrent(workQueue());
-    protectedContext()->endTransformFeedback();
+    protect(m_context)->endTransformFeedback();
 }
 
 void RemoteGraphicsContextGL::transformFeedbackVaryings(uint32_t program, Vector<CString>&& varyings, uint32_t bufferMode)
@@ -1641,7 +1641,7 @@ void RemoteGraphicsContextGL::transformFeedbackVaryings(uint32_t program, Vector
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
-    protectedContext()->transformFeedbackVaryings(program, varyings, bufferMode);
+    protect(m_context)->transformFeedbackVaryings(program, varyings, bufferMode);
 }
 
 void RemoteGraphicsContextGL::getTransformFeedbackVarying(uint32_t program, uint32_t index, CompletionHandler<void(std::optional<WebCore::GCGLTransformFeedbackActiveInfo>&&)>&& completionHandler)
@@ -1651,20 +1651,20 @@ void RemoteGraphicsContextGL::getTransformFeedbackVarying(uint32_t program, uint
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
-    returnValue = protectedContext()->getTransformFeedbackVarying(program, index);
+    returnValue = protect(m_context)->getTransformFeedbackVarying(program, index);
     completionHandler(WTF::move(returnValue));
 }
 
 void RemoteGraphicsContextGL::pauseTransformFeedback()
 {
     assertIsCurrent(workQueue());
-    protectedContext()->pauseTransformFeedback();
+    protect(m_context)->pauseTransformFeedback();
 }
 
 void RemoteGraphicsContextGL::resumeTransformFeedback()
 {
     assertIsCurrent(workQueue());
-    protectedContext()->resumeTransformFeedback();
+    protect(m_context)->resumeTransformFeedback();
 }
 
 void RemoteGraphicsContextGL::bindBufferBase(uint32_t target, uint32_t index, uint32_t buffer)
@@ -1673,7 +1673,7 @@ void RemoteGraphicsContextGL::bindBufferBase(uint32_t target, uint32_t index, ui
     MESSAGE_CHECK(m_objectNames.isValidKey(buffer));
     if (buffer)
         buffer = m_objectNames.get(buffer);
-    protectedContext()->bindBufferBase(target, index, buffer);
+    protect(m_context)->bindBufferBase(target, index, buffer);
 }
 
 void RemoteGraphicsContextGL::bindBufferRange(uint32_t target, uint32_t index, uint32_t buffer, uint64_t offset, uint64_t arg4)
@@ -1682,7 +1682,7 @@ void RemoteGraphicsContextGL::bindBufferRange(uint32_t target, uint32_t index, u
     MESSAGE_CHECK(m_objectNames.isValidKey(buffer));
     if (buffer)
         buffer = m_objectNames.get(buffer);
-    protectedContext()->bindBufferRange(target, index, buffer, static_cast<GCGLintptr>(offset), static_cast<GCGLsizeiptr>(arg4));
+    protect(m_context)->bindBufferRange(target, index, buffer, static_cast<GCGLintptr>(offset), static_cast<GCGLsizeiptr>(arg4));
 }
 
 void RemoteGraphicsContextGL::getUniformBlockIndex(uint32_t program, CString&& uniformBlockName, CompletionHandler<void(uint32_t)>&& completionHandler)
@@ -1692,7 +1692,7 @@ void RemoteGraphicsContextGL::getUniformBlockIndex(uint32_t program, CString&& u
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
-    returnValue = protectedContext()->getUniformBlockIndex(program, uniformBlockName);
+    returnValue = protect(m_context)->getUniformBlockIndex(program, uniformBlockName);
     completionHandler(returnValue);
 }
 
@@ -1703,7 +1703,7 @@ void RemoteGraphicsContextGL::getActiveUniformBlockName(uint32_t program, uint32
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
-    returnValue = protectedContext()->getActiveUniformBlockName(program, uniformBlockIndex);
+    returnValue = protect(m_context)->getActiveUniformBlockName(program, uniformBlockIndex);
     completionHandler(WTF::move(returnValue));
 }
 
@@ -1713,7 +1713,7 @@ void RemoteGraphicsContextGL::uniformBlockBinding(uint32_t program, uint32_t uni
     MESSAGE_CHECK(m_objectNames.isValidKey(program));
     if (program)
         program = m_objectNames.get(program);
-    protectedContext()->uniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
+    protect(m_context)->uniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
 }
 
 void RemoteGraphicsContextGL::getActiveUniformBlockiv(uint32_t program, uint32_t uniformBlockIndex, uint32_t pname, uint64_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
@@ -1725,7 +1725,7 @@ void RemoteGraphicsContextGL::getActiveUniformBlockiv(uint32_t program, uint32_t
     if (!WTF::isValidCapacityForVector<GCGLint>(paramsSize))
         paramsSize = 4;
     Vector<GCGLint, 4> params(paramsSize, 0);
-    protectedContext()->getActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
+    protect(m_context)->getActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
     completionHandler(spanReinterpretCast<const int32_t>(params.span()));
 }
 
@@ -1736,7 +1736,7 @@ void RemoteGraphicsContextGL::getTranslatedShaderSourceANGLE(uint32_t arg0, Comp
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    returnValue = protectedContext()->getTranslatedShaderSourceANGLE(arg0);
+    returnValue = protect(m_context)->getTranslatedShaderSourceANGLE(arg0);
     completionHandler(WTF::move(returnValue));
 }
 
@@ -1744,7 +1744,7 @@ void RemoteGraphicsContextGL::createQueryEXT(uint32_t name)
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createQueryEXT();
+    auto result = protect(m_context)->createQueryEXT();
     if (result)
         m_objectNames.add(name, result);
 }
@@ -1756,7 +1756,7 @@ void RemoteGraphicsContextGL::deleteQueryEXT(uint32_t query)
     if (!query) [[unlikely]]
         return;
     query = m_objectNames.take(query);
-    protectedContext()->deleteQueryEXT(query);
+    protect(m_context)->deleteQueryEXT(query);
 }
 
 void RemoteGraphicsContextGL::isQueryEXT(uint32_t query, CompletionHandler<void(bool)>&& completionHandler)
@@ -1766,7 +1766,7 @@ void RemoteGraphicsContextGL::isQueryEXT(uint32_t query, CompletionHandler<void(
     MESSAGE_CHECK(m_objectNames.isValidKey(query));
     if (query)
         query = m_objectNames.get(query);
-    returnValue = protectedContext()->isQueryEXT(query);
+    returnValue = protect(m_context)->isQueryEXT(query);
     completionHandler(static_cast<bool>(returnValue));
 }
 
@@ -1776,13 +1776,13 @@ void RemoteGraphicsContextGL::beginQueryEXT(uint32_t target, uint32_t query)
     MESSAGE_CHECK(m_objectNames.isValidKey(query));
     if (query)
         query = m_objectNames.get(query);
-    protectedContext()->beginQueryEXT(target, query);
+    protect(m_context)->beginQueryEXT(target, query);
 }
 
 void RemoteGraphicsContextGL::endQueryEXT(uint32_t target)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->endQueryEXT(target);
+    protect(m_context)->endQueryEXT(target);
 }
 
 void RemoteGraphicsContextGL::queryCounterEXT(uint32_t query, uint32_t target)
@@ -1791,14 +1791,14 @@ void RemoteGraphicsContextGL::queryCounterEXT(uint32_t query, uint32_t target)
     MESSAGE_CHECK(m_objectNames.isValidKey(query));
     if (query)
         query = m_objectNames.get(query);
-    protectedContext()->queryCounterEXT(query, target);
+    protect(m_context)->queryCounterEXT(query, target);
 }
 
 void RemoteGraphicsContextGL::getQueryiEXT(uint32_t target, uint32_t pname, CompletionHandler<void(int32_t)>&& completionHandler)
 {
     assertIsCurrent(workQueue());
     GCGLint returnValue = { };
-    returnValue = protectedContext()->getQueryiEXT(target, pname);
+    returnValue = protect(m_context)->getQueryiEXT(target, pname);
     completionHandler(returnValue);
 }
 
@@ -1809,7 +1809,7 @@ void RemoteGraphicsContextGL::getQueryObjectiEXT(uint32_t query, uint32_t pname,
     MESSAGE_CHECK(m_objectNames.isValidKey(query));
     if (query)
         query = m_objectNames.get(query);
-    returnValue = protectedContext()->getQueryObjectiEXT(query, pname);
+    returnValue = protect(m_context)->getQueryObjectiEXT(query, pname);
     completionHandler(returnValue);
 }
 
@@ -1820,7 +1820,7 @@ void RemoteGraphicsContextGL::getQueryObjectui64EXT(uint32_t query, uint32_t pna
     MESSAGE_CHECK(m_objectNames.isValidKey(query));
     if (query)
         query = m_objectNames.get(query);
-    returnValue = protectedContext()->getQueryObjectui64EXT(query, pname);
+    returnValue = protect(m_context)->getQueryObjectui64EXT(query, pname);
     completionHandler(static_cast<uint64_t>(returnValue));
 }
 
@@ -1828,92 +1828,92 @@ void RemoteGraphicsContextGL::getInteger64EXT(uint32_t pname, CompletionHandler<
 {
     assertIsCurrent(workQueue());
     GCGLint64 returnValue = { };
-    returnValue = protectedContext()->getInteger64EXT(pname);
+    returnValue = protect(m_context)->getInteger64EXT(pname);
     completionHandler(static_cast<int64_t>(returnValue));
 }
 
 void RemoteGraphicsContextGL::enableiOES(uint32_t target, uint32_t index)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->enableiOES(target, index);
+    protect(m_context)->enableiOES(target, index);
 }
 
 void RemoteGraphicsContextGL::disableiOES(uint32_t target, uint32_t index)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->disableiOES(target, index);
+    protect(m_context)->disableiOES(target, index);
 }
 
 void RemoteGraphicsContextGL::blendEquationiOES(uint32_t buf, uint32_t mode)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blendEquationiOES(buf, mode);
+    protect(m_context)->blendEquationiOES(buf, mode);
 }
 
 void RemoteGraphicsContextGL::blendEquationSeparateiOES(uint32_t buf, uint32_t modeRGB, uint32_t modeAlpha)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
+    protect(m_context)->blendEquationSeparateiOES(buf, modeRGB, modeAlpha);
 }
 
 void RemoteGraphicsContextGL::blendFunciOES(uint32_t buf, uint32_t src, uint32_t dst)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blendFunciOES(buf, src, dst);
+    protect(m_context)->blendFunciOES(buf, src, dst);
 }
 
 void RemoteGraphicsContextGL::blendFuncSeparateiOES(uint32_t buf, uint32_t srcRGB, uint32_t dstRGB, uint32_t srcAlpha, uint32_t dstAlpha)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
+    protect(m_context)->blendFuncSeparateiOES(buf, srcRGB, dstRGB, srcAlpha, dstAlpha);
 }
 
 void RemoteGraphicsContextGL::colorMaskiOES(uint32_t buf, bool red, bool green, bool blue, bool alpha)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->colorMaskiOES(buf, static_cast<GCGLboolean>(red), static_cast<GCGLboolean>(green), static_cast<GCGLboolean>(blue), static_cast<GCGLboolean>(alpha));
+    protect(m_context)->colorMaskiOES(buf, static_cast<GCGLboolean>(red), static_cast<GCGLboolean>(green), static_cast<GCGLboolean>(blue), static_cast<GCGLboolean>(alpha));
 }
 
 void RemoteGraphicsContextGL::drawArraysInstancedBaseInstanceANGLE(uint32_t mode, int32_t first, int32_t count, int32_t instanceCount, uint32_t baseInstance)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
+    protect(m_context)->drawArraysInstancedBaseInstanceANGLE(mode, first, count, instanceCount, baseInstance);
 }
 
 void RemoteGraphicsContextGL::drawElementsInstancedBaseVertexBaseInstanceANGLE(uint32_t mode, int32_t count, uint32_t type, uint64_t offset, int32_t instanceCount, int32_t baseVertex, uint32_t baseInstance)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<GCGLintptr>(offset), instanceCount, baseVertex, baseInstance);
+    protect(m_context)->drawElementsInstancedBaseVertexBaseInstanceANGLE(mode, count, type, static_cast<GCGLintptr>(offset), instanceCount, baseVertex, baseInstance);
 }
 
 void RemoteGraphicsContextGL::clipControlEXT(uint32_t origin, uint32_t depth)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->clipControlEXT(origin, depth);
+    protect(m_context)->clipControlEXT(origin, depth);
 }
 
 void RemoteGraphicsContextGL::provokingVertexANGLE(uint32_t provokeMode)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->provokingVertexANGLE(provokeMode);
+    protect(m_context)->provokingVertexANGLE(provokeMode);
 }
 
 void RemoteGraphicsContextGL::polygonModeANGLE(uint32_t face, uint32_t mode)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->polygonModeANGLE(face, mode);
+    protect(m_context)->polygonModeANGLE(face, mode);
 }
 
 void RemoteGraphicsContextGL::polygonOffsetClampEXT(float factor, float units, float clamp)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->polygonOffsetClampEXT(factor, units, clamp);
+    protect(m_context)->polygonOffsetClampEXT(factor, units, clamp);
 }
 
 void RemoteGraphicsContextGL::renderbufferStorageMultisampleANGLE(uint32_t target, int32_t samples, uint32_t internalformat, int32_t width, int32_t height)
 {
     assertIsCurrent(workQueue());
-    protectedContext()->renderbufferStorageMultisampleANGLE(target, samples, internalformat, width, height);
+    protect(m_context)->renderbufferStorageMultisampleANGLE(target, samples, internalformat, width, height);
 }
 
 void RemoteGraphicsContextGL::getInternalformativ(uint32_t target, uint32_t internalformat, uint32_t pname, uint64_t paramsSize, CompletionHandler<void(std::span<const int32_t>)>&& completionHandler)
@@ -1922,7 +1922,7 @@ void RemoteGraphicsContextGL::getInternalformativ(uint32_t target, uint32_t inte
     if (!WTF::isValidCapacityForVector<GCGLint>(paramsSize))
         paramsSize = 4;
     Vector<GCGLint, 4> params(paramsSize, 0);
-    protectedContext()->getInternalformativ(target, internalformat, pname, params);
+    protect(m_context)->getInternalformativ(target, internalformat, pname, params);
     completionHandler(spanReinterpretCast<const int32_t>(params.span()));
 }
 
@@ -1932,7 +1932,7 @@ void RemoteGraphicsContextGL::createExternalImage(uint32_t name, WebCore::Graphi
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(webXRPromptAccepted());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createExternalImage(WTF::move(arg0), internalFormat, layer);
+    auto result = protect(m_context)->createExternalImage(WTF::move(arg0), internalFormat, layer);
     if (result)
         m_objectNames.add(name, result);
 }
@@ -1945,7 +1945,7 @@ void RemoteGraphicsContextGL::deleteExternalImage(uint32_t handle)
     if (!handle) [[unlikely]]
         return;
     handle = m_objectNames.take(handle);
-    protectedContext()->deleteExternalImage(handle);
+    protect(m_context)->deleteExternalImage(handle);
 }
 
 void RemoteGraphicsContextGL::bindExternalImage(uint32_t target, uint32_t arg1)
@@ -1955,7 +1955,7 @@ void RemoteGraphicsContextGL::bindExternalImage(uint32_t target, uint32_t arg1)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg1));
     if (arg1)
         arg1 = m_objectNames.get(arg1);
-    protectedContext()->bindExternalImage(target, arg1);
+    protect(m_context)->bindExternalImage(target, arg1);
 }
 
 void RemoteGraphicsContextGL::createExternalSync(uint32_t name, WebCore::GraphicsContextGL::ExternalSyncSource&& arg0)
@@ -1963,7 +1963,7 @@ void RemoteGraphicsContextGL::createExternalSync(uint32_t name, WebCore::Graphic
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(webXRPromptAccepted());
     MESSAGE_CHECK(m_objectNames.isValidKey(name));
-    auto result = protectedContext()->createExternalSync(WTF::move(arg0));
+    auto result = protect(m_context)->createExternalSync(WTF::move(arg0));
     if (result)
         m_objectNames.add(name, result);
 }
@@ -1976,7 +1976,7 @@ void RemoteGraphicsContextGL::deleteExternalSync(uint32_t arg0)
     if (!arg0) [[unlikely]]
         return;
     arg0 = m_objectNames.take(arg0);
-    protectedContext()->deleteExternalSync(arg0);
+    protect(m_context)->deleteExternalSync(arg0);
 }
 
 void RemoteGraphicsContextGL::enableRequiredWebXRExtensions(CompletionHandler<void(bool)>&& completionHandler)
@@ -1984,7 +1984,7 @@ void RemoteGraphicsContextGL::enableRequiredWebXRExtensions(CompletionHandler<vo
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(webXREnabled());
     bool returnValue = { };
-    returnValue = protectedContext()->enableRequiredWebXRExtensions();
+    returnValue = protect(m_context)->enableRequiredWebXRExtensions();
     completionHandler(returnValue);
 }
 
@@ -1993,7 +1993,7 @@ void RemoteGraphicsContextGL::addFoveation(WebCore::IntSize&& physicalSizeLeft, 
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(webXRPromptAccepted());
     bool returnValue = { };
-    returnValue = protectedContext()->addFoveation(physicalSizeLeft, physicalSizeRight, screenSize, horizontalSamplesLeft, verticalSamples, horizontalSamplesRight);
+    returnValue = protect(m_context)->addFoveation(physicalSizeLeft, physicalSizeRight, screenSize, horizontalSamplesLeft, verticalSamples, horizontalSamplesRight);
     completionHandler(returnValue);
 }
 
@@ -2004,14 +2004,14 @@ void RemoteGraphicsContextGL::enableFoveation(uint32_t arg0)
     MESSAGE_CHECK(m_objectNames.isValidKey(arg0));
     if (arg0)
         arg0 = m_objectNames.get(arg0);
-    protectedContext()->enableFoveation(arg0);
+    protect(m_context)->enableFoveation(arg0);
 }
 
 void RemoteGraphicsContextGL::disableFoveation()
 {
     assertIsCurrent(workQueue());
     MESSAGE_CHECK(webXRPromptAccepted());
-    protectedContext()->disableFoveation();
+    protect(m_context)->disableFoveation();
 }
 
 void RemoteGraphicsContextGL::framebufferResolveRenderbuffer(uint32_t target, uint32_t attachment, uint32_t renderbuffertarget, uint32_t arg3)
@@ -2021,7 +2021,7 @@ void RemoteGraphicsContextGL::framebufferResolveRenderbuffer(uint32_t target, ui
     MESSAGE_CHECK(m_objectNames.isValidKey(arg3));
     if (arg3)
         arg3 = m_objectNames.get(arg3);
-    protectedContext()->framebufferResolveRenderbuffer(target, attachment, renderbuffertarget, arg3);
+    protect(m_context)->framebufferResolveRenderbuffer(target, attachment, renderbuffertarget, arg3);
 }
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp
@@ -121,9 +121,9 @@ void RemoteImageBufferSet::ensureBufferForDisplay(ImageBufferSetPrepareBufferFor
 {
     assertIsCurrent(workQueue());
     LOG_WITH_STREAM(RemoteLayerBuffers, stream << "GPU Process: ::ensureFrontBufferForDisplay " << " - front "
-        << m_frontBuffer << " (in-use " << (m_frontBuffer && protectedFrontBuffer()->isInUse()) << ") "
-        << m_backBuffer << " (in-use " << (m_backBuffer && protectedBackBuffer()->isInUse()) << ") "
-        << m_secondaryBackBuffer << " (in-use " << (m_secondaryBackBuffer && protectedSecondaryBackBuffer()->isInUse()) << ") ");
+        << m_frontBuffer << " (in-use " << (m_frontBuffer && protect(m_frontBuffer)->isInUse()) << ") "
+        << m_backBuffer << " (in-use " << (m_backBuffer && protect(m_backBuffer)->isInUse()) << ") "
+        << m_secondaryBackBuffer << " (in-use " << (m_secondaryBackBuffer && protect(m_secondaryBackBuffer)->isInUse()) << ") ");
 
     displayRequirement = swapBuffersForDisplay(inputData.hasEmptyDirtyRegion, inputData.supportsPartialRepaint && !isSmallLayerBacking({ m_configuration.logicalSize, m_configuration.resolutionScale, m_configuration.colorSpace, m_configuration.bufferFormat, m_configuration.renderingPurpose }));
     if (displayRequirement == SwapBuffersDisplayRequirement::NeedsFullDisplay) {

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp
@@ -121,7 +121,7 @@ void RemoteCDMInstanceProxy::createSession(uint64_t logIdentifier, CompletionHan
 
     auto identifier = RemoteCDMInstanceSessionIdentifier::generate();
     auto session = RemoteCDMInstanceSessionProxy::create(m_cdm.get(), privSession.releaseNonNull(), logIdentifier, identifier);
-    protect(protectedCdm()->factory())->addSession(identifier, WTF::move(session));
+    protect(protect(m_cdm)->factory())->addSession(identifier, WTF::move(session));
     completion(identifier);
 }
 
@@ -130,12 +130,7 @@ std::optional<SharedPreferencesForWebProcess> RemoteCDMInstanceProxy::sharedPref
     if (!m_cdm)
         return std::nullopt;
 
-    return protectedCdm()->sharedPreferencesForWebProcess();
-}
-
-RefPtr<RemoteCDMProxy> RemoteCDMInstanceProxy::protectedCdm() const
-{
-    return m_cdm.get();
+    return protect(m_cdm)->sharedPreferencesForWebProcess();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h
@@ -90,8 +90,6 @@ private:
     void setStorageDirectory(const String&);
     void createSession(uint64_t logIdentifier, CompletionHandler<void(std::optional<RemoteCDMInstanceSessionIdentifier>)>&&);
 
-    RefPtr<RemoteCDMProxy> protectedCdm() const;
-
     WeakPtr<RemoteCDMProxy> m_cdm;
     const Ref<WebCore::CDMInstance> m_instance;
     const UniqueRef<RemoteCDMInstanceConfiguration> m_configuration;

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -73,7 +73,7 @@ void RemoteCDMInstanceSessionProxy::requestLicense(LicenseType type, KeyGrouping
     }
 
     // Implement the CDMPrivate::supportsInitData() check here:
-    if (!protectedCdm()->supportsInitData(initDataType, *initData)) {
+    if (!protect(m_cdm)->supportsInitData(initDataType, *initData)) {
         completion({ }, emptyString(), false, false);
         return;
     }
@@ -91,7 +91,7 @@ void RemoteCDMInstanceSessionProxy::updateLicense(String sessionId, LicenseType 
     }
 
     // Implement the CDMPrivate::sanitizeResponse() check here:
-    auto sanitizedResponse = protectedCdm()->sanitizeResponse(*response);
+    auto sanitizedResponse = protect(m_cdm)->sanitizeResponse(*response);
     if (!sanitizedResponse) {
         completion(false, { }, std::nullopt, std::nullopt, false);
         return;
@@ -105,7 +105,7 @@ void RemoteCDMInstanceSessionProxy::updateLicense(String sessionId, LicenseType 
 void RemoteCDMInstanceSessionProxy::loadSession(LicenseType type, String sessionId, String origin, LoadSessionCallback&& completion)
 {
     // Implement the CDMPrivate::sanitizeSessionId() check here:
-    auto sanitizedSessionId = protectedCdm()->sanitizeSessionId(sessionId);
+    auto sanitizedSessionId = protect(m_cdm)->sanitizeSessionId(sessionId);
     if (!sanitizedSessionId) {
         completion(std::nullopt, std::nullopt, std::nullopt, false, CDMInstanceSession::SessionLoadFailure::MismatchedSessionType);
         return;
@@ -188,12 +188,7 @@ std::optional<SharedPreferencesForWebProcess> RemoteCDMInstanceSessionProxy::sha
     if (!m_cdm)
         return std::nullopt;
 
-    return protectedCdm()->sharedPreferencesForWebProcess();
-}
-
-RefPtr<RemoteCDMProxy> RemoteCDMInstanceSessionProxy::protectedCdm() const
-{
-    return m_cdm.get();
+    return protect(m_cdm)->sharedPreferencesForWebProcess();
 }
 
 }

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -87,7 +87,6 @@ private:
     void sessionIdChanged(const String&) final;
     PlatformDisplayID displayID() final { return m_displayID; }
 
-    RefPtr<RemoteCDMProxy> protectedCdm() const;
     Ref<WebCore::CDMInstanceSession> protectedSession() const { return m_session; }
 
     WeakPtr<RemoteCDMProxy> m_cdm;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp
@@ -146,7 +146,7 @@ void RemoteMediaPlayerProxy::connectionToWebProcessClosed()
 void RemoteMediaPlayerProxy::invalidate()
 {
     m_updateCachedStateMessageTimer.stop();
-    protectedPlayer()->invalidate();
+    protect(m_player)->invalidate();
     if (RefPtr sandboxExtension = m_sandboxExtension) {
         sandboxExtension->revoke();
         m_sandboxExtension = nullptr;
@@ -199,7 +199,7 @@ void RemoteMediaPlayerProxy::load(URL&& url, std::optional<SandboxExtension::Han
             WTFLogAlways("Unable to create sandbox extension for media url.\n");
     }
 
-    protectedPlayer()->load(url, options);
+    protect(m_player)->load(url, options);
     getConfiguration(configuration);
     completionHandler(WTF::move(configuration));
 }
@@ -223,10 +223,10 @@ void RemoteMediaPlayerProxy::loadMediaSource(URL&& url, const MediaPlayer::LoadO
         m_mediaSourceProxy = adoptRef(*new RemoteMediaSourceProxy(*manager, mediaSourceIdentifier, *this));
 
     RefPtr player = m_player;
-    player->load(url, options, *protectedMediaSourceProxy());
+    player->load(url, options, *protect(m_mediaSourceProxy));
 
     if (reattached)
-        protectedMediaSourceProxy()->setMediaPlayers(*this, player->protectedPlayerPrivate().get());
+        protect(m_mediaSourceProxy)->setMediaPlayers(*this, player->protectedPlayerPrivate().get());
     getConfiguration(configuration);
     completionHandler(WTF::move(configuration));
 }
@@ -235,7 +235,7 @@ void RemoteMediaPlayerProxy::loadMediaSource(URL&& url, const MediaPlayer::LoadO
 void RemoteMediaPlayerProxy::cancelLoad()
 {
     m_updateCachedStateMessageTimer.stop();
-    protectedPlayer()->cancelLoad();
+    protect(m_player)->cancelLoad();
 }
 
 void RemoteMediaPlayerProxy::prepareForPlayback(bool privateMode, WebCore::MediaPlayerEnums::Preload preload, bool preservesPitch, WebCore::MediaPlayerEnums::PitchCorrectionAlgorithm pitchCorrectionAlgorithm, bool prepareToPlay, bool prepareForRendering, WebCore::IntSize presentationSize, float videoContentScale, bool isFullscreen, WebCore::DynamicRangeMode preferredDynamicRangeMode, PlatformDynamicRangeLimit platformDynamicRangeLimit)
@@ -259,7 +259,7 @@ void RemoteMediaPlayerProxy::prepareForPlayback(bool privateMode, WebCore::Media
 void RemoteMediaPlayerProxy::prepareToPlay()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    protectedPlayer()->prepareToPlay();
+    protect(m_player)->prepareToPlay();
 }
 
 void RemoteMediaPlayerProxy::play()
@@ -275,72 +275,72 @@ void RemoteMediaPlayerProxy::pause()
 {
     m_updateCachedStateMessageTimer.stop();
     updateCachedVideoMetrics();
-    protectedPlayer()->pause();
+    protect(m_player)->pause();
     sendCachedState();
 }
 
 void RemoteMediaPlayerProxy::seekToTarget(const WebCore::SeekTarget& target)
 {
     ALWAYS_LOG(LOGIDENTIFIER, target);
-    protectedPlayer()->seekToTarget(target);
+    protect(m_player)->seekToTarget(target);
 }
 
 void RemoteMediaPlayerProxy::setVolumeLocked(bool volumeLocked)
 {
-    protectedPlayer()->setVolumeLocked(volumeLocked);
+    protect(m_player)->setVolumeLocked(volumeLocked);
 }
 
 void RemoteMediaPlayerProxy::setVolume(double volume)
 {
-    protectedPlayer()->setVolume(volume);
+    protect(m_player)->setVolume(volume);
 }
 
 void RemoteMediaPlayerProxy::setMuted(bool muted)
 {
-    protectedPlayer()->setMuted(muted);
+    protect(m_player)->setMuted(muted);
 }
 
 void RemoteMediaPlayerProxy::setPreload(WebCore::MediaPlayerEnums::Preload preload)
 {
-    protectedPlayer()->setPreload(preload);
+    protect(m_player)->setPreload(preload);
 }
 
 void RemoteMediaPlayerProxy::setPrivateBrowsingMode(bool privateMode)
 {
-    protectedPlayer()->setPrivateBrowsingMode(privateMode);
+    protect(m_player)->setPrivateBrowsingMode(privateMode);
 }
 
 void RemoteMediaPlayerProxy::setPreservesPitch(bool preservesPitch)
 {
-    protectedPlayer()->setPreservesPitch(preservesPitch);
+    protect(m_player)->setPreservesPitch(preservesPitch);
 }
 
 void RemoteMediaPlayerProxy::setPitchCorrectionAlgorithm(WebCore::MediaPlayer::PitchCorrectionAlgorithm algorithm)
 {
-    protectedPlayer()->setPitchCorrectionAlgorithm(algorithm);
+    protect(m_player)->setPitchCorrectionAlgorithm(algorithm);
 }
 
 void RemoteMediaPlayerProxy::prepareForRendering()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
-    protectedPlayer()->prepareForRendering();
+    protect(m_player)->prepareForRendering();
 }
 
 void RemoteMediaPlayerProxy::setPageIsVisible(bool visible)
 {
     ALWAYS_LOG(LOGIDENTIFIER, visible);
-    protectedPlayer()->setPageIsVisible(visible);
+    protect(m_player)->setPageIsVisible(visible);
 }
 
 void RemoteMediaPlayerProxy::setShouldMaintainAspectRatio(bool maintainRatio)
 {
-    protectedPlayer()->setShouldMaintainAspectRatio(maintainRatio);
+    protect(m_player)->setShouldMaintainAspectRatio(maintainRatio);
 }
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 void RemoteMediaPlayerProxy::setVideoFullscreenGravity(WebCore::MediaPlayerEnums::VideoGravity gravity)
 {
-    protectedPlayer()->setVideoFullscreenGravity(gravity);
+    protect(m_player)->setVideoFullscreenGravity(gravity);
 }
 #endif
 
@@ -348,22 +348,22 @@ void RemoteMediaPlayerProxy::acceleratedRenderingStateChanged(bool renderingCanB
 {
     ALWAYS_LOG(LOGIDENTIFIER, renderingCanBeAccelerated);
     m_renderingCanBeAccelerated = renderingCanBeAccelerated;
-    protectedPlayer()->acceleratedRenderingStateChanged();
+    protect(m_player)->acceleratedRenderingStateChanged();
 }
 
 void RemoteMediaPlayerProxy::setShouldDisableSleep(bool disable)
 {
-    protectedPlayer()->setShouldDisableSleep(disable);
+    protect(m_player)->setShouldDisableSleep(disable);
 }
 
 void RemoteMediaPlayerProxy::setRate(double rate)
 {
-    protectedPlayer()->setRate(rate);
+    protect(m_player)->setRate(rate);
 }
 
 void RemoteMediaPlayerProxy::didLoadingProgress(CompletionHandler<void(bool)>&& completionHandler)
 {
-    protectedPlayer()->didLoadingProgress(WTF::move(completionHandler));
+    protect(m_player)->didLoadingProgress(WTF::move(completionHandler));
 
     protectedConnection()->send(Messages::MediaPlayerPrivateRemote::ReportGPUMemoryFootprint(WTF::memoryFootprint()), m_id);
 }
@@ -374,55 +374,55 @@ void RemoteMediaPlayerProxy::setPresentationSize(const WebCore::IntSize& size)
         return;
 
     m_configuration.presentationSize = size;
-    protectedPlayer()->setPresentationSize(size);
+    protect(m_player)->setPresentationSize(size);
 }
 
 // MediaPlayerClient
 #if ENABLE(VIDEO_PRESENTATION_MODE)
 void RemoteMediaPlayerProxy::updateVideoFullscreenInlineImage()
 {
-    protectedPlayer()->updateVideoFullscreenInlineImage();
+    protect(m_player)->updateVideoFullscreenInlineImage();
 }
 
 void RemoteMediaPlayerProxy::setVideoFullscreenMode(MediaPlayer::VideoFullscreenMode mode)
 {
     m_fullscreenMode = mode;
-    protectedPlayer()->setVideoFullscreenMode(mode);
+    protect(m_player)->setVideoFullscreenMode(mode);
 }
 
 void RemoteMediaPlayerProxy::videoFullscreenStandbyChanged(bool standby)
 {
     m_videoFullscreenStandby = standby;
-    protectedPlayer()->videoFullscreenStandbyChanged();
+    protect(m_player)->videoFullscreenStandbyChanged();
 }
 #endif
 
 void RemoteMediaPlayerProxy::setBufferingPolicy(MediaPlayer::BufferingPolicy policy)
 {
-    protectedPlayer()->setBufferingPolicy(policy);
+    protect(m_player)->setBufferingPolicy(policy);
 }
 
 #if PLATFORM(IOS_FAMILY)
 void RemoteMediaPlayerProxy::accessLog(CompletionHandler<void(String)>&& completionHandler)
 {
-    completionHandler(protectedPlayer()->accessLog());
+    completionHandler(protect(m_player)->accessLog());
 }
 
 void RemoteMediaPlayerProxy::errorLog(CompletionHandler<void(String)>&& completionHandler)
 {
-    completionHandler(protectedPlayer()->errorLog());
+    completionHandler(protect(m_player)->errorLog());
 }
 
 void RemoteMediaPlayerProxy::setSceneIdentifier(String&& identifier)
 {
-    protectedPlayer()->setSceneIdentifier(identifier);
+    protect(m_player)->setSceneIdentifier(identifier);
 }
 #endif
 
 void RemoteMediaPlayerProxy::mediaPlayerNetworkStateChanged()
 {
     updateCachedState(true);
-    m_cachedState.networkState = protectedPlayer()->networkState();
+    m_cachedState.networkState = protect(m_player)->networkState();
     protectedConnection()->send(Messages::MediaPlayerPrivateRemote::NetworkStateChanged(m_cachedState), m_id);
 }
 
@@ -459,12 +459,12 @@ void RemoteMediaPlayerProxy::mediaPlayerReadyStateChanged()
 
 void RemoteMediaPlayerProxy::mediaPlayerVolumeChanged()
 {
-    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::VolumeChanged(protectedPlayer()->volume()), m_id);
+    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::VolumeChanged(protect(m_player)->volume()), m_id);
 }
 
 void RemoteMediaPlayerProxy::mediaPlayerMuteChanged()
 {
-    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::MuteChanged(protectedPlayer()->muted()), m_id);
+    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::MuteChanged(protect(m_player)->muted()), m_id);
 }
 
 static MediaTimeUpdateData timeUpdateData(const MediaPlayer& player, MediaTime time)
@@ -479,7 +479,7 @@ static MediaTimeUpdateData timeUpdateData(const MediaPlayer& player, MediaTime t
 void RemoteMediaPlayerProxy::mediaPlayerSeeked(const MediaTime& time)
 {
     ALWAYS_LOG(LOGIDENTIFIER, time);
-    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::Seeked(timeUpdateData(*protectedPlayer(), time)), m_id);
+    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::Seeked(timeUpdateData(*protect(m_player), time)), m_id);
 }
 
 void RemoteMediaPlayerProxy::mediaPlayerTimeChanged()
@@ -494,7 +494,7 @@ void RemoteMediaPlayerProxy::mediaPlayerTimeChanged()
 void RemoteMediaPlayerProxy::mediaPlayerDurationChanged()
 {
     updateCachedState(true);
-    m_cachedState.duration = protectedPlayer()->duration();
+    m_cachedState.duration = protect(m_player)->duration();
     protectedConnection()->send(Messages::MediaPlayerPrivateRemote::DurationChanged(m_cachedState), m_id);
 }
 
@@ -509,7 +509,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRateChanged()
 
 void RemoteMediaPlayerProxy::mediaPlayerEngineFailedToLoad()
 {
-    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::EngineFailedToLoad(protectedPlayer()->platformErrorCode()), m_id);
+    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::EngineFailedToLoad(protect(m_player)->platformErrorCode()), m_id);
 }
 
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) || ENABLE(ENCRYPTED_MEDIA)
@@ -791,7 +791,7 @@ void RemoteMediaPlayerProxy::mediaPlayerResourceNotSupported()
 
 void RemoteMediaPlayerProxy::mediaPlayerSizeChanged()
 {
-    m_cachedState.naturalSize = protectedPlayer()->naturalSize();
+    m_cachedState.naturalSize = protect(m_player)->naturalSize();
     protectedConnection()->send(Messages::MediaPlayerPrivateRemote::SizeChanged(m_cachedState.naturalSize), m_id);
 }
 
@@ -830,7 +830,7 @@ void RemoteMediaPlayerProxy::mediaPlayerInitializationDataEncountered(const Stri
 
 void RemoteMediaPlayerProxy::mediaPlayerWaitingForKeyChanged()
 {
-    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::WaitingForKeyChanged(protectedPlayer()->waitingForKey()), m_id);
+    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::WaitingForKeyChanged(protect(m_player)->waitingForKey()), m_id);
 }
 #endif
 
@@ -854,7 +854,7 @@ void RemoteMediaPlayerProxy::setWirelessVideoPlaybackDisabled(bool disabled)
 
 void RemoteMediaPlayerProxy::setShouldPlayToPlaybackTarget(bool shouldPlay)
 {
-    protectedPlayer()->setShouldPlayToPlaybackTarget(shouldPlay);
+    protect(m_player)->setShouldPlayToPlaybackTarget(shouldPlay);
 }
 
 void RemoteMediaPlayerProxy::setWirelessPlaybackTarget(MediaPlaybackTargetContextSerialized&& targetContext)
@@ -987,7 +987,7 @@ void RemoteMediaPlayerProxy::timerFired()
 
 void RemoteMediaPlayerProxy::currentTimeChanged(const MediaTime& mediaTime)
 {
-    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::CurrentTimeChanged(timeUpdateData(*protectedPlayer(), mediaTime)), m_id);
+    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::CurrentTimeChanged(timeUpdateData(*protect(m_player), mediaTime)), m_id);
 }
 
 void RemoteMediaPlayerProxy::videoFrameForCurrentTimeIfChanged(CompletionHandler<void(std::optional<RemoteVideoFrameProxy::Properties>&&, bool)>&& completionHandler)
@@ -1086,7 +1086,7 @@ void RemoteMediaPlayerProxy::setLegacyCDMSession(std::optional<RemoteLegacyCDMSe
 
 void RemoteMediaPlayerProxy::keyAdded()
 {
-    protectedPlayer()->keyAdded();
+    protect(m_player)->keyAdded();
 }
 #endif
 
@@ -1099,7 +1099,7 @@ void RemoteMediaPlayerProxy::cdmInstanceAttached(RemoteCDMInstanceIdentifier&& i
         return;
 
     if (RefPtr instanceProxy = protect(manager->gpuConnectionToWebProcess()->cdmFactoryProxy())->getInstance(instanceId))
-        protectedPlayer()->cdmInstanceAttached(instanceProxy->instance());
+        protect(m_player)->cdmInstanceAttached(instanceProxy->instance());
 }
 
 void RemoteMediaPlayerProxy::cdmInstanceDetached(RemoteCDMInstanceIdentifier&& instanceId)
@@ -1110,7 +1110,7 @@ void RemoteMediaPlayerProxy::cdmInstanceDetached(RemoteCDMInstanceIdentifier&& i
         return;
 
     if (RefPtr instanceProxy = protect(manager->gpuConnectionToWebProcess()->cdmFactoryProxy())->getInstance(instanceId))
-        protectedPlayer()->cdmInstanceDetached(instanceProxy->instance());
+        protect(m_player)->cdmInstanceDetached(instanceProxy->instance());
 }
 
 void RemoteMediaPlayerProxy::attemptToDecryptWithInstance(RemoteCDMInstanceIdentifier&& instanceId)
@@ -1121,7 +1121,7 @@ void RemoteMediaPlayerProxy::attemptToDecryptWithInstance(RemoteCDMInstanceIdent
         return;
 
     if (RefPtr instanceProxy = protect(manager->gpuConnectionToWebProcess()->cdmFactoryProxy())->getInstance(instanceId))
-        protectedPlayer()->attemptToDecryptWithInstance(instanceProxy->instance());
+        protect(m_player)->attemptToDecryptWithInstance(instanceProxy->instance());
 }
 #endif
 
@@ -1129,7 +1129,7 @@ void RemoteMediaPlayerProxy::attemptToDecryptWithInstance(RemoteCDMInstanceIdent
 #if ENABLE(LEGACY_ENCRYPTED_MEDIA) && ENABLE(ENCRYPTED_MEDIA)
 void RemoteMediaPlayerProxy::setShouldContinueAfterKeyNeeded(bool should)
 {
-    protectedPlayer()->setShouldContinueAfterKeyNeeded(should);
+    protect(m_player)->setShouldContinueAfterKeyNeeded(should);
 }
 #endif
 
@@ -1140,22 +1140,22 @@ void RemoteMediaPlayerProxy::notifyActiveSourceBuffersChanged()
 
 void RemoteMediaPlayerProxy::applicationWillResignActive()
 {
-    protectedPlayer()->applicationWillResignActive();
+    protect(m_player)->applicationWillResignActive();
 }
 
 void RemoteMediaPlayerProxy::applicationDidBecomeActive()
 {
-    protectedPlayer()->applicationDidBecomeActive();
+    protect(m_player)->applicationDidBecomeActive();
 }
 
 void RemoteMediaPlayerProxy::notifyTrackModeChanged()
 {
-    protectedPlayer()->notifyTrackModeChanged();
+    protect(m_player)->notifyTrackModeChanged();
 }
 
 void RemoteMediaPlayerProxy::tracksChanged()
 {
-    protectedPlayer()->tracksChanged();
+    protect(m_player)->tracksChanged();
 }
 
 void RemoteMediaPlayerProxy::performTaskAtTime(const MediaTime& taskTime, PerformTaskAtTimeCompletionHandler&& completionHandler)
@@ -1188,7 +1188,7 @@ void RemoteMediaPlayerProxy::performTaskAtTime(const MediaTime& taskTime, Perfor
 
 void RemoteMediaPlayerProxy::isCrossOrigin(WebCore::SecurityOriginData originData, CompletionHandler<void(std::optional<bool>)>&& completionHandler)
 {
-    completionHandler(protectedPlayer()->isCrossOrigin(originData.securityOrigin()));
+    completionHandler(protect(m_player)->isCrossOrigin(originData.securityOrigin()));
 }
 
 void RemoteMediaPlayerProxy::setVideoPlaybackMetricsUpdateInterval(double interval)
@@ -1216,7 +1216,7 @@ void RemoteMediaPlayerProxy::updateCachedVideoMetrics()
     if (m_hasPlaybackMetricsUpdatePending)
         return;
     m_hasPlaybackMetricsUpdatePending = true;
-    protectedPlayer()->asyncVideoPlaybackQualityMetrics()->whenSettled(RunLoop::currentSingleton(), [weakThis = WeakPtr { *this }](auto&& result) {
+    protect(m_player)->asyncVideoPlaybackQualityMetrics()->whenSettled(RunLoop::currentSingleton(), [weakThis = WeakPtr { *this }](auto&& result) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -1259,7 +1259,7 @@ void RemoteMediaPlayerProxy::createAudioSourceProvider()
 void RemoteMediaPlayerProxy::setShouldEnableAudioSourceProvider(bool shouldEnable)
 {
 #if ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
-    if (auto* provider = protectedPlayer()->audioSourceProvider())
+    if (auto* provider = protect(m_player)->audioSourceProvider())
         provider->setClient(shouldEnable ? m_remoteAudioSourceProvider.get() : nullptr);
 #endif
 }
@@ -1301,19 +1301,19 @@ void RemoteMediaPlayerProxy::playerContentBoxRectChanged(const WebCore::LayoutRe
 
 void RemoteMediaPlayerProxy::setShouldCheckHardwareSupport(bool value)
 {
-    protectedPlayer()->setShouldCheckHardwareSupport(value);
+    protect(m_player)->setShouldCheckHardwareSupport(value);
     m_shouldCheckHardwareSupport = value;
 }
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
 void RemoteMediaPlayerProxy::setDefaultSpatialTrackingLabel(const String& defaultSpatialTrackingLabel)
 {
-    protectedPlayer()->setDefaultSpatialTrackingLabel(defaultSpatialTrackingLabel);
+    protect(m_player)->setDefaultSpatialTrackingLabel(defaultSpatialTrackingLabel);
 }
 
 void RemoteMediaPlayerProxy::setSpatialTrackingLabel(const String& spatialTrackingLabel)
 {
-    protectedPlayer()->setSpatialTrackingLabel(spatialTrackingLabel);
+    protect(m_player)->setSpatialTrackingLabel(spatialTrackingLabel);
 }
 
 #endif
@@ -1321,13 +1321,13 @@ void RemoteMediaPlayerProxy::setSpatialTrackingLabel(const String& spatialTracki
 #if HAVE(SPATIAL_AUDIO_EXPERIENCE)
 void RemoteMediaPlayerProxy::setPrefersSpatialAudioExperience(bool value)
 {
-    protectedPlayer()->setPrefersSpatialAudioExperience(value);
+    protect(m_player)->setPrefersSpatialAudioExperience(value);
 }
 #endif
 
 void RemoteMediaPlayerProxy::isInFullscreenOrPictureInPictureChanged(bool isInFullscreenOrPictureInPicture)
 {
-    protectedPlayer()->setInFullscreenOrPictureInPicture(isInFullscreenOrPictureInPicture);
+    protect(m_player)->setInFullscreenOrPictureInPicture(isInFullscreenOrPictureInPicture);
 }
 
 #if !RELEASE_LOG_DISABLED
@@ -1375,12 +1375,12 @@ void RemoteMediaPlayerProxy::setSoundStageSize(SoundStageSize size)
         return;
     m_soundStageSize = size;
 
-    protectedPlayer()->soundStageSizeDidChange();
+    protect(m_player)->soundStageSizeDidChange();
 }
 
 void RemoteMediaPlayerProxy::setHasMessageClientForTesting(bool hasClient)
 {
-    protectedPlayer()->setMessageClientForTesting(hasClient ? this : nullptr);
+    protect(m_player)->setMessageClientForTesting(hasClient ? this : nullptr);
 }
 
 void RemoteMediaPlayerProxy::sendInternalMessage(const WebCore::MessageForTesting& message)

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -410,11 +410,6 @@ private:
     WTFLogChannel& logChannel() const;
 #endif
 
-    RefPtr<WebCore::MediaPlayer> protectedPlayer() const { return m_player; }
-#if ENABLE(MEDIA_SOURCE)
-    RefPtr<RemoteMediaSourceProxy> protectedMediaSourceProxy() const { return m_mediaSourceProxy; }
-#endif
-
     Ref<IPC::Connection> protectedConnection() const { return m_webProcessConnection; }
     Ref<RemoteVideoFrameObjectHeap> protectedVideoFrameObjectHeap() const;
 

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -68,7 +68,7 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
         false;
 #endif
 
-    if (auto hostingContext = m_layerHostingContextManager->createHostingContextIfNeeded(protectedPlayer()->platformLayer(), canShowWhileLocked))
+    if (auto hostingContext = m_layerHostingContextManager->createHostingContextIfNeeded(protect(m_player)->platformLayer(), canShowWhileLocked))
         protectedConnection()->send(Messages::MediaPlayerPrivateRemote::LayerHostingContextChanged(*hostingContext, m_layerHostingContextManager->videoLayerSize()), m_id);
 
     protectedConnection()->send(Messages::MediaPlayerPrivateRemote::RenderingModeChanged(), m_id);
@@ -85,7 +85,7 @@ void RemoteMediaPlayerProxy::setVideoLayerSizeFenced(const WebCore::FloatSize& s
 
     ALWAYS_LOG(LOGIDENTIFIER, size.width(), "x", size.height());
     m_layerHostingContextManager->setVideoLayerSizeFenced(size, WTF::MachSendRightAnnotated { sendRightAnnotated }, [&] {
-        protectedPlayer()->setVideoLayerSizeFenced(size, WTF::move(sendRightAnnotated));
+        protect(m_player)->setVideoLayerSizeFenced(size, WTF::move(sendRightAnnotated));
     });
 }
 

--- a/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.h
+++ b/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.h
@@ -66,8 +66,6 @@ public:
 #endif
 
 private:
-    RefPtr<GPUConnectionToWebProcess> protectedConnection() const { return m_gpuConnection.get(); }
-
     HashMap<WebCore::VideoReceiverEndpointIdentifier, WebCore::PlatformVideoTarget> m_videoTargetCache;
     struct VideoReceiverEndpointCacheEntry {
         Markable<WebCore::MediaPlayerIdentifier> playerIdentifier;

--- a/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.mm
@@ -164,13 +164,13 @@ void VideoReceiverEndpointManager::setVideoTargetIfValidIdentifier(std::optional
     if (!playerIdentifier)
         return;
 
-    if (RefPtr player = protect(protectedConnection()->remoteMediaPlayerManagerProxy())->mediaPlayer(playerIdentifier)) {
+    if (RefPtr player = protect(protect(m_gpuConnection)->remoteMediaPlayerManagerProxy())->mediaPlayer(playerIdentifier)) {
         ALWAYS_LOG(LOGIDENTIFIER, "Update entry; ", !videoTarget ? "removing target" : "setting target", " on player ", playerIdentifier->loggingString());
         player->setVideoTarget(videoTarget);
         return;
     }
 
-    if (RefPtr renderer = protect(protectedConnection()->remoteAudioVideoRendererProxyManager())->rendererFor(playerIdentifier)) {
+    if (RefPtr renderer = protect(protect(m_gpuConnection)->remoteAudioVideoRendererProxyManager())->rendererFor(playerIdentifier)) {
         ALWAYS_LOG(LOGIDENTIFIER, "Update entry; ", !videoTarget ? "removing target" : "setting target", " on A/V renderer ", playerIdentifier->loggingString());
         renderer->setVideoTarget(videoTarget);
     }

--- a/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
+++ b/Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h
@@ -76,8 +76,6 @@ public:
 private:
     RemoteSampleBufferDisplayLayer(GPUConnectionToWebProcess&, SampleBufferDisplayLayerIdentifier, Ref<IPC::Connection>&&, RemoteSampleBufferDisplayLayerManager&);
 
-    RefPtr<WebCore::LocalSampleBufferDisplayLayer> protectedSampleBufferDisplayLayer() const;
-
 #if !RELEASE_LOG_DISABLED
     void setLogIdentifier(uint64_t);
 #endif

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp
@@ -95,14 +95,9 @@ void BackgroundFetchLoad::abort()
     m_task = nullptr;
 }
 
-RefPtr<WebCore::BackgroundFetchRecordLoaderClient> BackgroundFetchLoad::protectedClient() const
-{
-    return m_client.get();
-}
-
 void BackgroundFetchLoad::didFinish(const ResourceError& error, const ResourceResponse& response)
 {
-    protectedClient()->didFinish(error);
+    protect(m_client)->didFinish(error);
 }
 
 void BackgroundFetchLoad::loadRequest(NetworkProcess& networkProcess, ResourceRequest&& request)
@@ -180,13 +175,13 @@ void BackgroundFetchLoad::didReceiveResponse(ResourceResponse&& response, Negoti
     if (!weakThis)
         return;
 
-    protectedClient()->didReceiveResponse(WTF::move(response));
+    protect(m_client)->didReceiveResponse(WTF::move(response));
 }
 
 void BackgroundFetchLoad::didReceiveData(const SharedBuffer& data)
 {
     BGLOAD_RELEASE_LOG("didReceiveData");
-    protectedClient()->didReceiveResponseBodyChunk(data);
+    protect(m_client)->didReceiveResponseBodyChunk(data);
 }
 
 void BackgroundFetchLoad::didCompleteWithError(const ResourceError& error, const NetworkLoadMetrics&)
@@ -201,7 +196,7 @@ void BackgroundFetchLoad::didCompleteWithError(const ResourceError& error, const
 
 void BackgroundFetchLoad::didSendData(uint64_t totalBytesSent, uint64_t totalBytesExpectedToSend)
 {
-    protectedClient()->didSendData(totalBytesSent);
+    protect(m_client)->didSendData(totalBytesSent);
 }
 
 void BackgroundFetchLoad::wasBlocked()

--- a/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
+++ b/Source/WebKit/NetworkProcess/BackgroundFetchLoad.h
@@ -80,8 +80,6 @@ private:
     void wasBlockedByRestrictions() final;
     void wasBlockedByDisabledFTP() final;
 
-    RefPtr<WebCore::BackgroundFetchRecordLoaderClient> protectedClient() const;
-
     // WebCore::BackgroundFetchRecordLoader
     void abort() final;
 

--- a/Source/WebKit/NetworkProcess/NetworkLoad.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.cpp
@@ -378,11 +378,6 @@ String NetworkLoad::attributedBundleIdentifier(WebPageProxyIdentifier pageID)
     return { };
 }
 
-RefPtr<NetworkDataTask> NetworkLoad::protectedTask()
-{
-    return m_task;
-}
-
 size_t NetworkLoad::bytesTransferredOverNetwork() const
 {
     if (RefPtr task = m_task)

--- a/Source/WebKit/NetworkProcess/NetworkLoad.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoad.h
@@ -79,7 +79,7 @@ public:
     void setPendingDownloadID(DownloadID);
     void setSuggestedFilename(const String&);
     void setPendingDownload(PendingDownload&);
-    std::optional<DownloadID> pendingDownloadID() { return protectedTask()->pendingDownloadID(); }
+    std::optional<DownloadID> pendingDownloadID() { return protect(m_task)->pendingDownloadID(); }
 
     bool shouldCaptureExtraNetworkLoadMetrics() const final;
 
@@ -118,8 +118,6 @@ private:
     void wasBlockedByRestrictions() final;
     void wasBlockedByDisabledFTP() final;
     void didNegotiateModernTLS(const URL&) final;
-
-    RefPtr<NetworkDataTask> protectedTask();
 
     void notifyDidReceiveResponse(WebCore::ResourceResponse&&, NegotiatedLegacyTLS, PrivateRelayed, ResponseCompletionHandler&&);
 

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -94,11 +94,6 @@ NetworkLoadChecker::NetworkLoadChecker(NetworkProcess& networkProcess, NetworkRe
 
 NetworkLoadChecker::~NetworkLoadChecker() = default;
 
-RefPtr<NetworkCORSPreflightChecker> NetworkLoadChecker::protectedCORSPreflightChecker() const
-{
-    return m_corsPreflightChecker;
-}
-
 bool NetworkLoadChecker::isSameOrigin(const URL& url, const SecurityOrigin* origin) const
 {
     return url.protocolIsData()
@@ -539,13 +534,13 @@ void NetworkLoadChecker::checkCORSRequestWithPreflight(ResourceRequest&& request
         }
 
         if (protectedThis->m_shouldCaptureExtraNetworkLoadMetrics)
-            protectedThis->m_loadInformation.transactions.append(protectedThis->protectedCORSPreflightChecker()->takeInformation());
+            protectedThis->m_loadInformation.transactions.append(protect(protectedThis->m_corsPreflightChecker)->takeInformation());
 
         auto corsPreflightChecker = std::exchange(protectedThis->m_corsPreflightChecker, nullptr);
         updateRequestForAccessControl(request, *protectedThis->origin(), protectedThis->m_storedCredentialsPolicy);
         handler(WTF::move(request));
     });
-    protectedCORSPreflightChecker()->startPreflight();
+    protect(m_corsPreflightChecker)->startPreflight();
 }
 
 bool NetworkLoadChecker::doesNotNeedCORSCheck(const URL& url) const

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.h
@@ -156,7 +156,6 @@ private:
     void processContentRuleListsForLoad(WebCore::ResourceRequest&&, ContentExtensionCallback&&);
 #endif
 
-    RefPtr<NetworkCORSPreflightChecker> protectedCORSPreflightChecker() const;
     RefPtr<WebCore::SecurityOrigin> parentOrigin() const { return m_parentOrigin; }
 
     bool checkTAO(const WebCore::ResourceResponse&);

--- a/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkLoadParameters.h
@@ -66,7 +66,6 @@ struct NetworkLoadParameters {
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
     bool isInitiatedByDedicatedWorker { false };
 
-    RefPtr<WebCore::SecurityOrigin> protectedSourceOrigin() const { return sourceOrigin; }
     uint64_t requiredCookiesVersion { 0 };
 };
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -77,7 +77,6 @@ struct NetworkResourceLoadParameters {
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections { };
     bool mayBlockNetworkRequest { false };
 
-    RefPtr<WebCore::SecurityOrigin> protectedSourceOrigin() const { return sourceOrigin; }
     uint64_t requiredCookiesVersion { 0 };
 
     Markable<WebCore::ResourceLoaderIdentifier> identifier { };

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -193,9 +193,6 @@ public:
 private:
     NetworkResourceLoader(NetworkResourceLoadParameters&&, NetworkConnectionToWebProcess&, CompletionHandler<void(const WebCore::ResourceError&, const WebCore::ResourceResponse, Vector<uint8_t>&&)>&&);
 
-    RefPtr<NetworkCache::Cache> protectedCache() const;
-    RefPtr<ServiceWorkerFetchTask> protectedServiceWorkerFetchTask() const;
-
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const override;
     uint64_t messageSenderDestinationID() const override { return m_parameters.identifier->toUInt64(); }

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -87,12 +87,12 @@ Ref<NetworkConnectionToWebProcess> NetworkSocketChannel::protectedConnectionToWe
 
 void NetworkSocketChannel::sendString(std::span<const uint8_t> message, CompletionHandler<void()>&& callback)
 {
-    protectedSocket()->sendString(message, WTF::move(callback));
+    protect(m_socket)->sendString(message, WTF::move(callback));
 }
 
 void NetworkSocketChannel::sendData(std::span<const uint8_t> data, CompletionHandler<void()>&& callback)
 {
-    protectedSocket()->sendData(data, WTF::move(callback));
+    protect(m_socket)->sendData(data, WTF::move(callback));
 }
 
 void NetworkSocketChannel::finishClosingIfPossible()
@@ -108,7 +108,7 @@ void NetworkSocketChannel::finishClosingIfPossible()
 
 void NetworkSocketChannel::close(int32_t code, const String& reason)
 {
-    protectedSocket()->close(code, reason);
+    protect(m_socket)->close(code, reason);
     finishClosingIfPossible();
 }
 
@@ -171,11 +171,6 @@ IPC::Connection* NetworkSocketChannel::messageSenderConnection() const
 NetworkSession* NetworkSocketChannel::session() const
 {
     return m_session.get();
-}
-
-RefPtr<WebSocketTask> NetworkSocketChannel::protectedSocket()
-{
-    return m_socket.get();
 }
 
 std::optional<SharedPreferencesForWebProcess> NetworkSocketChannel::sharedPreferencesForWebProcess() const

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -93,8 +93,6 @@ private:
 
     NetworkSession* session() const;
 
-    RefPtr<WebSocketTask> protectedSocket();
-
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final { return m_identifier.toUInt64(); }
 

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -75,7 +75,7 @@ void NetworkNotificationManager::getPendingPushMessage(CompletionHandler<void(co
         completionHandler(WTF::move(message));
     };
 
-    protectedConnection()->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessage(), WTF::move(replyHandler));
+    protect(m_connection)->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessage(), WTF::move(replyHandler));
 }
 
 void NetworkNotificationManager::getPendingPushMessages(CompletionHandler<void(const Vector<WebPushMessage>&)>&& completionHandler)
@@ -85,7 +85,7 @@ void NetworkNotificationManager::getPendingPushMessages(CompletionHandler<void(c
         completionHandler(WTF::move(messages));
     };
 
-    protectedConnection()->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessages(), WTF::move(replyHandler));
+    protect(m_connection)->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetPendingPushMessages(), WTF::move(replyHandler));
 }
 
 void NetworkNotificationManager::showNotification(const WebCore::NotificationData& notification, RefPtr<NotificationResources>&& notificationResources, CompletionHandler<void()>&& completionHandler)
@@ -252,12 +252,12 @@ static void getPushPermissionStateImpl(WebPushD::Connection* connection, WebCore
 
 void NetworkNotificationManager::getPermissionState(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
-    getPushPermissionStateImpl(protectedConnection().get(), WTF::move(origin), WTF::move(completionHandler));
+    getPushPermissionStateImpl(protect(m_connection).get(), WTF::move(origin), WTF::move(completionHandler));
 }
 
 void NetworkNotificationManager::getPermissionStateSync(WebCore::SecurityOriginData&& origin, CompletionHandler<void(WebCore::PushPermissionState)>&& completionHandler)
 {
-    getPushPermissionStateImpl(protectedConnection().get(), WTF::move(origin), WTF::move(completionHandler));
+    getPushPermissionStateImpl(protect(m_connection).get(), WTF::move(origin), WTF::move(completionHandler));
 }
 
 std::optional<SharedPreferencesForWebProcess> NetworkNotificationManager::sharedPreferencesForWebProcess(const IPC::Connection& connection) const
@@ -266,11 +266,6 @@ std::optional<SharedPreferencesForWebProcess> NetworkNotificationManager::shared
     if (!webProcessConnection)
         return std::nullopt;
     return webProcessConnection->sharedPreferencesForWebProcess();
-}
-
-RefPtr<WebPushD::Connection> NetworkNotificationManager::protectedConnection() const
-{
-    return m_connection;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -94,7 +94,6 @@ private:
     void pageWasNotifiedOfNotificationPermission() final { }
     void getPermissionStateSync(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&) final;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(const IPC::Connection&) const final;
-    RefPtr<WebPushD::Connection> protectedConnection() const;
 
     RefPtr<WebPushD::Connection> m_connection;
     const Ref<NetworkProcess> m_networkProcess;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h
@@ -138,8 +138,6 @@ private:
     template<typename Message> bool sendToClient(Message&&);
 
     void sendNavigationPreloadUpdate();
-
-    RefPtr<ServiceWorkerNavigationPreloader> protectedPreloader();
     void processPreloadResponse();
 
     WeakPtr<WebSWServerConnection> m_swServerConnection;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp
@@ -47,11 +47,6 @@ WebSWRegistrationStore::WebSWRegistrationStore(WebCore::SWServer& server, Networ
     ASSERT(RunLoop::isMain());
 }
 
-RefPtr<WebCore::SWServer> WebSWRegistrationStore::protectedServer() const
-{
-    return m_server.get();
-}
-
 void WebSWRegistrationStore::clearAll(CompletionHandler<void()>&& callback)
 {
     m_updates.clear();
@@ -136,7 +131,7 @@ void WebSWRegistrationStore::updateToStorage(CompletionHandler<void()>&& callbac
 
         auto allScripts = WTF::move(result.value());
         for (auto&& scripts : allScripts)
-            protectedThis->protectedServer()->didSaveWorkerScriptsToDisk(scripts.identifier, WTF::move(scripts.mainScript), WTF::move(scripts.importedScripts));
+            protect(protectedThis->m_server)->didSaveWorkerScriptsToDisk(scripts.identifier, WTF::move(scripts.mainScript), WTF::move(scripts.importedScripts));
 
         callback();
     });

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h
@@ -63,8 +63,6 @@ private:
     void updateToStorage(CompletionHandler<void()>&&);
     void updateTimerFired() { updateToStorage([] { }); }
 
-    RefPtr<WebCore::SWServer> protectedServer() const;
-
     WeakPtr<WebCore::SWServer> m_server;
     ThreadSafeWeakPtr<NetworkStorageManager> m_manager;
     WebCore::Timer m_updateTimer;

--- a/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
+++ b/Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h
@@ -105,8 +105,6 @@ public:
 private:
     WebSWServerToContextConnection(NetworkConnectionToWebProcess&, WebPageProxyIdentifier, WebCore::Site&&, std::optional<WebCore::ScriptExecutionContextIdentifier>, WebCore::SWServer&);
 
-    RefPtr<NetworkConnectionToWebProcess> protectedConnection() const;
-
     template<typename T> void sendToParentProcess(T&&);
     template<typename T, typename C> void sendWithAsyncReplyToParentProcess(T&&, C&&);
 

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h
@@ -86,8 +86,6 @@ private:
 
     void readNextMessage();
 
-    RefPtr<NetworkSocketChannel> protectedChannel() const;
-
     NSURLSessionTask* task() const final;
     WebCore::StoredCredentialsPolicy storedCredentialsPolicy() const final { return m_storedCredentialsPolicy; }
 

--- a/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm
@@ -73,7 +73,7 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifi
         blockCookies();
 
     readNextMessage();
-    protectedChannel()->didSendHandshakeRequest(ResourceRequest { [m_task currentRequest] });
+    protect(m_channel)->didSendHandshakeRequest(ResourceRequest { [m_task currentRequest] });
 
 #if ENABLE(OPT_IN_PARTITIONED_COOKIES) && defined(CFN_COOKIE_ACCEPTS_POLICY_PARTITION) && CFN_COOKIE_ACCEPTS_POLICY_PARTITION
     updateTaskWithStoragePartitionIdentifier(request);
@@ -81,11 +81,6 @@ WebSocketTask::WebSocketTask(NetworkSocketChannel& channel, WebPageProxyIdentifi
 }
 
 WebSocketTask::~WebSocketTask() = default;
-
-RefPtr<NetworkSocketChannel> WebSocketTask::protectedChannel() const
-{
-    return m_channel.get();
-}
 
 void WebSocketTask::readNextMessage()
 {
@@ -148,7 +143,7 @@ void WebSocketTask::didClose(unsigned short code, const String& reason)
         return;
 
     m_receivedDidClose = true;
-    protectedChannel()->didClose(code, reason);
+    protect(m_channel)->didClose(code, reason);
 }
 
 void WebSocketTask::sendString(std::span<const uint8_t> utf8String, CompletionHandler<void()>&& callback)
@@ -193,7 +188,7 @@ WebSocketTask::TaskIdentifier WebSocketTask::identifier() const
 
 NetworkSessionCocoa* WebSocketTask::networkSession()
 {
-    return downcast<NetworkSessionCocoa>(protectedChannel()->session());
+    return downcast<NetworkSessionCocoa>(protect(m_channel)->session());
 }
 
 NSURLSessionTask* WebSocketTask::task() const

--- a/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
+++ b/Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h
@@ -88,8 +88,6 @@ private:
     void didReceiveData(WebCore::CurlStreamID, const WebCore::SharedBuffer&) final;
     void didFail(WebCore::CurlStreamID, CURLcode, WebCore::CertificateInfo&&) final;
 
-    RefPtr<NetworkSocketChannel> protectedChannel() const;
-
     void tryServerTrustEvaluation(WebCore::AuthenticationChallenge&&, String&&);
 
     bool appendReceivedBuffer(const WebCore::SharedBuffer&);

--- a/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h
+++ b/Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h
@@ -60,8 +60,6 @@ private:
 
     String acceptedExtensions() const;
 
-    RefPtr<NetworkSocketChannel> protectedChannel() const;
-
     static void didReceiveMessageCallback(WebSocketTask*, SoupWebsocketDataType, GBytes*);
     static void didReceiveErrorCallback(WebSocketTask*, GError*);
     static void didCloseCallback(WebSocketTask*);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -162,7 +162,6 @@ private:
     NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled);
     ~NetworkStorageManager();
 
-    RefPtr<NetworkProcess> protectedProcess() const;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess(IPC::Connection&) const;
     bool isStorageTypeEnabled(IPC::Connection&, WebCore::StorageType) const;
     bool isStorageAreaTypeEnabled(IPC::Connection&, StorageAreaBase::StorageType) const;
@@ -289,8 +288,6 @@ private:
     void setStorageSiteValidationEnabledInternal(bool);
     void addAllowedSitesForConnectionInternal(IPC::Connection::UniqueID, const Vector<WebCore::RegistrableDomain>&);
     bool isSiteAllowedForConnection(IPC::Connection::UniqueID, const WebCore::RegistrableDomain&) const;
-
-    RefPtr<FileSystemStorageHandleRegistry> protectedFileSystemStorageHandleRegistry();
 
     WeakPtr<NetworkProcess> m_process;
     PAL::SessionID m_sessionID;

--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -647,7 +647,6 @@ private:
     Ref<SerialFunctionDispatcher> dispatcher();
 
     class SyncMessageState;
-    RefPtr<SyncMessageState> protectedSyncState() const;
 
     void addAsyncReplyHandler(AsyncReplyHandler&&);
     void addAsyncReplyHandlerWithDispatcher(AsyncReplyHandlerWithDispatcher&&);

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.cpp
@@ -78,7 +78,7 @@ void StreamServerConnection::invalidate()
         connection->invalidate();
         return;
     }
-    protectedWorkQueue()->removeStreamConnection(*this);
+    protect(m_workQueue)->removeStreamConnection(*this);
     connection->invalidate();
     connection->removeMessageReceiveQueue({ });
     m_workQueue = nullptr;
@@ -110,7 +110,7 @@ void StreamServerConnection::enqueueMessage(Connection&, UniqueRef<Decoder>&& me
         m_outOfStreamMessages.append(WTF::move(message));
     }
     ASSERT(m_workQueue);
-    protectedWorkQueue()->wakeUp();
+    protect(m_workQueue)->wakeUp();
 }
 
 void StreamServerConnection::didReceiveMessage(Connection&, Decoder&)
@@ -307,11 +307,5 @@ void StreamServerConnection::markCurrentlyDispatchedMessageAsInvalid(ASCIILitera
     ASSERT(m_isDispatchingMessage);
     m_didReceiveInvalidMessage = true;
 }
-
-RefPtr<StreamConnectionWorkQueue> StreamServerConnection::protectedWorkQueue() const
-{
-    return m_workQueue;
-}
-
 
 }

--- a/Source/WebKit/Platform/IPC/StreamServerConnection.h
+++ b/Source/WebKit/Platform/IPC/StreamServerConnection.h
@@ -141,8 +141,6 @@ private:
     bool dispatchStreamMessage(Decoder&, StreamMessageReceiver&);
     void dispatchDidReceiveInvalidMessage(Decoder&);
 
-    RefPtr<StreamConnectionWorkQueue> protectedWorkQueue() const;
-
     using WakeUpClient = StreamServerConnectionBuffer::WakeUpClient;
     const Ref<IPC::Connection> m_connection;
     RefPtr<StreamConnectionWorkQueue> m_workQueue;

--- a/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
+++ b/Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h
@@ -79,7 +79,6 @@ public:
     virtual ~PaymentAuthorizationPresenter() = default;
 
     Client* client() { return m_client; }
-    RefPtr<Client> protectedClient() { return m_client; }
 
     void completeMerchantValidation(const WebCore::PaymentMerchantSession&);
     void completePaymentMethodSelection(std::optional<WebCore::ApplePayPaymentMethodUpdate>&&);

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -201,8 +201,6 @@ private:
     void platformSetPaymentRequestUserAgent(PKPaymentRequest *, const String& userAgent);
 #endif
 
-    RefPtr<PaymentAuthorizationPresenter> protectedAuthorizationPresenter() { return m_authorizationPresenter; }
-
     WeakPtr<Client> m_client;
     std::optional<WebCore::PageIdentifier> m_destinationID;
 

--- a/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
+++ b/Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm
@@ -433,34 +433,34 @@ void WebPaymentCoordinatorProxy::platformSetPaymentRequestUserAgent(PKPaymentReq
 
 void WebPaymentCoordinatorProxy::platformCompletePaymentSession(WebCore::ApplePayPaymentAuthorizationResult&& result)
 {
-    protectedAuthorizationPresenter()->completePaymentSession(WTF::move(result));
+    protect(m_authorizationPresenter)->completePaymentSession(WTF::move(result));
 }
 
 void WebPaymentCoordinatorProxy::platformCompleteMerchantValidation(const WebCore::PaymentMerchantSession& paymentMerchantSession)
 {
-    protectedAuthorizationPresenter()->completeMerchantValidation(paymentMerchantSession);
+    protect(m_authorizationPresenter)->completeMerchantValidation(paymentMerchantSession);
 }
 
 void WebPaymentCoordinatorProxy::platformCompleteShippingMethodSelection(std::optional<WebCore::ApplePayShippingMethodUpdate>&& update)
 {
-    protectedAuthorizationPresenter()->completeShippingMethodSelection(WTF::move(update));
+    protect(m_authorizationPresenter)->completeShippingMethodSelection(WTF::move(update));
 }
 
 void WebPaymentCoordinatorProxy::platformCompleteShippingContactSelection(std::optional<WebCore::ApplePayShippingContactUpdate>&& update)
 {
-    protectedAuthorizationPresenter()->completeShippingContactSelection(WTF::move(update));
+    protect(m_authorizationPresenter)->completeShippingContactSelection(WTF::move(update));
 }
 
 void WebPaymentCoordinatorProxy::platformCompletePaymentMethodSelection(std::optional<WebCore::ApplePayPaymentMethodUpdate>&& update)
 {
-    protectedAuthorizationPresenter()->completePaymentMethodSelection(WTF::move(update));
+    protect(m_authorizationPresenter)->completePaymentMethodSelection(WTF::move(update));
 }
 
 #if ENABLE(APPLE_PAY_COUPON_CODE)
 
 void WebPaymentCoordinatorProxy::platformCompleteCouponCodeChange(std::optional<WebCore::ApplePayCouponCodeUpdate>&& update)
 {
-    protectedAuthorizationPresenter()->completeCouponCodeChange(WTF::move(update));
+    protect(m_authorizationPresenter)->completeCouponCodeChange(WTF::move(update));
 }
 
 #endif // ENABLE(APPLE_PAY_COUPON_CODE)

--- a/Source/WebKit/Shared/graphics/ImageBufferSet.h
+++ b/Source/WebKit/Shared/graphics/ImageBufferSet.h
@@ -70,10 +70,6 @@ public:
 
     ImageBufferSetIdentifier identifier() const { return m_identifier; }
 
-    RefPtr<WebCore::ImageBuffer> protectedFrontBuffer() { return m_frontBuffer; }
-    RefPtr<WebCore::ImageBuffer> protectedBackBuffer() { return m_backBuffer; }
-    RefPtr<WebCore::ImageBuffer> protectedSecondaryBackBuffer() { return m_secondaryBackBuffer; }
-
     const ImageBufferSetIdentifier m_identifier { ImageBufferSetIdentifier::generate() };
     RefPtr<WebCore::ImageBuffer> m_frontBuffer;
     RefPtr<WebCore::ImageBuffer> m_backBuffer;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h
@@ -385,12 +385,12 @@ protected:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return protectedStreamConnection()->send(std::forward<T>(message), m_identifier);
+        return protect(m_streamConnection)->send(std::forward<T>(message), m_identifier);
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return protectedStreamConnection()->sendSync(std::forward<T>(message), m_identifier);
+        return protect(m_streamConnection)->sendSync(std::forward<T>(message), m_identifier);
     }
 
     RemoteGraphicsContextGLIdentifier m_identifier { RemoteGraphicsContextGLIdentifier::generate() };
@@ -410,10 +410,6 @@ private:
     void abandonGpuProcess();
     uint32_t createObjectName();
 
-#if ENABLE(VIDEO)
-    RefPtr<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const;
-#endif
-    RefPtr<IPC::StreamClientConnection> protectedStreamConnection() const { return m_streamConnection; }
 
     WeakPtr<GPUProcessConnection> m_gpuProcessConnection; // Only main thread use.
     RefPtr<IPC::StreamClientConnection> m_streamConnection;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -243,7 +243,7 @@ void RemoteRenderingBackendProxy::disconnectGPUProcess()
     m_getPixelBufferSharedMemory = nullptr;
     m_renderingUpdateID = { };
     m_didRenderingUpdateID = { };
-    protectedConnection()->invalidate();
+    protect(m_connection)->invalidate();
     m_connection = nullptr;
     m_isResponsive = false;
     m_gpuProcessConnection = nullptr;

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -234,8 +234,6 @@ private:
     // SerialFunctionDispatcher
     void dispatch(Function<void()>&&) final;
 
-    RefPtr<IPC::StreamClientConnection> protectedConnection() const { return m_connection; }
-
     ThreadSafeWeakPtr<SerialFunctionDispatcher> m_dispatcher;
     WeakPtr<GPUProcessConnection> m_gpuProcessConnection; // Only for main thread operation.
     RefPtr<IPC::StreamClientConnection> m_connection;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -159,8 +159,6 @@ private:
     void dispatch(Function<void()>&&) final;
     bool isCurrent() const final;
 
-    RefPtr<IPC::StreamClientConnection> protectedStreamConnection() const { return m_streamConnection; }
-
     const Ref<WebGPU::ConvertToBackingContext> m_convertToBackingContext;
     const Ref<ModelConvertToBackingContext> m_modelConvertToBackingContext;
     ThreadSafeWeakPtr<SerialFunctionDispatcher> m_dispatcher;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp
@@ -175,19 +175,12 @@ RefPtr<WebCore::NativeImage> RemoteQueueProxy::getNativeImage(WebCore::VideoFram
 {
     RefPtr<WebCore::NativeImage> nativeImage;
 #if ENABLE(VIDEO) && PLATFORM(COCOA) && ENABLE(WEB_CODECS)
-    callOnMainRunLoopAndWait([&nativeImage, videoFrame = Ref { videoFrame }, videoFrameHeap = protectedVideoFrameObjectHeapProxy()] {
+    callOnMainRunLoopAndWait([&nativeImage, videoFrame = Ref { videoFrame }, videoFrameHeap = protect(m_videoFrameObjectHeapProxy)] {
         nativeImage = videoFrameHeap->getNativeImage(videoFrame);
     });
 #endif
     return nativeImage;
 }
-
-#if ENABLE(VIDEO)
-RefPtr<RemoteVideoFrameObjectHeapProxy> RemoteQueueProxy::protectedVideoFrameObjectHeapProxy() const
-{
-    return m_videoFrameObjectHeapProxy;
-}
-#endif
 
 
 } // namespace WebKit::WebGPU

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -110,9 +110,6 @@ private:
         const WebCore::WebGPU::Extent3D& copySize) final;
 
     void setLabelInternal(const String&) final;
-#if ENABLE(VIDEO)
-    RefPtr<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const;
-#endif
     RefPtr<WebCore::NativeImage> getNativeImage(WebCore::VideoFrame&) final;
 
     WebGPUIdentifier m_backing;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp
@@ -50,18 +50,13 @@ RemoteCDMInstanceSession::RemoteCDMInstanceSession(WeakPtr<RemoteCDMFactory>&& f
 
 RemoteCDMInstanceSession::~RemoteCDMInstanceSession()
 {
-    protectedFactory()->removeSession(m_identifier);
-}
-
-RefPtr<RemoteCDMFactory> RemoteCDMInstanceSession::protectedFactory() const
-{
-    return m_factory.get();
+    protect(m_factory.get())->removeSession(m_identifier);
 }
 
 #if !RELEASE_LOG_DISABLED
 void RemoteCDMInstanceSession::setLogIdentifier(uint64_t logIdentifier)
 {
-    protectedFactory()->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceSessionProxy::SetLogIdentifier(reinterpret_cast<uint64_t>(logIdentifier)), m_identifier);
+    protect(m_factory.get())->gpuProcessConnection().connection().send(Messages::RemoteCDMInstanceSessionProxy::SetLogIdentifier(reinterpret_cast<uint64_t>(logIdentifier)), m_identifier);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h
@@ -74,8 +74,6 @@ private:
     void removeSessionData(const String& sessionId, LicenseType, RemoveSessionDataCallback&&) final;
     void storeRecordOfKeyUsage(const String& sessionId) final;
 
-    RefPtr<RemoteCDMFactory> protectedFactory() const;
-
     WeakPtr<RemoteCDMFactory> m_factory;
     RemoteCDMInstanceSessionIdentifier m_identifier;
     WeakPtr<WebCore::CDMInstanceSessionClient> m_client;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -231,9 +231,6 @@ private:
     RefPtr<FramePromise> decodeFrameInternal(Decoder&, int64_t timeStamp, std::span<const uint8_t>, uint16_t width, uint16_t height);
     Ref<FramePromise> sendFrameToDecode(Decoder&, int64_t timeStamp, std::span<const uint8_t>, uint16_t width, uint16_t height);
 
-    RefPtr<IPC::Connection> protectedConnection() const WTF_REQUIRES_LOCK(m_connectionLock) { return m_connection; }
-    RefPtr<RemoteVideoFrameObjectHeapProxy> protectedVideoFrameObjectHeapProxy() const WTF_REQUIRES_LOCK(m_connectionLock);
-
     HashMap<VideoDecoderIdentifier, std::unique_ptr<Decoder>> m_decoders WTF_GUARDED_BY_CAPABILITY(workQueue());
     Lock m_encodersConnectionLock;
     HashMap<VideoEncoderIdentifier, std::unique_ptr<Encoder>> m_encoders WTF_GUARDED_BY_CAPABILITY(workQueue());

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm
@@ -286,7 +286,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 {
     if (RefPtr activeAnnotation = _pdfPlugin->activeAnnotation()) {
         if (WebCore::AXObjectCache* existingCache = _pdfPlugin->axObjectCache()) {
-            if (RefPtr object = existingCache->exportedGetOrCreate(activeAnnotation->protectedElement().get()))
+            if (RefPtr object = existingCache->exportedGetOrCreate(activeAnnotation->element()))
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
                 return [object->wrapper() accessibilityAttributeValue:@"_AXAssociatedPluginParent"];
 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -304,7 +304,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     id wrapper = nil;
     callOnMainRunLoopAndWait([activeAnnotation, protectedSelf = retainPtr(self), &wrapper] {
         if (auto* axObjectCache = protectedSelf->_pdfPlugin->axObjectCache()) {
-            if (RefPtr annotationElementAxObject = axObjectCache->exportedGetOrCreate(activeAnnotation->protectedElement().get()))
+            if (RefPtr annotationElementAxObject = axObjectCache->exportedGetOrCreate(activeAnnotation->element()))
                 wrapper = annotationElementAxObject->wrapper();
         }
     });

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h
@@ -58,8 +58,6 @@ public:
     RetainPtr<PDFAnnotation> protectedAnnotation() const { return m_annotation; }
     PDFPluginBase* plugin() const { return m_plugin.get(); }
 
-    RefPtr<WebCore::Element> protectedElement() const { return element(); }
-
     virtual void updateGeometry();
     virtual void commit();
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -474,9 +474,6 @@ protected:
 
     WebCore::Color pluginBackgroundColor() const;
 
-    RefPtr<PluginView> protectedView() const;
-    RefPtr<WebFrame> protectedFrame() const;
-
     SingleThreadWeakPtr<PluginView> m_view;
     WeakPtr<WebFrame> m_frame;
     WeakPtr<WebCore::HTMLPlugInElement, WebCore::WeakPtrImplWithEventTargetData> m_element;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -846,7 +846,7 @@ bool PDFPluginBase::formControlRefreshEnabled() const
 
 IntRect PDFPluginBase::scrollableAreaBoundingBox(bool*) const
 {
-    return protectedView()->frameRect();
+    return protect(m_view.get())->frameRect();
 }
 
 void PDFPluginBase::setScrollOffset(const ScrollOffset& offset)
@@ -1057,7 +1057,7 @@ void PDFPluginBase::updateScrollbars()
 
     if (horizontalScrollbar) {
         auto scrollbarRect = viewRelativeHorizontalScrollbarRect();
-        scrollbarRect.moveBy(protectedView()->location());
+        scrollbarRect.moveBy(protect(m_view.get())->location());
         horizontalScrollbar->setFrameRect(scrollbarRect);
 
         horizontalScrollbar->setSteps(Scrollbar::pixelsPerLineStep(), firstPageHeight());
@@ -1066,7 +1066,7 @@ void PDFPluginBase::updateScrollbars()
 
     if (verticalScrollbar) {
         auto scrollbarRect = viewRelativeVerticalScrollbarRect();
-        scrollbarRect.moveBy(protectedView()->location());
+        scrollbarRect.moveBy(protect(m_view.get())->location());
         verticalScrollbar->setFrameRect(scrollbarRect);
 
         verticalScrollbar->setSteps(Scrollbar::pixelsPerLineStep(), firstPageHeight());
@@ -1099,7 +1099,7 @@ Ref<Scrollbar> PDFPluginBase::createScrollbar(ScrollbarOrientation orientation)
             scrollAnimator().setWheelEventTestMonitor(page->wheelEventTestMonitor());
     }
 
-    if (RefPtr frame = protectedView()->frame()) {
+    if (RefPtr frame = protect(m_view.get())->frame()) {
         if (RefPtr frameView = frame->view())
             frameView->addChild(widget);
     }
@@ -1141,7 +1141,7 @@ void PDFPluginBase::wantsWheelEventsChanged()
 void PDFPluginBase::print()
 {
     if (RefPtr page = this->page())
-        page->chrome().print(*protect(protectedFrame()->coreLocalFrame()));
+        page->chrome().print(*protect(protect(m_frame.get())->coreLocalFrame()));
 }
 
 std::optional<PageIdentifier> PDFPluginBase::pageIdentifier() const
@@ -1265,7 +1265,7 @@ void PDFPluginBase::updateHUDLocation()
 {
     if (!shouldShowHUD())
         return;
-    protect(protectedFrame()->page())->updatePDFHUDLocation(*this, frameForHUDInRootViewCoordinates());
+    protect(protect(m_frame.get())->page())->updatePDFHUDLocation(*this, frameForHUDInRootViewCoordinates());
 }
 
 IntRect PDFPluginBase::frameForHUDInRootViewCoordinates() const
@@ -1518,7 +1518,7 @@ void PDFPluginBase::registerPDFTest(RefPtr<WebCore::VoidCallback>&& callback)
 
 std::optional<FrameIdentifier> PDFPluginBase::rootFrameID() const
 {
-    return protectedView()->frame()->rootFrame().frameID();
+    return protect(m_view.get())->frame()->rootFrame().frameID();
 }
 
 // FIXME: Share more of the style sheet between the embed/non-embed case.
@@ -1642,16 +1642,6 @@ unsigned PDFPluginBase::countFindMatches(const String& target, WebCore::FindOpti
 
     NSStringCompareOptions nsOptions = options.contains(FindOption::CaseInsensitive) ? NSCaseInsensitiveSearch : 0;
     return [[m_pdfDocument findString:target.createNSString().get() withOptions:nsOptions] count];
-}
-
-RefPtr<PluginView> PDFPluginBase::protectedView() const
-{
-    return m_view.get();
-}
-
-RefPtr<WebFrame> PDFPluginBase::protectedFrame() const
-{
-    return m_frame.get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm
@@ -59,7 +59,7 @@ void PDFPluginChoiceAnnotation::updateGeometry()
 
 void PDFPluginChoiceAnnotation::commit()
 {
-    protectedAnnotation().get().widgetStringValue = downcast<HTMLSelectElement>(protectedElement())->value().createNSString().get();
+    protectedAnnotation().get().widgetStringValue = downcast<HTMLSelectElement>(protect(element()))->value().createNSString().get();
 
     PDFPluginAnnotation::commit();
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm
@@ -45,7 +45,7 @@ Ref<PDFPluginPasswordField> PDFPluginPasswordField::create(PDFPluginBase* plugin
 
 PDFPluginPasswordField::~PDFPluginPasswordField()
 {
-    protectedElement()->removeEventListener(eventNames().keyupEvent, *eventListener(), { .capture = false });
+    protect(element())->removeEventListener(eventNames().keyupEvent, *eventListener(), { .capture = false });
 }
 
 Ref<Element> PDFPluginPasswordField::createAnnotationElement()

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm
@@ -75,7 +75,7 @@ Ref<PDFPluginTextAnnotation> PDFPluginTextAnnotation::create(PDFAnnotation *anno
 
 PDFPluginTextAnnotation::~PDFPluginTextAnnotation()
 {
-    protectedElement()->removeEventListener(eventNames().keydownEvent, *eventListener(), { .capture = false });
+    protect(element())->removeEventListener(eventNames().keydownEvent, *eventListener(), { .capture = false });
 }
 
 Ref<Element> PDFPluginTextAnnotation::createAnnotationElement()
@@ -116,12 +116,12 @@ void PDFPluginTextAnnotation::commit()
 
 String PDFPluginTextAnnotation::value() const
 {
-    return downcast<HTMLTextFormControlElement>(protectedElement())->value();
+    return downcast<HTMLTextFormControlElement>(protect(element()))->value();
 }
 
 void PDFPluginTextAnnotation::setValue(const String& value)
 {
-    downcast<HTMLTextFormControlElement>(protectedElement())->setValue(value);
+    downcast<HTMLTextFormControlElement>(protect(element()))->setValue(value);
 }
 
 bool PDFPluginTextAnnotation::handleEvent(Event& event)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h
@@ -68,7 +68,6 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     bool handleMouseEvent(const WebMouseEvent&, PDFDocumentLayout::PageIndex);
-    RefPtr<WebCore::PageOverlay> protectedOverlay() const { return m_overlay; }
 
     enum class ShouldUpdatePlatformHighlightData : bool { No, Yes };
     enum class ActiveHighlightChanged : bool { No, Yes };
@@ -99,8 +98,6 @@ private:
     void updateDataDetectorHighlightsIfNeeded(PDFDocumentLayout::PageIndex);
 
     bool handleDataDetectorAction(const WebCore::IntPoint&, PDFDataDetectorItem&);
-
-    RefPtr<UnifiedPDFPlugin> protectedPlugin() const;
 
     ThreadSafeWeakPtr<UnifiedPDFPlugin> m_plugin;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm
@@ -71,18 +71,13 @@ PDFDataDetectorOverlayController::PDFDataDetectorOverlayController(UnifiedPDFPlu
 
 PDFDataDetectorOverlayController::~PDFDataDetectorOverlayController() = default;
 
-RefPtr<UnifiedPDFPlugin> PDFDataDetectorOverlayController::protectedPlugin() const
-{
-    return m_plugin.get();
-}
-
 Ref<PageOverlay> PDFDataDetectorOverlayController::installProtectedOverlayIfNeeded()
 {
     if (m_overlay)
         return *m_overlay;
 
     m_overlay = PageOverlay::create(*this, PageOverlay::OverlayType::Document);
-    protectedPlugin()->installDataDetectorOverlay(Ref { *m_overlay });
+    protect(m_plugin.get())->installDataDetectorOverlay(Ref { *m_overlay });
 
     return *m_overlay;
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h
@@ -206,19 +206,11 @@ private:
         RefPtr<WebCore::GraphicsLayer> rightPageBackgroundLayer() const;
 
         RefPtr<WebCore::GraphicsLayer> backgroundLayerForPageIndex(PDFDocumentLayout::PageIndex) const;
-
-        RefPtr<WebCore::GraphicsLayer> protectedContainerLayer() const { return containerLayer; }
-        RefPtr<WebCore::GraphicsLayer> protectedLeftPageContainerLayer() const { return leftPageContainerLayer; }
-        RefPtr<WebCore::GraphicsLayer> protectedRightPageContainerLayer() const { return rightPageContainerLayer; }
-        RefPtr<WebCore::GraphicsLayer> protectedContentsLayer() const { return contentsLayer; }
-        RefPtr<WebCore::GraphicsLayer> protectedSelectionLayer() const { return selectionLayer; }
     };
 
     const RowData* rowDataForLayer(const WebCore::GraphicsLayer&) const;
     WebCore::FloatPoint positionForRowContainerLayer(const PDFLayoutRow&) const;
     WebCore::FloatSize rowContainerSize(const PDFLayoutRow&) const;
-
-    RefPtr<WebCore::GraphicsLayer> protectedRowsContainerLayer() const { return m_rowsContainerLayer; }
 
     RefPtr<WebCore::GraphicsLayer> m_rowsContainerLayer;
     Vector<RowData> m_rows;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h
@@ -106,13 +106,6 @@ private:
 
     void setSelectionLayerEnabled(bool) final;
 
-    RefPtr<WebCore::GraphicsLayer> protectedContentsLayer() { return m_contentsLayer; }
-    RefPtr<WebCore::GraphicsLayer> protectedPageBackgroundsContainerLayer() { return m_pageBackgroundsContainerLayer; }
-
-#if ENABLE(PDFKIT_PAINTED_SELECTIONS)
-    RefPtr<WebCore::GraphicsLayer> protectedSelectionLayer() { return m_selectionLayer; }
-#endif
-
     RefPtr<WebCore::GraphicsLayer> m_pageBackgroundsContainerLayer;
     RefPtr<WebCore::GraphicsLayer> m_contentsLayer;
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -187,7 +187,7 @@ void PDFScrollingPresentationController::updateLayersOnLayoutChange(FloatSize do
     transform.translate(centeringOffset.width(), centeringOffset.height());
 
     contentsLayer->setTransform(transform);
-    protectedPageBackgroundsContainerLayer()->setTransform(transform);
+    protect(m_pageBackgroundsContainerLayer)->setTransform(transform);
 
 #if ENABLE(PDFKIT_PAINTED_SELECTIONS)
     Ref selectionLayer = *m_selectionLayer;
@@ -270,13 +270,13 @@ void PDFScrollingPresentationController::didGeneratePreviewForPage(PDFDocumentLa
 
 void PDFScrollingPresentationController::updateIsInWindow(bool isInWindow)
 {
-    protectedContentsLayer()->setIsInWindow(isInWindow);
+    protect(m_contentsLayer)->setIsInWindow(isInWindow);
 
 #if ENABLE(PDFKIT_PAINTED_SELECTIONS)
-    protectedSelectionLayer()->setIsInWindow(isInWindow);
+    protect(m_selectionLayer)->setIsInWindow(isInWindow);
 #endif
 
-    for (auto& pageLayer : protectedPageBackgroundsContainerLayer()->children()) {
+    for (auto& pageLayer : protect(m_pageBackgroundsContainerLayer)->children()) {
         if (pageLayer->children().size()) {
             Ref pageContentsLayer = pageLayer->children()[0];
             pageContentsLayer->setIsInWindow(isInWindow);
@@ -323,7 +323,7 @@ void PDFScrollingPresentationController::updateForCurrentScrollability(OptionSet
         tiledBacking->setScrollability(scrollability);
 
 #if ENABLE(PDFKIT_PAINTED_SELECTIONS)
-    if (CheckedPtr tiledBacking = protectedSelectionLayer()->tiledBacking())
+    if (CheckedPtr tiledBacking = protect(m_selectionLayer)->tiledBacking())
         tiledBacking->setScrollability(scrollability);
 #endif
 }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -656,11 +656,6 @@ private:
 
     bool delegatesScrollingToMainFrame() const final;
 
-    RefPtr<PDFPresentationController> protectedPresentationController() const;
-
-    RefPtr<WebCore::GraphicsLayer> protectedScrollContainerLayer() const;
-    RefPtr<WebCore::GraphicsLayer> protectedOverflowControlsContainer() const;
-
     RefPtr<PDFPresentationController> m_presentationController;
 
     PDFDocumentLayout m_documentLayout;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -204,7 +204,7 @@ UnifiedPDFPlugin::UnifiedPDFPlugin(HTMLPlugInElement& element)
     if (isFullMainFramePlugin())
         [m_accessibilityDocumentObject setParent:protect(protect(frame->page())->accessibilityRemoteObject()).get()];
 
-    if (protectedPresentationController()->wantsWheelEvents())
+    if (protect(m_presentationController)->wantsWheelEvents())
         wantsWheelEventsChanged();
 
     if (shouldSizeToFitContent()) {
@@ -255,7 +255,7 @@ void UnifiedPDFPlugin::teardown()
 
     GraphicsLayer::unparentAndClear(m_rootLayer);
 
-    bool wantedWheelEvents = protectedPresentationController()->wantsWheelEvents();
+    bool wantedWheelEvents = protect(m_presentationController)->wantsWheelEvents();
     setPresentationController(nullptr); // Breaks retain cycle.
 
     if (wantedWheelEvents)
@@ -306,7 +306,7 @@ FrameView* UnifiedPDFPlugin::mainFrameView() const
     if (!m_frame)
         return nullptr;
 
-    RefPtr webPage = protectedFrame()->page();
+    RefPtr webPage = protect(m_frame)->page();
     if (!webPage)
         return nullptr;
 
@@ -359,7 +359,7 @@ void UnifiedPDFPlugin::installPDFDocument()
     enableDataDetection();
 #endif
 
-    if (protectedPresentationController()->wantsWheelEvents())
+    if (protect(m_presentationController)->wantsWheelEvents())
         wantsWheelEventsChanged();
 
     revealFragmentIfNeeded();
@@ -444,7 +444,7 @@ bool UnifiedPDFPlugin::canShowDataDetectorHighlightOverlays() const
 void UnifiedPDFPlugin::didInvalidateDataDetectorHighlightOverlayRects()
 {
     auto lastKnownMousePositionInDocumentSpace = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, lastKnownMousePositionInView());
-    auto pageIndex = protectedPresentationController()->pageIndexForDocumentPoint(lastKnownMousePositionInDocumentSpace);
+    auto pageIndex = protect(m_presentationController)->pageIndexForDocumentPoint(lastKnownMousePositionInDocumentSpace);
     protectedDataDetectorOverlayController()->didInvalidateHighlightOverlayRects(pageIndex);
 }
 
@@ -552,7 +552,7 @@ void UnifiedPDFPlugin::setNeedsRepaintForAnnotation(PDFAnnotation *annotation, R
         return;
 
     auto selectionCoverage = PDFPageCoverage::from(PerPageInfo { *pageIndex, layoutBoundsForPageAtIndex(*pageIndex), [annotation bounds] });
-    protectedPresentationController()->setNeedsRepaintForPageCoverage(repaintRequirements, selectionCoverage);
+    protect(m_presentationController)->setNeedsRepaintForPageCoverage(repaintRequirements, selectionCoverage);
 }
 
 void UnifiedPDFPlugin::scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps)
@@ -603,7 +603,7 @@ void UnifiedPDFPlugin::ensureLayers()
         rootLayer->addChild(*overflowControlsContainer);
     }
 
-    protectedPresentationController()->setupLayers(*scrolledContentsLayer);
+    protect(m_presentationController)->setupLayers(*scrolledContentsLayer);
 }
 
 void UnifiedPDFPlugin::incrementalLoadingRepaintTimerFired()
@@ -622,7 +622,7 @@ void UnifiedPDFPlugin::setNeedsRepaintForIncrementalLoad()
         auto pageBounds = layoutBoundsForPageAtIndex(i);
         pageCoverage.append({ i, pageBounds, pageBounds });
     }
-    protectedPresentationController()->setNeedsRepaintForPageCoverage({ RepaintRequirement::PDFContent, RepaintRequirement::HoverOverlay, RepaintRequirement::Selection }, pageCoverage);
+    protect(m_presentationController)->setNeedsRepaintForPageCoverage({ RepaintRequirement::PDFContent, RepaintRequirement::HoverOverlay, RepaintRequirement::Selection }, pageCoverage);
 }
 
 float UnifiedPDFPlugin::scaleForPagePreviews() const
@@ -667,7 +667,7 @@ void UnifiedPDFPlugin::createScrollingNodeIfNecessary()
         return;
 
     m_scrollingNodeID = scrollingCoordinator->uniqueScrollingNodeID();
-    scrollingCoordinator->createNode(protectedFrame()->coreLocalFrame()->rootFrame().frameID(), ScrollingNodeType::PluginScrolling, *m_scrollingNodeID);
+    scrollingCoordinator->createNode(protect(m_frame)->coreLocalFrame()->rootFrame().frameID(), ScrollingNodeType::PluginScrolling, *m_scrollingNodeID);
 
     RefPtr scrollContainerLayer = m_scrollContainerLayer;
 #if ENABLE(SCROLLING_THREAD)
@@ -683,7 +683,7 @@ void UnifiedPDFPlugin::createScrollingNodeIfNecessary()
         layer->setScrollingNodeID(*m_scrollingNodeID);
 #endif
 
-    protectedFrame()->coreLocalFrame()->protectedView()->setPluginScrollableAreaForScrollingNodeID(*m_scrollingNodeID, *this);
+    protect(m_frame)->coreLocalFrame()->protectedView()->setPluginScrollableAreaForScrollingNodeID(*m_scrollingNodeID, *this);
 
     scrollingCoordinator->setScrollingNodeScrollableAreaGeometry(*m_scrollingNodeID, *this);
 
@@ -703,14 +703,14 @@ void UnifiedPDFPlugin::updateLayerHierarchy()
 
     // The protect(graphicsLayer())'s position is set in RenderLayerBacking::updateAfterWidgetResize().
     protect(graphicsLayer())->setSize(size());
-    protectedOverflowControlsContainer()->setSize(size());
+    protect(m_overflowControlsContainer)->setSize(size());
 
     auto scrollContainerRect = availableContentsRect();
     Ref scrollContainerLayer = *m_scrollContainerLayer;
     scrollContainerLayer->setPosition(scrollContainerRect.location());
     scrollContainerLayer->setSize(scrollContainerRect.size());
 
-    protectedPresentationController()->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor);
+    protect(m_presentationController)->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor);
     updateSnapOffsets();
 
     didChangeSettings();
@@ -754,7 +754,7 @@ void UnifiedPDFPlugin::didChangeSettings()
     if (RefPtr layerForScrollCorner = m_layerForScrollCorner)
         propagateSettingsToLayer(*layerForScrollCorner);
 
-    protectedPresentationController()->updateDebugBorders(showDebugBorders, showRepaintCounter);
+    protect(m_presentationController)->updateDebugBorders(showDebugBorders, showRepaintCounter);
 }
 
 void UnifiedPDFPlugin::notifyFlushRequired(const GraphicsLayer*)
@@ -778,7 +778,7 @@ void UnifiedPDFPlugin::didChangeIsInWindow()
         return;
 
     bool isInWindow = page->isInWindow();
-    protectedPresentationController()->updateIsInWindow(isInWindow);
+    protect(m_presentationController)->updateIsInWindow(isInWindow);
 
     if (!isInWindow) {
         RefPtr scrollingCoordinator = page->scrollingCoordinator();
@@ -810,7 +810,7 @@ void UnifiedPDFPlugin::paint(GraphicsContext& context, const IntRect&)
 
     clipRect.scale(1.0f / m_scaleFactor);
 
-    paintPDFContent(nullptr, context, clipRect, protectedPresentationController()->visibleRow());
+    paintPDFContent(nullptr, context, clipRect, protect(m_presentationController)->visibleRow());
 }
 
 void UnifiedPDFPlugin::paintContents(const GraphicsLayer& layer, GraphicsContext& context, const FloatRect& clipRect, OptionSet<GraphicsLayerPaintBehavior>)
@@ -1219,7 +1219,7 @@ void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPo
 
     deviceOrPageScaleFactorChanged(CheckForMagnificationGesture::Yes);
 
-    protectedPresentationController()->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor);
+    protect(m_presentationController)->updateLayersOnLayoutChange(documentSize(), centeringOffset(), m_scaleFactor);
     updateSnapOffsets();
 
 #if PLATFORM(MAC)
@@ -1237,7 +1237,7 @@ void UnifiedPDFPlugin::setScaleFactor(double scale, std::optional<WebCore::IntPo
 
     scheduleRenderingUpdate();
 
-    protectedView()->pluginScaleFactorDidChange();
+    protect(m_view)->pluginScaleFactorDidChange();
 
     LOG_WITH_STREAM(PDF, stream << "UnifiedPDFPlugin::setScaleFactor " << scale << " - new scale factor " << m_scaleFactor << " (exposed as normalized scale factor " << scaleFactor() << ") normalization factor " << m_scaleNormalizationFactor << " layout scale " << m_documentLayout.scale());
 }
@@ -1253,7 +1253,7 @@ void UnifiedPDFPlugin::setPageScaleFactor(double scale, std::optional<WebCore::I
     if (origin) {
         // Compensate for the subtraction of content insets that happens in ViewGestureController::handleMagnificationGestureEvent();
         // origin is not in root view coordinates.
-        if (RefPtr frameView = protectedFrame()->coreLocalFrame()->view()) {
+        if (RefPtr frameView = protect(m_frame)->coreLocalFrame()->view()) {
             auto obscuredContentInsets = frameView->obscuredContentInsets();
             origin->move(std::round(obscuredContentInsets.left()), std::round(obscuredContentInsets.top()));
         }
@@ -1325,7 +1325,7 @@ void UnifiedPDFPlugin::deviceOrPageScaleFactorChanged(CheckForMagnificationGestu
         protect(graphicsLayer())->noteDeviceOrPageScaleFactorChangedIncludingDescendants();
 
     if (gestureAllowsScaleUpdate)
-        protectedPresentationController()->deviceOrPageScaleFactorChanged();
+        protect(m_presentationController)->deviceOrPageScaleFactorChanged();
 }
 
 IntRect UnifiedPDFPlugin::availableContentsRect() const
@@ -1477,9 +1477,9 @@ void UnifiedPDFPlugin::releaseMemory()
 void UnifiedPDFPlugin::didChangeScrollOffset()
 {
     if (this->currentScrollType() == ScrollType::User)
-        protectedScrollContainerLayer()->syncBoundsOrigin(IntPoint(m_scrollOffset));
+        protect(m_scrollContainerLayer)->syncBoundsOrigin(IntPoint(m_scrollOffset));
     else
-        protectedScrollContainerLayer()->setBoundsOrigin(IntPoint(m_scrollOffset));
+        protect(m_scrollContainerLayer)->setBoundsOrigin(IntPoint(m_scrollOffset));
 
 #if PLATFORM(MAC)
     if (RefPtr activeAnnotation = m_activeAnnotation)
@@ -1512,7 +1512,7 @@ void UnifiedPDFPlugin::didChangeVisibleRow()
     didInvalidateDataDetectorHighlightOverlayRects();
 #endif
 
-    protectedPresentationController()->updateForCurrentScrollability(computeScrollability());
+    protect(m_presentationController)->updateForCurrentScrollability(computeScrollability());
 }
 
 bool UnifiedPDFPlugin::updateOverflowControlsLayers(bool needsHorizontalScrollbarLayer, bool needsVerticalScrollbarLayer, bool needsScrollCornerLayer)
@@ -1542,7 +1542,7 @@ bool UnifiedPDFPlugin::updateOverflowControlsLayers(bool needsHorizontalScrollba
             layer->setScrollingNodeID(m_scrollingNodeID);
 #endif
 
-            protectedOverflowControlsContainer()->addChild(*layer);
+            protect(m_overflowControlsContainer)->addChild(*layer);
         } else
             GraphicsLayer::unparentAndClear(layer);
 
@@ -1679,7 +1679,7 @@ bool UnifiedPDFPlugin::shouldCachePagePreviews() const
 OptionSet<TiledBackingScrollability> UnifiedPDFPlugin::computeScrollability() const
 {
     if (shouldSizeToFitContent()) {
-        RefPtr frameView = protectedFrame()->coreLocalFrame()->view();
+        RefPtr frameView = protect(m_frame)->coreLocalFrame()->view();
         if (frameView)
             return frameView->computeScrollability();
     }
@@ -1827,13 +1827,13 @@ PDFDocumentLayout::PageIndex UnifiedPDFPlugin::indexForCurrentPageInView() const
 {
     // FIXME: <https://webkit.org/b/276981> This is not correct for discrete presentation mode.
     auto centerInDocumentSpace = convertDown(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, FloatPoint { flooredIntPoint(size() / 2) });
-    return protectedPresentationController()->nearestPageIndexForDocumentPoint(centerInDocumentSpace);
+    return protect(m_presentationController)->nearestPageIndexForDocumentPoint(centerInDocumentSpace);
 }
 
 RetainPtr<PDFAnnotation> UnifiedPDFPlugin::annotationForRootViewPoint(const IntPoint& point) const
 {
     auto pointInDocumentSpace = convertDown(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, FloatPoint { convertFromRootViewToPlugin(point) });
-    auto pageIndex = protectedPresentationController()->pageIndexForDocumentPoint(pointInDocumentSpace);
+    auto pageIndex = protect(m_presentationController)->pageIndexForDocumentPoint(pointInDocumentSpace);
     if (!pageIndex)
         return nullptr;
 
@@ -1843,12 +1843,12 @@ RetainPtr<PDFAnnotation> UnifiedPDFPlugin::annotationForRootViewPoint(const IntP
 
 FloatRect UnifiedPDFPlugin::convertFromContentsToPainting(const FloatRect& rect, std::optional<PDFDocumentLayout::PageIndex> pageIndex) const
 {
-    return protectedPresentationController()->convertFromContentsToPainting(rect, pageIndex);
+    return protect(m_presentationController)->convertFromContentsToPainting(rect, pageIndex);
 }
 
 FloatRect UnifiedPDFPlugin::convertFromPaintingToContents(const FloatRect& rect, std::optional<PDFDocumentLayout::PageIndex> pageIndex) const
 {
-    return protectedPresentationController()->convertFromPaintingToContents(rect, pageIndex);
+    return protect(m_presentationController)->convertFromPaintingToContents(rect, pageIndex);
 }
 
 #if !LOG_DISABLED
@@ -1888,7 +1888,7 @@ static BOOL annotationIsLinkWithDestination(PDFAnnotation *annotation)
 auto UnifiedPDFPlugin::pdfElementTypesForPluginPoint(const IntPoint& point) const -> PDFElementTypes
 {
     auto pointInDocumentSpace = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, point);
-    auto hitPageIndex = protectedPresentationController()->pageIndexForDocumentPoint(pointInDocumentSpace);
+    auto hitPageIndex = protect(m_presentationController)->pageIndexForDocumentPoint(pointInDocumentSpace);
     if (!hitPageIndex || *hitPageIndex >= m_documentLayout.pageCount())
         return { };
 
@@ -2144,7 +2144,7 @@ bool UnifiedPDFPlugin::wantsWheelEvents() const
 
 bool UnifiedPDFPlugin::handleWheelEvent(const WebWheelEvent& wheelEvent)
 {
-    auto handledByPresentationController = protectedPresentationController()->handleWheelEvent(wheelEvent);
+    auto handledByPresentationController = protect(m_presentationController)->handleWheelEvent(wheelEvent);
 
     LOG_WITH_STREAM(PDF, stream << "UnifiedPDFPlugin::handleWheelEvent " << platform(wheelEvent) << " - handledByPresentationController " << handledByPresentationController);
 
@@ -2159,7 +2159,7 @@ PlatformWheelEvent UnifiedPDFPlugin::wheelEventCopyWithVelocity(const PlatformWh
     if (!isFullMainFramePlugin())
         return wheelEvent;
 
-    RefPtr webPage = protectedFrame()->page();
+    RefPtr webPage = protect(m_frame)->page();
     if (!webPage)
         return wheelEvent;
 
@@ -2195,7 +2195,7 @@ bool UnifiedPDFPlugin::handleContextMenuEvent(const WebMouseEvent& event)
 
 bool UnifiedPDFPlugin::handleKeyboardEvent(const WebKeyboardEvent& event)
 {
-    return protectedPresentationController()->handleKeyboardEvent(event);
+    return protect(m_presentationController)->handleKeyboardEvent(event);
 }
 
 void UnifiedPDFPlugin::followLinkAnnotation(PDFAnnotation *annotation, std::optional<PlatformMouseEvent>&& event)
@@ -2289,7 +2289,7 @@ void UnifiedPDFPlugin::revealPDFDestination(PDFDestination *destination)
 
 void UnifiedPDFPlugin::revealRectInPage(const FloatRect& pageRect, PDFDocumentLayout::PageIndex pageIndex)
 {
-    protectedPresentationController()->ensurePageIsVisible(pageIndex);
+    protect(m_presentationController)->ensurePageIsVisible(pageIndex);
     auto contentsRect = convertUp(CoordinateSpace::PDFPage, CoordinateSpace::ScrolledContents, pageRect, pageIndex);
 
     auto pluginRectInContentsCoordinates = convertDown(CoordinateSpace::Plugin, CoordinateSpace::ScrolledContents, FloatRect { { 0, 0 }, size() });
@@ -2300,7 +2300,7 @@ void UnifiedPDFPlugin::revealRectInPage(const FloatRect& pageRect, PDFDocumentLa
 
 void UnifiedPDFPlugin::revealPointInPage(FloatPoint pointInPDFPageSpace, PDFDocumentLayout::PageIndex pageIndex)
 {
-    protectedPresentationController()->ensurePageIsVisible(pageIndex);
+    protect(m_presentationController)->ensurePageIsVisible(pageIndex);
     auto contentsPoint = convertUp(CoordinateSpace::PDFPage, CoordinateSpace::ScrolledContents, pointInPDFPageSpace, pageIndex);
     scrollToPointInContentsSpace(contentsPoint);
 }
@@ -2308,7 +2308,7 @@ void UnifiedPDFPlugin::revealPointInPage(FloatPoint pointInPDFPageSpace, PDFDocu
 bool UnifiedPDFPlugin::revealPage(PDFDocumentLayout::PageIndex pageIndex)
 {
     ASSERT(pageIndex < m_documentLayout.pageCount());
-    protectedPresentationController()->ensurePageIsVisible(pageIndex);
+    protect(m_presentationController)->ensurePageIsVisible(pageIndex);
 
     auto pageBounds = m_documentLayout.layoutBoundsForPageAtIndex(pageIndex);
     auto boundsInScrolledContents = convertUp(CoordinateSpace::PDFDocumentLayout, CoordinateSpace::ScrolledContents, pageBounds);
@@ -2318,7 +2318,7 @@ bool UnifiedPDFPlugin::revealPage(PDFDocumentLayout::PageIndex pageIndex)
 bool UnifiedPDFPlugin::scrollToPointInContentsSpace(FloatPoint pointInContentsSpace)
 {
     if (shouldSizeToFitContent()) {
-        RefPtr webPage = protectedFrame()->page();
+        RefPtr webPage = protect(m_frame)->page();
         if (!webPage)
             return false;
 
@@ -2531,7 +2531,7 @@ std::optional<PDFContextMenu> UnifiedPDFPlugin::createContextMenu(const WebMouse
     auto contextMenuEventPluginPoint = convertFromRootViewToPlugin(contextMenuEventRootViewPoint);
     // FIXME: <https://webkit.org/b/276981> Fix for rows.
     auto contextMenuEventDocumentPoint = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, contextMenuEventPluginPoint);
-    menuItems.appendVector(navigationContextMenuItemsForPageAtIndex(protectedPresentationController()->nearestPageIndexForDocumentPoint(contextMenuEventDocumentPoint)));
+    menuItems.appendVector(navigationContextMenuItemsForPageAtIndex(protect(m_presentationController)->nearestPageIndexForDocumentPoint(contextMenuEventDocumentPoint)));
 
     auto contextMenuPoint = frameView->contentsToScreen(IntRect(frameView->windowToContents(contextMenuEventRootViewPoint), IntSize())).location();
 
@@ -3111,7 +3111,7 @@ void UnifiedPDFPlugin::repaintOnSelectionChange(ActiveStateChangeReason reason, 
     }
 
     auto repaintCoverage = unite(pageCoverageForSelection(previousSelection), pageCoverageForSelection(protectedCurrentSelection().get()));
-    protectedPresentationController()->setNeedsRepaintForPageCoverage(RepaintRequirement::Selection, repaintCoverage);
+    protect(m_presentationController)->setNeedsRepaintForPageCoverage(RepaintRequirement::Selection, repaintCoverage);
 }
 
 RetainPtr<PDFSelection> UnifiedPDFPlugin::protectedCurrentSelection() const
@@ -3129,7 +3129,7 @@ void UnifiedPDFPlugin::setCurrentSelection(RetainPtr<PDFSelection>&& selection)
 #if ENABLE(TEXT_SELECTION)
     // FIXME: <https://webkit.org/b/268980> Selection painting requests should be only be made if the current selection has changed.
     // FIXME: <https://webkit.org/b/270070> Selection painting should be optimized by only repainting diff between old and new selection.
-    protectedPresentationController()->setSelectionLayerEnabled(hasSelection());
+    protect(m_presentationController)->setSelectionLayerEnabled(hasSelection());
     repaintOnSelectionChange(ActiveStateChangeReason::SetCurrentSelection, previousSelection.get());
 #endif
     notifySelectionChanged();
@@ -3193,7 +3193,7 @@ bool UnifiedPDFPlugin::existingSelectionContainsPoint(const FloatPoint& rootView
 {
     auto pluginPoint = convertFromRootViewToPlugin(roundedIntPoint(rootViewPoint));
     auto documentPoint = convertDown(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, FloatPoint { pluginPoint });
-    auto pageIndex = protectedPresentationController()->pageIndexForDocumentPoint(documentPoint);
+    auto pageIndex = protect(m_presentationController)->pageIndexForDocumentPoint(documentPoint);
     if (!pageIndex)
         return false;
 
@@ -3285,7 +3285,7 @@ void UnifiedPDFPlugin::continueAutoscroll()
     scrollWithDelta(scrollDelta);
 
     auto lastKnownMousePositionInDocumentSpace = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, lastKnownMousePositionInPluginSpace);
-    auto pageIndex = protectedPresentationController()->nearestPageIndexForDocumentPoint(lastKnownMousePositionInDocumentSpace);
+    auto pageIndex = protect(m_presentationController)->nearestPageIndexForDocumentPoint(lastKnownMousePositionInDocumentSpace);
     auto lastKnownMousePositionInPageSpace = convertDown(CoordinateSpace::PDFDocumentLayout, CoordinateSpace::PDFPage, lastKnownMousePositionInDocumentSpace, pageIndex);
 
     continueTrackingSelection(pageIndex, lastKnownMousePositionInPageSpace, IsDraggingSelection::Yes);
@@ -3483,7 +3483,7 @@ Vector<WebCore::FloatRect> UnifiedPDFPlugin::rectsForTextMatchesInRect(const Vec
 
 Vector<WebCore::FloatRect> UnifiedPDFPlugin::visibleRectsForFindMatchRects(const PDFPageCoverage& findMatchRects, const WebCore::IntRect& clipRect) const
 {
-    auto visibleRow = protectedPresentationController()->visibleRow();
+    auto visibleRow = protect(m_presentationController)->visibleRow();
 
     Vector<FloatRect> rectsInPluginCoordinates;
     if (!visibleRow)
@@ -3677,7 +3677,7 @@ bool UnifiedPDFPlugin::performDictionaryLookupAtLocation(const FloatPoint& rootV
 {
     auto pluginPoint = convertFromRootViewToPlugin(roundedIntPoint(rootViewPoint));
     auto documentPoint = convertDown(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, FloatPoint { pluginPoint });
-    auto pageIndex = protectedPresentationController()->pageIndexForDocumentPoint(documentPoint);
+    auto pageIndex = protect(m_presentationController)->pageIndexForDocumentPoint(documentPoint);
     if (!pageIndex)
         return false;
 
@@ -3708,7 +3708,7 @@ std::pair<String, RetainPtr<PDFSelection>> UnifiedPDFPlugin::textForImmediateAct
 
     auto pluginPoint = convertFromRootViewToPlugin(roundedIntPoint(rootViewPoint));
     auto documentPoint = convertDown(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, FloatPoint { pluginPoint });
-    auto pageIndex = protectedPresentationController()->pageIndexForDocumentPoint(documentPoint);
+    auto pageIndex = protect(m_presentationController)->pageIndexForDocumentPoint(documentPoint);
 
     if (!pageIndex)
         return { { }, m_currentSelection };
@@ -3765,7 +3765,7 @@ id UnifiedPDFPlugin::accessibilityHitTestIntPoint(const WebCore::IntPoint& point
 {
     Ref protectedThis { *this };
     return WebCore::Accessibility::retrieveValueFromMainThread<id>([&protectedThis, point] () -> id {
-        IntPoint pluginPoint = point + (-protectedThis->protectedView()->location());
+        IntPoint pluginPoint = point + (-protect(protectedThis->m_view)->location());
         auto pointInScreenSpaceCoordinate = protectedThis->convertFromPluginToScreenForAccessibility(pluginPoint);
         return [protectedThis->m_accessibilityDocumentObject accessibilityHitTest:pointInScreenSpaceCoordinate];
     });
@@ -4817,7 +4817,7 @@ auto UnifiedPDFPlugin::rootViewToPage(FloatPoint pointInRootView) const -> PageA
 {
     auto pointInPlugin = convertFromRootViewToPlugin(pointInRootView);
     auto pointInDocument = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, pointInPlugin);
-    auto pageIndex = protectedPresentationController()->nearestPageIndexForDocumentPoint(pointInDocument);
+    auto pageIndex = protect(m_presentationController)->nearestPageIndexForDocumentPoint(pointInDocument);
     auto pointInPage = convertDown(CoordinateSpace::PDFDocumentLayout, CoordinateSpace::PDFPage, pointInDocument, pageIndex);
     return { m_documentLayout.pageAtIndex(pageIndex), pointInPage };
 }
@@ -4826,7 +4826,7 @@ FloatRect UnifiedPDFPlugin::absoluteBoundingRectForSmartMagnificationAtPoint(Flo
 {
     auto pluginPoint = convertFromRootViewToPlugin(roundedIntPoint(rootViewPoint));
     auto documentPoint = convertDown(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, FloatPoint { pluginPoint });
-    auto pageIndex = protectedPresentationController()->pageIndexForDocumentPoint(documentPoint);
+    auto pageIndex = protect(m_presentationController)->pageIndexForDocumentPoint(documentPoint);
     if (!pageIndex)
         return { };
 
@@ -4850,21 +4850,6 @@ bool UnifiedPDFPlugin::layerNeedsPlatformContext(const GraphicsLayer& layer) con
 bool UnifiedPDFPlugin::delegatesScrollingToMainFrame() const
 {
     return !handlesPageScaleFactor() && isFullFramePlugin() && scrollingMode() == DelegatedScrollingMode::DelegatedToNativeScrollView;
-}
-
-RefPtr<PDFPresentationController> UnifiedPDFPlugin::protectedPresentationController() const
-{
-    return m_presentationController;
-}
-
-RefPtr<WebCore::GraphicsLayer> UnifiedPDFPlugin::protectedScrollContainerLayer() const
-{
-    return m_scrollContainerLayer;
-}
-
-RefPtr<WebCore::GraphicsLayer> UnifiedPDFPlugin::protectedOverflowControlsContainer() const
-{
-    return m_overflowControlsContainer;
 }
 
 void UnifiedPDFPlugin::effectiveAppearanceDidChange()

--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -163,7 +163,7 @@
     if (RefPtr plugin = _pdfPlugin.get()) {
         if (RefPtr activeAnnotation = plugin->activeAnnotation()) {
             if (CheckedPtr existingCache = plugin->axObjectCache()) {
-                if (RefPtr object = existingCache->exportedGetOrCreate(activeAnnotation->protectedElement().get())) {
+                if (RefPtr object = existingCache->exportedGetOrCreate(activeAnnotation->element())) {
                 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
                     return [protect(object->wrapper()) accessibilityAttributeValue:@"_AXAssociatedPluginParent"];
                 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -325,7 +325,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             return;
 
         if (CheckedPtr axObjectCache = protectedSelf->_pdfPlugin.get()->axObjectCache()) {
-            if (RefPtr annotationElementAxObject = axObjectCache->exportedGetOrCreate(activeAnnotation->protectedElement().get()))
+            if (RefPtr annotationElementAxObject = axObjectCache->exportedGetOrCreate(activeAnnotation->element()))
                 wrapper = annotationElementAxObject->wrapper();
         }
     });

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -262,11 +262,6 @@ PluginView::~PluginView()
     m_plugin->destroy();
 }
 
-RefPtr<WebPage> PluginView::protectedWebPage() const
-{
-    return m_webPage.get();
-}
-
 LocalFrame* PluginView::frame() const
 {
     return m_pluginElement->document().frame();
@@ -1085,7 +1080,7 @@ WebCore::FloatRect PluginView::rectForSelectionInRootView(PDFSelection *selectio
 
 bool PluginView::isUsingUISideCompositing() const
 {
-    return protectedWebPage()->isUsingUISideCompositing();
+    return protect(m_webPage.get())->isUsingUISideCompositing();
 }
 
 void PluginView::didChangeSettings()

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -234,8 +234,6 @@ private:
 
     void releaseMemory() final;
 
-    RefPtr<WebPage> protectedWebPage() const;
-
     const Ref<WebCore::HTMLPlugInElement> m_pluginElement;
     const Ref<PDFPluginBase> m_plugin;
     WeakPtr<WebPage> m_webPage;

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp
@@ -97,15 +97,10 @@ void WebContextMenuClient::stopSpeaking()
 
 void WebContextMenuClient::showContextMenu()
 {
-    protect(protectedPage()->contextMenu())->show();
+    protect(protect(m_page.get())->contextMenu())->show();
 }
 
 #endif
-
-RefPtr<WebPage> WebContextMenuClient::protectedPage() const
-{
-    return m_page.get();
-}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h
@@ -70,8 +70,6 @@ private:
     void showContextMenu() override;
 #endif
 
-    RefPtr<WebPage> protectedPage() const;
-
     WeakPtr<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp
@@ -39,9 +39,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WebDragClient);
 void WebDragClient::willPerformDragDestinationAction(DragDestinationAction action, const DragData&)
 {
     if (action == DragDestinationAction::Load)
-        protectedPage()->willPerformLoadDragDestinationAction();
+        protect(m_page.get())->willPerformLoadDragDestinationAction();
     else
-        protectedPage()->mayPerformUploadDragDestinationAction(); // Upload can happen from a drop event handler, so we should prepare early.
+        protect(m_page.get())->mayPerformUploadDragDestinationAction(); // Upload can happen from a drop event handler, so we should prepare early.
 }
 
 void WebDragClient::willPerformDragSourceAction(DragSourceAction, const IntPoint&, DataTransfer&)
@@ -50,7 +50,7 @@ void WebDragClient::willPerformDragSourceAction(DragSourceAction, const IntPoint
 
 OptionSet<DragSourceAction> WebDragClient::dragSourceActionMaskForPoint(const IntPoint&)
 {
-    return protectedPage()->allowedDragSourceActions();
+    return protect(m_page.get())->allowedDragSourceActions();
 }
 
 #if !PLATFORM(COCOA) && !PLATFORM(GTK) && !PLATFORM(WPE)
@@ -62,11 +62,6 @@ void WebDragClient::didConcludeEditDrag()
 {
 }
 #endif
-
-RefPtr<WebPage> WebDragClient::protectedPage()
-{
-    return m_page.get();
-}
 
 } // namespace WebKit
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h
@@ -54,8 +54,6 @@ private:
     void declareAndWriteDragImage(const String& pasteboardName, WebCore::Element&, const URL&, const String&, WebCore::LocalFrame*) override;
 #endif
 
-    RefPtr<WebPage> protectedPage();
-
     WeakPtr<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
@@ -46,17 +46,12 @@ PopupMenu* WebSearchPopupMenu::popupMenu()
     return m_popup.get();
 }
 
-RefPtr<WebPopupMenu> WebSearchPopupMenu::protectedPopup()
-{
-    return m_popup;
-}
-
 void WebSearchPopupMenu::saveRecentSearches(const AtomString& name, const Vector<RecentSearch>& searchItems)
 {
     if (name.isEmpty())
         return;
 
-    RefPtr page = protectedPopup()->page();
+    RefPtr page = m_popup->page();
     if (!page)
         return;
 
@@ -68,7 +63,7 @@ void WebSearchPopupMenu::loadRecentSearches(const AtomString& name, Vector<Recen
     if (name.isEmpty())
         return;
 
-    RefPtr page = protectedPopup()->page();
+    RefPtr page = m_popup->page();
     if (!page)
         return;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.h
@@ -37,7 +37,6 @@ public:
 
 private:
     WebSearchPopupMenu(WebPage*, WebCore::PopupMenuClient*);
-    RefPtr<WebPopupMenu> protectedPopup();
 
     RefPtr<WebPopupMenu> m_popup;
 };

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm
@@ -45,12 +45,12 @@ using namespace WebCore;
 
 void WebContextMenuClient::lookUpInDictionary(LocalFrame* frame)
 {
-    protectedPage()->performDictionaryLookupForSelection(*frame, frame->selection().selection(), TextIndicatorPresentationTransition::BounceAndCrossfade);
+    protect(m_page)->performDictionaryLookupForSelection(*frame, frame->selection().selection(), TextIndicatorPresentationTransition::BounceAndCrossfade);
 }
 
 bool WebContextMenuClient::isSpeaking() const
 {
-    return protectedPage()->isSpeaking();
+    return protect(m_page)->isSpeaking();
 }
 
 void WebContextMenuClient::speak(const String&)
@@ -64,14 +64,14 @@ void WebContextMenuClient::stopSpeaking()
 void WebContextMenuClient::searchWithGoogle(const LocalFrame* frame)
 {
     auto searchString = protect(frame->editor())->selectedText().trim(deprecatedIsSpaceOrNewline);
-    protectedPage()->send(Messages::WebPageProxy::SearchTheWeb(searchString));
+    protect(m_page)->send(Messages::WebPageProxy::SearchTheWeb(searchString));
 }
 
 #if HAVE(TRANSLATION_UI_SERVICES)
 
 void WebContextMenuClient::handleTranslation(const WebCore::TranslationContextMenuInfo& info)
 {
-    protectedPage()->send(Messages::WebPageProxy::HandleContextMenuTranslation(info));
+    protect(m_page)->send(Messages::WebPageProxy::HandleContextMenuTranslation(info));
 }
 
 #endif // HAVE(TRANSLATION_UI_SERVICES)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h
@@ -95,8 +95,6 @@ private:
 
     WebCore::Document* document() const;
 
-    RefPtr<WebPage> protectedWebPage() { return m_webPage.get(); }
-
     WeakPtr<WebPage> m_webPage;
 
     std::optional<WTF::UUID> m_initialAnimationID;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm
@@ -172,7 +172,7 @@ void TextAnimationController::removeTransparentMarkersForTextAnimationID(const W
 void TextAnimationController::removeInitialTextAnimationForActiveWritingToolsSession()
 {
     if (auto initialAnimationID = std::exchange(m_initialAnimationID, std::nullopt))
-        protectedWebPage()->removeTextAnimationForAnimationID(*initialAnimationID);
+        protect(m_webPage.get())->removeTextAnimationForAnimationID(*initialAnimationID);
 }
 
 static WebCore::CharacterRange remainingCharacterRange(WebCore::CharacterRange totalRange, WebCore::CharacterRange previousRange)
@@ -200,7 +200,7 @@ void TextAnimationController::addInitialTextAnimationForActiveWritingToolsSessio
 
     removeInitialTextAnimationForActiveWritingToolsSession();
 
-    protectedWebPage()->addTextAnimationForAnimationID(initialAnimationID, { WebCore::TextAnimationType::Initial, WebCore::TextAnimationRunMode::RunAnimation }, textIndicator);
+    protect(m_webPage.get())->addTextAnimationForAnimationID(initialAnimationID, { WebCore::TextAnimationType::Initial, WebCore::TextAnimationRunMode::RunAnimation }, textIndicator);
 
     m_initialAnimationID = initialAnimationID;
 }
@@ -242,7 +242,7 @@ void TextAnimationController::addSourceTextAnimationForActiveWritingToolsSession
     }
 
     // On iOS this will search for the completion handler to pass the text indicator to so that the animation can continue.
-    protectedWebPage()->addTextAnimationForAnimationID(sourceAnimationUUID, { WebCore::TextAnimationType::Source, runMode, WTF::UUID(WTF::UUID::emptyValue), sourceAnimationUUID, destinationAnimationUUID }, textIndicator, WTF::move(completionHandler));
+    protect(m_webPage.get())->addTextAnimationForAnimationID(sourceAnimationUUID, { WebCore::TextAnimationType::Source, runMode, WTF::UUID(WTF::UUID::emptyValue), sourceAnimationUUID, destinationAnimationUUID }, textIndicator, WTF::move(completionHandler));
     m_activeAnimation = sourceAnimationUUID;
     m_textAnimationRanges.append({ sourceAnimationUUID, replaceCharacterRange });
 }

--- a/Source/WebKit/WebProcess/WebPage/FindController.h
+++ b/Source/WebKit/WebProcess/WebPage/FindController.h
@@ -111,8 +111,6 @@ private:
 
     RefPtr<WebCore::LocalFrame> frameWithSelection(WebCore::Page*);
 
-    RefPtr<WebPage> protectedWebPage() const;
-
 #if ENABLE(PDF_PLUGIN)
     PluginView* mainFramePlugIn();
 #endif

--- a/Source/WebKit/WebProcess/WebPage/PageBanner.h
+++ b/Source/WebKit/WebProcess/WebPage/PageBanner.h
@@ -77,8 +77,6 @@ public:
 private:
 #if PLATFORM(MAC)
     explicit PageBanner(CALayer *, int height, std::unique_ptr<Client>&&);
-
-    RefPtr<WebPage> protectedWebPage();
 #endif
 
     std::unique_ptr<Client> m_client;

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h
@@ -97,9 +97,6 @@ private:
     WebCore::Document* documentForFoundTextRange(const WebFoundTextRange&) const;
     std::optional<WebCore::SimpleRange> simpleRangeFromFoundTextRange(WebFoundTextRange);
 
-    RefPtr<WebPage> protectedWebPage() const { return m_webPage.get(); }
-    RefPtr<WebCore::PageOverlay> protectedFindPageOverlay() const { return m_findPageOverlay; }
-
     WeakPtr<WebPage> m_webPage;
     RefPtr<WebCore::PageOverlay> m_findPageOverlay;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1993,7 +1993,7 @@ void WebPage::close()
 
     WEBPAGE_RELEASE_LOG_FORWARDABLE(Loading, WEBPAGE_CLOSE);
 
-    if (auto networkProcessConnection = WebProcess::singleton().protectedNetworkProcessConnection())
+    if (RefPtr networkProcessConnection = WebProcess::singleton().existingNetworkProcessConnection())
         networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::ClearPageSpecificData(m_identifier), 0);
 
     m_isClosed = true;

--- a/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm
@@ -100,9 +100,9 @@ void PageBanner::hide()
 {
     // We can hide the banner by removing the parent layer that hosts it.
     if (m_type == Header)
-        protect(protectedWebPage()->corePage())->setHeaderHeight(0);
+        protect(protect(m_webPage.get())->corePage())->setHeaderHeight(0);
     else if (m_type == Footer)
-        protect(protectedWebPage()->corePage())->setFooterHeight(0);
+        protect(protect(m_webPage.get())->corePage())->setFooterHeight(0);
 
     m_isHidden = true;
 }
@@ -129,7 +129,7 @@ bool PageBanner::mouseEvent(const WebMouseEvent& mouseEvent)
     if (m_isHidden)
         return false;
 
-    RefPtr frameView = protectedWebPage()->localMainFrameView();
+    RefPtr frameView = protect(m_webPage.get())->localMainFrameView();
     if (!frameView)
         return false;
 
@@ -162,11 +162,6 @@ bool PageBanner::mouseEvent(const WebMouseEvent& mouseEvent)
 CALayer *PageBanner::layer()
 {
     return m_layer.get();
-}
-
-RefPtr<WebPage> PageBanner::protectedWebPage()
-{
-    return m_webPage.get();
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1366,7 +1366,7 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
         m_networkProcessConnection->connection().send(Messages::NetworkConnectionToWebProcess::RegisterURLSchemesAsCORSEnabled(WebCore::LegacySchemeRegistry::allURLSchemesRegisteredAsCORSEnabled()), 0);
 
         if (!Document::allDocuments().isEmpty() || SharedWorkerThreadProxy::hasInstances())
-            protect(protectedNetworkProcessConnection()->serviceWorkerConnection())->registerServiceWorkerClients();
+            protect(protect(m_networkProcessConnection.get())->serviceWorkerConnection())->registerServiceWorkerClients();
 
 #if HAVE(LSDATABASECONTEXT)
         // On Mac, this needs to be called before NSApplication is being initialized.
@@ -1393,11 +1393,6 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
 Ref<NetworkProcessConnection> WebProcess::ensureProtectedNetworkProcessConnection()
 {
     return ensureNetworkProcessConnection();
-}
-
-RefPtr<NetworkProcessConnection> WebProcess::protectedNetworkProcessConnection()
-{
-    return existingNetworkProcessConnection();
 }
 
 void WebProcess::logDiagnosticMessageForNetworkProcessCrash()

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -293,7 +293,6 @@ public:
 
     void networkProcessConnectionClosed(NetworkProcessConnection*);
     NetworkProcessConnection* existingNetworkProcessConnection() { return m_networkProcessConnection.get(); }
-    RefPtr<NetworkProcessConnection> protectedNetworkProcessConnection();
     WebLoaderStrategy& webLoaderStrategy();
     WebFileSystemStorageConnection& fileSystemStorageConnection();
 

--- a/Tools/Scripts/generate-gpup-webgl
+++ b/Tools/Scripts/generate-gpup-webgl
@@ -947,7 +947,7 @@ class webkit_ipc_cpp_impl(object):
         in_exprs = ", ".join(str(e) for e in self.in_exprs)
         is_async = len(self.out_exprs) == 0
 
-        call_expr = f"protectedContext()->{self.name}({in_exprs})"
+        call_expr = f"protect(m_context)->{self.name}({in_exprs})"
         if not self.return_value_expr:
             self.call_stmts += [f"{call_expr};"]
         else:


### PR DESCRIPTION
#### db628492e5f463663cc3c393dfdd3a641f23d8f8
<pre>
Further reduce use of protected functions in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307637">https://bugs.webkit.org/show_bug.cgi?id=307637</a>

Reviewed by Ryosuke Niwa and Anne van Kesteren.

* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.cpp:
(WebKit::RemoteGraphicsContextGL::reshape):
(WebKit::RemoteGraphicsContextGL::getErrors):
(WebKit::RemoteGraphicsContextGL::ensureExtensionEnabled):
(WebKit::RemoteGraphicsContextGL::copyNativeImageYFlipped):
(WebKit::RemoteGraphicsContextGL::surfaceBufferToVideoFrame):
(WebKit::RemoteGraphicsContextGL::simulateEventForTesting):
(WebKit::RemoteGraphicsContextGL::multiDrawArraysANGLE):
(WebKit::RemoteGraphicsContextGL::multiDrawArraysInstancedANGLE):
(WebKit::RemoteGraphicsContextGL::multiDrawElementsANGLE):
(WebKit::RemoteGraphicsContextGL::multiDrawElementsInstancedANGLE):
(WebKit::RemoteGraphicsContextGL::multiDrawArraysInstancedBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGL::multiDrawElementsInstancedBaseVertexBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGL::drawBuffers):
(WebKit::RemoteGraphicsContextGL::drawBuffersEXT):
(WebKit::RemoteGraphicsContextGL::invalidateFramebuffer):
(WebKit::RemoteGraphicsContextGL::invalidateSubFramebuffer):
(WebKit::RemoteGraphicsContextGL::framebufferDiscard):
(WebKit::RemoteGraphicsContextGL::setDrawingBufferColorSpace):
(WebKit::RemoteGraphicsContextGL::protectedContext): Deleted.
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGL.h:
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLCocoa.cpp:
(WebKit::RemoteGraphicsContextGL::copyTextureFromVideoFrame):
* Source/WebKit/GPUProcess/graphics/RemoteGraphicsContextGLFunctionsGenerated.cpp:
(WebKit::RemoteGraphicsContextGL::activeTexture):
(WebKit::RemoteGraphicsContextGL::attachShader):
(WebKit::RemoteGraphicsContextGL::bindAttribLocation):
(WebKit::RemoteGraphicsContextGL::bindBuffer):
(WebKit::RemoteGraphicsContextGL::bindFramebuffer):
(WebKit::RemoteGraphicsContextGL::bindRenderbuffer):
(WebKit::RemoteGraphicsContextGL::bindTexture):
(WebKit::RemoteGraphicsContextGL::blendColor):
(WebKit::RemoteGraphicsContextGL::blendEquation):
(WebKit::RemoteGraphicsContextGL::blendEquationSeparate):
(WebKit::RemoteGraphicsContextGL::blendFunc):
(WebKit::RemoteGraphicsContextGL::blendFuncSeparate):
(WebKit::RemoteGraphicsContextGL::checkFramebufferStatus):
(WebKit::RemoteGraphicsContextGL::clear):
(WebKit::RemoteGraphicsContextGL::clearColor):
(WebKit::RemoteGraphicsContextGL::clearDepth):
(WebKit::RemoteGraphicsContextGL::clearStencil):
(WebKit::RemoteGraphicsContextGL::colorMask):
(WebKit::RemoteGraphicsContextGL::compileShader):
(WebKit::RemoteGraphicsContextGL::copyTexImage2D):
(WebKit::RemoteGraphicsContextGL::copyTexSubImage2D):
(WebKit::RemoteGraphicsContextGL::createBuffer):
(WebKit::RemoteGraphicsContextGL::createFramebuffer):
(WebKit::RemoteGraphicsContextGL::createProgram):
(WebKit::RemoteGraphicsContextGL::createRenderbuffer):
(WebKit::RemoteGraphicsContextGL::createShader):
(WebKit::RemoteGraphicsContextGL::createTexture):
(WebKit::RemoteGraphicsContextGL::cullFace):
(WebKit::RemoteGraphicsContextGL::deleteBuffer):
(WebKit::RemoteGraphicsContextGL::deleteFramebuffer):
(WebKit::RemoteGraphicsContextGL::deleteProgram):
(WebKit::RemoteGraphicsContextGL::deleteRenderbuffer):
(WebKit::RemoteGraphicsContextGL::deleteShader):
(WebKit::RemoteGraphicsContextGL::deleteTexture):
(WebKit::RemoteGraphicsContextGL::depthFunc):
(WebKit::RemoteGraphicsContextGL::depthMask):
(WebKit::RemoteGraphicsContextGL::depthRange):
(WebKit::RemoteGraphicsContextGL::detachShader):
(WebKit::RemoteGraphicsContextGL::disable):
(WebKit::RemoteGraphicsContextGL::disableVertexAttribArray):
(WebKit::RemoteGraphicsContextGL::drawArrays):
(WebKit::RemoteGraphicsContextGL::drawElements):
(WebKit::RemoteGraphicsContextGL::enable):
(WebKit::RemoteGraphicsContextGL::enableVertexAttribArray):
(WebKit::RemoteGraphicsContextGL::finish):
(WebKit::RemoteGraphicsContextGL::flush):
(WebKit::RemoteGraphicsContextGL::framebufferRenderbuffer):
(WebKit::RemoteGraphicsContextGL::framebufferTexture2D):
(WebKit::RemoteGraphicsContextGL::frontFace):
(WebKit::RemoteGraphicsContextGL::generateMipmap):
(WebKit::RemoteGraphicsContextGL::activeAttribs):
(WebKit::RemoteGraphicsContextGL::activeUniforms):
(WebKit::RemoteGraphicsContextGL::getBufferParameteri):
(WebKit::RemoteGraphicsContextGL::getString):
(WebKit::RemoteGraphicsContextGL::getFloatv):
(WebKit::RemoteGraphicsContextGL::getIntegerv):
(WebKit::RemoteGraphicsContextGL::getIntegeri_v):
(WebKit::RemoteGraphicsContextGL::getInteger64):
(WebKit::RemoteGraphicsContextGL::getInteger64i):
(WebKit::RemoteGraphicsContextGL::getProgrami):
(WebKit::RemoteGraphicsContextGL::getBooleanv):
(WebKit::RemoteGraphicsContextGL::getFramebufferAttachmentParameteri):
(WebKit::RemoteGraphicsContextGL::getProgramInfoLog):
(WebKit::RemoteGraphicsContextGL::getRenderbufferParameteri):
(WebKit::RemoteGraphicsContextGL::getShaderi):
(WebKit::RemoteGraphicsContextGL::getShaderInfoLog):
(WebKit::RemoteGraphicsContextGL::getShaderPrecisionFormat):
(WebKit::RemoteGraphicsContextGL::getTexParameterf):
(WebKit::RemoteGraphicsContextGL::getTexParameteri):
(WebKit::RemoteGraphicsContextGL::getUniformfv):
(WebKit::RemoteGraphicsContextGL::getUniformiv):
(WebKit::RemoteGraphicsContextGL::getUniformuiv):
(WebKit::RemoteGraphicsContextGL::getVertexAttribOffset):
(WebKit::RemoteGraphicsContextGL::hint):
(WebKit::RemoteGraphicsContextGL::isBuffer):
(WebKit::RemoteGraphicsContextGL::isEnabled):
(WebKit::RemoteGraphicsContextGL::isFramebuffer):
(WebKit::RemoteGraphicsContextGL::isProgram):
(WebKit::RemoteGraphicsContextGL::isRenderbuffer):
(WebKit::RemoteGraphicsContextGL::isShader):
(WebKit::RemoteGraphicsContextGL::isTexture):
(WebKit::RemoteGraphicsContextGL::lineWidth):
(WebKit::RemoteGraphicsContextGL::linkProgram):
(WebKit::RemoteGraphicsContextGL::pixelStorei):
(WebKit::RemoteGraphicsContextGL::polygonOffset):
(WebKit::RemoteGraphicsContextGL::renderbufferStorage):
(WebKit::RemoteGraphicsContextGL::sampleCoverage):
(WebKit::RemoteGraphicsContextGL::scissor):
(WebKit::RemoteGraphicsContextGL::shaderSource):
(WebKit::RemoteGraphicsContextGL::stencilFunc):
(WebKit::RemoteGraphicsContextGL::stencilFuncSeparate):
(WebKit::RemoteGraphicsContextGL::stencilMask):
(WebKit::RemoteGraphicsContextGL::stencilMaskSeparate):
(WebKit::RemoteGraphicsContextGL::stencilOp):
(WebKit::RemoteGraphicsContextGL::stencilOpSeparate):
(WebKit::RemoteGraphicsContextGL::texParameterf):
(WebKit::RemoteGraphicsContextGL::texParameteri):
(WebKit::RemoteGraphicsContextGL::uniform1f):
(WebKit::RemoteGraphicsContextGL::uniform1fv):
(WebKit::RemoteGraphicsContextGL::uniform1i):
(WebKit::RemoteGraphicsContextGL::uniform1iv):
(WebKit::RemoteGraphicsContextGL::uniform2f):
(WebKit::RemoteGraphicsContextGL::uniform2fv):
(WebKit::RemoteGraphicsContextGL::uniform2i):
(WebKit::RemoteGraphicsContextGL::uniform2iv):
(WebKit::RemoteGraphicsContextGL::uniform3f):
(WebKit::RemoteGraphicsContextGL::uniform3fv):
(WebKit::RemoteGraphicsContextGL::uniform3i):
(WebKit::RemoteGraphicsContextGL::uniform3iv):
(WebKit::RemoteGraphicsContextGL::uniform4f):
(WebKit::RemoteGraphicsContextGL::uniform4fv):
(WebKit::RemoteGraphicsContextGL::uniform4i):
(WebKit::RemoteGraphicsContextGL::uniform4iv):
(WebKit::RemoteGraphicsContextGL::uniformMatrix2fv):
(WebKit::RemoteGraphicsContextGL::uniformMatrix3fv):
(WebKit::RemoteGraphicsContextGL::uniformMatrix4fv):
(WebKit::RemoteGraphicsContextGL::useProgram):
(WebKit::RemoteGraphicsContextGL::validateProgram):
(WebKit::RemoteGraphicsContextGL::vertexAttrib1f):
(WebKit::RemoteGraphicsContextGL::vertexAttrib1fv):
(WebKit::RemoteGraphicsContextGL::vertexAttrib2f):
(WebKit::RemoteGraphicsContextGL::vertexAttrib2fv):
(WebKit::RemoteGraphicsContextGL::vertexAttrib3f):
(WebKit::RemoteGraphicsContextGL::vertexAttrib3fv):
(WebKit::RemoteGraphicsContextGL::vertexAttrib4f):
(WebKit::RemoteGraphicsContextGL::vertexAttrib4fv):
(WebKit::RemoteGraphicsContextGL::vertexAttribPointer):
(WebKit::RemoteGraphicsContextGL::viewport):
(WebKit::RemoteGraphicsContextGL::bufferData0):
(WebKit::RemoteGraphicsContextGL::bufferData1):
(WebKit::RemoteGraphicsContextGL::bufferSubData):
(WebKit::RemoteGraphicsContextGL::readPixelsBufferObject):
(WebKit::RemoteGraphicsContextGL::texImage2D0):
(WebKit::RemoteGraphicsContextGL::texImage2D1):
(WebKit::RemoteGraphicsContextGL::texSubImage2D0):
(WebKit::RemoteGraphicsContextGL::texSubImage2D1):
(WebKit::RemoteGraphicsContextGL::compressedTexImage2D0):
(WebKit::RemoteGraphicsContextGL::compressedTexImage2D1):
(WebKit::RemoteGraphicsContextGL::compressedTexSubImage2D0):
(WebKit::RemoteGraphicsContextGL::compressedTexSubImage2D1):
(WebKit::RemoteGraphicsContextGL::drawArraysInstanced):
(WebKit::RemoteGraphicsContextGL::drawElementsInstanced):
(WebKit::RemoteGraphicsContextGL::vertexAttribDivisor):
(WebKit::RemoteGraphicsContextGL::createVertexArray):
(WebKit::RemoteGraphicsContextGL::deleteVertexArray):
(WebKit::RemoteGraphicsContextGL::isVertexArray):
(WebKit::RemoteGraphicsContextGL::bindVertexArray):
(WebKit::RemoteGraphicsContextGL::copyBufferSubData):
(WebKit::RemoteGraphicsContextGL::blitFramebuffer):
(WebKit::RemoteGraphicsContextGL::framebufferTextureLayer):
(WebKit::RemoteGraphicsContextGL::readBuffer):
(WebKit::RemoteGraphicsContextGL::renderbufferStorageMultisample):
(WebKit::RemoteGraphicsContextGL::texStorage2D):
(WebKit::RemoteGraphicsContextGL::texStorage3D):
(WebKit::RemoteGraphicsContextGL::texImage3D0):
(WebKit::RemoteGraphicsContextGL::texImage3D1):
(WebKit::RemoteGraphicsContextGL::texSubImage3D0):
(WebKit::RemoteGraphicsContextGL::texSubImage3D1):
(WebKit::RemoteGraphicsContextGL::copyTexSubImage3D):
(WebKit::RemoteGraphicsContextGL::compressedTexImage3D0):
(WebKit::RemoteGraphicsContextGL::compressedTexImage3D1):
(WebKit::RemoteGraphicsContextGL::compressedTexSubImage3D0):
(WebKit::RemoteGraphicsContextGL::compressedTexSubImage3D1):
(WebKit::RemoteGraphicsContextGL::getFragDataLocation):
(WebKit::RemoteGraphicsContextGL::uniform1ui):
(WebKit::RemoteGraphicsContextGL::uniform2ui):
(WebKit::RemoteGraphicsContextGL::uniform3ui):
(WebKit::RemoteGraphicsContextGL::uniform4ui):
(WebKit::RemoteGraphicsContextGL::uniform1uiv):
(WebKit::RemoteGraphicsContextGL::uniform2uiv):
(WebKit::RemoteGraphicsContextGL::uniform3uiv):
(WebKit::RemoteGraphicsContextGL::uniform4uiv):
(WebKit::RemoteGraphicsContextGL::uniformMatrix2x3fv):
(WebKit::RemoteGraphicsContextGL::uniformMatrix3x2fv):
(WebKit::RemoteGraphicsContextGL::uniformMatrix2x4fv):
(WebKit::RemoteGraphicsContextGL::uniformMatrix4x2fv):
(WebKit::RemoteGraphicsContextGL::uniformMatrix3x4fv):
(WebKit::RemoteGraphicsContextGL::uniformMatrix4x3fv):
(WebKit::RemoteGraphicsContextGL::vertexAttribI4i):
(WebKit::RemoteGraphicsContextGL::vertexAttribI4iv):
(WebKit::RemoteGraphicsContextGL::vertexAttribI4ui):
(WebKit::RemoteGraphicsContextGL::vertexAttribI4uiv):
(WebKit::RemoteGraphicsContextGL::vertexAttribIPointer):
(WebKit::RemoteGraphicsContextGL::drawRangeElements):
(WebKit::RemoteGraphicsContextGL::clearBufferiv):
(WebKit::RemoteGraphicsContextGL::clearBufferuiv):
(WebKit::RemoteGraphicsContextGL::clearBufferfv):
(WebKit::RemoteGraphicsContextGL::clearBufferfi):
(WebKit::RemoteGraphicsContextGL::createQuery):
(WebKit::RemoteGraphicsContextGL::deleteQuery):
(WebKit::RemoteGraphicsContextGL::isQuery):
(WebKit::RemoteGraphicsContextGL::beginQuery):
(WebKit::RemoteGraphicsContextGL::endQuery):
(WebKit::RemoteGraphicsContextGL::getQuery):
(WebKit::RemoteGraphicsContextGL::getQueryObjectui):
(WebKit::RemoteGraphicsContextGL::createSampler):
(WebKit::RemoteGraphicsContextGL::deleteSampler):
(WebKit::RemoteGraphicsContextGL::isSampler):
(WebKit::RemoteGraphicsContextGL::bindSampler):
(WebKit::RemoteGraphicsContextGL::samplerParameteri):
(WebKit::RemoteGraphicsContextGL::samplerParameterf):
(WebKit::RemoteGraphicsContextGL::getSamplerParameterf):
(WebKit::RemoteGraphicsContextGL::getSamplerParameteri):
(WebKit::RemoteGraphicsContextGL::fenceSync):
(WebKit::RemoteGraphicsContextGL::isSync):
(WebKit::RemoteGraphicsContextGL::deleteSync):
(WebKit::RemoteGraphicsContextGL::clientWaitSync):
(WebKit::RemoteGraphicsContextGL::waitSync):
(WebKit::RemoteGraphicsContextGL::getSynci):
(WebKit::RemoteGraphicsContextGL::createTransformFeedback):
(WebKit::RemoteGraphicsContextGL::deleteTransformFeedback):
(WebKit::RemoteGraphicsContextGL::isTransformFeedback):
(WebKit::RemoteGraphicsContextGL::bindTransformFeedback):
(WebKit::RemoteGraphicsContextGL::beginTransformFeedback):
(WebKit::RemoteGraphicsContextGL::endTransformFeedback):
(WebKit::RemoteGraphicsContextGL::transformFeedbackVaryings):
(WebKit::RemoteGraphicsContextGL::getTransformFeedbackVarying):
(WebKit::RemoteGraphicsContextGL::pauseTransformFeedback):
(WebKit::RemoteGraphicsContextGL::resumeTransformFeedback):
(WebKit::RemoteGraphicsContextGL::bindBufferBase):
(WebKit::RemoteGraphicsContextGL::bindBufferRange):
(WebKit::RemoteGraphicsContextGL::getUniformBlockIndex):
(WebKit::RemoteGraphicsContextGL::getActiveUniformBlockName):
(WebKit::RemoteGraphicsContextGL::uniformBlockBinding):
(WebKit::RemoteGraphicsContextGL::getActiveUniformBlockiv):
(WebKit::RemoteGraphicsContextGL::getTranslatedShaderSourceANGLE):
(WebKit::RemoteGraphicsContextGL::createQueryEXT):
(WebKit::RemoteGraphicsContextGL::deleteQueryEXT):
(WebKit::RemoteGraphicsContextGL::isQueryEXT):
(WebKit::RemoteGraphicsContextGL::beginQueryEXT):
(WebKit::RemoteGraphicsContextGL::endQueryEXT):
(WebKit::RemoteGraphicsContextGL::queryCounterEXT):
(WebKit::RemoteGraphicsContextGL::getQueryiEXT):
(WebKit::RemoteGraphicsContextGL::getQueryObjectiEXT):
(WebKit::RemoteGraphicsContextGL::getQueryObjectui64EXT):
(WebKit::RemoteGraphicsContextGL::getInteger64EXT):
(WebKit::RemoteGraphicsContextGL::enableiOES):
(WebKit::RemoteGraphicsContextGL::disableiOES):
(WebKit::RemoteGraphicsContextGL::blendEquationiOES):
(WebKit::RemoteGraphicsContextGL::blendEquationSeparateiOES):
(WebKit::RemoteGraphicsContextGL::blendFunciOES):
(WebKit::RemoteGraphicsContextGL::blendFuncSeparateiOES):
(WebKit::RemoteGraphicsContextGL::colorMaskiOES):
(WebKit::RemoteGraphicsContextGL::drawArraysInstancedBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGL::drawElementsInstancedBaseVertexBaseInstanceANGLE):
(WebKit::RemoteGraphicsContextGL::clipControlEXT):
(WebKit::RemoteGraphicsContextGL::provokingVertexANGLE):
(WebKit::RemoteGraphicsContextGL::polygonModeANGLE):
(WebKit::RemoteGraphicsContextGL::polygonOffsetClampEXT):
(WebKit::RemoteGraphicsContextGL::renderbufferStorageMultisampleANGLE):
(WebKit::RemoteGraphicsContextGL::getInternalformativ):
(WebKit::RemoteGraphicsContextGL::createExternalImage):
(WebKit::RemoteGraphicsContextGL::deleteExternalImage):
(WebKit::RemoteGraphicsContextGL::bindExternalImage):
(WebKit::RemoteGraphicsContextGL::createExternalSync):
(WebKit::RemoteGraphicsContextGL::deleteExternalSync):
(WebKit::RemoteGraphicsContextGL::enableRequiredWebXRExtensions):
(WebKit::RemoteGraphicsContextGL::addFoveation):
(WebKit::RemoteGraphicsContextGL::enableFoveation):
(WebKit::RemoteGraphicsContextGL::disableFoveation):
(WebKit::RemoteGraphicsContextGL::framebufferResolveRenderbuffer):
* Source/WebKit/GPUProcess/graphics/RemoteImageBufferSet.cpp:
(WebKit::RemoteImageBufferSet::ensureBufferForDisplay):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.cpp:
(WebKit::RemoteCDMInstanceProxy::createSession):
(WebKit::RemoteCDMInstanceProxy::sharedPreferencesForWebProcess const):
(WebKit::RemoteCDMInstanceProxy::protectedCdm const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::requestLicense):
(WebKit::RemoteCDMInstanceSessionProxy::updateLicense):
(WebKit::RemoteCDMInstanceSessionProxy::loadSession):
(WebKit::RemoteCDMInstanceSessionProxy::sharedPreferencesForWebProcess const):
(WebKit::RemoteCDMInstanceSessionProxy::protectedCdm const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::invalidate):
(WebKit::RemoteMediaPlayerProxy::load):
(WebKit::RemoteMediaPlayerProxy::loadMediaSource):
(WebKit::RemoteMediaPlayerProxy::cancelLoad):
(WebKit::RemoteMediaPlayerProxy::prepareToPlay):
(WebKit::RemoteMediaPlayerProxy::pause):
(WebKit::RemoteMediaPlayerProxy::seekToTarget):
(WebKit::RemoteMediaPlayerProxy::setVolumeLocked):
(WebKit::RemoteMediaPlayerProxy::setVolume):
(WebKit::RemoteMediaPlayerProxy::setMuted):
(WebKit::RemoteMediaPlayerProxy::setPreload):
(WebKit::RemoteMediaPlayerProxy::setPrivateBrowsingMode):
(WebKit::RemoteMediaPlayerProxy::setPreservesPitch):
(WebKit::RemoteMediaPlayerProxy::setPitchCorrectionAlgorithm):
(WebKit::RemoteMediaPlayerProxy::prepareForRendering):
(WebKit::RemoteMediaPlayerProxy::setPageIsVisible):
(WebKit::RemoteMediaPlayerProxy::setShouldMaintainAspectRatio):
(WebKit::RemoteMediaPlayerProxy::setVideoFullscreenGravity):
(WebKit::RemoteMediaPlayerProxy::acceleratedRenderingStateChanged):
(WebKit::RemoteMediaPlayerProxy::setShouldDisableSleep):
(WebKit::RemoteMediaPlayerProxy::setRate):
(WebKit::RemoteMediaPlayerProxy::didLoadingProgress):
(WebKit::RemoteMediaPlayerProxy::setPresentationSize):
(WebKit::RemoteMediaPlayerProxy::updateVideoFullscreenInlineImage):
(WebKit::RemoteMediaPlayerProxy::setVideoFullscreenMode):
(WebKit::RemoteMediaPlayerProxy::videoFullscreenStandbyChanged):
(WebKit::RemoteMediaPlayerProxy::setBufferingPolicy):
(WebKit::RemoteMediaPlayerProxy::accessLog):
(WebKit::RemoteMediaPlayerProxy::errorLog):
(WebKit::RemoteMediaPlayerProxy::setSceneIdentifier):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerNetworkStateChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerVolumeChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerMuteChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerSeeked):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerDurationChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerEngineFailedToLoad):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerSizeChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerWaitingForKeyChanged):
(WebKit::RemoteMediaPlayerProxy::setShouldPlayToPlaybackTarget):
(WebKit::RemoteMediaPlayerProxy::currentTimeChanged):
(WebKit::RemoteMediaPlayerProxy::keyAdded):
(WebKit::RemoteMediaPlayerProxy::cdmInstanceAttached):
(WebKit::RemoteMediaPlayerProxy::cdmInstanceDetached):
(WebKit::RemoteMediaPlayerProxy::attemptToDecryptWithInstance):
(WebKit::RemoteMediaPlayerProxy::setShouldContinueAfterKeyNeeded):
(WebKit::RemoteMediaPlayerProxy::applicationWillResignActive):
(WebKit::RemoteMediaPlayerProxy::applicationDidBecomeActive):
(WebKit::RemoteMediaPlayerProxy::notifyTrackModeChanged):
(WebKit::RemoteMediaPlayerProxy::tracksChanged):
(WebKit::RemoteMediaPlayerProxy::isCrossOrigin):
(WebKit::RemoteMediaPlayerProxy::updateCachedVideoMetrics):
(WebKit::RemoteMediaPlayerProxy::setShouldEnableAudioSourceProvider):
(WebKit::RemoteMediaPlayerProxy::setShouldCheckHardwareSupport):
(WebKit::RemoteMediaPlayerProxy::setDefaultSpatialTrackingLabel):
(WebKit::RemoteMediaPlayerProxy::setSpatialTrackingLabel):
(WebKit::RemoteMediaPlayerProxy::setPrefersSpatialAudioExperience):
(WebKit::RemoteMediaPlayerProxy::isInFullscreenOrPictureInPictureChanged):
(WebKit::RemoteMediaPlayerProxy::setSoundStageSize):
(WebKit::RemoteMediaPlayerProxy::setHasMessageClientForTesting):
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):
(WebKit::RemoteMediaPlayerProxy::setVideoLayerSizeFenced):
* Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.h:
* Source/WebKit/GPUProcess/media/cocoa/VideoReceiverEndpointManager.mm:
(WebKit::VideoReceiverEndpointManager::setVideoTargetIfValidIdentifier const):
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.h:
* Source/WebKit/GPUProcess/webrtc/RemoteSampleBufferDisplayLayer.mm:
(WebKit::RemoteSampleBufferDisplayLayer::initialize):
(WebKit::RemoteSampleBufferDisplayLayer::bounds const):
(WebKit::RemoteSampleBufferDisplayLayer::updateDisplayMode):
(WebKit::RemoteSampleBufferDisplayLayer::updateBoundsAndPosition):
(WebKit::RemoteSampleBufferDisplayLayer::flush):
(WebKit::RemoteSampleBufferDisplayLayer::flushAndRemoveImage):
(WebKit::RemoteSampleBufferDisplayLayer::enqueueVideoFrame):
(WebKit::RemoteSampleBufferDisplayLayer::clearVideoFrames):
(WebKit::RemoteSampleBufferDisplayLayer::sampleBufferDisplayLayerStatusDidFail):
(WebKit::RemoteSampleBufferDisplayLayer::setShouldMaintainAspectRatio):
(WebKit::RemoteSampleBufferDisplayLayer::protectedSampleBufferDisplayLayer const): Deleted.
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.cpp:
(WebKit::BackgroundFetchLoad::didFinish):
(WebKit::BackgroundFetchLoad::didReceiveResponse):
(WebKit::BackgroundFetchLoad::didReceiveData):
(WebKit::BackgroundFetchLoad::didSendData):
(WebKit::BackgroundFetchLoad::protectedClient const): Deleted.
* Source/WebKit/NetworkProcess/BackgroundFetchLoad.h:
* Source/WebKit/NetworkProcess/NetworkLoad.cpp:
(WebKit::NetworkLoad::protectedTask): Deleted.
* Source/WebKit/NetworkProcess/NetworkLoad.h:
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::checkCORSRequestWithPreflight):
(WebKit::NetworkLoadChecker::protectedCORSPreflightChecker const): Deleted.
* Source/WebKit/NetworkProcess/NetworkLoadChecker.h:
* Source/WebKit/NetworkProcess/NetworkLoadParameters.h:
(WebKit::NetworkLoadParameters::protectedSourceOrigin const): Deleted.
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
(WebKit::NetworkResourceLoadParameters::protectedSourceOrigin const): Deleted.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::abort):
(WebKit::NetworkResourceLoader::didReceiveResponse):
(WebKit::NetworkResourceLoader::didReceiveBuffer):
(WebKit::NetworkResourceLoader::validateCacheEntryForMaxAgeCapValidation):
(WebKit::NetworkResourceLoader::willSendRedirectedRequestInternal):
(WebKit::NetworkResourceLoader::didFinishWithRedirectResponse):
(WebKit::NetworkResourceLoader::continueWillSendRequest):
(WebKit::NetworkResourceLoader::continueDidReceiveResponse):
(WebKit::NetworkResourceLoader::tryStoreAsCacheEntry):
(WebKit::NetworkResourceLoader::isCrossOriginPrefetch const):
(WebKit::NetworkResourceLoader::protectedCache const): Deleted.
(WebKit::NetworkResourceLoader::protectedServiceWorkerFetchTask const): Deleted.
* Source/WebKit/NetworkProcess/NetworkResourceLoader.h:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp:
(WebKit::NetworkSocketChannel::sendString):
(WebKit::NetworkSocketChannel::sendData):
(WebKit::NetworkSocketChannel::close):
(WebKit::NetworkSocketChannel::protectedSocket): Deleted.
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::getPendingPushMessage):
(WebKit::NetworkNotificationManager::getPendingPushMessages):
(WebKit::NetworkNotificationManager::getPermissionState):
(WebKit::NetworkNotificationManager::getPermissionStateSync):
(WebKit::NetworkNotificationManager::protectedConnection const): Deleted.
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.cpp:
(WebKit::ServiceWorkerFetchTask::ServiceWorkerFetchTask):
(WebKit::ServiceWorkerFetchTask::loadResponseFromPreloader):
(WebKit::ServiceWorkerFetchTask::loadBodyFromPreloader):
(WebKit::ServiceWorkerFetchTask::cancelPreloadIfNecessary):
(WebKit::ServiceWorkerFetchTask::protectedPreloader): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/ServiceWorkerFetchTask.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.cpp:
(WebKit::WebSWRegistrationStore::updateToStorage):
(WebKit::WebSWRegistrationStore::protectedServer const): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWRegistrationStore.h:
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.cpp:
(WebKit::WebSWServerToContextConnection::fireNotificationEvent):
(WebKit::WebSWServerToContextConnection::terminateWorker):
(WebKit::WebSWServerToContextConnection::setAsInspected):
(WebKit::WebSWServerToContextConnection::workerTerminated):
(WebKit::WebSWServerToContextConnection::terminateDueToUnresponsiveness):
(WebKit::WebSWServerToContextConnection::protectedConnection const): Deleted.
* Source/WebKit/NetworkProcess/ServiceWorker/WebSWServerToContextConnection.h:
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/WebSocketTaskCocoa.mm:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::didClose):
(WebKit::WebSocketTask::networkSession):
(WebKit::WebSocketTask::protectedChannel const): Deleted.
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.cpp:
(WebKit::WebSocketTask::networkSession):
(WebKit::WebSocketTask::didReceiveData):
(WebKit::WebSocketTask::didFail):
(WebKit::WebSocketTask::didClose):
(WebKit::WebSocketTask::protectedChannel const): Deleted.
* Source/WebKit/NetworkProcess/curl/WebSocketTaskCurl.h:
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.cpp:
(WebKit::WebSocketTask::WebSocketTask):
(WebKit::WebSocketTask::didReceiveMessageCallback):
(WebKit::WebSocketTask::didClose):
(WebKit::WebSocketTask::protectedChannel const): Deleted.
* Source/WebKit/NetworkProcess/soup/WebSocketTaskSoup.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::prepareForEviction):
(WebKit::NetworkStorageManager::fetchRegistrableDomainsForPersist):
(WebKit::NetworkStorageManager::fileSystemGetDirectory):
(WebKit::NetworkStorageManager::closeHandle):
(WebKit::NetworkStorageManager::isSameEntry):
(WebKit::NetworkStorageManager::move):
(WebKit::NetworkStorageManager::getFileHandle):
(WebKit::NetworkStorageManager::getDirectoryHandle):
(WebKit::NetworkStorageManager::removeEntry):
(WebKit::NetworkStorageManager::resolve):
(WebKit::NetworkStorageManager::getFile):
(WebKit::NetworkStorageManager::createSyncAccessHandle):
(WebKit::NetworkStorageManager::closeSyncAccessHandle):
(WebKit::NetworkStorageManager::requestNewCapacityForSyncAccessHandle):
(WebKit::NetworkStorageManager::createWritable):
(WebKit::NetworkStorageManager::closeWritable):
(WebKit::NetworkStorageManager::executeCommandForWritable):
(WebKit::NetworkStorageManager::getHandleNames):
(WebKit::NetworkStorageManager::getHandle):
(WebKit::NetworkStorageManager::protectedProcess const): Deleted.
(WebKit::NetworkStorageManager::protectedFileSystemStorageHandleRegistry): Deleted.
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Platform/IPC/Connection.cpp:
(IPC::Connection::waitForMessage):
(IPC::Connection::waitForSyncReply):
(IPC::Connection::processIncomingSyncReply):
(IPC::Connection::dispatchSyncMessage):
(IPC::Connection::protectedSyncState const): Deleted.
* Source/WebKit/Platform/IPC/Connection.h:
* Source/WebKit/Platform/IPC/StreamServerConnection.cpp:
(IPC::StreamServerConnection::invalidate):
(IPC::StreamServerConnection::enqueueMessage):
(IPC::StreamServerConnection::protectedWorkQueue const): Deleted.
* Source/WebKit/Platform/IPC/StreamServerConnection.h:
* Source/WebKit/Platform/cocoa/PaymentAuthorizationPresenter.h:
(WebKit::PaymentAuthorizationPresenter::client):
(WebKit::PaymentAuthorizationPresenter::protectedClient): Deleted.
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/ApplePay/cocoa/WebPaymentCoordinatorProxyCocoa.mm:
(WebKit::WebPaymentCoordinatorProxy::platformCompletePaymentSession):
(WebKit::WebPaymentCoordinatorProxy::platformCompleteMerchantValidation):
(WebKit::WebPaymentCoordinatorProxy::platformCompleteShippingMethodSelection):
(WebKit::WebPaymentCoordinatorProxy::platformCompleteShippingContactSelection):
(WebKit::WebPaymentCoordinatorProxy::platformCompletePaymentMethodSelection):
(WebKit::WebPaymentCoordinatorProxy::platformCompleteCouponCodeChange):
* Source/WebKit/Shared/graphics/ImageBufferSet.h:
(WebKit::ImageBufferSet::protectedFrontBuffer): Deleted.
(WebKit::ImageBufferSet::protectedBackBuffer): Deleted.
(WebKit::ImageBufferSet::protectedSecondaryBackBuffer): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.cpp:
(WebKit::RemoteGraphicsContextGLProxy::videoFrameToImage):
(WebKit::RemoteGraphicsContextGLProxy::wasCreated):
(WebKit::RemoteGraphicsContextGLProxy::waitUntilInitialized):
(WebKit::RemoteGraphicsContextGLProxy::abandonGpuProcess):
(WebKit::RemoteGraphicsContextGLProxy::disconnectGpuProcessIfNeeded):
(WebKit::RemoteGraphicsContextGLProxy::protectedVideoFrameObjectHeapProxy const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteGraphicsContextGLProxy.h:
(WebKit::RemoteGraphicsContextGLProxy::send):
(WebKit::RemoteGraphicsContextGLProxy::sendSync):
(WebKit::RemoteGraphicsContextGLProxy::protectedStreamConnection const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::disconnectGPUProcess):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
(WebKit::RemoteRenderingBackendProxy::protectedConnection const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::initializeIPC):
(WebKit::RemoteGPUProxy::disconnectGpuProcessIfNeeded):
(WebKit::RemoteGPUProxy::abandonGPUProcess):
(WebKit::RemoteGPUProxy::wasCreated):
(WebKit::RemoteGPUProxy::waitUntilInitialized):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.cpp:
(WebKit::WebGPU::RemoteQueueProxy::getNativeImage):
(WebKit::WebGPU::RemoteQueueProxy::protectedVideoFrameObjectHeapProxy const): Deleted.
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.cpp:
(WebKit::RemoteCDMInstanceSession::~RemoteCDMInstanceSession):
(WebKit::RemoteCDMInstanceSession::setLogIdentifier):
(WebKit::RemoteCDMInstanceSession::protectedFactory const): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteCDMInstanceSession.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::createDecoderInternal):
(WebKit::LibWebRTCCodecs::completedDecoding):
(WebKit::LibWebRTCCodecs::protectedVideoFrameObjectHeapProxy const): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
(WebKit::LibWebRTCCodecs::WTF_REQUIRES_LOCK): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPlugin.mm:
(-[WKPDFPluginAccessibilityObject accessibilityFocusedUIElement]):
(-[WKPDFPluginAccessibilityObject accessibilityAssociatedControlForAnnotation:]):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginAnnotation.h:
(WebKit::PDFPluginAnnotation::protectedElement const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::scrollableAreaBoundingBox const):
(WebKit::PDFPluginBase::updateScrollbars):
(WebKit::PDFPluginBase::createScrollbar):
(WebKit::PDFPluginBase::print):
(WebKit::PDFPluginBase::updateHUDLocation):
(WebKit::PDFPluginBase::rootFrameID const):
(WebKit::PDFPluginBase::protectedView const): Deleted.
(WebKit::PDFPluginBase::protectedFrame const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginChoiceAnnotation.mm:
(WebKit::PDFPluginChoiceAnnotation::commit):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginPasswordField.mm:
(WebKit::PDFPluginPasswordField::~PDFPluginPasswordField):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginTextAnnotation.mm:
(WebKit::PDFPluginTextAnnotation::~PDFPluginTextAnnotation):
(WebKit::PDFPluginTextAnnotation::value const):
(WebKit::PDFPluginTextAnnotation::setValue):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDataDetectorOverlayController.mm:
(WebKit::PDFDataDetectorOverlayController::installProtectedOverlayIfNeeded):
(WebKit::PDFDataDetectorOverlayController::protectedPlugin const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::startTransitionAnimation):
(WebKit::PDFDiscretePresentationController::updateLayersForTransitionState):
(WebKit::PDFDiscretePresentationController::deviceOrPageScaleFactorChanged):
(WebKit::PDFDiscretePresentationController::buildRows):
(WebKit::PDFDiscretePresentationController::updateLayersOnLayoutChange):
(WebKit::PDFDiscretePresentationController::updateLayersAfterChangeInVisibleRow):
(WebKit::PDFDiscretePresentationController::updateIsInWindow):
(WebKit::PDFDiscretePresentationController::updateDebugBorders):
(WebKit::PDFDiscretePresentationController::updateForCurrentScrollability):
(WebKit::PDFDiscretePresentationController::RowData::leftPageBackgroundLayer const):
(WebKit::PDFDiscretePresentationController::RowData::rightPageBackgroundLayer const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::updateLayersOnLayoutChange):
(WebKit::PDFScrollingPresentationController::updateIsInWindow):
(WebKit::PDFScrollingPresentationController::updateForCurrentScrollability):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::UnifiedPDFPlugin):
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::mainFrameView const):
(WebKit::UnifiedPDFPlugin::installPDFDocument):
(WebKit::UnifiedPDFPlugin::didInvalidateDataDetectorHighlightOverlayRects):
(WebKit::UnifiedPDFPlugin::setNeedsRepaintForAnnotation):
(WebKit::UnifiedPDFPlugin::ensureLayers):
(WebKit::UnifiedPDFPlugin::setNeedsRepaintForIncrementalLoad):
(WebKit::UnifiedPDFPlugin::createScrollingNodeIfNecessary):
(WebKit::UnifiedPDFPlugin::updateLayerHierarchy):
(WebKit::UnifiedPDFPlugin::didChangeSettings):
(WebKit::UnifiedPDFPlugin::didChangeIsInWindow):
(WebKit::UnifiedPDFPlugin::paint):
(WebKit::UnifiedPDFPlugin::setScaleFactor):
(WebKit::UnifiedPDFPlugin::setPageScaleFactor):
(WebKit::UnifiedPDFPlugin::deviceOrPageScaleFactorChanged):
(WebKit::UnifiedPDFPlugin::didChangeScrollOffset):
(WebKit::UnifiedPDFPlugin::didChangeVisibleRow):
(WebKit::UnifiedPDFPlugin::updateOverflowControlsLayers):
(WebKit::UnifiedPDFPlugin::computeScrollability const):
(WebKit::UnifiedPDFPlugin::indexForCurrentPageInView const):
(WebKit::UnifiedPDFPlugin::annotationForRootViewPoint const):
(WebKit::UnifiedPDFPlugin::convertFromContentsToPainting const):
(WebKit::UnifiedPDFPlugin::convertFromPaintingToContents const):
(WebKit::UnifiedPDFPlugin::pdfElementTypesForPluginPoint const):
(WebKit::UnifiedPDFPlugin::handleWheelEvent):
(WebKit::UnifiedPDFPlugin::wheelEventCopyWithVelocity const):
(WebKit::UnifiedPDFPlugin::handleKeyboardEvent):
(WebKit::UnifiedPDFPlugin::revealRectInPage):
(WebKit::UnifiedPDFPlugin::revealPointInPage):
(WebKit::UnifiedPDFPlugin::revealPage):
(WebKit::UnifiedPDFPlugin::scrollToPointInContentsSpace):
(WebKit::UnifiedPDFPlugin::createContextMenu const):
(WebKit::UnifiedPDFPlugin::repaintOnSelectionChange):
(WebKit::UnifiedPDFPlugin::setCurrentSelection):
(WebKit::UnifiedPDFPlugin::existingSelectionContainsPoint const):
(WebKit::UnifiedPDFPlugin::continueAutoscroll):
(WebKit::UnifiedPDFPlugin::visibleRectsForFindMatchRects const):
(WebKit::UnifiedPDFPlugin::performDictionaryLookupAtLocation):
(WebKit::UnifiedPDFPlugin::textForImmediateActionHitTestAtPoint):
(WebKit::UnifiedPDFPlugin::accessibilityHitTestIntPoint const):
(WebKit::UnifiedPDFPlugin::rootViewToPage const):
(WebKit::UnifiedPDFPlugin::absoluteBoundingRectForSmartMagnificationAtPoint const):
(WebKit::UnifiedPDFPlugin::protectedPresentationController const): Deleted.
(WebKit::UnifiedPDFPlugin::protectedScrollContainerLayer const): Deleted.
(WebKit::UnifiedPDFPlugin::protectedOverflowControlsContainer const): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject accessibilityFocusedUIElement]):
(-[WKAccessibilityPDFDocumentObject accessibilityAssociatedControlForAnnotation:]):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::isUsingUISideCompositing const):
(WebKit::PluginView::protectedWebPage const): Deleted.
* Source/WebKit/WebProcess/Plugins/PluginView.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.cpp:
(WebKit::WebContextMenuClient::showContextMenu):
(WebKit::WebContextMenuClient::protectedPage const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebContextMenuClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.cpp:
(WebKit::WebDragClient::willPerformDragDestinationAction):
(WebKit::WebDragClient::dragSourceActionMaskForPoint):
(WebKit::WebDragClient::protectedPage): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebDragClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp:
(WebKit::WebSearchPopupMenu::saveRecentSearches):
(WebKit::WebSearchPopupMenu::loadRecentSearches):
(WebKit::WebSearchPopupMenu::protectedPopup): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.h:
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebContextMenuClientMac.mm:
(WebKit::WebContextMenuClient::lookUpInDictionary):
(WebKit::WebContextMenuClient::isSpeaking const):
(WebKit::WebContextMenuClient::searchWithGoogle):
(WebKit::WebContextMenuClient::handleTranslation):
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/TextAnimationController.mm:
(WebKit::TextAnimationController::removeInitialTextAnimationForActiveWritingToolsSession):
(WebKit::TextAnimationController::addInitialTextAnimationForActiveWritingToolsSession):
(WebKit::TextAnimationController::addSourceTextAnimationForActiveWritingToolsSession):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::mainFramePlugIn):
(WebKit::FindController::findStringIncludingImages):
(WebKit::FindController::indicateFindMatch):
(WebKit::FindController::hideFindUI):
(WebKit::FindController::didFindString):
(WebKit::FindController::rectsForTextMatchesInRect):
(WebKit::FindController::drawRect):
(WebKit::FindController::protectedWebPage const): Deleted.
* Source/WebKit/WebProcess/WebPage/FindController.h:
* Source/WebKit/WebProcess/WebPage/PageBanner.h:
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::findTextRangesForStringMatches):
(WebKit::WebFoundTextRangeController::clearAllDecoratedFoundText):
(WebKit::WebFoundTextRangeController::didBeginTextSearchOperation):
(WebKit::WebFoundTextRangeController::redraw):
(WebKit::WebFoundTextRangeController::flashTextIndicatorAndUpdateSelectionWithRange):
(WebKit::WebFoundTextRangeController::flashTextIndicatorAndUpdateSelectionWithPDFRange):
(WebKit::WebFoundTextRangeController::frameForFoundTextRange const):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.h:
(WebKit::WebFoundTextRangeController::protectedWebPage const): Deleted.
(WebKit::WebFoundTextRangeController::protectedFindPageOverlay const): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::close):
* Source/WebKit/WebProcess/WebPage/mac/PageBannerMac.mm:
(WebKit::PageBanner::hide):
(WebKit::PageBanner::mouseEvent):
(WebKit::PageBanner::protectedWebPage): Deleted.
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureNetworkProcessConnection):
(WebKit::WebProcess::protectedNetworkProcessConnection): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Tools/Scripts/generate-gpup-webgl:
(webkit_ipc_cpp_impl.process_call):

Canonical link: <a href="https://commits.webkit.org/307351@main">https://commits.webkit.org/307351@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f27c5476473352c12f995326389ee1de0c603bc9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144110 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16789 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8343 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152780 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/145985 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17271 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16683 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110814 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147073 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13233 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129475 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91732 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12688 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10425 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/226 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6128 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155092 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16641 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7183 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118828 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16677 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13975 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119186 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30553 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15073 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127339 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72062 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16263 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5777 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15997 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16208 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16063 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->