### PR TITLE
[iOS] PDF display mode should be toggleable via context menu

### DIFF
--- a/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
+++ b/Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm
@@ -28,11 +28,8 @@
 
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)
 
-#import "PDFDisplayMode.h"
 #import "UIKitSPI.h"
 #import "WKWebViewIOS.h"
-#import "WKWebViewInternal.h"
-#import "WebPageProxy.h"
 #import <WebCore/LocalizedStrings.h>
 #import <pal/system/ios/UserInterfaceIdiom.h>
 #import <wtf/CompletionHandler.h>
@@ -51,52 +48,10 @@ static constexpr Seconds indicatorFadeInDuration { 0.1_s };
 static constexpr Seconds indicatorFadeOutDuration { 0.75_s };
 static constexpr Seconds indicatorMoveDuration { 0.3_s };
 
-static UIActionIdentifier const WKPDFActionSinglePageIdentifier = @"WKPDFActionSinglePageIdentifier";
-static UIActionIdentifier const WKPDFActionTwoPagesIdentifier = @"WKPDFActionPlayTwoPagesIdentifier";
-
-@class WKPDFPageNumberIndicatorButton;
-
-@protocol WKPDFPageNumberIndicatorButtonDelegate <NSObject>
-- (void)pdfPageNumberIndicatorButtonWillDisplayMenu:(WKPDFPageNumberIndicatorButton *)button;
-- (void)pdfPageNumberIndicatorButtonDidDismissMenu:(WKPDFPageNumberIndicatorButton *)button;
-@end
-
-@interface WKPDFPageNumberIndicatorButton : UIButton
-@property (nonatomic, weak) id<WKPDFPageNumberIndicatorButtonDelegate> delegate;
-@end
-
-@implementation WKPDFPageNumberIndicatorButton
-
-- (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willDisplayMenuForConfiguration:(UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionAnimating>)animator
-{
-    [super contextMenuInteraction:interaction willDisplayMenuForConfiguration:configuration animator:animator];
-    [protect(_delegate) pdfPageNumberIndicatorButtonWillDisplayMenu:self];
-}
-
-- (void)contextMenuInteraction:(UIContextMenuInteraction *)interaction willEndForConfiguration:(UIContextMenuConfiguration *)configuration animator:(id<UIContextMenuInteractionAnimating>)animator
-{
-    [super contextMenuInteraction:interaction willEndForConfiguration:configuration animator:animator];
-
-    [animator addCompletion:[weakSelf = WeakObjCPtr<WKPDFPageNumberIndicatorButton>(self)] {
-        RetainPtr strongSelf = weakSelf.get();
-        if (!strongSelf)
-            return;
-
-        [protect(strongSelf->_delegate) pdfPageNumberIndicatorButtonDidDismissMenu:strongSelf.get()];
-    }];
-}
-
-@end
-
-@interface WKPDFPageNumberIndicator () <WKPDFPageNumberIndicatorButtonDelegate>
-@end
-
 @implementation WKPDFPageNumberIndicator {
-    RetainPtr<WKPDFPageNumberIndicatorButton> _button;
+    RetainPtr<UIButton> _button;
     RetainPtr<NSTimer> _timer;
     WeakObjCPtr<WKWebView> _webView;
-
-    BOOL _isShowingMenu;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame view:(WKWebView *)view pageCount:(size_t)pageCount
@@ -106,14 +61,9 @@ static UIActionIdentifier const WKPDFActionTwoPagesIdentifier = @"WKPDFActionPla
         return nil;
 
     _webView = view;
-    _isShowingMenu = NO;
 
     self.alpha = 0;
-
-    BOOL shouldEnableUserInteraction = NO;
-    if (RefPtr page = view->_page)
-        shouldEnableUserInteraction = protect(page->preferences())->twoUpPDFDisplayModeSupportEnabled();
-    self.userInteractionEnabled = shouldEnableUserInteraction;
+    self.userInteractionEnabled = NO;
 
 #if HAVE(UI_GLASS_EFFECT)
     bool shouldUseBlurEffectForBackdrop = PAL::currentUserInterfaceIdiomIsVision();
@@ -141,50 +91,11 @@ static UIActionIdentifier const WKPDFActionTwoPagesIdentifier = @"WKPDFActionPla
         return attributes.autorelease();
     }];
 
-    _button = [WKPDFPageNumberIndicatorButton buttonWithType:UIButtonTypeSystem];
-    [_button setDelegate:self];
+    _button = [UIButton buttonWithType:UIButtonTypeSystem];
     [_button setConfiguration:buttonConfiguration.get()];
     [_button setFrame:self.bounds];
     [_button setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
     [self addSubview:_button.get()];
-
-    RetainPtr deferredMenu = [UIDeferredMenuElement elementWithUncachedProvider:[weakSelf = WeakObjCPtr<WKPDFPageNumberIndicator>(self)](void (^completion)(NSArray<UIMenuElement *> *)) {
-        RetainPtr strongSelf = weakSelf.get();
-        if (!strongSelf) {
-            completion(@[ ]);
-            return;
-        }
-
-        UIActionHandler actionHandler = [weakSelf](UIAction *action) {
-            RetainPtr strongSelf = weakSelf.get();
-            if (!strongSelf)
-                return;
-
-            if (RetainPtr webView = strongSelf->_webView.get()) {
-                if (RefPtr page = webView->_page) {
-                    BOOL isSinglePage = [action.identifier isEqualToString:WKPDFActionSinglePageIdentifier];
-
-                    if ([strongSelf _isSinglePage] == isSinglePage)
-                        return;
-
-                    page->requestPDFDisplayMode(isSinglePage ? WebKit::PDFDisplayMode::SinglePageContinuous : WebKit::PDFDisplayMode::TwoUpContinuous);
-                }
-            }
-        };
-
-        RetainPtr singlePageAction = [UIAction actionWithTitle:WebCore::contextMenuItemPDFSinglePage().createNSString().get() image:nil identifier:WKPDFActionSinglePageIdentifier handler:actionHandler];
-        RetainPtr twoPagesAction = [UIAction actionWithTitle:WebCore::contextMenuItemPDFTwoPages().createNSString().get() image:nil identifier:WKPDFActionTwoPagesIdentifier handler:actionHandler];
-
-        if ([strongSelf _isSinglePage])
-            [singlePageAction setState:UIMenuElementStateOn];
-        else
-            [twoPagesAction setState:UIMenuElementStateOn];
-
-        completion(@[ singlePageAction.get(), twoPagesAction.get() ]);
-    }];
-
-    [_button setMenu:[UIMenu menuWithTitle:@"" children:@[ deferredMenu.get() ]]];
-    [_button setShowsMenuAsPrimaryAction:YES];
 
     [self updatePosition:self.frame];
     [self setPageCount:pageCount];
@@ -245,11 +156,6 @@ static UIActionIdentifier const WKPDFActionTwoPagesIdentifier = @"WKPDFActionPla
 
 - (void)hide:(NSTimer *)timer
 {
-    if (_isShowingMenu) {
-        [std::exchange(_timer, nil) invalidate];
-        return;
-    }
-
     // FIXME: <rdar://162795344> Remove this workaround and directly setAlpha:0 after rdar://154649008.
     static constexpr auto effectivelyTransparentAlpha = 0.0101;
     auto animations = [view = retainPtr(self)] {
@@ -303,27 +209,6 @@ static UIActionIdentifier const WKPDFActionTwoPagesIdentifier = @"WKPDFActionPla
     if (!_pageCount || !_currentPageNumber)
         return;
 
-    [self show];
-}
-
-- (BOOL)_isSinglePage
-{
-    if (RetainPtr webView = _webView.get()) {
-        if (RefPtr page = webView->_page)
-            return page->pdfDisplayMode() == WebKit::PDFDisplayMode::SinglePageContinuous;
-    }
-
-    return YES;
-}
-
-- (void)pdfPageNumberIndicatorButtonWillDisplayMenu:(WKPDFPageNumberIndicatorButton *)button
-{
-    _isShowingMenu = YES;
-}
-
-- (void)pdfPageNumberIndicatorButtonDidDismissMenu:(WKPDFPageNumberIndicatorButton *)button
-{
-    _isShowingMenu = NO;
     [self show];
 }
 


### PR DESCRIPTION
#### 5a8c79c681d0746bed562b6551e1644b5f0cb69a
<pre>
[iOS] PDF display mode should be toggleable via context menu
<a href="https://bugs.webkit.org/show_bug.cgi?id=307638">https://bugs.webkit.org/show_bug.cgi?id=307638</a>
<a href="https://rdar.apple.com/170202790">rdar://170202790</a>

Reviewed by Abrar Rahman Protyasha.

Rollback changes to make the display mode toggleable via the page number
indicator. Instead, the display mode can be changed via context menu.

* Source/WebKit/UIProcess/PDF/WKPDFPageNumberIndicator.mm:
(-[WKPDFPageNumberIndicator initWithFrame:view:pageCount:]):
(-[WKPDFPageNumberIndicator hide:]):
(-[WKPDFPageNumberIndicatorButton contextMenuInteraction:willDisplayMenuForConfiguration:animator:]): Deleted.
(-[WKPDFPageNumberIndicatorButton contextMenuInteraction:willEndForConfiguration:animator:]): Deleted.
(-[WKPDFPageNumberIndicator _isSinglePage]): Deleted.
(-[WKPDFPageNumberIndicator pdfPageNumberIndicatorButtonWillDisplayMenu:]): Deleted.
(-[WKPDFPageNumberIndicator pdfPageNumberIndicatorButtonDidDismissMenu:]): Deleted.
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView contextMenuInteraction:configurationForMenuAtLocation:]):
(-[WKContentView _internalContextMenuInteraction:configurationForMenuAtLocation:completion:]):
(-[WKContentView continueContextMenuInteraction:completion:]):

The context menu containing PDF display options should only be shown if no other
menu would be presented. That is, a link or image is not context clicked.

Check the menu appearance style to prevent the menu from being accessible
via long press. The current intent is that the menu is only accessible using a
cursor.

(-[WKContentView shouldShowPDFDisplayOptions]):
(-[WKContentView continueContextMenuInteractionWithPDFDisplayOptions:]):
(-[WKContentView continueContextMenuInteraction:]): Deleted.

Canonical link: <a href="https://commits.webkit.org/307381@main">https://commits.webkit.org/307381@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6dda98e9cce4d04b13592a9953aba8b4392e5624

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144111 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97350 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b825e377-dff4-421c-972a-683e2815fe0a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16684 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110815 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79639 "Exiting early after 60 failures. 15403 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15c26008-336e-4a2d-b68c-af0684895c8a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147074 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13232 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91733 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49a66df0-1327-429c-a5aa-f2eff475a556) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12687 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10423 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/227 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122168 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155093 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16642 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7184 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118829 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13973 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119187 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15074 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72063 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22245 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16264 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5778 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80043 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16209 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16064 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->