### PR TITLE
Rebaseline sequoia test to account for 307212@main

### DIFF
--- a/LayoutTests/platform/mac-sequoia-wk2/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
+++ b/LayoutTests/platform/mac-sequoia-wk2/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt
@@ -1,4 +1,4 @@
-layer at (0,0) size 785x1447
+layer at (0,0) size 785x1445
   RenderView at (0,0) size 785x600
 layer at (8,8) size 769x1429
   RenderBlock {HTML} at (8,8) size 769x1429 [bgcolor=#008000] [border: (16px solid #00FF00)]


### PR DESCRIPTION
#### d759513fb145751aa64f4d9bc9204d4bdb22708d
<pre>
Rebaseline sequoia test to account for 307212@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=307639">https://bugs.webkit.org/show_bug.cgi?id=307639</a>
<a href="https://rdar.apple.com/170203556">rdar://170203556</a>
Reviewed by Simon Fraser.

307212@main changed how we calculate the overflow area of block containers,
and as a consequence needed rebaselining on a bunch of tests including this
one. But it wasn&apos;t rebaselined correctly, so let&apos;s fix it now.

* LayoutTests/platform/mac-sequoia-wk2/tables/mozilla_expected_failures/bugs/bug2479-5-expected.txt:

Canonical link: <a href="https://commits.webkit.org/307369@main">https://commits.webkit.org/307369@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5b475ad48b0b810345937f79f5cdea2b8765f887

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144112 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152782 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97351 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e26bb9c-2da2-44a0-9da7-4955b06ae26f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110816 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79640 "Exiting early after 60 failures. 15400 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e3ffb6b-b8e0-46e7-b62b-f2c4f50bd283) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147075 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13235 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129477 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91734 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12690 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/228 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122171 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155094 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16643 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7185 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118830 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13976 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30570 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15075 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127341 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72064 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16265 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5779 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/15999 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16210 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16065 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->