### PR TITLE
REGRESSION(302480@main): GRID Legends: Failed to switch the language to Simplified Chinese and Traditional Chinese)

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3425,9 +3425,9 @@ HTMLEnhancedSelectParsingEnabled:
    humanReadableDescription: "Enable enhanced HTML select element parsing"
    defaultValue:
      WebKitLegacy:
-       default: true
+       default: WebKit::defaultHTMLEnhancedSelectParsingEnabled()
      WebKit:
-       default: true
+       default: WebKit::defaultHTMLEnhancedSelectParsingEnabled()
      WebCore:
        default: true
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -108,6 +108,7 @@ enum class SDKAlignedBehavior {
     ProgrammaticFocusDuringUserScriptShowsInputViews,
     ScreenOrientationAPIEnabled,
     PopoverAttributeEnabled,
+    HTMLEnhancedSelectParsingEnabled,
     DoesNotOverrideUAFromNSUserDefault,
     EvaluateJavaScriptWithoutTransientActivation,
     ResettingTransitionCancelsRunningTransitionQuirk,

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.cpp
@@ -309,6 +309,16 @@ bool defaultPopoverAttributeEnabled()
 #endif
 }
 
+bool defaultHTMLEnhancedSelectParsingEnabled()
+{
+#if PLATFORM(COCOA)
+    static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::HTMLEnhancedSelectParsingEnabled);
+    return newSDK;
+#else
+    return true;
+#endif
+}
+
 bool defaultUseGPUProcessForDOMRenderingEnabled()
 {
 #if ENABLE(GPU_PROCESS_BY_DEFAULT) && ENABLE(GPU_PROCESS_DOM_RENDERING_BY_DEFAULT)

--- a/Source/WebKit/Shared/WebPreferencesDefaultValues.h
+++ b/Source/WebKit/Shared/WebPreferencesDefaultValues.h
@@ -162,6 +162,7 @@ bool defaultLinearMediaPlayerEnabled();
 
 bool defaultShouldEnableScreenOrientationAPI();
 bool defaultPopoverAttributeEnabled();
+bool defaultHTMLEnhancedSelectParsingEnabled();
 bool defaultUseGPUProcessForDOMRenderingEnabled();
 
 #if USE(LIBWEBRTC)

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
@@ -62,6 +62,7 @@ bool defaultAttachmentElementEnabled();
 bool defaultShouldRestrictBaseURLSchemes();
 bool defaultShouldConvertInvalidURLsToBlank();
 bool defaultPopoverAttributeEnabled();
+bool defaultHTMLEnhancedSelectParsingEnabled();
 bool defaultShowModalDialogEnabled();
 bool defaultFontFaceSetConstructorEnabled();
 

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
@@ -194,6 +194,12 @@ bool defaultPopoverAttributeEnabled()
     return newSDK;
 }
 
+bool defaultHTMLEnhancedSelectParsingEnabled()
+{
+    static bool newSDK = linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::HTMLEnhancedSelectParsingEnabled);
+    return newSDK;
+}
+
 #if PLATFORM(MAC)
 
 bool defaultPassiveWheelListenersAsDefaultOnDocument()


### PR DESCRIPTION
#### 00f71f6347e8c617c68f1ebe5062ec3f78c88081
<pre>
REGRESSION(<a href="https://commits.webkit.org/302480@main">302480@main</a>): GRID Legends: Failed to switch the language to Simplified Chinese and Traditional Chinese)
<a href="https://bugs.webkit.org/show_bug.cgi?id=307647">https://bugs.webkit.org/show_bug.cgi?id=307647</a>
<a href="https://rdar.apple.com/170187680">rdar://170187680</a>

Reviewed by NOBODY (OOPS!).

Disable new parsing behavior on apps linked with older SDK.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WebKit/Shared/WebPreferencesDefaultValues.cpp:
(WebKit::defaultHTMLEnhancedSelectParsingEnabled):
* Source/WebKit/Shared/WebPreferencesDefaultValues.h:
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h:
* Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm:
(WebKit::defaultHTMLEnhancedSelectParsingEnabled):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00f71f6347e8c617c68f1ebe5062ec3f78c88081

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144120 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16799 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152790 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97359 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17281 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16693 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110822 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79646 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147083 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13242 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129487 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91740 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b85b7f37-20b0-4ba2-b946-b1c631ddd524) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12696 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10432 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/236 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136111 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122178 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6139 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155102 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4928 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7194 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118837 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13983 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119195 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15081 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127350 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72072 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16273 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5788 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175407 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80052 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45217 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16218 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16073 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->