### PR TITLE
Change new willSubmitForm delegate in SwiftUI from WKFormInfo to WebPage.FormInfo

### DIFF
--- a/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift
@@ -151,7 +151,7 @@ extension WebPage {
         /// - Parameter formInfo: The form values that will be submitted for this navigation
         @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
         @MainActor
-        mutating func willSubmit(formInfo: WKFormInfo) async
+        mutating func willSubmit(formInfo: WebPage.FormInfo) async
     }
 }
 
@@ -187,7 +187,7 @@ extension WebPage.NavigationDeciding {
     /// By default, this method does nothing.
     @available(WK_IOS_TBA, WK_MAC_TBA, WK_XROS_TBA, *)
     @MainActor
-    public func willSubmit(formInfo: WKFormInfo) async {
+    public func willSubmit(formInfo: WebPage.FormInfo) async {
     }
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
+++ b/Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift
@@ -131,7 +131,8 @@ final class WKNavigationDelegateAdapter: NSObject, WKNavigationDelegate {
         _ webView: WKWebView,
         willSubmitForm formInfo: WKFormInfo
     ) async {
-        await navigationDecider.willSubmit(formInfo: formInfo)
+        let convertedFormInfo = WebPage.FormInfo(formInfo)
+        await navigationDecider.willSubmit(formInfo: convertedFormInfo)
     }
 }
 


### PR DESCRIPTION
#### b23b9c3ac17ded2d0155d65d0e72be9befbbb5b4
<pre>
Change new willSubmitForm delegate in SwiftUI from WKFormInfo to WebPage.FormInfo
<a href="https://rdar.apple.com/170208148">rdar://170208148</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307649">https://bugs.webkit.org/show_bug.cgi?id=307649</a>

Reviewed by Richard Robinson.

Tried to address this review feedback but merge-queue beat me to it!

* Source/WebKit/UIProcess/API/Swift/WebPage+NavigationDeciding.swift:
(NavigationDeciding.willSubmit(_:)):
(WebPage.willSubmit(_:)):
* Source/WebKit/UIProcess/Cocoa/WKNavigationDelegateAdapter.swift:

Canonical link: <a href="https://commits.webkit.org/307343@main">https://commits.webkit.org/307343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/97d6752e092a383eb92832186a9834bcfacf3cf4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144125 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152795 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dc3c4354-d69e-4290-b5e9-9702fcd20691) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17286 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110824 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147088 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13244 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129488 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91742 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/241 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155107 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16656 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7195 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118840 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/13986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119198 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30547 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15083 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127351 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72077 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16278 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5789 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16012 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80057 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16078 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->