### PR TITLE
[Site Isolation] Fix datalist picker for cross-origin iframes

### DIFF
--- a/LayoutTests/http/tests/site-isolation/datalist-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/datalist-cross-origin-iframe-expected.txt
@@ -1,0 +1,10 @@
+Test that selecting a datalist option in a cross-origin iframe updates the input value when site isolation is enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS selectedValue is "Apple"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/datalist-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/datalist-cross-origin-iframe.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/ui-helper.js"></script>
+</head>
+<body>
+<script>
+description("Test that selecting a datalist option in a cross-origin iframe updates the input value when site isolation is enabled.");
+jsTestIsAsync = true;
+
+window.addEventListener("message", async (event) => {
+    if (event.data.type === "result") {
+        window.selectedValue = event.data.value;
+        shouldBeEqualToString("selectedValue", "Apple");
+        finishJSTest();
+    }
+});
+
+async function runTest() {
+    const iframe = document.getElementById("frame");
+    const iframeRect = iframe.getBoundingClientRect();
+
+    const clickX = iframeRect.left + 50;
+    const clickY = iframeRect.top + 25;
+    await UIHelper.activateAndWaitForInputSessionAt(clickX, clickY);
+
+    if (UIHelper.isIOSFamily())
+        await UIHelper.tapAt(iframeRect.left + 290, iframeRect.top + 25);
+
+    await UIHelper.waitForDataListSuggestionsToChangeVisibility(true);
+
+    await UIHelper.activateDataListSuggestion(0);
+
+    await UIHelper.waitForDataListSuggestionsToChangeVisibility(false);
+}
+</script>
+<iframe id="frame" src="http://localhost:8000/site-isolation/resources/datalist-iframe.html" onload="runTest()"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/datalist-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/datalist-iframe.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+body { margin: 0; }
+input { width: 300px; height: 50px; }
+</style>
+</head>
+<body>
+<input id="input" list="fruits" type="text"/>
+<datalist id="fruits">
+    <option>Apple</option>
+    <option>Banana</option>
+    <option>Cherry</option>
+</datalist>
+<script>
+const input = document.getElementById("input");
+
+// Report value changes back to parent
+input.addEventListener("input", () => {
+    window.parent.postMessage({
+        type: "result",
+        value: input.value
+    }, "*");
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/DataListSuggestionInformation.h
+++ b/Source/WebCore/html/DataListSuggestionInformation.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/IntRect.h>
 #include <wtf/Vector.h>
 
@@ -46,6 +47,7 @@ struct DataListSuggestionInformation {
     DataListSuggestionActivationType activationType;
     Vector<DataListSuggestion> suggestions;
     IntRect elementRect;
+    std::optional<FrameIdentifier> rootFrameID;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -925,6 +925,17 @@ IntRect TextFieldInputType::elementRectInRootViewCoordinates() const
     return protect(element->document().view())->contentsToRootView(protect(element->renderer())->absoluteBoundingBoxRect());
 }
 
+std::optional<FrameIdentifier> TextFieldInputType::rootFrameID() const
+{
+    RefPtr element = this->element();
+    if (!element)
+        return std::nullopt;
+    RefPtr view = element->document().view();
+    if (!view)
+        return std::nullopt;
+    return view->rootFrameID();
+}
+
 Vector<DataListSuggestion> TextFieldInputType::suggestions()
 {
     // FIXME: Suggestions are "typing completions" and so should probably use the findPlainText algorithm rather than the simplistic "ignoring ASCII case" rules.

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -133,6 +133,7 @@ private:
     // DataListSuggestionsClient
     IntRect elementRectInRootViewCoordinates() const final;
     Vector<DataListSuggestion> suggestions() final;
+    std::optional<FrameIdentifier> rootFrameID() const final;
     void didSelectDataListOption(const String&) final;
     void didCloseSuggestions() final;
 

--- a/Source/WebCore/platform/DataListSuggestionsClient.h
+++ b/Source/WebCore/platform/DataListSuggestionsClient.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/FrameIdentifier.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Forward.h>
 
@@ -41,6 +42,7 @@ public:
 
     virtual IntRect elementRectInRootViewCoordinates() const = 0;
     virtual Vector<DataListSuggestion> suggestions() = 0;
+    virtual std::optional<FrameIdentifier> rootFrameID() const = 0;
 
     virtual void didSelectDataListOption(const String&) = 0;
     virtual void didCloseSuggestions() = 0;

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2498,6 +2498,7 @@ struct WebCore::DataListSuggestionInformation {
     WebCore::DataListSuggestionActivationType activationType;
     Vector<WebCore::DataListSuggestion> suggestions;
     WebCore::IntRect elementRect;
+    std::optional<WebCore::FrameIdentifier> rootFrameID;
 };
 
 struct WebCore::ClientOrigin {

--- a/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.cpp
+++ b/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.cpp
@@ -39,10 +39,17 @@ WebDataListSuggestionsDropdown::~WebDataListSuggestionsDropdown()
 {
 }
 
+void WebDataListSuggestionsDropdown::show(WebCore::DataListSuggestionInformation&& information)
+{
+    m_targetFrameID = information.rootFrameID;
+    platformShow(WTF::move(information));
+}
+
 void WebDataListSuggestionsDropdown::close()
 {
+    auto targetFrameID = std::exchange(m_targetFrameID, std::nullopt);
     if (auto page = std::exchange(m_page, nullptr))
-        page->didCloseSuggestions();
+        page->didCloseSuggestions(targetFrameID);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.h
+++ b/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/DataListSuggestionPicker.h>
+#include <WebCore/FrameIdentifier.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>
 #include <wtf/WeakPtr.h>
@@ -38,14 +39,17 @@ class WebDataListSuggestionsDropdown : public RefCountedAndCanMakeWeakPtr<WebDat
 public:
     virtual ~WebDataListSuggestionsDropdown();
 
-    virtual void show(WebCore::DataListSuggestionInformation&&) = 0;
+    void show(WebCore::DataListSuggestionInformation&&);
     virtual void handleKeydownWithIdentifier(const String&) = 0;
     virtual void close();
 
 protected:
     explicit WebDataListSuggestionsDropdown(WebPageProxy&);
 
+    virtual void platformShow(WebCore::DataListSuggestionInformation&&) = 0;
+
     WeakPtr<WebPageProxy> m_page;
+    std::optional<WebCore::FrameIdentifier> m_targetFrameID;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10551,21 +10551,21 @@ void WebPageProxy::endDataListSuggestions()
         dataListSuggestionsDropdown->close();
 }
 
-void WebPageProxy::didCloseSuggestions()
+void WebPageProxy::didCloseSuggestions(std::optional<WebCore::FrameIdentifier> targetFrameID)
 {
     if (!internals().dataListSuggestionsDropdown)
         return;
 
     internals().dataListSuggestionsDropdown = nullptr;
-    send(Messages::WebPage::DidCloseSuggestions());
+    sendToProcessContainingFrame(targetFrameID, Messages::WebPage::DidCloseSuggestions());
 }
 
-void WebPageProxy::didSelectOption(const String& selectedOption)
+void WebPageProxy::didSelectOption(const String& selectedOption, std::optional<WebCore::FrameIdentifier> targetFrameID)
 {
     if (!hasRunningProcess())
         return;
 
-    send(Messages::WebPage::DidSelectDataListOption(selectedOption));
+    sendToProcessContainingFrame(targetFrameID, Messages::WebPage::DidSelectDataListOption(selectedOption));
 }
 
 void WebPageProxy::showDateTimePicker(WebCore::DateTimeChooserParameters&& params)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2315,8 +2315,8 @@ public:
 
     WebCore::IntRect syncRootViewToScreen(const WebCore::IntRect& viewRect);
 
-    void didSelectOption(const String&);
-    void didCloseSuggestions();
+    void didSelectOption(const String&, std::optional<WebCore::FrameIdentifier>);
+    void didCloseSuggestions(std::optional<WebCore::FrameIdentifier>);
 
     void didChooseDate(StringView);
     void didEndDateTimePicker();

--- a/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
@@ -130,11 +130,11 @@ void WebDataListSuggestionsDropdownGtk::didSelectOption(const String& selectedOp
     if (!m_page)
         return;
 
-    m_page->didSelectOption(selectedOption);
+    m_page->didSelectOption(selectedOption, m_targetFrameID);
     close();
 }
 
-void WebDataListSuggestionsDropdownGtk::show(WebCore::DataListSuggestionInformation&& information)
+void WebDataListSuggestionsDropdownGtk::platformShow(WebCore::DataListSuggestionInformation&& information)
 {
     auto* model = GTK_LIST_STORE(gtk_tree_view_get_model(GTK_TREE_VIEW(m_treeView)));
     gtk_list_store_clear(model);
@@ -223,7 +223,7 @@ void WebDataListSuggestionsDropdownGtk::handleKeydownWithIdentifier(const String
         if (hasSelection) {
             GUniqueOutPtr<char> item;
             gtk_tree_model_get(model, &iter, 0, &item.outPtr(), -1);
-            m_page->didSelectOption(String::fromUTF8(item.get()));
+            m_page->didSelectOption(String::fromUTF8(item.get()), m_targetFrameID);
         }
         close();
         return;

--- a/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.h
@@ -47,7 +47,7 @@ public:
 private:
     WebDataListSuggestionsDropdownGtk(GtkWidget*, WebPageProxy&);
 
-    void show(WebCore::DataListSuggestionInformation&&) final;
+    void platformShow(WebCore::DataListSuggestionInformation&&) final;
     void handleKeydownWithIdentifier(const String&) final;
     void close() final;
 

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
@@ -61,7 +61,7 @@ public:
 private:
     WebDataListSuggestionsDropdownIOS(WebPageProxy&, WKContentView *);
 
-    void show(WebCore::DataListSuggestionInformation&&) final;
+    void platformShow(WebCore::DataListSuggestionInformation&&) final;
     void handleKeydownWithIdentifier(const String&) final;
     void close() final;
 

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -108,7 +108,7 @@ WebDataListSuggestionsDropdownIOS::WebDataListSuggestionsDropdownIOS(WebPageProx
 {
 }
 
-void WebDataListSuggestionsDropdownIOS::show(WebCore::DataListSuggestionInformation&& information)
+void WebDataListSuggestionsDropdownIOS::platformShow(WebCore::DataListSuggestionInformation&& information)
 {
     if (m_suggestionsControl) {
         [m_suggestionsControl updateWithInformation:WTF::move(information)];
@@ -148,7 +148,7 @@ void WebDataListSuggestionsDropdownIOS::didSelectOption(const String& selectedOp
     if (!m_page)
         return;
 
-    protect(m_page)->didSelectOption(selectedOption);
+    protect(m_page)->didSelectOption(selectedOption, m_targetFrameID);
     close();
 }
 

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.h
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.h
@@ -45,7 +45,7 @@ public:
 private:
     WebDataListSuggestionsDropdownMac(WebPageProxy&, NSView *);
 
-    void show(WebCore::DataListSuggestionInformation&&) final;
+    void platformShow(WebCore::DataListSuggestionInformation&&) final;
     void handleKeydownWithIdentifier(const String&) final;
     void close() final;
 

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -82,7 +82,7 @@ WebDataListSuggestionsDropdownMac::WebDataListSuggestionsDropdownMac(WebPageProx
 {
 }
 
-void WebDataListSuggestionsDropdownMac::show(WebCore::DataListSuggestionInformation&& information)
+void WebDataListSuggestionsDropdownMac::platformShow(WebCore::DataListSuggestionInformation&& information)
 {
     if (m_dropdownUI) {
         [m_dropdownUI updateWithInformation:WTF::move(information)];
@@ -99,7 +99,7 @@ void WebDataListSuggestionsDropdownMac::didSelectOption(const String& selectedOp
     if (!page)
         return;
 
-    page->didSelectOption(selectedOption);
+    page->didSelectOption(selectedOption, m_targetFrameID);
     close();
 }
 
@@ -111,7 +111,7 @@ void WebDataListSuggestionsDropdownMac::selectOption()
 
     String selectedOption = [m_dropdownUI currentSelectedString];
     if (!selectedOption.isNull())
-        page->didSelectOption(selectedOption);
+        page->didSelectOption(selectedOption, m_targetFrameID);
 
     close();
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
@@ -102,7 +102,7 @@ void WebDataListSuggestionPicker::displayWithActivationType(WebCore::DataListSug
 
     page->setActiveDataListSuggestionPicker(*this);
 
-    WebCore::DataListSuggestionInformation info { type, WTF::move(suggestions), WTF::move(elementRectInRootViewCoordinates) };
+    WebCore::DataListSuggestionInformation info { type, WTF::move(suggestions), WTF::move(elementRectInRootViewCoordinates), client->rootFrameID() };
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::ShowDataListSuggestions(info), page->identifier());
 }
 


### PR DESCRIPTION
#### dae6ae8ca62bef73b06eb3749782920897a1b4f2
<pre>
[Site Isolation] Fix datalist picker for cross-origin iframes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307654">https://bugs.webkit.org/show_bug.cgi?id=307654</a>
<a href="https://rdar.apple.com/164541257">rdar://164541257</a>

Reviewed by Aditya Keerthi.

When site isolation is enabled, cross-origin iframes run in separate
WebContent processes. The datalist picker was sending responses
(didSelectDataListOption, didCloseSuggestions) only to the main
process, which would fail to update the input element in the iframe&apos;s
process.

This patch fixes the issue by:
1. Adding rootFrameID() to DataListSuggestionsClient to identify which
   frame contains the datalist input element
2. Passing the frame identifier through the IPC message when showing
   the datalist suggestions
3. Using sendToProcessContainingFrame() to route responses back to the
   correct process

* LayoutTests/http/tests/site-isolation/datalist-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/datalist-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/datalist-iframe.html: Added.
* Source/WebCore/html/DataListSuggestionInformation.h:
* Source/WebCore/html/TextFieldInputType.cpp:
(WebCore::TextFieldInputType::rootFrameID const):
* Source/WebCore/html/TextFieldInputType.h:
* Source/WebCore/platform/DataListSuggestionsClient.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.cpp:
(WebKit::WebDataListSuggestionsDropdown::show):
(WebKit::WebDataListSuggestionsDropdown::close):
* Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCloseSuggestions):
(WebKit::WebPageProxy::didSelectOption):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp:
(WebKit::WebDataListSuggestionsDropdownGtk::didSelectOption):
(WebKit::WebDataListSuggestionsDropdownGtk::platformShow):
(WebKit::WebDataListSuggestionsDropdownGtk::handleKeydownWithIdentifier):
(WebKit::WebDataListSuggestionsDropdownGtk::show):
* Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.h:
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h:
* Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm:
(WebKit::WebDataListSuggestionsDropdownIOS::platformShow):
(WebKit::WebDataListSuggestionsDropdownIOS::didSelectOption):
(WebKit::WebDataListSuggestionsDropdownIOS::show):
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.h:
* Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm:
(WebKit::WebDataListSuggestionsDropdownMac::platformShow):
(WebKit::WebDataListSuggestionsDropdownMac::didSelectOption):
(WebKit::WebDataListSuggestionsDropdownMac::selectOption):
(WebKit::WebDataListSuggestionsDropdownMac::show):
* Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp:
(WebKit::WebDataListSuggestionPicker::displayWithActivationType):

Canonical link: <a href="https://commits.webkit.org/309034@main">https://commits.webkit.org/309034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cb33715c9bf7d4b79b4d72bc4c89a80298668c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149244 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21957 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15527 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157936 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/102675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/151117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22411 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/115066 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/102675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7f4b4a0-6a70-4694-8424-6d578d3d63d0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17225 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95816 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/77557363-b168-40ed-8d30-4925f71fc157) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/16323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/14201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5786 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125924 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160418 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/3414 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13382 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123112 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123330 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33519 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21768 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77968 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18569 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10393 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21369 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85182 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21101 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21250 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21158 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->