### PR TITLE
Add WKContentWorldConfiguration API

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/WebKit.h
+++ b/Source/WebKit/Shared/API/Cocoa/WebKit.h
@@ -29,6 +29,7 @@
 #import <WebKit/WKContentRuleList.h>
 #import <WebKit/WKContentRuleListStore.h>
 #import <WebKit/WKContentWorld.h>
+#import <WebKit/WKContentWorldConfiguration.h>
 #import <WebKit/WKContextMenuElementInfo.h>
 #import <WebKit/WKDownload.h>
 #import <WebKit/WKDownloadDelegate.h>

--- a/Source/WebKit/Shared/Cocoa/APIObject.mm
+++ b/Source/WebKit/Shared/Cocoa/APIObject.mm
@@ -30,6 +30,7 @@
 #import "WKBackForwardListItemInternal.h"
 #import "WKContentRuleListInternal.h"
 #import "WKContentRuleListStoreInternal.h"
+#import "WKContentWorldConfigurationInternal.h"
 #import "WKContentWorldInternal.h"
 #import "WKContextMenuElementInfoInternal.h"
 #import "WKDownloadInternal.h"
@@ -74,7 +75,6 @@
 #import "_WKAttachmentInternal.h"
 #import "_WKAutomationSessionInternal.h"
 #import "_WKContentRuleListActionInternal.h"
-#import "_WKContentWorldConfigurationInternal.h"
 #import "_WKContextMenuElementInfoInternal.h"
 #import "_WKCustomHeaderFieldsInternal.h"
 #import "_WKDataTaskInternal.h"
@@ -389,7 +389,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         break;
 
     case Type::ContentWorldConfiguration:
-        SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [_WKContentWorldConfiguration alloc];
+        SUPPRESS_RETAINPTR_CTOR_ADOPT wrapper = [WKContentWorldConfiguration alloc];
         break;
 
     case Type::TargetedElementInfo:

--- a/Source/WebKit/UIProcess/API/APIContentWorld.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.cpp
@@ -98,6 +98,11 @@ Ref<ContentWorld> ContentWorld::sharedWorldWithName(const WTF::String& name, Opt
     return newContentWorld ? newContentWorld.releaseNonNull() : Ref { result.iterator->value.get() };
 }
 
+Ref<ContentWorld> ContentWorld::createNamelessWorld(OptionSet<WebKit::ContentWorldOption> options)
+{
+    return adoptRef(*new ContentWorld(nullString(), options));
+}
+
 ContentWorld& ContentWorld::pageContentWorldSingleton()
 {
     static NeverDestroyed<Ref<ContentWorld>> world(adoptRef(*new ContentWorld(WebKit::pageContentWorldIdentifier())));

--- a/Source/WebKit/UIProcess/API/APIContentWorld.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorld.h
@@ -43,6 +43,7 @@ public:
     static OptionSet<WebKit::ContentWorldOption> defaultOptions();
     static ContentWorld* worldForIdentifier(WebKit::ContentWorldIdentifier);
     static Ref<ContentWorld> sharedWorldWithName(const WTF::String&, OptionSet<WebKit::ContentWorldOption> = defaultOptions() );
+    static Ref<ContentWorld> createNamelessWorld(OptionSet<WebKit::ContentWorldOption>);
     static ContentWorld& pageContentWorldSingleton();
     static ContentWorld& defaultClientWorldSingleton();
 

--- a/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "APIContentWorldConfiguration.h"
 
+#include "ContentWorldShared.h"
+
 namespace API {
 
 Ref<ContentWorldConfiguration> ContentWorldConfiguration::create()
@@ -38,6 +40,28 @@ ContentWorldConfiguration::Data::Data() = default;
 ContentWorldConfiguration::ContentWorldConfiguration() = default;
 
 ContentWorldConfiguration::~ContentWorldConfiguration() = default;
+
+OptionSet<WebKit::ContentWorldOption> ContentWorldConfiguration::optionSet() const
+{
+    OptionSet<WebKit::ContentWorldOption> result;
+
+    if (allowAccessToClosedShadowRoots())
+        result.add(WebKit::ContentWorldOption::AllowAccessToClosedShadowRoots);
+    if (allowAutofill())
+        result.add(WebKit::ContentWorldOption::AllowAutofill);
+    if (allowElementUserInfo())
+        result.add(WebKit::ContentWorldOption::AllowElementUserInfo);
+    if (disableLegacyBuiltinOverrides())
+        result.add(WebKit::ContentWorldOption::DisableLegacyBuiltinOverrides);
+    if (allowJSHandleCreation())
+        result.add(WebKit::ContentWorldOption::AllowJSHandleCreation);
+    if (allowNodeSerialization())
+        result.add(WebKit::ContentWorldOption::AllowNodeSerialization);
+    if (isInspectable())
+        result.add(WebKit::ContentWorldOption::Inspectable);
+
+    return result;
+}
 
 Ref<ContentWorldConfiguration> ContentWorldConfiguration::copy() const
 {

--- a/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h
@@ -28,6 +28,10 @@
 #include "APIObject.h"
 #include <wtf/text/WTFString.h>
 
+namespace WebKit {
+enum class ContentWorldOption : uint8_t;
+}
+
 namespace API {
 
 class ContentWorldConfiguration : public ObjectImpl<Object::Type::ContentWorldConfiguration> {
@@ -62,6 +66,8 @@ public:
 
     bool isInspectable() const;
     void setInspectable(bool);
+
+    OptionSet<WebKit::ContentWorldOption> optionSet() const;
 
 private:
     struct Data {

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h
@@ -27,6 +27,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+@class WKContentWorldConfiguration;
+
 /*! @abstract A WKContentWorld object allows you to separate your application's interaction with content displayed in a WKWebView into different roles that cannot interfere with one another.
 @discussion WKContentWorld objects should be treated as namespaces. This is useful for keeping your application's web content environment separate from the environment of the web page content itself,
 as well as managing multiple different environments within your own application.
@@ -58,6 +60,12 @@ Repeated calls will retrieve the same WKContentWorld instance.
 */
 @property (class, nonatomic, readonly) WKContentWorld *defaultClientWorld;
 
+/*! @abstract Creates a world with the given WKContentWorldConfiguration
+@discussion Unlike all other worlds, worlds created with this factory method cannot be retrieved later.
+Clients therefore need to take care to reference them for as long as they are needed.
+*/
++ (WKContentWorld *)worldWithConfiguration:(WKContentWorldConfiguration *)configuration NS_SWIFT_NAME(world(with:)) WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 /*! @abstract Retrieves a named content world for API client use.
 @param name The name of the WKContentWorld to retrieve.
 @discussion When using a content world different from the page content world you can still manipulate the DOM and built-in DOM APIs but without conflicting with other aspects of the page content (e.g. JavaScript from the web page content itself)
@@ -69,6 +77,7 @@ The name can be used to keep distinct worlds identifiable anywhere a world might
 
 /*! @abstract The name of the WKContentWorld
 @discussion The pageWorld and defaultClientWorld instances will have a nil name.
+Instances created with `worldWithConfiguration` will also have a nil name.
 All other instances will have the non-nil name they were accessed by.
 */
 @property (nullable, nonatomic, readonly, copy) NSString *name;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,40 +23,37 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#import <WebKit/WKContentWorldConfiguration.h>
 #import <WebKit/WKFoundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
-/*! @abstract A WKContentWorldConfiguration object allows you to specify configuration for WKContentWorld.
-@discussion WKContentWorldConfiguration allows applications to specify ways by which extra JavaScript capabilities should be exposed to the script in the environment.
+/*! @abstract A WKContentWorldConfiguration object allows you to specify custom behavior for a WKContentWorld instance.
+@discussion WKContentWorldConfiguration allows applications to create WKContentWorld instances which have extra JavaScript
+capabilities exposed to script in their environment. It does not change any default WebKit behaviors, nor change anything that web page
+JavaScript can do. Only application JavaScript run in the created `WKContentWorld` will have different capabilities.
+
 For example:
-- If your scripts have to access autofill capabilities, you may want to set allowAutofill to YES. */
+- If your scripts help provide autofill capabilities, you would want to set autofillEnabled to YES.
+*/
 WK_SWIFT_UI_ACTOR
 NS_SWIFT_SENDABLE
-WK_CLASS_AVAILABLE(macos(15.4), ios(18.4), visionos(2.4))
-@interface _WKContentWorldConfiguration : WKContentWorldConfiguration
-
-@property (nonatomic, copy) NSString *name;
+WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
+@interface WKContentWorldConfiguration : NSObject<NSCopying, NSSecureCoding>
 
 /*! @abstract A boolean value indicating whether every shadow root should be treated as open mode shadow root or not. */
-@property (nonatomic) BOOL allowAccessToClosedShadowRoots;
+@property (nonatomic) BOOL openClosedShadowRootsEnabled;
 
 /*! @abstract A boolean value indicating whether the capability to trigger autofill is exposed to scripts or not. */
-@property (nonatomic) BOOL allowAutofill;
+@property (nonatomic) BOOL autofillScriptingEnabled;
 
 /*! @abstract A boolean value indicating whether the ability to attach user info on an element is exposed to scripts or not. */
-@property (nonatomic) BOOL allowElementUserInfo;
+@property (nonatomic) BOOL elementUserInfoEnabled;
 
-/*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be disabled or not. */
-// FIXME: Give this a positive name like enableLegacyBuiltinOverrides to avoid double-negatives in code.
-@property (nonatomic) BOOL disableLegacyBuiltinOverrides;
+/*! @abstract A boolean value indicating whether the behavior that elements with a name attribute overrides builtin methods on document object should be enabled or not. */
+@property (nonatomic) BOOL legacyBuiltinOverridesEnabled;
 
-/*! @abstract A boolean indicating whether window.webkit.createJSHandle is available. */
-@property (nonatomic) BOOL allowJSHandleCreation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
-
-/*! @abstract A boolean indicating whether window.webkit.serializeNode is available. */
-@property (nonatomic) BOOL allowNodeSerialization WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+/*! @abstract A boolean indicating whether the JavaScript in this world is visible to the Web Inspector. */
+@property (nonatomic, getter=isInspectable) BOOL inspectable;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm
@@ -24,9 +24,11 @@
  */
 
 #include "config.h"
-#include "_WKContentWorldConfigurationInternal.h"
+#include "WKContentWorldConfigurationInternal.h"
 
-@implementation _WKContentWorldConfiguration
+#include "_WKContentWorldConfiguration.h"
+
+@implementation WKContentWorldConfiguration
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
@@ -42,7 +44,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)dealloc
 {
-    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKContentWorldConfiguration.class, self))
+    if (WebCoreObjCScheduleDeallocateOnMainRunLoop(WKContentWorldConfiguration.class, self))
         return;
 
     self._protectedWorldConfiguration->API::ContentWorldConfiguration::~ContentWorldConfiguration();
@@ -71,14 +73,16 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)encodeWithCoder:(NSCoder *)coder
 {
-    [coder encodeObject:retainPtr(self.name).get() forKey:@"name"];
-    [coder encodeBool:self.allowAccessToClosedShadowRoots forKey:@"allowAccessToClosedShadowRoots"];
-    [coder encodeBool:self.allowAutofill forKey:@"allowAutofill"];
-    [coder encodeBool:self.allowElementUserInfo forKey:@"allowElementUserInfo"];
-    [coder encodeBool:self.disableLegacyBuiltinOverrides forKey:@"disableLegacyBuiltinOverrides"];
-    [coder encodeBool:self.allowJSHandleCreation forKey:@"allowJSHandleCreation"];
-    [coder encodeBool:self.allowNodeSerialization forKey:@"allowNodeSerialization"];
-    [coder encodeBool:self.isInspectable forKey:@"inspectable"];
+    Ref<API::ContentWorldConfiguration> configuration = self._protectedWorldConfiguration;
+
+    [coder encodeObject:nsStringNilIfEmpty(configuration->name()) forKey:@"name"];
+    [coder encodeBool:configuration->allowAccessToClosedShadowRoots() forKey:@"allowAccessToClosedShadowRoots"];
+    [coder encodeBool:configuration->allowAutofill() forKey:@"allowAutofill"];
+    [coder encodeBool:configuration->allowElementUserInfo() forKey:@"allowElementUserInfo"];
+    [coder encodeBool:configuration->disableLegacyBuiltinOverrides() forKey:@"disableLegacyBuiltinOverrides"];
+    [coder encodeBool:configuration->allowJSHandleCreation() forKey:@"allowJSHandleCreation"];
+    [coder encodeBool:configuration->allowNodeSerialization() forKey:@"allowNodeSerialization"];
+    [coder encodeBool:configuration->isInspectable() forKey:@"inspectable"];
 }
 
 - (instancetype)initWithCoder:(NSCoder *)coder
@@ -86,14 +90,16 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     if (!(self = [self init]))
         return nil;
 
-    self.name = [coder decodeObjectOfClass:[NSString class] forKey:@"name"];
-    self.allowAccessToClosedShadowRoots = [coder decodeBoolForKey:@"allowAccessToClosedShadowRoots"];
-    self.allowAutofill = [coder decodeBoolForKey:@"allowAutofill"];
-    self.allowElementUserInfo = [coder decodeBoolForKey:@"allowElementUserInfo"];
-    self.disableLegacyBuiltinOverrides = [coder decodeBoolForKey:@"disableLegacyBuiltinOverrides"];
-    self.allowJSHandleCreation = [coder decodeBoolForKey:@"allowJSHandleCreation"];
-    self.allowNodeSerialization = [coder decodeBoolForKey:@"allowNodeSerialization"];
-    self.inspectable = [coder decodeBoolForKey:@"inspectable"];
+    Ref<API::ContentWorldConfiguration> configuration = self._protectedWorldConfiguration;
+
+    configuration->setName([coder decodeObjectOfClass:[NSString class] forKey:@"name"]);
+    configuration->setAllowAccessToClosedShadowRoots([coder decodeBoolForKey:@"allowAccessToClosedShadowRoots"]);
+    configuration->setAllowAutofill([coder decodeBoolForKey:@"allowAutofill"]);
+    configuration->setAllowElementUserInfo([coder decodeBoolForKey:@"allowElementUserInfo"]);
+    configuration->setDisableLegacyBuiltinOverrides([coder decodeBoolForKey:@"disableLegacyBuiltinOverrides"]);
+    configuration->setAllowJSHandleCreation([coder decodeBoolForKey:@"allowJSHandleCreation"]);
+    configuration->setAllowNodeSerialization([coder decodeBoolForKey:@"allowNodeSerialization"]);
+    configuration->setInspectable([coder decodeBoolForKey:@"inspectable"]);
 
     return self;
 }
@@ -103,6 +109,70 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (API::Object&)_apiObject
 {
     return *_worldConfiguration;
+}
+
+- (BOOL)openClosedShadowRootsEnabled
+{
+    return self._protectedWorldConfiguration->allowAccessToClosedShadowRoots();
+}
+
+- (void)setOpenClosedShadowRootsEnabled:(BOOL)allow
+{
+    self._protectedWorldConfiguration->setAllowAccessToClosedShadowRoots(allow);
+}
+
+- (BOOL)autofillScriptingEnabled
+{
+    return self._protectedWorldConfiguration->allowAutofill();
+}
+
+- (void)setAutofillScriptingEnabled:(BOOL)enabled
+{
+    self._protectedWorldConfiguration->setAllowAutofill(enabled);
+}
+
+- (BOOL)elementUserInfoEnabled
+{
+    return self._protectedWorldConfiguration->allowElementUserInfo();
+}
+
+- (void)setElementUserInfoEnabled:(BOOL)enabled
+{
+    self._protectedWorldConfiguration->setAllowElementUserInfo(enabled);
+}
+
+- (BOOL)legacyBuiltinOverridesEnabled
+{
+    return !self._protectedWorldConfiguration->disableLegacyBuiltinOverrides();
+}
+
+- (void)setLegacyBuiltinOverridesEnabled:(BOOL)enabled
+{
+    self._protectedWorldConfiguration->setDisableLegacyBuiltinOverrides(!enabled);
+}
+
+- (BOOL)isInspectable
+{
+    return self._protectedWorldConfiguration->isInspectable();
+}
+
+- (void)setInspectable:(BOOL)inspectable
+{
+    self._protectedWorldConfiguration->setInspectable(inspectable);
+}
+
+@end
+
+@implementation _WKContentWorldConfiguration
+
+WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
+
+- (instancetype)init
+{
+    if (!(self = [super init]))
+        return nil;
+
+    return self;
 }
 
 - (NSString *)name
@@ -173,16 +243,6 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (void)setAllowNodeSerialization:(BOOL)allow
 {
     self._protectedWorldConfiguration->setAllowNodeSerialization(allow);
-}
-
-- (BOOL)isInspectable
-{
-    return self._protectedWorldConfiguration->isInspectable();
-}
-
-- (void)setInspectable:(BOOL)inspectable
-{
-    self._protectedWorldConfiguration->setInspectable(inspectable);
 }
 
 @end

--- a/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfigurationInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfigurationInternal.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,18 +24,18 @@
  */
 
 #import "APIContentWorldConfiguration.h"
-#import "_WKContentWorldConfiguration.h"
+#import "WKContentWorldConfiguration.h"
 #import <wtf/AlignedStorage.h>
 
 namespace WebKit {
 
 template<> struct WrapperTraits<API::ContentWorldConfiguration> {
-    using WrapperClass = _WKContentWorldConfiguration;
+    using WrapperClass = WKContentWorldConfiguration;
 };
 
 }
 
-@interface _WKContentWorldConfiguration () <WKObject> {
+@interface WKContentWorldConfiguration () <WKObject> {
 @package
     AlignedStorage<API::ContentWorldConfiguration> _worldConfiguration;
 }

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -1319,6 +1319,8 @@
 		51D130561382EAC000351EDD /* SecItemResponseData.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D130521382EAC000351EDD /* SecItemResponseData.h */; };
 		51D1B6942B09723A00FEA5CB /* CoreIPCTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D1B6932B09723A00FEA5CB /* CoreIPCTypes.h */; };
 		51D7E0AD2356555E00A67D3A /* WKPDFConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D7E0AC2356555400A67D3A /* WKPDFConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		51D9342E2F3D717A00DDA950 /* WKContentWorldConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D9342C2F3D716F00DDA950 /* WKContentWorldConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		51D9342F2F3D803F00DDA950 /* WKContentWorldConfigurationInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51D9342D2F3D716F00DDA950 /* WKContentWorldConfigurationInternal.h */; };
 		51DD9F2916367DA2001578E9 /* NetworkConnectionToWebProcessMessages.h in Headers */ = {isa = PBXBuildFile; fileRef = 51DD9F2716367DA2001578E9 /* NetworkConnectionToWebProcessMessages.h */; };
 		51E0BD9D2C74711A0048411B /* _WKWebPushAction.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E0BD9B2C7471110048411B /* _WKWebPushAction.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		51E351CB180F2CCC00E53BE9 /* IDBUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E351C9180F2CCC00E53BE9 /* IDBUtilities.h */; };
@@ -6178,6 +6180,8 @@
 		51D1B6932B09723A00FEA5CB /* CoreIPCTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreIPCTypes.h; sourceTree = "<group>"; };
 		51D7E0AC2356555400A67D3A /* WKPDFConfiguration.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WKPDFConfiguration.h; sourceTree = "<group>"; };
 		51D7E0AE2356616300A67D3A /* WKPDFConfiguration.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WKPDFConfiguration.mm; sourceTree = "<group>"; };
+		51D9342C2F3D716F00DDA950 /* WKContentWorldConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKContentWorldConfiguration.h; sourceTree = "<group>"; };
+		51D9342D2F3D716F00DDA950 /* WKContentWorldConfigurationInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKContentWorldConfigurationInternal.h; sourceTree = "<group>"; };
 		51DAAEBF2AA198DE00DB2AA4 /* com.apple.WebKit.webpushd.relocatable.mac.sb */ = {isa = PBXFileReference; lastKnownFileType = file; path = com.apple.WebKit.webpushd.relocatable.mac.sb; sourceTree = "<group>"; };
 		51DD9F2616367DA2001578E9 /* NetworkConnectionToWebProcessMessageReceiver.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkConnectionToWebProcessMessageReceiver.cpp; sourceTree = "<group>"; };
 		51DD9F2716367DA2001578E9 /* NetworkConnectionToWebProcessMessages.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NetworkConnectionToWebProcessMessages.h; sourceTree = "<group>"; };
@@ -9052,7 +9056,6 @@
 		FA5C22432DC5719D00B13EF3 /* RemoteWebTouchEvent.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = RemoteWebTouchEvent.serialization.in; sourceTree = "<group>"; };
 		FA601C012EF1F71D005A14BC /* APIContentWorldConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = APIContentWorldConfiguration.h; sourceTree = "<group>"; };
 		FA601C022EF1F71D005A14BC /* APIContentWorldConfiguration.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = APIContentWorldConfiguration.cpp; sourceTree = "<group>"; };
-		FA601C042EF1F8CB005A14BC /* _WKContentWorldConfigurationInternal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = _WKContentWorldConfigurationInternal.h; sourceTree = "<group>"; };
 		FA6342192D9D98D300A6BECE /* WebFrame.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebFrame.messages.in; sourceTree = "<group>"; };
 		FA63421A2D9D990400A6BECE /* WebFrameProxy.messages.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = WebFrameProxy.messages.in; sourceTree = "<group>"; };
 		FA6757052B815C8300C1566A /* FrameProcess.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FrameProcess.cpp; sourceTree = "<group>"; };
@@ -12640,7 +12643,6 @@
 				5C4609E322430E4D009943C2 /* _WKContentRuleListAction.mm */,
 				5C4609E422430E4D009943C2 /* _WKContentRuleListActionInternal.h */,
 				9B17FFC52CD975EC002DDA6E /* _WKContentWorldConfiguration.h */,
-				FA601C042EF1F8CB005A14BC /* _WKContentWorldConfigurationInternal.h */,
 				1A5704F61BE01FF400874AF1 /* _WKContextMenuElementInfo.h */,
 				1A5704F51BE01FF400874AF1 /* _WKContextMenuElementInfo.mm */,
 				DFEAFFC529664BB200038490 /* _WKContextMenuElementInfoInternal.h */,
@@ -12887,7 +12889,9 @@
 				5CD286501E722F440094FDC8 /* WKContentRuleListStorePrivate.h */,
 				511065FA23EC956B005443D6 /* WKContentWorld.h */,
 				511065F923EC956B005443D6 /* WKContentWorld.mm */,
+				51D9342C2F3D716F00DDA950 /* WKContentWorldConfiguration.h */,
 				9B17FFC72CD97EAB002DDA6E /* WKContentWorldConfiguration.mm */,
+				51D9342D2F3D716F00DDA950 /* WKContentWorldConfigurationInternal.h */,
 				511065FB23EC956B005443D6 /* WKContentWorldInternal.h */,
 				DF462E1123F338AD00EFF35F /* WKContentWorldPrivate.h */,
 				5CE0C369229F2D4A003695F0 /* WKContextMenuElementInfo.h */,
@@ -19077,6 +19081,8 @@
 				0FCB4E4C18BBE044000FCFC9 /* WKContentView.h in Headers */,
 				0FCB4E6C18BBF26A000FCFC9 /* WKContentViewInteraction.h in Headers */,
 				511065FC23EC9572005443D6 /* WKContentWorld.h in Headers */,
+				51D9342E2F3D717A00DDA950 /* WKContentWorldConfiguration.h in Headers */,
+				51D9342F2F3D803F00DDA950 /* WKContentWorldConfigurationInternal.h in Headers */,
 				511065FD23EC957B005443D6 /* WKContentWorldInternal.h in Headers */,
 				DF462E1223F338BE00EFF35F /* WKContentWorldPrivate.h in Headers */,
 				BCB9E24B1120E15C00A137E0 /* WKContext.h in Headers */,
@@ -22288,7 +22294,9 @@
 		};
 		58E7CD782E78575C00338ED0 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 58E7CD662E78561D00338ED0 /* WebContentEnhancedSecurityExtension */;
 			targetProxy = 58E7CD772E78575C00338ED0 /* PBXContainerItemProxy */;
 		};
@@ -22319,7 +22327,9 @@
 		};
 		5C400E6A29DB8AB500446F6F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5C139DA129DB82E500D5117B /* WebContentCaptivePortalExtension */;
 			targetProxy = 5C400E6929DB8AB500446F6F /* PBXContainerItemProxy */;
 		};
@@ -22335,19 +22345,25 @@
 		};
 		5CE4B60729CEBB760038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5CA5A2C929CBBA1A000F1046 /* WebContentExtension */;
 			targetProxy = 5CE4B60629CEBB760038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62329CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5CE4B61529CF877F0038F565 /* GPUExtension */;
 			targetProxy = 5CE4B62229CF880B0038F565 /* PBXContainerItemProxy */;
 		};
 		5CE4B62529CF880B0038F565 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilter = ios;
+			platformFilters = (
+				ios,
+			);
 			target = 5CE4B60829CF87680038F565 /* NetworkingExtension */;
 			targetProxy = 5CE4B62429CF880B0038F565 /* PBXContainerItemProxy */;
 		};

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
@@ -35,6 +35,7 @@
 #import "UIKitSPIForTesting.h"
 #import "WKWebViewConfigurationExtras.h"
 #import <WebKit/WKContentWorld.h>
+#import <WebKit/WKContentWorldConfiguration.h>
 #import <WebKit/WKContentWorldPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKScriptMessage.h>
@@ -1246,8 +1247,8 @@ TEST(WKUserContentController, AllowAutofill)
     receivedScriptMessage = false;
 
     RetainPtr contentWorldConfiguration = adoptNS([[_WKContentWorldConfiguration alloc] init]);
-    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill"];
-    [contentWorldConfiguration setAllowAutofill:YES];
+    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill1"];
+    [contentWorldConfiguration setAutofillScriptingEnabled:YES];
 
     RetainPtr world = [WKContentWorld _worldWithConfiguration:contentWorldConfiguration.get()];
     RetainPtr handler = adoptNS([[ScriptMessageHandler alloc] init]);
@@ -1289,9 +1290,9 @@ TEST(WKUserContentController, AllowAutofill)
 TEST(WKUserContentController, DidAssociateFormControls)
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
-    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
-    configuration.get().allowAutofill = YES;
-    RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
+    configuration.get().autofillScriptingEnabled = YES;
+    RetainPtr autofillWorld = [WKContentWorld worldWithConfiguration:configuration.get()];
     NSString *pageWorldJS = @"window.addEventListener('webkitassociateformcontrols', () => alert('fail') )";
     NSString *autofillWorldJS = @"window.addEventListener('webkitassociateformcontrols', (e) => { setTimeout(() => alert('pass ' + e.target), 50)})";
     RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
@@ -1313,9 +1314,9 @@ TEST(WKUserContentController, DidAssociateFormControlsFromShadowTree)
 #endif
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
-    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
-    configuration.get().allowAutofill = YES;
-    RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
+    configuration.get().autofillScriptingEnabled = YES;
+    RetainPtr autofillWorld = [WKContentWorld worldWithConfiguration:configuration.get()];
     NSString *pageWorldJS = @"window.addEventListener('webkitassociateformcontrols', () => alert('fail') )";
     NSString *autofillWorldJS = @"window.addEventListener('webkitassociateformcontrols', (e) => { let composedTarget = e.composedPath()[0]; setTimeout(() => alert('pass ' + composedTarget), 50)})";
     RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
@@ -1348,9 +1349,9 @@ TEST(WKUserContentController, DidAssociateFormControlsFromShadowTree)
 TEST(WKUserContentController, BeforeFocusEvent)
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
-    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
-    configuration.get().allowAutofill = YES;
-    RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
+    configuration.get().autofillScriptingEnabled = YES;
+    RetainPtr autofillWorld = [WKContentWorld worldWithConfiguration:configuration.get()];
     NSString *pageWorldJS = @"window.addEventListener('webkitbeforefocus', () => alert('focus-fail') )";
     NSString *autofillWorldJS = @"window.addEventListener('webkitbeforefocus', () => { setTimeout(() => alert('focus-pass'), 50); })";
     RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
@@ -1377,9 +1378,9 @@ TEST(WKUserContentController, BeforeFocusEvent)
 TEST(WKUserContentController, BeforeBlurEvent)
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
-    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
-    configuration.get().allowAutofill = YES;
-    RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
+    configuration.get().autofillScriptingEnabled = YES;
+    RetainPtr autofillWorld = [WKContentWorld worldWithConfiguration:configuration.get()];
     NSString *pageWorldJS = @"window.addEventListener('webkitbeforeblur', () => alert('blur-fail') )";
     NSString *autofillWorldJS = @"window.addEventListener('webkitbeforeblur', () => { setTimeout(() => alert('blur-pass'), 50); })";
     RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
@@ -1403,9 +1404,9 @@ TEST(WKUserContentController, BeforeBlurEvent)
 TEST(WKUserContentController, ShadowRootAttachedEvent)
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
-    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
-    configuration.get().allowAccessToClosedShadowRoots = YES;
-    RetainPtr shadowRootWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
+    configuration.get().openClosedShadowRootsEnabled = YES;
+    RetainPtr shadowRootWorld = [WKContentWorld worldWithConfiguration:configuration.get()];
     NSString *pageWorldJS = @"window.addEventListener('webkitshadowrootattached', () => alert('fail') ); onload = () => { setTimeout(() => alert('fail'), 100); }";
     NSString *shadowRootWorldJS = @"window.addEventListener('webkitshadowrootattached', (e) => { setTimeout(() => alert('pass ' + e.target.localName), 50)})";
     RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
@@ -1426,7 +1427,7 @@ TEST(WKUserContentController, DisableAutofillSpellcheck)
     receivedScriptMessage = false;
 
     RetainPtr contentWorldConfiguration = adoptNS([[_WKContentWorldConfiguration alloc] init]);
-    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill"];
+    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill2"];
     [contentWorldConfiguration setAllowAutofill:YES];
 
     RetainPtr world = [WKContentWorld _worldWithConfiguration:contentWorldConfiguration.get()];
@@ -1495,7 +1496,7 @@ TEST(WKUserContentController, AllowElementUserInfo)
     receivedScriptMessage = false;
 
     RetainPtr contentWorldConfiguration = adoptNS([[_WKContentWorldConfiguration alloc] init]);
-    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill"];
+    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill3"];
     [contentWorldConfiguration setAllowElementUserInfo:YES];
     [contentWorldConfiguration setAllowAutofill:YES];
 
@@ -1544,7 +1545,7 @@ TEST(WKUserContentController, AllowElementUserInfoFromShadowTree)
     receivedScriptMessage = false;
 
     RetainPtr contentWorldConfiguration = adoptNS([[_WKContentWorldConfiguration alloc] init]);
-    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill"];
+    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill4"];
     [contentWorldConfiguration setAllowElementUserInfo:YES];
     [contentWorldConfiguration setAllowAutofill:YES];
 
@@ -1603,7 +1604,7 @@ TEST(WKUserContentController, LastChangeWasUserEdit)
     receivedScriptMessage = false;
 
     RetainPtr contentWorldConfiguration = adoptNS([[_WKContentWorldConfiguration alloc] init]);
-    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill"];
+    [contentWorldConfiguration setName:@"TestWorldAllowingAutofill5"];
     [contentWorldConfiguration setAllowAutofill:YES];
 
     RetainPtr world = [WKContentWorld _worldWithConfiguration:contentWorldConfiguration.get()];
@@ -1860,8 +1861,8 @@ TEST(WKUserContentController, FormSubmissionWithUserInfo)
 
 TEST(WKUserContentController, AutoFillWorldTrustedEventHandler)
 {
-    RetainPtr contentWorldConfiguration = adoptNS([[_WKContentWorldConfiguration alloc] init]);
-    [contentWorldConfiguration setAllowAutofill:YES];
+    RetainPtr contentWorldConfiguration = adoptNS([[WKContentWorldConfiguration alloc] init]);
+    [contentWorldConfiguration setAutofillScriptingEnabled:YES];
 
     __block int autoFillWorldEventCount = 0;
     __block int pageWorldEventCount = 0;
@@ -1869,7 +1870,7 @@ TEST(WKUserContentController, AutoFillWorldTrustedEventHandler)
 
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
 
-    RetainPtr world = [WKContentWorld _worldWithConfiguration:contentWorldConfiguration.get()];
+    RetainPtr world = [WKContentWorld worldWithConfiguration:contentWorldConfiguration.get()];
     RetainPtr autoFillHandler = adoptNS([[TestMessageHandler alloc] init]);
     [autoFillHandler addMessage:@"event" withHandler:^{
         autoFillWorldEventCount++;
@@ -1910,9 +1911,9 @@ TEST(WKUserContentController, AutoFillWorldTrustedEventHandler)
 TEST(WKUserContentController, WebKitSubmitEvent)
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
-    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
-    configuration.get().allowAutofill = YES;
-    RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
+    configuration.get().autofillScriptingEnabled = YES;
+    RetainPtr autofillWorld = [WKContentWorld worldWithConfiguration:configuration.get()];
     NSString *pageWorldJS = @"window.addEventListener('webkitsubmit', () => alert('fail') )";
     NSString *autofillWorldJS = @"window.addEventListener('webkitsubmit', (e) => { let composedTargetID = e.composedPath()[0].id; setTimeout(() => alert('pass ' + composedTargetID), 50)})";
     RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
@@ -1940,9 +1941,9 @@ TEST(WKUserContentController, WebKitSubmitEvent)
 TEST(WKUserContentController, EvaluateLargeJavaScriptStringInAutoFillWorld)
 {
     RetainPtr webView = adoptNS([TestWKWebView new]);
-    RetainPtr configuration = adoptNS([_WKContentWorldConfiguration new]);
-    configuration.get().allowAutofill = YES;
-    RetainPtr autofillWorld = [WKContentWorld _worldWithConfiguration:configuration.get()];
+    RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
+    configuration.get().autofillScriptingEnabled = YES;
+    RetainPtr autofillWorld = [WKContentWorld worldWithConfiguration:configuration.get()];
 
     [webView synchronouslyLoadHTMLString:@"<p>Hello<p>World"];
 


### PR DESCRIPTION
#### 30129fc4e3ebe6486a90bd14da65b1d5e4769ba6
<pre>
Add WKContentWorldConfiguration API
<a href="https://rdar.apple.com/170209641">rdar://170209641</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307655">https://bugs.webkit.org/show_bug.cgi?id=307655</a>

Reviewed by Ryosuke Niwa.

Need to maintain _WKContentWorldConfiguration for backwards compat,
and we decided most of the properties should change names,
and the object they create is the same... So this one is a little weird in details.

But the result is straight forward.

Test coverage by changing a random smattering of tests to use the API version as well.

Some unrelated API test changes involved where I noticed we were violating the SPI
contract in cases where all API tests were run in the same instance of UI Process.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm

* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebKit/Shared/API/Cocoa/WebKit.h:
* Source/WebKit/Shared/Cocoa/APIObject.mm:
(API::Object::newObject):
* Source/WebKit/UIProcess/API/APIContentWorld.cpp:
(API::ContentWorld::createNamelessWorld):
* Source/WebKit/UIProcess/API/APIContentWorld.h:
* Source/WebKit/UIProcess/API/APIContentWorldConfiguration.cpp:
(API::ContentWorldConfiguration::optionSet const):
* Source/WebKit/UIProcess/API/APIContentWorldConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.h:
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorld.mm:
(+[WKContentWorld worldWithConfiguration:]):
(+[WKContentWorld _worldWithConfiguration:]):
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.h: Copied from Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h.
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfiguration.mm:
(-[WKContentWorldConfiguration dealloc]):
(-[WKContentWorldConfiguration encodeWithCoder:]):
(-[WKContentWorldConfiguration initWithCoder:]):
(-[WKContentWorldConfiguration openClosedShadowRootsEnabled]):
(-[WKContentWorldConfiguration setOpenClosedShadowRootsEnabled:]):
(-[WKContentWorldConfiguration autofillScriptingEnabled]):
(-[WKContentWorldConfiguration setAutofillScriptingEnabled:]):
(-[WKContentWorldConfiguration elementUserInfoEnabled]):
(-[WKContentWorldConfiguration setElementUserInfoEnabled:]):
(-[WKContentWorldConfiguration legacyBuiltinOverridesEnabled]):
(-[WKContentWorldConfiguration setLegacyBuiltinOverridesEnabled:]):
(-[WKContentWorldConfiguration isInspectable]):
(-[WKContentWorldConfiguration setInspectable:]):
(-[_WKContentWorldConfiguration init]):
(-[_WKContentWorldConfiguration dealloc]): Deleted.
(-[_WKContentWorldConfiguration _protectedWorldConfiguration]): Deleted.
(-[_WKContentWorldConfiguration copyWithZone:]): Deleted.
(+[_WKContentWorldConfiguration supportsSecureCoding]): Deleted.
(-[_WKContentWorldConfiguration encodeWithCoder:]): Deleted.
(-[_WKContentWorldConfiguration initWithCoder:]): Deleted.
(-[_WKContentWorldConfiguration _apiObject]): Deleted.
(-[_WKContentWorldConfiguration isInspectable]): Deleted.
(-[_WKContentWorldConfiguration setInspectable:]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKContentWorldConfigurationInternal.h: Renamed from Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfigurationInternal.h.
* Source/WebKit/UIProcess/API/Cocoa/_WKContentWorldConfiguration.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST(WKUserContentController, AllowAutofill)):
(TEST(WKUserContentController, DidAssociateFormControls)):
(TEST(WKUserContentController, DidAssociateFormControlsFromShadowTree)):
(TEST(WKUserContentController, BeforeFocusEvent)):
(TEST(WKUserContentController, BeforeBlurEvent)):
(TEST(WKUserContentController, ShadowRootAttachedEvent)):
(TEST(WKUserContentController, DisableAutofillSpellcheck)):
(TEST(WKUserContentController, AllowElementUserInfo)):
(TEST(WKUserContentController, AllowElementUserInfoFromShadowTree)):
(TEST(WKUserContentController, LastChangeWasUserEdit)):
(TEST(WKUserContentController, AutoFillWorldTrustedEventHandler)):
(TEST(WKUserContentController, WebKitSubmitEvent)):
(TEST(WKUserContentController, EvaluateLargeJavaScriptStringInAutoFillWorld)):

Canonical link: <a href="https://commits.webkit.org/307401@main">https://commits.webkit.org/307401@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd0b60ab873b83b06e127a2573908b080d490211

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144264 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152934 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5bbc84c-81e5-4dd6-bbac-fdc988997817) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146139 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16837 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110933 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d34a09f0-57ea-45f4-81b6-547006beee22) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147227 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91850 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b16a524-2a9d-4c6e-8f54-766c28cca5ac) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10525 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/380 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6256 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155246 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16795 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118951 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16833 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14099 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119309 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30588 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15178 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127468 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72216 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16417 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5901 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16152 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16362 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16217 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->