### PR TITLE
Further reduce use of protected functions in Source/WebCore

### DIFF
--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp
@@ -188,12 +188,6 @@ void NavigatorGamepad::gamepadDisconnected(PlatformGamepad& platformGamepad)
     m_gamepads[platformGamepad.index()] = nullptr;
 }
 
-RefPtr<Page> NavigatorGamepad::protectedPage() const
-{
-    RefPtr frame = m_navigator->frame();
-    return frame ? protect(frame->page()) : nullptr;
-}
-
 } // namespace WebCore
 
 #endif // ENABLE(GAMEPAD)

--- a/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
+++ b/Source/WebCore/Modules/gamepad/NavigatorGamepad.h
@@ -67,8 +67,6 @@ public:
     WEBCORE_EXPORT static void setGamepadsRecentlyAccessedThreshold(Seconds);
     static Seconds gamepadsRecentlyAccessedThreshold();
 
-    RefPtr<Page> protectedPage() const;
-
 private:
     static ASCIILiteral supplementName() { return "NavigatorGamepad"_s; }
     bool isNavigatorGamepad() const final { return true; }

--- a/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
+++ b/Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp
@@ -848,7 +848,7 @@ bool MediaControlsHost::showMediaControlsContextMenu(HTMLElement& target, String
     page->chrome().client().showMediaControlsContextMenu(bounds, WTF::move(items), mediaElement.get(), WTF::move(handleItemSelected));
 #elif ENABLE(CONTEXT_MENUS) && USE(ACCESSIBILITY_CONTEXT_MENUS)
     target.addEventListener(eventNames().contextmenuEvent, MediaControlsContextMenuEventListener::create(MediaControlsContextMenuProvider::create(mediaElement->identifier(), WTF::move(items), WTF::move(handleItemSelected))), { { /*capture */ true }, /* passive */ std::nullopt, /* once */ true, nullptr, false });
-    page->contextMenuController().showContextMenuAt(*target.document().protectedFrame(), bounds.center());
+    page->contextMenuController().showContextMenuAt(*protect(target.document().frame()), bounds.center());
 #endif
 
     return true;

--- a/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
+++ b/Source/WebCore/Modules/webdatabase/DatabaseContext.cpp
@@ -195,7 +195,7 @@ void DatabaseContext::databaseExceededQuota(const String& name, DatabaseDetails 
     RefPtr context = scriptExecutionContext();
     if (RefPtr document = dynamicDowncast<Document>(*context)) {
         if (RefPtr page = document->page())
-            page->chrome().client().exceededDatabaseQuota(*document->protectedFrame(), name, details);
+            page->chrome().client().exceededDatabaseQuota(*protect(document->frame()), name, details);
         return;
     }
     ASSERT(context->isWorkerGlobalScope());

--- a/Source/WebCore/bindings/js/JSLazyEventListener.cpp
+++ b/Source/WebCore/bindings/js/JSLazyEventListener.cpp
@@ -140,7 +140,7 @@ JSObject* JSLazyEventListener::initializeJSFunction(ScriptExecutionContext& exec
     if (!isolatedWorld) [[unlikely]]
         return nullptr;
 
-    auto* globalObject = toJSDOMWindow(*executionContextDocument->protectedFrame(), *isolatedWorld);
+    auto* globalObject = toJSDOMWindow(*protect(executionContextDocument->frame()), *isolatedWorld);
     if (!globalObject)
         return nullptr;
 

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -283,7 +283,7 @@ static const IntegerSchema& colorFeatureSchema()
         "color"_s,
         OptionSet<MediaQueryDynamicDependency>(),
         [](auto& context) {
-            return screenDepthPerComponent(context.document->frame()->mainFrame().protectedVirtualView().get());
+            return screenDepthPerComponent(protect(context.document->frame()->mainFrame().virtualView()).get());
         }
     };
     return schema;
@@ -298,7 +298,7 @@ static const IdentifierSchema& colorGamutFeatureSchema()
         [](auto& context) {
             // FIXME: At some point we should start detecting displays that support more colors.
             MatchingIdentifiers identifiers { CSSValueSRGB };
-            if (screenSupportsExtendedColor(context.document->protectedFrame()->mainFrame().protectedVirtualView().get()))
+            if (screenSupportsExtendedColor(protect(protect(context.document->frame())->mainFrame().virtualView()).get()))
                 identifiers.append(CSSValueP3);
             return identifiers;
         }
@@ -385,7 +385,7 @@ static const IdentifierSchema& dynamicRangeFeatureSchema()
                     return true;
                 if (frame->settings().forcedSupportsHighDynamicRangeValue() == ForcedAccessibilityValue::Off)
                     return false;
-                return screenSupportsHighDynamicRange(frame->mainFrame().protectedVirtualView().get());
+                return screenSupportsHighDynamicRange(protect(frame->mainFrame().virtualView()).get());
             }();
 
             MatchingIdentifiers identifiers { CSSValueStandard };

--- a/Source/WebCore/dom/DataTransfer.cpp
+++ b/Source/WebCore/dom/DataTransfer.cpp
@@ -232,7 +232,7 @@ String DataTransfer::readStringFromPasteboard(Document& document, const String& 
     if (!is<StaticPasteboard>(*m_pasteboard) && lowercaseType == textHTMLContentTypeAtom()) {
         if (!document.frame())
             return { };
-        WebContentMarkupReader reader { document.protectedFrame().releaseNonNull() };
+        WebContentMarkupReader reader { protect(document.frame()).releaseNonNull() };
         m_pasteboard->read(reader, policy);
         return reader.takeMarkup();
     }

--- a/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp
@@ -79,7 +79,7 @@ void DeviceOrientationAndMotionAccessController::shouldAllowAccess(const Documen
         return callback(accessState);
 
     bool mayPrompt = UserGestureIndicator::processingUserGesture(&document);
-    page->chrome().client().shouldAllowDeviceOrientationAndMotionAccess(document.protectedFrame().releaseNonNull(), mayPrompt, [weakThis = WeakPtr { *this }, securityOrigin = Ref { document.securityOrigin() }, callback = WTF::move(callback)](DeviceOrientationOrMotionPermissionState permissionState) mutable {
+    page->chrome().client().shouldAllowDeviceOrientationAndMotionAccess(protect(document.frame()).releaseNonNull(), mayPrompt, [weakThis = WeakPtr { *this }, securityOrigin = Ref { document.securityOrigin() }, callback = WTF::move(callback)](DeviceOrientationOrMotionPermissionState permissionState) mutable {
         {
             CheckedPtr checkedThis = weakThis.get();
             if (!checkedThis)

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2174,7 +2174,7 @@ void Document::removeVisualUpdatePreventedReasons(OptionSet<VisualUpdatesPrevent
             if (frame()->isMainFrame()) {
                 frameView->addPaintPendingMilestones(LayoutMilestone::DidFirstPaintAfterSuppressedIncrementalRendering);
                 if (page->requestedLayoutMilestones() & LayoutMilestone::DidFirstLayoutAfterSuppressedIncrementalRendering)
-                    protectedFrame()->loader().didReachLayoutMilestone(LayoutMilestone::DidFirstLayoutAfterSuppressedIncrementalRendering);
+                    protect(frame())->loader().didReachLayoutMilestone(LayoutMilestone::DidFirstLayoutAfterSuppressedIncrementalRendering);
             }
         }
         m_visualUpdatesAllowedChangeRequiresLayoutMilestones = false;
@@ -3466,7 +3466,7 @@ void Document::createRenderTree()
 
 void Document::didBecomeCurrentDocumentInFrame()
 {
-    protect(protectedFrame()->script())->updateDocument();
+    protect(frame()->script())->updateDocument();
 
     // Many of these functions have event handlers which can detach the frame synchronously, so we must check repeatedly in this function.
     if (!m_frame)
@@ -3532,7 +3532,7 @@ void Document::willDetachPage()
     contentChangeObserver().willDetachPage();
 #endif
     if (window() && frame())
-        InspectorInstrumentation::frameWindowDiscarded(protectedFrame().releaseNonNull(), protect(window()).get());
+        InspectorInstrumentation::frameWindowDiscarded(protect(frame()).releaseNonNull(), protect(window()).get());
 }
 
 void Document::attachToCachedFrame(CachedFrameBase& cachedFrame)
@@ -4085,7 +4085,7 @@ ExceptionOr<void> Document::open(Document* entryDocument)
             frame->loader().policyChecker().stopCheck();
         // Null-checking m_frame again as `policyChecker().stopCheck()` may have cleared it.
         if (isNavigating && m_frame)
-            protectedFrame()->loader().stopAllLoaders();
+            protect(this->frame())->loader().stopAllLoaders();
     }
 
     removeAllEventListeners();
@@ -5409,7 +5409,7 @@ void Document::updateViewportArguments()
         return;
 
     page->chrome().dispatchViewportPropertiesDidChange(viewportArguments());
-    page->chrome().didReceiveDocType(protectedFrame().releaseNonNull());
+    page->chrome().didReceiveDocType(protect(frame()).releaseNonNull());
 }
 
 void Document::metaElementThemeColorChanged(HTMLMetaElement& metaElement)
@@ -8054,7 +8054,7 @@ void Document::applyPendingXSLTransformsTimerFired()
         if (!processor->transformToString(*this, resultMIMEType, newSource, resultEncoding))
             continue;
         // FIXME: If the transform failed we should probably report an error (like Mozilla does).
-        processor->createDocumentFromSource(newSource, resultEncoding, resultMIMEType, this, protectedFrame().get());
+        processor->createDocumentFromSource(newSource, resultEncoding, resultMIMEType, this, protect(frame()).get());
     }
 }
 
@@ -9656,7 +9656,7 @@ bool Document::allowsContentJavaScript() const
         return !m_contextDocument || m_contextDocument->allowsContentJavaScript();
     }
 
-    return protectedFrame()->loader().client().allowsContentJavaScriptFromMostRecentNavigation() == AllowsContentJavaScript::Yes;
+    return protect(frame())->loader().client().allowsContentJavaScriptFromMostRecentNavigation() == AllowsContentJavaScript::Yes;
 }
 
 Element* eventTargetElementForDocument(Document* document)
@@ -10086,7 +10086,7 @@ void Document::didAssociateFormControlsTimerFired()
 
     if (RefPtr page = this->page(); page && !controls.isEmpty()) {
         ASSERT(m_frame);
-        page->chrome().client().didAssociateFormControls(controls, protectedFrame().releaseNonNull());
+        page->chrome().client().didAssociateFormControls(controls, protect(frame()).releaseNonNull());
     }
 
     for (Ref control : controls) {

--- a/Source/WebCore/dom/DocumentPage.h
+++ b/Source/WebCore/dom/DocumentPage.h
@@ -36,11 +36,6 @@ inline Page* Frame::page() const
     return m_page.get();
 }
 
-inline RefPtr<Page> Frame::protectedPage() const
-{
-    return m_page.get();
-}
-
 inline std::optional<PageIdentifier> Frame::pageID() const
 {
     if (auto* page = this->page())

--- a/Source/WebCore/dom/DocumentView.h
+++ b/Source/WebCore/dom/DocumentView.h
@@ -36,11 +36,6 @@ inline LocalFrameView* LocalFrame::view() const
     return m_view.get();
 }
 
-inline RefPtr<LocalFrameView> LocalFrame::protectedView() const
-{
-    return m_view;
-}
-
 inline LocalFrameView* Document::view() const
 {
     return m_frame ? m_frame->view() : nullptr;

--- a/Source/WebCore/editing/FrameSelection.cpp
+++ b/Source/WebCore/editing/FrameSelection.cpp
@@ -2495,7 +2495,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
     if (caretBrowsing) {
         if (RefPtr anchor = enclosingAnchorElement(m_selection.base())) {
             CheckedRef focusController { document->page()->focusController() };
-            focusController->setFocusedElement(anchor.get(), document->protectedFrame().get());
+            focusController->setFocusedElement(anchor.get(), protect(document->frame()).get());
             return;
         }
     }
@@ -2510,7 +2510,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
                 FocusOptions focusOptions;
                 if (options & SetSelectionOption::ForBindings)
                     focusOptions.trigger = FocusTrigger::Bindings;
-                protect(document->page())->focusController().setFocusedElement(target.get(), document->protectedFrame().get(), focusOptions);
+                protect(document->page())->focusController().setFocusedElement(target.get(), protect(document->frame()).get(), focusOptions);
                 return;
             }
             target = target->parentOrShadowHostElement();
@@ -2519,7 +2519,7 @@ void FrameSelection::setFocusedElementIfNeeded(OptionSet<SetSelectionOption> opt
     }
 
     if (caretBrowsing)
-        protect(document->page())->focusController().setFocusedElement(nullptr, document->protectedFrame().get());
+        protect(document->page())->focusController().setFocusedElement(nullptr, protect(document->frame()).get());
 }
 
 void DragCaretController::paintDragCaret(LocalFrame* frame, GraphicsContext& p, const LayoutPoint& paintOffset) const

--- a/Source/WebCore/editing/glib/WebContentReaderGLib.cpp
+++ b/Source/WebCore/editing/glib/WebContentReaderGLib.cpp
@@ -48,7 +48,7 @@ bool WebContentReader::readFilePath(const String& path, PresentationSize, const 
         return false;
 
     auto markup = urlToMarkup(URL({ }, path), path);
-    addFragment(createFragmentFromMarkup(*frame().protectedDocument(), markup, "file://"_s, { }));
+    addFragment(createFragmentFromMarkup(*protect(frame().document()), markup, "file://"_s, { }));
 
     return true;
 }
@@ -58,7 +58,7 @@ bool WebContentReader::readHTML(const String& string)
     if (frame().settings().preferMIMETypeForImages() || !frame().document())
         return false;
 
-    addFragment(createFragmentFromMarkup(*frame().protectedDocument(), string, emptyString(), { }));
+    addFragment(createFragmentFromMarkup(*protect(frame().document()), string, emptyString(), { }));
     return true;
 }
 

--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -146,7 +146,7 @@ void CachedPage::restore(Page& page)
             localMainFrame->selection().suppressScrolling();
 
         bool hadProhibitsScrolling = false;
-        RefPtr frameView = localMainFrame->protectedVirtualView();
+        RefPtr frameView = localMainFrame->virtualView();
         if (frameView) {
             hadProhibitsScrolling = frameView->prohibitsScrolling();
             frameView->setProhibitsScrolling(true);
@@ -172,7 +172,7 @@ void CachedPage::restore(Page& page)
 #endif
 
     if (m_needsUpdateContentsSize) {
-        if (RefPtr frameView = localMainFrame->protectedVirtualView())
+        if (RefPtr frameView = localMainFrame->virtualView())
             frameView->updateContentsSize();
     }
 

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -173,7 +173,7 @@ void FileInputType::showPicker()
     ASSERT(element());
     if (auto* chrome = this->chrome()) {
         applyFileChooserSettings();
-        chrome->runOpenPanel(*element()->document().protectedFrame(), *protect(m_fileChooser));
+        chrome->runOpenPanel(*protect(element()->document().frame()), *protect(m_fileChooser));
     }
 }
 

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -353,7 +353,7 @@ void HTMLAnchorElement::sendPings(const URL& destinationURL)
     Ref document = this->document();
     SpaceSplitString pingURLs(pingValue, SpaceSplitString::ShouldFoldCase::No);
     for (auto& pingURL : pingURLs)
-        PingLoader::sendPing(*document->protectedFrame(), document->completeURL(pingURL), destinationURL);
+        PingLoader::sendPing(*protect(document->frame()), document->completeURL(pingURL), destinationURL);
 }
 
 #if USE(SYSTEM_PREVIEW)

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -78,7 +78,7 @@ bool HTMLFrameElementBase::canLoadURL(const URL& completeURL) const
 {
     if (completeURL.protocolIsJavaScript()) {
         RefPtr contentDocument = this->contentDocument();
-        if (contentDocument && !ScriptController::canAccessFromCurrentOrigin(contentDocument->protectedFrame().get(), protect(document()).get()))
+        if (contentDocument && !ScriptController::canAccessFromCurrentOrigin(protect(contentDocument->frame()).get(), protect(document()).get()))
             return false;
     }
 

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -281,7 +281,7 @@ RefPtr<PageInspectorController> InspectorFrontendClientLocal::protectedInspected
 
 void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 {
-    unsigned totalHeight = protect(protect(frontendPage())->mainFrame())->protectedVirtualView()->visibleHeight() + protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->protectedVirtualView()->visibleHeight();
+    unsigned totalHeight = protect(protect(protect(frontendPage())->mainFrame())->virtualView())->visibleHeight() + protect(protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->virtualView())->visibleHeight();
     unsigned attachedHeight = constrainedAttachedWindowHeight(height, totalHeight);
     m_settings->setProperty(inspectorAttachedHeightSetting, String::number(attachedHeight));
     setAttachedWindowHeight(attachedHeight);
@@ -289,7 +289,7 @@ void InspectorFrontendClientLocal::changeAttachedWindowHeight(unsigned height)
 
 void InspectorFrontendClientLocal::changeAttachedWindowWidth(unsigned width)
 {
-    unsigned totalWidth = protect(protect(frontendPage())->mainFrame())->protectedVirtualView()->visibleWidth() + protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->protectedVirtualView()->visibleWidth();
+    unsigned totalWidth = protect(protect(protect(frontendPage())->mainFrame())->virtualView())->visibleWidth() + protect(protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->virtualView())->visibleWidth();
     unsigned attachedWidth = constrainedAttachedWindowWidth(width, totalWidth);
     setAttachedWindowWidth(attachedWidth);
 }
@@ -359,7 +359,7 @@ void InspectorFrontendClientLocal::setAttachedWindow(DockSide dockSide)
 
 void InspectorFrontendClientLocal::restoreAttachedWindowHeight()
 {
-    unsigned inspectedPageHeight = protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->protectedVirtualView()->visibleHeight();
+    unsigned inspectedPageHeight = protect(protect(protect(protectedInspectedPageController()->inspectedPage())->mainFrame())->virtualView())->visibleHeight();
     String value = m_settings->getProperty(inspectorAttachedHeightSetting);
     unsigned preferredHeight = value.isEmpty() ? defaultAttachedHeight : parseIntegerAllowingTrailingJunk<unsigned>(value).value_or(0);
 

--- a/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
+++ b/Source/WebCore/loader/CrossOriginPreflightChecker.cpp
@@ -160,7 +160,7 @@ void CrossOriginPreflightChecker::doPreflight(DocumentThreadableLoader& loader, 
     ResourceResponse response;
     RefPtr<SharedBuffer> data;
 
-    auto identifier = loader.document().protectedFrame()->loader().loadResourceSynchronously(preflightRequest, ClientCredentialPolicy::CannotAskClientForCredentials, FetchOptions { }, { }, error, response, data);
+    auto identifier = protect(loader.document().frame())->loader().loadResourceSynchronously(preflightRequest, ClientCredentialPolicy::CannotAskClientForCredentials, FetchOptions { }, { }, error, response, data);
 
     if (!error.isNull()) {
         // If the preflight was cancelled by underlying code, it probably means the request was blocked due to some access control policy.

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -321,7 +321,7 @@ void LinkLoader::preconnectIfNeeded(const LinkLoadParameters& params, Document& 
     if (equalLettersIgnoringASCIICase(params.crossOrigin, "anonymous"_s) && !protect(document.securityOrigin())->isSameOriginDomain(SecurityOrigin::create(params.href)))
         storageCredentialsPolicy = StoredCredentialsPolicy::DoNotUse;
     ASSERT(document.frame()->loader().networkingContext());
-    platformStrategies()->loaderStrategy()->preconnectTo(document.protectedFrame()->loader(), WTF::move(request), storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::No, [weakDocument = WeakPtr { document }, href = params.href](ResourceError error) {
+    platformStrategies()->loaderStrategy()->preconnectTo(protect(document.frame())->loader(), WTF::move(request), storageCredentialsPolicy, LoaderStrategy::ShouldPreconnectAsFirstParty::No, [weakDocument = WeakPtr { document }, href = params.href](ResourceError error) {
         RefPtr document = weakDocument.get();
         if (!document)
             return;

--- a/Source/WebCore/page/Chrome.cpp
+++ b/Source/WebCore/page/Chrome.cpp
@@ -90,11 +90,6 @@ Chrome::~Chrome()
     m_client->chromeDestroyed();
 }
 
-Ref<Page> Chrome::protectedPage() const
-{
-    return m_page;
-}
-
 void Chrome::invalidateRootView(const IntRect& updateRect)
 {
     m_client->invalidateRootView(updateRect);
@@ -113,7 +108,7 @@ void Chrome::invalidateContentsForSlowScroll(const IntRect& updateRect)
 void Chrome::scroll(const IntSize& scrollDelta, const IntRect& rectToScroll, const IntRect& clipRect)
 {
     m_client->scroll(scrollDelta, rectToScroll, clipRect);
-    InspectorInstrumentation::didScroll(protectedPage());
+    InspectorInstrumentation::didScroll(protect(m_page));
 }
 
 IntPoint Chrome::screenToRootView(const IntPoint& point) const
@@ -306,7 +301,7 @@ bool Chrome::runJavaScriptConfirm(LocalFrame& frame, const String& message)
 {
     // Defer loads in case the client method runs a new event loop that would
     // otherwise cause the load to continue while we're in the middle of executing JavaScript.
-    PageGroupLoadDeferrer deferrer(protectedPage(), true);
+    PageGroupLoadDeferrer deferrer(protect(m_page), true);
 
     notifyPopupOpeningObservers();
     return m_client->runJavaScriptConfirm(frame, frame.displayStringModifiedByEncoding(message));
@@ -316,7 +311,7 @@ bool Chrome::runJavaScriptPrompt(LocalFrame& frame, const String& prompt, const 
 {
     // Defer loads in case the client method runs a new event loop that would
     // otherwise cause the load to continue while we're in the middle of executing JavaScript.
-    PageGroupLoadDeferrer deferrer(protectedPage(), true);
+    PageGroupLoadDeferrer deferrer(protect(m_page), true);
 
     notifyPopupOpeningObservers();
     String displayPrompt = frame.displayStringModifiedByEncoding(prompt);
@@ -335,7 +330,7 @@ void Chrome::mouseDidMoveOverElement(const HitTestResult& result, OptionSet<Plat
     getToolTip(result, toolTip, toolTipDirection);
     m_client->mouseDidMoveOverElement(result, modifiers, toolTip, toolTipDirection);
 
-    InspectorInstrumentation::mouseDidMoveOverElement(protectedPage(), result, modifiers);
+    InspectorInstrumentation::mouseDidMoveOverElement(protect(m_page), result, modifiers);
 }
 
 void Chrome::getToolTip(const HitTestResult& result, String& toolTip, TextDirection& toolTipDirection)
@@ -577,7 +572,7 @@ PlatformDisplayID Chrome::displayID() const
 
 void Chrome::windowScreenDidChange(PlatformDisplayID displayID, std::optional<FramesPerSecond> nominalFrameInterval)
 {
-    protectedPage()->windowScreenDidChange(displayID, nominalFrameInterval);
+    protect(m_page)->windowScreenDidChange(displayID, nominalFrameInterval);
 }
 
 RefPtr<PopupMenu> Chrome::createPopupMenu(PopupMenuClient& client) const

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -242,7 +242,6 @@ public:
 
 private:
     void notifyPopupOpeningObservers() const;
-    Ref<Page> protectedPage() const;
 
     WeakRef<Page> m_page;
     const UniqueRef<ChromeClient> m_client;

--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -112,7 +112,7 @@ bool DOMWindow::closed() const
 
 void DOMWindow::close(Document& document)
 {
-    if (document.canNavigate(protectedFrame().get()) != CanNavigateState::Able)
+    if (document.canNavigate(protect(frame()).get()) != CanNavigateState::Able)
         return;
     close();
 }
@@ -149,11 +149,6 @@ FrameConsoleClient* DOMWindow::console() const
 {
     RefPtr frame = dynamicDowncast<LocalFrame>(this->frame());
     return frame ? &frame->console() : nullptr;
-}
-
-RefPtr<Frame> DOMWindow::protectedFrame() const
-{
-    return frame();
 }
 
 WebCoreOpaqueRoot root(DOMWindow* window)
@@ -250,11 +245,6 @@ Document* DOMWindow::documentIfLocal()
     if (!localThis)
         return nullptr;
     return localThis->document();
-}
-
-RefPtr<Document> DOMWindow::protectedDocumentIfLocal()
-{
-    return documentIfLocal();
 }
 
 ExceptionOr<Document*> DOMWindow::document() const

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -105,7 +105,6 @@ public:
 
     const GlobalWindowIdentifier& identifier() const { return m_identifier; }
     virtual Frame* frame() const = 0;
-    RefPtr<Frame> protectedFrame() const;
 
     enum class DOMWindowType : bool { Local, Remote };
     bool isLocalDOMWindow() const { return m_type == DOMWindowType::Local; }
@@ -126,7 +125,6 @@ public:
 
     WindowProxy* opener() const;
     WEBCORE_EXPORT Document* documentIfLocal();
-    RefPtr<Document> protectedDocumentIfLocal();
 
     WindowProxy* top() const;
     WindowProxy* parent() const;

--- a/Source/WebCore/page/DOMWindowExtension.cpp
+++ b/Source/WebCore/page/DOMWindowExtension.cpp
@@ -58,11 +58,6 @@ LocalFrame* DOMWindowExtension::frame() const
     return window ? window->localFrame() : nullptr;
 }
 
-RefPtr<LocalFrame> DOMWindowExtension::protectedFrame() const
-{
-    return frame();
-}
-
 void DOMWindowExtension::suspendForBackForwardCache()
 {
     // Calling out to the client might result in this DOMWindowExtension being destroyed
@@ -83,7 +78,7 @@ void DOMWindowExtension::resumeFromBackForwardCache()
 
     m_disconnectedFrame = nullptr;
 
-    protectedFrame()->loader().client().dispatchDidReconnectDOMWindowExtensionToGlobalObject(this);
+    protect(frame())->loader().client().dispatchDidReconnectDOMWindowExtensionToGlobalObject(this);
 }
 
 void DOMWindowExtension::willDestroyGlobalObjectInCachedFrame()

--- a/Source/WebCore/page/DOMWindowExtension.h
+++ b/Source/WebCore/page/DOMWindowExtension.h
@@ -55,7 +55,6 @@ public:
     void willDetachGlobalObjectFromFrame() final;
 
     WEBCORE_EXPORT LocalFrame* frame() const;
-    RefPtr<LocalFrame> protectedFrame() const;
     DOMWrapperWorld& world() const { return m_world; }
 
 private:

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -69,7 +69,6 @@ public:
 
     void recomputeRegion();
     PageOverlay& overlay() { return *m_overlay; }
-    Ref<PageOverlay> protectedOverlay() { return *m_overlay; }
 
     void setRegionChanged() { m_regionChanged = true; }
 
@@ -312,7 +311,7 @@ private:
 
 bool InteractionRegionOverlay::updateRegion()
 {
-    protectedOverlay()->setNeedsDisplay();
+    protect(overlay())->setNeedsDisplay();
     return true;
 }
 
@@ -697,7 +696,7 @@ private:
 
     bool updateRegion() final
     {
-        protectedOverlay()->setNeedsDisplay();
+        protect(overlay())->setNeedsDisplay();
         return true;
     }
     void drawRect(PageOverlay&, GraphicsContext&, const IntRect& dirtyRect) final;
@@ -805,7 +804,7 @@ void RegionOverlay::recomputeRegion()
         return;
 
     if (updateRegion())
-        protectedOverlay()->setNeedsDisplay();
+        protect(overlay())->setNeedsDisplay();
 
     m_regionChanged = false;
 }
@@ -847,7 +846,7 @@ Ref<RegionOverlay> DebugPageOverlays::ensureRegionOverlayForPage(Page& page, Reg
 void DebugPageOverlays::showRegionOverlay(Page& page, RegionType regionType)
 {
     Ref visualizer = ensureRegionOverlayForPage(page, regionType);
-    page.pageOverlayController().installPageOverlay(visualizer->protectedOverlay(), PageOverlay::FadeMode::DoNotFade);
+    page.pageOverlayController().installPageOverlay(protect(visualizer->overlay()), PageOverlay::FadeMode::DoNotFade);
 }
 
 void DebugPageOverlays::hideRegionOverlay(Page& page, RegionType regionType)
@@ -858,7 +857,7 @@ void DebugPageOverlays::hideRegionOverlay(Page& page, RegionType regionType)
     auto& visualizer = it->value[indexOf(regionType)];
     if (!visualizer)
         return;
-    page.pageOverlayController().uninstallPageOverlay(visualizer->protectedOverlay(), PageOverlay::FadeMode::DoNotFade);
+    page.pageOverlayController().uninstallPageOverlay(protect(visualizer->overlay()), PageOverlay::FadeMode::DoNotFade);
     visualizer = nullptr;
 }
 

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -426,11 +426,6 @@ void DragController::updateSupportedTypeIdentifiersForDragHandlingMethod(DragHan
 
 #endif
 
-Ref<Page> DragController::protectedPage() const
-{
-    return m_page.get();
-}
-
 DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const DragData& dragData, OptionSet<DragDestinationAction> destinationActionMask, std::optional<DragOperation>& dragOperation)
 {
     if (!m_documentUnderMouse)
@@ -470,7 +465,7 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
         }
 
         IntPoint point = frameView->windowToContents(dragData.clientPosition());
-        RefPtr element = elementUnderMouse(*protectedDocumentUnderMouse(), point);
+        RefPtr element = elementUnderMouse(*protect(m_documentUnderMouse), point);
         if (!element)
             return DragHandlingMethod::None;
         
@@ -482,7 +477,7 @@ DragHandlingMethod DragController::tryDocumentDrag(LocalFrame& frame, const Drag
         }
         
         if (!m_fileInputElementUnderMouse)
-            protectedPage()->dragCaretController().setCaretPosition(m_documentUnderMouse->frame()->visiblePositionForPoint(point));
+            protect(m_page)->dragCaretController().setCaretPosition(m_documentUnderMouse->frame()->visiblePositionForPoint(point));
         else
             clearDragCaret();
 
@@ -581,7 +576,7 @@ bool DragController::concludeEditDrag(const DragData& dragData)
         return false;
 
     IntPoint point = protect(m_documentUnderMouse->view())->windowToContents(dragData.clientPosition());
-    RefPtr element = elementUnderMouse(*protectedDocumentUnderMouse(), point);
+    RefPtr element = elementUnderMouse(*protect(m_documentUnderMouse), point);
     if (!element)
         return false;
     RefPtr innerFrame = element->document().frame();
@@ -660,7 +655,7 @@ bool DragController::concludeEditDrag(const DragData& dragData)
                     options.add(ReplaceSelectionCommand::SmartReplace);
                 if (chosePlainText || dragData.shouldMatchStyleOnDrop())
                     options.add(ReplaceSelectionCommand::MatchStyle);
-                ReplaceSelectionCommand::create(protectedDocumentUnderMouse().releaseNonNull(), fragment.releaseNonNull(), options, EditAction::InsertFromDrop)->apply();
+                ReplaceSelectionCommand::create(protect(m_documentUnderMouse).releaseNonNull(), fragment.releaseNonNull(), options, EditAction::InsertFromDrop)->apply();
             }
         }
     } else {
@@ -674,7 +669,7 @@ bool DragController::concludeEditDrag(const DragData& dragData)
             return true;
 
         if (setSelectionToDragCaret(innerFrame.get(), dragCaret, point))
-            ReplaceSelectionCommand::create(protectedDocumentUnderMouse().releaseNonNull(), WTF::move(fragment), { ReplaceSelectionCommand::SelectReplacement, ReplaceSelectionCommand::MatchStyle, ReplaceSelectionCommand::PreventNesting }, EditAction::InsertFromDrop)->apply();
+            ReplaceSelectionCommand::create(protect(m_documentUnderMouse).releaseNonNull(), WTF::move(fragment), { ReplaceSelectionCommand::SelectReplacement, ReplaceSelectionCommand::MatchStyle, ReplaceSelectionCommand::PreventNesting }, EditAction::InsertFromDrop)->apply();
     }
 
     if (rootEditableElement) {
@@ -1608,7 +1603,7 @@ void DragController::placeDragCaret(const IntPoint& windowPoint)
         return;
     IntPoint framePoint = frameView->windowToContents(windowPoint);
 
-    protectedPage()->dragCaretController().setCaretPosition(frame->visiblePositionForPoint(framePoint));
+    protect(m_page)->dragCaretController().setCaretPosition(frame->visiblePositionForPoint(framePoint));
 }
 
 bool DragController::shouldUseCachedImageForDragImage(const Image& image) const

--- a/Source/WebCore/page/DragController.h
+++ b/Source/WebCore/page/DragController.h
@@ -90,7 +90,6 @@ public:
     DragHandlingMethod dragHandlingMethod() const { return m_dragHandlingMethod; }
 
     Document* documentUnderMouse() const { return m_documentUnderMouse.get(); }
-    RefPtr<Document> protectedDocumentUnderMouse() const { return m_documentUnderMouse; }
     OptionSet<DragDestinationAction> dragDestinationActionMask() const { return m_dragDestinationActionMask; }
     OptionSet<DragSourceAction> delegateDragSourceAction(const IntPoint& rootViewPoint);
 
@@ -153,7 +152,6 @@ private:
 
     void cleanupAfterSystemDrag();
     void declareAndWriteDragImage(DataTransfer&, Element&, const URL&, const String& label);
-    Ref<Page> protectedPage() const;
 
     WeakRef<Page> m_page;
     std::unique_ptr<DragClient> m_client;

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -205,7 +205,6 @@ public:
     DragEventTargetData performDragAndDrop(const PlatformMouseEvent&, std::unique_ptr<Pasteboard>&&, OptionSet<DragOperation>, bool draggingFiles, const HitTestResult&, DragData&&);
     void updateDragStateAfterEditDragIfNeeded(Element& rootEditableElement);
     static Element* draggedElement();
-    static RefPtr<Element> protectedDraggedElement();
 #endif
 
     void scheduleHoverStateUpdate();
@@ -660,8 +659,6 @@ private:
 
     bool isCapturingMouseEventsElement() const { return m_capturingMouseEventsElement || m_isCapturingRootElementForMouseEvents; }
     void resetCapturingMouseEventsElement();
-
-    Ref<LocalFrame> NODELETE protectedFrame() const;
 
     WeakRef<LocalFrame> m_frame;
     RefPtr<Node> m_mousePressNode;

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -511,7 +511,7 @@ void FocusController::setFocusedFrame(Frame* frame, BroadcastFocusedFrame broadc
     }
 
     if (shouldBroadcast)
-        protectedPage()->chrome().focusedFrameChanged(frame);
+        protect(m_page)->chrome().focusedFrameChanged(frame);
 
     m_isChangingFocusedFrame = false;
 }
@@ -528,7 +528,7 @@ LocalFrame* FocusController::focusedOrMainFrame() const
 
 void FocusController::setFocused(bool focused)
 {
-    protectedPage()->setActivityState(focused ? m_activityState | ActivityState::IsFocused : m_activityState - ActivityState::IsFocused);
+    protect(m_page)->setActivityState(focused ? m_activityState | ActivityState::IsFocused : m_activityState - ActivityState::IsFocused);
 }
 
 void FocusController::setFocusedInternal(bool focused)
@@ -736,7 +736,7 @@ FocusableElementSearchResult FocusController::findFocusableElementInDocumentOrde
     if (shouldFocusElement == ShouldFocusElement::No)
         return findResult;
 
-    setFocusedFrame(newDocument->protectedFrame().get());
+    setFocusedFrame(protect(newDocument->frame()).get());
 
     if (caretBrowsing) {
         VisibleSelection newSelection(firstPositionInOrBeforeNode(element.get()), Affinity::Downstream);
@@ -1109,14 +1109,9 @@ void FocusController::setActivityState(OptionSet<ActivityState> activityState)
     }
 }
 
-Ref<Page> FocusController::protectedPage() const
-{
-    return m_page.get();
-}
-
 void FocusController::setActive(bool active)
 {
-    protectedPage()->setActivityState(active ? m_activityState | ActivityState::WindowIsActive : m_activityState - ActivityState::WindowIsActive);
+    protect(m_page)->setActivityState(active ? m_activityState | ActivityState::WindowIsActive : m_activityState - ActivityState::WindowIsActive);
 }
 
 void FocusController::setActiveInternal(bool active)

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -62,7 +62,6 @@ public:
     Frame* focusedFrame() const { return m_focusedFrame.get(); }
     LocalFrame* focusedLocalFrame() const { return dynamicDowncast<LocalFrame>(m_focusedFrame.get()); }
     WEBCORE_EXPORT LocalFrame* focusedOrMainFrame() const;
-    RefPtr<LocalFrame> protectedFocusedOrMainFrame() const { return focusedOrMainFrame(); }
 
     WEBCORE_EXPORT bool setInitialFocus(FocusDirection, KeyboardEvent*);
     bool advanceFocus(FocusDirection, KeyboardEvent*, bool initialFocus = false);
@@ -130,7 +129,6 @@ private:
     void findFocusCandidateInContainer(const ContainerNode&, const LayoutRect& startingRect, FocusDirection, const FocusEventData&, FocusCandidate& closest);
 
     void focusRepaintTimerFired();
-    Ref<Page> NODELETE protectedPage() const;
 
     WeakRef<Page> m_page;
     WeakPtr<Frame> m_focusedFrame;

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -195,11 +195,6 @@ void Frame::takeWindowProxyAndOpenerFrom(Frame& frame)
     frame.m_openedFrames.clear();
 }
 
-RefPtr<DOMWindow> Frame::protectedWindow() const
-{
-    return window();
-}
-
 std::optional<uint64_t> Frame::indexInFrameTreeSiblings() const
 {
     if (!tree().parent())
@@ -240,11 +235,6 @@ RenderWidget* Frame::ownerRenderer() const
     // since ownerElement would be nullptr when the load is canceled.
     // https://bugs.webkit.org/show_bug.cgi?id=18585
     return dynamicDowncast<RenderWidget>(ownerElement->renderer());
-}
-
-RefPtr<FrameView> Frame::protectedVirtualView() const
-{
-    return virtualView();
 }
 
 #if ASSERT_ENABLED

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -77,14 +77,12 @@ public:
     const WindowProxy& windowProxy() const { return m_windowProxy; }
 
     DOMWindow* window() const { return virtualWindow(); }
-    RefPtr<DOMWindow> protectedWindow() const;
     FrameTree& tree() const { return m_treeNode; }
     WEBCORE_EXPORT std::optional<uint64_t> indexInFrameTreeSiblings() const;
     WEBCORE_EXPORT Vector<uint64_t> pathToFrame() const;
     FrameIdentifier frameID() const { return m_frameID; }
     WEBCORE_EXPORT SecurityOrigin& topOrigin() const;
     inline Page* page() const; // Defined in DocumentPage.h.
-    inline RefPtr<Page> protectedPage() const; // Defined in DocumentPage.h.
     inline std::optional<PageIdentifier> pageID() const; // Defined in DocumentPage.h.
     Settings& settings() const { return m_settings.get(); }
     Frame& mainFrame() { return *m_mainFrame; }
@@ -106,7 +104,6 @@ public:
 
     WEBCORE_EXPORT void setOwnerElement(HTMLFrameOwnerElement*);
     inline HTMLFrameOwnerElement* ownerElement() const; // Defined in FrameInlines.h.
-    inline RefPtr<HTMLFrameOwnerElement> protectedOwnerElement() const; // Defined in FrameInlines.h.
 
     WEBCORE_EXPORT void disconnectOwnerElement();
     NavigationScheduler& navigationScheduler() const { return m_navigationScheduler.get(); }
@@ -119,7 +116,6 @@ public:
     virtual void didFinishLoadInAnotherProcess() = 0;
 
     virtual FrameView* virtualView() const = 0;
-    WEBCORE_EXPORT RefPtr<FrameView> protectedVirtualView() const;
     virtual void disconnectView() = 0;
     virtual FrameLoaderClient& loaderClient() = 0;
     virtual void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) = 0;

--- a/Source/WebCore/page/FrameDestructionObserver.h
+++ b/Source/WebCore/page/FrameDestructionObserver.h
@@ -42,7 +42,6 @@ public:
     bool hasFrame() const { return !!m_frame; }
 
     inline LocalFrame* frame() const; // Defined in FrameDestructionObserverInlines.h.
-    inline RefPtr<LocalFrame> protectedFrame() const; // Defined in FrameDestructionObserverInlines.h.
 
 protected:
     WEBCORE_EXPORT virtual ~FrameDestructionObserver();

--- a/Source/WebCore/page/FrameDestructionObserverInlines.h
+++ b/Source/WebCore/page/FrameDestructionObserverInlines.h
@@ -35,9 +35,4 @@ inline LocalFrame* FrameDestructionObserver::frame() const
     return m_frame;
 }
 
-inline RefPtr<LocalFrame> FrameDestructionObserver::protectedFrame() const
-{
-    return m_frame;
-}
-
 }

--- a/Source/WebCore/page/FrameInlines.h
+++ b/Source/WebCore/page/FrameInlines.h
@@ -36,9 +36,4 @@ inline HTMLFrameOwnerElement* Frame::ownerElement() const
     return m_ownerElement.get();
 }
 
-inline RefPtr<HTMLFrameOwnerElement> Frame::protectedOwnerElement() const
-{
-    return m_ownerElement.get();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -132,11 +132,6 @@ void FrameTree::replaceChild(Frame& oldChild, Frame& newChild)
         oldPreviousSibling->tree().m_nextSibling = &newChild;
 }
 
-Ref<Frame> FrameTree::protectedThisFrame() const
-{
-    return m_thisFrame.get();
-}
-
 static bool inScope(Frame& frame, TreeScope& scope)
 {
     RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -101,8 +101,6 @@ private:
 
     template<typename F> RefPtr<Frame> find(const AtomString& name, F&& nameGetter, Frame& activeFrame) const;
 
-    Ref<Frame> protectedThisFrame() const;
-
     WeakRef<Frame> m_thisFrame;
 
     WeakPtr<Frame> m_parent;

--- a/Source/WebCore/page/ImageOverlayController.cpp
+++ b/Source/WebCore/page/ImageOverlayController.cpp
@@ -63,7 +63,7 @@ ImageOverlayController::ImageOverlayController(Page& page)
 
 void ImageOverlayController::selectionQuadsDidChange(LocalFrame& frame, const Vector<FloatQuad>& quads)
 {
-    if (!protectedPage()->chrome().client().needsImageOverlayControllerForSelectionPainting())
+    if (!protect(m_page)->chrome().client().needsImageOverlayControllerForSelectionPainting())
         return;
 
     if (frame.editor().ignoreSelectionChanges() || frame.editor().isGettingDictionaryPopupInfo())
@@ -135,7 +135,7 @@ PageOverlay& ImageOverlayController::installPageOverlayIfNeeded()
         return *m_overlay;
 
     m_overlay = PageOverlay::create(*this, PageOverlay::OverlayType::Document);
-    protectedPage()->pageOverlayController().installPageOverlay(*protectedOverlay(), PageOverlay::FadeMode::DoNotFade);
+    protect(m_page)->pageOverlayController().installPageOverlay(*protect(m_overlay), PageOverlay::FadeMode::DoNotFade);
     return *m_overlay;
 }
 
@@ -154,12 +154,7 @@ void ImageOverlayController::uninstallPageOverlay()
     if (!overlayToUninstall)
         return;
 
-    protectedPage()->pageOverlayController().uninstallPageOverlay(*overlayToUninstall, PageOverlay::FadeMode::DoNotFade);
-}
-
-Ref<Page> ImageOverlayController::protectedPage() const
-{
-    return m_page.get();
+    protect(m_page)->pageOverlayController().uninstallPageOverlay(*overlayToUninstall, PageOverlay::FadeMode::DoNotFade);
 }
 
 void ImageOverlayController::ref() const

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -111,9 +111,6 @@ private:
     void platformUpdateElementUnderMouse(LocalFrame&, Element* elementUnderMouse);
     bool platformHandleMouseEvent(const PlatformMouseEvent&);
 
-    Ref<Page> NODELETE protectedPage() const;
-    RefPtr<PageOverlay> protectedOverlay() const { return m_overlay; }
-
     WeakRef<Page> m_page;
     RefPtr<PageOverlay> m_overlay;
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_hostElementForSelection;

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -112,7 +112,6 @@ public:
 
     WEBCORE_EXPORT Frame* frame() const final;
     WEBCORE_EXPORT LocalFrame* localFrame() const;
-    RefPtr<LocalFrame> protectedFrame() const;
 
     RefPtr<WebCore::MediaQueryList> matchMedia(const String&);
 
@@ -163,7 +162,6 @@ public:
     DOMSelection* getSelection();
 
     HTMLFrameOwnerElement* frameElement() const;
-    RefPtr<HTMLFrameOwnerElement> protectedFrameElement() const;
 
     WEBCORE_EXPORT void focus(bool allowFocus = false);
     void focus(LocalDOMWindow& incumbentWindow);
@@ -213,7 +211,6 @@ public:
     // DOM Level 2 AbstractView Interface
 
     WEBCORE_EXPORT Document* document() const;
-    WEBCORE_EXPORT RefPtr<Document> protectedDocument() const;
 
     // CSSOM View Module
 
@@ -373,7 +370,6 @@ public:
     bool mayReuseForNavigation() const { return m_mayReuseForNavigation; }
 
     Page* page() const;
-    RefPtr<Page> protectedPage() const;
 
     WEBCORE_EXPORT static void forEachWindowInterestedInStorageEvents(NOESCAPE const Function<void(LocalDOMWindow&)>&);
 

--- a/Source/WebCore/page/LocalDOMWindowProperty.cpp
+++ b/Source/WebCore/page/LocalDOMWindowProperty.cpp
@@ -42,11 +42,6 @@ LocalFrame* LocalDOMWindowProperty::frame() const
     return m_window ? protect(window())->localFrame() : nullptr;
 }
 
-RefPtr<LocalFrame> LocalDOMWindowProperty::protectedFrame() const
-{
-    return frame();
-}
-
 LocalDOMWindow* LocalDOMWindowProperty::window() const
 {
     return m_window.get();

--- a/Source/WebCore/page/LocalDOMWindowProperty.h
+++ b/Source/WebCore/page/LocalDOMWindowProperty.h
@@ -35,9 +35,7 @@ class LocalFrame;
 class LocalDOMWindowProperty {
 public:
     WEBCORE_EXPORT LocalFrame* frame() const;
-    RefPtr<LocalFrame> protectedFrame() const;
     LocalDOMWindow* NODELETE window() const;
-    RefPtr<LocalDOMWindow> protectedWindow() const { return window(); }
 
 protected:
     explicit LocalDOMWindowProperty(LocalDOMWindow*);

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -1011,11 +1011,6 @@ LocalDOMWindow* LocalFrame::window() const
     return document() ? document()->window() : nullptr;
 }
 
-RefPtr<LocalDOMWindow> LocalFrame::protectedWindow() const
-{
-    return window();
-}
-
 DOMWindow* LocalFrame::virtualWindow() const
 {
     return window();

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -151,7 +151,6 @@ public:
     WEBCORE_EXPORT ~LocalFrame();
 
     WEBCORE_EXPORT LocalDOMWindow* window() const;
-    WEBCORE_EXPORT RefPtr<LocalDOMWindow> protectedWindow() const;
 
     void addDestructionObserver(FrameDestructionObserver&);
     void removeDestructionObserver(FrameDestructionObserver&);
@@ -159,9 +158,7 @@ public:
     WEBCORE_EXPORT void willDetachPage();
 
     inline Document* document() const; // Defined in LocalFrameInlines.h
-    inline RefPtr<Document> protectedDocument() const; // Defined in LocalFrameInlines.h
     inline LocalFrameView* view() const; // Defined in DocumentView.h
-    inline RefPtr<LocalFrameView> protectedView() const; // Defined in DocumentView.h.
     WEBCORE_EXPORT RefPtr<const LocalFrame> localMainFrame() const;
     WEBCORE_EXPORT RefPtr<LocalFrame> localMainFrame();
 
@@ -179,6 +176,7 @@ public:
     ScriptController& script() { return m_script; }
     const ScriptController& script() const { return m_script; }
     void resetScript();
+    FrameView* NODELETE virtualView() const final;
 
     bool isRootFrame() const final { return m_rootFrame.get() == this; }
     const LocalFrame& rootFrame() const { return *m_rootFrame; }
@@ -391,7 +389,6 @@ private:
     std::optional<DocumentSecurityPolicy> frameDocumentSecurityPolicy() const final;
     String frameURLProtocol() const final;
 
-    FrameView* NODELETE virtualView() const final;
     void disconnectView() final;
     DOMWindow* virtualWindow() const final;
     void reinitializeDocumentSecurityContext() final;

--- a/Source/WebCore/page/LocalFrameInlines.h
+++ b/Source/WebCore/page/LocalFrameInlines.h
@@ -39,19 +39,14 @@ inline Document* LocalFrame::document() const
     return m_doc.get();
 }
 
-inline RefPtr<Document> LocalFrame::protectedDocument() const
-{
-    return document();
-}
-
 inline Editor& LocalFrame::editor()
 {
-    return protectedDocument()->editor();
+    return protect(document())->editor();
 }
 
 inline const Editor& LocalFrame::editor() const
 {
-    return protectedDocument()->editor();
+    return protect(document())->editor();
 }
 
 inline FrameSelection& LocalFrame::selection()

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -229,11 +229,9 @@ private:
     void enablePercentHeightResolveFor(const RenderBox& flexItem);
 
     LocalFrame& frame() const;
-    Ref<LocalFrame> protectedFrame();
-    LocalFrameView& NODELETE view() const;
+    LocalFrameView& view() const;
     RenderView* renderView() const;
     Document* document() const;
-    RefPtr<Document> NODELETE protectedDocument() const;
 
     SingleThreadWeakRef<LocalFrameView> m_frameView;
     Timer m_layoutTimer;

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -333,11 +333,6 @@ ExceptionOr<void> Location::setLocation(LocalDOMWindow& incumbentWindow, LocalDO
     return { };
 }
 
-RefPtr<DOMWindow> Location::protectedWindow()
-{
-    return m_window.get();
-}
-
 Location::~Location() = default;
 
 } // namespace WebCore

--- a/Source/WebCore/page/Location.h
+++ b/Source/WebCore/page/Location.h
@@ -75,7 +75,6 @@ public:
     Ref<DOMStringList> ancestorOrigins() const;
 
     DOMWindow* window() { return m_window.get(); }
-    RefPtr<DOMWindow> protectedWindow();
 
     const URL& url() const;
 

--- a/Source/WebCore/page/MouseEventWithHitTestResults.h
+++ b/Source/WebCore/page/MouseEventWithHitTestResults.h
@@ -38,7 +38,6 @@ public:
     bool isOverLink() const;
     bool isOverWidget() const { return m_hitTestResult.isOverWidget(); }
     Node* targetNode() const { return m_hitTestResult.targetNode(); }
-    RefPtr<Node> protectedTargetNode() const { return m_hitTestResult.targetNode(); }
 
 private:
     PlatformMouseEvent m_event;

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -133,7 +133,6 @@ public:
 
     const Vector<Ref<NavigationHistoryEntry>>& entries() const;
     NavigationHistoryEntry* currentEntry() const;
-    RefPtr<NavigationHistoryEntry> protectedCurrentEntry() const { return currentEntry(); }
     NavigationTransition* transition() { return m_transition.get(); };
     NavigationActivation* activation() { return m_activation.get(); };
 
@@ -171,7 +170,6 @@ public:
 
     // EventTarget.
     ScriptExecutionContext* scriptExecutionContext() const final;
-    RefPtr<ScriptExecutionContext> protectedScriptExecutionContext() const;
 
     void rejectFinishedPromise(NavigationAPIMethodTracker*);
     NavigationAPIMethodTracker* upcomingTraverseMethodTracker(const String& key) const;
@@ -238,7 +236,6 @@ public:
     RateLimiter& rateLimiterForTesting() { return m_rateLimiter; }
 
     NavigateEvent* ongoingNavigateEvent() { return m_ongoingNavigateEvent.get(); } // This may get called on the GC thread.
-    RefPtr<NavigateEvent> protectedOngoingNavigateEvent() { return m_ongoingNavigateEvent; }
     bool hasInterceptedOngoingNavigateEvent() const { return m_ongoingNavigateEvent && m_ongoingNavigateEvent->wasIntercepted(); }
 
     void updateNavigationEntry(Ref<HistoryItem>&&, ShouldCopyStateObjectFromCurrentEntry);

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -400,11 +400,6 @@ Page* Navigator::page()
     return frame ? frame->page() : nullptr;
 }
 
-RefPtr<Page> Navigator::protectedPage()
-{
-    return page();
-}
-
 const Document* Navigator::document() const
 {
     RefPtr frame = this->frame();
@@ -415,11 +410,6 @@ Document* Navigator::document()
 {
     RefPtr frame = this->frame();
     return frame ? frame->document() : nullptr;
-}
-
-RefPtr<Document> Navigator::protectedDocument()
-{
-    return document();
 }
 
 void Navigator::setAppBadge(std::optional<unsigned long long> badge, Ref<DeferredPromise>&& promise)

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -72,11 +72,9 @@ public:
     WEBCORE_EXPORT GPU* gpu();
 
     Page* page();
-    RefPtr<Page> protectedPage();
 
     const Document* document() const;
     Document* document();
-    RefPtr<Document> protectedDocument();
 
     void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);
     void clearAppBadge(Ref<DeferredPromise>&&);

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -679,15 +679,10 @@ ScrollingCoordinator* Page::scrollingCoordinator()
         if (!m_scrollingCoordinator)
             m_scrollingCoordinator = ScrollingCoordinator::create(this);
 
-        protectedScrollingCoordinator()->windowScreenDidChange(m_displayID, m_displayNominalFramesPerSecond);
+        protect(m_scrollingCoordinator)->windowScreenDidChange(m_displayID, m_displayNominalFramesPerSecond);
     }
 
     return m_scrollingCoordinator;
-}
-
-RefPtr<ScrollingCoordinator> Page::protectedScrollingCoordinator()
-{
-    return scrollingCoordinator();
 }
 
 String Page::scrollingStateTreeAsText()
@@ -1736,7 +1731,7 @@ void Page::setDeviceScaleFactor(float scaleFactor)
 void Page::screenPropertiesDidChange(bool affectsStyle)
 {
 #if ENABLE(VIDEO)
-    auto mode = preferredDynamicRangeMode(protect(mainFrame())->protectedVirtualView().get());
+    auto mode = preferredDynamicRangeMode(protect(protect(mainFrame())->virtualView()).get());
     forEachMediaElement([mode] (auto& element) {
         element.setPreferredDynamicRangeMode(mode);
     });
@@ -1788,7 +1783,7 @@ void Page::windowScreenDidChange(PlatformDisplayID displayID, std::optional<Fram
     updateScreenSupportedContentsFormats();
 
 #if ENABLE(VIDEO)
-    auto mode = preferredDynamicRangeMode(protect(mainFrame())->protectedVirtualView().get());
+    auto mode = preferredDynamicRangeMode(protect(protect(mainFrame())->virtualView()).get());
     forEachMediaElement([mode] (auto& element) {
         element.setPreferredDynamicRangeMode(mode);
     });

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -521,7 +521,6 @@ public:
     void scheduleValidationMessageUpdate(ValidatedFormListedElement&, HTMLElement&);
 
     WEBCORE_EXPORT ScrollingCoordinator* scrollingCoordinator();
-    WEBCORE_EXPORT RefPtr<ScrollingCoordinator> protectedScrollingCoordinator();
 
     WEBCORE_EXPORT String scrollingStateTreeAsText();
     WEBCORE_EXPORT String synchronousScrollingReasonsAsText();

--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -201,7 +201,7 @@ bool PageOverlay::mouseEvent(const PlatformMouseEvent& mouseEvent)
     IntPoint mousePositionInOverlayCoordinates(flooredIntPoint(mouseEvent.position()));
 
     if (m_overlayType == PageOverlay::OverlayType::Document)
-        mousePositionInOverlayCoordinates = protect(m_page->mainFrame())->protectedVirtualView()->windowToContents(mousePositionInOverlayCoordinates);
+        mousePositionInOverlayCoordinates = protect(protect(m_page->mainFrame())->virtualView())->windowToContents(mousePositionInOverlayCoordinates);
     mousePositionInOverlayCoordinates.moveBy(-frame().location());
 
     // Ignore events outside the bounds.

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -51,7 +51,6 @@ public:
 
     GraphicsLayer& layerWithDocumentOverlays();
     GraphicsLayer& layerWithViewOverlays();
-    Ref<GraphicsLayer> protectedLayerWithViewOverlays();
 
     const Vector<Ref<PageOverlay>>& pageOverlays() const { return m_pageOverlays; }
 
@@ -85,10 +84,8 @@ private:
     void createRootLayersIfNeeded();
 
     WEBCORE_EXPORT GraphicsLayer* NODELETE documentOverlayRootLayer() const;
-    RefPtr<GraphicsLayer> protectedDocumentOverlayRootLayer() const;
 
     WEBCORE_EXPORT GraphicsLayer* NODELETE viewOverlayRootLayer() const;
-    RefPtr<GraphicsLayer> protectedViewOverlayRootLayer() const;
 
     void installedPageOverlaysChanged();
     void attachViewOverlayLayers();
@@ -104,8 +101,6 @@ private:
     bool shouldSkipLayerInDump(const GraphicsLayer*, OptionSet<LayerTreeAsTextOptions>) const override;
     bool shouldDumpPropertyForLayer(const GraphicsLayer*, ASCIILiteral propertyName, OptionSet<LayerTreeAsTextOptions>) const override;
     void tiledBackingUsageChanged(const GraphicsLayer*, bool) override;
-
-    Ref<Page> NODELETE protectedPage() const;
 
     WeakRef<Page> m_page;
     RefPtr<GraphicsLayer> m_documentOverlayRootLayer;

--- a/Source/WebCore/page/PerformanceObserver.cpp
+++ b/Source/WebCore/page/PerformanceObserver.cpp
@@ -50,11 +50,6 @@ PerformanceObserver::PerformanceObserver(ScriptExecutionContext& scriptExecution
         ASSERT_NOT_REACHED();
 }
 
-RefPtr<Performance> PerformanceObserver::protectedPerformance() const
-{
-    return m_performance;
-}
-
 void PerformanceObserver::disassociate()
 {
     m_performance = nullptr;
@@ -93,7 +88,7 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
         if (init.buffered) {
             isBuffered = true;
             auto oldSize = m_entriesToDeliver.size();
-            protectedPerformance()->appendBufferedEntriesByType(init.type, m_entriesToDeliver, *this);
+            protect(m_performance)->appendBufferedEntriesByType(init.type, m_entriesToDeliver, *this);
             auto entriesToDeliver = m_entriesToDeliver.mutableSpan();
             auto begin = entriesToDeliver.begin();
             auto oldEnd = entriesToDeliver.subspan(oldSize).begin();
@@ -108,12 +103,12 @@ ExceptionOr<void> PerformanceObserver::observe(Init&& init)
     }
 
     if (!m_registered) {
-        protectedPerformance()->registerPerformanceObserver(*this);
+        protect(m_performance)->registerPerformanceObserver(*this);
         m_registered = true;
     }
 
     if (isBuffered && m_entriesToDeliver.size())
-        protectedPerformance()->scheduleTaskIfNeeded();
+        protect(m_performance)->scheduleTaskIfNeeded();
 
     return { };
 }

--- a/Source/WebCore/page/PerformanceObserver.h
+++ b/Source/WebCore/page/PerformanceObserver.h
@@ -77,8 +77,6 @@ public:
 private:
     PerformanceObserver(ScriptExecutionContext&, Ref<PerformanceObserverCallback>&&);
 
-    RefPtr<Performance> protectedPerformance() const;
-
     RefPtr<Performance> m_performance;
     Vector<Ref<PerformanceEntry>> m_entriesToDeliver;
     const Ref<PerformanceObserverCallback> m_callback;

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1113,7 +1113,7 @@ bool Quirks::shouldEnableRTCEncodedStreamsQuirk() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldEnableRTCEncodedStreamsQuirk) && protectedDocument() && protectedDocument()->settings().rtcEncodedStreamsQuirkEnabled();
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldEnableRTCEncodedStreamsQuirk) && m_document && protect(m_document)->settings().rtcEncodedStreamsQuirkEnabled();
 }
 #endif
 
@@ -1250,11 +1250,6 @@ Quirks::StorageAccessResult Quirks::requestStorageAccessAndHandleClick(Completio
         });
     });
     return Quirks::StorageAccessResult::ShouldCancelEvent;
-}
-
-RefPtr<Document> Quirks::protectedDocument() const
-{
-    return m_document.get();
 }
 
 void Quirks::triggerOptionalStorageAccessIframeQuirk(const URL& frameURL, CompletionHandler<void()>&& completionHandler) const
@@ -1785,7 +1780,7 @@ bool Quirks::shouldUseEphemeralPartitionedStorageForDOMCookies(const URL& url) c
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    auto firstPartyDomain = RegistrableDomain(protectedDocument()->firstPartyForCookies()).string();
+    auto firstPartyDomain = RegistrableDomain(protect(m_document)->firstPartyForCookies()).string();
     auto domain = RegistrableDomain(url).string();
 
     // rdar://113830141
@@ -1811,7 +1806,7 @@ bool Quirks::needsLaxSameSiteCookieQuirk(const URL& requestURL) const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
 
-    auto url = protectedDocument()->url();
+    auto url = protect(m_document)->url();
     return url.protocolIs("https"_s) && url.host() == "login.microsoftonline.com"_s && requestURL.protocolIs("https"_s) && requestURL.host() == "www.bing.com"_s;
 }
 
@@ -2411,7 +2406,7 @@ URL Quirks::topDocumentURL() const
     if (!m_topDocumentURLForTesting.isEmpty()) [[unlikely]]
         return m_topDocumentURLForTesting;
 
-    return protectedDocument()->topURL();
+    return protect(m_document)->topURL();
 }
 
 void Quirks::setTopDocumentURLForTesting(URL&& url)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -334,8 +334,6 @@ private:
     static bool domainShouldDisableEndFullscreenEventWhenEnteringPictureInPictureFromFullscreenQuirk(const URL&, QuirksData&);
 #endif
 
-    RefPtr<Document> NODELETE protectedDocument() const;
-
     URL topDocumentURL() const;
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;

--- a/Source/WebCore/page/ResizeObservation.cpp
+++ b/Source/WebCore/page/ResizeObservation.cpp
@@ -123,11 +123,6 @@ FloatSize ResizeObservation::snappedContentBoxSize() const
     return m_lastObservationSizes.contentBoxLogicalSize; // FIXME: Need to pixel snap.
 }
 
-RefPtr<Element> ResizeObservation::protectedTarget() const
-{
-    return m_target.get();
-}
-
 std::optional<ResizeObservation::BoxSizes> ResizeObservation::elementSizeChanged() const
 {
     auto currentSizes = computeObservedSizes();

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -65,7 +65,6 @@ public:
     FloatSize snappedContentBoxSize() const;
 
     Element* target() const { return m_target.get(); }
-    RefPtr<Element> NODELETE protectedTarget() const;
     ResizeObserverBoxOptions observedBox() const { return m_observedBox; }
     size_t targetElementDepth() const;
 

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -149,7 +149,7 @@ size_t ResizeObserver::gatherObservations(size_t deeperThan)
                 m_activeObservations.append(observation.get());
                 {
                     Locker locker { m_observationTargetsLock };
-                    m_activeObservationTargets.append(*observation->protectedTarget());
+                    m_activeObservationTargets.append(*protect(observation->target()));
                 }
                 minObservedDepth = std::min(depth, minObservedDepth);
             } else
@@ -250,7 +250,7 @@ bool ResizeObserver::removeTarget(Element& target)
 void ResizeObserver::removeAllTargets()
 {
     for (auto& observation : m_observations) {
-        bool removed = removeTarget(*observation->protectedTarget());
+        bool removed = removeTarget(*protect(observation->target()));
         ASSERT_UNUSED(removed, removed);
     }
     {

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -539,14 +539,9 @@ void SettingsBase::useSystemAppearanceChanged()
         m_page->useSystemAppearanceChanged();
 }
 
-RefPtr<Page> SettingsBase::protectedPage() const
-{
-    return m_page.get();
-}
-
 void SettingsBase::fontFallbackPrefersPictographsChanged()
 {
-    invalidateAfterGenericFamilyChange(protectedPage().get());
+    invalidateAfterGenericFamilyChange(protect(m_page).get());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/SettingsBase.h
+++ b/Source/WebCore/page/SettingsBase.h
@@ -135,7 +135,6 @@ public:
 
     WEBCORE_EXPORT void resetToConsistentState();
 
-    WEBCORE_EXPORT RefPtr<Page> NODELETE protectedPage() const;
     WeakPtr<Page> page() const { return m_page; }
 
 protected:

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -362,7 +362,7 @@ bool scrollInDirection(LocalFrame* frame, FocusDirection direction)
 bool scrollInDirection(const ContainerNode& container, FocusDirection direction)
 {
     if (is<Document>(container))
-        return scrollInDirection(downcast<Document>(container).protectedFrame().get(), direction);
+        return scrollInDirection(protect(downcast<Document>(container).frame()).get(), direction);
 
     if (!canScrollInDirection(container, direction))
         return false;
@@ -442,7 +442,7 @@ bool canScrollInDirection(const ContainerNode& container, FocusDirection directi
         return false;
 
     if (is<Document>(container))
-        return canScrollInDirection(downcast<Document>(container).protectedFrame().get(), direction);
+        return canScrollInDirection(protect(downcast<Document>(container).frame()).get(), direction);
 
     if (!isScrollableNode(container))
         return false;
@@ -517,10 +517,10 @@ LayoutRect nodeRectInAbsoluteCoordinates(const ContainerNode& containerNode, boo
     ASSERT(containerNode.renderer() && !containerNode.document().view()->needsLayout());
 
     if (is<Document>(containerNode))
-        return frameRectInAbsoluteCoordinates(downcast<Document>(containerNode).protectedFrame().get());
+        return frameRectInAbsoluteCoordinates(protect(downcast<Document>(containerNode).frame()).get());
 
     if (CheckedPtr renderer = containerNode.renderer()) {
-        auto rect = rectToAbsoluteCoordinates(containerNode.document().protectedFrame().get(), renderer->absoluteBoundingBoxRect());
+        auto rect = rectToAbsoluteCoordinates(protect(containerNode.document().frame()).get(), renderer->absoluteBoundingBoxRect());
         // For authors that use border instead of outline in their CSS, we compensate by ignoring the border when calculating
         // the rect of the focused element.
         if (ignoreBorder) {
@@ -758,7 +758,7 @@ LayoutRect virtualRectForAreaElementAndDirection(HTMLAreaElement* area, FocusDir
     ASSERT(area->imageElement());
     // Area elements tend to overlap more than other focusable elements. We flatten the rect of the area elements
     // to minimize the effect of overlapping areas.
-    LayoutRect rect = virtualRectForDirection(direction, rectToAbsoluteCoordinates(area->document().protectedFrame().get(), area->computeRect(protect(area->imageElement()->renderer()).get())), 1);
+    LayoutRect rect = virtualRectForDirection(direction, rectToAbsoluteCoordinates(protect(area->document().frame()).get(), area->computeRect(protect(area->imageElement()->renderer()).get())), 1);
     return rect;
 }
 

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -167,7 +167,6 @@ public:
     Image* contentImageWithHighlight() const { return m_data.contentImageWithHighlight.get(); }
     Image* contentImageWithoutSelection() const { return m_data.contentImageWithoutSelection.get(); }
     Image* contentImage() const { return m_data.contentImage.get(); }
-    RefPtr<Image> protectedContentImage() const { return contentImage(); }
 
     TextIndicatorPresentationTransition presentationTransition() const { return m_data.presentationTransition; }
     void setPresentationTransition(TextIndicatorPresentationTransition transition) { m_data.presentationTransition = transition; }

--- a/Source/WebCore/page/UndoItem.cpp
+++ b/Source/WebCore/page/UndoItem.cpp
@@ -58,9 +58,4 @@ Document* UndoItem::document() const
     return m_document.get();
 }
 
-RefPtr<Document> UndoItem::protectedDocument() const
-{
-    return document();
-}
-
 } // namespace WebCore

--- a/Source/WebCore/page/UndoItem.h
+++ b/Source/WebCore/page/UndoItem.h
@@ -55,7 +55,6 @@ public:
     void invalidate();
 
     Document* NODELETE document() const;
-    RefPtr<Document> protectedDocument() const;
 
     UndoManager* NODELETE undoManager() const;
     void setUndoManager(UndoManager*);

--- a/Source/WebCore/page/WebKitNamespace.cpp
+++ b/Source/WebCore/page/WebKitNamespace.cpp
@@ -55,8 +55,8 @@ namespace WebCore {
 
 WebKitNamespace::WebKitNamespace(LocalDOMWindow& window, UserContentProvider& userContentProvider)
     : LocalDOMWindowProperty(&window)
-    , m_messageHandlerNamespace(UserMessageHandlersNamespace::create(*window.protectedFrame(), userContentProvider))
-    , m_buffers(WebKitBufferNamespace::create(*window.protectedFrame(), userContentProvider))
+    , m_messageHandlerNamespace(UserMessageHandlersNamespace::create(*protect(window.localFrame()), userContentProvider))
+    , m_buffers(WebKitBufferNamespace::create(*protect(window.localFrame()), userContentProvider))
 {
     ASSERT(window.frame());
 }

--- a/Source/WebCore/page/cocoa/ContentChangeObserver.cpp
+++ b/Source/WebCore/page/cocoa/ContentChangeObserver.cpp
@@ -600,7 +600,7 @@ void ContentChangeObserver::adjustObservedState(Event event)
         LOG_WITH_STREAM(ContentObservation, stream << "notifyClientIfNeeded: sending observedContentChange ->" << observedContentChange());
         ASSERT(m_document->page());
         ASSERT(m_document->frame());
-        m_document->page()->chrome().client().didFinishContentChangeObserving(*m_document->protectedFrame(), observedContentChange());
+        m_document->page()->chrome().client().didFinishContentChangeObserving(*protect(m_document->frame()), observedContentChange());
         stopContentObservation();
     };
 

--- a/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
+++ b/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
@@ -231,7 +231,7 @@ static RetainPtr<CAKeyframeAnimation> createBounceAnimation(CFTimeInterval durat
 static RetainPtr<CABasicAnimation> createContentCrossfadeAnimation(CFTimeInterval duration, WebCore::TextIndicator& textIndicator)
 {
     RetainPtr crossfadeAnimation = [CABasicAnimation animationWithKeyPath:@"contents"];
-    RefPtr contentsImage = textIndicator.protectedContentImage()->nativeImage();
+    RefPtr contentsImage = protect(textIndicator.contentImage())->nativeImage();
     [crossfadeAnimation setToValue:(__bridge id)contentsImage->platformImage().get()];
     [crossfadeAnimation setFillMode:kCAFillModeForwards];
     [crossfadeAnimation setRemovedOnCompletion:NO];

--- a/Source/WebCore/page/ios/EventHandlerIOS.mm
+++ b/Source/WebCore/page/ios/EventHandlerIOS.mm
@@ -188,7 +188,7 @@ void EventHandler::focusDocumentView()
     }
 
     RELEASE_ASSERT(page == m_frame->page());
-    page->focusController().setFocusedFrame(protectedFrame().ptr());
+    page->focusController().setFocusedFrame(protect(m_frame).ptr());
 }
 
 bool EventHandler::passWidgetMouseDownEventToWidget(const MouseEventWithHitTestResults& event)
@@ -466,7 +466,7 @@ void EventHandler::mouseDown(WebEvent *event)
     BEGIN_BLOCK_OBJC_EXCEPTIONS
 
     // FIXME: Why is this here? EventHandler::handleMousePressEvent() calls it.
-    protectedFrame()->loader().resetMultipleFormSubmissionProtection();
+    protect(m_frame)->loader().resetMultipleFormSubmissionProtection();
 
     m_mouseDownView = nil;
 
@@ -514,7 +514,7 @@ void EventHandler::mouseMoved(WebEvent *event)
         // Run style recalc to be able to capture content changes as the result of the mouse move event.
         document->updateStyleIfNeeded();
 #if ENABLE(CONTENT_CHANGE_OBSERVER)
-        callOnMainThread([frame = protectedFrame()] {
+        callOnMainThread([frame = protect(m_frame)] {
             // This is called by WebKitLegacy only.
             if (RefPtr document = frame->document())
                 document->contentChangeObserver().willNotProceedWithFixedObservationTimeWindow();

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -194,7 +194,7 @@ void EventHandler::focusDocumentView()
     }
 
     RELEASE_ASSERT(page == m_frame->page());
-    page->focusController().setFocusedFrame(protectedFrame().ptr());
+    page->focusController().setFocusedFrame(protect(m_frame).ptr());
 }
 
 bool EventHandler::passWidgetMouseDownEventToWidget(const MouseEventWithHitTestResults& event)
@@ -862,7 +862,7 @@ void EventHandler::determineWheelEventTarget(const PlatformWheelEvent& wheelEven
     if (wheelEvent.shouldResetLatching() || wheelEvent.isNonGestureEvent())
         return;
 
-    page->scrollLatchingController().updateAndFetchLatchingStateForFrame(protectedFrame(), wheelEvent, wheelEventTarget, scrollableArea, isOverWidget);
+    page->scrollLatchingController().updateAndFetchLatchingStateForFrame(protect(m_frame), wheelEvent, wheelEventTarget, scrollableArea, isOverWidget);
 }
 
 bool EventHandler::processWheelEventForScrolling(const PlatformWheelEvent& wheelEvent, const WeakPtr<ScrollableArea>& scrollableArea, OptionSet<EventHandling> eventHandling)

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -171,7 +171,7 @@ bool ImageOverlayController::handleDataDetectorAction(const HTMLElement& element
     if (!renderer)
         return false;
 
-    protectedPage()->chrome().client().handleClickForDataDetectionResult({ WTF::move(dataDetectionResult), frameView->contentsToWindow(renderer->absoluteBoundingBoxRect()) }, frameView->contentsToWindow(locationInContents));
+    protect(m_page)->chrome().client().handleClickForDataDetectionResult({ WTF::move(dataDetectionResult), frameView->contentsToWindow(renderer->absoluteBoundingBoxRect()) }, frameView->contentsToWindow(locationInContents));
     return true;
 }
 
@@ -246,17 +246,17 @@ void ImageOverlayController::elementUnderMouseDidChange(LocalFrame& frame, Eleme
 
 void ImageOverlayController::scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps)
 {
-    protectedPage()->scheduleRenderingUpdate(requestedSteps);
+    protect(m_page)->scheduleRenderingUpdate(requestedSteps);
 }
 
 float ImageOverlayController::deviceScaleFactor() const
 {
-    return protectedPage()->deviceScaleFactor();
+    return protect(m_page)->deviceScaleFactor();
 }
 
 RefPtr<GraphicsLayer> ImageOverlayController::createGraphicsLayer(GraphicsLayerClient& client)
 {
-    return GraphicsLayer::create(protectedPage()->chrome().client().graphicsLayerFactory(), client);
+    return GraphicsLayer::create(protect(m_page)->chrome().client().graphicsLayerFactory(), client);
 }
 
 #endif

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -102,7 +102,6 @@ private:
     Vector<SimpleRange> telephoneNumberRangesForFocusedFrame();
 
     Page& page() const { return m_page; }
-    Ref<Page> protectedPage() const { return m_page.get(); }
 
     WeakRef<Page> m_page;
     WeakPtr<PageOverlay> m_servicesOverlay;

--- a/Source/WebCore/page/mac/ServicesOverlayController.mm
+++ b/Source/WebCore/page/mac/ServicesOverlayController.mm
@@ -679,17 +679,17 @@ void ServicesOverlayController::handleClick(const IntPoint& clickPoint, DataDete
 
 void ServicesOverlayController::scheduleRenderingUpdate(OptionSet<RenderingUpdateStep> requestedSteps)
 {
-    protectedPage()->scheduleRenderingUpdate(requestedSteps);
+    protect(m_page)->scheduleRenderingUpdate(requestedSteps);
 }
 
 float ServicesOverlayController::deviceScaleFactor() const
 {
-    return protectedPage()->deviceScaleFactor();
+    return protect(m_page)->deviceScaleFactor();
 }
 
 RefPtr<GraphicsLayer> ServicesOverlayController::createGraphicsLayer(GraphicsLayerClient& client)
 {
-    return GraphicsLayer::create(protectedPage()->chrome().client().graphicsLayerFactory(), client);
+    return GraphicsLayer::create(protect(m_page)->chrome().client().graphicsLayerFactory(), client);
 }
 
 #endif

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.cpp
@@ -259,11 +259,6 @@ Page* ScrollingCoordinator::page() const
     return m_page.get();
 }
 
-RefPtr<Page> ScrollingCoordinator::protectedPage() const
-{
-    return m_page.get();
-}
-
 GraphicsLayer* ScrollingCoordinator::counterScrollingLayerForFrameView(LocalFrameView& frameView)
 {
     if (auto* renderView = frameView.frame().contentRenderer())

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -246,7 +246,6 @@ protected:
     virtual void willCommitTree(FrameIdentifier) { }
 
     WEBCORE_EXPORT Page* NODELETE page() const;
-    WEBCORE_EXPORT RefPtr<Page> protectedPage() const;
 
 private:
     virtual bool hasVisibleSlowRepaintViewportConstrainedObjects(const LocalFrameView&) const;

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -899,7 +899,7 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
         pushCurrentNode(newElement.ptr());
 
     if (!m_parsingFragment && isFirstElement && document->frame())
-        document->protectedFrame()->injectUserScripts(UserScriptInjectionTime::DocumentStart);
+        protect(document->frame())->injectUserScripts(UserScriptInjectionTime::DocumentStart);
 }
 
 void XMLDocumentParser::endElementNs()

--- a/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
+++ b/Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp
@@ -1032,7 +1032,7 @@ void WebAutomationSessionProxy::takeScreenshot(WebCore::PageIdentifier pageID, s
         RefPtr localMainFrame = dynamicDowncast<LocalFrame>(frame->coreFrame()->mainFrame());
         if (!localMainFrame)
             return;
-        auto snapshotRect = WebCore::IntRect(localMainFrame->protectedView()->clientToDocumentRect(rect));
+        auto snapshotRect = WebCore::IntRect(protect(localMainFrame->view())->clientToDocumentRect(rect));
         RefPtr<WebImage> image = page->scaledSnapshotWithOptions(snapshotRect, 1, SnapshotOption::Shareable);
         if (!image)
             return completionHandler(std::nullopt, Inspector::Protocol::AutomationHelpers::getEnumConstantValue(Inspector::Protocol::Automation::ErrorMessage::ScreenshotError));
@@ -1090,7 +1090,7 @@ void WebAutomationSessionProxy::snapshotRectForScreenshot(WebCore::PageIdentifie
         return;
     }
 
-    completionHandler(std::nullopt, WebCore::IntRect(localMainFrame->protectedView()->documentToClientRect(snapshotRect)));
+    completionHandler(std::nullopt, WebCore::IntRect(protect(localMainFrame->view())->documentToClientRect(snapshotRect)));
 }
 
 void WebAutomationSessionProxy::getCookiesForFrame(WebCore::PageIdentifier pageID, std::optional<WebCore::FrameIdentifier> frameID, CompletionHandler<void(std::optional<String>, Vector<WebCore::Cookie>)>&& completionHandler)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp
@@ -253,7 +253,7 @@ void WKAccessibilityAnnounce(WKBundlePageRef pageRef, WKStringRef message)
     if (!core->document())
         return;
 
-    if (CheckedPtr cache = core->protectedDocument()->axObjectCache())
+    if (CheckedPtr cache = protect(core->document())->axObjectCache())
         cache->announce(WebKit::toWTFString(message));
 }
 

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -404,7 +404,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
     if (!webCoreMainFrame)
         return nil;
 
-    return WebKit::toWKDOMDocument(webCoreMainFrame->protectedDocument().get());
+    return WebKit::toWKDOMDocument(protect(webCoreMainFrame->document()).get());
 }
 
 - (WKDOMRange *)selectedRange

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -169,9 +169,9 @@ int InjectedBundle::numberOfPages(WebFrame* frame, double pageWidthInPixels, dou
     if (!coreFrame)
         return -1;
     if (!pageWidthInPixels)
-        pageWidthInPixels = coreFrame->protectedView()->width();
+        pageWidthInPixels = protect(coreFrame->view())->width();
     if (!pageHeightInPixels)
-        pageHeightInPixels = coreFrame->protectedView()->height();
+        pageHeightInPixels = protect(coreFrame->view())->height();
 
     return PrintContext::numberOfPages(*coreFrame, FloatSize(pageWidthInPixels, pageHeightInPixels));
 }
@@ -182,14 +182,14 @@ int InjectedBundle::pageNumberForElementById(WebFrame* frame, const String& id, 
     if (!coreFrame)
         return -1;
 
-    RefPtr element = coreFrame->protectedDocument()->getElementById(id);
+    RefPtr element = protect(coreFrame->document())->getElementById(id);
     if (!element)
         return -1;
 
     if (!pageWidthInPixels)
-        pageWidthInPixels = coreFrame->protectedView()->width();
+        pageWidthInPixels = protect(coreFrame->view())->width();
     if (!pageHeightInPixels)
-        pageHeightInPixels = coreFrame->protectedView()->height();
+        pageHeightInPixels = protect(coreFrame->view())->height();
 
     return PrintContext::pageNumberForElement(element.get(), FloatSize(pageWidthInPixels, pageHeightInPixels));
 }

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp
@@ -59,7 +59,7 @@ InjectedBundleDOMWindowExtension* InjectedBundleDOMWindowExtension::get(DOMWindo
 }
 
 InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension(WebFrame* frame, InjectedBundleScriptWorld* world)
-    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? protect(frame->coreLocalFrame())->protectedWindow().get() : nullptr, protect(world->coreWorld()).get()))
+    : m_coreExtension(DOMWindowExtension::create(frame->coreLocalFrame() ? protect(protect(frame->coreLocalFrame())->window()).get() : nullptr, protect(world->coreWorld()).get()))
 {
     allExtensions().add(m_coreExtension.get(), *this);
 }

--- a/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp
@@ -280,8 +280,8 @@ bool WebInspectorBackend::canAttachWindow()
     RefPtr localMainFrame = RefPtr { m_page.get() }->localMainFrame();
     if (!localMainFrame)
         return false;
-    unsigned inspectedPageHeight = localMainFrame->protectedView()->visibleHeight();
-    unsigned inspectedPageWidth = localMainFrame->protectedView()->visibleWidth();
+    unsigned inspectedPageHeight = protect(localMainFrame->view())->visibleHeight();
+    unsigned inspectedPageWidth = protect(localMainFrame->view())->visibleWidth();
     unsigned maximumAttachedHeight = inspectedPageHeight * maximumAttachedHeightRatio;
     return minimumAttachedHeight <= maximumAttachedHeight && minimumAttachedWidth <= inspectedPageWidth;
 }

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -152,9 +152,9 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& url, const 
         return ConnectStatus::KO;
     auto frameID = frame ? std::optional(frame->frameID()) : std::nullopt;
     pageID = mainFrame->pageID();
-    if (RefPtr policySourceDocumentLoader = mainFrame->document() ? mainFrame->protectedDocument()->loader() : nullptr) {
+    if (RefPtr policySourceDocumentLoader = mainFrame->document() ? protect(mainFrame->document())->loader() : nullptr) {
         if (!policySourceDocumentLoader->request().url().hasSpecialScheme() && frame->document()->url().protocolIsInHTTPFamily())
-            policySourceDocumentLoader = frame->protectedDocument()->loader();
+            policySourceDocumentLoader = protect(frame->document())->loader();
 
         if (policySourceDocumentLoader) {
             allowPrivacyProxy = policySourceDocumentLoader->allowPrivacyProxy();

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -134,7 +134,7 @@ PluginInfo PDFPluginBase::pluginInfo()
 }
 
 PDFPluginBase::PDFPluginBase(HTMLPlugInElement& element)
-    : m_frame(*WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame()))
+    : m_frame(*WebFrame::fromCoreFrame(*protect(element.document().frame())))
     , m_element(element)
 #if HAVE(INCREMENTAL_PDF_APIS)
     , m_incrementalPDFLoadingEnabled(element.document().settings().incrementalPDFLoadingEnabled())
@@ -942,13 +942,13 @@ IntRect PDFPluginBase::convertFromScrollbarToContainingView(const Scrollbar& scr
     IntRect rect = scrollbarRect;
     rect.move(scrollbar.location() - view->location());
 
-    return view->frame()->protectedView()->convertFromRendererToContainingView(protect(view->pluginElement().renderer()).get(), rect);
+    return protect(view->frame()->view())->convertFromRendererToContainingView(protect(view->pluginElement().renderer()).get(), rect);
 }
 
 IntRect PDFPluginBase::convertFromContainingViewToScrollbar(const Scrollbar& scrollbar, const IntRect& parentRect) const
 {
     Ref view = *m_view;
-    IntRect rect = view->frame()->protectedView()->convertFromContainingViewToRenderer(protect(view->pluginElement().renderer()).get(), parentRect);
+    IntRect rect = protect(view->frame()->view())->convertFromContainingViewToRenderer(protect(view->pluginElement().renderer()).get(), parentRect);
     rect.move(view->location() - scrollbar.location());
 
     return rect;
@@ -960,13 +960,13 @@ IntPoint PDFPluginBase::convertFromScrollbarToContainingView(const Scrollbar& sc
     IntPoint point = scrollbarPoint;
     point.move(scrollbar.location() - view->location());
 
-    return view->frame()->protectedView()->convertFromRendererToContainingView(protect(view->pluginElement().renderer()).get(), point);
+    return protect(view->frame()->view())->convertFromRendererToContainingView(protect(view->pluginElement().renderer()).get(), point);
 }
 
 IntPoint PDFPluginBase::convertFromContainingViewToScrollbar(const Scrollbar& scrollbar, const IntPoint& parentPoint) const
 {
     Ref view = *m_view;
-    IntPoint point = view->frame()->protectedView()->convertFromContainingViewToRenderer(protect(view->pluginElement().renderer()).get(), parentPoint);
+    IntPoint point = protect(view->frame()->view())->convertFromContainingViewToRenderer(protect(view->pluginElement().renderer()).get(), parentPoint);
     point.move(view->location() - scrollbar.location());
 
     return point;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -266,7 +266,7 @@ void UnifiedPDFPlugin::teardown()
     if (m_scrollingNodeID && page) {
         RefPtr scrollingCoordinator = page->scrollingCoordinator();
         scrollingCoordinator->unparentChildrenAndDestroyNode(*m_scrollingNodeID);
-        frame->coreLocalFrame()->protectedView()->removePluginScrollableAreaForScrollingNodeID(*m_scrollingNodeID);
+        protect(frame->coreLocalFrame()->view())->removePluginScrollableAreaForScrollingNodeID(*m_scrollingNodeID);
     }
 
     [[NSNotificationCenter defaultCenter] removeObserver:m_pdfMutationObserver.get() name:mutationObserverNotificationString().createNSString().get() object:m_pdfDocument.get()];
@@ -683,7 +683,7 @@ void UnifiedPDFPlugin::createScrollingNodeIfNecessary()
         layer->setScrollingNodeID(*m_scrollingNodeID);
 #endif
 
-    protect(m_frame)->coreLocalFrame()->protectedView()->setPluginScrollableAreaForScrollingNodeID(*m_scrollingNodeID, *this);
+    protect(protect(m_frame)->coreLocalFrame()->view())->setPluginScrollableAreaForScrollingNodeID(*m_scrollingNodeID, *this);
 
     scrollingCoordinator->setScrollingNodeScrollableAreaGeometry(*m_scrollingNodeID, *this);
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -424,7 +424,7 @@ void PluginView::initializePlugin()
 
 #if PLATFORM(COCOA)
     if (plugin->isComposited() && frame()) {
-        frame()->protectedView()->enterCompositingMode();
+        protect(frame()->view())->enterCompositingMode();
         m_pluginElement->invalidateStyleAndLayerComposition();
     }
     plugin->visibilityDidChange(isVisible());
@@ -929,7 +929,7 @@ IntRect PluginView::clipRectInWindowCoordinates() const
     RefPtr frame = this->frame();
 
     // Get the window clip rect for the plugin element (in window coordinates).
-    IntRect windowClipRect = frame->protectedView()->windowClipRectForFrameOwner(m_pluginElement.ptr(), true);
+    IntRect windowClipRect = protect(frame->view())->windowClipRectForFrameOwner(m_pluginElement.ptr(), true);
 
     // Intersect the two rects to get the view clip rect in window coordinates.
     frameRectInWindowCoordinates.intersect(windowClipRect);
@@ -946,7 +946,7 @@ void PluginView::focusPluginElement()
     if (RefPtr page = frame->page())
         page->focusController().setFocusedElement(pluginElement.ptr(), frame.get());
     else
-        frame->protectedDocument()->setFocusedElement(pluginElement.ptr());
+        protect(frame->document())->setFocusedElement(pluginElement.ptr());
 }
 
 void PluginView::pendingResourceRequestTimerFired()

--- a/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp
@@ -49,7 +49,7 @@ using namespace WebCore;
 RefPtr<ShareableBitmap> createShareableBitmap(RenderImage& renderImage, CreateShareableBitmapFromImageOptions&& options)
 {
     Ref frame = renderImage.frame();
-    auto colorSpaceForBitmap = screenColorSpace(protect(frame->mainFrame())->protectedVirtualView().get());
+    auto colorSpaceForBitmap = screenColorSpace(protect(protect(frame->mainFrame())->virtualView()).get());
     if (!renderImage.isRenderMedia() && !renderImage.opacity() && options.useSnapshotForTransparentImages == UseSnapshotForTransparentImages::Yes) {
         auto snapshotRect = renderImage.absoluteBoundingBoxRect();
         if (snapshotRect.isEmpty())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp
@@ -454,7 +454,7 @@ void WebEditorClient::textFieldDidEndEditing(Element& element)
     if (!inputElement)
         return;
 
-    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(protect(element.document())->frame()));
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())
@@ -469,7 +469,7 @@ void WebEditorClient::textDidChangeInTextField(Element& element)
 
     bool initiatedByUserTyping = UserTypingGestureIndicator::processingUserTypingGesture() && UserTypingGestureIndicator::focusedElementAtGestureStart() == inputElement;
 
-    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(protect(element.document())->frame()));
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())
@@ -485,7 +485,7 @@ void WebEditorClient::textDidChangeInTextArea(Element& element)
     if (!textAreaElement)
         return;
 
-    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(protect(element.document())->frame()));
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())
@@ -572,7 +572,7 @@ bool WebEditorClient::doTextFieldCommandFromEvent(Element& element, KeyboardEven
     if (!getActionTypeForKeyEvent(event, actionType))
         return false;
 
-    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(protect(element.document())->frame()));
     ASSERT(webFrame);
 
     RefPtr page = m_page.get();
@@ -585,7 +585,7 @@ void WebEditorClient::textWillBeDeletedInTextField(Element& element)
     if (!inputElement)
         return;
 
-    auto webFrame = WebFrame::fromCoreFrame(*protect(element.document())->protectedFrame());
+    auto webFrame = WebFrame::fromCoreFrame(*protect(protect(element.document())->frame()));
     ASSERT(webFrame);
 
     if (RefPtr page = m_page.get())

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -970,7 +970,7 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceRe
     uint64_t listenerID = protectedFrame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::No);
 
     bool isShowingInitialAboutBlank = m_localFrame->loader().stateMachine().isDisplayingInitialEmptyDocument();
-    auto activeDocumentCOOPValue = m_localFrame->document() ? m_localFrame->protectedDocument()->crossOriginOpenerPolicy().value : CrossOriginOpenerPolicyValue::SameOrigin;
+    auto activeDocumentCOOPValue = m_localFrame->document() ? protect(m_localFrame->document())->crossOriginOpenerPolicy().value : CrossOriginOpenerPolicyValue::SameOrigin;
 
     webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForResponse(protectedFrame->info(), navigationID, response, request, canShowResponse, downloadAttribute, isShowingInitialAboutBlank, activeDocumentCOOPValue), [frame = protectedFrame, listenerID] (PolicyDecision&& policyDecision) {
         frame->didReceivePolicyDecision(listenerID, WTF::move(policyDecision));
@@ -1108,7 +1108,7 @@ void WebLocalFrameLoaderClient::dispatchWillSendSubmitEvent(Ref<FormState>&& for
     Ref form = formState->form();
 
     ASSERT(formState->sourceDocument().frame());
-    auto sourceFrame = WebFrame::fromCoreFrame(*formState->sourceDocument().protectedFrame());
+    auto sourceFrame = WebFrame::fromCoreFrame(*protect(formState->sourceDocument().frame()));
     ASSERT(sourceFrame);
 
     webPage->injectedBundleFormClient().willSendSubmitEvent(webPage.get(), form.ptr(), m_frame.ptr(), sourceFrame.get(), formState->textFieldValues());

--- a/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
+++ b/Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm
@@ -71,7 +71,7 @@ using DragImage = CGImageRef;
 
 static RefPtr<ShareableBitmap> convertDragImageToBitmap(DragImage image, const IntSize& size, Frame& frame)
 {
-    auto bitmap = ShareableBitmap::create({ size, screenColorSpace(protect(frame.mainFrame())->protectedVirtualView().get()) });
+    auto bitmap = ShareableBitmap::create({ size, screenColorSpace(protect(protect(frame.mainFrame())->virtualView()).get()) });
     if (!bitmap)
         return nullptr;
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -304,7 +304,7 @@ void WebPage::performDictionaryLookupAtLocation(const FloatPoint& floatPoint)
         return;
     // Find the frame the point is over.
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent, HitTestRequest::Type::AllowChildFrameContent };
-    auto result = localMainFrame->eventHandler().hitTestResultAtPoint(localMainFrame->protectedView()->windowToContents(roundedIntPoint(floatPoint)), hitType);
+    auto result = localMainFrame->eventHandler().hitTestResultAtPoint(protect(localMainFrame->view())->windowToContents(roundedIntPoint(floatPoint)), hitType);
 
     RefPtr frame = result.innerNonSharedNode() ? result.innerNonSharedNode()->document().frame() : corePage()->focusController().focusedOrMainFrame();
     if (!frame)
@@ -349,7 +349,7 @@ DictionaryPopupInfo WebPage::dictionaryPopupInfoForRange(LocalFrame& frame, cons
 
     DictionaryPopupInfo dictionaryPopupInfo;
 
-    IntRect rangeRect = frame.protectedView()->contentsToWindow(quads[0].enclosingBoundingBox());
+    IntRect rangeRect = protect(frame.view())->contentsToWindow(quads[0].enclosingBoundingBox());
 
     const CheckedPtr style = protect(range.startContainer())->renderStyle();
     float scaledAscent = style ? style->metricsOfPrimaryFont().intAscent() * pageScaleFactor() : 0;
@@ -645,7 +645,7 @@ WebPaymentCoordinator* WebPage::paymentCoordinator()
 void WebPage::getContentsAsAttributedString(CompletionHandler<void(const WebCore::AttributedString&)>&& completionHandler)
 {
     RefPtr localFrame = protect(corePage())->localMainFrame();
-    completionHandler(localFrame ? attributedString(makeRangeSelectingNodeContents(*localFrame->protectedDocument()), IgnoreUserSelectNone::No) : AttributedString { });
+    completionHandler(localFrame ? attributedString(makeRangeSelectingNodeContents(*protect(localFrame->document())), IgnoreUserSelectNone::No) : AttributedString { });
 }
 
 void WebPage::setRemoteObjectRegistry(WebRemoteObjectRegistry* registry)

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -555,7 +555,7 @@ Vector<FloatRect> FindController::rectsForTextMatchesInRect(IntRect clipRect)
 
         for (FloatRect rect : protect(document->markers())->renderedRectsForMarkers(DocumentMarkerType::TextMatch)) {
             if (!localFrame->isMainFrame())
-                rect = mainFrameView->windowToContents(localFrame->protectedView()->contentsToWindow(enclosingIntRect(rect)));
+                rect = mainFrameView->windowToContents(protect(localFrame->view())->contentsToWindow(enclosingIntRect(rect)));
 
             if (rect.isEmpty() || !rect.intersects(clipRect))
                 continue;
@@ -621,7 +621,7 @@ void FindController::drawRect(PageOverlay&, GraphicsContext& graphicsContext, co
         return;
 
     if (RefPtr selectedFrame = frameWithSelection(protect(protect(m_webPage)->corePage()))) {
-        auto findIndicatorRect = selectedFrame->protectedView()->contentsToRootView(enclosingIntRect(protect(selectedFrame->selection())->selectionBounds(FrameSelection::ClipToVisibleContent::No)));
+        auto findIndicatorRect = protect(selectedFrame->view())->contentsToRootView(enclosingIntRect(protect(selectedFrame->selection())->selectionBounds(FrameSelection::ClipToVisibleContent::No)));
 
         if (findIndicatorRect != m_findIndicatorRect) {
             // We are underneath painting, so it's not safe to mutate the layer tree synchronously.

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm
@@ -165,19 +165,19 @@ void RemoteScrollingCoordinator::startMonitoringWheelEvents(bool clearLatchingSt
 
 void RemoteScrollingCoordinator::receivedWheelEventWithPhases(WebCore::PlatformWheelEventPhase phase, WebCore::PlatformWheelEventPhase momentumPhase)
 {
-    if (auto monitor = protectedPage()->wheelEventTestMonitor())
+    if (auto monitor = protect(page())->wheelEventTestMonitor())
         monitor->receivedWheelEventWithPhases(phase, momentumPhase);
 }
 
 void RemoteScrollingCoordinator::startDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason)
 {
-    if (auto monitor = protectedPage()->wheelEventTestMonitor())
+    if (auto monitor = protect(page())->wheelEventTestMonitor())
         monitor->deferForReason(nodeID, reason);
 }
 
 void RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode(WebCore::ScrollingNodeID nodeID, OptionSet<WebCore::WheelEventTestMonitor::DeferReason> reason)
 {
-    if (auto monitor = protectedPage()->wheelEventTestMonitor())
+    if (auto monitor = protect(page())->wheelEventTestMonitor())
         monitor->removeDeferralForReason(nodeID, reason);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
+++ b/Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp
@@ -138,7 +138,7 @@ void ViewGestureGeometryCollector::collectGeometryForSmartMagnificationGesture(F
     HitTestResult hitTestResult = HitTestResult(originInContentsSpace);
 
     if (RefPtr mainFrame = dynamicDowncast<WebCore::LocalFrame>(webPage->mainFrame()))
-        mainFrame->protectedDocument()->hitTest(HitTestRequest(), hitTestResult);
+        protect(mainFrame->document())->hitTest(HitTestRequest(), hitTestResult);
 
     RefPtr node = hitTestResult.innerNode();
     if (!node) {

--- a/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp
@@ -134,7 +134,7 @@ static WebCore::ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieB
 
 String WebCookieJar::cookies(WebCore::Document& document, const URL& url) const
 {
-    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*document.protectedFrame()) : nullptr;
+    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*protect(document.frame())) : nullptr;
     if (!webFrame)
         return { };
 
@@ -162,7 +162,7 @@ String WebCookieJar::cookies(WebCore::Document& document, const URL& url) const
 
 void WebCookieJar::setCookies(WebCore::Document& document, const URL& url, const String& cookieString)
 {
-    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*document.protectedFrame()) : nullptr;
+    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*protect(document.frame())) : nullptr;
     if (!webFrame)
         return;
 
@@ -225,7 +225,7 @@ void WebCookieJar::clearCacheForHost(const String& host)
 
 bool WebCookieJar::cookiesEnabled(Document& document)
 {
-    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*document.protectedFrame()) : nullptr;
+    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*protect(document.frame())) : nullptr;
     if (!webFrame || !webFrame->page())
         return false;
 
@@ -244,7 +244,7 @@ bool WebCookieJar::cookiesEnabled(Document& document)
 
 bool WebCookieJar::remoteCookiesEnabledSync(Document& document) const
 {
-    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*document.protectedFrame()) : nullptr;
+    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*protect(document.frame())) : nullptr;
     if (!webFrame)
         return false;
 
@@ -265,7 +265,7 @@ bool WebCookieJar::remoteCookiesEnabledSync(Document& document) const
 
 void WebCookieJar::remoteCookiesEnabled(const Document& document, CompletionHandler<void(bool)>&& completionHandler) const
 {
-    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*document.protectedFrame()) : nullptr;
+    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*protect(document.frame())) : nullptr;
     if (!webFrame)
         return completionHandler(false);
 
@@ -298,7 +298,7 @@ std::pair<String, WebCore::SecureCookiesAccessed> WebCookieJar::cookieRequestHea
 
 bool WebCookieJar::getRawCookies(WebCore::Document& document, const URL& url, Vector<WebCore::Cookie>& rawCookies) const
 {
-    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*document.protectedFrame()) : nullptr;
+    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*protect(document.frame())) : nullptr;
     if (shouldBlockCookies(webFrame.get(), document.firstPartyForCookies(), url) == BlockCookies::Yes)
         return false;
 
@@ -410,7 +410,7 @@ void WebCookieJar::addChangeListenerWithAccess(const URL& url, const URL& firstP
 
 void WebCookieJar::addChangeListener(const WebCore::Document& document, const WebCore::CookieChangeListener& listener)
 {
-    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*document.protectedFrame()) : nullptr;
+    RefPtr webFrame = document.frame() ? WebFrame::fromCoreFrame(*protect(document.frame())) : nullptr;
     if (!webFrame)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp
@@ -544,7 +544,7 @@ Vector<WebCore::FloatRect> WebFoundTextRangeController::rectsForTextMatchesInRec
 
         for (auto rect : protect(document->markers())->renderedRectsForMarkers(WebCore::DocumentMarkerType::TextMatch)) {
             if (!localFrame->isMainFrame())
-                rect = mainFrameView->windowToContents(localFrame->protectedView()->contentsToWindow(enclosingIntRect(rect)));
+                rect = mainFrameView->windowToContents(protect(localFrame->view())->contentsToWindow(enclosingIntRect(rect)));
 
             if (rect.isEmpty() || !rect.intersects(clipRect))
                 continue;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -458,7 +458,7 @@ void WebFrame::createProvisionalFrame(ProvisionalFrameCreationParameters&& param
     m_provisionalFrame = localFrame.ptr();
     m_frameIDBeforeProvisionalNavigation = parameters.frameIDBeforeProvisionalNavigation;
     localFrame->init();
-    localFrame->protectedDocument()->setURL(URL { aboutBlankURL() });
+    protect(localFrame->document())->setURL(URL { aboutBlankURL() });
 
     if (parameters.layerHostingContextIdentifier)
         setLayerHostingContextIdentifier(*parameters.layerHostingContextIdentifier);
@@ -630,7 +630,7 @@ void WebFrame::startDownload(const WebCore::ResourceRequest& request, const Stri
         return;
     }
     RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-    auto topOrigin = localFrame && localFrame->document() ? std::optional { localFrame->protectedDocument()->topOrigin().data() } : std::nullopt;
+    auto topOrigin = localFrame && localFrame->document() ? std::optional { protect(localFrame->document())->topOrigin().data() } : std::nullopt;
     auto policyDownloadID = *std::exchange(m_policyDownloadID, std::nullopt);
 
     std::optional<NavigatingToAppBoundDomain> isAppBound = NavigatingToAppBoundDomain::No;
@@ -646,7 +646,7 @@ void WebFrame::convertMainResourceLoadToDownload(DocumentLoader* documentLoader,
         return;
     }
     RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
-    auto topOrigin = localFrame && localFrame->document() ? std::optional { localFrame->protectedDocument()->topOrigin().data() } : std::nullopt;
+    auto topOrigin = localFrame && localFrame->document() ? std::optional { protect(localFrame->document())->topOrigin().data() } : std::nullopt;
     auto policyDownloadID = *std::exchange(m_policyDownloadID, std::nullopt);
 
     RefPtr mainResourceLoader = documentLoader->mainResourceLoader();
@@ -1382,7 +1382,7 @@ bool WebFrame::handleContextMenuEvent(const PlatformMouseEvent& platformMouseEve
     RefPtr coreLocalFrame = dynamicDowncast<LocalFrame>(coreFrame());
     if (!coreLocalFrame)
         return false;
-    IntPoint point = coreLocalFrame->protectedView()->windowToContents(flooredIntPoint(platformMouseEvent.position()));
+    IntPoint point = protect(coreLocalFrame->view())->windowToContents(flooredIntPoint(platformMouseEvent.position()));
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::DisallowUserAgentShadowContent,  HitTestRequest::Type::AllowChildFrameContent };
     HitTestResult result = coreLocalFrame->eventHandler().hitTestResultAtPoint(point, hitType);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2498,7 +2498,7 @@ void WebPage::drawRect(GraphicsContext& graphicsContext, const IntRect& rect)
     GraphicsContextStateSaver stateSaver(graphicsContext);
     graphicsContext.clip(rect);
 
-    m_mainFrame->coreLocalFrame()->protectedView()->paint(graphicsContext, rect);
+    protect(m_mainFrame->coreLocalFrame()->view())->paint(graphicsContext, rect);
 
 #if PLATFORM(GTK) || PLATFORM(WIN) || PLATFORM(PLAYSTATION)
     if (!m_page->settings().acceleratedCompositingEnabled() && m_page->inspectorController().enabled() && m_page->inspectorController().shouldShowOverlay()) {
@@ -2967,7 +2967,7 @@ void WebPage::viewportPropertiesDidChange(const ViewportArguments& viewportArgum
 
 FloatSize WebPage::screenSizeForFingerprintingProtections(const LocalFrame& frame, FloatSize defaultSize) const
 {
-    return frame.view() ? FloatSize { frame.protectedView()->unobscuredContentRectIncludingScrollbars().size() } : defaultSize;
+    return frame.view() ? FloatSize { protect(frame.view())->unobscuredContentRectIncludingScrollbars().size() } : defaultSize;
 }
 
 #endif // !PLATFORM(IOS_FAMILY)
@@ -3324,7 +3324,7 @@ static DestinationColorSpace snapshotColorSpace(SnapshotOptions options, WebPage
 {
 #if USE(CG)
     if (options.contains(SnapshotOption::UseScreenColorSpace)) {
-        auto screenColorSpace = WebCore::screenColorSpace(protect(protect(page.corePage())->mainFrame())->protectedVirtualView().get());
+        auto screenColorSpace = WebCore::screenColorSpace(protect(protect(protect(page.corePage())->mainFrame())->virtualView()).get());
 #if HAVE(SUPPORT_HDR_DISPLAY)
         if (options.contains(SnapshotOption::AllowHDR) && protect(page.corePage())->drawsHDRContent()) {
             if (auto extendedScreenColorSpace = screenColorSpace.asExtended())
@@ -4263,7 +4263,7 @@ void WebPage::setInitialFocus(bool forward, bool isKeyboardEventValid, const std
     RefPtr frame = focusController->focusedOrMainFrame();
     if (!frame)
         return completionHandler();
-    frame->protectedDocument()->setFocusedElement(nullptr);
+    protect(frame->document())->setFocusedElement(nullptr);
 
     if (isKeyboardEventValid && event && event->type() == WebEventType::KeyDown) {
         PlatformKeyboardEvent platformEvent(platform(CheckedRef { *event }));
@@ -6066,7 +6066,7 @@ bool WebPage::hasRichlyEditableSelection() const
 
 void WebPage::changeSpellingToWord(const String& word)
 {
-    replaceSelectionWithText(corePage()->focusController().protectedFocusedOrMainFrame().get(), word);
+    replaceSelectionWithText(protect(corePage()->focusController().focusedOrMainFrame()).get(), word);
 }
 
 void WebPage::unmarkAllMisspellings()
@@ -7529,7 +7529,7 @@ void WebPage::setAutoSizingShouldExpandToViewHeight(bool shouldExpand)
     m_autoSizingShouldExpandToViewHeight = shouldExpand;
 
     if (RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame()))
-        localMainFrame->protectedView()->setAutoSizeFixedMinimumHeight(shouldExpand ? m_viewSize.height() : 0);
+        protect(localMainFrame->view())->setAutoSizeFixedMinimumHeight(shouldExpand ? m_viewSize.height() : 0);
 }
 
 void WebPage::setViewportSizeForCSSViewportUnits(std::optional<WebCore::FloatSize> viewportSize)
@@ -7540,7 +7540,7 @@ void WebPage::setViewportSizeForCSSViewportUnits(std::optional<WebCore::FloatSiz
     m_viewportSizeForCSSViewportUnits = viewportSize;
     if (m_viewportSizeForCSSViewportUnits) {
         if (RefPtr localMainFrame = dynamicDowncast<WebCore::LocalFrame>(corePage()->mainFrame()))
-            localMainFrame->protectedView()->setSizeForCSSDefaultViewportUnits(*m_viewportSizeForCSSViewportUnits);
+            protect(localMainFrame->view())->setSizeForCSSDefaultViewportUnits(*m_viewportSizeForCSSViewportUnits);
     }
 }
 
@@ -7799,7 +7799,7 @@ void WebPage::didCommitLoad(WebFrame* frame)
 
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
     if (coreFrame->isMainFrame() && !usesEphemeralSession()) {
-        if (RefPtr loader = coreFrame->protectedDocument()->loader(); loader
+        if (RefPtr loader = protect(coreFrame->document())->loader(); loader
             && loader->advancedPrivacyProtections().contains(AdvancedPrivacyProtections::BaselineProtections))
             WEBPAGE_RELEASE_LOG(AdvancedPrivacyProtections, "didCommitLoad: advanced privacy protections enabled in non-ephemeral session");
     }
@@ -8096,7 +8096,7 @@ unsigned WebPage::extendIncrementalRenderingSuppression()
 
     m_activeRenderingSuppressionTokens.add(token);
     if (RefPtr localMainFrame = this->localMainFrame())
-        localMainFrame->protectedView()->setVisualUpdatesAllowedByClient(false);
+        protect(localMainFrame->view())->setVisualUpdatesAllowedByClient(false);
 
     m_maximumRenderingSuppressionToken = token;
 
@@ -8109,7 +8109,7 @@ void WebPage::stopExtendingIncrementalRenderingSuppression(unsigned token)
         return;
 
     if (RefPtr localMainFrame = this->localMainFrame())
-        localMainFrame->protectedView()->setVisualUpdatesAllowedByClient(!shouldExtendIncrementalRenderingSuppression());
+        protect(localMainFrame->view())->setVisualUpdatesAllowedByClient(!shouldExtendIncrementalRenderingSuppression());
 }
 
 WebCore::ScrollPinningBehavior WebPage::scrollPinningBehavior()
@@ -8121,7 +8121,7 @@ void WebPage::setScrollPinningBehavior(WebCore::ScrollPinningBehavior pinning)
 {
     m_internals->scrollPinningBehavior = pinning;
     if (RefPtr localMainFrame = this->localMainFrame())
-        localMainFrame->protectedView()->setScrollPinningBehavior(m_internals->scrollPinningBehavior);
+        protect(localMainFrame->view())->setScrollPinningBehavior(m_internals->scrollPinningBehavior);
 }
 
 void WebPage::setScrollbarOverlayStyle(std::optional<WebCore::ScrollbarOverlayStyle> scrollbarStyle)
@@ -8129,7 +8129,7 @@ void WebPage::setScrollbarOverlayStyle(std::optional<WebCore::ScrollbarOverlaySt
     m_scrollbarOverlayStyle = scrollbarStyle;
 
     if (RefPtr localMainFrame = this->localMainFrame())
-        localMainFrame->protectedView()->recalculateScrollbarOverlayStyle();
+        protect(localMainFrame->view())->recalculateScrollbarOverlayStyle();
 }
 
 Ref<DocumentLoader> WebPage::createDocumentLoader(LocalFrame& frame, ResourceRequest&& request, SubstituteData&& substituteData, ResourceRequest&& originalRequest)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -886,7 +886,7 @@ void WebPage::handleSyntheticClick(std::optional<WebCore::FrameIdentifier> frame
         if (!localRootFrame)
             return;
         dispatchSyntheticMouseMove(*localRootFrame, location, modifiers, pointerId);
-        localRootFrame->protectedDocument()->updateStyleIfNeeded();
+        protect(localRootFrame->document())->updateStyleIfNeeded();
         if (m_isClosed)
             return;
     }
@@ -4989,7 +4989,7 @@ void WebPage::requestDocumentEditingContext(DocumentEditingContextRequest&& requ
     if (!view)
         return completionHandler({ });
 
-    frame->protectedDocument()->updateLayout(LayoutOptions::IgnorePendingStylesheets);
+    protect(frame->document())->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     VisibleSelection selection = frame->selection().selection();
 
@@ -5284,7 +5284,7 @@ void WebPage::focusTextInputContextAndPlaceCaret(const ElementContext& elementCo
     ASSERT(target->document().frame());
     Ref targetFrame = *target->document().frame();
 
-    targetFrame->protectedDocument()->updateLayout(LayoutOptions::IgnorePendingStylesheets);
+    protect(targetFrame->document())->updateLayout(LayoutOptions::IgnorePendingStylesheets);
 
     // Performing layout could have could torn down the element's renderer. Check that we still
     // have one. Otherwise, bail out as this function only focuses elements that have a visual

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -212,10 +212,10 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
 
     auto quads = RenderObject::absoluteTextQuads(*selectedRange);
     if (!quads.isEmpty())
-        postLayoutData.selectionBoundingRect = frame.protectedView()->contentsToWindow(enclosingIntRect(unitedBoundingBoxes(quads)));
+        postLayoutData.selectionBoundingRect = protect(frame.view())->contentsToWindow(enclosingIntRect(unitedBoundingBoxes(quads)));
     else if (selection.isCaret()) {
         // Quads will be empty at the start of a paragraph.
-        postLayoutData.selectionBoundingRect = frame.protectedView()->contentsToWindow(protect(frame.selection())->absoluteCaretBounds());
+        postLayoutData.selectionBoundingRect = protect(frame.view())->contentsToWindow(protect(frame.selection())->absoluteCaretBounds());
     }
 }
 
@@ -550,7 +550,7 @@ void WebPage::shouldDelayWindowOrderingEvent(const WebKit::WebMouseEvent& event,
     bool result = false;
 #if ENABLE(DRAG_SUPPORT)
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent };
-    HitTestResult hitResult = frame->eventHandler().hitTestResultAtPoint(frame->protectedView()->windowToContents(flooredIntPoint(event.position())), hitType);
+    HitTestResult hitResult = frame->eventHandler().hitTestResultAtPoint(protect(frame->view())->windowToContents(flooredIntPoint(event.position())), hitType);
     if (hitResult.isSelected())
         result = frame->eventHandler().eventMayStartDrag(platform(event));
 #endif
@@ -571,7 +571,7 @@ void WebPage::requestAcceptsFirstMouse(int eventNumber, const WebKit::WebMouseEv
         return;
 
     constexpr OptionSet<HitTestRequest::Type> hitType { HitTestRequest::Type::ReadOnly, HitTestRequest::Type::Active, HitTestRequest::Type::AllowChildFrameContent };
-    HitTestResult hitResult = frame->eventHandler().hitTestResultAtPoint(frame->protectedView()->windowToContents(flooredIntPoint(event.position())), hitType);
+    HitTestResult hitResult = frame->eventHandler().hitTestResultAtPoint(protect(frame->view())->windowToContents(flooredIntPoint(event.position())), hitType);
     frame->eventHandler().setActivationEventNumber(eventNumber);
     bool result = false;
 #if ENABLE(DRAG_SUPPORT)
@@ -743,7 +743,7 @@ void WebPage::performImmediateActionHitTestAtLocation(WebCore::FrameIdentifier f
         return;
     }
 
-    auto locationInContentCoordinates = localCurrentFrame->protectedView()->rootViewToContents(roundedIntPoint(locationInViewCoordinates));
+    auto locationInContentCoordinates = protect(localCurrentFrame->view())->rootViewToContents(roundedIntPoint(locationInViewCoordinates));
     auto hitTestResult = localCurrentFrame->eventHandler().hitTestResultAtPoint(locationInContentCoordinates, {
         HitTestRequest::Type::ReadOnly,
         HitTestRequest::Type::Active,
@@ -861,10 +861,10 @@ std::optional<WebCore::SimpleRange> WebPage::lookupTextAtLocation(FrameIdentifie
 {
     RefPtr currentFrame = WebProcess::singleton().webFrame(frameID);
     RefPtr localCurrentFrame = dynamicDowncast<LocalFrame>(currentFrame->coreFrame());
-    if (!localCurrentFrame || !localCurrentFrame->view() || !localCurrentFrame->protectedView()->renderView())
+    if (!localCurrentFrame || !localCurrentFrame->view() || !protect(localCurrentFrame->view())->renderView())
         return std::nullopt;
 
-    return DictionaryLookup::rangeAtHitTestResult(localCurrentFrame->eventHandler().hitTestResultAtPoint(localCurrentFrame->protectedView()->windowToContents(roundedIntPoint(locationInViewCoordinates)), {
+    return DictionaryLookup::rangeAtHitTestResult(localCurrentFrame->eventHandler().hitTestResultAtPoint(protect(localCurrentFrame->view())->windowToContents(roundedIntPoint(locationInViewCoordinates)), {
         HitTestRequest::Type::ReadOnly,
         HitTestRequest::Type::Active,
         HitTestRequest::Type::DisallowUserAgentShadowContentExceptForImageOverlays,


### PR DESCRIPTION
#### 4ffc81513e8b73e0edcf4cab3f712c92bf731fd4
<pre>
Further reduce use of protected functions in Source/WebCore
<a href="https://bugs.webkit.org/show_bug.cgi?id=307645">https://bugs.webkit.org/show_bug.cgi?id=307645</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/Modules/gamepad/NavigatorGamepad.cpp:
(WebCore::NavigatorGamepad::protectedPage const): Deleted.
* Source/WebCore/Modules/gamepad/NavigatorGamepad.h:
* Source/WebCore/Modules/mediacontrols/MediaControlsHost.cpp:
(WebCore::MediaControlsHost::showMediaControlsContextMenu):
* Source/WebCore/Modules/webdatabase/DatabaseContext.cpp:
(WebCore::DatabaseContext::databaseExceededQuota):
* Source/WebCore/bindings/js/JSLazyEventListener.cpp:
(WebCore::JSLazyEventListener::initializeJSFunction const):
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::colorFeatureSchema):
(WebCore::MQ::Features::colorGamutFeatureSchema):
(WebCore::MQ::Features::dynamicRangeFeatureSchema):
* Source/WebCore/dom/DataTransfer.cpp:
(WebCore::DataTransfer::readStringFromPasteboard const):
* Source/WebCore/dom/DeviceOrientationAndMotionAccessController.cpp:
(WebCore::DeviceOrientationAndMotionAccessController::shouldAllowAccess):
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::removeVisualUpdatePreventedReasons):
(WebCore::Document::didBecomeCurrentDocumentInFrame):
(WebCore::Document::willDetachPage):
(WebCore::Document::open):
(WebCore::Document::updateViewportArguments):
(WebCore::Document::applyPendingXSLTransformsTimerFired):
(WebCore::Document::allowsContentJavaScript const):
(WebCore::Document::didAssociateFormControlsTimerFired):
* Source/WebCore/dom/DocumentPage.h:
(WebCore::Frame::protectedPage const): Deleted.
* Source/WebCore/dom/DocumentView.h:
(WebCore::LocalFrame::protectedView const): Deleted.
* Source/WebCore/editing/FrameSelection.cpp:
(WebCore::FrameSelection::setFocusedElementIfNeeded):
* Source/WebCore/editing/glib/WebContentReaderGLib.cpp:
(WebCore::WebContentReader::readFilePath):
(WebCore::WebContentReader::readHTML):
* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):
* Source/WebCore/html/FileInputType.cpp:
(WebCore::FileInputType::showPicker):
* Source/WebCore/html/HTMLAnchorElement.cpp:
(WebCore::HTMLAnchorElement::sendPings):
* Source/WebCore/html/HTMLFrameElementBase.cpp:
(WebCore::HTMLFrameElementBase::canLoadURL const):
* Source/WebCore/inspector/InspectorFrontendClientLocal.cpp:
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowHeight):
(WebCore::InspectorFrontendClientLocal::changeAttachedWindowWidth):
(WebCore::InspectorFrontendClientLocal::restoreAttachedWindowHeight):
* Source/WebCore/loader/CrossOriginPreflightChecker.cpp:
(WebCore::CrossOriginPreflightChecker::doPreflight):
* Source/WebCore/loader/LinkLoader.cpp:
(WebCore::LinkLoader::preconnectIfNeeded):
* Source/WebCore/page/Chrome.cpp:
(WebCore::Chrome::scroll):
(WebCore::Chrome::runJavaScriptConfirm):
(WebCore::Chrome::runJavaScriptPrompt):
(WebCore::Chrome::mouseDidMoveOverElement):
(WebCore::Chrome::windowScreenDidChange):
(WebCore::Chrome::protectedPage const): Deleted.
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/DOMWindow.cpp:
(WebCore::DOMWindow::close):
(WebCore::DOMWindow::protectedFrame const): Deleted.
(WebCore::DOMWindow::protectedDocumentIfLocal): Deleted.
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/DOMWindowExtension.cpp:
(WebCore::DOMWindowExtension::resumeFromBackForwardCache):
(WebCore::DOMWindowExtension::protectedFrame const): Deleted.
* Source/WebCore/page/DOMWindowExtension.h:
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::RegionOverlay::overlay):
(WebCore::InteractionRegionOverlay::updateRegion):
(WebCore::RegionOverlay::recomputeRegion):
(WebCore::DebugPageOverlays::showRegionOverlay):
(WebCore::DebugPageOverlays::hideRegionOverlay):
(WebCore::RegionOverlay::protectedOverlay): Deleted.
* Source/WebCore/page/DragController.cpp:
(WebCore::DragController::tryDocumentDrag):
(WebCore::DragController::concludeEditDrag):
(WebCore::DragController::placeDragCaret):
(WebCore::DragController::protectedPage const): Deleted.
* Source/WebCore/page/DragController.h:
(WebCore::DragController::documentUnderMouse const):
(WebCore::DragController::protectedDocumentUnderMouse const): Deleted.
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::updateSelectionForMouseDownDispatchingSelectStart):
(WebCore::EventHandler::handleMousePressEventDoubleClick):
(WebCore::EventHandler::handleMousePressEvent):
(WebCore::EventHandler::lostMouseCapture):
(WebCore::EventHandler::scrollRecursively):
(WebCore::EventHandler::logicalScrollRecursively):
(WebCore::EventHandler::subframeForHitTestResult):
(WebCore::EventHandler::useHandCursor):
(WebCore::EventHandler::handleMouseDoubleClickEvent):
(WebCore::EventHandler::handleMouseMoveEvent):
(WebCore::EventHandler::swallowAnyClickEvent):
(WebCore::EventHandler::handleMouseReleaseEvent):
(WebCore::EventHandler::handleMouseForceEvent):
(WebCore::EventHandler::handlePasteGlobalSelection):
(WebCore::EventHandler::clearElementUnderMouse):
(WebCore::EventHandler::dispatchMouseEvent):
(WebCore::EventHandler::handleWheelEventInternal):
(WebCore::EventHandler::sendContextMenuEvent):
(WebCore::EventHandler::handleKeyboardSelectionMovementForAccessibility):
(WebCore::EventHandler::dispatchEventToDragSourceElement):
(WebCore::EventHandler::dispatchDragStartEventOnSourceElement):
(WebCore::EventHandler::keyboardScrollRecursively):
(WebCore::EventHandler::focusDocumentView):
(WebCore::EventHandler::protectedDraggedElement): Deleted.
(WebCore::EventHandler::protectedFrame const): Deleted.
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::FocusController::setFocusedFrame):
(WebCore::FocusController::setFocused):
(WebCore::FocusController::findFocusableElementInDocumentOrderStartingWithFrame):
(WebCore::FocusController::setActive):
(WebCore::FocusController::protectedPage const): Deleted.
* Source/WebCore/page/FocusController.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::protectedWindow const): Deleted.
(WebCore::Frame::protectedVirtualView const): Deleted.
* Source/WebCore/page/Frame.h:
(WebCore::Frame::window const):
* Source/WebCore/page/FrameDestructionObserver.h:
* Source/WebCore/page/FrameDestructionObserverInlines.h:
(WebCore::FrameDestructionObserver::protectedFrame const): Deleted.
* Source/WebCore/page/FrameInlines.h:
(WebCore::Frame::protectedOwnerElement const): Deleted.
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::protectedThisFrame const): Deleted.
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/ImageOverlayController.cpp:
(WebCore::ImageOverlayController::selectionQuadsDidChange):
(WebCore::ImageOverlayController::installPageOverlayIfNeeded):
(WebCore::ImageOverlayController::uninstallPageOverlay):
(WebCore::ImageOverlayController::protectedPage const): Deleted.
* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::willDetachDocumentFromFrame):
(WebCore::LocalDOMWindow::crypto const):
(WebCore::LocalDOMWindow::performance const):
(WebCore::LocalDOMWindow::processPostMessage):
(WebCore::LocalDOMWindow::closePage):
(WebCore::LocalDOMWindow::outerHeight const):
(WebCore::LocalDOMWindow::outerWidth const):
(WebCore::LocalDOMWindow::screenX const):
(WebCore::LocalDOMWindow::screenY const):
(WebCore::LocalDOMWindow::length const):
(WebCore::LocalDOMWindow::getMatchedCSSRules const):
(WebCore::LocalDOMWindow::scrollBy const):
(WebCore::LocalDOMWindow::scrollTo const):
(WebCore::LocalDOMWindow::webkitRequestAnimationFrame):
(WebCore::LocalDOMWindow::deviceOrientationController const):
(WebCore::LocalDOMWindow::deviceMotionController const):
(WebCore::LocalDOMWindow::failedToRegisterDeviceMotionEventListener):
(WebCore::LocalDOMWindow::dispatchLoadEvent):
(WebCore::LocalDOMWindow::queueEventTimingCandidateForDispatch):
(WebCore::LocalDOMWindow::setLocation):
(WebCore::LocalDOMWindow::cookieStore):
(WebCore::LocalDOMWindow::protectedPage const): Deleted.
(WebCore::LocalDOMWindow::protectedFrameElement const): Deleted.
(WebCore::LocalDOMWindow::protectedDocument const): Deleted.
(WebCore::LocalDOMWindow::protectedFrame const): Deleted.
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalDOMWindowProperty.cpp:
(WebCore::LocalDOMWindowProperty::protectedFrame const): Deleted.
* Source/WebCore/page/LocalDOMWindowProperty.h:
(WebCore::LocalDOMWindowProperty::protectedWindow const): Deleted.
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::LocalFrame::protectedWindow const): Deleted.
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameInlines.h:
(WebCore::LocalFrame::editor):
(WebCore::LocalFrame::editor const):
(WebCore::LocalFrame::protectedDocument const): Deleted.
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::layout):
(WebCore::LocalFrameViewLayoutContext::performLayout):
(WebCore::LocalFrameViewLayoutContext::flushUpdateLayerPositions):
(WebCore::LocalFrameViewLayoutContext::updateCompositingLayersAfterStyleChange):
(WebCore::LocalFrameViewLayoutContext::scheduleLayout):
(WebCore::LocalFrameViewLayoutContext::scheduleSubtreeLayout):
(WebCore::LocalFrameViewLayoutContext::applyTextSizingIfNeeded):
(WebCore::LocalFrameViewLayoutContext::protectedFrame): Deleted.
(WebCore::LocalFrameViewLayoutContext::protectedDocument const): Deleted.
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/Location.cpp:
(WebCore::Location::protectedWindow): Deleted.
* Source/WebCore/page/Location.h:
* Source/WebCore/page/MouseEventWithHitTestResults.h:
(WebCore::MouseEventWithHitTestResults::targetNode const):
(WebCore::MouseEventWithHitTestResults::protectedTargetNode const): Deleted.
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::createForPageswapEvent):
(WebCore::Navigation::serializeState):
(WebCore::Navigation::navigate):
(WebCore::Navigation::updateCurrentEntry):
(WebCore::Navigation::rejectFinishedPromise):
(WebCore::Navigation::disposeOfForwardEntriesInParents):
(WebCore::Navigation::updateForNavigation):
(WebCore::Navigation::innerDispatchNavigateEvent):
(WebCore::Navigation::protectedScriptExecutionContext const): Deleted.
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/Navigator.cpp:
(WebCore::Navigator::protectedPage): Deleted.
(WebCore::Navigator::protectedDocument): Deleted.
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::scrollingCoordinator):
(WebCore::Page::screenPropertiesDidChange):
(WebCore::Page::windowScreenDidChange):
(WebCore::Page::protectedScrollingCoordinator): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageOverlay.cpp:
(WebCore::PageOverlay::mouseEvent):
* Source/WebCore/page/PageOverlayController.cpp:
(WebCore::PageOverlayController::createRootLayersIfNeeded):
(WebCore::PageOverlayController::installedPageOverlaysChanged):
(WebCore::PageOverlayController::attachViewOverlayLayers):
(WebCore::PageOverlayController::detachViewOverlayLayers):
(WebCore::PageOverlayController::layerWithDocumentOverlays):
(WebCore::PageOverlayController::layerWithViewOverlays):
(WebCore::PageOverlayController::installPageOverlay):
(WebCore::PageOverlayController::updateForceSynchronousScrollLayerPositionUpdates):
(WebCore::PageOverlayController::didChangeDeviceScaleFactor):
(WebCore::PageOverlayController::didChangeViewExposedRect):
(WebCore::PageOverlayController::notifyFlushRequired):
(WebCore::PageOverlayController::protectedPage const): Deleted.
(WebCore::PageOverlayController::protectedLayerWithViewOverlays): Deleted.
(WebCore::PageOverlayController::protectedDocumentOverlayRootLayer const): Deleted.
(WebCore::PageOverlayController::protectedViewOverlayRootLayer const): Deleted.
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/page/PerformanceObserver.cpp:
(WebCore::PerformanceObserver::observe):
(WebCore::PerformanceObserver::protectedPerformance const): Deleted.
* Source/WebCore/page/PerformanceObserver.h:
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldEnableRTCEncodedStreamsQuirk const):
(WebCore::Quirks::shouldUseEphemeralPartitionedStorageForDOMCookies const):
(WebCore::Quirks::needsLaxSameSiteCookieQuirk const):
(WebCore::Quirks::topDocumentURL const):
(WebCore::Quirks::protectedDocument const): Deleted.
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/ResizeObservation.cpp:
(WebCore::ResizeObservation::protectedTarget const): Deleted.
* Source/WebCore/page/ResizeObservation.h:
(WebCore::ResizeObservation::target const):
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::gatherObservations):
(WebCore::ResizeObserver::removeAllTargets):
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::SettingsBase::fontFallbackPrefersPictographsChanged):
(WebCore::SettingsBase::protectedPage const): Deleted.
* Source/WebCore/page/SettingsBase.h:
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::scrollInDirection):
(WebCore::canScrollInDirection):
(WebCore::nodeRectInAbsoluteCoordinates):
(WebCore::virtualRectForAreaElementAndDirection):
* Source/WebCore/page/TextIndicator.h:
(WebCore::TextIndicator::contentImage const):
(WebCore::TextIndicator::protectedContentImage const): Deleted.
* Source/WebCore/page/UndoItem.cpp:
(WebCore::UndoItem::protectedDocument const): Deleted.
* Source/WebCore/page/UndoItem.h:
* Source/WebCore/page/WebKitNamespace.cpp:
(WebCore::WebKitNamespace::WebKitNamespace):
* Source/WebCore/page/cocoa/ContentChangeObserver.cpp:
(WebCore::ContentChangeObserver::adjustObservedState):
* Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm:
(createContentCrossfadeAnimation):
* Source/WebCore/page/ios/EventHandlerIOS.mm:
(WebCore::EventHandler::focusDocumentView):
(WebCore::EventHandler::mouseDown):
(WebCore::EventHandler::mouseMoved):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::EventHandler::focusDocumentView):
(WebCore::EventHandler::determineWheelEventTarget):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::handleDataDetectorAction):
(WebCore::ImageOverlayController::scheduleRenderingUpdate):
(WebCore::ImageOverlayController::deviceScaleFactor const):
(WebCore::ImageOverlayController::createGraphicsLayer):
* Source/WebCore/page/mac/ServicesOverlayController.h:
(WebCore::ServicesOverlayController::page const):
(WebCore::ServicesOverlayController::protectedPage const): Deleted.
* Source/WebCore/page/mac/ServicesOverlayController.mm:
(WebCore::ServicesOverlayController::scheduleRenderingUpdate):
(WebCore::ServicesOverlayController::deviceScaleFactor const):
(WebCore::ServicesOverlayController::createGraphicsLayer):
* Source/WebCore/page/scrolling/ScrollingCoordinator.cpp:
(WebCore::ScrollingCoordinator::protectedPage const): Deleted.
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp:
(WebCore::XMLDocumentParser::startElementNs):
* Source/WebKit/WebProcess/Automation/WebAutomationSessionProxy.cpp:
(WebKit::WebAutomationSessionProxy::takeScreenshot):
(WebKit::WebAutomationSessionProxy::snapshotRectForScreenshot):
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundlePage.cpp:
(WKAccessibilityAnnounce):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(-[WKWebProcessPlugInBrowserContextController mainFrameDocument]):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::numberOfPages):
(WebKit::InjectedBundle::pageNumberForElementById):
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundleDOMWindowExtension.cpp:
(WebKit::InjectedBundleDOMWindowExtension::InjectedBundleDOMWindowExtension):
* Source/WebKit/WebProcess/Inspector/WebInspectorBackend.cpp:
(WebKit::WebInspectorBackend::canAttachWindow):
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::connect):
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::convertFromScrollbarToContainingView const):
(WebKit::PDFPluginBase::convertFromContainingViewToScrollbar const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::teardown):
(WebKit::UnifiedPDFPlugin::createScrollingNodeIfNecessary):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::initializePlugin):
(WebKit::PluginView::clipRectInWindowCoordinates const):
(WebKit::PluginView::focusPluginElement):
* Source/WebKit/WebProcess/WebCoreSupport/ShareableBitmapUtilities.cpp:
(WebKit::createShareableBitmap):
* Source/WebKit/WebProcess/WebCoreSupport/WebEditorClient.cpp:
(WebKit::WebEditorClient::textFieldDidEndEditing):
(WebKit::WebEditorClient::textDidChangeInTextField):
(WebKit::WebEditorClient::textDidChangeInTextArea):
(WebKit::WebEditorClient::doTextFieldCommandFromEvent):
(WebKit::WebEditorClient::textWillBeDeletedInTextField):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse):
(WebKit::WebLocalFrameLoaderClient::dispatchWillSendSubmitEvent):
* Source/WebKit/WebProcess/WebCoreSupport/mac/WebDragClientMac.mm:
(WebKit::convertDragImageToBitmap):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::performDictionaryLookupAtLocation):
(WebKit::WebPage::dictionaryPopupInfoForRange):
(WebKit::WebPage::getContentsAsAttributedString):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::rectsForTextMatchesInRect):
(WebKit::FindController::drawRect):
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteScrollingCoordinator.mm:
(WebKit::RemoteScrollingCoordinator::receivedWheelEventWithPhases):
(WebKit::RemoteScrollingCoordinator::startDeferringScrollingTestCompletionForNode):
(WebKit::RemoteScrollingCoordinator::stopDeferringScrollingTestCompletionForNode):
* Source/WebKit/WebProcess/WebPage/ViewGestureGeometryCollector.cpp:
(WebKit::ViewGestureGeometryCollector::collectGeometryForSmartMagnificationGesture):
* Source/WebKit/WebProcess/WebPage/WebCookieJar.cpp:
(WebKit::WebCookieJar::cookies const):
(WebKit::WebCookieJar::setCookies):
(WebKit::WebCookieJar::cookiesEnabled):
(WebKit::WebCookieJar::remoteCookiesEnabledSync const):
(WebKit::WebCookieJar::remoteCookiesEnabled const):
(WebKit::WebCookieJar::getRawCookies const):
(WebKit::WebCookieJar::addChangeListener):
* Source/WebKit/WebProcess/WebPage/WebFoundTextRangeController.cpp:
(WebKit::WebFoundTextRangeController::rectsForTextMatchesInRect):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createProvisionalFrame):
(WebKit::WebFrame::startDownload):
(WebKit::WebFrame::convertMainResourceLoadToDownload):
(WebKit::WebFrame::handleContextMenuEvent):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::drawRect):
(WebKit::WebPage::screenSizeForFingerprintingProtections const):
(WebKit::snapshotColorSpace):
(WebKit::WebPage::setInitialFocus):
(WebKit::WebPage::changeSpellingToWord):
(WebKit::WebPage::setAutoSizingShouldExpandToViewHeight):
(WebKit::WebPage::setViewportSizeForCSSViewportUnits):
(WebKit::WebPage::didCommitLoad):
(WebKit::WebPage::extendIncrementalRenderingSuppression):
(WebKit::WebPage::stopExtendingIncrementalRenderingSuppression):
(WebKit::WebPage::setScrollPinningBehavior):
(WebKit::WebPage::setScrollbarOverlayStyle):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::handleSyntheticClick):
(WebKit::WebPage::requestDocumentEditingContext):
(WebKit::WebPage::focusTextInputContextAndPlaceCaret):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::getPlatformEditorState const):
(WebKit::WebPage::shouldDelayWindowOrderingEvent):
(WebKit::WebPage::requestAcceptsFirstMouse):
(WebKit::WebPage::performImmediateActionHitTestAtLocation):
(WebKit::WebPage::lookupTextAtLocation):

Canonical link: <a href="https://commits.webkit.org/307448@main">https://commits.webkit.org/307448@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cca44aef231d54afa3183f39088459d3ff090e3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8676 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153107 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17598 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17010 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111070 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147400 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13454 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91983 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/553 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155419 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16968 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7461 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119071 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119432 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30616 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15270 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127618 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72501 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16590 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6027 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16326 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16390 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->