### PR TITLE
::picker(select) should not support most pseudo-classes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-animations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-animations.html
@@ -21,12 +21,12 @@ select::picker(select) {
   color: black;
 }
 
-select::picker(select):popover-open {
+select:open::picker(select) {
   opacity: 1;
   color: rgb(200, 0, 0);
 }
 @starting-style {
-  select::picker(select):popover-open {
+  select:open::picker(select) {
     opacity: 0;
     color: black;
   }

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-popover-open-invalid.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-popover-open-invalid.tentative-expected.txt
@@ -1,0 +1,4 @@
+
+PASS "::picker(select):popover-open" should be an invalid selector
+PASS "select::picker(select):popover-open" should be an invalid selector
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-popover-open-invalid.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-picker-popover-open-invalid.tentative.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>::picker(select):popover-open is not a valid selector</title>
+<link rel=author href="mailto:annevk@annevk.nl">
+<link rel=help href="https://drafts.csswg.org/css-forms-1/">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script>
+test_invalid_selector("::picker(select):popover-open");
+test_invalid_selector("select::picker(select):popover-open");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance-expected.txt
@@ -3,7 +3,7 @@
 FAIL Basic functionality of select picker and appearance assert_equals: expected "none" but got ""
 FAIL Basic functionality of select picker with appearance:auto assert_equals: expected "none" but got ""
 FAIL Basic functionality of select picker with appearance:none assert_equals: expected "none" but got ""
-FAIL Switching appearance in popover-open should close the picker assert_equals: expected "none" but got ""
+FAIL Switching appearance in :open should close the picker assert_equals: expected "none" but got ""
 FAIL Switching appearance in JS after picker is open should close the picker assert_equals: expected "none" but got ""
 FAIL Test of the test harness assert_true: picker should open when clicked expected true got false
 FAIL The select picker is closed if the <select> appearance value is changed via CSS while the picker is open assert_true: picker should open when clicked expected true got false

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/switch-picker-appearance.html
@@ -18,7 +18,7 @@
   #test1::picker(select) {
     background-color: red;
   }
-  #test1::picker(select):popover-open {
+  #test1:open::picker(select) {
     background-color: green;
   }
 </style>
@@ -36,7 +36,7 @@ promise_test(async (t) => {
   assert_equals(getComputedStyle(select1,'::picker(select)').backgroundColor,red);
   style.innerHTML = '#test1::picker(select) {appearance: base-select}';
   assert_equals(getComputedStyle(select1,'::picker(select)').appearance,'base-select');
-  assert_equals(getComputedStyle(select1,'::picker(select)').backgroundColor,red,'still closed, so popover-open doesn\'t match');
+  assert_equals(getComputedStyle(select1,'::picker(select)').backgroundColor,red,'still closed, so :open doesn\'t match');
 
   // Now open the picker
   assert_throws_dom('NotAllowedError',() => select1.showPicker(),'showPicker requires user activation');
@@ -45,7 +45,7 @@ promise_test(async (t) => {
   select1.showPicker();
   assert_true(select1.matches(':open'));
   assert_equals(getComputedStyle(select1,'::picker(select)').appearance,'base-select');
-  assert_equals(getComputedStyle(select1,'::picker(select)').backgroundColor,green,'now open, so popover-open matches');
+  assert_equals(getComputedStyle(select1,'::picker(select)').backgroundColor,green,'now open, so :open matches');
 
   // Close the picker
   await clickOn(select1);
@@ -90,12 +90,12 @@ promise_test(async (t) => {
   assert_equals(getComputedStyle(select1,'::picker(select)').appearance,'none');
   style.innerHTML = `
     #test1::picker(select) {appearance: base-select}
-    #test1::picker(select):popover-open {appearance: auto}
+    #test1:open::picker(select) {appearance: auto}
     `;
   assert_equals(getComputedStyle(select1,'::picker(select)').appearance,'base-select');
   await test_driver.bless('showPicker');
   select1.showPicker();
-  assert_false(select1.matches(':open'),'Switching appearance in :popover-open should re-close the picker');
+  assert_false(select1.matches(':open'),'Switching appearance in :open should re-close the picker');
   assert_equals(getComputedStyle(select1,'::picker(select)').backgroundColor,red);
   await new Promise(resolve => requestAnimationFrame(resolve));
   assert_false(select1.matches(':open'),'There should be no oscillation or re-opening the picker');
@@ -103,7 +103,7 @@ promise_test(async (t) => {
   assert_false(select1.matches(':open'),'There should be no oscillation or re-opening the picker (2)');
   await new Promise(resolve => requestAnimationFrame(resolve));
   assert_false(select1.matches(':open'),'There should be no oscillation or re-opening the picker (3)');
-}, 'Switching appearance in popover-open should close the picker');
+}, 'Switching appearance in :open should close the picker');
 
 promise_test(async (t) => {
   const style = document.createElement('style');

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -526,10 +526,6 @@ static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClass pseudo
     switch (compoundPseudoElement) {
     case CSSSelector::PseudoElement::Part:
         return !isTreeStructuralPseudoClass(pseudoClass);
-    case CSSSelector::PseudoElement::Picker:
-        return !isTreeStructuralPseudoClass(pseudoClass);
-    case CSSSelector::PseudoElement::Slotted:
-        return false;
     case CSSSelector::PseudoElement::WebKitResizer:
     case CSSSelector::PseudoElement::WebKitScrollbar:
     case CSSSelector::PseudoElement::WebKitScrollbarCorner:
@@ -545,6 +541,7 @@ static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClass pseudo
     case CSSSelector::PseudoElement::ViewTransitionNew:
     case CSSSelector::PseudoElement::ViewTransitionOld:
         return pseudoClass == CSSSelector::PseudoClass::OnlyChild;
+    case CSSSelector::PseudoElement::Picker:
     case CSSSelector::PseudoElement::UserAgentPart:
     case CSSSelector::PseudoElement::UserAgentPartLegacyAlias:
     case CSSSelector::PseudoElement::WebKitUnknown:


### PR DESCRIPTION
#### fab41f77378211c46d9e37fd61fafd0689f9fe85
<pre>
::picker(select) should not support most pseudo-classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307661">https://bugs.webkit.org/show_bug.cgi?id=307661</a>

Reviewed by Tim Nguyen.

It was long ago decided to not duplicate pseudo-class API surface,
including with ::picker(select).

Let ::slotted take the default path (which returns false).
Canonical link: <a href="https://commits.webkit.org/307375@main">https://commits.webkit.org/307375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3f0a7be58cf9f858d98d8f4d099bea19b5c2b4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144214 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8449 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152884 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9bc40dd9-b250-4e23-9d64-165951640e7f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16787 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110898 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e2d77f3-1eca-4305-ae86-c26d37fa44b6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13312 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91814 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8a83bed-222f-48f6-962c-33ad1f833335) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12742 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10490 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/330 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122239 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6222 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155196 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16745 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7277 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118916 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16782 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/14063 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119273 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15144 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127433 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72166 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22241 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16367 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5869 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16102 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16312 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16167 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->