### PR TITLE
[LBSE] Fix viewSpec functionality

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -275,7 +275,6 @@ imported/w3c/web-platform-tests/svg/embedded/image-modify-href-4.svg            
 imported/w3c/web-platform-tests/svg/embedded/image-remove-href-1.svg                                   [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/embedded/image-remove-href-2.svg                                   [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/embedded/image-remove-href-3.svg                                   [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/svg/linking/reftests/svgview-viewbox-override-multiple.html            [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/marker-009.svg                                            [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/non-scaling-stroke-001.html                      [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/painting/reftests/non-scaling-stroke-002.html                      [ ImageOnlyFailure ]
@@ -330,15 +329,6 @@ svg/custom/use-nested.svg                          [ ImageOnlyFailure ]
 # SMIL animation issues
 svg/animations/animateMotion-additive-1.svg [ ImageOnlyFailure ]
 svg/stroke/animated-non-scaling-stroke.html [ ImageOnlyFailure ]
-
-# SVGViewSpec / svgView() support broken
-svg/custom/linking-a-03-b-all.svg               [ ImageOnlyFailure ]
-svg/custom/linking-a-03-b-transform.svg         [ ImageOnlyFailure ]
-svg/custom/linking-a-03-b-viewBox-transform.svg [ ImageOnlyFailure ]
-svg/custom/linking-a-03-b-viewBox.svg           [ ImageOnlyFailure ]
-svg/custom/linking-uri-01-b.svg                 [ ImageOnlyFailure ]
-svg/custom/multiple-view-elements.html          [ ImageOnlyFailure ]
-svg/dom/complex-svgView-specification.html      [ ImageOnlyFailure ]
 
 # Empty viewBox doesn't disable rendering for inline SVG documents
 svg/custom/viewBox-empty.html [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/linking-a-03-b-viewBox-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/linking-a-03-b-viewBox-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 480x360
   RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
-layer at (64,9) size 326x326
-  RenderSVGTransformableContainer {g} at (64,9) size 326x325.77
-layer at (100,9) size 187x14
+layer at (64,9.19) size 326x326
+  RenderSVGTransformableContainer {g} at (64,9.19) size 326x325.58
+layer at (100,9.19) size 187x14
   RenderSVGText {text} at (36,0) size 188x14 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 188x14
       chunk 1 text run 1 at (100.00,20.00) startOffset 0 endOffset 41 width 187.31: "Some circles with ids, for linking tests."
-layer at (185,105) size 70x70
-  RenderSVGEllipse {circle} at (121,96) size 70x70 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#FF0000]}] [cx=220.00] [cy=140.00] [r=35.00]
-layer at (203,87.75) size 39x14
+layer at (185,105) size 70x71
+  RenderSVGEllipse {circle} at (121,95.81) size 70x70 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#FF0000]}] [cx=220.00] [cy=140.00] [r=35.00]
+layer at (203,87.95) size 39x14
   RenderSVGText {text} at (139,78) size 39x15 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 39x14
       chunk 1 text run 1 at (203.00,99.00) startOffset 0 endOffset 8 width 38.67: "circle-1"
-layer at (80,240) size 40x40
-  RenderSVGEllipse {circle} at (16,231) size 40x40 [stroke={[type=SOLID] [color=#00FF00] [stroke width=4.00]}] [fill={[type=SOLID] [color=#FFFF00]}] [cx=100.00] [cy=260.00] [r=20.00]
-layer at (80,283.75) size 39x14
+layer at (80,240) size 40x41
+  RenderSVGEllipse {circle} at (16,230.81) size 40x40 [stroke={[type=SOLID] [color=#00FF00] [stroke width=4.00]}] [fill={[type=SOLID] [color=#FFFF00]}] [cx=100.00] [cy=260.00] [r=20.00]
+layer at (80,283.95) size 39x14
   RenderSVGText {text} at (16,274) size 39x15 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 39x14
       chunk 1 text run 1 at (80.00,295.00) startOffset 0 endOffset 8 width 38.67: "circle-2"
-layer at (64,227) size 72x72
-  RenderSVGRect {rect} at (0,218) size 72x72 [stroke={[type=SOLID] [color=#000000]}] [x=64.00] [y=227.00] [width=72.00] [height=72.00]
-layer at (290,210) size 100x100
-  RenderSVGEllipse {circle} at (226,201) size 100x100 [stroke={[type=SOLID] [color=#0000FF] [stroke width=10.00]}] [cx=340.00] [cy=260.00] [r=50.00]
-layer at (320,320.75) size 39x14
+layer at (64,227) size 72x73
+  RenderSVGRect {rect} at (0,217.81) size 72x72 [stroke={[type=SOLID] [color=#000000]}] [x=64.00] [y=227.00] [width=72.00] [height=72.00]
+layer at (290,210) size 100x101
+  RenderSVGEllipse {circle} at (226,200.81) size 100x100 [stroke={[type=SOLID] [color=#0000FF] [stroke width=10.00]}] [cx=340.00] [cy=260.00] [r=50.00]
+layer at (320,320.95) size 39x14
   RenderSVGText {text} at (256,311) size 39x15 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 39x14
       chunk 1 text run 1 at (320.00,332.00) startOffset 0 endOffset 8 width 38.67: "circle-3"

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/linking-a-03-b-viewBox-transform-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/linking-a-03-b-viewBox-transform-expected.txt
@@ -4,29 +4,29 @@ layer at (0,0) size 480x360
   RenderSVGRoot {svg} at (0,0) size 480x360
 layer at (0,0) size 480x360
   RenderSVGViewportContainer at (0,0) size 480x360
-layer at (64,9) size 326x326
-  RenderSVGTransformableContainer {g} at (64,9) size 326x325.77
-layer at (100,9) size 187x14
+layer at (64,9.19) size 326x326
+  RenderSVGTransformableContainer {g} at (64,9.19) size 326x325.58
+layer at (100,9.19) size 187x14
   RenderSVGText {text} at (36,0) size 188x14 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 188x14
       chunk 1 text run 1 at (100.00,20.00) startOffset 0 endOffset 41 width 187.31: "Some circles with ids, for linking tests."
-layer at (185,105) size 70x70
-  RenderSVGEllipse {circle} at (121,96) size 70x70 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#FF0000]}] [cx=220.00] [cy=140.00] [r=35.00]
-layer at (203,87.75) size 39x14
+layer at (185,105) size 70x71
+  RenderSVGEllipse {circle} at (121,95.81) size 70x70 [stroke={[type=SOLID] [color=#000000]}] [fill={[type=SOLID] [color=#FF0000]}] [cx=220.00] [cy=140.00] [r=35.00]
+layer at (203,87.95) size 39x14
   RenderSVGText {text} at (139,78) size 39x15 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 39x14
       chunk 1 text run 1 at (203.00,99.00) startOffset 0 endOffset 8 width 38.67: "circle-1"
-layer at (80,240) size 40x40
-  RenderSVGEllipse {circle} at (16,231) size 40x40 [stroke={[type=SOLID] [color=#00FF00] [stroke width=4.00]}] [fill={[type=SOLID] [color=#FFFF00]}] [cx=100.00] [cy=260.00] [r=20.00]
-layer at (80,283.75) size 39x14
+layer at (80,240) size 40x41
+  RenderSVGEllipse {circle} at (16,230.81) size 40x40 [stroke={[type=SOLID] [color=#00FF00] [stroke width=4.00]}] [fill={[type=SOLID] [color=#FFFF00]}] [cx=100.00] [cy=260.00] [r=20.00]
+layer at (80,283.95) size 39x14
   RenderSVGText {text} at (16,274) size 39x15 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 39x14
       chunk 1 text run 1 at (80.00,295.00) startOffset 0 endOffset 8 width 38.67: "circle-2"
-layer at (64,227) size 72x72
-  RenderSVGRect {rect} at (0,218) size 72x72 [stroke={[type=SOLID] [color=#000000]}] [x=64.00] [y=227.00] [width=72.00] [height=72.00]
-layer at (290,210) size 100x100
-  RenderSVGEllipse {circle} at (226,201) size 100x100 [stroke={[type=SOLID] [color=#0000FF] [stroke width=10.00]}] [cx=340.00] [cy=260.00] [r=50.00]
-layer at (320,320.75) size 39x14
+layer at (64,227) size 72x73
+  RenderSVGRect {rect} at (0,217.81) size 72x72 [stroke={[type=SOLID] [color=#000000]}] [x=64.00] [y=227.00] [width=72.00] [height=72.00]
+layer at (290,210) size 100x101
+  RenderSVGEllipse {circle} at (226,200.81) size 100x100 [stroke={[type=SOLID] [color=#0000FF] [stroke width=10.00]}] [cx=340.00] [cy=260.00] [r=50.00]
+layer at (320,320.95) size 39x14
   RenderSVGText {text} at (256,311) size 39x15 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 39x14
       chunk 1 text run 1 at (320.00,332.00) startOffset 0 endOffset 8 width 38.67: "circle-3"

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/linking-uri-01-b-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/linking-uri-01-b-expected.txt
@@ -4,109 +4,109 @@ layer at (0,0) size 800x600
   RenderSVGRoot {svg} at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderSVGViewportContainer at (0,0) size 800x600
-layer at (33.58,4.75) size 412x295
-  RenderSVGTransformableContainer {g} at (33.58,4.75) size 411.42x293.48
-layer at (65,4.75) size 334x14
+layer at (33.58,4.88) size 412x295
+  RenderSVGTransformableContainer {g} at (33.58,4.88) size 411.42x293.36
+layer at (65,4.88) size 334x14
   RenderSVGText {text} at (31,0) size 334x14 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 334x14
       chunk 1 text run 1 at (65.00,16.00) startOffset 0 endOffset 69 width 333.43: "Link test of the 'view' element and its attributes, 1 of 2, internal."
 layer at (33.58,29) size 412x270
-  RenderSVGTransformableContainer {g} at (0,24.25) size 411.42x269.23
+  RenderSVGTransformableContainer {g} at (0,24.13) size 411.42x269.23
 layer at (300,55) size 126x112
   RenderSVGTransformableContainer {g} at (266.42,26) size 125x111.77
 layer at (300,55) size 125x85
   RenderSVGRect {rect} at (0,0) size 125x85 [fill={[type=SOLID] [color=#AAAAAA]}] [x=300.00] [y=55.00] [width=125.00] [height=85.00]
-layer at (310,57.22) size 102x17
-  RenderSVGTransformableContainer {a} at (10,2.22) size 101.17x16.02
-layer at (310,57.22) size 101x16
-  RenderSVGText {text} at (0,0) size 102x16 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 102x16
+layer at (310,57.16) size 102x17
+  RenderSVGTransformableContainer {a} at (10,2.16) size 101.17x16.08
+layer at (310,57.16) size 101x16
+  RenderSVGText {text} at (0,0) size 102x17 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 102x17
       chunk 1 text run 1 at (310.00,70.00) startOffset 0 endOffset 15 width 101.17: "Go to Rectangle"
-layer at (310,77.22) size 80x17
-  RenderSVGTransformableContainer {a} at (10,22.22) size 79.38x16.02
-layer at (310,77.22) size 79x16
-  RenderSVGText {text} at (0,0) size 80x16 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 80x16
+layer at (310,77.16) size 80x17
+  RenderSVGTransformableContainer {a} at (10,22.16) size 79.38x16.08
+layer at (310,77.16) size 79x16
+  RenderSVGText {text} at (0,0) size 80x17 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 80x17
       chunk 1 text run 1 at (310.00,90.00) startOffset 0 endOffset 13 width 79.37: "Go to Ellipse"
-layer at (310,97.22) size 74x17
-  RenderSVGTransformableContainer {a} at (10,42.22) size 73.92x16.02
-layer at (310,97.22) size 74x16
-  RenderSVGText {text} at (0,0) size 74x16 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 74x16
+layer at (310,97.16) size 74x17
+  RenderSVGTransformableContainer {a} at (10,42.16) size 73.92x16.08
+layer at (310,97.16) size 74x16
+  RenderSVGText {text} at (0,0) size 74x17 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 74x17
       chunk 1 text run 1 at (310.00,110.00) startOffset 0 endOffset 12 width 73.91: "Go to Circle"
-layer at (310,117.22) size 89x17
-  RenderSVGTransformableContainer {a} at (10,62.22) size 88.73x16.02
-layer at (310,117.22) size 89x16
-  RenderSVGText {text} at (0,0) size 89x16 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 89x16
+layer at (310,117.16) size 89x17
+  RenderSVGTransformableContainer {a} at (10,62.16) size 88.73x16.08
+layer at (310,117.16) size 89x16
+  RenderSVGText {text} at (0,0) size 89x17 contains 1 chunk(s)
+    RenderSVGInlineText {#text} at (0,0) size 89x17
       chunk 1 text run 1 at (310.00,130.00) startOffset 0 endOffset 13 width 88.72: "Go to Polygon"
-layer at (315,140.75) size 102x14
+layer at (315,140.88) size 102x14
   RenderSVGText {text} at (15,85) size 103x15 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 103x14
       chunk 1 text run 1 at (315.00,152.00) startOffset 0 endOffset 20 width 102.33: "Click element's line"
-layer at (315,152.75) size 87x14
+layer at (315,152.88) size 87x14
   RenderSVGText {text} at (15,97) size 88x15 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 88x14
       chunk 1 text run 1 at (315.00,164.00) startOffset 0 endOffset 19 width 87.36: "to link to its view"
 layer at (295,36) size 136x68
   RenderSVGRect {rect} at (261.42,7) size 135x68 [fill={[type=SOLID] [color=#800080]}] [x=295.00] [y=36.00] [width=135.00] [height=68.00]
-layer at (330.97,103.22) size 63x16
+layer at (330.97,103.16) size 63x16
   RenderSVGText {text} at (297,74) size 64x17 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 64x16
+    RenderSVGInlineText {#text} at (0,0) size 64x17
       chunk 1 (middle anchor) text run 1 at (330.98,116.00) startOffset 0 endOffset 9 width 63.04: "Rectangle"
 layer at (292,29) size 142x91
   RenderSVGRect {rect} at (258.42,0) size 141x91 [stroke={[type=SOLID] [color=#000000]}] [x=292.00] [y=29.00] [width=141.00] [height=91.00]
-layer at (299.97,122.30) size 125x12
+layer at (299.97,122.80) size 125x11
   RenderSVGText {text} at (266,93) size 126x13 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 126x12
       chunk 1 (middle anchor) text run 1 at (299.97,132.00) startOffset 0 endOffset 29 width 125.06: "No view attributes except id."
 layer at (298,219) size 145x64
   RenderSVGEllipse {ellipse} at (264.42,190) size 144x64 [fill={[type=SOLID] [color=#0000FF]}] [cx=370.00] [cy=251.00] [rx=72.00] [ry=32.00]
-layer at (349.38,282.22) size 41x16
+layer at (349.38,282.16) size 41x16
   RenderSVGText {text} at (315,253) size 43x17 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 42x16
+    RenderSVGInlineText {#text} at (0,0) size 42x17
       chunk 1 (middle anchor) text run 1 at (349.38,295.00) startOffset 0 endOffset 7 width 41.24: "Ellipse"
 layer at (295,216) size 151x82
   RenderSVGRect {rect} at (261.42,187) size 150x82 [stroke={[type=SOLID] [color=#000000]}] [x=295.00] [y=216.00] [width=150.00] [height=82.00]
-layer at (315,202.30) size 116x12
+layer at (315,202.80) size 116x11
   RenderSVGText {text} at (281,173) size 117x13 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 116x12
       chunk 1 text run 1 at (315.00,212.00) startOffset 0 endOffset 27 width 115.60: "viewBox, should fill frame."
 layer at (49,32) size 73x72
   RenderSVGEllipse {circle} at (15.42,3) size 72x72 [fill={[type=SOLID] [color=#FFFF00]}] [cx=85.00] [cy=68.00] [r=36.00]
-layer at (67.11,103.22) size 35x16
+layer at (67.11,103.16) size 35x16
   RenderSVGText {text} at (33,74) size 37x17 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 36x16
+    RenderSVGInlineText {#text} at (0,0) size 36x17
       chunk 1 (middle anchor) text run 1 at (67.11,116.00) startOffset 0 endOffset 6 width 35.78: "Circle"
 layer at (36,29) size 99x91
   RenderSVGRect {rect} at (2.42,0) size 98x91 [stroke={[type=SOLID] [color=#000000]}] [x=36.00] [y=29.00] [width=98.00] [height=91.00]
-layer at (33.58,120.30) size 103x12
+layer at (33.58,120.80) size 103x11
   RenderSVGText {text} at (0,91) size 103x13 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 103x12
       chunk 1 (middle anchor) text run 1 at (33.59,130.00) startOffset 0 endOffset 21 width 102.82: "viewBox & non-uniform"
-layer at (38.58,129.30) size 93x12
+layer at (38.58,129.80) size 93x11
   RenderSVGText {text} at (5,100) size 93x13 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 93x12
       chunk 1 (middle anchor) text run 1 at (38.59,139.00) startOffset 0 endOffset 19 width 92.82: "preserveAspectRatio"
 layer at (39,211) size 96x72
   RenderSVGPath {polygon} at (5.42,182) size 95x72 [fill={[type=SOLID] [color=#008000]}] [points="87 211 134 238 116 283 57 283 39 238 87 211"]
-layer at (59.70,282.22) size 51x16
+layer at (59.70,282.16) size 51x16
   RenderSVGText {text} at (26,253) size 51x17 contains 1 chunk(s)
-    RenderSVGInlineText {#text} at (0,0) size 51x16
+    RenderSVGInlineText {#text} at (0,0) size 51x17
       chunk 1 (middle anchor) text run 1 at (59.70,295.00) startOffset 0 endOffset 7 width 50.59: "Polygon"
 layer at (36,208) size 101x89
   RenderSVGRect {rect} at (2.42,179) size 100x89 [stroke={[type=SOLID] [color=#000000]}] [x=36.00] [y=208.00] [width=100.00] [height=89.00]
-layer at (52.20,185.30) size 65x12
+layer at (52.20,185.80) size 65x11
   RenderSVGText {text} at (18,156) size 67x13 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 66x12
       chunk 1 (middle anchor) text run 1 at (52.21,195.00) startOffset 0 endOffset 14 width 65.59: "viewTarget, no"
-layer at (40.52,194.30) size 89x12
+layer at (40.52,194.80) size 89x11
   RenderSVGText {text} at (6,165) size 90x13 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 89x12
       chunk 1 (middle anchor) text run 1 at (40.53,204.00) startOffset 0 endOffset 19 width 88.94: "changes to viewport"
-layer at (10,310.36) size 248x38
-  RenderSVGTransformableContainer {g} at (10,310.36) size 247.27x37
-layer at (10,310.36) size 247x37
+layer at (10,310.48) size 248x38
+  RenderSVGTransformableContainer {g} at (10,310.48) size 247.27x36.88
+layer at (10,310.48) size 247x37
   RenderSVGText {text} at (0,0) size 248x37 contains 1 chunk(s)
     RenderSVGInlineText {#text} at (0,0) size 248x37
       chunk 1 text run 1 at (10.00,340.00) startOffset 0 endOffset 17 width 247.27: "$Revision: 1.12 $"

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -714,7 +714,11 @@ bool SVGSVGElement::scrollToFragment(StringView fragmentIdentifier)
 
     auto invalidateView = [&](RenderElement& renderer) {
         if (renderer.document().settings().layerBasedSVGEngineEnabled()) {
-            renderer.repaint();
+            if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(renderer)) {
+                ASSERT(svgRoot->viewportContainer());
+                svgRoot->checkedViewportContainer()->updateHasSVGTransformFlags();
+            }
+            updateSVGRendererForElementChange();
             return;
         }
 


### PR DESCRIPTION
#### 88dd4bbe6c3a1d38fe5e6b83dc2dca356162f211
<pre>
[LBSE] Fix viewSpec functionality
<a href="https://bugs.webkit.org/show_bug.cgi?id=307663">https://bugs.webkit.org/show_bug.cgi?id=307663</a>

Reviewed by Nikolas Zimmermann.

Fix viewSpec functionality by making sure updateLayerTransform takes the
viewSpec viewBox into account. needsHasSVGTransformFlags is always true
if there is a currentView, this check could be made more specific (testing for viewBox/transform),
but viewSpec usage is rare so a quick test should be fine.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/linking-a-03-b-viewBox-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/linking-a-03-b-viewBox-transform-expected.txt:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/svg/custom/linking-uri-01-b-expected.txt:
* Source/WebCore/rendering/svg/RenderSVGViewportContainer.cpp:
(WebCore::RenderSVGViewportContainer::needsHasSVGTransformFlags const):
(WebCore::RenderSVGViewportContainer::updateLayerTransform):
* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::scrollToFragment):

Canonical link: <a href="https://commits.webkit.org/307462@main">https://commits.webkit.org/307462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/47d0c54cfc68a845e310f576e6a2c93c7c3dc0f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144498 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153168 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146373 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17071 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111111 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92024 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12882 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10640 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/614 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6446 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155481 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17029 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119110 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14251 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119468 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30623 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15293 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127659 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16651 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6068 "Passed tests") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80430 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16451 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->