### PR TITLE
VideoFrameCV is not able to create NativeImage in WebContent process

### DIFF
--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.cpp
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.cpp
@@ -40,6 +40,7 @@ SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVBufferGetAttachments, CFDict
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVBufferRemoveAttachment, void, (CVBufferRef buffer, CFStringRef key), (buffer, key))
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVBufferSetAttachment, void, (CVBufferRef buffer, CFStringRef key, CFTypeRef value, CVAttachmentMode attachmentMode), (buffer, key, value, attachmentMode))
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVPixelBufferGetTypeID, CFTypeID, (), ())
+SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVPixelBufferGetDataSize, size_t, (CVPixelBufferRef pixelBuffer), (pixelBuffer))
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVPixelBufferGetWidth, size_t, (CVPixelBufferRef pixelBuffer), (pixelBuffer))
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVPixelBufferGetWidthOfPlane, size_t, (CVPixelBufferRef pixelBuffer, size_t planeIndex), (pixelBuffer, planeIndex))
 SOFT_LINK_FUNCTION_FOR_SOURCE(WebCore, CoreVideo, CVPixelBufferGetHeight, size_t, (CVPixelBufferRef pixelBuffer), (pixelBuffer))

--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
@@ -54,6 +54,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVBufferSetAttachment, void, (
 #define CVBufferGetAttachments softLink_CoreVideo_CVBufferGetAttachments
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferGetTypeID, CFTypeID, (), ())
 #define CVPixelBufferGetTypeID softLink_CoreVideo_CVPixelBufferGetTypeID
+SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferGetDataSize, size_t, (CVPixelBufferRef pixelBuffer), (pixelBuffer))
+#define CVPixelBufferGetDataSize softLink_CoreVideo_CVPixelBufferGetDataSize
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferGetWidth, size_t, (CVPixelBufferRef pixelBuffer), (pixelBuffer))
 #define CVPixelBufferGetWidth softLink_CoreVideo_CVPixelBufferGetWidth
 SOFT_LINK_FUNCTION_FOR_HEADER(WebCore, CoreVideo, CVPixelBufferGetWidthOfPlane, size_t, (CVPixelBufferRef pixelBuffer, size_t planeIndex), (pixelBuffer, planeIndex))

--- a/Source/WebCore/platform/graphics/cv/CVUtilities.h
+++ b/Source/WebCore/platform/graphics/cv/CVUtilities.h
@@ -56,4 +56,5 @@ WEBCORE_EXPORT void setOwnershipIdentityForCVPixelBuffer(CVPixelBufferRef, const
 
 WEBCORE_EXPORT RetainPtr<CVPixelBufferRef> createBlackPixelBuffer(size_t width, size_t height, bool shouldUseIOSurface = false);
 
+WEBCORE_EXPORT RetainPtr<CGImageRef> createImageFrom32BGRAPixelBuffer(RetainPtr<CVPixelBufferRef>&&, CGColorSpaceRef);
 }

--- a/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
+++ b/Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h
@@ -72,6 +72,7 @@ public:
     RetainPtr<CMSampleBufferRef> convertCMSampleBuffer(CMSampleBufferRef, const IntSize&, const WTF::MediaTime* = nullptr);
     void setCroppingRectangle(std::optional<FloatRect>, FloatSize = { });
 
+    WEBCORE_EXPORT static RetainPtr<CVPixelBufferRef> convertPixelBuffer(CVPixelBufferRef source, uint32_t targetPixelFormat);
 private:
     WEBCORE_EXPORT ImageTransferSessionVT(uint32_t pixelFormat, bool shouldUseIOSurface);
 

--- a/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
+++ b/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2016-2019 Apple Inc. All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
@@ -29,9 +29,7 @@
 #include "CVUtilities.h"
 #include "GraphicsContextCG.h"
 #include "ImageBufferUtilitiesCG.h"
-#include "Logging.h"
 #include <pal/spi/cg/CoreGraphicsSPI.h>
-#include <wtf/StackTrace.h>
 #include <wtf/TZoneMallocInlines.h>
 
 #include "CoreVideoSoftLink.h"
@@ -40,29 +38,6 @@
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PixelBufferConformerCV);
-
-#if RELEASE_LOG_DISABLED
-#define RELEASE_LOG_STACKTRACE(channel) ((void)0)
-#else
-static constexpr int kDefaultFramesToShow = 31;
-static constexpr int kDefaultFramesToSkip = 2;
-
-static void logStackTrace(WTFLogChannel* channel)
-{
-    std::array<void*, kDefaultFramesToShow + kDefaultFramesToSkip> stack;
-    int frameCount = kDefaultFramesToShow + kDefaultFramesToSkip;
-    WTFGetBacktrace(stack.data(), &frameCount);
-    StackTraceSymbolResolver { std::span { stack }.first(frameCount) }.forEach([&](int frameNumber, void* stackFrame, const char* name) {
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-        if (name)
-            os_log(channel->osLogChannel, "%-3d %p %{public}s", frameNumber, stackFrame, name);
-        else
-            os_log(channel->osLogChannel, "%-3d %p", frameNumber, stackFrame);
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
-    });
-}
-#define RELEASE_LOG_STACKTRACE(channel) logStackTrace(&LOG_CHANNEL(channel))
-#endif
 
 RetainPtr<VTPixelBufferConformerRef> PixelBufferConformerCV::createPixelConformer(CFDictionaryRef attributes)
 {
@@ -75,96 +50,6 @@ RetainPtr<VTPixelBufferConformerRef> PixelBufferConformerCV::createPixelConforme
 PixelBufferConformerCV::PixelBufferConformerCV(CFDictionaryRef attributes)
     : m_pixelConformer(createPixelConformer(attributes))
 {
-}
-
-struct CVPixelBufferInfo {
-    RetainPtr<CVPixelBufferRef> pixelBuffer;
-    int lockCount { 0 };
-};
-
-static const void* CVPixelBufferGetBytePointerCallback(void* refcon)
-{
-    ASSERT(refcon);
-    if (!refcon) {
-        RELEASE_LOG_ERROR(Media, "CVPixelBufferGetBytePointerCallback() called with NULL refcon");
-        RELEASE_LOG_STACKTRACE(Media);
-        return nullptr;
-    }
-    auto info = static_cast<CVPixelBufferInfo*>(refcon);
-
-    CVReturn result = CVPixelBufferLockBaseAddress(info->pixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
-
-    ASSERT(result == kCVReturnSuccess);
-    if (result != kCVReturnSuccess) {
-        RELEASE_LOG_ERROR(Media, "CVPixelBufferLockBaseAddress() returned error code %d", result);
-        RELEASE_LOG_STACKTRACE(Media);
-        return nullptr;
-    }
-
-    ++info->lockCount;
-    auto bytes = CVPixelBufferGetSpan(info->pixelBuffer.get());
-    if (!bytes.data()) {
-        RELEASE_LOG_ERROR(Media, "CVPixelBufferGetSpan returned null");
-        RELEASE_LOG_STACKTRACE(Media);
-        return nullptr;
-    }
-
-    verifyImageBufferIsBigEnough(bytes);
-    RELEASE_LOG_INFO(Media, "CVPixelBufferGetBytePointerCallback() returning bytePointer: %p, size: %zu", bytes.data(), bytes.size());
-    return bytes.data();
-}
-
-static void CVPixelBufferReleaseBytePointerCallback(void* refcon, const void*)
-{
-    ASSERT(refcon);
-    if (!refcon) {
-        RELEASE_LOG_ERROR(Media, "CVPixelBufferReleaseBytePointerCallback() called with NULL refcon");
-        RELEASE_LOG_STACKTRACE(Media);
-        return;
-    }
-    auto info = static_cast<CVPixelBufferInfo*>(refcon);
-
-    CVReturn result = CVPixelBufferUnlockBaseAddress(info->pixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
-    ASSERT(result == kCVReturnSuccess);
-    if (result != kCVReturnSuccess) {
-        RELEASE_LOG_ERROR(Media, "CVPixelBufferLockBaseAddress() returned error code %d", result);
-        RELEASE_LOG_STACKTRACE(Media);
-        return;
-    }
-
-    ASSERT(info->lockCount);
-    if (!info->lockCount) {
-        RELEASE_LOG_ERROR(Media, "CVPixelBufferReleaseBytePointerCallback() called without matching CVPixelBufferGetBytePointerCallback()");
-        RELEASE_LOG_STACKTRACE(Media);
-    }
-    --info->lockCount;
-}
-
-static void CVPixelBufferReleaseInfoCallback(void* refcon)
-{
-    ASSERT(refcon);
-    if (!refcon) {
-        RELEASE_LOG_ERROR(Media, "CVPixelBufferReleaseInfoCallback() called with NULL refcon");
-        RELEASE_LOG_STACKTRACE(Media);
-        return;
-    }
-    auto info = static_cast<CVPixelBufferInfo*>(refcon);
-
-    ASSERT(!info->lockCount);
-    if (info->lockCount) {
-        RELEASE_LOG_ERROR(Media, "CVPixelBufferReleaseInfoCallback() called with a non-zero lockCount: %d", info->lockCount);
-        RELEASE_LOG_STACKTRACE(Media);
-
-        CVReturn result = CVPixelBufferUnlockBaseAddress(info->pixelBuffer.get(), kCVPixelBufferLock_ReadOnly);
-        ASSERT(result == kCVReturnSuccess);
-        if (result != kCVReturnSuccess) {
-            RELEASE_LOG_ERROR(Media, "CVPixelBufferLockBaseAddress() returned error code %d", result);
-            RELEASE_LOG_STACKTRACE(Media);
-        }
-    }
-
-    info->pixelBuffer = nullptr;
-    delete info;
 }
 
 RetainPtr<CVPixelBufferRef> PixelBufferConformerCV::convert(CVPixelBufferRef rawBuffer)
@@ -183,7 +68,8 @@ RetainPtr<CVPixelBufferRef> PixelBufferConformerCV::convert(CVPixelBufferRef raw
 
 RetainPtr<CGImageRef> PixelBufferConformerCV::createImageFromPixelBuffer(CVPixelBufferRef rawBuffer)
 {
-    RetainPtr<CVPixelBufferRef> buffer { rawBuffer };
+    RetainPtr buffer { rawBuffer };
+    RetainPtr colorSpace = createCGColorSpaceForCVPixelBuffer(buffer.get());
 
     if (!VTPixelBufferConformerIsConformantPixelBuffer(m_pixelConformer.get(), buffer.get())) {
         CVPixelBufferRef outputBuffer = nullptr;
@@ -193,42 +79,7 @@ RetainPtr<CGImageRef> PixelBufferConformerCV::createImageFromPixelBuffer(CVPixel
         buffer = adoptCF(outputBuffer);
     }
 
-    auto colorSpace = createCGColorSpaceForCVPixelBuffer(rawBuffer);
-    return imageFrom32BGRAPixelBuffer(WTF::move(buffer), colorSpace.get());
-}
-
-RetainPtr<CGImageRef> PixelBufferConformerCV::imageFrom32BGRAPixelBuffer(RetainPtr<CVPixelBufferRef>&& buffer, CGColorSpaceRef colorSpace)
-{
-    size_t width = CVPixelBufferGetWidth(buffer.get());
-    size_t height = CVPixelBufferGetHeight(buffer.get());
-
-    CGBitmapInfo bitmapInfo = static_cast<CGBitmapInfo>(kCGBitmapByteOrder32Little) | static_cast<CGBitmapInfo>(kCGImageAlphaFirst);
-    size_t bytesPerRow = CVPixelBufferGetBytesPerRow(buffer.get());
-    size_t byteLength = bytesPerRow * height;
-
-    ASSERT(byteLength);
-    if (!byteLength)
-        return nullptr;
-
-    CVPixelBufferInfo* info = new CVPixelBufferInfo();
-    info->pixelBuffer = WTF::move(buffer);
-    info->lockCount = 0;
-
-    CGDataProviderDirectCallbacks providerCallbacks = { 0, CVPixelBufferGetBytePointerCallback, CVPixelBufferReleaseBytePointerCallback, 0, CVPixelBufferReleaseInfoCallback };
-    RetainPtr<CGDataProviderRef> provider = adoptCF(CGDataProviderCreateDirect(info, byteLength, &providerCallbacks));
-
-    RetainPtr<CGImageRef> image = adoptCF(CGImageCreate(width, height, 8, 32, bytesPerRow, colorSpace, bitmapInfo, provider.get(), nullptr, false, kCGRenderingIntentDefault));
-
-    // For historical reasons, CoreAnimation will adjust certain video color
-    // spaces when displaying the video. If the video frame derived image we
-    // create here is drawn to an accelerated image buffer (e.g. for a canvas),
-    // CA may not do this same adjustment, resulting in the canvas pixels not
-    // matching the source video. Setting this CGImage property (despite the
-    // image not being IOSurface backed), avoids this non-adjustment of the
-    // image color space. <rdar://88804270>
-    CGImageSetProperty(image.get(), CFSTR("CA_IOSURFACE_IMAGE"), kCFBooleanTrue);
-
-    return image;
+    return createImageFrom32BGRAPixelBuffer(WTF::move(buffer), colorSpace.get());
 }
 
 }

--- a/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.h
+++ b/Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.h
@@ -42,7 +42,6 @@ public:
     WEBCORE_EXPORT PixelBufferConformerCV(uint32_t format);
     WEBCORE_EXPORT RetainPtr<CVPixelBufferRef> convert(CVPixelBufferRef);
     WEBCORE_EXPORT RetainPtr<CGImageRef> createImageFromPixelBuffer(CVPixelBufferRef);
-    static WEBCORE_EXPORT RetainPtr<CGImageRef> imageFrom32BGRAPixelBuffer(RetainPtr<CVPixelBufferRef>&&, CGColorSpaceRef);
 
 private:
     static RetainPtr<VTPixelBufferConformerRef> createPixelConformer(CFDictionaryRef attributes);

--- a/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp
@@ -33,8 +33,8 @@
 #include "RemoteVideoFrameObjectHeapProxyProcessorMessages.h"
 #include "RemoteVideoFrameProxy.h"
 #include "WebProcess.h"
+#include <WebCore/CVUtilities.h>
 #include <WebCore/NativeImage.h>
-#include <WebCore/PixelBufferConformerCV.h>
 
 namespace WebKit {
 
@@ -171,8 +171,8 @@ RefPtr<NativeImage> RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage(con
 
     m_conversionSemaphore.wait();
 
-    auto pixelBuffer = WTF::move(m_convertedBuffer);
-    return pixelBuffer ? NativeImage::create(PixelBufferConformerCV::imageFrom32BGRAPixelBuffer(WTF::move(pixelBuffer), RetainPtr { destinationColorSpace.platformColorSpace() }.get())) : nullptr;
+    RetainPtr pixelBuffer = std::exchange(m_convertedBuffer, { });
+    return pixelBuffer ? NativeImage::create(createImageFrom32BGRAPixelBuffer(WTF::move(pixelBuffer), RetainPtr { destinationColorSpace.platformColorSpace() }.get())) : nullptr;
 }
 
 }


### PR DESCRIPTION
#### 3bfb17abf725a8e30298903bee04565968697bdd
<pre>
VideoFrameCV is not able to create NativeImage in WebContent process
<a href="https://bugs.webkit.org/show_bug.cgi?id=307664">https://bugs.webkit.org/show_bug.cgi?id=307664</a>
<a href="https://rdar.apple.com/170219081">rdar://170219081</a>

Reviewed by Youenn Fablet.

VideoFrameCV::copyNativeImage() would use VTPixelBufferConformer
to change the video frame CVPixelBuffer to BGRA CVPixelBuffer.
VTPixelBufferConformer forces use of IOKit. This makes the
implementation less than useful, as copyNativeImage() cannot be used
in general, polymorphic code because it would need to special-case
fetching the converted data from GPUP in GPUP cases.

Prepare for removing the special-casing by implementing copyNativeImage()
via VTPixelTransferSession. This supports configuring the use of
IOKit.

The VTPixelTransferSession is also useful in the way that it is an API,
VTPixelBufferConformer is a SPI.

* Source/WebCore/platform/graphics/cv/CVUtilities.h:
* Source/WebCore/platform/graphics/cv/CVUtilities.mm:
(WebCore::createImageFrom32BGRAPixelBuffer):
* Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.h:
* Source/WebCore/platform/graphics/cv/ImageTransferSessionVT.mm:
(WebCore::createTransferSession):
(WebCore::ImageTransferSessionVT::ImageTransferSessionVT):
(WebCore::ImageTransferSessionVT::convertPixelBuffer):
* Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.cpp:
(WebCore::PixelBufferConformerCV::createImageFromPixelBuffer):
(WebCore::logStackTrace): Deleted.
(): Deleted.
(WebCore::CVPixelBufferGetBytePointerCallback): Deleted.
(WebCore::CVPixelBufferReleaseBytePointerCallback): Deleted.
(WebCore::CVPixelBufferReleaseInfoCallback): Deleted.
(WebCore::PixelBufferConformerCV::imageFrom32BGRAPixelBuffer): Deleted.
* Source/WebCore/platform/graphics/cv/PixelBufferConformerCV.h:
* Source/WebCore/platform/graphics/cv/VideoFrameCV.mm:
(WebCore::VideoFrame::copyNativeImage const):
* Source/WebKit/WebProcess/GPU/webrtc/RemoteVideoFrameObjectHeapProxyProcessor.cpp:
(WebKit::RemoteVideoFrameObjectHeapProxyProcessor::getNativeImage):

Canonical link: <a href="https://commits.webkit.org/308288@main">https://commits.webkit.org/308288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/92b63347138eb641928af10cad2b3a20aca3501e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19700 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13290 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155702 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5dec8cb1-da9e-4099-8337-c3a318646801) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148894 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19601 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113290 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7bf4b2df-c7be-4d7d-b5ff-889c4da1c8d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149982 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132085 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94046 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9049f2e-e456-4c03-83a4-8889ce9a0c4e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3144 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20159 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10005 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158033 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1164 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11444 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121314 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19502 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16369 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121515 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31128 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19511 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131761 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17076 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8585 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19117 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82872 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18847 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18998 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18906 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->