### PR TITLE
[LBSE] Fix svg/transforms/svgsvgelement-transform.svg

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -295,9 +295,6 @@ svg/foreignObject/filter.html                 [ ImageOnlyFailure ]
 svg/foreignObject/vertical-foreignObject.html [ ImageOnlyFailure ]
 svg/overflow/overflow-on-foreignObject.svg    [ ImageOnlyFailure ]
 
-# TODO: Test needs to be adapted (see test), then it will pass with LBSE, but fail legacy -- leaving it as-is for now.
-svg/transforms/svgsvgelement-transform.svg [ ImageOnlyFailure ]
-
 # Outline / focus-ring support
 svg/custom/focus-ring.svg [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/mac-tahoe-wk2-pixel/svg/transforms/svgsvgelement-transform-expected.svg
+++ b/LayoutTests/platform/mac-tahoe-wk2-pixel/svg/transforms/svgsvgelement-transform-expected.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="400" height="400">
+  <rect width="100" height="100" fill="green"/>
+  <text x="0" y="120">This test passes if a green square is visible, and no red.</text>
+</svg>


### PR DESCRIPTION
#### 9f674a16b9d68f3337501ca677f646ea8e6b42c0
<pre>
[LBSE] Fix svg/transforms/svgsvgelement-transform.svg
<a href="https://bugs.webkit.org/show_bug.cgi?id=307667">https://bugs.webkit.org/show_bug.cgi?id=307667</a>

Reviewed by Nikolas Zimmermann.

This test actually passes for LBSE and not legacy SVG, so provide
an expected svg for LBSE that is the traditional green rectangle.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-tahoe-wk2-pixel/svg/transforms/svgsvgelement-transform-expected.svg: Added.

Canonical link: <a href="https://commits.webkit.org/307461@main">https://commits.webkit.org/307461@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/310173001f65bb075db1e431c0c9cddf99b4f7ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16850 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8406 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152841 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97410 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110862 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79663 "Exiting early after 60 failures. 15424 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13276 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91780 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12718 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10463 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/287 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122208 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6185 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155153 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16702 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7240 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118879 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16739 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119237 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30621 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15114 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127396 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72123 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16324 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5832 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16058 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16269 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16124 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->