### PR TITLE
[WPE] Messages pile up in the queues

### DIFF
--- a/LayoutTests/platform/wpe/workers/message-channel-overload-with-busy-worker-expected.txt
+++ b/LayoutTests/platform/wpe/workers/message-channel-overload-with-busy-worker-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: MessageChannel's message queue size exceeded - at least one message has been dropped.
+PASS

--- a/LayoutTests/platform/wpe/workers/message-channel-overload-with-busy-worker.html
+++ b/LayoutTests/platform/wpe/workers/message-channel-overload-with-busy-worker.html
@@ -1,0 +1,71 @@
+<html><!-- webkit-test-runner [ MessageQueueCapacity=100 ] -->
+  <head>
+    <script id='myWorker' type='text/worker'>
+      self.onmessage = (initialMessage) => {
+          const port = initialMessage.data.port;
+          port.onmessage = (message) => {
+              if (message.data.id == 2) {
+                  function busyLoop(durationMs) {
+                      const begin = Date.now();
+                      while (true) {
+                          for (var i = 0; i < 1000000; ++i)
+                              continue;
+                          if (Date.now() - begin >= durationMs)
+                              break;
+                      }
+                  }
+                  busyLoop(2000);
+              }
+              port.postMessage(message.data);
+          };
+          postMessage('Start spamming please.');
+      };
+    </script>
+  </head>
+  <body>
+    <script>
+      if (window.testRunner) {
+          testRunner.waitUntilDone();
+          testRunner.dumpAsText();
+
+          const timeoutId = setTimeout(() => {
+              document.body.innerText = "TIMEOUT";
+              testRunner.notifyDone();
+          }, 5000);
+
+          const workerBlob = new Blob([document.getElementById('myWorker').textContent]);
+          const worker = new Worker(URL.createObjectURL(workerBlob));
+          const messageChannel = new MessageChannel();
+
+          worker.onmessage = (message) => {
+              for (let i = 1; i <= 200; i++) {
+                  messageChannel.port1.postMessage({ id: i });
+              }
+          };
+          let messagesAcknowledgedByWorker = 0;
+          let flushSent = false;
+          const flush = 999;
+          messageChannel.port1.onmessage = (message) => {
+              messagesAcknowledgedByWorker++;
+              if (message.data.id > 1 && !flushSent) {
+                  messageChannel.port1.postMessage({ id: flush });
+                  flushSent = true;
+              }
+              if (message.data.id == flush) {
+                  clearTimeout(timeoutId);
+                  if (messagesAcknowledgedByWorker < 201) {
+                      document.body.innerText = "PASS";
+                  } else {
+                      document.body.innerText = "FAIL";
+                  }
+                  testRunner.notifyDone();
+              }
+          };
+
+          worker.postMessage({
+              port: messageChannel.port2,
+          }, [ messageChannel.port2 ]);
+      }
+    </script>
+  </body>
+</html>

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -5344,6 +5344,20 @@ MediaVideoCodecIDsAllowedInLockdownMode:
     WebKit:
       default: '"avc1,zavc,qavc,cavc"_str'
 
+MessageQueueCapacity:
+  type: uint32_t
+  status: embedder
+  condition: PLATFORM(WPE)
+  humanReadableName: "Message Queue Capacity"
+  humanReadableDescription: "Capacity of message queue for each WebSocket, MessageChannel, etc."
+  defaultValue:
+    WebKitLegacy:
+      default: 1000
+    WebKit:
+      default: 1000
+    WebCore:
+      default: 1000
+
 MetaViewportInteractiveWidgetEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/Modules/websockets/WebSocket.cpp
+++ b/Source/WebCore/Modules/websockets/WebSocket.cpp
@@ -225,6 +225,21 @@ void WebSocket::failAsynchronously()
     });
 }
 
+#if PLATFORM(WPE)
+bool WebSocket::failIfDispatchQueueSizeExceeded()
+{
+    if (m_messagesInDispatchQueue > protect(scriptExecutionContext())->settingsValues().messageQueueCapacity) {
+        m_messagesInDispatchQueue--;
+        LOG(Network, "WebSocket's message queue size exceeded - connection will be closed.");
+        protect(scriptExecutionContext())->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "WebSocket's message queue size exceeded."_s);
+        close(std::nullopt, "WebSocket's message queue size exceeded."_s);
+        return true;
+    }
+
+    return false;
+}
+#endif
+
 ExceptionOr<void> WebSocket::connect(const String& url, const Vector<String>& protocols)
 {
     LOG(Network, "WebSocket %p connect() url='%s'", this, url.utf8().data());
@@ -551,7 +566,18 @@ void WebSocket::didConnect()
 void WebSocket::didReceiveMessage(String&& message)
 {
     LOG(Network, "WebSocket %p didReceiveMessage() Text message '%s'", this, message.utf8().data());
+
+#if PLATFORM(WPE)
+    m_messagesInDispatchQueue++;
+    if (failIfDispatchQueueSizeExceeded())
+        return;
+#endif
+
     queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [message = WTF::move(message)](auto& socket) mutable {
+#if PLATFORM(WPE)
+        socket.m_messagesInDispatchQueue--;
+#endif
+
         if (socket.m_state != OPEN)
             return;
 
@@ -569,7 +595,18 @@ void WebSocket::didReceiveMessage(String&& message)
 void WebSocket::didReceiveBinaryData(Vector<uint8_t>&& binaryData)
 {
     LOG(Network, "WebSocket %p didReceiveBinaryData() %u byte binary message", this, static_cast<unsigned>(binaryData.size()));
+
+#if PLATFORM(WPE)
+    m_messagesInDispatchQueue++;
+    if (failIfDispatchQueueSizeExceeded())
+        return;
+#endif
+
     queueTaskKeepingObjectAlive(*this, TaskSource::WebSocket, [binaryData = WTF::move(binaryData)](auto& socket) mutable {
+#if PLATFORM(WPE)
+        socket.m_messagesInDispatchQueue--;
+#endif
+
         if (socket.m_state != OPEN)
             return;
 

--- a/Source/WebCore/Modules/websockets/WebSocket.h
+++ b/Source/WebCore/Modules/websockets/WebSocket.h
@@ -134,6 +134,10 @@ private:
 
     void failAsynchronously();
 
+#if PLATFORM(WPE)
+    bool failIfDispatchQueueSizeExceeded();
+#endif
+
     static Lock s_allActiveWebSocketsLock;
     RefPtr<ThreadableWebSocketChannel> m_channel;
 
@@ -148,6 +152,10 @@ private:
 
     bool m_dispatchedErrorEvent { false };
     RefPtr<PendingActivity<WebSocket>> m_pendingActivity;
+
+#if PLATFORM(WPE)
+    unsigned long m_messagesInDispatchQueue { 0 };
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -299,8 +299,24 @@ void MessagePort::dispatchMessages()
                 return;
             }
 
+#if PLATFORM(WPE)
+            pendingActivity->object().m_messagesInDispatchQueue++;
+            if (pendingActivity->object().m_messagesInDispatchQueue > context->settingsValues().messageQueueCapacity) {
+                pendingActivity->object().m_messagesInDispatchQueue--;
+                static std::once_flag onceFlag;
+                std::call_once(onceFlag, [&context] {
+                    LOG(MessagePorts, "MessageChannel's message queue size exceeded - at least one message has been dropped.");
+                    context->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "MessageChannel's message queue size exceeded - at least one message has been dropped."_s);
+                });
+                return;
+            }
+#endif
+
             // Per specification, each MessagePort object has a task source called the port message queue.
             queueTaskKeepingObjectAlive(pendingActivity->object(), TaskSource::PostedMessageQueue, [event = WTF::move(event)](auto& port) {
+#if PLATFORM(WPE)
+                port.m_messagesInDispatchQueue--;
+#endif
                 port.dispatchEvent(event.event);
             });
         }

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -130,6 +130,10 @@ private:
     MessagePortIdentifier m_remoteIdentifier;
 
     MessageHandler m_messageHandler;
+
+#if PLATFORM(WPE)
+    unsigned long m_messagesInDispatchQueue { 0 };
+#endif
 };
 
 WebCoreOpaqueRoot root(MessagePort*);

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -121,6 +121,19 @@ void WebMessagePortChannelProvider::postMessageToRemote(MessageWithMessagePorts&
 {
     auto iterator = m_inProcessPortMessages.find(remoteTarget);
     if (iterator != m_inProcessPortMessages.end()) {
+#if PLATFORM(WPE)
+        if (WebPage* page = WebProcess::singleton().focusedWebPage()) {
+            if (iterator->value.size() >= page->corePage()->settings().messageQueueCapacity()) {
+                static std::once_flag onceFlag;
+                std::call_once(onceFlag, [&page] {
+                    LOG(MessagePorts, "MessageChannel's message queue size exceeded - at least one message has been dropped.");
+                    if (RefPtr localTopDocument = protect(page->corePage())->localTopDocument())
+                        localTopDocument->addConsoleMessage(MessageSource::Other, MessageLevel::Error, "MessageChannel's message queue size exceeded - at least one message has been dropped."_s);
+                });
+                return;
+            }
+        }
+#endif
         iterator->value.append(WTF::move(message));
         WebProcess::singleton().messagesAvailableForPort(remoteTarget);
         return;


### PR DESCRIPTION
#### 160873a45c67bf902a1938115a0f692cc89ac0d3
<pre>
[WPE] Messages pile up in the queues
<a href="https://bugs.webkit.org/show_bug.cgi?id=307665">https://bugs.webkit.org/show_bug.cgi?id=307665</a>

Reviewed by NOBODY (OOPS!).

Many embedded applications using WPE are running for a very long time
(hours, days, weeks, etc.). If such an application suffers from
performance problems and it processes messages on receiving end at
lower rate than the sending end sends them, the messages tend to pile
up in internal WebKit queues and hence lead to memory growing
indefinitely. This is true for all message channels such as WebSocket,
MessageChannel, etc.

This change implements fixed message queue limits that have following
consequences:
- in case of WebSocket, if the limit is exceeded, the connection gets
  disconnected (just like chromium does),
- in case of MessageChannel, if the limit is exceeded, all messages
  above the limit are getting dropped and the error is communicated
  on console.

Test: platform/wpe/workers/message-channel-overload-with-busy-worker.html
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/160873a45c67bf902a1938115a0f692cc89ac0d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144175 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8410 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152845 "Hash 160873a4 for PR 58503 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17336 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16748 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/152845 "Hash 160873a4 for PR 58503 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79665 "1 flakes 2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129535 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/152845 "Hash 160873a4 for PR 58503 does not build (failure)") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12720 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10466 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/291 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136166 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122210 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6190 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155157 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/4983 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16706 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7245 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118886 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16743 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14029 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119244 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15116 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127401 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72127 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16328 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5837 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175462 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16062 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80107 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45222 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16273 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16128 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->