### PR TITLE
[macOS] webanimations/accelerated-animation-slot-invalidation.html is a flaky image failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2476,5 +2476,3 @@ webkit.org/b/307385 fast/events/onunload-not-on-body.html [ Pass Failure ]
 webkit.org/b/307377 [ Tahoe Release arm64 ] compositing/webgl/update-composited-canvas-layer.html [ ImageOnlyFailure Pass ]
 
 webkit.org/b/307571 imported/w3c/web-platform-tests/workers/SharedWorkerPerformanceNow.html [ Pass Failure ]
-
-webkit.org/b/307598 webanimations/accelerated-animation-slot-invalidation.html [ ImageOnlyFailure Pass ]

--- a/LayoutTests/webanimations/accelerated-animation-slot-invalidation.html
+++ b/LayoutTests/webanimations/accelerated-animation-slot-invalidation.html
@@ -19,7 +19,7 @@ div {
 }
 
 .animate-class {
-    animation: 1s linear 0s 1 normal scale;
+    animation: scale 1s linear;
 }
 
 .first-letter::first-letter {
@@ -27,24 +27,15 @@ div {
 }
 
 @keyframes scale {
-    0% {
-        transform: scale(0);
-    }
-
-    10% {
-        transform: scale(1);
-    }
-
-    100% {
-        transform: scale(1);
-    }
+    0% { scale: 0.5 }
+    5%, 100% { scale: 1 }
 }
 
 </style>
+<script src="threaded-animations/threaded-animations-utils.js"></script>
 <script>
 
-if (window.testRunner)
-    testRunner.waitUntilDone();
+window.testRunner?.waitUntilDone();
 
 window.onload = async function() {
     let shadowRoot = document.body.attachShadow({ mode: "open" });
@@ -69,20 +60,18 @@ window.onload = async function() {
 
     const animation = secondElement.getAnimations()[0];
 
-    await animation.ready;
-
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
-    await new Promise(requestAnimationFrame);
+    await animationAcceleration(animation);
 
     firstElement.remove();
 
     // Wait until animation has progressed some before snapshotting the test result.
-    while (animation.currentTime < 100)
+    while (animation.currentTime <= 50)
         await new Promise(requestAnimationFrame);
 
-    if (window.testRunner)
-        testRunner.notifyDone();
+    // Wait another frame to ensure the accelerated animations has reached the same 10% keyframe.
+    await new Promise(requestAnimationFrame);
+
+    window.testRunner?.notifyDone();
 }
 
 </script>


### PR DESCRIPTION
#### c67f2da8d48124fc55da026f54d87c9ec4e048f9
<pre>
[macOS] webanimations/accelerated-animation-slot-invalidation.html is a flaky image failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=307598">https://bugs.webkit.org/show_bug.cgi?id=307598</a>
<a href="https://rdar.apple.com/170177882">rdar://170177882</a>

Reviewed by Tim Nguyen.

Harden this test by using `animationAcceleration()` to determine when an accelerated animation
is ready, and wait an additional frame before ending the test to make sure we have update the
accelerated animation to reach the 5% keyframe. We also cut down the wait from 100ms to 50ms
as this should be a reliably long-enough wait after animation acceleration and cuts down the
time this test runs for by 2.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webanimations/accelerated-animation-slot-invalidation.html:

Canonical link: <a href="https://commits.webkit.org/307361@main">https://commits.webkit.org/307361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72ac7eb67ef16b419d70bb173d3d5e8d313e4e68

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16859 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152850 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17341 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16753 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110868 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97419 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91786 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b09475ec-3c4f-449a-bd51-5054b9ea6868) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10468 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/296 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6195 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155162 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16711 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118887 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16748 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14032 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119245 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15117 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72132 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22236 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16333 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5842 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16067 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16278 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16133 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->