### PR TITLE
Add a `protect()` overload for `WeakObjCPtr<T>`

### DIFF
--- a/Source/WTF/wtf/RetainPtr.h
+++ b/Source/WTF/wtf/RetainPtr.h
@@ -343,6 +343,9 @@ ALWAYS_INLINE CLANG_POINTER_CONVERSION RetainPtr<T> protect(const RetainPtr<T>& 
     return ptr;
 }
 
+template<typename T>
+RetainPtr<T> protect(RetainPtr<T>&&) = delete;
+
 template<typename T> struct IsSmartPtr<RetainPtr<T>> {
     static constexpr bool value = true;
     static constexpr bool isNullable = true;

--- a/Source/WTF/wtf/WeakObjCPtr.h
+++ b/Source/WTF/wtf/WeakObjCPtr.h
@@ -121,6 +121,13 @@ RetainPtr<typename WeakObjCPtr<T>::ValueType> WeakObjCPtr<T>::get() const
 }
 #endif
 
+template<typename T>
+inline RetainPtr<typename WeakObjCPtr<T>::ValueType> protect(const WeakObjCPtr<T>& weakPtr)
+{
+    return weakPtr.get();
+}
+
 } // namespace WTF
 
+using WTF::protect;
 using WTF::WeakObjCPtr;

--- a/Source/WTF/wtf/cf/CFTypeTraits.h
+++ b/Source/WTF/wtf/cf/CFTypeTraits.h
@@ -70,6 +70,16 @@ WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFData, CFMutableData);
 WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFDictionary, CFMutableDictionary);
 WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CFString, CFMutableString);
 
+#if USE(CG)
+#include <CoreGraphics/CGColor.h>
+#include <CoreGraphics/CGImage.h>
+#include <CoreGraphics/CGPath.h>
+WTF_DECLARE_CF_TYPE_TRAIT(CGColor);
+WTF_DECLARE_CF_TYPE_TRAIT(CGImage);
+WTF_DECLARE_CF_TYPE_TRAIT(CGPath);
+WTF_DECLARE_CF_MUTABLE_TYPE_TRAIT(CGPath, CGMutablePath);
+#endif
+
 namespace WTF {
 
 namespace detail {

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp
@@ -343,7 +343,7 @@ static auto convertToBacking(const ComputePipelineDescriptor& descriptor, Conver
         .label = label.data(),
         .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*descriptor.protectedLayout().get()) : nullptr,
         .compute = WGPUProgrammableStageDescriptor {
-            .module = convertToBackingContext.convertToBacking(protect(descriptor.compute.module.get()).get()),
+            .module = convertToBackingContext.convertToBacking(protect(descriptor.compute.module).get()),
             .entryPoint = entryPoint ? entryPoint->data() : nullptr,
             .constantCount = backingConstantEntries.size(),
             .constants = backingConstantEntries.size() ? backingConstantEntries.span().data() : nullptr,
@@ -496,7 +496,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
     }
 
     WGPUFragmentState fragmentState {
-        .module = descriptor.fragment ? convertToBackingContext.convertToBacking(protect(descriptor.fragment->module.get()).get()) : nullptr,
+        .module = descriptor.fragment ? convertToBackingContext.convertToBacking(protect(descriptor.fragment->module).get()) : nullptr,
         .entryPoint = fragmentEntryPoint ? fragmentEntryPoint->data() : nullptr,
         .constantCount = fragmentConstantEntries.size(),
         .constants = fragmentConstantEntries.size() ? fragmentConstantEntries.span().data() : nullptr,
@@ -508,7 +508,7 @@ static auto convertToBacking(const RenderPipelineDescriptor& descriptor, Convert
         .label = label.data(),
         .layout = descriptor.layout ? convertToBackingContext.convertToBacking(*descriptor.protectedLayout()) : nullptr,
         .vertex = {
-            .module = convertToBackingContext.convertToBacking(protect(descriptor.vertex.module.get()).get()),
+            .module = convertToBackingContext.convertToBacking(protect(descriptor.vertex.module).get()),
             .entryPoint = vertexEntryPoint ? vertexEntryPoint->data() : nullptr,
             .constantCount = vertexConstantEntries.size(),
             .constants = vertexConstantEntries.size() ? vertexConstantEntries.span().data() : nullptr,

--- a/Source/WebCore/loader/cache/CachedResourceHandle.h
+++ b/Source/WebCore/loader/cache/CachedResourceHandle.h
@@ -91,27 +91,27 @@ template <class R, class RR> bool operator==(const CachedResourceHandle<R>& h, c
 
 namespace WTF {
 
-template<typename T> requires std::derived_from<T, WebCore::CachedResource>
+template<typename T> requires (requires { sizeof(T); } && std::derived_from<T, WebCore::CachedResource>)
 WebCore::CachedResourceHandle<T> protect(T* resource)
 {
     return WebCore::CachedResourceHandle<T> { resource };
 }
 
-template<typename T> requires std::derived_from<T, WebCore::CachedResource>
+template<typename T> requires (requires { sizeof(T); } && std::derived_from<T, WebCore::CachedResource>)
 WebCore::CachedResourceHandle<T> protect(T& resource)
 {
     return WebCore::CachedResourceHandle<T> { resource };
 }
 
 template<typename T, typename WeakPtrImpl, typename PtrTraits>
-    requires std::derived_from<T, WebCore::CachedResource>
+    requires (requires { sizeof(T); } && std::derived_from<T, WebCore::CachedResource>)
 ALWAYS_INLINE CLANG_POINTER_CONVERSION WebCore::CachedResourceHandle<T> protect(const WeakPtr<T, WeakPtrImpl, PtrTraits>& resource)
 {
     return WebCore::CachedResourceHandle<T> { resource.get() };
 }
 
 template<typename T, typename WeakPtrImpl>
-    requires std::derived_from<T, WebCore::CachedResource>
+    requires (requires { sizeof(T); } && std::derived_from<T, WebCore::CachedResource>)
 ALWAYS_INLINE CLANG_POINTER_CONVERSION WebCore::CachedResourceHandle<T> protect(const WeakRef<T, WeakPtrImpl>& resource)
 {
     return WebCore::CachedResourceHandle<T> { resource.get() };

--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -56,12 +56,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
-#if USE(CG)
-typedef struct CGColor* CGColorRef;
-extern "C" CFTypeID CGColorGetTypeID();
-WTF_DECLARE_CF_TYPE_TRAIT(CGColor);
-#endif
-
 namespace WebCore {
 
 struct OutOfLineColorDataForIPC {

--- a/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h
@@ -55,52 +55,52 @@ private:
 
     void willChangeIsLoading() override
     {
-        [m_object.get() willChangeValueForKey:@"loading"];
+        [protect(m_object) willChangeValueForKey:@"loading"];
     }
 
     void didChangeIsLoading() override
     {
-        [m_object.get() didChangeValueForKey:@"loading"];
+        [protect(m_object) didChangeValueForKey:@"loading"];
     }
 
     void willChangeTitle() override
     {
-        [m_object.get() willChangeValueForKey:@"title"];
+        [protect(m_object) willChangeValueForKey:@"title"];
     }
 
     void didChangeTitle() override
     {
-        [m_object.get() didChangeValueForKey:@"title"];
+        [protect(m_object) didChangeValueForKey:@"title"];
     }
 
     void willChangeActiveURL() override
     {
-        [m_object.get() willChangeValueForKey:m_activeURLKey.get()];
+        [protect(m_object) willChangeValueForKey:m_activeURLKey.get()];
     }
 
     void didChangeActiveURL() override
     {
-        [m_object.get() didChangeValueForKey:m_activeURLKey.get()];
+        [protect(m_object) didChangeValueForKey:m_activeURLKey.get()];
     }
 
     void willChangeHasOnlySecureContent() override
     {
-        [m_object.get() willChangeValueForKey:@"hasOnlySecureContent"];
+        [protect(m_object) willChangeValueForKey:@"hasOnlySecureContent"];
     }
 
     void didChangeHasOnlySecureContent() override
     {
-        [m_object.get() didChangeValueForKey:@"hasOnlySecureContent"];
+        [protect(m_object) didChangeValueForKey:@"hasOnlySecureContent"];
     }
 
     void willChangeEstimatedProgress() override
     {
-        [m_object.get() willChangeValueForKey:@"estimatedProgress"];
+        [protect(m_object) willChangeValueForKey:@"estimatedProgress"];
     }
 
     void didChangeEstimatedProgress() override
     {
-        [m_object.get() didChangeValueForKey:@"estimatedProgress"];
+        [protect(m_object) didChangeValueForKey:@"estimatedProgress"];
     }
 
     void willChangeCanGoBack() override { }
@@ -115,12 +115,12 @@ private:
 
     void willChangeWebProcessIsResponsive() override
     {
-        [m_object.get() willChangeValueForKey:@"_webProcessIsResponsive"];
+        [protect(m_object) willChangeValueForKey:@"_webProcessIsResponsive"];
     }
 
     void didChangeWebProcessIsResponsive() override
     {
-        [m_object.get() didChangeValueForKey:@"_webProcessIsResponsive"];
+        [protect(m_object) didChangeValueForKey:@"_webProcessIsResponsive"];
     }
 
     WeakObjCPtr<id> m_object;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -4014,7 +4014,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
 
 - (void)_frames:(void (^)(_WKFrameTreeNode *))completionHandler
 {
-    _page->getAllFrames([completionHandler = makeBlockPtr(completionHandler), page = protect(*_page.get())] (std::optional<WebKit::FrameTreeNodeData>&& data) {
+    _page->getAllFrames([completionHandler = makeBlockPtr(completionHandler), page = protect(*_page)] (std::optional<WebKit::FrameTreeNodeData>&& data) {
         if (!data)
             return completionHandler(nil);
         completionHandler(wrapper(API::FrameTreeNode::create(WTF::move(*data), page.get())).get());
@@ -4023,7 +4023,7 @@ FOR_EACH_PRIVATE_WKCONTENTVIEW_ACTION(FORWARD_ACTION_TO_WKCONTENTVIEW)
 
 - (void)_frameTrees:(void (^)(NSSet<_WKFrameTreeNode *> *))completionHandler
 {
-    _page->getAllFrameTrees([completionHandler = makeBlockPtr(completionHandler), page = protect(*_page.get())] (Vector<WebKit::FrameTreeNodeData>&& vector) {
+    _page->getAllFrameTrees([completionHandler = makeBlockPtr(completionHandler), page = protect(*_page)] (Vector<WebKit::FrameTreeNodeData>&& vector) {
         auto set = adoptNS([[NSMutableSet alloc] initWithCapacity:vector.size()]);
         for (auto& data : vector)
             [set addObject:wrapper(API::FrameTreeNode::create(WTF::move(data), page.get())).get()];

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -650,7 +650,7 @@ enum class AllowPageBackgroundColorOverride : bool { No, Yes };
 static WebCore::Color baseScrollViewBackgroundColor(WKWebView *webView, AllowPageBackgroundColorOverride allowPageBackgroundColorOverride)
 {
     if (webView->_customContentView)
-        return WebCore::roundAndClampToSRGBALossy(protect<CGColorRef>([webView->_customContentView backgroundColor].CGColor));
+        return WebCore::roundAndClampToSRGBALossy(protect([webView->_customContentView backgroundColor].CGColor));
 
     if (webView->_gestureController) {
         WebCore::Color color = webView->_gestureController->backgroundColorForCurrentSnapshot();
@@ -674,10 +674,10 @@ static WebCore::Color scrollViewBackgroundColor(WKWebView *webView, AllowPageBac
         color = baseScrollViewBackgroundColor(webView.get(), allowPageBackgroundColorOverride);
 
         if (!color.isValid() && webView->_contentView)
-            color = WebCore::roundAndClampToSRGBALossy(protect<CGColorRef>([webView->_contentView backgroundColor].CGColor));
+            color = WebCore::roundAndClampToSRGBALossy(protect([webView->_contentView backgroundColor].CGColor));
 
         if (!color.isValid())
-            color = WebCore::roundAndClampToSRGBALossy(protect<CGColorRef>(UIColor.systemBackgroundColor.CGColor));
+            color = WebCore::roundAndClampToSRGBALossy(protect(UIColor.systemBackgroundColor.CGColor));
     }];
 
     return color;

--- a/Source/WebKit/UIProcess/ApplicationStateTracker.mm
+++ b/Source/WebKit/UIProcess/ApplicationStateTracker.mm
@@ -169,8 +169,8 @@ ApplicationStateTracker::ApplicationStateTracker(UIView *view, SEL didEnterBackg
     , m_didCompleteSnapshotSequenceSelector(didCompleteSnapshotSequenceSelector)
     , m_isInBackground(true)
 {
-    ASSERT([m_view.get() respondsToSelector:m_didEnterBackgroundSelector]);
-    ASSERT([m_view.get() respondsToSelector:m_willEnterForegroundSelector]);
+    ASSERT([protect(m_view) respondsToSelector:m_didEnterBackgroundSelector]);
+    ASSERT([protect(m_view) respondsToSelector:m_willEnterForegroundSelector]);
 
     allApplicationStateTrackers().add(*this);
 }

--- a/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp
@@ -105,7 +105,7 @@ void WebInspectorUIExtensionControllerProxy::registerExtension(const Inspector::
             return;
         }
 
-        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [protectedThis = protect(*weakThis.get()), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::RegisterExtension { extensionID, extensionBundleIdentifier, displayName }, [protectedThis = protect(*weakThis), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::RegistrationFailed));
                 return;
@@ -132,7 +132,7 @@ void WebInspectorUIExtensionControllerProxy::unregisterExtension(const Inspector
             return;
         }
 
-        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [protectedThis = protect(*weakThis.get()), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
+        protect(protect(weakThis->m_inspectorPage)->legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebInspectorUIExtensionController::UnregisterExtension { extensionID }, [protectedThis = protect(*weakThis), extensionID, completionHandler = WTF::move(completionHandler)](Expected<void, Inspector::ExtensionError> result) mutable {
             if (!result) {
                 completionHandler(makeUnexpected(Inspector::ExtensionError::InvalidRequest));
                 return;

--- a/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp
@@ -62,7 +62,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MediaKeySystemPermissionRequestManagerProxy);
 
 const Logger& MediaKeySystemPermissionRequestManagerProxy::logger() const
 {
-    return protect(m_page.get())->logger();
+    return protect(m_page)->logger();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/WebProcessActivityState.cpp
+++ b/Source/WebKit/UIProcess/WebProcessActivityState.cpp
@@ -234,7 +234,7 @@ bool WebProcessActivityState::hasValidOpeningAppLinkActivity() const
 void WebProcessActivityState::updateWebProcessSuspensionDelay()
 {
     Seconds timeout = WTF::visit(WTF::makeVisitor([&](const WeakRef<WebPageProxy>& page) {
-        return webProcessSuspensionDelay(protect(page.get()).ptr());
+        return webProcessSuspensionDelay(protect(page).ptr());
     }, [&] (const WeakRef<RemotePageProxy>& page) {
         return webProcessSuspensionDelay(protect(page->page()).get());
     }), m_page);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -768,7 +768,7 @@ WebPageProxy* WebProcessProxy::webPage(PageIdentifier pageID)
 WebPageProxy* WebProcessProxy::audioCapturingWebPage()
 {
     for (WeakRef page : globalPageMap().values()) {
-        if (protect(page.get())->hasActiveAudioStream())
+        if (protect(page)->hasActiveAudioStream())
             return page.ptr();
     }
     return nullptr;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -140,7 +140,7 @@ WorkQueue& WebsiteDataStore::websiteDataStoreIOQueueSingleton()
 void WebsiteDataStore::forEachWebsiteDataStore(NOESCAPE Function<void(WebsiteDataStore&)>&& function)
 {
     for (auto& dataStore : allDataStores().values())
-        function(protect(dataStore.get()));
+        function(protect(dataStore));
 }
 
 Ref<WebsiteDataStore> WebsiteDataStore::createNonPersistent()
@@ -282,7 +282,7 @@ Ref<WebsiteDataStore> WebsiteDataStore::dataStoreForIdentifier(const WTF::UUID& 
     InitializeWebKit2();
     for (auto& dataStore : allDataStores().values()) {
         if (dataStore->configuration().identifier() == uuid)
-            return protect(dataStore.get());
+            return protect(dataStore);
     }
 
     Ref configuration = WebsiteDataStoreConfiguration::create(uuid);
@@ -2566,7 +2566,7 @@ void WebsiteDataStore::forwardAppBoundDomainsToITPIfInitialized(CompletionHandle
     propagateAppBoundDomains(protectedGlobalDefaultDataStore().get(), *appBoundDomains);
 
     for (auto& store : allDataStores().values())
-        propagateAppBoundDomains(protect(store.get()).ptr(), *appBoundDomains);
+        propagateAppBoundDomains(protect(store).ptr(), *appBoundDomains);
 }
 
 void WebsiteDataStore::setAppBoundDomainsForITP(const HashSet<WebCore::RegistrableDomain>& domains, CompletionHandler<void()>&& completionHandler)
@@ -2595,7 +2595,7 @@ void WebsiteDataStore::forwardManagedDomainsToITPIfInitialized(CompletionHandler
     propagateManagedDomains(protectedGlobalDefaultDataStore().get(), *managedDomains);
 
     for (auto& store : allDataStores().values())
-        propagateManagedDomains(protect(store.get()).ptr(), *managedDomains);
+        propagateManagedDomains(protect(store).ptr(), *managedDomains);
 }
 
 void WebsiteDataStore::setManagedDomainsForITP(const HashSet<WebCore::RegistrableDomain>& domains, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
+++ b/Source/WebKit/UIProcess/ios/DragDropInteractionState.mm
@@ -307,7 +307,7 @@ RetainPtr<UITargetedDragPreview> DragDropInteractionState::createDragPreviewInte
         ASSERT(image);
         if (shouldUseVisiblePathToCreatePreviewForDragSource(source)) {
             auto path = source.visiblePath.value();
-            RetainPtr visiblePath = [UIBezierPath bezierPathWithCGPath:protect<CGPathRef>(path.platformPath()).get()];
+            RetainPtr visiblePath = [UIBezierPath bezierPathWithCGPath:protect(path.platformPath()).get()];
             return createTargetedDragPreview(image->get(), contentView, previewContainer, source.dragPreviewFrameInRootViewCoordinates, { }, nil, visiblePath, addPreviewViewToContainer).autorelease();
         }
         return createTargetedDragPreview(image->get(), contentView, previewContainer, source.dragPreviewFrameInRootViewCoordinates, { }, nil, nil, addPreviewViewToContainer).autorelease();

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -1439,12 +1439,12 @@ void PageClientImpl::scheduleVisibleContentRectUpdate()
 
 bool PageClientImpl::isPotentialTapInProgress() const
 {
-    return [m_contentView.get() isPotentialTapInProgress];
+    return [protect(m_contentView) isPotentialTapInProgress];
 }
 
 bool PageClientImpl::canStartNavigationSwipeAtLastInteractionLocation() const
 {
-    return [m_contentView.get() _canStartNavigationSwipeAtLastInteractionLocation];
+    return [protect(m_contentView) _canStartNavigationSwipeAtLastInteractionLocation];
 }
 
 #if ENABLE(PDF_PAGE_NUMBER_INDICATOR)

--- a/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm
+++ b/Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm
@@ -126,7 +126,7 @@ WebCore::FloatPoint PointerTouchCompatibilitySimulator::locationInScreen() const
 
 RetainPtr<UIWindow> PointerTouchCompatibilitySimulator::window() const
 {
-    return [m_view.get() window];
+    return [protect(m_view) window];
 }
 
 void PointerTouchCompatibilitySimulator::setEnabled(bool enabled)

--- a/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.mm
+++ b/Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.mm
@@ -50,7 +50,7 @@ void RevealFocusedElementDeferrer::fulfill(RevealFocusedElementDeferralReason re
     if (!m_reasons.isEmpty())
         return;
 
-    [m_view.get() _zoomToRevealFocusedElement];
+    [protect(m_view) _zoomToRevealFocusedElement];
     m_view = nil;
 }
 

--- a/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
+++ b/Source/WebKit/UIProcess/ios/SmartMagnificationController.mm
@@ -79,7 +79,7 @@ void SmartMagnificationController::handleSmartMagnificationGesture(FloatPoint or
 
 void SmartMagnificationController::handleResetMagnificationGesture(FloatPoint origin)
 {
-    [protect(m_contentView.get()) _zoomOutWithOrigin:origin];
+    [protect(m_contentView) _zoomOutWithOrigin:origin];
 }
 
 std::tuple<FloatRect, double, double> SmartMagnificationController::smartMagnificationTargetRectAndZoomScales(FloatRect targetRect, double minimumScale, double maximumScale, bool addMagnificationPadding)
@@ -153,7 +153,7 @@ void SmartMagnificationController::didCollectGeometryForSmartMagnificationGestur
 
 void SmartMagnificationController::scrollToRect(FloatPoint origin, FloatRect targetRect)
 {
-    [protect(m_contentView.get()) _scrollToRect:targetRect withOrigin:origin minimumScrollDistance:0];
+    [protect(m_contentView) _scrollToRect:targetRect withOrigin:origin minimumScrollDistance:0];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -10403,7 +10403,7 @@ static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
     if (!_contextMenuHintContainerView)
         return;
 
-    CGPoint newOffset = [protect(_scrollViewForTargetedPreview.get()) convertPoint:CGPointZero toView:[protect(_contextMenuHintContainerView.get()) superview]];
+    CGPoint newOffset = [protect(_scrollViewForTargetedPreview) convertPoint:CGPointZero toView:[protect(_contextMenuHintContainerView.get()) superview]];
 
     CGRect frame = [_contextMenuHintContainerView frame];
     frame.origin.x = newOffset.x - _scrollViewForTargetedPreviewInitialOffset.x;
@@ -10421,7 +10421,7 @@ static WebCore::DataOwnerType coreDataOwnerType(_UIDataOwner platformType)
     if (!_scrollViewForTargetedPreview)
         _scrollViewForTargetedPreview = self.webView.scrollView;
 
-    _scrollViewForTargetedPreviewInitialOffset = [protect(_scrollViewForTargetedPreview.get()) convertPoint:CGPointZero toView:[protect(_contextMenuHintContainerView.get()) superview]];
+    _scrollViewForTargetedPreviewInitialOffset = [protect(_scrollViewForTargetedPreview) convertPoint:CGPointZero toView:[protect(_contextMenuHintContainerView.get()) superview]];
 }
 
 #pragma mark - WKDeferringGestureRecognizerDelegate
@@ -12983,7 +12983,7 @@ static RetainPtr<NSItemProvider> createItemProvider(const WebKit::WebPageProxy& 
 - (NSData *)provideDataForItem:(QLItem *)item
 {
     ASSERT(_visualSearchPreviewImage);
-    return WebKit::transcode(protect<CGImageRef>([_visualSearchPreviewImage CGImage]), protect((__bridge CFStringRef)UTTypeTIFF.identifier).get()).autorelease();
+    return WebKit::transcode(protect([_visualSearchPreviewImage CGImage]), protect((__bridge CFStringRef)UTTypeTIFF.identifier).get()).autorelease();
 }
 
 #pragma mark - WKActionSheetAssistantDelegate
@@ -13412,7 +13412,7 @@ static BOOL shouldUseMachineReadableCodeMenuFromImageAnalysisResult(CocoaImageAn
     if (!self.subjectResultForImageContextMenu)
         return;
 
-    auto [data, type] = WebKit::imageDataForRemoveBackground(protect<CGImageRef>(self.subjectResultForImageContextMenu), protect((__bridge CFStringRef)sourceMIMEType).get());
+    auto [data, type] = WebKit::imageDataForRemoveBackground(protect(self.subjectResultForImageContextMenu), protect((__bridge CFStringRef)sourceMIMEType).get());
     if (!data)
         return;
 

--- a/Source/WebKit/UIProcess/ios/WKTapHighlightView.mm
+++ b/Source/WebKit/UIProcess/ios/WKTapHighlightView.mm
@@ -154,7 +154,7 @@
 
     if (_innerFrames.size()) {
         auto corePath = WebCore::PathUtilities::pathWithShrinkWrappedRects(_innerFrames, _cornerRadii);
-        [path appendPath:[UIBezierPath bezierPathWithCGPath:protect<CGPathRef>(corePath.platformPath()).get()]];
+        [path appendPath:[UIBezierPath bezierPathWithCGPath:protect(corePath.platformPath()).get()]];
     } else {
         for (auto& quad : _innerQuads) {
             UIBezierPath *subpath = [UIBezierPath bezierPath];
@@ -175,13 +175,13 @@
 
     CGContextSetLineJoin(context.get(), kCGLineJoinRound);
 
-    auto alpha = CGColorGetAlpha(protect<CGColorRef>([_color CGColor]));
+    auto alpha = CGColorGetAlpha(protect([_color CGColor]));
 
     [[_color colorWithAlphaComponent:1] set];
 
     CGContextSetAlpha(context.get(), alpha);
     CGContextBeginTransparencyLayer(context.get(), nil);
-    CGContextAddPath(context.get(), protect<CGPathRef>(path.CGPath));
+    CGContextAddPath(context.get(), protect(path.CGPath));
     CGContextDrawPath(context.get(), kCGPathFillStroke);
     CGContextEndTransparencyLayer(context.get());
 

--- a/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm
@@ -180,7 +180,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
         return;
 
     SetForScope isDismissingDatePicker { _isDismissingDatePicker, YES };
-    [protect(_view.get()) accessoryDone];
+    [protect(_view) accessoryDone];
 }
 
 - (void)removeDatePickerPresentation
@@ -192,7 +192,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
         }
 
         _datePickerController = nil;
-        [[protect(_view.get()) webView] _didDismissContextMenu];
+        [[protect(_view) webView] _didDismissContextMenu];
     }
 }
 
@@ -205,19 +205,19 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 {
     RetainPtr view = _view.get();
 #if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
-    if ([protect(view.get()) focusedElementInformation].elementType == WebKit::InputType::Week)
+    if ([view focusedElementInformation].elementType == WebKit::InputType::Week)
         _datePickerController = adoptNS([[WKDatePickerPopoverController alloc] initWithCalendarView:_calendarView.get() selectionWeekOfYear:_selectionWeekOfYear.get() delegate:self]);
     else
 #endif
         _datePickerController = adoptNS([[WKDatePickerPopoverController alloc] initWithDatePicker:_datePicker.get() delegate:self]);
-    [_datePickerController presentInView:protect(view.get()) sourceRect:[protect(view) focusedElementInformation].interactionRect completion:[strongSelf = retainPtr(self)] {
-        [[protect(strongSelf->_view.get()) webView] _didShowContextMenu];
+    [_datePickerController presentInView:view.get() sourceRect:[view focusedElementInformation].interactionRect completion:[strongSelf = retainPtr(self)] {
+        [[protect(strongSelf->_view) webView] _didShowContextMenu];
     }];
 }
 
 - (BOOL)shouldForceGregorianCalendar
 {
-    auto autofillFieldName = [protect(_view.get()) focusedElementInformation].autofillFieldName;
+    auto autofillFieldName = [protect(_view) focusedElementInformation].autofillFieldName;
     return autofillFieldName == WebCore::AutofillFieldName::CcExpMonth
         || autofillFieldName == WebCore::AutofillFieldName::CcExp
         || autofillFieldName == WebCore::AutofillFieldName::CcExpYear;
@@ -262,7 +262,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
     auto englishLocale = adoptNS([[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"]);
     auto dateFormatter = adoptNS([[NSDateFormatter alloc] init]);
     [dateFormatter setTimeZone:[_datePicker timeZone]];
-    [dateFormatter setDateFormat:protect(_formatString.get())];
+    [dateFormatter setDateFormat:protect(_formatString)];
     // Force English locale because that is what HTML5 value parsing expects.
     [dateFormatter setLocale:englishLocale.get()];
     return dateFormatter;
@@ -272,15 +272,15 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 {
     RetainPtr view = _view.get();
 #if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
-    if ([protect(view.get()) focusedElementInformation].elementType == WebKit::InputType::Week) {
+    if ([view focusedElementInformation].elementType == WebKit::InputType::Week) {
         RetainPtr dateFormatter = [self iso8601DateFormatterForCalendarView];
-        [protect(view) updateFocusedElementValue:[dateFormatter stringFromDate:[[NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601] dateFromComponents:[_selectionWeekOfYear selectedWeekOfYear]]]];
+        [view updateFocusedElementValue:[dateFormatter stringFromDate:[[NSCalendar calendarWithIdentifier:NSCalendarIdentifierISO8601] dateFromComponents:[_selectionWeekOfYear selectedWeekOfYear]]]];
         return;
     }
 #endif
 
     RetainPtr dateFormatter = [self dateFormatterForPicker];
-    [protect(view) updateFocusedElementValue:[dateFormatter stringFromDate:[_datePicker date]]];
+    [view updateFocusedElementValue:[dateFormatter stringFromDate:[_datePicker date]]];
 }
 
 #if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
@@ -311,7 +311,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 - (void)setDateTimePickerToInitialValue
 {
 #if HAVE(UI_CALENDAR_SELECTION_WEEK_OF_YEAR)
-    if ([protect(_view.get()) focusedElementInformation].elementType == WebKit::InputType::Week)
+    if ([protect(_view) focusedElementInformation].elementType == WebKit::InputType::Week)
         return [self setWeekPickerToInitialValue];
 #endif
 
@@ -345,18 +345,18 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
     // first responder to the focused element to avoid immediately blurring the focused element.
     bool shouldRelinquishFirstResponder = true;
 #else
-    auto elementType = [protect(view.get()) focusedElementInformation].elementType;
+    auto elementType = [view focusedElementInformation].elementType;
     bool shouldRelinquishFirstResponder = elementType == WebKit::InputType::Time || elementType == WebKit::InputType::DateTimeLocal;
 #endif
     if (shouldRelinquishFirstResponder)
-        [protect(view) startRelinquishingFirstResponderToFocusedElement];
+        [view startRelinquishingFirstResponderToFocusedElement];
 
     // Set the time zone in case it changed.
     [_datePicker setTimeZone:NSTimeZone.localTimeZone];
 
     // Currently no value for the <input>. Start the picker with the current time.
     // Also, update the actual <input> value.
-    _initialValue = [protect(view.get()) focusedElementInformation].value.createNSString().get();
+    _initialValue = [view focusedElementInformation].value.createNSString().get();
     [self setDateTimePickerToInitialValue];
     [self showDateTimePicker];
 }
@@ -367,7 +367,7 @@ static constexpr auto yearAndMonthDatePickerMode = static_cast<UIDatePickerMode>
 
 - (void)controlEndEditing
 {
-    [protect(_view.get()) stopRelinquishingFirstResponderToFocusedElement];
+    [protect(_view) stopRelinquishingFirstResponderToFocusedElement];
     [self removeDatePickerPresentation];
 }
 

--- a/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
+++ b/Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm
@@ -897,7 +897,7 @@ static const CGFloat groupHeaderCollapseButtonTransitionDuration = 0.3f;
 
 - (void)didTapHeader:(id)sender
 {
-    [protect(_tableViewController.get()) didTapSelectPickerGroupHeaderView:self];
+    [protect(_tableViewController) didTapSelectPickerGroupHeaderView:self];
     [self setCollapsed:!_collapsed animated:YES];
 }
 

--- a/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
+++ b/Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm
@@ -1185,7 +1185,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         [CATransaction begin];
         [CATransaction setDisableActions:YES];
 
-        [[_webViewPlaceholder layer] setContents:(id)protect<CGImage>([snapshotImage CGImage]).get()];
+        [[_webViewPlaceholder layer] setContents:(id)protect([snapshotImage CGImage]).get()];
         WebKit::replaceViewWithView(webView.get(), _webViewPlaceholder.get());
 
         [webView setAutoresizingMask:(UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight)];

--- a/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
+++ b/Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm
@@ -654,8 +654,6 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     [window exitFullScreenMode:self];
 }
 
-WTF_DECLARE_CF_TYPE_TRAIT(CGImage);
-
 static RetainPtr<CGImageRef> takeWindowSnapshot(CGSWindowID windowID, bool captureAtNominalResolution)
 {
     CGSWindowCaptureOptions options = kCGSCaptureIgnoreGlobalClipShape;

--- a/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
+++ b/Source/WebKit/UIProcess/mac/WKImmediateActionController.mm
@@ -113,7 +113,7 @@
 - (void)_clearImmediateActionState
 {
     if (_page)
-        protect(_page.get())->clearTextIndicator();
+        protect(_page)->clearTextIndicator();
 
     if (_currentActionContext && _hasActivatedActionContext) {
         _hasActivatedActionContext = NO;
@@ -150,7 +150,7 @@
 
 - (void)dismissContentRelativeChildWindows
 {
-    protect(_page.get())->setMaintainsInactiveSelection(false);
+    protect(_page)->setMaintainsInactiveSelection(false);
     [_currentQLPreviewMenuItem close];
 }
 
@@ -172,7 +172,7 @@
         viewImpl->dismissContentRelativeChildWindowsWithAnimation(true);
     }
 
-    protect(_page.get())->setMaintainsInactiveSelection(true);
+    protect(_page)->setMaintainsInactiveSelection(true);
 
     _state = WebKit::ImmediateActionState::Pending;
     immediateActionRecognizer.animationController = nil;
@@ -180,7 +180,7 @@
     if (!_page->mainFrame())
         return;
 
-    protect(_page.get())->performImmediateActionHitTestAtLocation(_page->mainFrame()->frameID(), [immediateActionRecognizer locationInView:retainPtr(immediateActionRecognizer.view).get()]);
+    protect(_page)->performImmediateActionHitTestAtLocation(_page->mainFrame()->frameID(), [immediateActionRecognizer locationInView:retainPtr(immediateActionRecognizer.view).get()]);
 }
 
 - (void)immediateActionRecognizerWillBeginAnimation:(NSImmediateActionGestureRecognizer *)immediateActionRecognizer
@@ -188,7 +188,7 @@
     if (immediateActionRecognizer != _immediateActionRecognizer)
         return;
 
-    Ref mainFrameProcess = protect(_page.get())->legacyMainFrameProcess();
+    Ref mainFrameProcess = protect(_page)->legacyMainFrameProcess();
     if (_state == WebKit::ImmediateActionState::None || !mainFrameProcess->hasConnection())
         return;
 
@@ -198,7 +198,7 @@
     // FIXME: Connection can be null if the process is closed; we should clean up better in that case.
     if (_state == WebKit::ImmediateActionState::Pending) {
         Ref connection = mainFrameProcess->connection();
-        bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(protect(_page.get())->webPageIDInMainFrameProcess(), 500_ms) == IPC::Error::NoError;
+        bool receivedReply = connection->waitForAndDispatchImmediately<Messages::WebPageProxy::DidPerformImmediateActionHitTest>(protect(_page)->webPageIDInMainFrameProcess(), 500_ms) == IPC::Error::NoError;
         if (!receivedReply)
             _state = WebKit::ImmediateActionState::TimedOut;
     }
@@ -222,11 +222,11 @@
     if (immediateActionRecognizer != _immediateActionRecognizer)
         return;
 
-    protect(_page.get())->immediateActionDidUpdate();
+    protect(_page)->immediateActionDidUpdate();
     if (_contentPreventsDefault)
         return;
 
-    protect(_page.get())->setTextIndicatorAnimationProgress([immediateActionRecognizer animationProgress]);
+    protect(_page)->setTextIndicatorAnimationProgress([immediateActionRecognizer animationProgress]);
 }
 
 - (void)immediateActionRecognizerDidCancelAnimation:(NSImmediateActionGestureRecognizer *)immediateActionRecognizer
@@ -234,13 +234,13 @@
     if (immediateActionRecognizer != _immediateActionRecognizer)
         return;
 
-    protect(_page.get())->immediateActionDidCancel();
+    protect(_page)->immediateActionDidCancel();
 
     CheckedPtr { _viewImpl.get() }->cancelImmediateActionAnimation();
 
-    protect(_page.get())->setTextIndicatorAnimationProgress(0);
+    protect(_page)->setTextIndicatorAnimationProgress(0);
     [self _clearImmediateActionState];
-    protect(_page.get())->setMaintainsInactiveSelection(false);
+    protect(_page)->setMaintainsInactiveSelection(false);
 }
 
 - (void)immediateActionRecognizerDidCompleteAnimation:(NSImmediateActionGestureRecognizer *)immediateActionRecognizer
@@ -248,11 +248,11 @@
     if (immediateActionRecognizer != _immediateActionRecognizer)
         return;
 
-    protect(_page.get())->immediateActionDidComplete();
+    protect(_page)->immediateActionDidComplete();
 
     CheckedPtr { _viewImpl.get() }->completeImmediateActionAnimation();
 
-    protect(_page.get())->setTextIndicatorAnimationProgress(1);
+    protect(_page)->setTextIndicatorAnimationProgress(1);
 }
 
 - (RefPtr<API::HitTestResult>)_webHitTestResult
@@ -305,7 +305,7 @@
             _currentQLPreviewMenuItem = item.get();
 
             if (RefPtr textIndicator = _hitTestResultData.linkTextIndicator)
-                protect(_page.get())->setTextIndicator(WTF::move(textIndicator), WebCore::TextIndicatorLifetime::Permanent);
+                protect(_page)->setTextIndicator(WTF::move(textIndicator), WebCore::TextIndicatorLifetime::Permanent);
 
             return (id<NSImmediateActionAnimationController>)item.autorelease();
         }
@@ -343,7 +343,7 @@
         return;
     }
 
-    RetainPtr<id> customClientAnimationController = protect(_page.get())->immediateActionAnimationControllerForHitTestResult(hitTestResult, _type, _userData);
+    RetainPtr<id> customClientAnimationController = protect(_page)->immediateActionAnimationControllerForHitTestResult(hitTestResult, _type, _userData);
     if (customClientAnimationController.get() == [NSNull null]) {
         [self _cancelImmediateAction];
         return;
@@ -507,9 +507,9 @@
 
     CheckedPtr { _viewImpl.get() }->prepareForDictionaryLookup();
     return WebCore::DictionaryLookup::animationControllerForPopup(dictionaryPopupInfo, _view.get().get(), [self](WebCore::TextIndicator& textIndicator) {
-        protect(_page.get())->setTextIndicator(textIndicator, WebCore::TextIndicatorLifetime::Permanent);
+        protect(_page)->setTextIndicator(textIndicator, WebCore::TextIndicatorLifetime::Permanent);
     }, nullptr, [strongSelf = retainPtr(self)]() {
-        protect(strongSelf->_page.get())->clearTextIndicatorWithAnimation(WebCore::TextIndicatorDismissalAnimation::None);
+        protect(strongSelf->_page)->clearTextIndicatorWithAnimation(WebCore::TextIndicatorDismissalAnimation::None);
     });
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -206,8 +206,6 @@ SOFT_LINK_CLASS(AVKit, AVTouchBarScrubber)
 static NSString * const WKMediaExitFullScreenItem = @"WKMediaExitFullScreenItem";
 #endif // HAVE(TOUCH_BAR) && ENABLE(WEB_PLAYBACK_CONTROLS_MANAGER)
 
-WTF_DECLARE_CF_TYPE_TRAIT(CGImage);
-
 @interface NSApplication ()
 - (BOOL)isSpeaking;
 - (void)speakString:(NSString *)string;
@@ -5640,7 +5638,7 @@ NSTextInputContext *WebViewImpl::inputContext()
     if (!m_page->editorState().isContentEditable)
         return nil;
 
-    return [protect(m_view.get()) _web_superInputContext];
+    return [protect(m_view) _web_superInputContext];
 }
 
 NSTextInputContext *WebViewImpl::inputContextIncludingNonEditable()
@@ -5651,7 +5649,7 @@ NSTextInputContext *WebViewImpl::inputContextIncludingNonEditable()
     if (!m_page->editorState().isContentEditable && !m_page->editorState().selectionIsRange)
         return nil;
 
-    return [protect(m_view.get()) _web_superInputContext];
+    return [protect(m_view) _web_superInputContext];
 }
 
 void WebViewImpl::unmarkText()

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -3827,7 +3827,7 @@ id UnifiedPDFPlugin::accessibilityHitTestInPageForIOS(WebCore::FloatPoint point)
 WebCore::AXCoreObject* UnifiedPDFPlugin::accessibilityCoreObject()
 {
     if (CheckedPtr cache = axObjectCache())
-        return cache->exportedGetOrCreate(protect(m_element.get()));
+        return cache->exportedGetOrCreate(protect(m_element));
     return nullptr;
 }
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 4d65004e7f2c70bb4a7afa231853bf1ec7492c00
<pre>
Add a `protect()` overload for `WeakObjCPtr&lt;T&gt;`
<a href="https://bugs.webkit.org/show_bug.cgi?id=307668">https://bugs.webkit.org/show_bug.cgi?id=307668</a>

Reviewed by Geoffrey Garen.

Add a `protect()` overload for `WeakObjCPtr&lt;T&gt;`, for convenience and
consistency with other weak pointer types.

Adopt it in a few places.

* Source/WTF/wtf/RetainPtr.h:
* Source/WTF/wtf/WeakObjCPtr.h:
(WTF::protect):
* Source/WTF/wtf/cf/CFTypeTraits.h:
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUDeviceImpl.cpp:
(WebCore::WebGPU::convertToBacking):
* Source/WebCore/loader/cache/CachedResourceHandle.h:
(WTF::requires):
* Source/WebCore/platform/graphics/Color.h:
* Source/WebKit/UIProcess/API/Cocoa/PageLoadStateObserver.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _frames:]):
(-[WKWebView _frameTrees:]):
* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(baseScrollViewBackgroundColor):
(scrollViewBackgroundColor):
* Source/WebKit/UIProcess/ApplicationStateTracker.mm:
(WebKit::m_isInBackground):
* Source/WebKit/UIProcess/Inspector/WebInspectorUIExtensionControllerProxy.cpp:
(WebKit::WebInspectorUIExtensionControllerProxy::registerExtension):
(WebKit::WebInspectorUIExtensionControllerProxy::unregisterExtension):
* Source/WebKit/UIProcess/MediaKeySystemPermissionRequestManagerProxy.cpp:
(WebKit::MediaKeySystemPermissionRequestManagerProxy::logger const):
* Source/WebKit/UIProcess/WebProcessActivityState.cpp:
(WebKit::WebProcessActivityState::updateWebProcessSuspensionDelay):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::audioCapturingWebPage):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::forEachWebsiteDataStore):
(WebKit::WebsiteDataStore::dataStoreForIdentifier):
(WebKit::WebsiteDataStore::forwardAppBoundDomainsToITPIfInitialized):
(WebKit::WebsiteDataStore::forwardManagedDomainsToITPIfInitialized):
* Source/WebKit/UIProcess/ios/DragDropInteractionState.mm:
(WebKit::DragDropInteractionState::createDragPreviewInternal const):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::isPotentialTapInProgress const):
(WebKit::PageClientImpl::canStartNavigationSwipeAtLastInteractionLocation const):
* Source/WebKit/UIProcess/ios/PointerTouchCompatibilitySimulator.mm:
(WebKit::PointerTouchCompatibilitySimulator::window const):
* Source/WebKit/UIProcess/ios/RevealFocusedElementDeferrer.mm:
(WebKit::RevealFocusedElementDeferrer::fulfill):
* Source/WebKit/UIProcess/ios/SmartMagnificationController.mm:
(WebKit::SmartMagnificationController::handleResetMagnificationGesture):
(WebKit::SmartMagnificationController::scrollToRect):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _updateFrameOfContainerForContextMenuHintPreviewsIfNeeded]):
(-[WKContentView _updateTargetedPreviewScrollViewUsingContainerScrollingNodeID:]):
(-[WKContentView provideDataForItem:]):
(-[WKContentView actionSheetAssistant:copySubject:sourceMIMEType:]):
* Source/WebKit/UIProcess/ios/WKTapHighlightView.mm:
(-[WKTapHighlightView drawRect:]):
* Source/WebKit/UIProcess/ios/forms/WKDateTimeInputControl.mm:
(-[WKDateTimePicker handleDatePickerPresentationDismissal]):
(-[WKDateTimePicker removeDatePickerPresentation]):
(-[WKDateTimePicker showDateTimePicker]):
(-[WKDateTimePicker shouldForceGregorianCalendar]):
(-[WKDateTimePicker dateFormatterForPicker]):
(-[WKDateTimePicker _dateChanged]):
(-[WKDateTimePicker setDateTimePickerToInitialValue]):
(-[WKDateTimePicker controlBeginEditing]):
(-[WKDateTimePicker controlEndEditing]):
* Source/WebKit/UIProcess/ios/forms/WKFormSelectPicker.mm:
(-[WKSelectPickerGroupHeaderView didTapHeader:]):
* Source/WebKit/UIProcess/ios/fullscreen/WKFullScreenWindowControllerIOS.mm:
(-[WKFullScreenWindowController _enterFullScreen:windowScene:completionHandler:]):
* Source/WebKit/UIProcess/mac/WKFullScreenWindowController.mm:
* Source/WebKit/UIProcess/mac/WKImmediateActionController.mm:
(-[WKImmediateActionController _clearImmediateActionState]):
(-[WKImmediateActionController dismissContentRelativeChildWindows]):
(-[WKImmediateActionController immediateActionRecognizerWillPrepare:]):
(-[WKImmediateActionController immediateActionRecognizerWillBeginAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidUpdateAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidCancelAnimation:]):
(-[WKImmediateActionController immediateActionRecognizerDidCompleteAnimation:]):
(-[WKImmediateActionController _defaultAnimationController]):
(-[WKImmediateActionController _updateImmediateActionItem]):
(-[WKImmediateActionController _animationControllerForText]):
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::inputContext):
(WebKit::WebViewImpl::inputContextIncludingNonEditable):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::accessibilityCoreObject):

Canonical link: <a href="https://commits.webkit.org/307438@main">https://commits.webkit.org/307438@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e74cc2262628f889a8017458129f432e6915f1d5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8605 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153036 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e565cc12-8549-434e-9a3e-a0f2c26910ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146241 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17527 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16939 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111011 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e37ab719-a2c0-4493-9652-82de87e56a2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147329 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13408 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129673 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91930 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12822 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10575 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/482 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136357 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122327 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155348 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5175 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16897 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7406 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119019 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16935 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14163 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119382 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15236 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72318 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16519 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5978 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175653 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16255 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80298 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45254 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16464 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16319 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->