### PR TITLE
Swift Back Forward List: Cease string conformances

### DIFF
--- a/Source/WebKit/UIProcess/StdlibExtras.swift
+++ b/Source/WebKit/UIProcess/StdlibExtras.swift
@@ -49,9 +49,11 @@ protocol CxxRefVector {
     func __atUnsafe(_ index: Int) -> UnsafePointer<Element>
 }
 
-extension WTF.String: LosslessStringConvertible {
+// FIXME(rdar://164119356)): conform to LosslessStringConvertible
+// when this moves to WTF (requires members to be public)
+extension WTF.String {
     /// Construct a `WTF.String` from a `Swift.String`.
-    public init(_ string: Swift.String) {
+    init(_ string: Swift.String) {
         // rdar://162517354 prevents us from simply writing
         // self = WTF.String.fromUTF8(swiftString.utf8CString.span);
         // Safety - we are guaranteed to get a valid buffer from the Swift
@@ -67,16 +69,18 @@ extension WTF.String: LosslessStringConvertible {
     }
 
     /// Return a `Swift.String` from this `WTF.String`.
-    public var description: Swift.String {
+    var description: Swift.String {
         // We could possibly make this quicker by treating a C++ span as
         // a Sequence. For now, we want to avoid unsafe as much as possible.
         String(utf8(WTF.LenientConversion).toStdString())
     }
 }
 
-extension WTF.String: ExpressibleByStringLiteral {
+// FIXME(rdar://164119356)): conform to ExpressibleByStringLiteral
+// when this moves to WTF (requires members to be public)
+extension WTF.String {
     /// Construct a `WTF.String` from a string literal.
-    public init(stringLiteral: Swift.String) {
+    init(stringLiteral: Swift.String) {
         self.init(stringLiteral)
     }
 }

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -707,7 +707,7 @@ final class WebBackForwardList {
 
         for (i, entry) in entries.enumerated() {
             let prefix = (currentIndex == i) ? " * " : " - "
-            result += prefix + String(entry.loggingString())
+            result += prefix + String(entry.loggingString().description)
         }
 
         return result


### PR DESCRIPTION
#### 1679afdebd1386242f9310e77de04d3c986b263d
<pre>
Swift Back Forward List: Cease string conformances
<a href="https://bugs.webkit.org/show_bug.cgi?id=307670">https://bugs.webkit.org/show_bug.cgi?id=307670</a>
<a href="https://rdar.apple.com/170223704">rdar://170223704</a>

Reviewed by Richard Robinson.

This removes &apos;public&apos; from our Swift additions to WebKit for the Swift Back
Forward List. New public Swift APIs within WebKit present various problems, but
the immediate problem is that these APIs depend upon WTF types and WTF is not
public.

To do this, we have to cease to confirm to a couple of standard Swift protocols.
We can reinstate those conformances when this code moves from the WebKit
project to the WTF project, a task tracked by <a href="https://rdar.apple.com/164119356">rdar://164119356</a>.

Canonical link: <a href="https://commits.webkit.org/307411@main">https://commits.webkit.org/307411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7378001eadfdfb2752ba5e5c4c79051bac75596c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16863 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8419 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152854 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97423 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da120e66-1e12-4096-bf02-edb1c8b5d857) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17345 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16757 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110871 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79667 "2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47d272ac-7708-4631-a65f-e392db3f235e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147147 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91789 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afde2dcf-bf0b-4b18-b0c9-c7e76e07f35e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12722 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10469 "Found 1 new API test failure: TestWebKitAPI.MediaLoading.LockdownModeHLS (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/300 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122213 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155166 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16715 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118890 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14034 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119248 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30591 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15121 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127408 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72136 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16337 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5844 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16071 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80116 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16282 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16137 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->