### PR TITLE
[GTK][WPE] Add base class FrameRenderer implemented by both LayerTreeHost and NonCompositedFrameRenderer

### DIFF
--- a/Source/WebKit/SourcesGTK.txt
+++ b/Source/WebKit/SourcesGTK.txt
@@ -358,6 +358,7 @@ WebProcess/WebPage/ViewGestureGeometryCollector.cpp
 WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp @no-unify
 WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
 WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
+WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp
 WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
 WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
 WebProcess/WebPage/CoordinatedGraphics/ScrollbarsControllerCoordinated.cpp

--- a/Source/WebKit/SourcesWPE.txt
+++ b/Source/WebKit/SourcesWPE.txt
@@ -329,6 +329,7 @@ WebProcess/WebCoreSupport/wpe/WebEditorClientWPE.cpp
 WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
 WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.cpp
 WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
+WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp
 WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
 WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
 WebProcess/WebPage/CoordinatedGraphics/ScrollbarsControllerCoordinated.cpp

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h
@@ -33,11 +33,10 @@
 
 namespace WebCore {
 class GraphicsContext;
-class RunLoopObserver;
 }
 
 namespace WebKit {
-class NonCompositedFrameRenderer;
+class FrameRenderer;
 struct RenderProcessInfo;
 
 class DrawingAreaCoordinatedGraphics final : public DrawingArea {
@@ -108,12 +107,6 @@ private:
     void suspendPainting();
     void resumePainting();
 
-    void scheduleUpdate();
-    void scheduleRenderingUpdateRunLoopObserver();
-    void invalidateRenderingUpdateRunLoopObserver();
-    void renderingUpdateRunLoopObserverFired();
-    void updateRendering();
-
     // Whether we're currently processing an UpdateGeometry message.
     bool m_inUpdateGeometry { false };
 
@@ -128,15 +121,9 @@ private:
     // won't paint until painting has resumed again.
     bool m_isPaintingSuspended { false };
 
-    // The layer tree host that handles accelerated compositing.
-    std::unique_ptr<LayerTreeHost> m_layerTreeHost;
-
-    // Frame renderer used in non-composited mode.
-    std::unique_ptr<NonCompositedFrameRenderer> m_nonCompositedFrameRenderer;
+    std::unique_ptr<FrameRenderer> m_renderer;
 
     bool m_supportsAsyncScrolling { true };
-
-    std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
 
 #if PLATFORM(GTK)
     bool m_transientZoom { false };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FrameRenderer.h"
+
+#if USE(COORDINATED_GRAPHICS)
+#include <WebCore/RunLoopObserver.h>
+#include <WebCore/WindowEventLoop.h>
+#include <wtf/SystemTracing.h>
+
+namespace WebKit {
+using namespace WebCore;
+
+FrameRenderer::FrameRenderer()
+{
+    m_renderingUpdateRunLoopObserver = makeUnique<RunLoopObserver>(RunLoopObserver::WellKnownOrder::RenderingUpdate, [this] {
+        renderingUpdateRunLoopObserverFired();
+    });
+}
+
+FrameRenderer::~FrameRenderer()
+{
+    if (m_forcedRepaintAsyncCallback)
+        m_forcedRepaintAsyncCallback();
+
+    invalidateRenderingUpdateRunLoopObserver();
+}
+
+void FrameRenderer::scheduleRenderingUpdateRunLoopObserver()
+{
+    if (m_renderingUpdateRunLoopObserver->isScheduled())
+        return;
+
+    if (m_isUpdatingRendering)
+        return;
+
+    tracePoint(RenderingUpdateRunLoopObserverStart);
+    m_renderingUpdateRunLoopObserver->schedule();
+
+    // Avoid running any more tasks before the runloop observer fires.
+    WindowEventLoop::breakToAllowRenderingUpdate();
+}
+
+void FrameRenderer::invalidateRenderingUpdateRunLoopObserver()
+{
+    if (!m_renderingUpdateRunLoopObserver->isScheduled())
+        return;
+
+    tracePoint(RenderingUpdateRunLoopObserverEnd);
+    m_renderingUpdateRunLoopObserver->invalidate();
+}
+
+void FrameRenderer::renderingUpdateRunLoopObserverFired()
+{
+    WTFEmitSignpost(this, RenderingUpdateRunLoopObserverFired, "canUpdateRendering %s", canUpdateRendering() ? "yes" : "no");
+
+    invalidateRenderingUpdateRunLoopObserver();
+
+    if (m_layerTreeStateIsFrozen || m_isSuspended)
+        return;
+
+    if (canUpdateRendering())
+        updateRendering();
+}
+
+void FrameRenderer::setLayerTreeStateIsFrozen(bool isFrozen)
+{
+    if (m_layerTreeStateIsFrozen == isFrozen)
+        return;
+
+    m_layerTreeStateIsFrozen = isFrozen;
+
+    if (m_layerTreeStateIsFrozen)
+        invalidateRenderingUpdateRunLoopObserver();
+    else
+        scheduleRenderingUpdate();
+}
+
+void FrameRenderer::suspend()
+{
+    m_isSuspended = true;
+}
+
+void FrameRenderer::resume()
+{
+    m_isSuspended = false;
+    scheduleRenderingUpdate();
+}
+
+void FrameRenderer::updateRenderingWithForcedRepaintAsync(CompletionHandler<void()>&& callback)
+{
+    ASSERT(!m_forcedRepaintAsyncCallback);
+    m_forcedRepaintAsyncCallback = WTF::move(callback);
+    updateRenderingWithForcedRepaint();
+}
+
+} // namespace WebKit
+
+#endif // USE(COORDINATED_GRAPHICS)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(COORDINATED_GRAPHICS)
+#include <wtf/CompletionHandler.h>
+
+namespace WebCore {
+class FloatPoint;
+class GraphicsLayer;
+class GraphicsLayerFactory;
+class IntRect;
+class Region;
+class RunLoopObserver;
+}
+
+namespace WebKit {
+struct RenderProcessInfo;
+
+class FrameRenderer {
+public:
+    virtual ~FrameRenderer();
+
+    virtual uint64_t surfaceID() const = 0;
+    virtual void setNeedsDisplay() { }
+    virtual void setNeedsDisplayInRect(const WebCore::IntRect&) { }
+    virtual void updateRenderingWithForcedRepaint() = 0;
+    virtual void scheduleRenderingUpdate() = 0;
+    virtual void suspend();
+    virtual void resume();
+    virtual void sizeDidChange() = 0;
+    virtual void backgroundColorDidChange() { }
+    virtual bool ensureDrawing() = 0;
+    virtual void fillGLInformation(RenderProcessInfo&&, CompletionHandler<void(RenderProcessInfo&&)>&&) = 0;
+
+    virtual WebCore::GraphicsLayerFactory* graphicsLayerFactory() { RELEASE_ASSERT_NOT_REACHED(); }
+    virtual void setRootCompositingLayer(WebCore::GraphicsLayer*) { RELEASE_ASSERT_NOT_REACHED(); }
+    virtual void setViewOverlayRootLayer(WebCore::GraphicsLayer*) { RELEASE_ASSERT_NOT_REACHED(); }
+
+#if PLATFORM(WPE) && ENABLE(WPE_PLATFORM) && (USE(GBM) || OS(ANDROID))
+    virtual void preferredBufferFormatsDidChange() { }
+#endif
+
+#if ENABLE(DAMAGE_TRACKING)
+    virtual void resetDamageHistoryForTesting() = 0;
+    virtual void foreachRegionInDamageHistoryForTesting(Function<void(const WebCore::Region&)>&&) const = 0;
+#endif
+
+#if PLATFORM(GTK)
+    virtual void adjustTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint) = 0;
+    virtual void commitTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint) = 0;
+#endif
+
+    void setLayerTreeStateIsFrozen(bool);
+    void updateRenderingWithForcedRepaintAsync(CompletionHandler<void()>&&);
+
+protected:
+    FrameRenderer();
+
+    virtual bool canUpdateRendering() const = 0;
+    virtual void updateRendering() = 0;
+
+    void scheduleRenderingUpdateRunLoopObserver();
+    void invalidateRenderingUpdateRunLoopObserver();
+    void renderingUpdateRunLoopObserverFired();
+
+    std::unique_ptr<WebCore::RunLoopObserver> m_renderingUpdateRunLoopObserver;
+    bool m_layerTreeStateIsFrozen { false };
+    bool m_isSuspended { false };
+    bool m_isUpdatingRendering { false };
+    CompletionHandler<void()> m_forcedRepaintAsyncCallback;
+};
+
+} // namespace WebKit
+
+#endif // USE(COORDINATED_GRAPHICS)


### PR DESCRIPTION
#### 58e29976e563d421f4957ea8cfa8f8a9dcc18ce3
<pre>
[GTK][WPE] Add base class FrameRenderer implemented by both LayerTreeHost and NonCompositedFrameRenderer
<a href="https://bugs.webkit.org/show_bug.cgi?id=307673">https://bugs.webkit.org/show_bug.cgi?id=307673</a>

Reviewed by Adrian Perez de Castro.

This allows to remove duplicated code and simplify drawing area code
that creates a renderer and uses it without having to check which one is
used everywhere.

* Source/WebKit/SourcesGTK.txt:
* Source/WebKit/SourcesWPE.txt:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::DrawingAreaCoordinatedGraphics):
(WebKit::DrawingAreaCoordinatedGraphics::setNeedsDisplay):
(WebKit::DrawingAreaCoordinatedGraphics::setNeedsDisplayInRect):
(WebKit::DrawingAreaCoordinatedGraphics::scroll):
(WebKit::DrawingAreaCoordinatedGraphics::updateRenderingWithForcedRepaint):
(WebKit::DrawingAreaCoordinatedGraphics::updateRenderingWithForcedRepaintAsync):
(WebKit::DrawingAreaCoordinatedGraphics::setLayerTreeStateIsFrozen):
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingModeIfNeeded):
(WebKit::DrawingAreaCoordinatedGraphics::backgroundColorDidChange):
(WebKit::DrawingAreaCoordinatedGraphics::setDeviceScaleFactor):
(WebKit::DrawingAreaCoordinatedGraphics::graphicsLayerFactory):
(WebKit::DrawingAreaCoordinatedGraphics::setRootCompositingLayer):
(WebKit::DrawingAreaCoordinatedGraphics::attachViewOverlayGraphicsLayer):
(WebKit::DrawingAreaCoordinatedGraphics::triggerRenderingUpdate):
(WebKit::DrawingAreaCoordinatedGraphics::updateGeometry):
(WebKit::DrawingAreaCoordinatedGraphics::dispatchAfterEnsuringDrawing):
(WebKit::DrawingAreaCoordinatedGraphics::adjustTransientZoom):
(WebKit::DrawingAreaCoordinatedGraphics::commitTransientZoom):
(WebKit::DrawingAreaCoordinatedGraphics::suspendPainting):
(WebKit::DrawingAreaCoordinatedGraphics::resumePainting):
(WebKit::DrawingAreaCoordinatedGraphics::sendEnterAcceleratedCompositingModeIfNeeded):
(WebKit::DrawingAreaCoordinatedGraphics::preferredBufferFormatsDidChange):
(WebKit::DrawingAreaCoordinatedGraphics::resetDamageHistoryForTesting):
(WebKit::DrawingAreaCoordinatedGraphics::foreachRegionInDamageHistoryForTesting const):
(WebKit::DrawingAreaCoordinatedGraphics::fillGLInformation):
(WebKit::DrawingAreaCoordinatedGraphics::~DrawingAreaCoordinatedGraphics): Deleted.
(WebKit::DrawingAreaCoordinatedGraphics::scheduleUpdate): Deleted.
(WebKit::DrawingAreaCoordinatedGraphics::scheduleRenderingUpdateRunLoopObserver): Deleted.
(WebKit::DrawingAreaCoordinatedGraphics::invalidateRenderingUpdateRunLoopObserver): Deleted.
(WebKit::DrawingAreaCoordinatedGraphics::renderingUpdateRunLoopObserverFired): Deleted.
(WebKit::DrawingAreaCoordinatedGraphics::updateRendering): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.cpp: Added.
(WebKit::FrameRenderer::FrameRenderer):
(WebKit::FrameRenderer::~FrameRenderer):
(WebKit::FrameRenderer::scheduleRenderingUpdateRunLoopObserver):
(WebKit::FrameRenderer::invalidateRenderingUpdateRunLoopObserver):
(WebKit::FrameRenderer::renderingUpdateRunLoopObserverFired):
(WebKit::FrameRenderer::setLayerTreeStateIsFrozen):
(WebKit::FrameRenderer::suspend):
(WebKit::FrameRenderer::resume):
(WebKit::FrameRenderer::updateRenderingWithForcedRepaintAsync):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/FrameRenderer.h: Added.
(WebKit::FrameRenderer::setNeedsDisplay):
(WebKit::FrameRenderer::setNeedsDisplayInRect):
(WebKit::FrameRenderer::backgroundColorDidChange):
(WebKit::FrameRenderer::graphicsLayerFactory):
(WebKit::FrameRenderer::setRootCompositingLayer):
(WebKit::FrameRenderer::setViewOverlayRootLayer):
(WebKit::FrameRenderer::preferredBufferFormatsDidChange):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::~LayerTreeHost):
(WebKit::LayerTreeHost::surfaceID const):
(WebKit::LayerTreeHost::scheduleRenderingUpdate):
(WebKit::LayerTreeHost::canUpdateRendering const):
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaint):
(WebKit::LayerTreeHost::ensureDrawing):
(WebKit::LayerTreeHost::suspend):
(WebKit::LayerTreeHost::resume):
(WebKit::LayerTreeHost::requestCompositionForRenderingUpdate):
(WebKit::LayerTreeHost::adjustTransientZoom):
(WebKit::LayerTreeHost::commitTransientZoom):
(WebKit::LayerTreeHost::foreachRegionInDamageHistoryForTesting const):
(WebKit::LayerTreeHost::setLayerTreeStateIsFrozen): Deleted.
(WebKit::LayerTreeHost::scheduleRenderingUpdateRunLoopObserver): Deleted.
(WebKit::LayerTreeHost::invalidateRenderingUpdateRunLoopObserver): Deleted.
(WebKit::LayerTreeHost::renderingUpdateRunLoopObserverFired): Deleted.
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaintAsync): Deleted.
(WebKit::LayerTreeHost::pauseRendering): Deleted.
(WebKit::LayerTreeHost::resumeRendering): Deleted.
(WebKit::LayerTreeHost::foreachRegionInDamageHistoryForTesting): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp:
(WebKit::NonCompositedFrameRenderer::NonCompositedFrameRenderer):
(WebKit::NonCompositedFrameRenderer::addDirtyRect):
(WebKit::NonCompositedFrameRenderer::setNeedsDisplay):
(WebKit::NonCompositedFrameRenderer::setNeedsDisplayInRect):
(WebKit::NonCompositedFrameRenderer::resetFrameDamage):
(WebKit::NonCompositedFrameRenderer::sizeDidChange):
(WebKit::NonCompositedFrameRenderer::scheduleRenderingUpdate):
(WebKit::NonCompositedFrameRenderer::canUpdateRendering const):
(WebKit::NonCompositedFrameRenderer::updateRendering):
(WebKit::NonCompositedFrameRenderer::frameComplete):
(WebKit::NonCompositedFrameRenderer::updateRenderingWithForcedRepaint):
(WebKit::NonCompositedFrameRenderer::ensureDrawing):
(WebKit::NonCompositedFrameRenderer::foreachRegionInDamageHistoryForTesting const):
(WebKit::NonCompositedFrameRenderer::adjustTransientZoom):
(WebKit::NonCompositedFrameRenderer::commitTransientZoom):
(WebKit::NonCompositedFrameRenderer::fillGLInformation):
(WebKit::NonCompositedFrameRenderer::display): Deleted.
(WebKit::NonCompositedFrameRenderer::updateRenderingWithForcedRepaintAsync): Deleted.
(WebKit::NonCompositedFrameRenderer::foreachRegionInDamageHistoryForTesting): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h:
(WebKit::NonCompositedFrameRenderer::surfaceID const): Deleted.

Canonical link: <a href="https://commits.webkit.org/307700@main">https://commits.webkit.org/307700@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c75e34a7052f8064db9d2efe93af159a306943f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17884 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9663 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153875 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18367 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111650 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98839 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14012 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92549 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13369 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11132 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1320 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122894 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156187 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17735 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8269 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119659 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14799 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119993 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15760 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128439 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73401 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22397 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17356 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6697 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81135 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->