### PR TITLE
IndexedDB: Remove unnecessary assertion in IDBRequest::uncaughtExceptionInEventHandler()

### DIFF
--- a/LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers-expected.txt
+++ b/LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers-expected.txt
@@ -1,0 +1,2 @@
+CONSOLE MESSAGE: Error: One unhandled exception
+This test passes if it doesn't crash.

--- a/LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers.html
+++ b/LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers.html
@@ -1,0 +1,37 @@
+  <script>
+   testRunner?.waitUntilDone();
+   testRunner?.dumpAsText();
+   (async () => {
+       let dbName = 'db2';
+       let storeName = 'os1';
+       function transactionHelper2(transaction) {
+           let objectStore = transaction.objectStore(storeName);
+           let countRequest = objectStore.count();
+           countRequest.addEventListener('success', ev => {
+               throw new Error("One unhandled exception");
+           });
+           countRequest.addEventListener('success', ev => {
+               testRunner?.notifyDone();
+               throw new Error("Two unhandled exceptions.");
+           });
+       }
+       await (async () => {
+           let req = indexedDB.open(dbName, 1);
+           req.addEventListener('upgradeneeded', ev => {
+               let db = ev.target.result;
+               os = db.createObjectStore(storeName);
+           });
+       })();
+       await (async () => {
+           let req = indexedDB.open(dbName, 1);
+           req.addEventListener('success', async ev => {
+               let db = ev.target.result;
+               let transaction = db.transaction(storeName);
+               transactionHelper2(transaction);
+           });
+       })();
+   })();
+  </script>
+<div>
+    This test passes if it doesn't crash.
+</div>

--- a/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBRequest.cpp
@@ -366,7 +366,6 @@ void IDBRequest::uncaughtExceptionInEventHandler()
     ASSERT(canCurrentThreadAccessThreadLocalData(originThread()));
 
     if (m_eventBeingDispatched) {
-        ASSERT(!m_hasUncaughtException);
         m_hasUncaughtException = true;
         return;
     }


### PR DESCRIPTION
#### 5d59ec36262dc5ef610fe661dfae743918441365
<pre>
IndexedDB: Remove unnecessary assertion in IDBRequest::uncaughtExceptionInEventHandler()
<a href="https://bugs.webkit.org/show_bug.cgi?id=307675">https://bugs.webkit.org/show_bug.cgi?id=307675</a>

Reviewed by Sihui Liu.

The assertion is incorrect, as it assumes that only one event handler can have
an uncaught exception for an IDBRequest, but it&apos;s actually possible to have more
than one event handler, and more than one of them can have unhandled exceptions as
the test-case shows.

Test: storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers.html

* LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers-expected.txt: Added.
* LayoutTests/storage/indexeddb/multiple-unhandled-exceptions-in-request-event-handlers.html: Added.
* Source/WebCore/Modules/indexeddb/IDBRequest.cpp:
(WebCore::IDBRequest::uncaughtExceptionInEventHandler):

Canonical link: <a href="https://commits.webkit.org/307481@main">https://commits.webkit.org/307481@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6b8208c4342ff0ca7f4d1a433f968679b0e70d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152873 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97442 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146078 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16776 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110889 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79675 "2 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13301 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91805 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12734 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10482 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/319 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122228 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6207 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155185 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16734 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118907 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16771 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14055 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119284 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30635 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15136 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127418 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72155 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16356 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5854 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16091 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80135 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16301 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16156 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->