### PR TITLE
REGRESSION(302297@main): Dark mode is broken in Wikipedia

### DIFF
--- a/LayoutTests/fast/selectors/empty-rule-invalidation-expected.html
+++ b/LayoutTests/fast/selectors/empty-rule-invalidation-expected.html
@@ -1,0 +1,4 @@
+<style>
+.green { color: green }
+</style>
+<div id=t class=green>This should be green.</div>

--- a/LayoutTests/fast/selectors/empty-rule-invalidation.html
+++ b/LayoutTests/fast/selectors/empty-rule-invalidation.html
@@ -1,0 +1,9 @@
+<style>
+.green { }
+.green { color: green }
+</style>
+<div id=t>This should be green.</div>
+<script>
+t.offsetLeft;
+t.classList.add("green");
+</script>

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -442,6 +442,10 @@ static PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::Ps
 
 void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const RuleData& ruleData, const Vector<Ref<const StyleRuleScope>>& scopeRules)
 {
+    // Empty rules don't affect style so we never need to invalidate for them.
+    if (ruleData.styleRule().properties().isEmpty())
+        return;
+
     SelectorFeatures selectorFeatures;
 
     auto& selector = ruleData.selector();


### PR DESCRIPTION
#### 1961f4c243df1223b330a9af9d21e4e04b2d1bf6
<pre>
REGRESSION(302297@main): Dark mode is broken in Wikipedia
<a href="https://bugs.webkit.org/show_bug.cgi?id=307593">https://bugs.webkit.org/show_bug.cgi?id=307593</a>
<a href="https://rdar.apple.com/169362651">rdar://169362651</a>

Reviewed by Matthieu Dubet.

Wikipedia has an empty CSS rule

html.skin-theme-clientpref-night {
}

and then further non-empty rules with the same selector. We would pick the first rule to our invalidation ruleset
and proceed to dedupe other rules to it. However ElementRuleCollector ignores empty rules and no invalidation happens.

Test: fast/selectors/empty-rule-invalidation.html
* LayoutTests/fast/selectors/empty-rule-invalidation-expected.html: Added.
* LayoutTests/fast/selectors/empty-rule-invalidation.html: Added.
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::collectFeatures):

Don&apos;t collect features from empty rules. They can never affect style and don&apos;t need invalidation.

Canonical link: <a href="https://commits.webkit.org/307366@main">https://commits.webkit.org/307366@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/064c79018e2051a010c9c07432ea3a3b0430b15f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152877 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e920eef6-4262-4879-ae0a-be6308f8cbf9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146082 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17368 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16780 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110893 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/023fdf1f-a3f2-495d-b36d-4b9f0965e48f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13306 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129563 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91809 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2539d803-a677-4000-889e-a83f9244a83c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/323 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155189 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7273 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118911 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16775 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119268 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30567 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15137 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127429 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72159 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16360 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5865 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16095 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16305 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16160 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->