### PR TITLE
AX: Fix for accessibility/text-marker-ranges-intersect.html.

### DIFF
--- a/LayoutTests/accessibility/mac/text-marker-ranges-intersect-expected.txt
+++ b/LayoutTests/accessibility/mac/text-marker-ranges-intersect-expected.txt
@@ -1,44 +1,44 @@
 Tests the intersectTextMarkerRanges method.
 
 text, AXRole: AXGroup
-elementRange: text: 'abcdefghij', start: {{ID 74, role StaticText, offset 0}}, end: {{ID 74, role StaticText, offset 10}}
-range1: text: 'abc', start: {{ID 74, role StaticText, offset 0}}, end: {{ID 74, role StaticText, offset 3}}
-range2: text: 'hij', start: {{ID 74, role StaticText, offset 7}}, end: {{ID 74, role StaticText, offset 10}}
-elementRange range1 intersection: text: 'abc', start: {{ID 74, role StaticText, offset 0}}, end: {{ID 74, role StaticText, offset 3}}
-elementRange range2 intersection: text: 'hij', start: {{ID 74, role StaticText, offset 7}}, end: {{ID 74, role StaticText, offset 10}}
-range1 range2 intersection: null
+elementRange: 'abcdefghij'
+range1: 'abc'
+range2: 'hij'
+elementRange range1 intersection: 'abc'
+elementRange range2 intersection: 'hij'
+range1 range2 intersection: 'null'
 
 text, AXRole: AXGroup
-elementRange: text: 'abcdefghij', start: {{ID 74, role StaticText, offset 0}}, end: {{ID 74, role StaticText, offset 10}}
-range1: text: 'def', start: {{ID 74, role StaticText, offset 3}}, end: {{ID 74, role StaticText, offset 6}}
-range2: text: 'efghij', start: {{ID 74, role StaticText, offset 4}}, end: {{ID 74, role StaticText, offset 10}}
-elementRange range1 intersection: text: 'def', start: {{ID 74, role StaticText, offset 3}}, end: {{ID 74, role StaticText, offset 6}}
-elementRange range2 intersection: text: 'efghij', start: {{ID 74, role StaticText, offset 4}}, end: {{ID 74, role StaticText, offset 10}}
-range1 range2 intersection: text: 'ef', start: {{ID 74, role StaticText, offset 4}}, end: {{ID 74, role StaticText, offset 6}}
+elementRange: 'abcdefghij'
+range1: 'def'
+range2: 'efghij'
+elementRange range1 intersection: 'def'
+elementRange range2 intersection: 'efghij'
+range1 range2 intersection: 'ef'
 
 textarea, AXRole: AXTextArea
-elementRange: text: 'Write something here.', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 21}}
-range1: text: 'Write some', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 10}}
-range2: text: 'thing here.', start: {{ID 76, role StaticText, offset 10}}, end: {{ID 76, role StaticText, offset 21}}
-elementRange range1 intersection: text: 'Write some', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 10}}
-elementRange range2 intersection: text: 'thing here.', start: {{ID 76, role StaticText, offset 10}}, end: {{ID 76, role StaticText, offset 21}}
-range1 range2 intersection: text: '', start: {{ID 76, role StaticText, offset 10}}, end: {{ID 76, role StaticText, offset 10}}
+elementRange: 'Write something here.'
+range1: 'Write some'
+range2: 'thing here.'
+elementRange range1 intersection: 'Write some'
+elementRange range2 intersection: 'thing here.'
+range1 range2 intersection: ''
 
 textarea, AXRole: AXTextArea
-elementRange: text: 'Write something here.', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 21}}
-range1: text: 'Write some', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 10}}
-range2: text: 'something here.', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 21}}
-elementRange range1 intersection: text: 'Write some', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 10}}
-elementRange range2 intersection: text: 'something here.', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 21}}
-range1 range2 intersection: text: 'some', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 10}}
+elementRange: 'Write something here.'
+range1: 'Write some'
+range2: 'something here.'
+elementRange range1 intersection: 'Write some'
+elementRange range2 intersection: 'something here.'
+range1 range2 intersection: 'some'
 
 textarea, AXRole: AXTextArea
-elementRange: text: 'Write something here.', start: {{ID 76, role StaticText, offset 0}}, end: {{ID 76, role StaticText, offset 21}}
-range1: text: 'te something h', start: {{ID 76, role StaticText, offset 3}}, end: {{ID 76, role StaticText, offset 17}}
-range2: text: 'something here.', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 21}}
-elementRange range1 intersection: text: 'te something h', start: {{ID 76, role StaticText, offset 3}}, end: {{ID 76, role StaticText, offset 17}}
-elementRange range2 intersection: text: 'something here.', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 21}}
-range1 range2 intersection: text: 'something h', start: {{ID 76, role StaticText, offset 6}}, end: {{ID 76, role StaticText, offset 17}}
+elementRange: 'Write something here.'
+range1: 'te something h'
+range2: 'something here.'
+elementRange range1 intersection: 'te something h'
+elementRange range2 intersection: 'something here.'
+range1 range2 intersection: 'something h'
 
 
 PASS successfullyParsed is true

--- a/LayoutTests/accessibility/mac/text-marker-ranges-intersect.html
+++ b/LayoutTests/accessibility/mac/text-marker-ranges-intersect.html
@@ -26,18 +26,18 @@ function moveTextMarker(axElement, marker, number) {
 
 function testIntersectRanges(axElement, elementRange, range1, range2) {
     output += `${axElement.domIdentifier}, ${axElement.role}\n`;
-    output += `elementRange: ${axElement.textMarkerRangeDebugDescription(elementRange)}\n`;
-    output += `range1: ${axElement.textMarkerRangeDebugDescription(range1)}\n`;
-    output += `range2: ${axElement.textMarkerRangeDebugDescription(range2)}\n`;
+    output += `elementRange: '${axElement.stringForTextMarkerRange(elementRange)}'\n`;
+    output += `range1: '${axElement.stringForTextMarkerRange(range1)}'\n`;
+    output += `range2: '${axElement.stringForTextMarkerRange(range2)}'\n`;
 
     intersection = axElement.intersectTextMarkerRanges(elementRange, range1);
-    output += `elementRange range1 intersection: ${axElement.textMarkerRangeDebugDescription(intersection)}\n`;
+    output += `elementRange range1 intersection: '${axElement.stringForTextMarkerRange(intersection)}'\n`;
 
     intersection = axElement.intersectTextMarkerRanges(elementRange, range2);
-    output += `elementRange range2 intersection: ${axElement.textMarkerRangeDebugDescription(intersection)}\n`;
+    output += `elementRange range2 intersection: '${axElement.stringForTextMarkerRange(intersection)}'\n`;
 
     intersection = axElement.intersectTextMarkerRanges(range1, range2);
-    output += `range1 range2 intersection: ${axElement.textMarkerRangeDebugDescription(intersection)}\n\n`;
+    output += `range1 range2 intersection: '${axElement.stringForTextMarkerRange(intersection)}'\n\n`;
 }
 
 if (window.accessibilityController) {


### PR DESCRIPTION
#### 6d1a90684215e6865a99d7d2dd0e595733c59641
<pre>
AX: Fix for accessibility/text-marker-ranges-intersect.html.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307680">https://bugs.webkit.org/show_bug.cgi?id=307680</a>
&lt;<a href="https://rdar.apple.com/problem/170235668">rdar://problem/170235668</a>&gt;

Reviewed by Tyler Wilcock.

Amend to commit cd47ffff2464757df28031da4b2a267a648b4eab where this test was added.

The problem was that the TextMarkerRange debug descriptions include the object IDs which can change from run to run, making the output file vary and thus the test fail. Fixed it by outputting the string of the range instead of the whole debug description. This has the added benefit of making the output file more readable.

* LayoutTests/accessibility/mac/text-marker-ranges-intersect-expected.txt:
* LayoutTests/accessibility/mac/text-marker-ranges-intersect.html:

Canonical link: <a href="https://commits.webkit.org/307428@main">https://commits.webkit.org/307428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1eed04a1a001ee53ff2a478a1c9dd114c561e3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144241 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16920 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152911 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97480 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71319839-20d1-48ae-af82-6ee37091e592) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146116 "Build is in progress. Recent messages:") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110920 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79686 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147204 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91837 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb4626a5-a300-48eb-9a17-82a1916bb455) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/143567 "Build is in progress. Recent messages:") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12771 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10515 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/357 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6247 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155223 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16772 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7302 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118938 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/143646 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16809 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14089 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119296 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30606 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15170 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72193 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16394 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5892 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16129 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16339 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->