### PR TITLE
[JSC] Improve op_mod for int32 uses and add LOL support

### DIFF
--- a/JSTests/stress/int32-mod-edge-cases.js
+++ b/JSTests/stress/int32-mod-edge-cases.js
@@ -1,0 +1,54 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected))
+        throw new Error('bad value: ' + actual + ', expected: ' + expected);
+}
+
+function testMod(x, y) {
+    return x % y;
+}
+noInline(testMod);
+
+// Test negative zero case: when numerator is negative and remainder is 0
+function testNegativeZero() {
+    // -0 % 1 should be -0
+    shouldBe(testMod(-0, 1), -0);
+    shouldBe(testMod(-0, 2), -0);
+    shouldBe(testMod(-0, 10), -0);
+
+    // -4 % 2 should be -0 (evenly divisible)
+    shouldBe(testMod(-4, 2), -0);
+    shouldBe(testMod(-10, 5), -0);
+    shouldBe(testMod(-100, 10), -0);
+}
+
+// Test overflow case: when (x / y) * y would overflow
+function testOverflow() {
+    // On ARM64, the multiply check can overflow for large values
+    // INT32_MIN % -1 is a special case that should return -0
+    shouldBe(testMod(-2147483648, -1), -0);
+
+    // Other cases near overflow boundaries
+    shouldBe(testMod(2147483647, 2147483647), 0);
+    shouldBe(testMod(-2147483648, 2147483647), -1);
+    shouldBe(testMod(2147483647, -2147483648), 2147483647);
+}
+
+// Test regular modulo operations to ensure we JIT compile
+function testRegularMod() {
+    shouldBe(testMod(10, 3), 1);
+    shouldBe(testMod(17, 5), 2);
+    shouldBe(testMod(-10, 3), -1);
+    shouldBe(testMod(-17, 5), -2);
+    shouldBe(testMod(10, -3), 1);
+    shouldBe(testMod(17, -5), 2);
+    shouldBe(testMod(-10, -3), -1);
+    shouldBe(testMod(-17, -5), -2);
+    shouldBe(testMod(0, -1), 0);
+}
+
+// Main test loop - ensures JIT compilation
+for (var i = 0; i < testLoopCount; ++i) {
+    testRegularMod();
+    testNegativeZero();
+    testOverflow();
+}

--- a/Source/JavaScriptCore/assembler/ARMv7Assembler.h
+++ b/Source/JavaScriptCore/assembler/ARMv7Assembler.h
@@ -1719,7 +1719,7 @@ public:
     }
 
 #if HAVE(ARM_IDIV_INSTRUCTIONS)
-    template<int datasize>
+    template<int datasize = 32>
     ALWAYS_INLINE void sdiv(RegisterID rd, RegisterID rn, RegisterID rm)
     {
         static_assert(datasize == 32, "sdiv datasize must be 32 for armv7s");        

--- a/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerARMv7.h
@@ -645,6 +645,14 @@ public:
         m_assembler.umull(destLo, destHi, left, right);
     }
 
+#if HAVE(ARM_IDIV_INSTRUCTIONS)
+    // FIXME: Add more of div flavors.
+    void div32(RegisterID left, RegisterID right, RegisterID dest)
+    {
+        m_assembler.sdiv(dest, left, right);
+    }
+#endif
+
     void neg32(RegisterID srcDest)
     {
         m_assembler.neg(srcDest, srcDest);

--- a/Source/JavaScriptCore/lol/LOLJIT.h
+++ b/Source/JavaScriptCore/lol/LOLJIT.h
@@ -53,6 +53,7 @@ namespace JSC::LOL {
     macro(op_add) \
     macro(op_mul) \
     macro(op_sub) \
+    macro(op_mod) \
     macro(op_negate) \
     macro(op_inc) \
     macro(op_dec) \


### PR DESCRIPTION
#### 7cda7d7ad56dce3c984801c7a9c7002eef133a95
<pre>
[JSC] Improve op_mod for int32 uses and add LOL support
<a href="https://bugs.webkit.org/show_bug.cgi?id=307683">https://bugs.webkit.org/show_bug.cgi?id=307683</a>
<a href="https://rdar.apple.com/170243169">rdar://170243169</a>

Reviewed by Marcus Plutowski.

Right now Baseline just goes to the slow path for ARM64 on op_mod. This
patch adds a fast path for binary int32s (assuming the divisor is
non-zero). Also, clean-up some of the DFG&apos;s equivalent code.

Test: JSTests/stress/int32-mod-edge-cases.js
Canonical link: <a href="https://commits.webkit.org/307425@main">https://commits.webkit.org/307425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b570730d5b9c064d0fddd64975e855ea8400c922

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144344 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17023 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8582 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153014 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16917 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110994 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97583 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/207a152d-9873-4d32-9798-f6c0429d5bd5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13390 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91914 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10560 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/460 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136335 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155326 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5153 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7390 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119003 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16913 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119364 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30602 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/15213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127547 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16497 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5963 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175631 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16233 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45249 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16297 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->