### PR TITLE
[AutoFill Debugging] Allow clients to extract specific event listener categories

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -4,15 +4,15 @@ root
     navigation,role='navigation',aria-label='Main navigation'
         list
             list-item
-                link,uid=…,events=[click],url='mailto:wenson_hsieh@apple.com','Section 1',[…]
+                link,uid=…,events=click,url='mailto:wenson_hsieh@apple.com','Section 1',[…]
             list-item
-                link,uid=…,events=[click],url='https://example.com/','Section 2',[…]
+                link,uid=…,events=click,url='https://example.com/','Section 2',[…]
     role='main'
         section,aria-label='Interactive Elements'
-            button,uid=…,events=[click],aria-describedby='This button does nothing',aria-label='Test button','Click Me',[…]
+            button,uid=…,events=click,aria-describedby='This button does nothing',aria-label='Test button','Click Me',[…]
             'This button does nothing',[…]
             input,'text',uid=…,[…],placeholder='Enter text here'
-            uid=…,role='button',events=[click,keyboard],'Clickable Div',[…]
+            uid=…,role='button',events=click,'Clickable Div',[…]
         section,aria-label='ARIA Labeling Examples'
             'Name Field',[…]
             'Description',[…]
@@ -32,12 +32,12 @@ root
                 'Related Links',[…]
                 list
                     list-item
-                        link,uid=…,events=[hover],url='https://webkit.org/','Example Link',[…]
+                        link,uid=…,url='https://webkit.org/','Example Link',[…]
                     list-item
-                        link,uid=…,events=[hover],url='https://apple.com/','Test Link',[…]
+                        link,uid=…,url='https://apple.com/','Test Link',[…]
             role='region'
                 role='status','Ready',[…]
-                button,uid=…,events=[click],'Update Status',[…]
+                button,uid=…,events=click,'Update Status',[…]
             aria-label='Figure 1'
                 canvas,uid=…,[…]
             textarea,uid=…,'This is a text box',[…]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -156,7 +156,7 @@ addEventListener("load", async () => {
         includeRects: true,
         includeURLs: true,
         nodeIdentifierInclusion: "interactive",
-        includeEventListeners: true,
+        eventListenerCategories: ["click"],
         includeAccessibilityAttributes: true,
         includeTextInAutoFilledControls: true,
     });

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html
@@ -113,7 +113,7 @@ addEventListener("load", async () => {
             includeRects: false,
             includeURLs: false,
             nodeIdentifierInclusion: "editableOnly",
-            includeEventListeners: false,
+            eventListenerCategories: ["none"],
             includeAccessibilityAttributes: true,
             includeTextInAutoFilledControls: true,
             outputFormat,

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html
@@ -34,7 +34,7 @@
 
         const debugText = await UIHelper.requestDebugText({
             nodeIdentifierInclusion: "interactive",
-            includeEventListeners: true,
+            eventListenerCategories: ["all"],
             includeAccessibilityAttributes: true,
             includeTextInAutoFilledControls: true,
         });

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -53,7 +53,7 @@
 
         const debugText = await UIHelper.requestDebugText({
             nodeIdentifierInclusion: "interactive",
-            includeEventListeners: true,
+            eventListenerCategories: ["all"],
             includeAccessibilityAttributes: true,
         });
 

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary.html
@@ -89,7 +89,7 @@ addEventListener("load", async () => {
         includeRects: false,
         includeURLs: false,
         nodeIdentifierInclusion: "none",
-        includeEventListeners: false,
+        eventListenerCategories: ["none"],
         includeAccessibilityAttributes: false,
         wordLimit: 10,
         wordLimitPolicy: "discretionary"

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html
@@ -89,7 +89,7 @@ addEventListener("load", async () => {
         includeRects: false,
         includeURLs: false,
         nodeIdentifierInclusion: "none",
-        includeEventListeners: false,
+        eventListenerCategories: ["none"],
         includeAccessibilityAttributes: false,
         wordLimit: 5
     });

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-markup.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-markup.html
@@ -155,7 +155,7 @@ addEventListener("load", async () => {
         includeRects: true,
         includeURLs: true,
         nodeIdentifierInclusion: "interactive",
-        includeEventListeners: true,
+        eventListenerCategories: ["all"],
         includeAccessibilityAttributes: true,
         includeTextInAutoFilledControls: true,
         outputFormat: "html",

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -101,7 +101,7 @@ struct Request {
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
     NodeIdentifierInclusion nodeIdentifierInclusion { NodeIdentifierInclusion::None };
-    bool includeEventListeners { false };
+    OptionSet<EventListenerCategory> eventListenerCategories;
     bool includeAccessibilityAttributes { false };
     bool includeTextInAutoFilledControls { false };
     bool includeOffscreenPasswordFields { false };

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -855,8 +855,12 @@ static Vector<String> partsForItem(const TextExtraction::Item& item, const TextE
         parts.append(makeString("title='"_s, escapeString(item.title), '\''));
 
     auto listeners = eventListenerTypesToStringArray(item.eventListeners);
-    if (!listeners.isEmpty() && !aggregator.useHTMLOutput())
-        parts.append(makeString("events=["_s, commaSeparatedString(listeners), ']'));
+    if (!listeners.isEmpty() && !aggregator.useHTMLOutput()) {
+        if (listeners.size() == 1)
+            parts.append(makeString("events="_s, listeners.first()));
+        else
+            parts.append(makeString("events=["_s, commaSeparatedString(listeners), ']'));
+    }
 
     for (auto& key : sortedKeys(item.ariaAttributes))
         parts.append(makeString(key, "='"_s, escapeString(item.ariaAttributes.get(key)), '\''));

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6904,7 +6904,7 @@ header: <WebCore/TextExtractionTypes.h>
     bool mergeParagraphs;
     bool skipNearlyTransparentContent;
     WebCore::TextExtraction::NodeIdentifierInclusion nodeIdentifierInclusion;
-    bool includeEventListeners;
+    OptionSet<WebCore::TextExtraction::EventListenerCategory> eventListenerCategories;
     bool includeAccessibilityAttributes;
     bool includeTextInAutoFilledControls;
     bool includeOffscreenPasswordFields;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7284,6 +7284,22 @@ static HashMap<String, HashMap<WebCore::JSHandleIdentifier, String>> extractClie
     return result;
 }
 
+static OptionSet<WebCore::TextExtraction::EventListenerCategory> coreEventListenerCategories(_WKTextExtractionEventListenerCategory categories)
+{
+    OptionSet<WebCore::TextExtraction::EventListenerCategory> coreCategories;
+    if (categories & _WKTextExtractionEventListenerCategoryClick)
+        coreCategories.add(WebCore::TextExtraction::EventListenerCategory::Click);
+    if (categories & _WKTextExtractionEventListenerCategoryHover)
+        coreCategories.add(WebCore::TextExtraction::EventListenerCategory::Hover);
+    if (categories & _WKTextExtractionEventListenerCategoryTouch)
+        coreCategories.add(WebCore::TextExtraction::EventListenerCategory::Touch);
+    if (categories & _WKTextExtractionEventListenerCategoryWheel)
+        coreCategories.add(WebCore::TextExtraction::EventListenerCategory::Wheel);
+    if (categories & _WKTextExtractionEventListenerCategoryKeyboard)
+        coreCategories.add(WebCore::TextExtraction::EventListenerCategory::Keyboard);
+    return coreCategories;
+}
+
 #if ENABLE(DATA_DETECTION)
 
 static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtractionDataDetectorTypes types)
@@ -7351,7 +7367,7 @@ static OptionSet<WebCore::DataDetectorType> coreDataDetectorTypes(_WKTextExtract
             .mergeParagraphs = mergeParagraphs,
             .skipNearlyTransparentContent = skipNearlyTransparentContent,
             .nodeIdentifierInclusion = nodeIdentifierInclusion,
-            .includeEventListeners = !!configuration.includeEventListeners,
+            .eventListenerCategories = coreEventListenerCategories(configuration.eventListenerCategories),
             .includeAccessibilityAttributes = !!configuration.includeAccessibilityAttributes,
             .includeTextInAutoFilledControls = !!configuration.includeTextInAutoFilledControls,
             .includeOffscreenPasswordFields = !!configuration.includeOffscreenPasswordFields,

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -55,6 +55,18 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionOutputFormat) {
     _WKTextExtractionOutputFormatJSON,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
+#define WK_TEXT_EXTRACTION_HAS_EVENT_LISTENER_CATEGORIES 1
+
+typedef NS_OPTIONS(NSUInteger, _WKTextExtractionEventListenerCategory) {
+    _WKTextExtractionEventListenerCategoryNone          = 0,
+    _WKTextExtractionEventListenerCategoryClick         = 1 << 0,
+    _WKTextExtractionEventListenerCategoryHover         = 1 << 1,
+    _WKTextExtractionEventListenerCategoryTouch         = 1 << 2,
+    _WKTextExtractionEventListenerCategoryWheel         = 1 << 3,
+    _WKTextExtractionEventListenerCategoryKeyboard      = 1 << 4,
+    _WKTextExtractionEventListenerCategoryAll           = NSUIntegerMax
+} WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
+
 #define WK_TEXT_EXTRACTION_HAS_DATA_DETECTOR_TYPES 1
 
 typedef NS_OPTIONS(NSUInteger, _WKTextExtractionDataDetectorTypes) {
@@ -117,6 +129,13 @@ WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))
  The default value is `YES`.
  */
 @property (nonatomic) BOOL includeEventListeners;
+
+/*!
+ Specifies categories of event listeners to include in text extraction output.
+ Setting this to `.none` excludes all event listener data, while `.all` includes all categories.
+ The default value is `.all`.
+ */
+@property (nonatomic) _WKTextExtractionEventListenerCategory eventListenerCategories;
 
 /*!
  Include accessibility attributes (e.g. `role`, `aria-label`).

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm
@@ -60,7 +60,7 @@
     _includeURLs = !onlyVisibleText;
     _includeRects = !onlyVisibleText;
     _nodeIdentifierInclusion = onlyVisibleText ? _WKTextExtractionNodeIdentifierInclusionNone : _WKTextExtractionNodeIdentifierInclusionInteractive;
-    _includeEventListeners = !onlyVisibleText;
+    _eventListenerCategories = onlyVisibleText ? _WKTextExtractionEventListenerCategoryNone : _WKTextExtractionEventListenerCategoryAll;
     _includeAccessibilityAttributes = !onlyVisibleText;
     _includeTextInAutoFilledControls = !onlyVisibleText;
     _onlyIncludeVisibleText = onlyVisibleText;
@@ -153,11 +153,23 @@
     _nodeIdentifierInclusion = value;
 }
 
+- (BOOL)includeEventListeners
+{
+    return _eventListenerCategories != _WKTextExtractionEventListenerCategoryNone;
+}
+
 - (void)setIncludeEventListeners:(BOOL)value
 {
     ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
 
-    _includeEventListeners = value;
+    _eventListenerCategories = value ? _WKTextExtractionEventListenerCategoryAll : _WKTextExtractionEventListenerCategoryNone;
+}
+
+- (void)setEventListenerCategories:(_WKTextExtractionEventListenerCategory)value
+{
+    ENSURE_VALID_TEXT_ONLY_CONFIGURATION(value);
+
+    _eventListenerCategories = value;
 }
 
 - (void)setIncludeAccessibilityAttributes:(BOOL)value

--- a/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
+++ b/Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift
@@ -107,7 +107,7 @@ extension WKWebView {
             configuration.mergeParagraphs = true
             configuration.skipNearlyTransparentContent = true
             configuration.nodeIdentifierInclusion = .none
-            configuration.includeEventListeners = false
+            configuration.eventListenerCategories = []
             configuration.includeAccessibilityAttributes = false
             configuration.filterOptions = []
             if let rootItem = await _requestTextExtraction(configuration) {

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -49,7 +49,7 @@ dictionary TextExtractionTestOptions {
     boolean includeURLs = false;
     boolean shortenURLs = false;
     DOMString nodeIdentifierInclusion = "none";
-    boolean includeEventListeners = false;
+    object eventListenerCategories;
     boolean includeAccessibilityAttributes = false;
     boolean includeTextInAutoFilledControls = false;
     boolean includeOffscreenPasswordFields = false;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -64,7 +64,7 @@ struct TextExtractionTestOptions {
     bool includeURLs { false };
     bool shortenURLs { false };
     JSRetainPtr<JSStringRef> nodeIdentifierInclusion;
-    bool includeEventListeners { false };
+    JSValueRef eventListenerCategories { nullptr };
     bool includeAccessibilityAttributes { false };
     bool includeTextInAutoFilledControls { false };
     bool includeOffscreenPasswordFields { false };

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp
@@ -75,7 +75,13 @@ TextExtractionTestOptions* toTextExtractionTestOptions(JSContextRef context, JSV
     options.includeRects = booleanProperty(context, (JSObjectRef)argument, "includeRects", false);
     options.includeURLs = booleanProperty(context, (JSObjectRef)argument, "includeURLs", false);
     options.shortenURLs = booleanProperty(context, (JSObjectRef)argument, "shortenURLs", false);
-    options.includeEventListeners = booleanProperty(context, (JSObjectRef)argument, "includeEventListeners", false);
+    options.eventListenerCategories = [&] -> JSValueRef {
+        auto value = property(context, (JSObjectRef)argument, "eventListenerCategories");
+        if (isValidValue(context, value))
+            return value;
+
+        return nullptr;
+    }();
     options.includeAccessibilityAttributes = booleanProperty(context, (JSObjectRef)argument, "includeAccessibilityAttributes", false);
     options.includeTextInAutoFilledControls = booleanProperty(context, (JSObjectRef)argument, "includeTextInAutoFilledControls", false);
     options.includeOffscreenPasswordFields = booleanProperty(context, (JSObjectRef)argument, "includeOffscreenPasswordFields", false);


### PR DESCRIPTION
#### c839a88ec84718126aa70cbcbde53feaea7be3d7
<pre>
[AutoFill Debugging] Allow clients to extract specific event listener categories
<a href="https://bugs.webkit.org/show_bug.cgi?id=307684">https://bugs.webkit.org/show_bug.cgi?id=307684</a>
<a href="https://rdar.apple.com/problem/170245590">rdar://problem/170245590</a>

Reviewed by Abrar Rahman Protyasha.

Replace the `includeEventListeners` boolean flag with an options enumeration which encompasses
various event listener types; this allows clients to request only specific types of event handlers.

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-highlight-text.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight-discretionary.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-lightweight.html:
* LayoutTests/fast/text-extraction/debug-text-extraction-markup.html:

Adjust layout tests to use the new property.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):
(WebCore::TextExtraction::extractItem):
* Source/WebCore/page/text-extraction/TextExtractionTypes.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::partsForItem):

In the case where there&apos;s only a single item, make this attribute easier to read by omitting the
square brackets representing a list.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(coreEventListenerCategories):
(-[WKWebView _requestTextExtractionInternal:completion:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.mm:
(-[_WKTextExtractionConfiguration _initForOnlyVisibleText:]):
(-[_WKTextExtractionConfiguration includeEventListeners]):
(-[_WKTextExtractionConfiguration setIncludeEventListeners:]):

Leave the old property intact, since it&apos;s still used by some internal clients; make it simply map to
either the `.none` or `.all` value of `eventListenerCategories`.

(-[_WKTextExtractionConfiguration setEventListenerCategories:]):
* Source/WebKit/UIProcess/Cocoa/TextExtraction/WKWebView+TextExtraction.swift:
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
* Tools/TestRunnerShared/UIScriptContext/UIScriptControllerShared.cpp:
(WTR::toTextExtractionTestOptions):
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::eventListenerCategories):
(WTR::createTextExtractionConfiguration):

Canonical link: <a href="https://commits.webkit.org/307400@main">https://commits.webkit.org/307400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45b615090dd6197eb372cd69bc418e7d85f5aca4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144238 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16917 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8473 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152908 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73cc3e9a-da44-42ee-be27-e3e462b18554) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146113 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17399 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16811 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110917 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85b45793-f3ba-488a-aa69-fc8d412d105c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147201 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129588 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91833 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/607e90d6-5005-407b-aca9-13e58959a27b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12761 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10511 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/354 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155220 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16769 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7298 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118935 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14084 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119293 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30586 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15168 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127454 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72190 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16391 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5888 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16126 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16336 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16191 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->