### PR TITLE
[GFC][Integration] Allow min-content as track sizing function for rows

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -354,6 +354,9 @@ static Vector<LayoutUnit> rowSizesForFirstIterationColumnSizing(const TrackSizin
                 ASSERT(gridContainerInnerInlineSize, "The formatting context should have transformed this track size to auto");
                 return Style::evaluate<LayoutUnit>(calculatedValue, *gridContainerInnerInlineSize, Style::ZoomNeeded { });
             },
+            [](const CSS::Keyword::MinContent&) -> LayoutUnit {
+                return LayoutUnit::max();
+            },
             [](const auto&) -> LayoutUnit {
                 ASSERT_NOT_IMPLEMENTED_YET();
                 return { };

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -348,8 +348,8 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
 
                 if (minBreadth.isLength()) {
                     auto& gridTrackBreadthLength = minBreadth.length();
-                    // Length types like auto, min-content, max-content, etc. not yet supported
-                    if (!gridTrackBreadthLength.isFixed())
+                    // Length types like auto, max-content, etc. not yet supported
+                    if (!gridTrackBreadthLength.isFixed() && !gridTrackBreadthLength.isMinContent())
                         return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
                     return std::nullopt;
                 }


### PR DESCRIPTION
#### d9f9c8a600c8053f0d05ad2fe510a0870aa9a800
<pre>
[GFC][Integration] Allow min-content as track sizing function for rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=307687">https://bugs.webkit.org/show_bug.cgi?id=307687</a>
<a href="https://rdar.apple.com/170246267">rdar://170246267</a>

Reviewed by Vitor Roriz.

Relax the requirements by allowing min-content to be a valid track
sizing function for the row template list.

This allows content like the following to run through GFC:

&lt;div style=&quot;display: grid; width: 100px; height: 100px; grid-template-columns: 10px 100px; grid-template-rows: min-content; min-width: 0; min-height: 0; outline: 3px solid green;&quot;&gt;
  &lt;div style=&quot;outline: 1px solid red; grid-column: 1/2; grid-row: 1/2; min-width: 0; min-height: 0;&quot;&gt;x x x x&lt;/div&gt;
  &lt;div style=&quot;outline: 1px solid red; grid-column: 2/3; grid-row: 1/2; min-width: 0; min-height: 0;&quot;&gt;xxxxxxx&lt;/div&gt;
&lt;/div&gt;

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::rowSizesForFirstIterationColumnSizing):
We were hitting an ASSERT_NOT_IMPLEMENTED here because we didn&apos;t have
anything to handle the min-content case. This code implements this
portion of the spec:
&quot;If calculating the layout of a grid item in this step depends on the
available space in the block axis, assume the available space that it
would have if any row with a definite max track sizing function had
that size and all other rows were infinite.&quot;

Since min-content is not a definite value for the max-track sizing
function we map it to LayoutUnit::max();

Canonical link: <a href="https://commits.webkit.org/307396@main">https://commits.webkit.org/307396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ab13da0eb3af2aef9fb2597eec2d3594d1c1e9df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144242 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16921 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152912 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146117 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17403 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16815 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110922 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147205 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13343 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91839 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c72dea55-3ffe-4f5e-b1de-3139cd688be7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12770 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10512 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/358 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122272 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6248 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155224 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16773 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7303 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118937 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14085 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119295 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30583 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15169 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127460 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72194 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16395 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5893 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16130 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16340 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16195 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->