### PR TITLE
Weak link Reality frameworks

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -25,11 +25,11 @@ internal import Metal
 internal import WebKit_Internal
 
 #if canImport(RealityCoreRenderer, _version: 9) && (os(macOS) || (os(iOS) && canImport(SwiftUI, _version: "8.0.36"))) && canImport(_USDKit_RealityKit)
-@_spi(RealityCoreRendererAPI) internal import RealityKit
-@_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
-@_spi(SwiftAPI) internal import DirectResource
-internal import _USDKit_RealityKit
-internal import ShaderGraph
+@_weakLinked @_spi(RealityCoreRendererAPI) internal import RealityKit
+@_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
+@_weakLinked @_spi(SwiftAPI) internal import DirectResource
+@_weakLinked internal import _USDKit_RealityKit
+@_weakLinked internal import ShaderGraph
 #endif
 
 @objc

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
@@ -24,8 +24,8 @@
 #if canImport(RealityCoreRenderer, _version: 9) && (os(macOS) || (os(iOS) && canImport(SwiftUI, _version: "8.0.36"))) && canImport(_USDKit_RealityKit)
 
 internal import Metal
-@_spi(RealityCoreRendererAPI) internal import RealityKit
-@_spi(RealityCoreTextureProcessingAPI) internal import RealityKit
+@_weakLinked @_spi(RealityCoreRendererAPI) internal import RealityKit
+@_weakLinked @_spi(RealityCoreTextureProcessingAPI) internal import RealityKit
 
 class IBLTextures {
     static func loadIBLTextures(

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
@@ -23,7 +23,7 @@
 
 #if canImport(RealityCoreRenderer, _version: 9) && (os(macOS) || (os(iOS) && canImport(SwiftUI, _version: "8.0.36"))) && canImport(_USDKit_RealityKit)
 
-@_spi(RealityCoreRendererAPI) internal import RealityKit
+@_weakLinked @_spi(RealityCoreRendererAPI) internal import RealityKit
 
 nonisolated func makeParameters(
     for function: _Proto_LowLevelMaterialResource_v1.Function,

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -24,7 +24,7 @@
 #if canImport(RealityCoreRenderer, _version: 9) && (os(macOS) || (os(iOS) && canImport(SwiftUI, _version: "8.0.36"))) && canImport(_USDKit_RealityKit)
 
 internal import QuartzCore
-@_spi(RealityCoreRendererAPI) @_spi(Private) internal import RealityKit
+@_weakLinked @_spi(RealityCoreRendererAPI) @_spi(Private) internal import RealityKit
 internal import simd
 
 extension RealityCoreRenderer._Proto_LowLevelGlobalConstantsEncoder_v1 {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -23,10 +23,10 @@
 
 #if canImport(RealityCoreRenderer, _version: 9) && (os(macOS) || (os(iOS) && canImport(SwiftUI, _version: "8.0.36"))) && canImport(_USDKit_RealityKit)
 
-internal import DirectResource
+@_weakLinked internal import DirectResource
 internal import Metal
-@_spi(RealityCoreRendererAPI) internal import RealityKit
-@_spi(SGInternal) internal import RealityKit
+@_weakLinked @_spi(RealityCoreRendererAPI) internal import RealityKit
+@_weakLinked @_spi(SGInternal) internal import RealityKit
 
 nonisolated func mapSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> _Proto_LowLevelMeshResource_v1.VertexSemantic {
     switch semantic {

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -27,14 +27,14 @@ internal import WebKit_Internal
 internal import simd
 
 #if canImport(RealityCoreRenderer, _version: 9) && (os(macOS) || (os(iOS) && canImport(SwiftUI, _version: "8.0.36"))) && canImport(_USDKit_RealityKit)
-@_spi(RealityCoreRendererAPI) internal import RealityKit
-@_spi(RealityCoreTextureProcessingAPI) internal import RealityCoreTextureProcessing
-@_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
-@_spi(SwiftAPI) internal import DirectResource
-internal import _USDKit_RealityKit
-internal import RealityKit
-@_spi(SGPrivate) internal import ShaderGraph
-internal import RealityCoreDeformation
+@_weakLinked @_spi(RealityCoreRendererAPI) internal import RealityKit
+@_weakLinked @_spi(RealityCoreTextureProcessingAPI) internal import RealityCoreTextureProcessing
+@_weakLinked @_spi(UsdLoaderAPI) internal import _USDKit_RealityKit
+@_weakLinked @_spi(SwiftAPI) internal import DirectResource
+@_weakLinked internal import _USDKit_RealityKit
+@_weakLinked internal import RealityKit
+@_weakLinked @_spi(SGPrivate) internal import ShaderGraph
+@_weakLinked internal import RealityCoreDeformation
 
 extension _USDKit_RealityKit._Proto_MeshDataUpdate_v1 {
     @_silgen_name("$s18_USDKit_RealityKit24_Proto_MeshDataUpdate_v1V18instanceTransformsSaySo13simd_float4x4aGvg")


### PR DESCRIPTION
#### 400bbeb46dc0d14ee18c3803267d43579b63dbff
<pre>
Weak link Reality frameworks
<a href="https://bugs.webkit.org/show_bug.cgi?id=307690">https://bugs.webkit.org/show_bug.cgi?id=307690</a>
<a href="https://rdar.apple.com/170243249">rdar://170243249</a>

Reviewed by Aditya Keerthi, Tim Horton, and Etienne Segonzac.

These frameworks might not always exist, so weak link them.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:

Canonical link: <a href="https://commits.webkit.org/307387@main">https://commits.webkit.org/307387@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4774e71ce5d0c0e339a213cc941fc9d57c5b984c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144258 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/16937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8493 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152928 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/479bfa95-ab63-4e85-a9d1-8ea4d46bf4e6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17419 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16831 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/110930 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01f9426b-89e6-4a61-8f09-96f8e03e2d59) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147221 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13339 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129599 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91847 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6015134-a8a9-42ff-a7a6-e15907f9bdf2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/374 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155240 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16789 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7309 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/118946 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/16827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/14094 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/119304 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30580 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127466 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/16411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/5899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/16211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->