### PR TITLE
Use a more declarative style for parsing the CSS display property

### DIFF
--- a/Source/WTF/wtf/EnumeratedArray.h
+++ b/Source/WTF/wtf/EnumeratedArray.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2022-2023 Apple Inc. All rights reserved.
+ * Copyright (C) 2026 Samuel Weinig <sam@webkit.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -35,7 +36,7 @@ namespace WTF {
 // This assumes the values of the enum start at 0 and monotonically increase by 1
 // (so the conversion function between size_t and the enum is just a simple static_cast).
 // LastValue is the maximum value of the enum, which determines the size of the array.
-template <typename Key, typename T, Key LastValue = EnumTraits<Key>::values::max>
+template<typename Key, typename T, Key LastValue = EnumTraits<Key>::values::max>
 class EnumeratedArray {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(EnumeratedArray);
 public:
@@ -51,35 +52,35 @@ public:
     using reverse_iterator = std::reverse_iterator<iterator>;
     using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
-    EnumeratedArray() = default;
+    constexpr EnumeratedArray() = default;
 
-    EnumeratedArray(const EnumeratedArray& from)
+    constexpr EnumeratedArray(const EnumeratedArray& from)
         : m_storage(from.m_storage)
     {
     }
 
-    EnumeratedArray(EnumeratedArray&& from)
+    constexpr EnumeratedArray(EnumeratedArray&& from)
         : m_storage(WTF::move(from.m_storage))
     {
     }
 
-    EnumeratedArray(const UnderlyingType& from)
+    constexpr EnumeratedArray(const UnderlyingType& from)
         : m_storage(from)
     {
     }
 
-    EnumeratedArray(UnderlyingType&& from)
+    constexpr EnumeratedArray(UnderlyingType&& from)
         : m_storage(WTF::move(from))
     {
     }
 
-    EnumeratedArray& operator=(const EnumeratedArray& from)
+    constexpr EnumeratedArray& operator=(const EnumeratedArray& from)
     {
         m_storage = from.m_storage;
         return *this;
     }
 
-    EnumeratedArray& operator=(EnumeratedArray&& from)
+    constexpr EnumeratedArray& operator=(EnumeratedArray&& from)
     {
         m_storage = WTF::move(from.m_storage);
         return *this;
@@ -220,20 +221,20 @@ public:
         return m_storage.swap(other.m_storage);
     }
 
-    template <typename Key2, typename T2, Key2 LastValue2>
+    template<typename Key2, typename T2, Key2 LastValue2>
     constexpr bool operator==(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
     {
         return m_storage == rhs.m_storage;
     }
 
-    template <typename Key2, typename T2, Key2 LastValue2>
-    std::strong_ordering operator<=>(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
+    template<typename Key2, typename T2, Key2 LastValue2>
+    constexpr std::strong_ordering operator<=>(const EnumeratedArray<Key2, T2, LastValue2>& rhs) const
     {
         return m_storage <=> rhs.m_storage;
     }
 
 private:
-    typename UnderlyingType::size_type index(size_type pos) const
+    static constexpr typename UnderlyingType::size_type index(size_type pos)
     {
         return static_cast<typename UnderlyingType::size_type>(pos);
     }


### PR DESCRIPTION
#### 194f9227e3d8a1cbb52927c4ccd4815642a3b278
<pre>
Use a more declarative style for parsing the CSS display property
<a href="https://bugs.webkit.org/show_bug.cgi?id=307692">https://bugs.webkit.org/show_bug.cgi?id=307692</a>

Reviewed by Antti Koivisto.

Streamline the parser for the CSS display property by dispatching
from a single switch and using a compile time generated mapping of
&lt;display-outside&gt; + &lt;display-inside&gt; pairs to CSSValueIDs.

* Source/WTF/wtf/EnumeratedArray.h:
    - Make remaining functions constexpr.

* Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp:
(WebCore::CSSPropertyParserHelpers::makeDisplayOutsideInsideMap):
    - Generate a compile time mapping of &lt;display-outside&gt; + &lt;display-inside&gt;
      pairs to CSSValueIDs, using EnumeratedArray as the backing to allow a
      nice syntax for lookup.
(WebCore::CSSPropertyParserHelpers::consumeAfterInitialDisplayOutside):
(WebCore::CSSPropertyParserHelpers::consumeAfterInitialDisplayInside):
(WebCore::CSSPropertyParserHelpers::consumeDisplay):
    - Implement the initial dispatch using a single switch on all possible
      initial keywords and two generic helpers for the &lt;display-outside&gt; then
      &lt;display-inside&gt; case and the &lt;display-inside&gt; then &lt;display-inside&gt; case.

Canonical link: <a href="https://commits.webkit.org/307644@main">https://commits.webkit.org/307644@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90e34c345035088adc0b7e82d0ad5b21dd0f51e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16941 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152932 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97501 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110932 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79687 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13348 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129611 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91849 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12775 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10528 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/378 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136253 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122277 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6269 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155244 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5070 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16793 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7324 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118949 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16831 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14102 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119307 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30740 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15180 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127481 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72214 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16415 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5910 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175549 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16150 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80194 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45239 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16360 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->