### PR TITLE
[GFC][Integration] Allow max-content as track sizing function for rows

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -388,6 +388,9 @@ static Vector<LayoutUnit> rowSizesForFirstIterationColumnSizing(const TrackSizin
             [](const CSS::Keyword::MinContent&) -> LayoutUnit {
                 return LayoutUnit::max();
             },
+            [](const CSS::Keyword::MaxContent&) {
+                return LayoutUnit::max();
+            },
             [](const auto&) -> LayoutUnit {
                 ASSERT_NOT_IMPLEMENTED_YET();
                 return { };

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -346,8 +346,8 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
 
                 if (minBreadth.isLength()) {
                     auto& gridTrackBreadthLength = minBreadth.length();
-                    // Length types like auto, max-content, etc. not yet supported
-                    if (!gridTrackBreadthLength.isFixed() && !gridTrackBreadthLength.isMinContent())
+                    // Length types like auto, min-content, etc. not yet supported
+                    if (!gridTrackBreadthLength.isFixed() && !gridTrackBreadthLength.isMinContent() && !gridTrackBreadthLength.isMaxContent())
                         return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
                     return std::nullopt;
                 }


### PR DESCRIPTION
#### 22f518d5d3b320978a944766ded2803643534496
<pre>
[GFC][Integration] Allow max-content as track sizing function for rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=307698">https://bugs.webkit.org/show_bug.cgi?id=307698</a>
<a href="https://rdar.apple.com/170251237">rdar://170251237</a>

Reviewed by Vitor Roriz.

Relax the restrictions for GFC by allowing max-content as a valid track
sizing function for the rows.

This allows content like the following to run through GFC:
&lt;div style=&quot;display: grid; width: 100px; height: 100px; grid-template-columns: 30px 50px; grid-template-rows: max-content; min-width: 0; min-height: 0; outline: 3px solid green;&quot;&gt;
  &lt;div style=&quot;outline: 1px solid red; grid-column: 1/2; grid-row: 1/2; min-width: 0; min-height: 0;&quot;&gt;x x x x&lt;/div&gt;
  &lt;div style=&quot;outline: 1px solid red; grid-column: 2/3; grid-row: 1/2; min-width: 0; min-height: 0;&quot;&gt;x x x x xx&lt;/div&gt;
&lt;/div&gt;

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::rowSizesForFirstIterationColumnSizing):
We were hitting an ASSERT_NOT_IMPLEMENTED_YET() here because we did not
have any logic for the max-content case. This code is supposed to
implement:

&quot;If calculating the layout of a grid item in this step depends on the
available space in the block axis, assume the available space that it
would have if any row with a definite max track sizing function had
that size and all other rows were infinite.&quot;

Since max-content is not a definite value for the max-track sizing
function we map it to LayoutUnit::max();

Canonical link: <a href="https://commits.webkit.org/307418@main">https://commits.webkit.org/307418@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b57b087beb841bde53840fcaab38cc872eaed300

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144317 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16996 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8554 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152987 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1a2d6f1-ea32-45fc-9f6a-19e25e9d3d36) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17478 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16890 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110973 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97556 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e2d967e-e28d-485c-b20c-339c8f99784c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13376 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91891 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4dba09f-45e9-4427-9842-0e70a244d686) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12795 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/433 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122301 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155299 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/16848 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7368 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118984 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16886 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119344 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30598 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15202 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127525 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16470 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5942 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16205 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80249 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16415 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16270 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->