### PR TITLE
Fix Safer CPP static analyzer regressions in Source/WebKit

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm
@@ -163,7 +163,7 @@
     if (RefPtr plugin = _pdfPlugin.get()) {
         if (RefPtr activeAnnotation = plugin->activeAnnotation()) {
             if (CheckedPtr existingCache = plugin->axObjectCache()) {
-                if (RefPtr object = existingCache->exportedGetOrCreate(activeAnnotation->element())) {
+                if (RefPtr object = existingCache->exportedGetOrCreate(protect(activeAnnotation->element()))) {
                 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
                     return [protect(object->wrapper()) accessibilityAttributeValue:@"_AXAssociatedPluginParent"];
                 ALLOW_DEPRECATED_DECLARATIONS_END
@@ -325,7 +325,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
             return;
 
         if (CheckedPtr axObjectCache = protectedSelf->_pdfPlugin.get()->axObjectCache()) {
-            if (RefPtr annotationElementAxObject = axObjectCache->exportedGetOrCreate(activeAnnotation->element()))
+            if (RefPtr annotationElementAxObject = axObjectCache->exportedGetOrCreate(protect(activeAnnotation->element())))
                 wrapper = annotationElementAxObject->wrapper();
         }
     });

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp
@@ -51,7 +51,7 @@ void WebSearchPopupMenu::saveRecentSearches(const AtomString& name, const Vector
     if (name.isEmpty())
         return;
 
-    RefPtr page = m_popup->page();
+    RefPtr page = protect(m_popup)->page();
     if (!page)
         return;
 
@@ -63,7 +63,7 @@ void WebSearchPopupMenu::loadRecentSearches(const AtomString& name, Vector<Recen
     if (name.isEmpty())
         return;
 
-    RefPtr page = m_popup->page();
+    RefPtr page = protect(m_popup)->page();
     if (!page)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -620,7 +620,7 @@ void FindController::drawRect(PageOverlay&, GraphicsContext& graphicsContext, co
     if (!m_isShowingFindIndicator)
         return;
 
-    if (RefPtr selectedFrame = frameWithSelection(protect(m_webPage)->corePage())) {
+    if (RefPtr selectedFrame = frameWithSelection(protect(protect(m_webPage)->corePage()))) {
         auto findIndicatorRect = selectedFrame->protectedView()->contentsToRootView(enclosingIntRect(protect(selectedFrame->selection())->selectionBounds(FrameSelection::ClipToVisibleContent::No)));
 
         if (findIndicatorRect != m_findIndicatorRect) {


### PR DESCRIPTION
#### bd4d4d7aa43d54c000ed3702da9296fc18727a23
<pre>
Fix Safer CPP static analyzer regressions in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307700">https://bugs.webkit.org/show_bug.cgi?id=307700</a>

Reviewed by Anne van Kesteren.

Deployed more smart pointers to fix recent Safer CPP regressions in Source/WebKit.

* Source/WebKit/WebProcess/Plugins/PDF/WKAccessibilityPDFDocumentObject.mm:
(-[WKAccessibilityPDFDocumentObject accessibilityFocusedUIElement]):
(-[WKAccessibilityPDFDocumentObject accessibilityAssociatedControlForAnnotation:]):
* Source/WebKit/WebProcess/WebCoreSupport/WebSearchPopupMenu.cpp:
(WebKit::WebSearchPopupMenu::saveRecentSearches):
(WebKit::WebSearchPopupMenu::loadRecentSearches):
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::drawRect):

Canonical link: <a href="https://commits.webkit.org/307422@main">https://commits.webkit.org/307422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e5829805e3753880261ea8dc8eeb4d1d7526dfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144269 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8504 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152939 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29001226-d32f-4e0d-805f-d3531df6518d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110936 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00c7b705-d6a7-4c60-b4cd-e460c5849bd5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147232 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13347 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129605 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91854 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d06889ba-8522-44f2-beab-3fa714d86e94) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12774 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10529 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/385 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122276 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155251 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16800 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7315 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118953 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16838 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14103 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119311 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15176 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127472 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72221 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22266 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16422 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5905 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16157 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80201 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16367 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16222 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->