### PR TITLE
REGRESSION(307364@main): [macOS iOS] editing/execCommand/insert-line-break-no-scroll.html is a constant text failure

### DIFF
--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8474,6 +8474,4 @@ webkit.org/b/307091 inspector/network/intercept-aborted-request.html [ Skip ]
 # Requires mousedown
 media/caption-display-settings/caption-display-settings-default-anchorBounds.html [ Skip ]
 
-webkit.org/b/307682 editing/execCommand/insert-line-break-no-scroll.html [ Failure ]
-
 webkit.org/b/307582 compositing/overflow/rtl-scrollbar-layer-positioning.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2476,7 +2476,7 @@ webkit.org/b/307377 [ Tahoe Release arm64 ] compositing/webgl/update-composited-
 
 webkit.org/b/307571 imported/w3c/web-platform-tests/workers/SharedWorkerPerformanceNow.html [ Pass Failure ]
 
-webkit.org/b/307682 editing/execCommand/insert-line-break-no-scroll.html [ Failure ]
+webkit.org/b/307688 [ arm64 ] http/tests/site-isolation/inspector/unit-tests/target-manager.html [ Failure ]
 
 webkit.org/b/307691 [ Tahoe Release arm64 ] svg/gradients/spreadMethod.svg [ ImageOnlyFailure Pass ]
 

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -574,10 +574,10 @@ void ScrollAnchoringController::updateBeforeLayout()
 // https://drafts.csswg.org/css-scroll-anchoring/#scroll-adjustment
 void ScrollAnchoringController::adjustScrollPositionForAnchoring()
 {
-    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " adjustScrollPositionForAnchoring() - anchor " << m_anchorObject << " offset " << m_lastAnchorOffset << " suppressedByStyleChange  " << m_anchoringSuppressedByStyleChange);
+    LOG_WITH_STREAM(ScrollAnchoring, stream << "ScrollAnchoringController " << this << " adjustScrollPositionForAnchoring() - anchor " << m_anchorObject << " offset " << m_lastAnchorOffset << " suppressedByStyleChange  " << m_anchoringSuppressedByStyleChange << " in scroll event " << !!m_inScrollEventCount << " in suppression scope " << !!m_suppressionCount);
 
     // FIXME: Test for running animated scrolls?
-    if (m_inScrollEventCount) {
+    if (m_inScrollEventCount || m_suppressionCount) {
         m_anchoringSuppressedByStyleChange = false;
         clearAnchor();
         return;
@@ -630,6 +630,17 @@ void ScrollAnchoringController::didDispatchScrollEvent()
 {
     ASSERT(m_inScrollEventCount);
     --m_inScrollEventCount;
+}
+
+void ScrollAnchoringController::startSuppressingScrollAnchoring()
+{
+    ++m_suppressionCount;
+}
+
+void ScrollAnchoringController::stopSuppressingScrollAnchoring()
+{
+    ASSERT(m_suppressionCount);
+    --m_suppressionCount;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -75,6 +75,10 @@ public:
 
     bool hasAnchorElement() const { return !!m_anchorObject; }
 
+    // These nest.
+    void startSuppressingScrollAnchoring();
+    void stopSuppressingScrollAnchoring();
+
 private:
     static bool isViableStatus(AnchorSearchStatus status)
     {
@@ -115,6 +119,7 @@ private:
     bool m_isQueuedForScrollPositionUpdate { false };
     bool m_anchoringSuppressedByStyleChange { false };
     unsigned m_inScrollEventCount { 0 };
+    unsigned m_suppressionCount { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -1743,6 +1743,7 @@ std::unique_ptr<ScrollView::ProhibitScrollingWhenChangingContentSizeForScope> Sc
 
 ScrollView::ProhibitScrollingWhenChangingContentSizeForScope::ProhibitScrollingWhenChangingContentSizeForScope(ScrollView& scrollView)
     : m_scrollView(scrollView)
+    , m_anchoringSuppressor(scrollView)
 {
     scrollView.incrementProhibitsScrollingWhenChangingContentSizeCount();
 }

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -174,6 +174,7 @@ public:
 
     private:
         SingleThreadWeakPtr<ScrollView> m_scrollView;
+        ScrollAnchoringSuppressionScope m_anchoringSuppressor;
     };
 
     WEBCORE_EXPORT std::unique_ptr<ProhibitScrollingWhenChangingContentSizeForScope> prohibitScrollingWhenChangingContentSizeForScope();

--- a/Source/WebCore/platform/ScrollableArea.cpp
+++ b/Source/WebCore/platform/ScrollableArea.cpp
@@ -1080,5 +1080,23 @@ ScrollbarRevealBehaviorScope::~ScrollbarRevealBehaviorScope()
     scrollableArea->setScrollbarRevealBehavior(m_oldBehavior);
 }
 
+// MARK: -
+
+ScrollAnchoringSuppressionScope::ScrollAnchoringSuppressionScope(ScrollableArea& scrollableArea)
+    : m_scrollableArea(scrollableArea)
+{
+    if (CheckedPtr controller = scrollableArea.scrollAnchoringController())
+        controller->startSuppressingScrollAnchoring();
+}
+
+ScrollAnchoringSuppressionScope::~ScrollAnchoringSuppressionScope()
+{
+    CheckedPtr scrollableArea = m_scrollableArea.get();
+    if (!scrollableArea)
+        return;
+
+    if (CheckedPtr controller = scrollableArea->scrollAnchoringController())
+        controller->stopSuppressingScrollAnchoring();
+}
 
 } // namespace WebCore

--- a/Source/WebCore/platform/ScrollableArea.h
+++ b/Source/WebCore/platform/ScrollableArea.h
@@ -548,6 +548,15 @@ private:
     ScrollbarRevealBehavior m_oldBehavior;
 };
 
+class ScrollAnchoringSuppressionScope {
+public:
+    ScrollAnchoringSuppressionScope(ScrollableArea&);
+    ~ScrollAnchoringSuppressionScope();
+
+private:
+    WeakPtr<ScrollableArea> m_scrollableArea;
+};
+
 WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const ScrollableArea&);
 
 } // namespace WebCore


### PR DESCRIPTION
#### e1d7c1732a67c84687b520b836e5704f936cccfe
<pre>
REGRESSION(307364@main): [macOS iOS] editing/execCommand/insert-line-break-no-scroll.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=307682">https://bugs.webkit.org/show_bug.cgi?id=307682</a>
<a href="https://rdar.apple.com/170242709">rdar://170242709</a>

Reviewed by Wenson Hsieh.

We need to suppress scroll anchoring during editing operations to avoid unexpected jumping, as revealed by
`editing/execCommand/insert-line-break-no-scroll.html`.

Do this by piggy-backing on top of `ScrollView::ProhibitScrollingWhenChangingContentSizeForScope`, adding
a `ScrollAnchoringSuppressionScope` data member; that class maintains a &quot;no scroll anchoring&quot; scope,
implemented via a counter on ScrollAnchoringController.

This only fixes things for document scrolling. webkit.org/b/307695 tracks fixing this more generally
for subscrollers.

* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):
(WebCore::ScrollAnchoringController::startSuppressingScrollAnchoring):
(WebCore::ScrollAnchoringController::stopSuppressingScrollAnchoring):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::ProhibitScrollingWhenChangingContentSizeForScope::ProhibitScrollingWhenChangingContentSizeForScope):
* Source/WebCore/platform/ScrollView.h:
* Source/WebCore/platform/ScrollableArea.cpp:
(WebCore::ScrollAnchoringSuppressionScope::ScrollAnchoringSuppressionScope):
(WebCore::ScrollAnchoringSuppressionScope::~ScrollAnchoringSuppressionScope):
* Source/WebCore/platform/ScrollableArea.h:

Canonical link: <a href="https://commits.webkit.org/307477@main">https://commits.webkit.org/307477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f67bb7c7a9f678c52d0302f45f99a0c7d36d58c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17089 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97649 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b802430-9e61-4dd0-ac41-0207be7a14e0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146285 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16983 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111046 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79725 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1db976f-bd08-4bf1-9ab1-661d659d5813) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13444 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91961 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3782c66-cd14-42a8-a2e7-6bc35354da3c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12849 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10598 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/526 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122355 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6385 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155392 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119049 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16979 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14191 "1 flakes") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119412 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30630 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15255 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127597 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72465 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16563 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6007 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16299 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80342 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16508 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16363 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->