### PR TITLE
Digital Credentials: Convert ISO18013 DocumentRequestInfo after parsing

### DIFF
--- a/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift
+++ b/Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift
@@ -40,7 +40,51 @@ extension WKIdentityDocumentPresentmentMobileDocumentIndividualDocumentRequest {
                 $0.mapValues(WKIdentityDocumentPresentmentMobileDocumentElementInfo.init(_:))
             }
         )
+
+        #if ENABLE_ISO18013_DOCUMENT_REQUEST_INFO
+        if let requestInfo = source.requestInformation {
+            self.applicationSpecificExtensions = Self.convertSendableExtensions(requestInfo.applicationSpecificExtensions)
+        }
+        #endif // ENABLE_ISO18013_DOCUMENT_REQUEST_INFO
     }
+
+    #if ENABLE_ISO18013_DOCUMENT_REQUEST_INFO
+    private static func convertSendableExtensions(
+        _ extensions: [ISO18013MobileDocumentRequest.ApplicationSpecificExtensionKey: any Sendable]
+    ) -> [String: Any] {
+        var result: [String: Any] = [:]
+        for (key, value) in extensions {
+            result[key.rawValue] = convertSendableValue(value)
+        }
+        return result
+    }
+
+    private static func convertSendableValue(_ value: any Sendable) -> Any {
+        // Convert Swift types to Objective-C compatible types
+        switch value {
+        case let string as String:
+            return string as NSString
+        case let number as Int:
+            return NSNumber(value: number)
+        case let number as Double:
+            return NSNumber(value: number)
+        case let number as Float:
+            return NSNumber(value: number)
+        case let bool as Bool:
+            return NSNumber(value: bool)
+        case let array as [any Sendable]:
+            return array.map { Self.convertSendableValue($0) } as NSArray
+        case let dict as [String: any Sendable]:
+            var objcDict: [String: Any] = [:]
+            for (key, val) in dict {
+                objcDict[key] = Self.convertSendableValue(val)
+            }
+            return objcDict as NSDictionary
+        default:
+            return value as Any
+        }
+    }
+    #endif // ENABLE_ISO18013_DOCUMENT_REQUEST_INFO
 }
 
 extension WKIdentityDocumentPresentmentMobileDocumentPresentmentRequest {

--- a/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
+++ b/Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm
@@ -41,6 +41,7 @@
 #import <WebCore/SecurityOrigin.h>
 #import <WebCore/UnvalidatedDigitalCredentialRequest.h>
 #import <WebKit/WKIdentityDocumentPresentmentMobileDocumentRequest.h>
+#import <wtf/Box.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import "WebKitSwiftSoftLink.h"
 
@@ -86,6 +87,58 @@ static Vector<WebCore::CertificateInfo> buildRequestAuthentications(WKIdentityDo
     return requestAuthentications;
 }
 
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+static WebCore::ISO18013Any convertObjCValueToISO18013Any(id value)
+{
+    WebCore::ISO18013Any result;
+
+    if ([value isKindOfClass:[NSString class]]) {
+        result.data = String(static_cast<NSString*>(value));
+    } else if ([value isKindOfClass:[NSNumber class]]) {
+        NSNumber* number = static_cast<NSNumber*>(value);
+        NSString* objCType = @(number.objCType);
+        if ([objCType isEqualToString:@(@encode(BOOL))] || [objCType isEqualToString:@(@encode(bool))])
+            result.data = static_cast<bool>([number boolValue]);
+        else
+            result.data = static_cast<int>([number intValue]);
+    } else if ([value isKindOfClass:[NSArray class]]) {
+        NSArray* array = static_cast<NSArray*>(value);
+        Vector<Box<WebCore::ISO18013Any>> vecArray;
+        for (id item in array) {
+            auto convertedItem = convertObjCValueToISO18013Any(item);
+            vecArray.append(Box<WebCore::ISO18013Any>::create(WTF::move(convertedItem)));
+        }
+        result.data = WTF::move(vecArray);
+    } else if ([value isKindOfClass:[NSDictionary class]]) {
+        NSDictionary* dict = static_cast<NSDictionary*>(value);
+        HashMap<String, Box<WebCore::ISO18013Any>> hashMap;
+        for (NSString* key in dict) {
+            auto convertedValue = convertObjCValueToISO18013Any(dict[key]);
+            hashMap.set(String(key), Box<WebCore::ISO18013Any>::create(WTF::move(convertedValue)));
+        }
+        result.data = WTF::move(hashMap);
+    } else
+        result.data = std::monostate();
+
+    return result;
+}
+
+static WebCore::ISO18013DocumentRequestInfoExtension convertApplicationSpecificExtensions(NSDictionary<NSString*, id> *extensions)
+{
+    WebCore::ISO18013DocumentRequestInfoExtension result;
+
+    if (!extensions)
+        return result;
+
+    for (NSString* key in extensions) {
+        auto convertedValue = convertObjCValueToISO18013Any(extensions[key]);
+        result.set(String(key), WTF::move(convertedValue));
+    }
+
+    return result;
+}
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+
 static WebCore::ISO18013DocumentRequest buildDocumentRequest(WKIdentityDocumentPresentmentMobileDocumentIndividualDocumentRequest *individualDocumentRequest)
 {
     WebCore::ISO18013DocumentRequest mappedDocumentRequest;
@@ -109,6 +162,14 @@ static WebCore::ISO18013DocumentRequest buildDocumentRequest(WKIdentityDocumentP
 
         mappedDocumentRequest.namespaces.append(std::make_pair(WTF::move(mappedNamespaceKey), WTF::move(innerVector)));
     }
+
+#if ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
+    if (individualDocumentRequest.applicationSpecificExtensions) {
+        WebCore::ISO18013DocumentRequestInfo requestInfo;
+        requestInfo.extension = convertApplicationSpecificExtensions(individualDocumentRequest.applicationSpecificExtensions);
+        mappedDocumentRequest.requestInfo = WTF::move(requestInfo);
+    }
+#endif // ENABLE(ISO18013_DOCUMENT_REQUEST_INFO)
 
     return mappedDocumentRequest;
 }


### PR DESCRIPTION
#### 3621c82e4206fe0500494b2cc5c2ef44c59f9763
<pre>
Digital Credentials: Convert ISO18013 DocumentRequestInfo after parsing
<a href="https://bugs.webkit.org/show_bug.cgi?id=307702">https://bugs.webkit.org/show_bug.cgi?id=307702</a>
<a href="https://rdar.apple.com/168942804">rdar://168942804</a>

Reviewed by NOBODY (OOPS!).

After the ISO18013 DocumentRequestInfo field is parsed, it needs
to be converted to the appropriate WebCore C++ types.

* Source/WebKit/WebKitSwift/IdentityDocumentServices/WKIdentityDocumentPresentmentMobileDocumentRequest+Extras.swift:
(WKIdentityDocumentPresentmentMobileDocumentIndividualDocumentRequest.result):
(WKIdentityDocumentPresentmentMobileDocumentIndividualDocumentRequest.convertSendableValue(_:)):
* Source/WebKit/WebProcess/cocoa/IdentityDocumentServices/DigitalCredentialsRequestValidatorBridge.mm:
(WebKit::convertObjCValueToISO18013Any):
(WebKit::convertApplicationSpecificExtensions):
(WebKit::buildDocumentRequest):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3621c82e4206fe0500494b2cc5c2ef44c59f9763

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144282 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8517 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97521 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16855 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110945 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79691 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebcfb3a7-48a7-45ab-845c-e9f7a680651b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147245 "Passed tests") | [⏳ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91863 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bafe5960-20e4-45cb-8312-13a5d3820016) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10533 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/398 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155264 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16813 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118960 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16851 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14108 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119318 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15185 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127484 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72234 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16435 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80214 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16380 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16235 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->