### PR TITLE
[MacOS Debug]webaudio/silent-audio-interrupted-in-background.html is a flaky text failure.

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2451,8 +2451,6 @@ webkit.org/b/306629 [ Release arm64 ] imported/w3c/web-platform-tests/media-sour
 
 webkit.org/b/306301 [ x86_64 ] http/tests/webgpu/webgpu/api/validation/state/device_lost/destroy.html [ Failure ]
 
-webkit.org/b/306663 [ Debug arm64 ] webaudio/silent-audio-interrupted-in-background.html [ Pass Failure ]
-
 webkit.org/b/306670 [ Debug arm64 ] http/tests/webgpu/webgpu/api/validation/render_pipeline/resource_compatibility.html [ Pass Failure ]
 
 webkit.org/b/306785 imported/w3c/web-platform-tests/storage-access-api/requestStorageAccess-insecure.sub.window.html [ Pass Failure ]

--- a/LayoutTests/webaudio/silent-audio-interrupted-in-background.html
+++ b/LayoutTests/webaudio/silent-audio-interrupted-in-background.html
@@ -7,7 +7,7 @@ description("Tests silent WebAudio rendering in hidden pages.");
 jsTestIsAsync = true;
 
 let counter = 0;
-document.onvisibilitychange = async function() {
+document.onvisibilitychange = function() {
     if (!counter) {
          counter = 1;
          shouldBeTrue("document.hidden");
@@ -23,15 +23,15 @@ document.onvisibilitychange = async function() {
 function showPage()
 {
     debug("* Setting page visibility to visible");
-    if (window.internals)
-        internals.setPageVisibility(true);
+    if (window.testRunner)
+        testRunner.setPageVisibility("visible");
 }
 
 function hidePage()
 {
     debug("* Setting page visibility to hidden");
-    if (window.internals)
-        internals.setPageVisibility(false);
+    if (window.testRunner)
+        testRunner.setPageVisibility("hidden");
 }
 
 onload = function() {


### PR DESCRIPTION
#### 5c5ea52134e0b69e39c5423a213aa262312aa493
<pre>
[MacOS Debug]webaudio/silent-audio-interrupted-in-background.html is a flaky text failure.
<a href="https://rdar.apple.com/169312061">rdar://169312061</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=306663">https://bugs.webkit.org/show_bug.cgi?id=306663</a>

Reviewed by NOBODY (OOPS!).

Flaky test failure  was caused by the use of internals.setPageVisibility(false/true) which has a race condition where
the visibilitychange event can fire before document.hidden is updated. Changed to testRunner.setPageVisibility(&quot;hidden&quot;/&quot;visible&quot;)
which properly sets the visibility state synchronously before firing the event.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webaudio/silent-audio-interrupted-in-background.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c5ea52134e0b69e39c5423a213aa262312aa493

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/16983 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8540 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/152974 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97543 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17465 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16877 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110963 "Found 1 new test failure: webaudio/silent-audio-interrupted-in-background.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79696 "3 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13369 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91881 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12789 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10543 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecords, TestWebKitAPI.PermissionsAPI.GeolocationPermissionGrantedPermanentlyAndGeolocationRequestedSinceLoad (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/420 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122295 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6296 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155286 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16835 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7350 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118976 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16873 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14123 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119335 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15196 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127508 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72256 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16457 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5926 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16257 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->