### PR TITLE
Reduce number of ElementRareData allocations due to lang

### DIFF
--- a/LayoutTests/fast/css/lang-document-element-flag-expected.txt
+++ b/LayoutTests/fast/css/lang-document-element-flag-expected.txt
@@ -1,0 +1,14 @@
+Tests that the document element has effectiveLangKnownToMatchDocumentElement flag set to true
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.effectiveLangKnownToMatchDocumentElement(document.documentElement) is true
+PASS internals.effectiveLangKnownToMatchDocumentElement(iframeDocElement) is true
+PASS internals.effectiveLangKnownToMatchDocumentElement(iframeDocElement) is false
+PASS internals.effectiveLangKnownToMatchDocumentElement(body) is true
+PASS internals.effectiveLangKnownToMatchDocumentElement(newDocElement) is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/css/lang-document-element-flag.html
+++ b/LayoutTests/fast/css/lang-document-element-flag.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<script src="../../resources/js-test.js"></script>
+<body>
+<script>
+description("Tests that the document element has effectiveLangKnownToMatchDocumentElement flag set to true");
+
+var frame, iframeDocElement, newDocElement, body;
+
+if (window.internals) {
+    shouldBeTrue('internals.effectiveLangKnownToMatchDocumentElement(document.documentElement)');
+
+    frame = document.createElement("iframe");
+    frame.srcdoc = "<!DOCTYPE html><html lang=en><body>";
+    document.body.append(frame);
+
+    frame.onload = function() {
+        iframeDocElement = frame.contentDocument.documentElement;
+        shouldBeTrue('internals.effectiveLangKnownToMatchDocumentElement(iframeDocElement)');
+        iframeDocElement.remove();
+        shouldBeFalse('internals.effectiveLangKnownToMatchDocumentElement(iframeDocElement)');
+        body = iframeDocElement.querySelector("body");
+        shouldBeTrue('internals.effectiveLangKnownToMatchDocumentElement(body)');
+        newDocElement = frame.contentDocument.createElement("html");
+        newDocElement.lang = "de";
+        frame.contentDocument.append(newDocElement);
+        shouldBeTrue('internals.effectiveLangKnownToMatchDocumentElement(newDocElement)');
+        frame.remove();
+        finishJSTest();
+    };
+
+    var jsTestIsAsync = true;
+} else
+    testFailed("This test requires window.internals");
+</script>
+</body>

--- a/LayoutTests/fast/css/lang-matching-document-invalidation-expected.txt
+++ b/LayoutTests/fast/css/lang-matching-document-invalidation-expected.txt
@@ -67,6 +67,22 @@ PASS matchedLang(child) is "zh"
 ----
 PASS matchedLang(container) is "de"
 ----
+PASS matchedLang(container) is "de"
+PASS matchedLang(child) is "de"
+----
+PASS matchedLang(container) is "zh"
+PASS matchedLang(child) is "zh"
+----
+PASS matchedLang(container) is "zh"
+PASS matchedLang(child) is "zh"
+----
+PASS matchedLang(container) is ""
+PASS matchedLang(grandchild) is ""
+----
+PASS matchedLang(container) is ""
+PASS matchedLang(child) is "de"
+PASS matchedLang(grandchild) is "de"
+----
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/css/lang-matching-document-invalidation.html
+++ b/LayoutTests/fast/css/lang-matching-document-invalidation.html
@@ -2,7 +2,7 @@
 <script src="../../resources/js-test.js"></script>
 <body>
 <script>
-var container, child, otherFrame;
+var container, child, grandchild, otherFrame;
 var testNumber = 0;
 
 description("This tests invalidation of :lang selectors when the document element's lang attribute changes and a descendant element is using the 'explicit language matching document element language' optimization");
@@ -24,6 +24,7 @@ function test(f) {
     f();
     container = null;
     child = null;
+    grandchild = null;
     debug("----");
 }
 
@@ -250,5 +251,58 @@ testWithOtherDocument(function() {
     container.lang = "de";
     container.remove();
     shouldMatchLang("container", "de");
+});
+
+testWithOtherDocument(function() {
+    otherFrame.contentDocument.documentElement.lang = "de";
+    makeContainerWithChild();
+    otherFrame.contentDocument.body.append(container);
+    let oldRoot = otherFrame.contentDocument.documentElement;
+    oldRoot.remove();
+    let newRoot = document.createElement("html");
+    newRoot.lang = "zh";
+    otherFrame.contentDocument.append(newRoot);
+    shouldMatchLang("container", "de");
+    shouldMatchLang("child", "de");
+});
+
+testWithOtherDocument(function() {
+    otherFrame.contentDocument.documentElement.lang = "de";
+    makeContainerWithChild();
+    otherFrame.contentDocument.body.append(container);
+    let oldRoot = otherFrame.contentDocument.documentElement;
+    oldRoot.remove();
+    oldRoot.lang = "zh";
+    shouldMatchLang("container", "zh");
+    shouldMatchLang("child", "zh");
+});
+
+testWithOtherDocument(function() {
+    otherFrame.contentDocument.documentElement.lang = "de";
+    makeContainerWithChild();
+    otherFrame.contentDocument.body.append(container);
+    container.remove();
+    otherFrame.contentDocument.documentElement.lang = "zh";
+    otherFrame.contentDocument.body.append(container);
+    shouldMatchLang("container", "zh");
+    shouldMatchLang("child", "zh");
+});
+
+test(function() {
+    grandchild = document.createElement("div");
+    makeContainerWithChild();
+    child.append(grandchild);
+    shouldMatchLang("container", "");
+    shouldBe('matchedLang(grandchild)', '""');
+});
+
+test(function() {
+    makeContainerWithChild();
+    child.lang = "de";
+    grandchild = document.createElement("div");
+    child.append(grandchild);
+    shouldMatchLang("container", "");
+    shouldMatchLang("child", "de");
+    shouldBe('matchedLang(grandchild)', '"de"');
 });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/lang-attribute-document-element-replacement-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/lang-attribute-document-element-replacement-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Disconnected descendants of a replaced document element should resolve lang from their actual ancestor
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/lang-attribute-document-element-replacement.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/lang-attribute-document-element-replacement.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>lang attribute: disconnected subtree after document element replacement</title>
+<link rel="help" href="https://html.spec.whatwg.org/#the-lang-and-xml:lang-attributes">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<script>
+test(() => {
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+
+    const doc = iframe.contentDocument;
+    doc.documentElement.lang = "de";
+
+    const container = document.createElement("div");
+    const child = document.createElement("div");
+    container.append(child);
+    doc.body.append(container);
+
+    assert_true(container.matches(":lang(de)"), "container should match de while connected");
+    assert_true(child.matches(":lang(de)"), "child should match de while connected");
+
+    const oldRoot = doc.documentElement;
+    oldRoot.remove();
+
+    const newRoot = document.createElement("html");
+    newRoot.lang = "zh";
+    doc.append(newRoot);
+
+    assert_true(container.matches(":lang(de)"), "container should still match de after document element replacement");
+    assert_false(container.matches(":lang(zh)"), "container should not match zh after document element replacement");
+    assert_true(child.matches(":lang(de)"), "child should still match de after document element replacement");
+    assert_false(child.matches(":lang(zh)"), "child should not match zh after document element replacement");
+
+    iframe.remove();
+}, "Disconnected descendants of a replaced document element should resolve lang from their actual ancestor");
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -566,6 +566,7 @@ public:
     const AtomString& effectiveLang() const;
     const AtomString& langFromAttribute() const;
     Locale& locale() const;
+    bool effectiveLangKnownToMatchDocumentElement() const { return hasStateFlag(StateFlag::EffectiveLangKnownToMatchDocumentElement); }
 
     void updateEffectiveLangStateAndPropagateToDescendants();
 
@@ -1057,7 +1058,6 @@ private:
     bool hasXMLLangAttr() const { return hasEventTargetFlag(EventTargetFlag::HasXMLLangAttr); }
     void setHasXMLLangAttr(bool has) { setEventTargetFlag(EventTargetFlag::HasXMLLangAttr, has); }
 
-    bool effectiveLangKnownToMatchDocumentElement() const { return hasStateFlag(StateFlag::EffectiveLangKnownToMatchDocumentElement); }
     void setEffectiveLangKnownToMatchDocumentElement(bool matches) { setStateFlag(StateFlag::EffectiveLangKnownToMatchDocumentElement, matches); }
 
     bool hasLanguageAttribute() const { return hasLangAttr() || hasXMLLangAttr(); }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1534,6 +1534,11 @@ bool Internals::hasPausedImageAnimations(Element& element)
     return element.renderer() && element.renderer()->hasPausedImageAnimations();
 }
 
+bool Internals::effectiveLangKnownToMatchDocumentElement(Element& element)
+{
+    return element.effectiveLangKnownToMatchDocumentElement();
+}
+
 bool Internals::isFullyActive(Document& document)
 {
     return document.isFullyActive();

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -230,6 +230,7 @@ public:
 
     ExceptionOr<String> elementRenderTreeAsText(Element&);
     bool hasPausedImageAnimations(Element&);
+    bool effectiveLangKnownToMatchDocumentElement(Element&);
     void markFrontBufferVolatile(Element&);
 
     bool isFullyActive(Document&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -523,6 +523,9 @@ enum ContentsFormat {
     // Animated image pausing testing.
     boolean hasPausedImageAnimations(Element element);
 
+    // lang attribute testing.
+    boolean effectiveLangKnownToMatchDocumentElement(Element element);
+
     undefined markFrontBufferVolatile(Element element);
     boolean isFullyActive(Document document);
     // Must be called on an element whose enclosingLayer() is self-painting.


### PR DESCRIPTION
#### 8c142edd53ed1b7ddef9dd6846e5915603d98f1e
<pre>
Reduce number of ElementRareData allocations due to lang
<a href="https://bugs.webkit.org/show_bug.cgi?id=307706">https://bugs.webkit.org/show_bug.cgi?id=307706</a>
<a href="https://rdar.apple.com/170261859">rdar://170261859</a>

Reviewed by Ryosuke Niwa.

This patch fixes an issue where the document element&apos;s
effectiveLangKnownToMatchDocumentElement flag was not being set correctly,
which had the effect of propagating a lang attribute from that document
element unconditionally. There was also an existing issue where
descendants of an disconnected root with a lang would instead take the new
document element&apos;s lang instead of walking their own ancestor chain.

This fix is implemented by having effectiveLang() check isConnected()
prior to using the cached document element language, and walks the
ancestor chain for disconnected elements.

Additionally, this fixes setEffectiveLangStateOnOldDocumentElement()
to clear the flag and changes clearEffectiveLangStateOnNewDocumentElement()
to unconditionally set effectiveLangKnownToMatchDocumentElement to true
as the document element must by definition match itself.

* LayoutTests/fast/css/lang-document-element-flag-expected.txt: Added.
* LayoutTests/fast/css/lang-document-element-flag.html: Added.
* LayoutTests/fast/css/lang-matching-document-invalidation-expected.txt:
* LayoutTests/fast/css/lang-matching-document-invalidation.html:
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/lang-attribute-document-element-replacement-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/dom/elements/global-attributes/lang-attribute-document-element-replacement.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::clearEffectiveLangStateOnNewDocumentElement):
(WebCore::Element::setEffectiveLangStateOnOldDocumentElement):
(WebCore::Element::removedFromAncestor):
(WebCore::Element::effectiveLang const):
* Source/WebCore/dom/Element.h:
(WebCore::Element::effectiveLangKnownToMatchDocumentElement const):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::effectiveLangKnownToMatchDocumentElement):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/307769@main">https://commits.webkit.org/307769@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8302eed334ced349d3cdace11104c948a6f95383

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145277 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153949 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98914 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147152 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18441 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17850 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111712 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80067 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14079 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130500 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92612 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13430 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11189 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1395 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122958 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7262 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156261 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17809 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8351 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119720 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17855 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14868 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120055 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30818 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15824 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128521 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73497 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17430 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6772 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81209 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17375 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->