### PR TITLE
[Site Isolation] Support visibility propagation on all platforms

### DIFF
--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -654,4 +654,15 @@ AuxiliaryProcessProxy::InitializationActivityAndGrant AuxiliaryProcessProxy::ini
     };
 }
 
+String AuxiliaryProcessProxy::environmentIdentifier()
+{
+    if (m_environmentIdentifier.isEmpty()) {
+        StringBuilder builder;
+        builder.append(clientName());
+        builder.append(processID());
+        m_environmentIdentifier = builder.toString();
+    }
+    return m_environmentIdentifier;
+}
+
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -249,7 +249,7 @@ public:
     virtual void sendProcessDidResume(ResumeReason) = 0;
     virtual void didChangeThrottleState(ProcessThrottleState);
     virtual ASCIILiteral clientName() const = 0;
-    virtual String environmentIdentifier() const { return emptyString(); }
+    virtual String environmentIdentifier();
     virtual void prepareToDropLastAssertion(CompletionHandler<void()>&& completionHandler) { completionHandler(); }
     virtual void didDropLastAssertion() { }
 
@@ -330,6 +330,7 @@ private:
 #if ENABLE(EXTENSION_CAPABILITIES)
     ExtensionCapabilityGrantMap m_extensionCapabilityGrants;
 #endif
+    String m_environmentIdentifier;
     HashMap<Vector<uint8_t>, std::pair<unsigned, std::unique_ptr<IPC::Encoder>>> m_messagesToSendOnResume;
     unsigned m_messagesToSendOnResumeIndex { 0 };
 } SWIFT_SHARED_REFERENCE(refAuxiliaryProcessProxy, derefAuxiliaryProcessProxy);

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -234,9 +234,7 @@ class WebFullScreenManagerProxyClient;
 class InstallMissingMediaPluginsPermissionRequest;
 #endif
 
-#if HAVE(VISIBILITY_PROPAGATION_VIEW)
 using LayerHostingContextID = uint32_t;
-#endif
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
 class WebKitWebResourceLoadManager;
@@ -303,7 +301,7 @@ public:
     virtual void processDidExit() = 0;
     virtual void processWillSwap() { processDidExit(); }
     virtual void didRelaunchProcess() = 0;
-    virtual void didStartUsingProcessForSiteIsolation(WebProcessProxy&) { }
+    virtual void didStartUsingProcessForSiteIsolation(WebProcessProxy&, LayerHostingContextID) { }
     virtual void didStopUsingProcessForSiteIsolation(WebProcessProxy&) { }
     virtual void processDidUpdateThrottleState() { }
     virtual void pageClosed() = 0;

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -82,6 +82,8 @@ struct FrameInfoData;
 struct FrameTreeCreationParameters;
 struct NavigationActionData;
 
+using LayerHostingContextID = uint32_t;
+
 enum class ProcessTerminationReason : uint8_t;
 
 class RemotePageProxy : public IPC::MessageReceiver, public RefCounted<RemotePageProxy> {
@@ -117,6 +119,11 @@ public:
 
     void disconnect();
 
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
+    void didCreateContextInWebProcessForVisibilityPropagation(LayerHostingContextID);
+    LayerHostingContextID contextIDForVisibilityPropagationInWebProcess() const { return m_contextIDForVisibilityPropagationInWebProcess; }
+#endif
+
 private:
     RemotePageProxy(WebPageProxy&, WebProcessProxy&, const WebCore::Site&, WebPageProxyMessageReceiverRegistration*, std::optional<WebCore::PageIdentifier>);
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
@@ -151,6 +158,10 @@ private:
 #if ASSERT_ENABLED
     bool m_disconnected { false };
 #endif
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
+    LayerHostingContextID m_contextIDForVisibilityPropagationInWebProcess { 0 };
+#endif
+
 };
 
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1980,17 +1980,6 @@ void WebProcessProxy::prepareToDropLastAssertion(CompletionHandler<void()>&& com
 #endif
 }
 
-String WebProcessProxy::environmentIdentifier() const
-{
-    if (m_environmentIdentifier.isEmpty()) {
-        StringBuilder builder;
-        builder.append(clientName());
-        builder.append(processID());
-        m_environmentIdentifier = builder.toString();
-    }
-    return m_environmentIdentifier;
-}
-
 void WebProcessProxy::updateAudibleMediaAssertions()
 {
     bool hasAudibleMainPage = std::ranges::any_of(pages(), [](auto& page) {

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -428,7 +428,6 @@ public:
     void prepareToDropLastAssertion(CompletionHandler<void()>&&) final;
     void didDropLastAssertion() final;
     ASCIILiteral clientName() const final { return "WebProcess"_s; }
-    String environmentIdentifier() const final;
 
 #if PLATFORM(COCOA)
     enum SandboxExtensionType : uint32_t {
@@ -892,7 +891,6 @@ private:
 #if PLATFORM(COCOA)
     bool m_platformSuspendDidReleaseNearSuspendedAssertion { false };
 #endif
-    mutable String m_environmentIdentifier;
     mutable SharedPreferencesForWebProcess m_sharedPreferencesForWebProcess;
     uint64_t m_sharedPreferencesVersionInNetworkProcess { 0 };
 #if ENABLE(GPU_PROCESS)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -87,7 +87,7 @@ private:
     void processDidExit() override;
     void processWillSwap() override;
     void didRelaunchProcess() override;
-    void didStartUsingProcessForSiteIsolation(WebProcessProxy&) override;
+    void didStartUsingProcessForSiteIsolation(WebProcessProxy&, LayerHostingContextID) override;
     void didStopUsingProcessForSiteIsolation(WebProcessProxy&) override;
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -264,9 +264,9 @@ void PageClientImpl::didRelaunchProcess()
     [webView() _didRelaunchProcess];
 }
 
-void PageClientImpl::didStartUsingProcessForSiteIsolation(WebProcessProxy& webProcessProxy)
+void PageClientImpl::didStartUsingProcessForSiteIsolation(WebProcessProxy& webProcessProxy, LayerHostingContextID contextID)
 {
-    [contentView() _didStartUsingProcessForSiteIsolation:webProcessProxy];
+    [contentView() _didStartUsingProcessForSiteIsolation:webProcessProxy contextID:contextID];
 }
 
 void PageClientImpl::didStopUsingProcessForSiteIsolation(WebProcessProxy& webProcessProxy)

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -53,6 +53,7 @@ class WebProcessPool;
 struct MainFrameData;
 struct PageData;
 enum class ViewStabilityFlag : uint8_t;
+using LayerHostingContextID = uint32_t;
 }
 
 @interface WKContentView : WKApplicationStateTrackingView {
@@ -103,7 +104,7 @@ enum class ViewStabilityFlag : uint8_t;
 #endif
 - (void)_processWillSwap;
 - (void)_didRelaunchProcess;
-- (void)_didStartUsingProcessForSiteIsolation:(WebKit::WebProcessProxy&)webProcessProxy;
+- (void)_didStartUsingProcessForSiteIsolation:(WebKit::WebProcessProxy&)webProcessProxy contextID:(WebKit::LayerHostingContextID)contextID;
 - (void)_didStopUsingProcessForSiteIsolation:(WebKit::WebProcessProxy&)webProcessProxy;
 
 #if HAVE(VISIBILITY_PROPAGATION_VIEW)

--- a/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.h
+++ b/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)propagateVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process;
 - (void)stopPropagatingVisibilityToProcess:(WebKit::AuxiliaryProcessProxy&)process;
+- (void)clear;
 
 @end
 

--- a/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm
+++ b/Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm
@@ -84,6 +84,11 @@ using ProcessAndInteractionPair = std::pair<WeakPtr<AuxiliaryProcessProxy>, Reta
     });
 }
 
+- (void)clear
+{
+    _processesAndInteractions.clear();
+}
+
 @end
 
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW) && USE(EXTENSIONKIT)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1176,12 +1176,16 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     setViewportConfigurationViewLayoutSize(parameters.viewportConfigurationViewLayoutSize, parameters.viewportConfigurationLayoutSizeScaleFactorFromClient, parameters.viewportConfigurationMinimumEffectiveDeviceWidth);
 #endif
 
-#if HAVE(VISIBILITY_PROPAGATION_VIEW) && !HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
+#if HAVE(VISIBILITY_PROPAGATION_VIEW)
+    LayerHostingContextID contextID = 0;
+#if !HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
     m_contextForVisibilityPropagation = LayerHostingContext::create({
         canShowWhileLocked()
     });
     WEBPAGE_RELEASE_LOG(Process, "WebPage: Created context with ID %u for visibility propagation from UIProcess", m_contextForVisibilityPropagation->contextID());
-    send(Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation(m_contextForVisibilityPropagation->cachedContextID()));
+    contextID = m_contextForVisibilityPropagation->cachedContextID();
+#endif // !HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
+    send(Messages::WebPageProxy::DidCreateContextInWebProcessForVisibilityPropagation(contextID));
 #endif // HAVE(VISIBILITY_PROPAGATION_VIEW) && !HAVE(NON_HOSTING_VISIBILITY_PROPAGATION_VIEW)
 
 #if ENABLE(VP9) && PLATFORM(COCOA)


### PR DESCRIPTION
#### 1f35590a65b66c746355b45831765807577a008b
<pre>
[Site Isolation] Support visibility propagation on all platforms
<a href="https://bugs.webkit.org/show_bug.cgi?id=307707">https://bugs.webkit.org/show_bug.cgi?id=307707</a>
<a href="https://rdar.apple.com/170262571">rdar://170262571</a>

Reviewed by Sihui Liu.

In <a href="https://commits.webkit.org/307072@main">https://commits.webkit.org/307072@main</a> and <a href="https://commits.webkit.org/307398@main">https://commits.webkit.org/307398@main</a> we added support
for visibility propagation with Site Isolation enabled when ExtensionKit is used. This patch adds
the same support for all platforms.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::environmentIdentifier):
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::environmentIdentifier const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::continueNavigationInNewProcess):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::environmentIdentifier const): Deleted.
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _installVisibilityPropagationViews]):
(-[WKContentView _setupVisibilityPropagationForWebProcess:]):
(-[WKContentView _removeVisibilityPropagationForWebProcess:]):
(-[WKContentView _setupVisibilityPropagationForAllWebProcesses]):
(-[WKContentView _setupVisibilityPropagationForGPUProcess]):
(-[WKContentView _setupVisibilityPropagationForModelProcess]):
(-[WKContentView _removeVisibilityPropagationViewForWebProcess]):
(-[WKContentView _removeVisibilityPropagationViewForGPUProcess]):
(-[WKContentView _resetVisibilityPropagation]):
(-[WKContentView _setupVisibilityPropagation]):
(-[WKContentView _didRelaunchProcess]):
(-[WKContentView _createVisibilityPropagationView]):
* Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.h:
* Source/WebKit/UIProcess/ios/WKVisibilityPropagationView.mm:
(-[WKVisibilityPropagationView propagateVisibilityToProcess:]):
(-[WKVisibilityPropagationView stopPropagatingVisibilityToProcess:]):
(-[WKVisibilityPropagationView clear]):

Canonical link: <a href="https://commits.webkit.org/307587@main">https://commits.webkit.org/307587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4b7516e7f8faa6493b3ca393eca73f35aa4fe52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144804 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17483 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153475 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49014e36-8510-4fec-b39a-0538dd5ff726) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17966 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17377 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111340 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98439 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/da77d73f-af18-4157-a565-8094aca930d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147767 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130024 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92235 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bea75daf-4e6c-4c56-9925-519cd0541504) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13078 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10835 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/920 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122593 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155787 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7844 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119344 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119672 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15483 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128011 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72893 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22347 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16957 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6328 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16693 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80736 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16902 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16757 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->