### PR TITLE
Introduce caching for shaped text in canvas fillText/strokeText operations

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -107,6 +107,7 @@ public:
     unsigned fontSelectorVersion() const;
 
     enum class CustomFontNotReadyAction : bool { DoNotPaintIfFontNotReady, UseFallbackIfFontNotReady };
+    enum class ForTextEmphasisOrNot : bool { NotForTextEmphasis, ForTextEmphasis };
     WEBCORE_EXPORT FloatSize drawText(GraphicsContext&, const TextRun&, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt, CustomFontNotReadyAction = CustomFontNotReadyAction::DoNotPaintIfFontNotReady) const;
     static void drawGlyphs(GraphicsContext&, const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode);
     void drawEmphasisMarks(GraphicsContext&, const TextRun&, const AtomString& mark, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) const;
@@ -205,12 +206,12 @@ public:
 
     unsigned generation() const { return m_generation; }
 
-private:
-    enum class ForTextEmphasisOrNot : bool { NotForTextEmphasis, ForTextEmphasis };
-
-    GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
-    GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
+    GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis, float* outWidth = nullptr) const;
     void drawGlyphBuffer(GraphicsContext&, const GlyphBuffer&, FloatPoint&, CustomFontNotReadyAction) const;
+
+private:
+
+    GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis, float* outWidth = nullptr) const;
     void drawEmphasisMarks(GraphicsContext&, const GlyphBuffer&, const AtomString&, const FloatPoint&) const;
     int offsetForPositionForSimpleText(const TextRun&, float position, bool includePartialGlyphs) const;
     void adjustSelectionRectForSimpleText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
@@ -225,7 +226,7 @@ private:
     static constexpr bool canReturnFallbackFontsForComplexText();
     static constexpr bool canExpandAroundIdeographsInComplexText();
 
-    GlyphBuffer layoutComplexText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis) const;
+    GlyphBuffer layoutComplexText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis, float* outWidth = nullptr) const;
     int offsetForPositionForComplexText(const TextRun&, float position, bool includePartialGlyphs) const;
     void adjustSelectionRectForComplexText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
 

--- a/Source/WebCore/platform/graphics/GlyphBuffer.h
+++ b/Source/WebCore/platform/graphics/GlyphBuffer.h
@@ -37,6 +37,7 @@
 #include <limits>
 #include <wtf/CheckedRef.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 
 namespace WebCore {
@@ -46,6 +47,7 @@ static const constexpr GlyphBufferGlyph deletedGlyph = 0xFFFF;
 class Font;
 
 class GlyphBuffer {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(GlyphBuffer);
 public:
     bool isEmpty() const { return m_fonts.isEmpty(); }
     unsigned size() const { return m_fonts.size(); }


### PR DESCRIPTION
#### a21ec7df273fd4e5118dba01cccd5dbeb84d8af4
<pre>
Introduce caching for shaped text in canvas fillText/strokeText operations
<a href="https://bugs.webkit.org/show_bug.cgi?id=307203">https://bugs.webkit.org/show_bug.cgi?id=307203</a>
<a href="https://rdar.apple.com/164044082">rdar://164044082</a>

Reviewed by Simon Fraser.

Currently, canvas text rendering operations like fillText() and strokeText() repeatedly
shape the same text strings for drawing. This patch introduces a cache for shaped text
(CachedShapedText) to avoid redundant text shaping. FontCascade::width() already interfaces
with a cache (GlyphGeometryCache) but only for width calculation. So, even if we would hit this
cache, we would have to shape at least once for drawing.

Now, we are caching shaping results in the form of GlyphBuffers. While we build the glyph buffer,
we can directly calculate width from the text engine iterators (WidthIterator / ComplexTextController),
so both CachedShapedText can store both GlyphBuffer and width values. Therefore, now, in case of a hit
we don&apos;t have to shape at all.

In order to do that we need to make TextMeasurementCache configurable via template parameters
for cache behavior (sampling intervals, max size, max text length). This allows different cache
instances to use different policies: ShapedTextCache uses aggressive immediate caching with
128 character limit, while the existing GlyphGeometryCache maintains conservative sampling with
64-character limit.

We will just try to hit the cache for the simple path. The simple path is defined by content
without strong directionality. This is because, for such content, we don&apos;t have to invoke the
BidiResolver (all content is guaranteed to compose a single bidi run) and we don&apos;t have to introduce
directionality into our key. This could be extended in the future.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::layoutText const):
(WebCore::FontCascade::layoutSimpleText const):
(WebCore::FontCascade::layoutComplexText const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::getOrCreateCachedShapedText):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::FontCascadeFonts::shapedTextCache):
(WebCore::FontCascadeFonts::shapedTextCache const):
* Source/WebCore/platform/graphics/GlyphBuffer.h:
* Source/WebCore/platform/graphics/TextMeasurementCache.h:
(WebCore::TextMeasurementCache::TextMeasurementCache):
(WebCore::TextMeasurementCache::add):
(WebCore::TextMeasurementCache::addSlowCase):

Canonical link: <a href="https://commits.webkit.org/307515@main">https://commits.webkit.org/307515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01461bcba2686f8640d7c35e5ec85bfa8d38454b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144578 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153249 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/821e4e69-55ce-4869-8156-dee96c49e2d9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146453 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17151 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111197 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98213 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/81341af1-43c4-4534-815f-a6771f9cd7ad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147541 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13569 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129844 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92092 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0221919-00c0-4f01-8553-313addeb1423) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12947 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10700 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/694 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122459 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6538 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155561 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17109 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119200 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17147 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119537 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30655 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15358 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127767 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16731 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6151 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16467 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80510 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16676 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16531 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->