### PR TITLE
Add relayProtocol and url support to RTCIceCandidate

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCIceCandidate-constructor-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCIceCandidate-constructor-expected.txt
@@ -15,9 +15,9 @@ PASS new RTCIceCandidate({ ... }) with valid candidate string and sdpMid
 PASS new RTCIceCandidate({ ... }) with invalid candidate string and sdpMid
 PASS new RTCIceCandidate({ ... }) with nondefault values for most fields
 PASS new RTCIceCandidate({ ... }) with nondefault values for most fields, tcp candidate
-FAIL new RTCIceCandidate({ ... }) with nondefault values for all fields assert_equals: relayProtocol expected (string) "udp" but got (undefined) undefined
-FAIL new RTCIceCandidate({ ... }) with nondefault values for all fields, tcp candidate assert_equals: url expected (string) "turn:turn.example.net" but got (undefined) undefined
-FAIL new RTCIceCandidate({ relayProtocol, url }) cloned vs signaled assert_equals: relayProtocol cloned expected (string) "tls" but got (undefined) undefined
+FAIL new RTCIceCandidate({ ... }) with nondefault values for all fields assert_equals: relayProtocol expected (string) "udp" but got (object) null
+FAIL new RTCIceCandidate({ ... }) with nondefault values for all fields, tcp candidate assert_equals: url expected (string) "turn:turn.example.net" but got (object) null
+FAIL new RTCIceCandidate({ relayProtocol, url }) cloned vs signaled assert_equals: relayProtocol cloned expected (string) "tls" but got (object) null
 PASS new RTCIceCandidate({ ... }) with invalid sdpMid
 PASS new RTCIceCandidate({ ... }) with invalid sdpMLineIndex
 

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
@@ -164,8 +164,8 @@ PASS RTCIceCandidate interface: attribute tcpType
 PASS RTCIceCandidate interface: attribute relatedAddress
 PASS RTCIceCandidate interface: attribute relatedPort
 PASS RTCIceCandidate interface: attribute usernameFragment
-FAIL RTCIceCandidate interface: attribute relayProtocol assert_true: The prototype object must have a property "relayProtocol" expected true got false
-FAIL RTCIceCandidate interface: attribute url assert_true: The prototype object must have a property "url" expected true got false
+PASS RTCIceCandidate interface: attribute relayProtocol
+PASS RTCIceCandidate interface: attribute url
 PASS RTCIceCandidate interface: operation toJSON()
 PASS RTCIceCandidate must be primary interface of new RTCIceCandidate({ sdpMid: 1 })
 PASS Stringification of new RTCIceCandidate({ sdpMid: 1 })
@@ -183,8 +183,8 @@ PASS RTCIceCandidate interface: new RTCIceCandidate({ sdpMid: 1 }) must inherit 
 PASS RTCIceCandidate interface: new RTCIceCandidate({ sdpMid: 1 }) must inherit property "relatedAddress" with the proper type
 PASS RTCIceCandidate interface: new RTCIceCandidate({ sdpMid: 1 }) must inherit property "relatedPort" with the proper type
 PASS RTCIceCandidate interface: new RTCIceCandidate({ sdpMid: 1 }) must inherit property "usernameFragment" with the proper type
-FAIL RTCIceCandidate interface: new RTCIceCandidate({ sdpMid: 1 }) must inherit property "relayProtocol" with the proper type assert_inherits: property "relayProtocol" not found in prototype chain
-FAIL RTCIceCandidate interface: new RTCIceCandidate({ sdpMid: 1 }) must inherit property "url" with the proper type assert_inherits: property "url" not found in prototype chain
+PASS RTCIceCandidate interface: new RTCIceCandidate({ sdpMid: 1 }) must inherit property "relayProtocol" with the proper type
+PASS RTCIceCandidate interface: new RTCIceCandidate({ sdpMid: 1 }) must inherit property "url" with the proper type
 PASS RTCIceCandidate interface: new RTCIceCandidate({ sdpMid: 1 }) must inherit property "toJSON()" with the proper type
 PASS RTCIceCandidate interface: toJSON operation on new RTCIceCandidate({ sdpMid: 1 })
 PASS RTCPeerConnectionIceEvent interface: existence and properties of interface object

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidate.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidate.cpp
@@ -2,6 +2,7 @@
  * Copyright (C) 2012 Google Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
  * Copyright (C) 2015, 2016 Ericsson AB. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidate.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidate.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -65,6 +66,8 @@ public:
     std::optional<unsigned short> relatedPort() const { return m_fields.relatedPort; }
 
     String usernameFragment() const { return m_fields.usernameFragment; }
+    std::optional<RTCIceServerTransportProtocol> relayProtocol() const { return m_fields.relayProtocol; }
+    String url() const { return m_fields.url; }
     RTCIceCandidateInit toJSON() const;
 
 private:

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidate.idl
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidate.idl
@@ -1,7 +1,7 @@
 /*
  * Copyright (C) 2012 Google Inc. All rights reserved.
  * Copyright (C) 2013 Nokia Corporation and/or its subsidiary(-ies).
- * Copyright (C) 2017 Apple Inc. All rights reserved.
+ * Copyright (C) 2017-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -53,6 +53,8 @@
     readonly attribute DOMString? relatedAddress;
     readonly attribute unsigned short? relatedPort;
     readonly attribute DOMString? usernameFragment;
+    readonly attribute RTCIceServerTransportProtocol? relayProtocol;
+    readonly attribute USVString? url;
 
     RTCIceCandidateInit toJSON();
 };

--- a/Source/WebCore/Modules/mediastream/RTCIceCandidateFields.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceCandidateFields.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2022-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -27,6 +27,7 @@
 #include <WebCore/RTCIceCandidateType.h>
 #include <WebCore/RTCIceComponent.h>
 #include <WebCore/RTCIceProtocol.h>
+#include <WebCore/RTCIceServerTransportProtocol.h>
 #include <WebCore/RTCIceTcpCandidateType.h>
 #include <optional>
 #include <wtf/text/WTFString.h>
@@ -45,8 +46,10 @@ struct RTCIceCandidateFields {
     String relatedAddress;
     std::optional<unsigned short> relatedPort;
     String usernameFragment;
+    std::optional<RTCIceServerTransportProtocol> relayProtocol;
+    String url;
 
-    RTCIceCandidateFields isolatedCopy() && { return { WTF::move(foundation).isolatedCopy(), component, priority, WTF::move(address).isolatedCopy(), protocol, port, type, tcpType, WTF::move(relatedAddress).isolatedCopy(), relatedPort, WTF::move(usernameFragment).isolatedCopy() }; }
+    RTCIceCandidateFields isolatedCopy() && { return { WTF::move(foundation).isolatedCopy(), component, priority, WTF::move(address).isolatedCopy(), protocol, port, type, tcpType, WTF::move(relatedAddress).isolatedCopy(), relatedPort, WTF::move(usernameFragment).isolatedCopy(), relayProtocol, WTF::move(url).isolatedCopy() }; }
 };
 
 std::optional<RTCIceCandidateFields> parseIceCandidateSDP(const String&);


### PR DESCRIPTION
#### 583c9446ce8bbbe70c826172b4040de44fe67e44
<pre>
Add relayProtocol and url support to RTCIceCandidate
<a href="https://bugs.webkit.org/show_bug.cgi?id=307709">https://bugs.webkit.org/show_bug.cgi?id=307709</a>
<a href="https://rdar.apple.com/170265483">rdar://170265483</a>

Reviewed by NOBODY (OOPS!).

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Add readonly relayProtocol and url attributes to RTCIceCandidate interface
and RTCIceCandidateInit dictionary. These fields are preserved when passed
to the constructor but excluded from toJSON() serialization as they contain
local information not signaled over the network.

* Source/WebCore/Modules/mediastream/RTCIceCandidate.cpp:
* Source/WebCore/Modules/mediastream/RTCIceCandidate.h:
* Source/WebCore/Modules/mediastream/RTCIceCandidate.idl:
* Source/WebCore/Modules/mediastream/RTCIceCandidateFields.h:
(WebCore::RTCIceCandidateFields::isolatedCopy):

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCIceCandidate-constructor-expected.txt:

&gt; Rebaseline:
* LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/583c9446ce8bbbe70c826172b4040de44fe67e44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144621 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17300 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153292 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98256 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30abf200-cbfd-4650-99e8-8dff5e4ea02f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146496 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111226 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79763 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147584 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13597 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92118 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46af04a7-35cb-4521-9031-56d423e3aa70) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12972 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10723 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/737 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122485 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155604 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7634 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119227 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17190 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119561 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15376 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72694 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16774 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6167 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16510 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80553 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16719 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16574 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->