### PR TITLE
AX: add Mac client accessibility test infrastructure for bounding boxes

### DIFF
--- a/LayoutTests/accessibility/mac/client/div-bounds-expected.txt
+++ b/LayoutTests/accessibility/mac/client/div-bounds-expected.txt
@@ -1,0 +1,17 @@
+Test x, y, width, height via the client accessibility APIs.
+
+webArea role: AXRole: AXWebArea
+webArea childrenCount: 2
+div1 role: AXRole: AXGroup
+div2 role: AXRole: AXGroup
+div1 width: 200
+div1 height: 80
+div2 width: 120
+div2 height: 60
+x difference (div2.x - div1.x): 50
+y difference (div2.y - div1.y): 130
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/client/div-bounds.html
+++ b/LayoutTests/accessibility/mac/client/div-bounds.html
@@ -1,0 +1,75 @@
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<style>
+body { margin: 0; padding: 0; }
+.box {
+    position: absolute;
+    border: none;
+    background: #ccc;
+}
+#div1 {
+    left: 100px;
+    top: 50px;
+    width: 200px;
+    height: 80px;
+}
+#div2 {
+    left: 150px;
+    top: 180px;
+    width: 120px;
+    height: 60px;
+}
+</style>
+</head>
+<body>
+
+<div id="div1" class="box" role="group">First div</div>
+<div id="div2" class="box" role="group">Second div</div>
+
+<script>
+var output = "Test x, y, width, height via the client accessibility APIs.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setForceInitialFrameCaching(true);
+    accessibilityController.setClientAccessibilityMode(true);
+
+    setTimeout(async function() {
+        await waitForElements([
+            (element) => element.role.includes("AXGroup"),
+        ]);
+
+        var webArea = accessibilityController.rootElement.childAtIndex(0);
+        output += `webArea role: ${webArea.role}\n`;
+        output += `webArea childrenCount: ${webArea.childrenCount}\n`;
+
+        var div1 = webArea.childAtIndex(0);
+        output += `div1 role: ${div1.role}\n`;
+
+        var div2 = webArea.childAtIndex(1);
+        output += `div2 role: ${div2.role}\n`;
+
+        // Check exact sizes
+        output += `div1 width: ${div1.width}\n`;
+        output += `div1 height: ${div1.height}\n`;
+        output += `div2 width: ${div2.width}\n`;
+        output += `div2 height: ${div2.height}\n`;
+
+        // Check relative positions (div2.x - div1.x should be 50, div2.y - div1.y should be 130)
+        // Absolute positions depend on window location so only test relative differences
+        var xDiff = div2.x - div1.x;
+        var yDiff = div2.y - div1.y;
+        output += `x difference (div2.x - div1.x): ${xDiff}\n`;
+        output += `y difference (div2.y - div1.y): ${yDiff}\n`;
+
+        debug(output);
+        document.getElementById("div1").hidden = true;
+        document.getElementById("div2").hidden = true;
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/client/hierarchical-level-expected.txt
+++ b/LayoutTests/accessibility/mac/client/hierarchical-level-expected.txt
@@ -1,0 +1,10 @@
+Test hierarchicalLevel via the client accessibility APIs.
+
+Tree role: AXRole: AXOutline
+Item 1 hierarchicalLevel: 0
+Item 2 hierarchicalLevel: 1
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/client/hierarchical-level.html
+++ b/LayoutTests/accessibility/mac/client/hierarchical-level.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<ul id="tree" role="tree" tabindex="0">
+    <li id="item1" role="treeitem" aria-level="1">Level 1 item</li>
+    <li id="item2" role="treeitem" aria-level="2">Level 2 item</li>
+</ul>
+
+<script>
+var output = "Test hierarchicalLevel via the client accessibility APIs.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setClientAccessibilityMode(true);
+
+    setTimeout(async function() {
+        await waitForElements([
+            (element) => element.role.includes("AXOutline"),
+        ]);
+
+        var tree = accessibilityController.rootElement.childAtIndex(0).childAtIndex(0);
+        output += `Tree role: ${tree.role}\n`;
+
+        var item1 = tree.childAtIndex(0);
+        output += `Item 1 hierarchicalLevel: ${item1.hierarchicalLevel}\n`;
+
+        var item2 = tree.childAtIndex(1);
+        output += `Item 2 hierarchicalLevel: ${item2.hierarchicalLevel}\n`;
+
+        debug(output);
+        document.getElementById("tree").hidden = true;
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/mac/client/range-values-expected.txt
+++ b/LayoutTests/accessibility/mac/client/range-values-expected.txt
@@ -1,0 +1,10 @@
+Test minValue and maxValue via the client accessibility APIs.
+
+Slider role: AXRole: AXSlider
+Slider minValue: 10
+Slider maxValue: 100
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/client/range-values.html
+++ b/LayoutTests/accessibility/mac/client/range-values.html
@@ -1,0 +1,35 @@
+<html>
+<head>
+<script src="../../../resources/accessibility-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input type="range" id="slider" min="10" max="100" value="50">
+
+<script>
+var output = "Test minValue and maxValue via the client accessibility APIs.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+    accessibilityController.setClientAccessibilityMode(true);
+
+    setTimeout(async function() {
+        await waitForElements([
+            (element) => element.role.includes("AXSlider"),
+        ]);
+
+        var webArea = accessibilityController.rootElement.childAtIndex(0);
+        var slider = webArea.childAtIndex(0);
+        output += `Slider role: ${slider.role}\n`;
+        output += `Slider minValue: ${slider.minValue}\n`;
+        output += `Slider maxValue: ${slider.maxValue}\n`;
+
+        debug(output);
+        document.getElementById("slider").hidden = true;
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/testing/js/WebCoreTestSupport.cpp
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.cpp
@@ -168,6 +168,13 @@ void setLinkedOnOrAfterEverythingForTesting()
 #endif
 }
 
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+void setAccessibilityIsolatedTreeEnabled(bool isEnabled)
+{
+    DeprecatedGlobalSettings::setIsAccessibilityIsolatedTreeEnabled(isEnabled);
+}
+#endif
+
 void installMockGamepadProvider()
 {
 #if ENABLE(GAMEPAD)

--- a/Source/WebCore/testing/js/WebCoreTestSupport.h
+++ b/Source/WebCore/testing/js/WebCoreTestSupport.h
@@ -63,6 +63,10 @@ TEST_SUPPORT_EXPORT void setAllowsAnySSLCertificate(bool);
 TEST_SUPPORT_EXPORT bool allowsAnySSLCertificate();
 TEST_SUPPORT_EXPORT void setLinkedOnOrAfterEverythingForTesting();
 
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+TEST_SUPPORT_EXPORT void setAccessibilityIsolatedTreeEnabled(bool);
+#endif
+
 TEST_SUPPORT_EXPORT void installMockGamepadProvider();
 TEST_SUPPORT_EXPORT void connectMockGamepad(unsigned index);
 TEST_SUPPORT_EXPORT void disconnectMockGamepad(unsigned index);

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm
@@ -35,6 +35,7 @@
 #import "InjectedBundle.h"
 #import "InjectedBundlePage.h"
 #import "JSBasics.h"
+#import "WebCoreTestSupport.h"
 #import <JavaScriptCore/JSStringRefCF.h>
 #import <WebKit/WKBundle.h>
 #import <WebKit/WKBundleFramePrivate.h>
@@ -154,6 +155,7 @@ JSRetainPtr<JSStringRef> AccessibilityController::platformName()
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
 void AccessibilityController::updateIsolatedTreeMode()
 {
+    WebCoreTestSupport::setAccessibilityIsolatedTreeEnabled(m_accessibilityIsolatedTreeMode);
     _AXSSetIsolatedTreeMode(m_accessibilityIsolatedTreeMode ? AXSIsolatedTreeModeSecondaryThread : AXSIsolatedTreeModeOff);
 }
 #endif

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h
@@ -53,9 +53,17 @@ public:
     JSRetainPtr<JSStringRef> stringValue() override;
     unsigned childrenCount() override;
     RefPtr<AccessibilityUIElement> childAtIndex(unsigned) override;
+    int hierarchicalLevel() const override;
+    double minValue() override;
+    double maxValue() override;
+    double x() override;
+    double y() override;
+    double width() override;
+    double height() override;
 
     // Helpers.
     JSRetainPtr<JSStringRef> getStringAttribute(const char* attributeName) const;
+    double getNumberAttribute(const char* attributeName) const;
     Vector<RefPtr<AccessibilityUIElement>> getChildren() const;
     Vector<RefPtr<AccessibilityUIElement>> getChildrenInRange(unsigned location, unsigned length) const;
 

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -3420,6 +3420,12 @@ void TestController::didReceiveSynchronousMessageFromInjectedBundle(WKStringRef 
 
     if (WKStringIsEqualToUTF8CString(messageName, "AXCopyAttributeValueAsBoolean"))
         return completionHandler(handleAXCopyAttributeValueAsBoolean(dictionaryValue(messageBody)).get());
+
+    if (WKStringIsEqualToUTF8CString(messageName, "AXCopyAttributeValueAsPoint"))
+        return completionHandler(handleAXCopyAttributeValueAsPoint(dictionaryValue(messageBody)).get());
+
+    if (WKStringIsEqualToUTF8CString(messageName, "AXCopyAttributeValueAsSize"))
+        return completionHandler(handleAXCopyAttributeValueAsSize(dictionaryValue(messageBody)).get());
 #endif
 
     completionHandler(protectedCurrentInvocation()->didReceiveSynchronousMessageFromInjectedBundle(messageName, messageBody).get());
@@ -5566,6 +5572,44 @@ WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsBoolean(WKDic
     bool boolValue = CFBooleanGetValue(static_cast<CFBooleanRef>(value.get()));
 
     return adoptWK(WKBooleanCreate(boolValue));
+}
+
+WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsPoint(WKDictionaryRef messageBody)
+{
+    RetainPtr value = axCopyAttributeValue(messageBody);
+    if (!value)
+        return nullptr;
+
+    if (CFGetTypeID(value.get()) != AXValueGetTypeID())
+        return nullptr;
+
+    CGPoint point;
+    if (!AXValueGetValue(static_cast<AXValueRef>(value.get()), static_cast<AXValueType>(kAXValueCGPointType), &point))
+        return nullptr;
+
+    WKRetainPtr dictionary = adoptWK(WKMutableDictionaryCreate());
+    setValue(dictionary, "x", point.x);
+    setValue(dictionary, "y", point.y);
+    return dictionary;
+}
+
+WKRetainPtr<WKTypeRef> TestController::handleAXCopyAttributeValueAsSize(WKDictionaryRef messageBody)
+{
+    RetainPtr value = axCopyAttributeValue(messageBody);
+    if (!value)
+        return nullptr;
+
+    if (CFGetTypeID(value.get()) != AXValueGetTypeID())
+        return nullptr;
+
+    CGSize size;
+    if (!AXValueGetValue(static_cast<AXValueRef>(value.get()), static_cast<AXValueType>(kAXValueCGSizeType), &size))
+        return nullptr;
+
+    WKRetainPtr dictionary = adoptWK(WKMutableDictionaryCreate());
+    setValue(dictionary, "width", size.width);
+    setValue(dictionary, "height", size.height);
+    return dictionary;
 }
 
 #endif // PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -584,6 +584,8 @@ private:
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsElementArray(WKDictionaryRef);
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsNumber(WKDictionaryRef);
     WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsBoolean(WKDictionaryRef);
+    WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsPoint(WKDictionaryRef);
+    WKRetainPtr<WKTypeRef> handleAXCopyAttributeValueAsSize(WKDictionaryRef);
 #endif
 
     // WKContextClient


### PR DESCRIPTION
#### d529b66b00f9ca2ee024a03015afda69e469ab59
<pre>
AX: add Mac client accessibility test infrastructure for bounding boxes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307651">https://bugs.webkit.org/show_bug.cgi?id=307651</a>
<a href="https://rdar.apple.com/170208415">rdar://170208415</a>

Reviewed by Tyler Wilcock.

Fill in more AccessibilityUIElementClientMac code, including
some numeric attributes and the fields to get an element&apos;s
bounding box, and add some test coverage for those.
A small fix was needed to ensure isolated tree mode was
fully enabled for the bounding box calculations to work.

Tests: accessibility/mac/client/div-bounds.html
       accessibility/mac/client/hierarchical-level.html
       accessibility/mac/client/range-values.html

* LayoutTests/accessibility/mac/client/div-bounds-expected.txt: Added.
* LayoutTests/accessibility/mac/client/div-bounds.html: Added.
* LayoutTests/accessibility/mac/client/hierarchical-level-expected.txt: Added.
* LayoutTests/accessibility/mac/client/hierarchical-level.html: Added.
* LayoutTests/accessibility/mac/client/range-values-expected.txt: Added.
* LayoutTests/accessibility/mac/client/range-values.html: Added.
* Source/WebCore/testing/js/WebCoreTestSupport.cpp:
(WebCoreTestSupport::setAccessibilityIsolatedTreeEnabled):
* Source/WebCore/testing/js/WebCoreTestSupport.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityControllerMac.mm:
(WTR::AccessibilityController::updateIsolatedTreeMode):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementClientMac.mm:
(WTR::axCopyAttributeValueAsNumber):
(WTR::axCopyAttributeValueAsPoint):
(WTR::axCopyAttributeValueAsSize):
(WTR::AccessibilityUIElementClientMac::getNumberAttribute const):
(WTR::AccessibilityUIElementClientMac::hierarchicalLevel const):
(WTR::AccessibilityUIElementClientMac::minValue):
(WTR::AccessibilityUIElementClientMac::maxValue):
(WTR::AccessibilityUIElementClientMac::x):
(WTR::AccessibilityUIElementClientMac::y):
(WTR::AccessibilityUIElementClientMac::width):
(WTR::AccessibilityUIElementClientMac::height):
* Tools/WebKitTestRunner/TestController.cpp:
* Tools/WebKitTestRunner/TestController.h:

Canonical link: <a href="https://commits.webkit.org/307432@main">https://commits.webkit.org/307432@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7aa5c6da21ca002a2d125540d163b02d93203f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144331 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17010 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153001 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17492 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110984 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97570 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147294 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129648 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91903 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12799 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10555 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/447 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122305 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155313 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118993 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16900 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119354 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30605 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15209 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127534 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72283 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16484 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5950 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16219 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80263 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16429 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16284 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->