### PR TITLE
[GFC][Integration] min and max content height of the grid is size of rows and gutters

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.cpp
@@ -166,7 +166,7 @@ static Style::GridTemplateList gridTemplateListWithPercentagesConvertedToAuto(co
     return Style::GridTemplateList { WTF::move(transformedList) };
 }
 
-void GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
+UsedTrackSizes GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
 {
     auto unplacedGridItems = constructUnplacedGridItems();
     CheckedRef gridStyle = root().style();
@@ -217,6 +217,7 @@ void GridFormattingContext::layout(GridLayoutConstraints layoutConstraints)
     };
     mapGridItemLocationsToGrid();
     setGridItemGeometries(gridItemRects);
+    return usedTrackSizes;
 }
 
 PlacedGridItems GridFormattingContext::constructPlacedGridItems(const GridAreas& gridAreas) const

--- a/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridFormattingContext.h
@@ -42,6 +42,7 @@ class UnplacedGridItem;
 
 struct GridAreaLines;
 struct UnplacedGridItems;
+struct UsedTrackSizes;
 
 enum class PackingStrategy : bool {
     Sparse,
@@ -127,7 +128,7 @@ public:
 
     GridFormattingContext(const ElementBox& gridBox, LayoutState&);
 
-    void layout(GridLayoutConstraints);
+    UsedTrackSizes layout(GridLayoutConstraints);
 
     struct IntrinsicWidths {
         LayoutUnit minimum;

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -43,6 +43,12 @@ LayoutUnit computeGapValue(const Style::GapGutter& gap)
     return { };
 }
 
+LayoutUnit totalGuttersSize(size_t tracksCount, LayoutUnit gapsSize)
+{
+    ASSERT(tracksCount);
+    return gapsSize * (tracksCount - 1);
+}
+
 static bool spansAutoMinTrackSizingFunction(WTF::Range<size_t> spannedTrackIndexes, const TrackSizingFunctionsList& trackSizingFunctions)
 {
     for (auto trackIndex : std::views::iota(spannedTrackIndexes.begin(), spannedTrackIndexes.end())) {

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.h
@@ -37,6 +37,7 @@ struct GridItemSizingFunctions;
 namespace GridLayoutUtils {
 
 LayoutUnit computeGapValue(const Style::GapGutter&);
+LayoutUnit totalGuttersSize(size_t tracksCount, LayoutUnit gapsSize);
 
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizingFunctionsList&, LayoutUnit columnsSize, const IntegrationUtils&);
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem&, LayoutUnit borderAndPadding, const TrackSizingFunctionsList&, LayoutUnit rowsSize, const IntegrationUtils&);

--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -321,12 +321,6 @@ static void resolveIntrinsicTrackSizes(UnsizedTracks& unsizedTracks, const Place
     }
 }
 
-static LayoutUnit totalGuttersSize(size_t tracksCount, LayoutUnit gapsSize)
-{
-    ASSERT(tracksCount);
-    return gapsSize * (tracksCount - 1);
-}
-
 // https://drafts.csswg.org/css-grid-1/#algo-terms
 // Equal to the available grid space minus the sum of the base sizes of all the grid tracks (including gutters),
 // floored at zero. If available grid space is indefinite, the free space is indefinite as well.
@@ -338,7 +332,7 @@ static std::optional<LayoutUnit> computeFreeSpace(std::optional<LayoutUnit> avai
     auto sumOfBaseSizes = std::accumulate(unsizedTracks.begin(), unsizedTracks.end(), 0_lu, [](LayoutUnit sum, const UnsizedTrack& unsizedTrack) {
         return unsizedTrack.baseSize + sum;
     });
-    auto guttersSize = totalGuttersSize(unsizedTracks.size(), gapSize);
+    auto guttersSize = GridLayoutUtils::totalGuttersSize(unsizedTracks.size(), gapSize);
 
     return std::max({ }, *availableGridSpace - (sumOfBaseSizes + guttersSize));
 }
@@ -557,7 +551,7 @@ LayoutUnit TrackSizingAlgorithm::findSizeOfFr(const UnsizedTracks& tracks, const
 
     // https://www.w3.org/TR/css-grid-1/#algo-terms
     // free space = available grid space - sum of base sizes - gutters.
-    LayoutUnit totalGutters = totalGuttersSize(tracks.size(), gapSize);
+    LayoutUnit totalGutters = GridLayoutUtils::totalGuttersSize(tracks.size(), gapSize);
 
     InflexibleTrackState state;
     FrSizeComponents components;

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridLayout.h
@@ -38,6 +38,8 @@ class RenderGrid;
 
 namespace Layout {
 class ElementBox;
+struct GridLayoutConstraints;
+struct UsedTrackSizes;
 }
 
 namespace LayoutIntegration {
@@ -56,7 +58,7 @@ public:
 
 private:
     void updateGridItemRenderers();
-    void updateFormattingContextRootRenderer();
+    void updateFormattingContextRootRenderer(const Layout::GridLayoutConstraints&, const Layout::UsedTrackSizes&);
 
     const Layout::ElementBox& gridBox() const { return *m_gridBox; }
     Layout::ElementBox& gridBox() { return *m_gridBox; }


### PR DESCRIPTION
#### 90bcb7bdb7bd5f7c45f069e0e9b612a0dac58f39
<pre>
[GFC][Integration] min and max content height of the grid is size of rows and gutters
<a href="https://bugs.webkit.org/show_bug.cgi?id=307713">https://bugs.webkit.org/show_bug.cgi?id=307713</a>
<a href="https://rdar.apple.com/170267496">rdar://170267496</a>

Reviewed by Alan Baradlay.

The spec defines the min/max content height of the grid as the sum of
the rows and gutters.
<a href="https://drafts.csswg.org/css-grid-1/#intrinsic-sizes">https://drafts.csswg.org/css-grid-1/#intrinsic-sizes</a>

The track sizes are outputted as part of GridLayout, so we need to make
sure that this is reflected on RenderGrid. This is because RenderGrid
treats height: auto always as max-content barring any overriding sizes
or something else computed by RenderGrid::availableLogicalHeightForContentBox/RenderGrid::hasDefiniteLogicalHeight.

So if we see a MinContent or MaxContent constraint in the block axis,
which was determined by constraintsForGridContent, we should sum the
rows and gutters to make sure RenderGrid has its height set properly.

* Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp:
(WebCore::Layout::GridLayoutUtils::totalGuttersSize):
Make this available to use outside of TrackSizingAlgorithm.

Canonical link: <a href="https://commits.webkit.org/307492@main">https://commits.webkit.org/307492@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/724553b69e2daf4878393a66b784aabadb040895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8576 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97578 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acff5ed9-f1cf-4d75-99d7-925757970c2e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17500 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16912 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110990 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79699 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3271bc10-cde2-4b81-b461-1ff9ad2e7f3b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147302 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129651 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91910 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c3a3e0e-f5c1-4921-87be-82541342f4d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12812 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10557 "Found 2 new API test failures: TestWebKitAPI.PermissionsAPI.GeolocationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad, TestWebKitAPI.LockdownMode.AllowedFontLoadingAPI (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/455 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122317 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155321 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16870 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7380 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/118999 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16908 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14142 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119360 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30641 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15208 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127537 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72291 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16492 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5953 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16227 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80271 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16437 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16292 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->