### PR TITLE
[MacOS] 2x tests in TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecords are flaky failures

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm
@@ -48,7 +48,12 @@ static auto *dataRecordTestTwoManifest = @{
 
 static auto *allDataTypesSet = [NSSet setWithArray:@[ WKWebExtensionDataTypeLocal, WKWebExtensionDataTypeSession, WKWebExtensionDataTypeSynchronized ]];
 
+// FIXME rdar://167044676 for macOS
+#if PLATFORM(MAC)
+TEST(WKWebExtensionDataRecord, DISABLED_GetDataRecords)
+#else
 TEST(WKWebExtensionDataRecord, GetDataRecords)
+#endif
 {
     auto *backgroundScript = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",
@@ -94,12 +99,8 @@ TEST(WKWebExtensionDataRecord, GetDataRecords)
     TestWebKitAPI::Util::run(&fetchComplete);
 }
 
-// FIXME rdar://147858640 and rdar://167044676 for macOS Debug
-#if !defined(NDEBUG)
+// FIXME rdar://147858640 for iOS Debug and rdar://167044676 for macOS
 TEST(WKWebExtensionDataRecord, DISABLED_GetDataRecordsForMultipleContexts)
-#else
-TEST(WKWebExtensionDataRecord, GetDataRecordsForMultipleContexts)
-#endif
 {
     auto *backgroundScriptOne = Util::constructScript(@[
         @"const data = { 'string': 'string', 'number': 1, 'boolean': true, 'dictionary': {'key': 'value'}, 'array': [1, true, 'string'] }",


### PR DESCRIPTION
#### 37b08246e6f2bfe5015ce12a21a05ea749ef371a
<pre>
[MacOS] 2x tests in TestWebKitAPI.WKWebExtensionDataRecord.GetDataRecords are flaky failures
<a href="https://rdar.apple.com/167044676">rdar://167044676</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=304609">https://bugs.webkit.org/show_bug.cgi?id=304609</a>

Unreviewed test gardening

Skipping 2 API tests on macOS due to flakiness in both Debug and Release

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionDataRecord.mm:
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, GetDataRecords)):
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, DISABLED_GetDataRecordsForMultipleContexts)):
(TestWebKitAPI::TEST(WKWebExtensionDataRecord, GetDataRecordsForMultipleContexts)): Deleted.

Canonical link: <a href="https://commits.webkit.org/307442@main">https://commits.webkit.org/307442@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bcd4c988d2b8c7a0404c848d6d57d83ae36e6540

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8584 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153016 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16919 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/110995 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97585 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e7610013-7de8-4595-b44b-b8d7bf7e93bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147309 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13388 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91915 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1deac44-27c1-46d8-b811-3954e7c2646d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12805 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10561 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/462 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122311 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6338 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155328 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16877 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7393 "Passed tests") | [⏳ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/GTK-WK2-Tests-EWS "Waiting to run tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16915 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14147 "Passed tests") | [⏳ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/API-Tests-GTK-EWS "Waiting to run tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15215 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127550 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72298 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22275 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16499 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5965 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16235 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16444 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16299 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->