### PR TITLE
[GFC][Integration] Allow auto as track sizing function for rows

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -391,6 +391,9 @@ static Vector<LayoutUnit> rowSizesForFirstIterationColumnSizing(const TrackSizin
             [](const CSS::Keyword::MaxContent&) {
                 return LayoutUnit::max();
             },
+            [](const CSS::Keyword::Auto&) -> LayoutUnit {
+                return LayoutUnit::max();
+            },
             [](const auto&) -> LayoutUnit {
                 ASSERT_NOT_IMPLEMENTED_YET();
                 return { };

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -324,24 +324,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
                 // MaxTrackBreadth to the same value we only need to check one.
                 if (!trackSize.isBreadth())
                     return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
-
-                auto& minBreadth = trackSize.minTrackBreadth();
-
-                if (minBreadth.isLength()) {
-                    auto& gridTrackBreadthLength = minBreadth.length();
-                    // Length types like auto, min-content, etc. not yet supported
-                    if (!gridTrackBreadthLength.isFixed() && !gridTrackBreadthLength.isMinContent() && !gridTrackBreadthLength.isMaxContent())
-                        return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
-                    return std::nullopt;
-                }
-
-                if (minBreadth.isFlex()) {
-                    // Flex tracks (fr units) are now supported
-                    return std::nullopt;
-                }
-
-                ASSERT_NOT_REACHED();
-                return GridAvoidanceReason::GridHasUnsupportedGridTemplateRows;
+                return { };
             },
             [&](const Vector<String>& names) -> std::optional<GridAvoidanceReason> {
                 if (!names.isEmpty())


### PR DESCRIPTION
#### 388c734de77de805cc8029020ced570d971acfd7
<pre>
[GFC][Integration] Allow auto as track sizing function for rows
<a href="https://bugs.webkit.org/show_bug.cgi?id=307725">https://bugs.webkit.org/show_bug.cgi?id=307725</a>
<a href="https://rdar.apple.com/170275313">rdar://170275313</a>

Reviewed by Alan Baradlay.

We should now have an implementation inside of GFC to be able to size
rows with an auto track sizing function (assuming no other
restrictions to enter GFC like spanning items). We can now relax this
requirement and allow GFC to run this type of content, such as the
following:

&lt;div style=&quot;display: grid; width: 100px; height: 100px; grid-template-columns: 25px 25px 5px; grid-template-rows: auto; min-width: 0; min-height: 0; outline: 3px solid green;&quot;&gt;
  &lt;div style=&quot;outline: 1px solid red; grid-column: 1/2; grid-row: 1/2; min-width: 0; min-height: 0;&quot;&gt;x x x x&lt;/div&gt;
  &lt;div style=&quot;outline: 1px solid red; grid-column: 2/3; grid-row: 1/2; min-width: 0; min-height: 0;&quot;&gt;x x x x xx&lt;/div&gt;
&lt;/div&gt;

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::rowSizesForFirstIterationColumnSizing):
We need to return LayoutUnit::max() here since &quot;auto,&quot; is not a definite
max track sizing function. This comes from the following portion of the
spec:

&quot;If calculating the layout of a grid item in this step depends on the
available space in the block axis, assume the available space that it
would have if any row with a definite max track sizing function had
that size and all other rows were infinite.&quot;
<a href="https://drafts.csswg.org/css-grid-1/#algo-grid-sizing">https://drafts.csswg.org/css-grid-1/#algo-grid-sizing</a>

* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
(WebCore::LayoutIntegration::gridLayoutAvoidanceReason):
&quot;auto&quot; is the last bit of the &lt;track-breadth&gt; syntax
&lt;track-breadth&gt; = &lt;length-percentage [0,∞]&gt; | &lt;flex [0,∞]&gt; | min-content | max-content | auto
Since we know the track size is a track-breadth at this point and since
we support all other values, we can remove the rest of the logic and
just return std::nullopt.

Canonical link: <a href="https://commits.webkit.org/307498@main">https://commits.webkit.org/307498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fa705395a711e627bf8aec9c5bc2ee470ead462b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153040 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97609 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9114a7d-7afe-472c-b6c5-3acfde66f08e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17531 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111013 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79710 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9319028f-9696-49de-8ba6-c04d83e813ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13409 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91932 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f923187a-0336-45fe-88d4-4b185e5eb443) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12823 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10577 "Found 1 new API test failure: TestWebKitAPI.EditorStateTests.TypingAttributesBold (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/486 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122328 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6349 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155352 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16901 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119021 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16939 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119384 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30646 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15221 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127561 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72322 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16523 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5976 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16259 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16468 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->