### PR TITLE
[GFC] Implement Steps 3 and 4 of grid auto-placement for single-cell items.

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1875,6 +1875,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     layout/formattingContexts/grid/GridItemRect.h
     layout/formattingContexts/grid/GridLayoutState.h
     layout/formattingContexts/grid/GridTypeAliases.h
+    layout/formattingContexts/grid/ImplicitGrid.h
 
     layout/formattingContexts/inline/AbstractLineBuilder.h
     layout/formattingContexts/inline/AvailableLineWidthOverride.h

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -65,7 +65,8 @@ private:
     auto placeGridItems(UnplacedGridItems&, const Vector<Style::GridTrackSize>& gridTemplateColumnsTrackSizes,
         const Vector<Style::GridTrackSize>& gridTemplateRowsTrackSizes, GridAutoFlowOptions);
 
-    GridDimensions calculateGridDimensions(const UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
+    GridDimensions calculateInitialImplicitGridDimensions(const UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
+    ImplicitGrid constructInitialImplicitGrid(UnplacedGridItems&, size_t explicitColumnsCount, size_t explicitRowsCount);
 
     static TrackSizingFunctions convertGridTrackSizeToTrackSizingFunctions(const Style::GridTrackSize&);
     static TrackSizingFunctionsList generateImplicitTrackSizingFunctions(size_t explicitTracksCount, size_t totalTracksCount, const Style::GridTrackSizes& gridAutoTrackSizes);

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp
@@ -115,15 +115,8 @@ void ImplicitGrid::insertDefiniteRowItem(const UnplacedGridItem& unplacedGridIte
 
         // Retry finding position in the grown grid
         columnPosition = findColumnPositionForDefiniteRowItem(normalizedRowStart, normalizedRowEnd, columnSpan, autoFlowOptions);
-#ifndef NDEBUG
-        ASSERT(columnPosition); // Must succeed after growing
-
-        // Verify the found position doesn't overlap with existing items
-        ASSERT(isCellRangeEmpty(*columnPosition, *columnPosition + columnSpan, normalizedRowStart, normalizedRowEnd),
-            "After grid growth, placed item overlaps with occupied cells.");
-
-        verifyHasEmptyLastColumn();
-#endif
+        ASSERT(columnPosition);
+        ASSERT(isCellRangeEmpty(*columnPosition, *columnPosition + columnSpan, normalizedRowStart, normalizedRowEnd));
     }
 
     insertItemInArea(unplacedGridItem, *columnPosition, *columnPosition + columnSpan, normalizedRowStart, normalizedRowEnd);
@@ -131,6 +124,56 @@ void ImplicitGrid::insertDefiniteRowItem(const UnplacedGridItem& unplacedGridIte
     if (autoFlowOptions.strategy != PackingStrategy::Dense) {
         for (size_t row = normalizedRowStart; row < normalizedRowEnd; ++row)
             m_rowCursors.set(row, *columnPosition + columnSpan);
+    }
+}
+
+// https://drafts.csswg.org/css-grid-1/#auto-placement-algo
+// Step 3: Determine the columns in the implicit grid.
+void ImplicitGrid::determineImplicitGridColumns(const Vector<UnplacedGridItem>& autoPositionedItems)
+{
+    size_t requiredColumns = columnsCount();
+
+    // Part 1: "Among all the items with a definite column position, add columns to the end
+    // of the implicit grid as necessary to accommodate those items."
+    for (const auto& item : autoPositionedItems) {
+        if (item.hasDefiniteColumnPosition()) {
+            auto [columnStart, columnEnd] = item.normalizedColumnStartEnd();
+            requiredColumns = std::max(requiredColumns, columnEnd);
+        }
+    }
+
+    // Part 2: "If the largest column span among all the items without a definite column position
+    // is larger than the width of the implicit grid, add columns to accommodate that column span."
+    size_t maxColumnSpan = 0;
+    for (const auto& item : autoPositionedItems) {
+        if (!item.hasDefiniteColumnPosition())
+            maxColumnSpan = std::max(maxColumnSpan, item.columnSpanSize());
+    }
+    requiredColumns = std::max(requiredColumns, maxColumnSpan);
+
+    // Grow grid once to accommodate both requirements
+    if (requiredColumns > columnsCount())
+        growColumnsToFit(requiredColumns);
+}
+
+// https://drafts.csswg.org/css-grid-1/#auto-placement-algo
+// Step 4 of CSS Grid auto-placement algorithm: Position the remaining grid items
+void ImplicitGrid::insertAutoPositionedItems(const Vector<UnplacedGridItem>& autoPositionedItems, GridAutoFlowOptions autoFlowOptions)
+{
+    if (autoFlowOptions.direction != GridAutoFlowDirection::Row) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return;
+    }
+
+    // Process each auto-positioned item with the appropriate search strategy
+    for (const auto& item : autoPositionedItems) {
+        // Multi-span items should be blocked by coverage check in LayoutIntegrationGridCoverage.cpp
+        ASSERT(item.rowSpanSize() == 1 && item.columnSpanSize() == 1);
+
+        if (item.hasDefiniteColumnPosition())
+            placeAutoPositionedItemWithDefiniteColumn(item, autoFlowOptions);
+        else
+            placeAutoPositionedItemWithAutoColumnAndRow(item, autoFlowOptions);
     }
 }
 
@@ -204,13 +247,105 @@ void ImplicitGrid::insertItemInArea(const UnplacedGridItem& unplacedGridItem, si
     }
 }
 
-#ifndef NDEBUG
-void ImplicitGrid::verifyHasEmptyLastColumn() const
+void ImplicitGrid::growColumnsToFit(size_t requiredCount)
 {
-    for (size_t row = 0; row < m_gridMatrix.size(); ++row)
-        ASSERT(m_gridMatrix[row].last().isEmpty());
+    if (requiredCount > columnsCount()) {
+        for (auto& row : m_gridMatrix)
+            row.resize(requiredCount);
+    }
 }
-#endif
+
+void ImplicitGrid::growRowsToFit(size_t requiredRowIndex)
+{
+    while (requiredRowIndex >= rowsCount())
+        m_gridMatrix.append(Vector<GridCell>(columnsCount()));
+}
+
+// FIXME: optimize cursor setting by setting to an empty slot instead of to the start for dense placement.
+void ImplicitGrid::placeAutoPositionedItemWithDefiniteColumn(const UnplacedGridItem& item, GridAutoFlowOptions autoFlowOptions)
+{
+    ASSERT(item.hasDefiniteColumnPosition());
+    ASSERT(!item.hasDefiniteRowPosition());
+
+    // Items with definite column position and auto row position
+    // Search vertically down the specified column.
+    auto [normalizedColumnStart, normalizedColumnEnd] = item.normalizedColumnStartEnd();
+    auto rowSpan = item.rowSpanSize();
+
+    if (autoFlowOptions.strategy == PackingStrategy::Dense) {
+        // Set the row position of the cursor to the start-most row line in the implicit grid.
+        m_autoPlacementCursorRow = 0;
+    } else {
+        // Sparse packing: Check if we would be going backwards (to earlier column)
+        // If so, advance the row count to avoid backtracking.
+        if (normalizedColumnStart < m_autoPlacementCursorColumn)
+            ++m_autoPlacementCursorRow;
+    }
+
+    // "Set the column position of the cursor to the grid item's column-start line."
+    m_autoPlacementCursorColumn = normalizedColumnStart;
+
+    // Increment the cursor's row position until a value is found where the grid item
+    // does not overlap any occupied grid cells (creating new rows in the implicit grid as necessary).
+    while (true) {
+        growRowsToFit(m_autoPlacementCursorRow + rowSpan - 1);
+
+        if (isCellRangeEmpty(normalizedColumnStart, normalizedColumnEnd, m_autoPlacementCursorRow, m_autoPlacementCursorRow + rowSpan)) {
+            // Set the item's row-start line to the cursor's row position.
+            insertItemInArea(item, normalizedColumnStart, normalizedColumnEnd,
+                m_autoPlacementCursorRow, m_autoPlacementCursorRow + rowSpan);
+            // Cursor remains at the placed position (row at placed row, column was already set).
+            break;
+        }
+
+        // Try next row down this column.
+        ++m_autoPlacementCursorRow;
+    }
+}
+
+// FIXME: optimize cursor setting by setting to an empty slot instead of to the start for dense placement.
+void ImplicitGrid::placeAutoPositionedItemWithAutoColumnAndRow(const UnplacedGridItem& item, GridAutoFlowOptions autoFlowOptions)
+{
+    ASSERT(!item.hasDefiniteColumnPosition() && !item.hasDefiniteRowPosition());
+
+    auto rowSpan = item.rowSpanSize();
+    auto columnSpan = item.columnSpanSize();
+
+    // Position items with automatic grid position in both axes.
+    // Search left-to-right, top-to-bottom.
+    if (autoFlowOptions.strategy == PackingStrategy::Dense) {
+        // Set the row position of the cursor to the start-most position in the implicit grid.
+        m_autoPlacementCursorRow = 0;
+        m_autoPlacementCursorColumn = 0;
+    }
+
+    // Increment the column position of the auto-placement cursor until either this item's grid area
+    // does not overlap any occupied grid cells, or the cursor's column position, plus the item's column span,
+    // overflow the number of columns in the implicit grid, then move the cursor to the start of the next row.
+    while (true) {
+        // Check if we need to move to a new row.
+        if (m_autoPlacementCursorColumn + columnSpan > columnsCount()) {
+            // Advance to next row, reset column to 0.
+            ++m_autoPlacementCursorRow;
+            m_autoPlacementCursorColumn = 0;
+            growRowsToFit(m_autoPlacementCursorRow + rowSpan - 1);
+        }
+
+        // Try to place at current cursor position.
+        if (isCellRangeEmpty(m_autoPlacementCursorColumn, m_autoPlacementCursorColumn + columnSpan, m_autoPlacementCursorRow, m_autoPlacementCursorRow + rowSpan)) {
+            insertItemInArea(item, m_autoPlacementCursorColumn, m_autoPlacementCursorColumn + columnSpan,
+                m_autoPlacementCursorRow, m_autoPlacementCursorRow + rowSpan);
+            // Sparse packing: Advance cursor past this item to maintain document order.
+            // Spec: "Set the auto-placement cursor to the end of the item's grid area."
+            // Dense packing: Cursor will be reset to (0, 0) before the next fully-auto item.
+            if (autoFlowOptions.strategy == PackingStrategy::Sparse)
+                m_autoPlacementCursorColumn += columnSpan;
+            return;
+        }
+        // Spec: "Increment the column position of the auto-placement cursor."
+        ++m_autoPlacementCursorColumn;
+    }
+}
 
 } // namespace Layout
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
+++ b/Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h
@@ -46,24 +46,34 @@ public:
 
     void insertUnplacedGridItem(const UnplacedGridItem&);
     void insertDefiniteRowItem(const UnplacedGridItem&, GridAutoFlowOptions);
+    void determineImplicitGridColumns(const Vector<UnplacedGridItem>&);
+    void insertAutoPositionedItems(const Vector<UnplacedGridItem>&, GridAutoFlowOptions);
 
     GridAreas gridAreas() const;
 
 private:
-    using RowCursors = HashMap<size_t, size_t, DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>;
+    using RowCursors = HashMap<size_t, size_t, WTF::DefaultHash<size_t>, WTF::UnsignedWithZeroKeyHashTraits<size_t>>;
     std::optional<size_t> findFirstAvailableColumnPosition(size_t rowStart, size_t rowEnd, size_t columnSpan, size_t startSearchColumn) const;
     std::optional<size_t> findColumnPositionForDefiniteRowItem(size_t normalizedRowStart, size_t normalizedRowEnd, size_t columnSpan, GridAutoFlowOptions) const;
     void growGridColumnsToFit(size_t columnSpan, size_t normalizedRowStart, size_t normalizedRowEnd);
     bool isCellRangeEmpty(size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd) const;
     void insertItemInArea(const UnplacedGridItem&, size_t columnStart, size_t columnEnd, size_t rowStart, size_t rowEnd);
 
-#ifndef NDEBUG
-    void verifyHasEmptyLastColumn() const;
-#endif
+    // Helper functions for auto-positioned items
+    void growColumnsToFit(size_t requiredCount);
+    void growRowsToFit(size_t requiredRowIndex);
+    void placeAutoPositionedItemWithDefiniteColumn(const UnplacedGridItem&, GridAutoFlowOptions);
+    void placeAutoPositionedItemWithAutoColumnAndRow(const UnplacedGridItem&, GridAutoFlowOptions);
 
     GridMatrix m_gridMatrix;
 
+    // Per-row cursors for sparse packing in Step 2 (definite row items only).
     RowCursors m_rowCursors;
+
+    // Global cursor for Step 4 (auto-positioned items with both axes automatic).
+    // Tracks the current insertion point as (row, column) to ensure monotonic placement.
+    size_t m_autoPlacementCursorRow { 0 };
+    size_t m_autoPlacementCursorColumn { 0 };
 };
 
 } // namespace Layout


### PR DESCRIPTION
#### cb6b33a71e6da84074becc264a56355ff82c56f0
<pre>
[GFC] Implement Steps 3 and 4 of grid auto-placement for single-cell items.
<a href="https://bugs.webkit.org/show_bug.cgi?id=306960">https://bugs.webkit.org/show_bug.cgi?id=306960</a>
&lt;<a href="https://rdar.apple.com/169629496">rdar://169629496</a>&gt;

Reviewed by Elika Etemad.

This PR implements Steps 3 and 4 of the CSS Grid auto-placement algorithm
for Grid Formatting Context. Step 3 sets the column count for the implicit grid
by checking the column positions and spans of the unplaced items.

Step 4 positions the remaining auto-positioned items using the auto placement
cursor tracking the current insertion point.

This PR supports both sparse and dense packing.

Definite column positioned items are positioned by searching down their
specificed column, while fully automatically positioned items are positioned
by searching left-&gt;right and top-&gt;down. We dynamically add implicit rows as
needed during placement.

* Source/WebCore/Headers.cmake:
* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::calculateInitialImplicitGridDimensions):
(WebCore::Layout::GridLayout::constructInitialImplicitGrid):
(WebCore::Layout::GridLayout::placeGridItems):
(WebCore::Layout::GridLayout::calculateGridDimensions): Deleted.
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.cpp:
(WebCore::Layout::ImplicitGrid::insertDefiniteRowItem):
(WebCore::Layout::ImplicitGrid::determineImplicitGridColumns):
(WebCore::Layout::ImplicitGrid::insertAutoPositionedItems):
(WebCore::Layout::ImplicitGrid::growColumnsToFit):
(WebCore::Layout::ImplicitGrid::growRowsToFit):
(WebCore::Layout::ImplicitGrid::placeAutoPositionedItemWithDefiniteColumn):
(WebCore::Layout::ImplicitGrid::placeAutoPositionedItemWithAutoColumnAndRow):
(WebCore::Layout::ImplicitGrid::verifyHasEmptyLastColumn const): Deleted.
* Source/WebCore/layout/formattingContexts/grid/ImplicitGrid.h:

Canonical link: <a href="https://commits.webkit.org/307590@main">https://commits.webkit.org/307590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4bb05159b9cb01f1dc6bb111f8982fd766a33040

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144775 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98410 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1480fb9a-31bb-4fe0-8d96-a3f4c73e7676) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146650 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17937 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111318 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79806 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb9d101c-55bc-4cd9-9caf-05755c562b3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147738 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92213 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40889753-c116-46df-ab39-711ceeddff31) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13059 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10811 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/891 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122573 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6680 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155758 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17306 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7760 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119321 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14453 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119649 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30699 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15461 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72848 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16928 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6275 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16664 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80707 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16873 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16728 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->