### PR TITLE
[JSC] Optimize `String#startsWith` and `String#endsWith` for single char on rope strings

### DIFF
--- a/JSTests/microbenchmarks/rope-endsWith-one-char.js
+++ b/JSTests/microbenchmarks/rope-endsWith-one-char.js
@@ -1,0 +1,23 @@
+// Benchmark: String.prototype.endsWith with single char on rope strings.
+// Simulates checking the trailing character of dynamically built strings
+// (e.g. trailing slash detection, line ending check) without resolving the rope.
+
+// A resolved base (~300 chars), just above the minLengthForRopeWalk threshold (296).
+let base = "https://example.com/api/v2/users?query=" + "a".repeat(260) + "&token=xyz";
+base.charCodeAt(0); // Force resolve
+
+function endsWithMatch(a, b) {
+    return (a + b).endsWith("/");
+}
+noInline(endsWithMatch);
+
+function endsWithMismatch(a, b) {
+    return (a + b).endsWith("?");
+}
+noInline(endsWithMismatch);
+
+let suffix = "/";
+for (let i = 0; i < 5e4; i++) {
+    endsWithMatch(base, suffix);
+    endsWithMismatch(base, suffix);
+}

--- a/JSTests/microbenchmarks/rope-startsWith-one-char.js
+++ b/JSTests/microbenchmarks/rope-startsWith-one-char.js
@@ -1,0 +1,23 @@
+// Benchmark: String.prototype.startsWith with single char on rope strings.
+// Simulates checking the leading character of dynamically built strings
+// (e.g. protocol detection, path classification) without resolving the rope.
+
+// A resolved base (~300 chars), just above the minLengthForRopeWalk threshold (296).
+let base = "https://example.com/api/v2/users?query=" + "a".repeat(260) + "&token=xyz";
+base.charCodeAt(0); // Force resolve
+
+function startsWithMatch(a, b) {
+    return (a + b).startsWith("h");
+}
+noInline(startsWithMatch);
+
+function startsWithMismatch(a, b) {
+    return (a + b).startsWith("/");
+}
+noInline(startsWithMismatch);
+
+let suffix = "&page=1";
+for (let i = 0; i < 5e4; i++) {
+    startsWithMatch(base, suffix);
+    startsWithMismatch(base, suffix);
+}

--- a/JSTests/stress/rope-string-startsWith-endsWith.js
+++ b/JSTests/stress/rope-string-startsWith-endsWith.js
@@ -1,0 +1,175 @@
+function assert(condition, message) {
+    if (!condition)
+        throw new Error(message || "Assertion failed");
+}
+
+// Build a rope string that exceeds the 0x128 (296) length threshold.
+function makeLongRope() {
+    let a = "a".repeat(200);
+    let b = "b".repeat(200);
+    return a + b;
+}
+
+// Basic: rope startsWith with single character.
+function testBasicRopeStartsWith() {
+    let rope = makeLongRope();
+    assert(rope.startsWith("a"), "startsWith 'a' should be true");
+    assert(!rope.startsWith("b"), "startsWith 'b' should be false");
+    assert(!rope.startsWith("z"), "startsWith 'z' should be false");
+}
+
+// Basic: rope endsWith with single character.
+function testBasicRopeEndsWith() {
+    let rope = makeLongRope();
+    assert(rope.endsWith("b"), "endsWith 'b' should be true");
+    assert(!rope.endsWith("a"), "endsWith 'a' should be false");
+    assert(!rope.endsWith("z"), "endsWith 'z' should be false");
+}
+
+// startsWith with position argument.
+function testRopeStartsWithPosition() {
+    let rope = makeLongRope();
+    assert(rope.startsWith("a", 0), "startsWith 'a' at 0");
+    assert(rope.startsWith("a", 100), "startsWith 'a' at 100");
+    assert(rope.startsWith("a", 199), "startsWith 'a' at 199");
+    assert(!rope.startsWith("a", 200), "startsWith 'a' at 200 should be false");
+    assert(rope.startsWith("b", 200), "startsWith 'b' at 200");
+    assert(rope.startsWith("b", 399), "startsWith 'b' at 399");
+    assert(!rope.startsWith("a", 400), "startsWith 'a' at length should be false");
+}
+
+// endsWith with endPosition argument.
+function testRopeEndsWithEndPosition() {
+    let rope = makeLongRope();
+    assert(rope.endsWith("b", 400), "endsWith 'b' at 400");
+    assert(rope.endsWith("b", 201), "endsWith 'b' at 201");
+    assert(rope.endsWith("a", 200), "endsWith 'a' at 200");
+    assert(rope.endsWith("a", 1), "endsWith 'a' at 1");
+    assert(!rope.endsWith("b", 200), "endsWith 'b' at 200 should be false");
+    assert(!rope.endsWith("a", 0), "endsWith 'a' at 0 should be false");
+}
+
+// Three-fiber rope.
+function testThreeFiberRope() {
+    let a = "a".repeat(100);
+    let b = "b".repeat(100);
+    let c = "c".repeat(100);
+    let rope = a + b + c; // 300 chars, JSC may create a 3-fiber rope
+    assert(rope.startsWith("a"), "3-fiber: startsWith 'a'");
+    assert(!rope.startsWith("b"), "3-fiber: startsWith 'b' should be false");
+    assert(rope.startsWith("b", 100), "3-fiber: startsWith 'b' at 100");
+    assert(rope.startsWith("c", 200), "3-fiber: startsWith 'c' at 200");
+    assert(rope.endsWith("c"), "3-fiber: endsWith 'c'");
+    assert(!rope.endsWith("b"), "3-fiber: endsWith 'b' should be false");
+    assert(rope.endsWith("b", 200), "3-fiber: endsWith 'b' at 200");
+    assert(rope.endsWith("a", 100), "3-fiber: endsWith 'a' at 100");
+}
+
+// Substring rope as root: slice() creates a substring rope.
+function testSubstringRopeRoot() {
+    let base = "a".repeat(200) + "b".repeat(200);
+    // Force resolve so slice() creates a substring rope over a resolved base.
+    base.charCodeAt(0);
+    let sub = base.slice(100, 350); // 250 chars, substring rope
+    assert(sub.startsWith("a"), "sub: startsWith 'a'");
+    assert(!sub.startsWith("b"), "sub: startsWith 'b' should be false");
+    assert(sub.startsWith("b", 100), "sub: startsWith 'b' at 100");
+    assert(sub.endsWith("b"), "sub: endsWith 'b'");
+    assert(!sub.endsWith("a"), "sub: endsWith 'a' should be false");
+    assert(sub.endsWith("a", 100), "sub: endsWith 'a' at 100");
+}
+
+// Substring rope as fiber: concat a substring with another string.
+function testSubstringRopeFiber() {
+    let base = "x".repeat(400);
+    base.charCodeAt(0);
+    let sub = base.slice(0, 200); // substring rope, 200 chars of 'x'
+    let rope = sub + "y".repeat(200); // fiber0=substring rope, fiber1=resolved
+    assert(rope.startsWith("x"), "fiber sub: startsWith 'x'");
+    assert(!rope.startsWith("y"), "fiber sub: startsWith 'y' should be false");
+    assert(rope.endsWith("y"), "fiber sub: endsWith 'y'");
+    assert(!rope.endsWith("x"), "fiber sub: endsWith 'x' should be false");
+    assert(rope.startsWith("y", 200), "fiber sub: startsWith 'y' at 200");
+    assert(rope.endsWith("x", 200), "fiber sub: endsWith 'x' at 200");
+}
+
+// Multi-character search strings should still work (not affected by optimization).
+function testMultiCharSearch() {
+    let rope = makeLongRope();
+    assert(rope.startsWith("aaa"), "multi: startsWith 'aaa'");
+    assert(!rope.startsWith("bbb"), "multi: startsWith 'bbb' should be false");
+    assert(rope.endsWith("bbb"), "multi: endsWith 'bbb'");
+    assert(!rope.endsWith("aaa"), "multi: endsWith 'aaa' should be false");
+}
+
+// Empty search string edge case.
+function testEmptySearch() {
+    let rope = makeLongRope();
+    assert(rope.startsWith(""), "startsWith empty string should be true");
+    assert(rope.endsWith(""), "endsWith empty string should be true");
+    assert(rope.startsWith("", 200), "startsWith empty at 200 should be true");
+    assert(rope.endsWith("", 0), "endsWith empty at 0 should be true");
+}
+
+// 16-bit character test.
+function testSixteenBit() {
+    let a = "\u{1234}".repeat(200);
+    let b = "\u{5678}".repeat(200);
+    let rope = a + b;
+    assert(rope.startsWith("\u{1234}"), "16-bit: startsWith U+1234");
+    assert(!rope.startsWith("\u{5678}"), "16-bit: startsWith U+5678 should be false");
+    assert(rope.endsWith("\u{5678}"), "16-bit: endsWith U+5678");
+    assert(!rope.endsWith("\u{1234}"), "16-bit: endsWith U+1234 should be false");
+}
+
+// 8-bit and 16-bit mixed rope.
+function testMixed8And16Bit() {
+    let ascii = "a".repeat(200); // 8-bit
+    let wide = "\u{00FF}".repeat(200); // 8-bit Latin1
+    let rope = ascii + wide;
+    assert(rope.startsWith("a"), "mixed: startsWith 'a'");
+    assert(rope.endsWith("\u{00FF}"), "mixed: endsWith U+00FF");
+    assert(!rope.startsWith("\u{00FF}"), "mixed: startsWith U+00FF should be false");
+    assert(!rope.endsWith("a"), "mixed: endsWith 'a' should be false");
+}
+
+// Short rope (below threshold) should still work correctly.
+function testShortRope() {
+    let rope = "hello" + " world";
+    assert(rope.startsWith("h"), "short: startsWith 'h'");
+    assert(!rope.startsWith("x"), "short: startsWith 'x' should be false");
+    assert(rope.endsWith("d"), "short: endsWith 'd'");
+    assert(!rope.endsWith("x"), "short: endsWith 'x' should be false");
+}
+
+// Nested rope: fiber0 is an unresolved non-substring rope.
+// tryGetCharAt should bail out and fall through to the existing path.
+function testNestedRope() {
+    let partA = "a".repeat(500);
+    let partB = "b".repeat(500);
+    let inner = partA + partB; // 1000 chars, rope
+    let partC = "c".repeat(200);
+    let rope = inner + partC; // 1200 chars, fiber0 = inner (rope)
+    // startsWith should still work (may or may not hit fast path)
+    assert(rope.startsWith("a"), "nested: startsWith 'a'");
+    assert(!rope.startsWith("c"), "nested: startsWith 'c' should be false");
+    // endsWith should use backward direction and find partC
+    assert(rope.endsWith("c"), "nested: endsWith 'c'");
+    assert(!rope.endsWith("a"), "nested: endsWith 'a' should be false");
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    testBasicRopeStartsWith();
+    testBasicRopeEndsWith();
+    testRopeStartsWithPosition();
+    testRopeEndsWithEndPosition();
+    testThreeFiberRope();
+    testSubstringRopeRoot();
+    testSubstringRopeFiber();
+    testMultiCharSearch();
+    testEmptySearch();
+    testSixteenBit();
+    testMixed8And16Bit();
+    testShortRope();
+    testNestedRope();
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -3430,6 +3430,15 @@ JSC_DEFINE_JIT_OPERATION(operationStringStartsWith, bool, (JSGlobalObject* globa
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    unsigned baseLength = base->length();
+    if (prefix->length() == 1 && base->isRope() && baseLength >= JSString::minLengthForRopeWalk) {
+        if (auto ch = base->tryGetCharAt(0)) {
+            auto prefixView = prefix->view(globalObject);
+            OPERATION_RETURN_IF_EXCEPTION(scope, false);
+            OPERATION_RETURN(scope, *ch == prefixView[0]);
+        }
+    }
+
     auto baseView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
@@ -3447,16 +3456,30 @@ JSC_DEFINE_JIT_OPERATION(operationStringStartsWithWithIndex, bool, (JSGlobalObje
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    unsigned baseLength = base->length();
+    if (prefix->length() == 1 && base->isRope() && baseLength >= JSString::minLengthForRopeWalk) {
+        unsigned start = 0;
+        if (position >= 0)
+            start = std::min<uint32_t>(position, baseLength);
+        if (start < baseLength) {
+            if (auto ch = base->tryGetCharAt(start)) {
+                auto prefixView = prefix->view(globalObject);
+                OPERATION_RETURN_IF_EXCEPTION(scope, false);
+                OPERATION_RETURN(scope, *ch == prefixView[0]);
+            }
+        } else
+            OPERATION_RETURN(scope, false);
+    }
+
     auto baseView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
     auto prefixView = prefix->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
-    int32_t length = baseView->length();
     unsigned start = 0;
     if (position >= 0)
-        start = std::min<uint32_t>(position, length);
+        start = std::min<uint32_t>(position, baseLength);
 
     OPERATION_RETURN(scope, baseView->hasInfixStartingAt(prefixView, start));
 }
@@ -3468,6 +3491,15 @@ JSC_DEFINE_JIT_OPERATION(operationStringEndsWith, bool, (JSGlobalObject* globalO
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
 
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    unsigned baseLength = base->length();
+    if (suffix->length() == 1 && base->isRope() && baseLength >= JSString::minLengthForRopeWalk) {
+        if (auto ch = base->tryGetCharAt(baseLength - 1)) {
+            auto suffixView = suffix->view(globalObject);
+            OPERATION_RETURN_IF_EXCEPTION(scope, false);
+            OPERATION_RETURN(scope, *ch == suffixView[0]);
+        }
+    }
 
     auto baseView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
@@ -3486,16 +3518,32 @@ JSC_DEFINE_JIT_OPERATION(operationStringEndsWithWithEndPosition, bool, (JSGlobal
 
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    unsigned baseLength = base->length();
+    if (suffix->length() == 1 && base->isRope() && baseLength >= JSString::minLengthForRopeWalk) {
+        unsigned end = baseLength;
+        if (endPosition >= 0)
+            end = std::min<uint32_t>(endPosition, baseLength);
+        else
+            end = 0;
+        if (end >= 1) {
+            if (auto ch = base->tryGetCharAt(end - 1)) {
+                auto suffixView = suffix->view(globalObject);
+                OPERATION_RETURN_IF_EXCEPTION(scope, false);
+                OPERATION_RETURN(scope, *ch == suffixView[0]);
+            }
+        } else
+            OPERATION_RETURN(scope, false);
+    }
+
     auto baseView = base->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
     auto suffixView = suffix->view(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, false);
 
-    int32_t length = baseView->length();
-    unsigned end = length;
+    unsigned end = baseLength;
     if (endPosition >= 0)
-        end = std::min<uint32_t>(endPosition, length);
+        end = std::min<uint32_t>(endPosition, baseLength);
     else
         end = 0;
 

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -130,7 +130,7 @@ public:
     static constexpr unsigned MaxLength = std::numeric_limits<int32_t>::max();
     static_assert(MaxLength == String::MaxLength);
 
-    // Minimum rope length for rope-walk optimizations (tryFindOneChar, tryReplaceOneChar).
+    // Minimum rope length for rope-walk optimizations (tryFindOneChar, tryGetCharAt, tryReplaceOneChar).
     static constexpr unsigned minLengthForRopeWalk = 0x128;
 
     static constexpr uintptr_t isRopeInPointer = 0x1;
@@ -282,6 +282,8 @@ public:
 
     ALWAYS_INLINE JSString* tryReplaceOneChar(JSGlobalObject*, char16_t, JSString* replacement);
     inline std::optional<size_t> tryFindOneChar(JSGlobalObject*, char16_t character, unsigned& startPosition) const;
+
+    inline std::optional<char16_t> tryGetCharAt(unsigned position) const;
 
     bool isSubstring() const;
 protected:

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -221,6 +221,47 @@ std::optional<size_t> JSString::tryFindOneChar(JSGlobalObject*, char16_t charact
     return WTF::notFound;
 }
 
+std::optional<char16_t> JSString::tryGetCharAt(unsigned position) const
+{
+    ASSERT(isRope());
+    ASSERT(position < length());
+
+    // Retrieve a single character at `position` from a rope without resolving it.
+    // Returns the character if accessible, or std::nullopt if the rope structure
+    // is too complex (i.e. an unresolved non-substring fiber is encountered).
+
+    if (isSubstring()) {
+        const JSRopeString* rope = static_cast<const JSRopeString*>(this);
+        JSString* base = rope->substringBase();
+        ASSERT(!base->isRope());
+        return base->valueInternal().characterAt(rope->substringOffset() + position);
+    }
+
+    const JSRopeString* rope = static_cast<const JSRopeString*>(this);
+    unsigned offset = 0;
+    for (unsigned i = 0; i < JSRopeString::s_maxInternalRopeLength; ++i) {
+        JSString* fiber = rope->fiber(i);
+        if (!fiber)
+            break;
+        unsigned fiberLength = fiber->length();
+        if (position < offset + fiberLength) {
+            unsigned localPos = position - offset;
+            if (!fiber->isRope())
+                return fiber->valueInternal().characterAt(localPos);
+            if (fiber->isSubstring()) {
+                const JSRopeString* subRope = static_cast<const JSRopeString*>(fiber);
+                JSString* base = subRope->substringBase();
+                ASSERT(!base->isRope());
+                return base->valueInternal().characterAt(subRope->substringOffset() + localPos);
+            }
+            return std::nullopt;
+        }
+        offset += fiberLength;
+    }
+
+    return std::nullopt;
+}
+
 template<typename StringType>
 inline JSValue jsMakeNontrivialString(VM& vm, StringType&& string)
 {

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -1346,9 +1346,6 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
     auto* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto stringToSearchIn = string->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue a0 = callFrame->argument(0);
     bool isRegularExpression = isRegExp(vm, globalObject, a0);
     RETURN_IF_EXCEPTION(scope, { });
@@ -1361,8 +1358,8 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
     auto searchString = search->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
+    unsigned length = string->length();
     JSValue positionArg = callFrame->argument(1);
-    unsigned length = stringToSearchIn->length();
     unsigned start;
     if (positionArg.isInt32())
         start = std::min(clampTo<unsigned>(positionArg.asInt32()), length);
@@ -1370,6 +1367,17 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncStartsWith, (JSGlobalObject* globalObjec
         start = clampAndTruncateToUnsigned(positionArg.toIntegerOrInfinity(globalObject), 0, length);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
+
+    if (searchString->length() == 1 && string->isRope() && length >= JSString::minLengthForRopeWalk) {
+        if (start < length) {
+            if (auto ch = string->tryGetCharAt(start))
+                return JSValue::encode(jsBoolean(*ch == searchString[0]));
+        } else
+            return JSValue::encode(jsBoolean(false));
+    }
+
+    auto stringToSearchIn = string->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(jsBoolean(stringToSearchIn->hasInfixStartingAt(searchString, start)));
 }
@@ -1386,9 +1394,6 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
     auto* string = thisValue.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    auto stringToSearchIn = string->view(globalObject);
-    RETURN_IF_EXCEPTION(scope, { });
-
     JSValue a0 = callFrame->argument(0);
     bool isRegularExpression = isRegExp(vm, globalObject, a0);
     RETURN_IF_EXCEPTION(scope, encodedJSValue());
@@ -1401,8 +1406,8 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
     auto searchString = search->view(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
+    unsigned length = string->length();
     JSValue endPositionArg = callFrame->argument(1);
-    unsigned length = stringToSearchIn->length();
     unsigned end;
     if (endPositionArg.isUndefined())
         end = length;
@@ -1412,6 +1417,17 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncEndsWith, (JSGlobalObject* globalObject,
         end = clampAndTruncateToUnsigned(endPositionArg.toIntegerOrInfinity(globalObject), 0, length);
         RETURN_IF_EXCEPTION(scope, encodedJSValue());
     }
+
+    if (searchString->length() == 1 && string->isRope() && length >= JSString::minLengthForRopeWalk) {
+        if (end >= 1) {
+            if (auto ch = string->tryGetCharAt(end - 1))
+                return JSValue::encode(jsBoolean(*ch == searchString[0]));
+        } else
+            return JSValue::encode(jsBoolean(false));
+    }
+
+    auto stringToSearchIn = string->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
 
     return JSValue::encode(jsBoolean(stringToSearchIn->hasInfixEndingAt(searchString, end)));
 }


### PR DESCRIPTION
#### 1a5877957d8488b28973f9ca741b9fe2a9051a04
<pre>
[JSC] Optimize `String#startsWith` and `String#endsWith` for single char on rope strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=307728">https://bugs.webkit.org/show_bug.cgi?id=307728</a>

Reviewed by NOBODY (OOPS!).

Add JSString::tryGetCharAt to extract a character from a rope without
resolving it. Use it as a fast path in startsWith/endsWith when the
search string is a single character and the base is a long rope.

                                  TipOfTree                  Patched

rope-endsWith-one-char          2.9173+-0.2000     ^      0.9482+-0.0300        ^ definitely 3.0767x faster
rope-startsWith-one-char        3.0725+-0.0696     ^      0.9681+-0.0293        ^ definitely 3.1738x faster

Tests: JSTests/microbenchmarks/rope-endsWith-one-char.js
       JSTests/microbenchmarks/rope-startsWith-one-char.js
       JSTests/stress/rope-string-startsWith-endsWith.js

* JSTests/microbenchmarks/rope-endsWith-one-char.js: Added.
(endsWithMatch):
(endsWithMismatch):
* JSTests/microbenchmarks/rope-startsWith-one-char.js: Added.
(startsWithMatch):
(startsWithMismatch):
* JSTests/stress/rope-string-startsWith-endsWith.js: Added.
(assert):
(makeLongRope):
(testBasicRopeStartsWith):
(testBasicRopeEndsWith):
(testRopeStartsWithPosition):
(testRopeEndsWithEndPosition):
(testThreeFiberRope):
(testSubstringRopeRoot):
(testSubstringRopeFiber):
(testMultiCharSearch):
(testEmptySearch):
(testSixteenBit):
(testMixed8And16Bit):
(testShortRope):
(testNestedRope):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/runtime/JSString.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
(JSC::JSString::tryGetCharAt const):
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a5877957d8488b28973f9ca741b9fe2a9051a04

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148499 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21185 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14781 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157183 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101929 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21642 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114477 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81535 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151459 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133317 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95247 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15800 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13631 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4619 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140466 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125413 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11230 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159518 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/9286 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2650 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12750 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122526 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20983 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17622 "Found 1 new test failure: imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122747 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20992 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133023 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77144 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18102 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9792 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179927 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20600 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84422 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/46062 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20332 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20477 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20386 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->