### PR TITLE
[Scroll anchoring] Optimize scrollAnchoringSuppressionStyleDidChange()

### DIFF
--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -1129,7 +1129,7 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
         issueRepaintForOutlineAuto(hasOutlineAuto ? outlineStyleForRepaint().usedOutlineSize() : oldStyle->usedOutlineSize());
     }
 
-    if (settings().cssScrollAnchoringEnabled() && style().scrollAnchoringSuppressionStyleDidChange(oldStyle)) {
+    if (settings().cssScrollAnchoringEnabled() && (diff >= Style::DifferenceResult::Layout) && style().scrollAnchoringSuppressionStyleDidChange(oldStyle)) {
         auto findNearestScrollAnchoringController = [](const RenderElement& renderer) -> CheckedPtr<ScrollAnchoringController> {
             // At this point we can't find the appropriate enclosing ScrollAnchoringController, because we haven't done layout.
             // We will, however, have created a ScrollAnchoringController for potentially scrollable ancestors, so store

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -167,7 +167,7 @@ bool RenderStyle::scrollAnchoringSuppressionStyleDidChange(const RenderStyle* ot
     if (position() != other->position())
         return true;
 
-    if (m_computedStyle.m_nonInheritedData->surroundData.ptr() && other->m_computedStyle.m_nonInheritedData->surroundData.ptr()) {
+    if (m_computedStyle.m_nonInheritedData->surroundData.ptr() != other->m_computedStyle.m_nonInheritedData->surroundData.ptr()) {
         SUPPRESS_UNCOUNTED_LOCAL auto& surroundData = m_computedStyle.m_nonInheritedData->surroundData.get();
         SUPPRESS_UNCOUNTED_LOCAL auto& otherSurroundData = other->m_computedStyle.m_nonInheritedData->surroundData.get();
         if (surroundData.margin != otherSurroundData.margin)
@@ -182,9 +182,24 @@ bool RenderStyle::scrollAnchoringSuppressionStyleDidChange(const RenderStyle* ot
         }
     }
 
-    if (hasTransformRelatedProperty() != other->hasTransformRelatedProperty() || transform() != other->transform())
-        return true;
+    if (m_computedStyle.m_nonInheritedData->miscData.ptr() != other->m_computedStyle.m_nonInheritedData->miscData.ptr()) {
+        SUPPRESS_UNCOUNTED_LOCAL auto& miscData = m_computedStyle.m_nonInheritedData->miscData.get();
+        SUPPRESS_UNCOUNTED_LOCAL auto& otherMiscData = other->m_computedStyle.m_nonInheritedData->miscData.get();
+        if (miscData.transform != otherMiscData.transform)
+            return true;
+    }
 
+    // The spec doesn't list `translate`, `rotate`, `scale` but test them here.
+    // https://github.com/w3c/csswg-drafts/issues/13489
+    if (m_computedStyle.m_nonInheritedData->rareData.ptr() != other->m_computedStyle.m_nonInheritedData->rareData.ptr()) {
+        SUPPRESS_UNCOUNTED_LOCAL auto& rareData = m_computedStyle.m_nonInheritedData->rareData.get();
+        SUPPRESS_UNCOUNTED_LOCAL auto& otherRareData = other->m_computedStyle.m_nonInheritedData->rareData.get();
+        if (rareData.translate != otherRareData.translate
+            || rareData.rotate != otherRareData.rotate
+            || rareData.scale != otherRareData.scale) {
+            return true;
+        }
+    }
     return false;
 }
 


### PR DESCRIPTION
#### 9de807e954f2c20d01c231a32bbcdf6d4707d82f
<pre>
[Scroll anchoring] Optimize scrollAnchoringSuppressionStyleDidChange()
<a href="https://bugs.webkit.org/show_bug.cgi?id=307729">https://bugs.webkit.org/show_bug.cgi?id=307729</a>
<a href="https://rdar.apple.com/170277397">rdar://170277397</a>

Reviewed by Alan Baradlay.

`scrollAnchoringSuppressionStyleDidChange()` shows up in some MotionMark tests.

Fix an erroneous `&amp;&amp;` to instead test pointer inequality, as we do everywhere else,
since his pointer is usually the same.

Check for `diff &gt;= Style::DifferenceResult::Layout` because, by definition, things
that invalidate scroll anchoring affect layout.

Optimize the testing for the various transform properties; `transform` is stored in
`miscData`, and the others are stored in `rareData`. Also just test for `transform`,
`translate`, `scale`, and `rotate`. The spec only mentions the first [1] but it makes
sense to test the others as well. I purposefully removed testing for offset path
and perspective.

[1] <a href="https://drafts.csswg.org/css-scroll-anchoring/#suppression-trigger">https://drafts.csswg.org/css-scroll-anchoring/#suppression-trigger</a>
[2] <a href="https://github.com/w3c/csswg-drafts/issues/13489">https://github.com/w3c/csswg-drafts/issues/13489</a>

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::styleDidChange):
* Source/WebCore/rendering/style/RenderStyle.cpp:
(WebCore::RenderStyle::scrollAnchoringSuppressionStyleDidChange const):

Canonical link: <a href="https://commits.webkit.org/307474@main">https://commits.webkit.org/307474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e24c19481c10329de507da96c3314cac1fb1c70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144383 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17062 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8622 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97622 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c2251b04-c735-4440-ab2c-e1c63256c7c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146258 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111026 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79714 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147346 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91944 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c847ca23-9906-499d-8149-99c36417e74c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12836 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10585 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/499 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122341 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155365 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16914 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119032 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16952 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14173 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119395 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30629 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15230 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127572 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72335 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16536 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5986 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16272 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80315 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16481 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16336 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->