### PR TITLE
[AppKit Gestures] Update gesture failure requirements to comply with updated system interaction

### DIFF
--- a/Source/WebKit/Platform/spi/mac/AppKitSPI.h
+++ b/Source/WebKit/Platform/spi/mac/AppKitSPI.h
@@ -211,11 +211,11 @@ typedef void (^NSWindowSnapshotReadinessHandler) (void);
 
 NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
-@protocol NSTextSelectionManagerDelegateForWebKit <NSObject>
+@protocol NSTextSelectionManagerDelegateForWebKit_Staging <NSObject>
 
 - (BOOL)isTextSelectedAtPoint:(NSPoint)point;
 - (void)moveInsertionCursorToPoint:(NSPoint)point;
-- (void)handleClickAtPoint:(NSPoint)point;
+- (void)handleClickAtPoint:(NSPoint)point clickCount:(NSUInteger)clickCount;
 - (void)showContextMenuAtPoint:(NSPoint)point;
 - (void)dragSelectionWithGesture:(NSGestureRecognizer *)gesture completionHandler:(void(^)(NSDraggingSession*))completionHandler;
 - (void)beginRangeSelectionAtPoint:(NSPoint)point withGranularity:(NSTextSelectionGranularity)granularity;
@@ -225,7 +225,7 @@ NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 @end
 
 @interface NSTextSelectionManager (WebKit_SPI)
-@property (weak) id <NSTextSelectionManagerDelegateForWebKit> _webkitDelegate;
+@property (weak) id <NSTextSelectionManagerDelegateForWebKit_Staging> _webkitDelegate;
 @end
 
 NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
@@ -46,7 +46,7 @@ NS_SWIFT_UI_ACTOR
 
 @end
 
-@interface WKTextSelectionController (NSTextSelectionManagerDelegate) <NSTextSelectionManagerDelegateForWebKit>
+@interface WKTextSelectionController (NSTextSelectionManagerDelegate) <NSTextSelectionManagerDelegateForWebKit_Staging>
 
 // FIXME: (rdar://170015885) Remove this declaration and its definition when possible.
 - (NSDraggingSession *)selectionManager:(NSTextSelectionManager *)selectionManager makeDraggingSessionWithGesture:(NSGestureRecognizer *)gesture;

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -139,22 +139,28 @@ extension WKTextSelectionController {
         }
     }
 
-    @objc(handleClickAtPoint:)
-    func handleClick(at point: NSPoint) {
+    @objc(handleClickAtPoint:clickCount:)
+    func handleClick(at point: NSPoint, clickCount: Int) {
         Task.immediate {
-            await handleClickInternal(at: point)
+            await handleClickInternal(at: point, clickCount: clickCount)
         }
     }
 
     @MainActor
-    private func handleClickInternal(at point: NSPoint) async {
+    private func handleClickInternal(at point: NSPoint, clickCount: Int) async {
         // The `point` location is relative to the view.
 
         guard let view, let page = view._protectedPage().get() else {
             return
         }
 
-        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Handling click at point \(point.debugDescription)...")
+        Logger.viewGestures.log(
+            "[pageProxyID=\(page.logIdentifier())] \(#function) point \(point.debugDescription) clickCount \(clickCount)"
+        )
+
+        guard clickCount == 1 else {
+            return
+        }
 
         let previousState = unsafe page.editorState
         let previousVisualData = unsafe Optional(fromCxx: previousState.visualData)


### PR DESCRIPTION
#### 54cd72fa0a89b844c2fadaa2bdf7709883e70997
<pre>
[AppKit Gestures] Update gesture failure requirements to comply with updated system interaction
<a href="https://bugs.webkit.org/show_bug.cgi?id=307731">https://bugs.webkit.org/show_bug.cgi?id=307731</a>
<a href="https://rdar.apple.com/170278113">rdar://170278113</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/Platform/spi/mac/AppKitSPI.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKAppKitGestureController gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]):
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]):
(-[WKAppKitGestureController gestureRecognizer:shouldRequireFailureOfGestureRecognizer:]): Deleted.
* Source/WebKit/UIProcess/mac/WKTextSelectionController.h:
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.handleClick(at:clickCount:)):
(WKTextSelectionController.handleClickInternal(at:clickCount:)):
(WKTextSelectionController.handleClick(at:)): Deleted.
(WKTextSelectionController.handleClickInternal(at:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/307433@main">https://commits.webkit.org/307433@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc0d849d90f129c94316647bb090c6c86b1a413f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144380 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153050 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17541 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16953 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111023 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13414 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91941 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12827 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/496 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155362 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16911 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119028 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16949 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119391 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30607 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15229 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127569 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72332 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16533 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/5983 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16269 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80312 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16333 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->