### PR TITLE
Reduce Ref counting operations in TextUtil::width

### DIFF
--- a/Source/WebCore/platform/graphics/Font.h
+++ b/Source/WebCore/platform/graphics/Font.h
@@ -192,7 +192,7 @@ public:
 
     Path pathForGlyph(Glyph) const;
 
-    float spaceWidth(SyntheticBoldInclusion SyntheticBoldInclusion = SyntheticBoldInclusion::Incorporate) const
+    float NODELETE spaceWidth(SyntheticBoldInclusion SyntheticBoldInclusion = SyntheticBoldInclusion::Incorporate) const
     {
         return m_spaceWidth + (SyntheticBoldInclusion == SyntheticBoldInclusion::Incorporate ? syntheticBoldOffset() : 0);
     }

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -386,6 +386,8 @@ private:
 
 inline const Font& FontCascade::primaryFont() const
 {
+    if (m_fonts->cachedPrimaryFont())
+        return *m_fonts->cachedPrimaryFont();
     WeakRef font = protect(m_fonts)->primaryFont(m_fontDescription, protect(fontSelector()).get());
     m_fontDescription.resolveFontSizeAdjustFromFontIfNeeded(protect(font));
     return font;
@@ -403,6 +405,9 @@ inline bool FontCascade::isFixedPitch() const
 
 inline bool FontCascade::canTakeFixedPitchFastContentMeasuring() const
 {
+    auto cachedCanTakeFixedPitch = m_fonts->cachedCanTakeFixedPitchFastContentMeasuring();
+    if (cachedCanTakeFixedPitch != TriState::Indeterminate)
+        return cachedCanTakeFixedPitch == TriState::True;
     return protect(m_fonts)->canTakeFixedPitchFastContentMeasuring(m_fontDescription, protect(fontSelector()).get());
 }
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.h
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.h
@@ -115,6 +115,10 @@ public:
     bool isFixedPitch(const FontCascadeDescription&, FontSelector*);
 
     bool canTakeFixedPitchFastContentMeasuring(const FontCascadeDescription&, FontSelector*);
+    TriState NODELETE cachedCanTakeFixedPitchFastContentMeasuring() const
+    {
+        return m_canTakeFixedPitchFastContentMeasuring;
+    }
 
     bool isLoadingCustomFonts() const;
 
@@ -143,6 +147,7 @@ public:
     const TextShapingResult* getOrCreateCachedShapedText(const TextRun&, const FontCascade&, unsigned from, std::optional<unsigned> to, ForTextEmphasis);
 
     const Font& primaryFont(const FontCascadeDescription&, FontSelector*);
+    const Font* NODELETE cachedPrimaryFont() const { return m_cachedPrimaryFont.get(); }
     WEBCORE_EXPORT const FontRanges& realizeFallbackRangesAt(const FontCascadeDescription&, FontSelector*, unsigned fallbackIndex);
 
     void pruneSystemFallbacks();


### PR DESCRIPTION
#### e20f666f105ba9f902201fb018ce20ceafe35fd8
<pre>
Reduce Ref counting operations in TextUtil::width
<a href="https://rdar.apple.com/170275347">rdar://170275347</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307738">https://bugs.webkit.org/show_bug.cgi?id=307738</a>

Reviewed by Vitor Roriz.

Add NODELETE cachedPrimaryFont() and cachedCanTakeFixedPitchFastContentMeasuring()
to reduce ref-count operations in TextUtil::width().

TextUtil::width() is a hot function with many ref()/deref(). Each call to
FontCascade::primaryFont() uses
protect(m_fonts) / protect(fontSelector()), causing
ref/deref operations per call. Similarly,
canTakeFixedPitchFastContentMeasuring() uses protect() internally.

Add cachedPrimaryFont() which returns const Font* directly
from the cached weak pointer, and cachedCanTakeFixedPitchFastContentMeasuring()
which reads the cached TriState without protect(). On cache hit,
this eliminates all ref counting. On the cache miss,
fall back to the existing ref-counted methods. Cache hit is much more common than cache miss.

Accessing m_fonts without protect() and returning a raw pointer instead
of a Ref is safe because the FontCascade owns the FontCascadeFonts through
a RefPtr, and the FontCascadeFonts holds the Font alive through a
chain of strong references (FontRanges -&gt; FontAccessor -&gt; Font).
Since every caller of cachedPrimaryFont() is operating on a live
FontCascade, the returned Font pointer is valid for the duration of
the call.
The existing code already assumes m_fonts is non-null at the time of access because
protect(m_fonts)-&gt;primaryFont() would crash on a null m_fonts,
since protect() of a null RefPtr returns a null RefPtr.

The NODELETE annotation verifies that the called method
cannot free the returned object&apos;s memory.

A/B testing shows this is a small performance improvement.

* Source/WebCore/platform/graphics/Font.h:
(WebCore::Font::spaceWidth const):
* Source/WebCore/platform/graphics/FontCascade.h:
(WebCore::FontCascade::primaryFont const):
(WebCore::FontCascade::canTakeFixedPitchFastContentMeasuring const):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:
(WebCore::FontCascadeFonts::cachedCanTakeFixedPitchFastContentMeasuring const):
(WebCore::FontCascadeFonts::cachedPrimaryFont const):

Canonical link: <a href="https://commits.webkit.org/309020@main">https://commits.webkit.org/309020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0be18f05043ca07cf2c01a0a5d6ca0dcb3bc270d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20592 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14186 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101320 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d4ac2f2-35f8-4fc2-8c9e-0f095cea8567) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149779 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21047 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114026 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81315 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a1b18ba-004e-4fef-aac8-c29a61a05e73) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16269 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94790 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dbab67e9-5437-40a0-91f3-c131881607f8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13210 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4027 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10752 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158922 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2057 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12246 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122060 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20389 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17139 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122263 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33510 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132552 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76542 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9314 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83767 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19737 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19885 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19793 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->