### PR TITLE
[Site Isolation] Fix drag-and-drop pasteboard tests to return after finishJSTest()

### DIFF
--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-html-when-dragging-in-null-origin.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-html-when-dragging-in-null-origin.html
@@ -113,6 +113,7 @@ onmessage = (event) => {
         if (!event.data.documentLabel.includes('null')) {
             document.getElementById('container').remove();
             finishJSTest();
+            return;
         }
         break;
     }

--- a/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-url-when-dragging-in-null-origin.html
+++ b/LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-url-when-dragging-in-null-origin.html
@@ -118,6 +118,7 @@ onmessage = (event) => {
         if (!event.data.documentLabel.includes('null')) {
             document.getElementById('container').remove();
             finishJSTest();
+            return;
         }
         break;
     }


### PR DESCRIPTION
#### afc47a2719e7157bdcf04183b30d741a1f86eb9a
<pre>
[Site Isolation] Fix drag-and-drop pasteboard tests to return after finishJSTest()
<a href="https://bugs.webkit.org/show_bug.cgi?id=307735">https://bugs.webkit.org/show_bug.cgi?id=307735</a>
<a href="https://rdar.apple.com/170279307">rdar://170279307</a>

Reviewed by Sihui Liu.

After the call to finishJSTest(), the break statement exits the switch
and allows debug(&apos;&apos;) to execute, which adds an extra BR element.
Without site isolation, notifyDone() captures the DOM synchronously
before debug(&apos;&apos;) runs, so the BR isn&apos;t captured and aligns with the expected
test output. With site isolation, the async capture includes the extra BR,
causing a newline mismatch in the expected vs actual test output.

Add a return statement immediately following finishJSTest() so that the
handler exits immediately and prevents debug(&apos;&apos;) from executing at all.

* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-html-when-dragging-in-null-origin.html:
* LayoutTests/editing/pasteboard/data-transfer-set-data-sanitize-url-when-dragging-in-null-origin.html:

Canonical link: <a href="https://commits.webkit.org/307483@main">https://commits.webkit.org/307483@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/26e7055b03825f086122510692a7f386f8b93e5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144537 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8785 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153208 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17110 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111151 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98172 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ffcfdb86-b9a5-496b-92f3-731b2d640e28) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147500 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13536 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92056 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84de8724-e53c-4717-95a4-b172617d520c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12919 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10668 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/653 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122427 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6491 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155520 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17068 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119154 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17106 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119500 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30634 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15333 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127704 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72609 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16690 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6107 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16426 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16635 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16490 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->