### PR TITLE
[AutoFill Debugging] Add more filtering rules for debug text extraction

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-sanitization-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-sanitization-expected.txt
@@ -1,0 +1,46 @@
+--- markdown
+
+ZeroWidthJoiner
+ZeroWidthSpace
+ZeroWidthNonJoiner
+WordJoinerTest
+BOMTest
+- First item
+- Second item
+- Third item
+Repeated text
+Different text
+
+--- text-tree
+
+root
+	'ZeroWidthJoiner'
+	'ZeroWidthSpace'
+	'ZeroWidthNonJoiner'
+	'WordJoinerTest'
+	'BOMTest'
+	list
+		list-item,'First item'
+		list-item,'Second item'
+		list-item,'Third item'
+	'Repeated text'
+	'Different text'
+
+--- html
+
+<body>
+	ZeroWidthJoiner
+	ZeroWidthSpace
+	ZeroWidthNonJoiner
+	WordJoinerTest
+	BOMTest
+	<ul>
+		<li>First item</li>
+		<li>Second item</li>
+		<li>Third item</li>
+	</ul>
+	Repeated text
+	Different text
+</body>
+
+

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-sanitization.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-sanitization.html
@@ -1,0 +1,67 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<!-- Strip zero-width characters -->
+<p>Zero&#x200D;Width&#x200D;Joiner</p>
+<p>Zero&#x200B;Width&#x200B;Space</p>
+<p>Zero&#x200C;Width&#x200C;Non&#x200C;Joiner</p>
+<p>Word&#x2060;Joiner&#x2060;Test</p>
+<p>BOM&#xFEFF;Test</p>
+
+<!-- Remove empty markdown list items -->
+<ul id="list-with-empty">
+    <li>First item</li>
+    <li></li>
+    <li>Second item</li>
+    <li>   </li>
+    <li>Third item</li>
+</ul>
+
+<!-- De-duplicate consecutive lines -->
+<div id="duplicates">
+    <p>Repeated text</p>
+    <p>Repeated text</p>
+    <p>Repeated text</p>
+    <p>Different text</p>
+    <p>Different text</p>
+</div>
+
+<script>
+function createResultDiv(text) {
+    let div = document.createElement("div");
+    div.textContent = text;
+    div.style.whiteSpace = "pre";
+    return div;
+}
+
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+
+    const resultDivs = [];
+    for (let outputFormat of ["markdown", "text-tree", "html"]) {
+        resultDivs.push(createResultDiv(`--- ${outputFormat}`))
+        resultDivs.push(createResultDiv("\n"))
+        resultDivs.push(createResultDiv(await UIHelper.requestDebugText({
+            outputFormat,
+            includeRects: false,
+            includeURLs: false,
+        })));
+        resultDivs.push(createResultDiv("\n"))
+    }
+
+    document.body.replaceChildren(...resultDivs);
+    testRunner.notifyDone();
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
#### 9883ba9167830378e0913fd31dfcd48a2480307d
<pre>
[AutoFill Debugging] Add more filtering rules for debug text extraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=307741">https://bugs.webkit.org/show_bug.cgi?id=307741</a>
<a href="https://rdar.apple.com/170228978">rdar://170228978</a>

Reviewed by Abrar Rahman Protyasha.

Add a few more post-processing steps to further streamline debug text extraction:
- Remove zero-width joiners and other non-rendered unicode characters.
- Remove identical and repetitive lines.
- When extracting markdown, remove empty list items.

Test: fast/text-extraction/debug-text-extraction-sanitization.html

* LayoutTests/fast/text-extraction/debug-text-extraction-sanitization-expected.txt: Added.
* LayoutTests/fast/text-extraction/debug-text-extraction-sanitization.html: Added.
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::removeZeroWidthCharacters):
(WebKit::isEmptyMarkdownListItem):
(WebKit::TextExtractionAggregator::takeResults):
(WebKit::addJSONTextContent):

Canonical link: <a href="https://commits.webkit.org/307470@main">https://commits.webkit.org/307470@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1648584748e6415535b60498f1c3a42226ce7513

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8656 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153087 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/97893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe0771eb-5ed5-408d-b501-aae5716bef2b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16990 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111051 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/97893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0bacbe9a-f8ca-4dfc-b302-9867df5802bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147380 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91966 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7efca71c-9e27-4f5c-bbb9-b089f576160a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12846 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10601 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/533 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155399 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16948 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7441 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119055 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16986 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14195 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119418 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30627 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15251 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127598 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16570 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6008 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16306 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80349 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16515 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16370 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->