### PR TITLE
iOS UIProcess should instantiate a WebParentalControlsURLFilter

### DIFF
--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -37,6 +37,10 @@
 #include <WebCore/LocalFrameLoaderClient.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER)
+#include "WebParentalControlsURLFilter.h"
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -52,7 +56,9 @@ PendingDownload::PendingDownload(IPC::Connection* parentProcessConnection, Netwo
     relaxAdoptionRequirement();
 
 #if ENABLE(CONTENT_FILTERING)
-    NetworkProcess::setSharedParentalControlsURLFilterIfNecessary();
+#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary();
+#endif
 #endif
 
 #if HAVE(WEBCONTENTRESTRICTIONS)

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -205,18 +205,6 @@ NetworkProcess::NetworkProcess(AuxiliaryProcessInitializationParameters&& parame
 
 NetworkProcess::~NetworkProcess() = default;
 
-void NetworkProcess::setSharedParentalControlsURLFilterIfNecessary()
-{
-#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
-    ASSERT(isMainRunLoop());
-    static bool initialized = false;
-    if (!initialized) {
-        WebCore::ParentalControlsURLFilter::setGlobalFilter(WebParentalControlsURLFilter::create());
-        initialized = true;
-    }
-#endif
-}
-
 AuthenticationManager& NetworkProcess::authenticationManager()
 {
     return *supplement<AuthenticationManager>();

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -157,8 +157,6 @@ public:
     using DomainInNeedOfStorageAccess = WebCore::RegistrableDomain;
     using OpenerDomain = WebCore::RegistrableDomain;
 
-    static void setSharedParentalControlsURLFilterIfNecessary();
-
     NetworkProcess(AuxiliaryProcessInitializationParameters&&);
     ~NetworkProcess();
     static constexpr WTF::AuxiliaryProcessType processType = WTF::AuxiliaryProcessType::Network;

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -280,7 +280,9 @@ void NetworkResourceLoader::startContentFiltering(ResourceRequest&& request, Com
         completionHandler(WTF::move(request));
         return;
     }
-    NetworkProcess::setSharedParentalControlsURLFilterIfNecessary();
+#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary();
+#endif
     m_contentFilter = ContentFilter::create(*this);
     RefPtr contentFilter = m_contentFilter;
 #if HAVE(AUDIT_TOKEN)

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
@@ -35,6 +35,7 @@ namespace WebKit {
 
 class WebParentalControlsURLFilter final : public WebCore::ParentalControlsURLFilter {
 public:
+    static void setSharedParentalControlsURLFilterIfNecessary();
     static Ref<WebParentalControlsURLFilter> create();
     ~WebParentalControlsURLFilter();
 

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
@@ -110,6 +110,16 @@ void WebParentalControlsURLFilter::allowURL(const URL& url, CompletionHandler<vo
     });
 }
 
+void WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary()
+{
+    ASSERT(isMainRunLoop());
+    static bool initialized = false;
+    if (!initialized) {
+        WebCore::ParentalControlsURLFilter::setGlobalFilter(WebParentalControlsURLFilter::create());
+        initialized = true;
+    }
+}
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -85,6 +85,10 @@
 #include <WebCore/ParentalControlsURLFilterParameters.h>
 #endif
 
+#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER)
+#include "WebParentalControlsURLFilter.h"
+#endif
+
 #define MESSAGE_CHECK(assertion) MESSAGE_CHECK_BASE(assertion, process().connection())
 
 namespace WebKit {
@@ -447,6 +451,10 @@ bool WebFrameProxy::didHandleContentFilterUnblockNavigation(const ResourceReques
             return true;
         }
     }
+#endif
+
+#if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary();
 #endif
 
     m_contentFilterUnblockHandler.requestUnblockAsync([page](bool unblocked) {


### PR DESCRIPTION
#### 66170343c1d5fa33f51da5f12c9ac0d900aa1cf4
<pre>
iOS UIProcess should instantiate a WebParentalControlsURLFilter
<a href="https://bugs.webkit.org/show_bug.cgi?id=307740">https://bugs.webkit.org/show_bug.cgi?id=307740</a>
<a href="https://rdar.apple.com/170288522">rdar://170288522</a>

Reviewed by Sihui Liu.

Right now, WebParentalControlsURLFilter is only used on iOS NetworkProcess. Currently, iOS UIProcess is
using a ParentalControlsURLFilter. We should be using a WebParentalControlsURLFilter instead.

No new tests needed.
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
(WebKit::PendingDownload::PendingDownload):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::setSharedParentalControlsURLFilterIfNecessary): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::startContentFiltering):
* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h:
* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm:
(WebKit::WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didHandleContentFilterUnblockNavigation):

Canonical link: <a href="https://commits.webkit.org/307484@main">https://commits.webkit.org/307484@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e9ae2f8eef038258f89ae288f9df30470f89185

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144413 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17092 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8652 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153083 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/97668 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7711932e-79aa-4b4f-afdf-6a93e5ec96a8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/16986 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111048 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79726 "1 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5174428e-3db5-4b3a-85a9-c34565f116e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13437 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129696 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/91963 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12845 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10600 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/529 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122350 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155395 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/16944 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119051 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/16982 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14193 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119414 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15248 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127593 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22295 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16566 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6004 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16302 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80345 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16511 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16366 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->