### PR TITLE
Further reduce use of protected functions in Source/WebKit

### DIFF
--- a/Source/WTF/wtf/ThreadSafeWeakPtr.h
+++ b/Source/WTF/wtf/ThreadSafeWeakPtr.h
@@ -786,6 +786,12 @@ ALWAYS_INLINE RefPtr<T> protect(const ThreadSafeWeakPtr<T, TaggingTraits>& weakP
     return weakPtr.get();
 }
 
+template<typename T, typename TaggingTraits = NoTaggingTraits<T>>
+ALWAYS_INLINE Ref<T> protect(const ThreadSafeWeakRef<T, TaggingTraits>& weakRef)
+{
+    return weakRef.get();
+}
+
 }
 
 using WTF::ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr;

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp
@@ -59,10 +59,10 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
     Ref convertToBackingContext = m_convertToBackingContext;
     for (const auto& colorAttachment : descriptor.colorAttachments) {
         if (colorAttachment) {
-            RefPtr texture = colorAttachment->protectedTexture().get();
-            RefPtr textureView = colorAttachment->protectedView().get();
-            RefPtr resolveTexture = colorAttachment->protectedResolveTexture().get();
-            RefPtr resolveTarget = colorAttachment->protectedResolveTarget().get();
+            RefPtr texture = colorAttachment->texture();
+            RefPtr textureView = colorAttachment->textureView();
+            RefPtr resolveTexture = colorAttachment->resolveTexture();
+            RefPtr resolveTarget = colorAttachment->resolveTextureView();
             colorAttachments.append(WGPURenderPassColorAttachment {
                 .texture = texture ? convertToBackingContext->convertToBacking(*texture) : nullptr,
                 .view = textureView ? convertToBackingContext->convertToBacking(*textureView) : nullptr,
@@ -88,8 +88,8 @@ RefPtr<RenderPassEncoder> CommandEncoderImpl::beginRenderPass(const RenderPassDe
 
     std::optional<WGPURenderPassDepthStencilAttachment> depthStencilAttachment;
     if (descriptor.depthStencilAttachment) {
-        RefPtr texture = descriptor.depthStencilAttachment->protectedTexture().get();
-        RefPtr textureView = descriptor.depthStencilAttachment->protectedView().get();
+        RefPtr texture = descriptor.depthStencilAttachment->texture();
+        RefPtr textureView = descriptor.depthStencilAttachment->textureView();
 
         depthStencilAttachment = WGPURenderPassDepthStencilAttachment {
             .texture = texture ? convertToBackingContext->convertToBacking(*texture) : nullptr,

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h
@@ -52,42 +52,42 @@ struct RenderPassColorAttachment {
     LoadOp loadOp { LoadOp::Load };
     StoreOp storeOp { StoreOp::Store };
 
-    const RefPtr<Texture> protectedTexture() const
+    Texture* texture() const
     {
-        return WTF::switchOn(view, [&](const WeakRef<Texture>& texture) -> const RefPtr<Texture> {
+        return WTF::switchOn(view, [&](const WeakRef<Texture>& texture) -> Texture* {
             return texture.ptr();
-        }, [&](const WeakRef<TextureView>&) -> const RefPtr<Texture> {
+        }, [&](const WeakRef<TextureView>&) -> Texture* {
             return nullptr;
         });
     }
-    const RefPtr<TextureView> protectedView() const
+    TextureView* textureView() const
     {
-        return WTF::switchOn(view, [&](const WeakRef<Texture>&) -> const RefPtr<TextureView> {
+        return WTF::switchOn(view, [&](const WeakRef<Texture>&) -> TextureView* {
             return nullptr;
-        }, [&](const WeakRef<TextureView>& view) -> const RefPtr<TextureView> {
-            return view.ptr();
+        }, [&](const WeakRef<TextureView>& textureView) -> TextureView* {
+            return textureView.ptr();
         });
     }
-    RefPtr<Texture> protectedResolveTexture() const
+    Texture* resolveTexture() const
     {
         if (!resolveTarget)
             return nullptr;
 
-        return WTF::switchOn(*resolveTarget, [&](const WeakPtr<Texture>& texture) -> const RefPtr<Texture> {
+        return WTF::switchOn(*resolveTarget, [&](const WeakPtr<Texture>& texture) -> Texture* {
             return texture.get();
-        }, [&](const WeakPtr<TextureView>&) -> const RefPtr<Texture> {
+        }, [&](const WeakPtr<TextureView>&) -> Texture* {
             return nullptr;
         });
     }
-    RefPtr<TextureView> protectedResolveTarget() const
+    TextureView* resolveTextureView() const
     {
         if (!resolveTarget)
             return nullptr;
 
-        return WTF::switchOn(*resolveTarget, [&](const WeakPtr<Texture>&) -> const RefPtr<TextureView> {
+        return WTF::switchOn(*resolveTarget, [&](const WeakPtr<Texture>&) -> TextureView* {
             return nullptr;
-        }, [&](const WeakPtr<TextureView>& view) -> const RefPtr<TextureView> {
-            return view.get();
+        }, [&](const WeakPtr<TextureView>& textureView) -> TextureView* {
+            return textureView.get();
         });
     }
 };

--- a/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
+++ b/Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h
@@ -52,20 +52,20 @@ struct RenderPassDepthStencilAttachment {
     std::optional<StoreOp> stencilStoreOp;
     bool stencilReadOnly { false };
 
-    RefPtr<Texture> protectedTexture() const
+    Texture* texture() const
     {
-        return WTF::switchOn(view, [&](const WeakRef<Texture>& texture) -> const RefPtr<Texture> {
+        return WTF::switchOn(view, [&](const WeakRef<Texture>& texture) -> Texture* {
             return texture.ptr();
-        }, [&](const WeakRef<TextureView>&) -> const RefPtr<Texture> {
+        }, [&](const WeakRef<TextureView>&) -> Texture* {
             return nullptr;
         });
     }
-    RefPtr<TextureView> protectedView() const
+    TextureView* textureView() const
     {
-        return WTF::switchOn(view, [&](const WeakRef<Texture>&) -> const RefPtr<TextureView> {
+        return WTF::switchOn(view, [&](const WeakRef<Texture>&) -> TextureView* {
             return nullptr;
-        }, [&](const WeakRef<TextureView>& view) -> const RefPtr<TextureView> {
-            return view.ptr();
+        }, [&](const WeakRef<TextureView>& textureView) -> TextureView* {
+            return textureView.ptr();
         });
     }
 };

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -402,13 +402,6 @@ GPUConnectionToWebProcess::~GPUConnectionToWebProcess()
     --gObjectCountForTesting;
 }
 
-#if PLATFORM(COCOA) && USE(LIBWEBRTC)
-Ref<LibWebRTCCodecsProxy> GPUConnectionToWebProcess::protectedLibWebRTCCodecsProxy() const
-{
-    return *m_libWebRTCCodecsProxy.get();
-}
-#endif
-
 Ref<RemoteSharedResourceCache> GPUConnectionToWebProcess::sharedResourceCache()
 {
     if (!m_sharedResourceCache)
@@ -563,7 +556,7 @@ bool GPUConnectionToWebProcess::allowsExitUnderMemoryPressure() const
         return false;
 #endif
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
-    if (!protectedLibWebRTCCodecsProxy()->allowsExitUnderMemoryPressure())
+    if (!protect(m_libWebRTCCodecsProxy.get())->allowsExitUnderMemoryPressure())
         return false;
 #endif
     return true;
@@ -1247,7 +1240,7 @@ void GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess(SharedPrefe
 {
     m_sharedPreferencesForWebProcess = WTF::move(sharedPreferencesForWebProcess);
 #if PLATFORM(COCOA) && USE(LIBWEBRTC)
-    protectedLibWebRTCCodecsProxy()->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
+    protect(m_libWebRTCCodecsProxy.get())->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);
 #endif
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     m_sampleBufferDisplayLayerManager->updateSharedPreferencesForWebProcess(m_sharedPreferencesForWebProcess);

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -284,10 +284,6 @@ public:
 private:
     GPUConnectionToWebProcess(GPUProcess&, WebCore::ProcessIdentifier, PAL::SessionID, IPC::Connection::Handle&&, GPUProcessConnectionParameters&&);
 
-#if PLATFORM(COCOA) && USE(LIBWEBRTC)
-    Ref<LibWebRTCCodecsProxy> protectedLibWebRTCCodecsProxy() const;
-#endif
-
 #if ENABLE(WEB_AUDIO)
     RemoteAudioDestinationManager& remoteAudioDestinationManager();
 #endif

--- a/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp
@@ -94,7 +94,7 @@ RefPtr<PixelBuffer> ImageBufferShareableAllocator::createPixelBuffer(const Pixel
     if (!pixelBuffer)
         return nullptr;
 
-    auto handle = pixelBuffer->protectedData()->createHandle(SharedMemory::Protection::ReadOnly);
+    auto handle = protect(pixelBuffer->data())->createHandle(SharedMemory::Protection::ReadOnly);
     if (!handle)
         return nullptr;
 

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -71,7 +71,7 @@ void RemoteMesh::stopListeningForIPC()
 
 void RemoteMesh::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteMesh::setLabel(String&& label)

--- a/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp
@@ -57,9 +57,4 @@ RefPtr<PixelBuffer> ShareablePixelBuffer::createScratchPixelBuffer(const IntSize
     return ShareablePixelBuffer::tryCreate(format(), size);
 }
 
-Ref<WebCore::SharedMemory> ShareablePixelBuffer::protectedData() const
-{
-    return m_data;
-}
-
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.h
@@ -38,7 +38,6 @@ public:
     static RefPtr<ShareablePixelBuffer> tryCreate(const WebCore::PixelBufferFormat&, const WebCore::IntSize&);
 
     WebCore::SharedMemory& data() const { return m_data.get(); }
-    Ref<WebCore::SharedMemory> NODELETE protectedData() const;
 
     RefPtr<WebCore::PixelBuffer> createScratchPixelBuffer(const WebCore::IntSize&) const override;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp
@@ -59,7 +59,7 @@ RemoteAdapter::~RemoteAdapter() = default;
 
 void RemoteAdapter::destruct()
 {
-    protectedObjectHeap()->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteAdapter::stopListeningForIPC()
@@ -76,7 +76,7 @@ void RemoteAdapter::requestDevice(const WebGPU::DeviceDescriptor& descriptor, We
         return;
     }
 
-    Ref { m_backing }->requestDevice(*convertedDescriptor, [callback = WTF::move(callback), objectHeap = protectedObjectHeap(), streamConnection = m_streamConnection.copyRef(), identifier, queueIdentifier, gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get(), gpu = protectedGPU()] (RefPtr<WebCore::WebGPU::Device>&& devicePtr) mutable {
+    protect(m_backing)->requestDevice(*convertedDescriptor, [callback = WTF::move(callback), objectHeap = protect(m_objectHeap), streamConnection = protect(m_streamConnection), identifier, queueIdentifier, gpuConnectionToWebProcess = m_gpuConnectionToWebProcess.get(), gpu = protect(m_gpu)] (RefPtr<WebCore::WebGPU::Device>&& devicePtr) mutable {
         if (!devicePtr.get() || !gpuConnectionToWebProcess) {
             callback({ }, { });
             return;

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h
@@ -78,8 +78,6 @@ private:
     RemoteAdapter& operator=(RemoteAdapter&&) = delete;
 
     WebCore::WebGPU::Adapter& backing() { return m_backing; }
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp
@@ -47,42 +47,32 @@ RemoteBindGroup::RemoteBindGroup(WebCore::WebGPU::BindGroup& bindGroup, WebGPU::
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteBindGroup::~RemoteBindGroup() = default;
 
 void RemoteBindGroup::destruct()
 {
-    protectedObjectHeap()->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteBindGroup::updateExternalTextures(WebGPUIdentifier externalTextureIdentifier, CompletionHandler<void(bool)>&& completion)
 {
-    if (auto externalTexture = protectedObjectHeap()->convertExternalTextureFromBacking(externalTextureIdentifier); externalTexture.get())
-        completion(protectedBacking()->updateExternalTextures(*externalTexture.get()));
+    if (auto externalTexture = protect(m_objectHeap)->convertExternalTextureFromBacking(externalTextureIdentifier); externalTexture.get())
+        completion(protect(m_backing)->updateExternalTextures(*externalTexture.get()));
     else
         completion(false);
 }
 
 void RemoteBindGroup::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteBindGroup::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteBindGroup::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::BindGroup> RemoteBindGroup::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteBindGroup::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h
@@ -74,10 +74,6 @@ private:
     RemoteBindGroup& operator=(RemoteBindGroup&&) = delete;
 
     WebCore::WebGPU::BindGroup& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::BindGroup> NODELETE protectedBacking();
-
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp
@@ -45,29 +45,24 @@ RemoteBindGroupLayout::RemoteBindGroupLayout(WebCore::WebGPU::BindGroupLayout& b
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteBindGroupLayout::~RemoteBindGroupLayout() = default;
 
 void RemoteBindGroupLayout::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteBindGroupLayout::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteBindGroupLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteBindGroupLayout::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTF::move(label));
-}
-
-Ref<IPC::StreamServerConnection> RemoteBindGroupLayout::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h
@@ -75,8 +75,6 @@ private:
 
     WebCore::WebGPU::BindGroupLayout& backing() { return m_backing; }
 
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
-
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h
@@ -83,9 +83,6 @@ private:
     RemoteBuffer& operator=(RemoteBuffer&&) = delete;
 
     WebCore::WebGPU::Buffer& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::Buffer> NODELETE protectedBacking();
-
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp
@@ -45,29 +45,24 @@ RemoteCommandBuffer::RemoteCommandBuffer(WebCore::WebGPU::CommandBuffer& command
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteCommandBuffer::~RemoteCommandBuffer() = default;
 
 void RemoteCommandBuffer::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteCommandBuffer::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteCommandBuffer::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteCommandBuffer::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTF::move(label));
-}
-
-Ref<IPC::StreamServerConnection> RemoteCommandBuffer::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h
@@ -74,7 +74,6 @@ private:
     RemoteCommandBuffer& operator=(RemoteCommandBuffer&&) = delete;
 
     WebCore::WebGPU::CommandBuffer& backing() { return m_backing; }
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h
@@ -84,10 +84,6 @@ private:
     RemoteCommandEncoder& operator=(RemoteCommandEncoder&&) = delete;
 
     WebCore::WebGPU::CommandEncoder& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::CommandEncoder> NODELETE protectedBacking();
-
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp
@@ -50,20 +50,20 @@ RemoteCompositorIntegration::RemoteCompositorIntegration(WebCore::WebGPU::Compos
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteCompositorIntegration::~RemoteCompositorIntegration() = default;
 
 void RemoteCompositorIntegration::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteCompositorIntegration::paintCompositedResultsToCanvas(WebCore::RenderingResourceIdentifier imageBufferIdentifier, uint32_t bufferIndex, CompletionHandler<void()>&& completionHandler)
 {
     UNUSED_PARAM(imageBufferIdentifier);
-    protectedBacking()->withDisplayBufferAsNativeImage(bufferIndex, [gpu = m_gpu, imageBufferIdentifier, completionHandler = WTF::move(completionHandler)] (WebCore::NativeImage* image) mutable {
+    protect(m_backing)->withDisplayBufferAsNativeImage(bufferIndex, [gpu = m_gpu, imageBufferIdentifier, completionHandler = WTF::move(completionHandler)] (WebCore::NativeImage* image) mutable {
         if (image && gpu.ptr())
             gpu->paintNativeImageToImageBuffer(*image, imageBufferIdentifier);
         completionHandler();
@@ -72,39 +72,29 @@ void RemoteCompositorIntegration::paintCompositedResultsToCanvas(WebCore::Render
 
 void RemoteCompositorIntegration::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteCompositorIntegration::messageReceiverName(), m_identifier.toUInt64());
 }
 
 #if PLATFORM(COCOA)
 void RemoteCompositorIntegration::recreateRenderBuffers(int width, int height, WebCore::DestinationColorSpace&& destinationColorSpace, WebCore::AlphaPremultiplication alphaMode, WebCore::WebGPU::TextureFormat textureFormat, unsigned bufferCount, WebKit::WebGPUIdentifier deviceIdentifier, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
 {
-    auto convertedDevice = protectedObjectHeap()->convertDeviceFromBacking(deviceIdentifier);
+    auto convertedDevice = protect(m_objectHeap)->convertDeviceFromBacking(deviceIdentifier);
     MESSAGE_CHECK_COMPLETION(convertedDevice, callback({ }));
 
-    callback(protectedBacking()->recreateRenderBuffers(width, height, WTF::move(destinationColorSpace), alphaMode, textureFormat, bufferCount, *convertedDevice));
+    callback(protect(m_backing)->recreateRenderBuffers(width, height, WTF::move(destinationColorSpace), alphaMode, textureFormat, bufferCount, *convertedDevice));
 }
 #endif
 
 void RemoteCompositorIntegration::prepareForDisplay(uint32_t frameIndex, CompletionHandler<void(bool)>&& completionHandler)
 {
-    protectedBacking()->prepareForDisplay(frameIndex, [completionHandler = WTF::move(completionHandler)]() mutable {
+    protect(m_backing)->prepareForDisplay(frameIndex, [completionHandler = WTF::move(completionHandler)]() mutable {
         completionHandler(true);
     });
 }
 
-Ref<WebCore::WebGPU::CompositorIntegration> RemoteCompositorIntegration::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteCompositorIntegration::protectedStreamConnection() const
-{
-    return m_streamConnection;
-}
-
 void RemoteCompositorIntegration::updateContentsHeadroom(float headroom)
 {
-    protectedBacking()->updateContentsHeadroom(headroom);
+    protect(m_backing)->updateContentsHeadroom(headroom);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h
@@ -90,12 +90,6 @@ private:
     RemoteCompositorIntegration& operator=(RemoteCompositorIntegration&&) = delete;
 
     WebCore::WebGPU::CompositorIntegration& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::CompositorIntegration> NODELETE protectedBacking();
-
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
-
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp
@@ -48,100 +48,85 @@ RemoteComputePassEncoder::RemoteComputePassEncoder(WebCore::WebGPU::ComputePassE
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteComputePassEncoder::~RemoteComputePassEncoder() = default;
 
 void RemoteComputePassEncoder::destruct()
 {
-    protectedObjectHeap()->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteComputePassEncoder::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteComputePassEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteComputePassEncoder::setPipeline(WebGPUIdentifier computePipeline)
 {
-    auto convertedComputePipeline = protectedObjectHeap()->convertComputePipelineFromBacking(computePipeline);
+    auto convertedComputePipeline = protect(m_objectHeap)->convertComputePipelineFromBacking(computePipeline);
     ASSERT(convertedComputePipeline);
     if (!convertedComputePipeline)
         return;
 
-    protectedBacking()->setPipeline(*convertedComputePipeline);
+    protect(m_backing)->setPipeline(*convertedComputePipeline);
 }
 
 void RemoteComputePassEncoder::dispatch(WebCore::WebGPU::Size32 workgroupCountX, WebCore::WebGPU::Size32 workgroupCountY, WebCore::WebGPU::Size32 workgroupCountZ)
 {
-    protectedBacking()->dispatch(workgroupCountX, workgroupCountY, workgroupCountZ);
+    protect(m_backing)->dispatch(workgroupCountX, workgroupCountY, workgroupCountZ);
 }
 
 void RemoteComputePassEncoder::dispatchIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = protectedObjectHeap()->convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
-    protectedBacking()->dispatchIndirect(*convertedIndirectBuffer, indirectOffset);
+    protect(m_backing)->dispatchIndirect(*convertedIndirectBuffer, indirectOffset);
 }
 
 void RemoteComputePassEncoder::end()
 {
-    protectedBacking()->end();
+    protect(m_backing)->end();
 }
 
 void RemoteComputePassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std::optional<WebGPUIdentifier> bindGroup,
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& offsets)
 {
     if (!bindGroup) {
-        protectedBacking()->setBindGroup(index, nullptr, WTF::move(offsets));
+        protect(m_backing)->setBindGroup(index, nullptr, WTF::move(offsets));
         return;
     }
 
-    RefPtr convertedBindGroup = protectedObjectHeap()->convertBindGroupFromBacking(*bindGroup).get();
+    RefPtr convertedBindGroup = protect(m_objectHeap)->convertBindGroupFromBacking(*bindGroup).get();
     ASSERT(convertedBindGroup);
     if (!convertedBindGroup)
         return;
 
-    protectedBacking()->setBindGroup(index, convertedBindGroup.get(), WTF::move(offsets));
+    protect(m_backing)->setBindGroup(index, convertedBindGroup.get(), WTF::move(offsets));
 }
 
 void RemoteComputePassEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
+    protect(m_backing)->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void RemoteComputePassEncoder::popDebugGroup()
 {
-    protectedBacking()->popDebugGroup();
+    protect(m_backing)->popDebugGroup();
 }
 
 void RemoteComputePassEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
+    protect(m_backing)->insertDebugMarker(WTF::move(markerLabel));
 }
 
 void RemoteComputePassEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::ComputePassEncoder> RemoteComputePassEncoder::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteComputePassEncoder::protectedStreamConnection() const
-{
-    return m_streamConnection;
-}
-
-Ref<WebGPU::ObjectHeap> RemoteComputePassEncoder::protectedObjectHeap() const
-{
-    return m_objectHeap;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h
@@ -75,10 +75,6 @@ private:
     RemoteComputePassEncoder& operator=(RemoteComputePassEncoder&&) = delete;
 
     WebCore::WebGPU::ComputePassEncoder& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::ComputePassEncoder> NODELETE protectedBacking();
-
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
-    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp
@@ -47,43 +47,33 @@ RemoteComputePipeline::RemoteComputePipeline(WebCore::WebGPU::ComputePipeline& c
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteComputePipeline::~RemoteComputePipeline() = default;
 
 void RemoteComputePipeline::destruct()
 {
-    protectedObjectHeap()->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteComputePipeline::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteComputePipeline::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteComputePipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier identifier)
 {
     // "A new GPUBindGroupLayout wrapper is returned each time"
     Ref objectHeap = m_objectHeap.get();
-    auto bindGroupLayout = protectedBacking()->getBindGroupLayout(index);
-    auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto bindGroupLayout = protect(m_backing)->getBindGroupLayout(index);
+    auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteBindGroupLayout);
 }
 
 void RemoteComputePipeline::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::ComputePipeline> RemoteComputePipeline::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteComputePipeline::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h
@@ -74,12 +74,6 @@ private:
     RemoteComputePipeline& operator=(RemoteComputePipeline&&) = delete;
 
     WebCore::WebGPU::ComputePipeline& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::ComputePipeline> NODELETE protectedBacking();
-
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
-
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp
@@ -124,14 +124,14 @@ void RemoteDevice::destroy()
 
 void RemoteDevice::destruct()
 {
-    protectedObjectHeap()->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteDevice::createXRBinding(WebGPUIdentifier identifier)
 {
     Ref objectHeap = m_objectHeap.get();
     auto binding = m_backing->createXRBinding();
-    auto remoteBinding = RemoteXRBinding::create(*m_gpuConnectionToWebProcess.get(), *binding, objectHeap, protectedGPU(), m_streamConnection.copyRef(), identifier);
+    auto remoteBinding = RemoteXRBinding::create(*m_gpuConnectionToWebProcess.get(), *binding, objectHeap, protect(m_gpu), protect(m_streamConnection), identifier);
     objectHeap->addObject(identifier, remoteBinding);
 }
 
@@ -143,7 +143,7 @@ void RemoteDevice::createBuffer(const WebGPU::BufferDescriptor& descriptor, WebG
 
     auto buffer = m_backing->createBuffer(*convertedDescriptor);
     MESSAGE_CHECK(buffer);
-    auto remoteBuffer = RemoteBuffer::create(*buffer, objectHeap, m_streamConnection.copyRef(), protectedGPU(), descriptor.mappedAtCreation, identifier);
+    auto remoteBuffer = RemoteBuffer::create(*buffer, objectHeap, protect(m_streamConnection), protect(m_gpu), descriptor.mappedAtCreation, identifier);
     objectHeap->addObject(identifier, remoteBuffer);
 }
 
@@ -155,7 +155,7 @@ void RemoteDevice::createTexture(const WebGPU::TextureDescriptor& descriptor, We
 
     auto texture = m_backing->createTexture(*convertedDescriptor);
     MESSAGE_CHECK(texture);
-    auto remoteTexture = RemoteTexture::create(*m_gpuConnectionToWebProcess.get(), protectedGPU(), texture.releaseNonNull(), objectHeap, m_streamConnection.copyRef(), identifier);
+    auto remoteTexture = RemoteTexture::create(*m_gpuConnectionToWebProcess.get(), protect(m_gpu), texture.releaseNonNull(), objectHeap, protect(m_streamConnection), identifier);
     objectHeap->addObject(identifier, remoteTexture);
 }
 
@@ -167,7 +167,7 @@ void RemoteDevice::createSampler(const WebGPU::SamplerDescriptor& descriptor, We
 
     auto sampler = m_backing->createSampler(*convertedDescriptor);
     MESSAGE_CHECK(sampler);
-    auto remoteSampler = RemoteSampler::create(*sampler, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteSampler = RemoteSampler::create(*sampler, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteSampler);
 }
 
@@ -211,13 +211,13 @@ void RemoteDevice::importExternalTextureFromVideoFrame(const WebGPU::ExternalTex
 
     auto externalTexture = m_backing->importExternalTexture(*convertedDescriptor);
     MESSAGE_CHECK(externalTexture);
-    auto remoteExternalTexture = RemoteExternalTexture::create(*externalTexture, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteExternalTexture = RemoteExternalTexture::create(*externalTexture, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteExternalTexture);
 }
 
 void RemoteDevice::updateExternalTexture(WebKit::WebGPUIdentifier externalTextureIdentifier, const WebCore::MediaPlayerIdentifier& mediaPlayerIdentifier)
 {
-    auto externalTexture = protectedObjectHeap()->convertExternalTextureFromBacking(externalTextureIdentifier);
+    auto externalTexture = protect(m_objectHeap)->convertExternalTextureFromBacking(externalTextureIdentifier);
     if (!externalTexture.get())
         return;
 
@@ -245,7 +245,7 @@ void RemoteDevice::createBindGroupLayout(const WebGPU::BindGroupLayoutDescriptor
 
     auto bindGroupLayout = m_backing->createBindGroupLayout(*convertedDescriptor);
     MESSAGE_CHECK(bindGroupLayout);
-    auto remoteBindGroupLayout = RemoteBindGroupLayout::create(*bindGroupLayout, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteBindGroupLayout = RemoteBindGroupLayout::create(*bindGroupLayout, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteBindGroupLayout);
 }
 
@@ -257,7 +257,7 @@ void RemoteDevice::createPipelineLayout(const WebGPU::PipelineLayoutDescriptor& 
 
     auto pipelineLayout = m_backing->createPipelineLayout(*convertedDescriptor);
     MESSAGE_CHECK(pipelineLayout);
-    auto remotePipelineLayout = RemotePipelineLayout::create(*pipelineLayout,  objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remotePipelineLayout = RemotePipelineLayout::create(*pipelineLayout,  objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remotePipelineLayout);
 }
 
@@ -269,7 +269,7 @@ void RemoteDevice::createBindGroup(const WebGPU::BindGroupDescriptor& descriptor
 
     auto bindGroup = m_backing->createBindGroup(*convertedDescriptor);
     MESSAGE_CHECK(bindGroup);
-    auto remoteBindGroup = RemoteBindGroup::create(*bindGroup, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteBindGroup = RemoteBindGroup::create(*bindGroup, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteBindGroup);
 }
 
@@ -281,7 +281,7 @@ void RemoteDevice::createShaderModule(const WebGPU::ShaderModuleDescriptor& desc
 
     auto shaderModule = m_backing->createShaderModule(*convertedDescriptor);
     MESSAGE_CHECK(shaderModule);
-    auto remoteShaderModule = RemoteShaderModule::create(*shaderModule, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteShaderModule = RemoteShaderModule::create(*shaderModule, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteShaderModule);
 
 }
@@ -294,7 +294,7 @@ void RemoteDevice::createComputePipeline(const WebGPU::ComputePipelineDescriptor
 
     auto computePipeline = m_backing->createComputePipeline(*convertedDescriptor);
     MESSAGE_CHECK(computePipeline);
-    auto remoteComputePipeline = RemoteComputePipeline::create(*computePipeline, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteComputePipeline = RemoteComputePipeline::create(*computePipeline, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteComputePipeline);
 }
 
@@ -306,7 +306,7 @@ void RemoteDevice::createRenderPipeline(const WebGPU::RenderPipelineDescriptor& 
 
     auto renderPipeline = m_backing->createRenderPipeline(*convertedDescriptor);
     MESSAGE_CHECK(renderPipeline);
-    auto remoteRenderPipeline = RemoteRenderPipeline::create(*renderPipeline, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteRenderPipeline = RemoteRenderPipeline::create(*renderPipeline, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteRenderPipeline);
 }
 
@@ -320,7 +320,7 @@ void RemoteDevice::createComputePipelineAsync(const WebGPU::ComputePipelineDescr
         return;
     }
 
-    m_backing->createComputePipelineAsync(*convertedDescriptor, [callback = WTF::move(callback), objectHeap, streamConnection = m_streamConnection.copyRef(), gpu = protectedGPU(), identifier] (RefPtr<WebCore::WebGPU::ComputePipeline>&& computePipeline, String&& error) mutable {
+    m_backing->createComputePipelineAsync(*convertedDescriptor, [callback = WTF::move(callback), objectHeap, streamConnection = protect(m_streamConnection), gpu = protect(m_gpu), identifier] (RefPtr<WebCore::WebGPU::ComputePipeline>&& computePipeline, String&& error) mutable {
         bool result = computePipeline.get();
         if (result) {
             auto remoteComputePipeline = RemoteComputePipeline::create(computePipeline.releaseNonNull(), objectHeap, WTF::move(streamConnection), gpu, identifier);
@@ -340,7 +340,7 @@ void RemoteDevice::createRenderPipelineAsync(const WebGPU::RenderPipelineDescrip
         return;
     }
 
-    m_backing->createRenderPipelineAsync(*convertedDescriptor, [callback = WTF::move(callback), objectHeap, streamConnection = m_streamConnection.copyRef(), gpu = protectedGPU(), identifier] (RefPtr<WebCore::WebGPU::RenderPipeline>&& renderPipeline, String&& error) mutable {
+    m_backing->createRenderPipelineAsync(*convertedDescriptor, [callback = WTF::move(callback), objectHeap, streamConnection = protect(m_streamConnection), gpu = protect(m_gpu), identifier] (RefPtr<WebCore::WebGPU::RenderPipeline>&& renderPipeline, String&& error) mutable {
         bool result = renderPipeline.get();
         if (result) {
             auto remoteRenderPipeline = RemoteRenderPipeline::create(renderPipeline.releaseNonNull(), objectHeap, WTF::move(streamConnection), gpu, identifier);
@@ -361,7 +361,7 @@ void RemoteDevice::createCommandEncoder(const std::optional<WebGPU::CommandEncod
     }
     auto commandEncoder = m_backing->createCommandEncoder(convertedDescriptor);
     MESSAGE_CHECK(commandEncoder);
-    auto remoteCommandEncoder = RemoteCommandEncoder::create(*m_gpuConnectionToWebProcess.get(), protectedGPU(), *commandEncoder, objectHeap, m_streamConnection.copyRef(), identifier);
+    auto remoteCommandEncoder = RemoteCommandEncoder::create(*m_gpuConnectionToWebProcess.get(), protect(m_gpu), *commandEncoder, objectHeap, protect(m_streamConnection), identifier);
     objectHeap->addObject(identifier, remoteCommandEncoder);
 }
 
@@ -373,7 +373,7 @@ void RemoteDevice::createRenderBundleEncoder(const WebGPU::RenderBundleEncoderDe
 
     auto renderBundleEncoder = m_backing->createRenderBundleEncoder(*convertedDescriptor);
     MESSAGE_CHECK(renderBundleEncoder);
-    auto remoteRenderBundleEncoder = RemoteRenderBundleEncoder::create(*m_gpuConnectionToWebProcess.get(), protectedGPU(), *renderBundleEncoder, objectHeap, m_streamConnection.copyRef(), identifier);
+    auto remoteRenderBundleEncoder = RemoteRenderBundleEncoder::create(*m_gpuConnectionToWebProcess.get(), protect(m_gpu), *renderBundleEncoder, objectHeap, protect(m_streamConnection), identifier);
     objectHeap->addObject(identifier, remoteRenderBundleEncoder);
 }
 
@@ -385,7 +385,7 @@ void RemoteDevice::createQuerySet(const WebGPU::QuerySetDescriptor& descriptor, 
 
     auto querySet = m_backing->createQuerySet(*convertedDescriptor);
     MESSAGE_CHECK(querySet);
-    auto remoteQuerySet = RemoteQuerySet::create(*querySet, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteQuerySet = RemoteQuerySet::create(*querySet, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteQuerySet);
 }
 
@@ -440,11 +440,6 @@ void RemoteDevice::resolveDeviceLostPromise(CompletionHandler<void(WebCore::WebG
 void RemoteDevice::setLabel(String&& label)
 {
     m_backing->setLabel(WTF::move(label));
-}
-
-Ref<WebGPU::ObjectHeap> RemoteDevice::protectedObjectHeap() const
-{
-    return m_objectHeap;
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h
@@ -115,8 +115,6 @@ private:
     RemoteDevice& operator=(RemoteDevice&&) = delete;
 
     WebCore::WebGPU::Device& backing() { return m_backing; }
-    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp
@@ -45,44 +45,34 @@ RemoteExternalTexture::RemoteExternalTexture(WebCore::WebGPU::ExternalTexture& e
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteExternalTexture::~RemoteExternalTexture() = default;
 
 void RemoteExternalTexture::destroy()
 {
-    protectedBacking()->destroy();
+    protect(m_backing)->destroy();
 }
 
 void RemoteExternalTexture::undestroy()
 {
-    protectedBacking()->undestroy();
+    protect(m_backing)->undestroy();
 }
 
 void RemoteExternalTexture::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteExternalTexture::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteExternalTexture::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteExternalTexture::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::ExternalTexture> RemoteExternalTexture::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteExternalTexture::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h
@@ -74,9 +74,6 @@ private:
     RemoteExternalTexture& operator=(RemoteExternalTexture&&) = delete;
 
     WebCore::WebGPU::ExternalTexture& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::ExternalTexture> NODELETE protectedBacking();
-
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -109,7 +109,6 @@ private:
 
     void initialize();
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
-    Ref<IPC::StreamConnectionWorkQueue> protectedWorkQueue() const { return m_workQueue; }
     void workQueueInitialize();
     void workQueueUninitialize();
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp
@@ -45,29 +45,24 @@ RemotePipelineLayout::RemotePipelineLayout(WebCore::WebGPU::PipelineLayout& pipe
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemotePipelineLayout::~RemotePipelineLayout() = default;
 
 void RemotePipelineLayout::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemotePipelineLayout::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemotePipelineLayout::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemotePipelineLayout::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTF::move(label));
-}
-
-Ref<IPC::StreamServerConnection> RemotePipelineLayout::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h
@@ -74,7 +74,6 @@ private:
     RemotePipelineLayout& operator=(RemotePipelineLayout&&) = delete;
 
     WebCore::WebGPU::PipelineLayout& backing() { return m_backing; }
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h
@@ -77,10 +77,6 @@ private:
     RemotePresentationContext& operator=(RemotePresentationContext&&) = delete;
 
     WebCore::WebGPU::PresentationContext& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::PresentationContext> NODELETE protectedBacking();
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
-    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp
@@ -45,39 +45,29 @@ RemoteQuerySet::RemoteQuerySet(WebCore::WebGPU::QuerySet& querySet, WebGPU::Obje
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteQuerySet::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteQuerySet::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteQuerySet::~RemoteQuerySet() = default;
 
 void RemoteQuerySet::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteQuerySet::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteQuerySet::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteQuerySet::destroy()
 {
-    protectedBacking()->destroy();
+    protect(m_backing)->destroy();
 }
 
 void RemoteQuerySet::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteQuerySet::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::QuerySet> RemoteQuerySet::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteQuerySet::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h
@@ -74,9 +74,6 @@ private:
     RemoteQuerySet& operator=(RemoteQuerySet&&) = delete;
 
     WebCore::WebGPU::QuerySet& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::QuerySet> NODELETE protectedBacking();
-
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h
@@ -87,9 +87,6 @@ private:
     RemoteQueue& operator=(RemoteQueue&&) = delete;
 
     WebCore::WebGPU::Queue& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::Queue> NODELETE protectedBacking();
-
-    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp
@@ -45,29 +45,24 @@ RemoteRenderBundle::RemoteRenderBundle(WebCore::WebGPU::RenderBundle& renderBund
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteRenderBundle::~RemoteRenderBundle() = default;
 
 void RemoteRenderBundle::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteRenderBundle::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteRenderBundle::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteRenderBundle::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTF::move(label));
-}
-
-Ref<IPC::StreamServerConnection> RemoteRenderBundle::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h
@@ -75,8 +75,6 @@ private:
 
     WebCore::WebGPU::RenderBundle& backing() { return m_backing; }
 
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
-
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 
     void setLabel(String&&);

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp
@@ -55,60 +55,60 @@ RemoteRenderBundleEncoder::RemoteRenderBundleEncoder(GPUConnectionToWebProcess& 
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteRenderBundleEncoder::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteRenderBundleEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteRenderBundleEncoder::~RemoteRenderBundleEncoder() = default;
 
 void RemoteRenderBundleEncoder::destruct()
 {
-    protectedObjectHeap()->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteRenderBundleEncoder::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteRenderBundleEncoder::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteRenderBundleEncoder::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteRenderBundleEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 {
-    auto convertedRenderPipeline = protectedObjectHeap()->convertRenderPipelineFromBacking(renderPipeline);
+    auto convertedRenderPipeline = protect(m_objectHeap)->convertRenderPipelineFromBacking(renderPipeline);
     ASSERT(convertedRenderPipeline);
     if (!convertedRenderPipeline)
         return;
 
-    protectedBacking()->setPipeline(*convertedRenderPipeline);
+    protect(m_backing)->setPipeline(*convertedRenderPipeline);
 }
 
 void RemoteRenderBundleEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore::WebGPU::IndexFormat indexFormat, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    RefPtr convertedBuffer = protectedObjectHeap()->convertBufferFromBacking(buffer).get();
+    RefPtr convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer).get();
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
 
-    protectedBacking()->setIndexBuffer(*convertedBuffer, indexFormat, offset, size);
+    protect(m_backing)->setIndexBuffer(*convertedBuffer, indexFormat, offset, size);
 }
 
 void RemoteRenderBundleEncoder::setVertexBuffer(WebCore::WebGPU::Index32 slot, WebGPUIdentifier buffer, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    RefPtr convertedBuffer = protectedObjectHeap()->convertBufferFromBacking(buffer).get();
+    RefPtr convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer).get();
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
 
-    protectedBacking()->setVertexBuffer(slot, convertedBuffer.get(), offset, size);
+    protect(m_backing)->setVertexBuffer(slot, convertedBuffer.get(), offset, size);
 }
 
 void RemoteRenderBundleEncoder::unsetVertexBuffer(WebCore::WebGPU::Index32 slot, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    protectedBacking()->setVertexBuffer(slot, nullptr, offset, size);
+    protect(m_backing)->setVertexBuffer(slot, nullptr, offset, size);
 }
 
 void RemoteRenderBundleEncoder::draw(WebCore::WebGPU::Size32 vertexCount, WebCore::WebGPU::Size32 instanceCount,
     WebCore::WebGPU::Size32 firstVertex, WebCore::WebGPU::Size32 firstInstance)
 {
-    protectedBacking()->draw(vertexCount, instanceCount, firstVertex, firstInstance);
+    protect(m_backing)->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
 void RemoteRenderBundleEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount, WebCore::WebGPU::Size32 instanceCount,
@@ -116,58 +116,58 @@ void RemoteRenderBundleEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount, 
     WebCore::WebGPU::SignedOffset32 baseVertex,
     WebCore::WebGPU::Size32 firstInstance)
 {
-    protectedBacking()->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
+    protect(m_backing)->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }
 
 void RemoteRenderBundleEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    RefPtr convertedIndirectBuffer = protectedObjectHeap()->convertBufferFromBacking(indirectBuffer).get();
+    RefPtr convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer).get();
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
-    protectedBacking()->drawIndirect(*convertedIndirectBuffer, indirectOffset);
+    protect(m_backing)->drawIndirect(*convertedIndirectBuffer, indirectOffset);
 }
 
 void RemoteRenderBundleEncoder::drawIndexedIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    RefPtr convertedIndirectBuffer = protectedObjectHeap()->convertBufferFromBacking(indirectBuffer).get();
+    RefPtr convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer).get();
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
-    protectedBacking()->drawIndexedIndirect(*convertedIndirectBuffer, indirectOffset);
+    protect(m_backing)->drawIndexedIndirect(*convertedIndirectBuffer, indirectOffset);
 }
 
 void RemoteRenderBundleEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std::optional<WebGPUIdentifier> bindGroup,
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
     if (!bindGroup) {
-        protectedBacking()->setBindGroup(index, nullptr, WTF::move(dynamicOffsets));
+        protect(m_backing)->setBindGroup(index, nullptr, WTF::move(dynamicOffsets));
         return;
     }
 
-    RefPtr convertedBindGroup = protectedObjectHeap()->convertBindGroupFromBacking(*bindGroup).get();
+    RefPtr convertedBindGroup = protect(m_objectHeap)->convertBindGroupFromBacking(*bindGroup).get();
     ASSERT(convertedBindGroup);
     if (!convertedBindGroup)
         return;
 
-    protectedBacking()->setBindGroup(index, convertedBindGroup.get(), WTF::move(dynamicOffsets));
+    protect(m_backing)->setBindGroup(index, convertedBindGroup.get(), WTF::move(dynamicOffsets));
 }
 
 void RemoteRenderBundleEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
+    protect(m_backing)->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void RemoteRenderBundleEncoder::popDebugGroup()
 {
-    protectedBacking()->popDebugGroup();
+    protect(m_backing)->popDebugGroup();
 }
 
 void RemoteRenderBundleEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
+    protect(m_backing)->insertDebugMarker(WTF::move(markerLabel));
 }
 
 void RemoteRenderBundleEncoder::finish(const WebGPU::RenderBundleDescriptor& descriptor, WebGPUIdentifier identifier)
@@ -176,30 +176,15 @@ void RemoteRenderBundleEncoder::finish(const WebGPU::RenderBundleDescriptor& des
     auto convertedDescriptor = objectHeap->convertFromBacking(descriptor);
     MESSAGE_CHECK(convertedDescriptor);
 
-    auto renderBundle = protectedBacking()->finish(*convertedDescriptor);
+    auto renderBundle = protect(m_backing)->finish(*convertedDescriptor);
     MESSAGE_CHECK(renderBundle);
-    auto remoteRenderBundle = RemoteRenderBundle::create(*renderBundle, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteRenderBundle = RemoteRenderBundle::create(*renderBundle, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteRenderBundle);
 }
 
 void RemoteRenderBundleEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::RenderBundleEncoder> RemoteRenderBundleEncoder::protectedBacking() const
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteRenderBundleEncoder::protectedStreamConnection() const
-{
-    return m_streamConnection;
-}
-
-Ref<WebGPU::ObjectHeap> RemoteRenderBundleEncoder::protectedObjectHeap() const
-{
-    return m_objectHeap;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h
@@ -80,10 +80,6 @@ private:
     RemoteRenderBundleEncoder& operator=(RemoteRenderBundleEncoder&&) = delete;
 
     WebCore::WebGPU::RenderBundleEncoder& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::RenderBundleEncoder> NODELETE protectedBacking() const;
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
-    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp
@@ -56,7 +56,7 @@ RemoteRenderPassEncoder::~RemoteRenderPassEncoder() = default;
 
 void RemoteRenderPassEncoder::destruct()
 {
-    protectedObjectHeap()->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteRenderPassEncoder::stopListeningForIPC()
@@ -66,43 +66,43 @@ void RemoteRenderPassEncoder::stopListeningForIPC()
 
 void RemoteRenderPassEncoder::setPipeline(WebGPUIdentifier renderPipeline)
 {
-    auto convertedRenderPipeline = protectedObjectHeap()->convertRenderPipelineFromBacking(renderPipeline);
+    auto convertedRenderPipeline = protect(m_objectHeap)->convertRenderPipelineFromBacking(renderPipeline);
     ASSERT(convertedRenderPipeline);
     if (!convertedRenderPipeline)
         return;
 
-    protectedBacking()->setPipeline(*convertedRenderPipeline);
+    protect(m_backing)->setPipeline(*convertedRenderPipeline);
 }
 
 void RemoteRenderPassEncoder::setIndexBuffer(WebGPUIdentifier buffer, WebCore::WebGPU::IndexFormat indexFormat, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    auto convertedBuffer = protectedObjectHeap()->convertBufferFromBacking(buffer);
+    auto convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer);
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
 
-    protectedBacking()->setIndexBuffer(*convertedBuffer, indexFormat, offset, size);
+    protect(m_backing)->setIndexBuffer(*convertedBuffer, indexFormat, offset, size);
 }
 
 void RemoteRenderPassEncoder::setVertexBuffer(WebCore::WebGPU::Index32 slot, WebGPUIdentifier buffer, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    RefPtr convertedBuffer = protectedObjectHeap()->convertBufferFromBacking(buffer).get();
+    RefPtr convertedBuffer = protect(m_objectHeap)->convertBufferFromBacking(buffer).get();
     ASSERT(convertedBuffer);
     if (!convertedBuffer)
         return;
 
-    protectedBacking()->setVertexBuffer(slot, convertedBuffer.get(), offset, size);
+    protect(m_backing)->setVertexBuffer(slot, convertedBuffer.get(), offset, size);
 }
 
 void RemoteRenderPassEncoder::unsetVertexBuffer(WebCore::WebGPU::Index32 slot, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> size)
 {
-    protectedBacking()->setVertexBuffer(slot, nullptr, offset, size);
+    protect(m_backing)->setVertexBuffer(slot, nullptr, offset, size);
 }
 
 void RemoteRenderPassEncoder::draw(WebCore::WebGPU::Size32 vertexCount, WebCore::WebGPU::Size32 instanceCount,
     WebCore::WebGPU::Size32 firstVertex, WebCore::WebGPU::Size32 firstInstance)
 {
-    protectedBacking()->draw(vertexCount, instanceCount, firstVertex, firstInstance);
+    protect(m_backing)->draw(vertexCount, instanceCount, firstVertex, firstInstance);
 }
 
 void RemoteRenderPassEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount,
@@ -111,95 +111,95 @@ void RemoteRenderPassEncoder::drawIndexed(WebCore::WebGPU::Size32 indexCount,
     WebCore::WebGPU::SignedOffset32 baseVertex,
     WebCore::WebGPU::Size32 firstInstance)
 {
-    protectedBacking()->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
+    protect(m_backing)->drawIndexed(indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
 }
 
 void RemoteRenderPassEncoder::drawIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = protectedObjectHeap()->convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
-    protectedBacking()->drawIndirect(*convertedIndirectBuffer, indirectOffset);
+    protect(m_backing)->drawIndirect(*convertedIndirectBuffer, indirectOffset);
 }
 
 void RemoteRenderPassEncoder::drawIndexedIndirect(WebGPUIdentifier indirectBuffer, WebCore::WebGPU::Size64 indirectOffset)
 {
-    auto convertedIndirectBuffer = protectedObjectHeap()->convertBufferFromBacking(indirectBuffer);
+    auto convertedIndirectBuffer = protect(m_objectHeap)->convertBufferFromBacking(indirectBuffer);
     ASSERT(convertedIndirectBuffer);
     if (!convertedIndirectBuffer)
         return;
 
-    protectedBacking()->drawIndexedIndirect(*convertedIndirectBuffer, indirectOffset);
+    protect(m_backing)->drawIndexedIndirect(*convertedIndirectBuffer, indirectOffset);
 }
 
 void RemoteRenderPassEncoder::setBindGroup(WebCore::WebGPU::Index32 index, std::optional<WebGPUIdentifier> bindGroup,
     std::optional<Vector<WebCore::WebGPU::BufferDynamicOffset>>&& dynamicOffsets)
 {
     if (!bindGroup) {
-        protectedBacking()->setBindGroup(index, nullptr, WTF::move(dynamicOffsets));
+        protect(m_backing)->setBindGroup(index, nullptr, WTF::move(dynamicOffsets));
         return;
     }
 
-    RefPtr convertedBindGroup = protectedObjectHeap()->convertBindGroupFromBacking(*bindGroup).get();
+    RefPtr convertedBindGroup = protect(m_objectHeap)->convertBindGroupFromBacking(*bindGroup).get();
     if (!convertedBindGroup)
         return;
 
-    protectedBacking()->setBindGroup(index, convertedBindGroup.get(), WTF::move(dynamicOffsets));
+    protect(m_backing)->setBindGroup(index, convertedBindGroup.get(), WTF::move(dynamicOffsets));
 }
 
 void RemoteRenderPassEncoder::pushDebugGroup(String&& groupLabel)
 {
-    protectedBacking()->pushDebugGroup(WTF::move(groupLabel));
+    protect(m_backing)->pushDebugGroup(WTF::move(groupLabel));
 }
 
 void RemoteRenderPassEncoder::popDebugGroup()
 {
-    protectedBacking()->popDebugGroup();
+    protect(m_backing)->popDebugGroup();
 }
 
 void RemoteRenderPassEncoder::insertDebugMarker(String&& markerLabel)
 {
-    protectedBacking()->insertDebugMarker(WTF::move(markerLabel));
+    protect(m_backing)->insertDebugMarker(WTF::move(markerLabel));
 }
 
 void RemoteRenderPassEncoder::setViewport(float x, float y,
     float width, float height,
     float minDepth, float maxDepth)
 {
-    protectedBacking()->setViewport(x, y, width, height, minDepth, maxDepth);
+    protect(m_backing)->setViewport(x, y, width, height, minDepth, maxDepth);
 }
 
 void RemoteRenderPassEncoder::setScissorRect(WebCore::WebGPU::IntegerCoordinate x, WebCore::WebGPU::IntegerCoordinate y,
     WebCore::WebGPU::IntegerCoordinate width, WebCore::WebGPU::IntegerCoordinate height)
 {
-    protectedBacking()->setScissorRect(x, y, width, height);
+    protect(m_backing)->setScissorRect(x, y, width, height);
 }
 
 void RemoteRenderPassEncoder::setBlendConstant(WebGPU::Color color)
 {
-    auto convertedColor = protectedObjectHeap()->convertFromBacking(color);
+    auto convertedColor = protect(m_objectHeap)->convertFromBacking(color);
     ASSERT(convertedColor);
     if (!convertedColor)
         return;
 
-    protectedBacking()->setBlendConstant(*convertedColor);
+    protect(m_backing)->setBlendConstant(*convertedColor);
 }
 
 void RemoteRenderPassEncoder::setStencilReference(WebCore::WebGPU::StencilValue stencilValue)
 {
-    protectedBacking()->setStencilReference(stencilValue);
+    protect(m_backing)->setStencilReference(stencilValue);
 }
 
 void RemoteRenderPassEncoder::beginOcclusionQuery(WebCore::WebGPU::Size32 queryIndex)
 {
-    protectedBacking()->beginOcclusionQuery(queryIndex);
+    protect(m_backing)->beginOcclusionQuery(queryIndex);
 }
 
 void RemoteRenderPassEncoder::endOcclusionQuery()
 {
-    protectedBacking()->endOcclusionQuery();
+    protect(m_backing)->endOcclusionQuery();
 }
 
 void RemoteRenderPassEncoder::executeBundles(Vector<WebGPUIdentifier>&& renderBundles)
@@ -207,33 +207,23 @@ void RemoteRenderPassEncoder::executeBundles(Vector<WebGPUIdentifier>&& renderBu
     Vector<Ref<WebCore::WebGPU::RenderBundle>> convertedBundles;
     convertedBundles.reserveInitialCapacity(renderBundles.size());
     for (WebGPUIdentifier identifier : renderBundles) {
-        auto convertedBundle = protectedObjectHeap()->convertRenderBundleFromBacking(identifier);
+        auto convertedBundle = protect(m_objectHeap)->convertRenderBundleFromBacking(identifier);
         ASSERT(convertedBundle);
         if (!convertedBundle)
             return;
         convertedBundles.append(*convertedBundle);
     }
-    protectedBacking()->executeBundles(WTF::move(convertedBundles));
+    protect(m_backing)->executeBundles(WTF::move(convertedBundles));
 }
 
 void RemoteRenderPassEncoder::end()
 {
-    protectedBacking()->end();
+    protect(m_backing)->end();
 }
 
 void RemoteRenderPassEncoder::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::RenderPassEncoder> RemoteRenderPassEncoder::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<WebGPU::ObjectHeap> RemoteRenderPassEncoder::protectedObjectHeap() const
-{
-    return m_objectHeap;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h
@@ -77,10 +77,6 @@ private:
     RemoteRenderPassEncoder& operator=(RemoteRenderPassEncoder&&) = delete;
 
     WebCore::WebGPU::RenderPassEncoder& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::RenderPassEncoder> NODELETE protectedBacking();
-
-    Ref<WebGPU::ObjectHeap> NODELETE protectedObjectHeap() const;
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp
@@ -47,43 +47,33 @@ RemoteRenderPipeline::RemoteRenderPipeline(WebCore::WebGPU::RenderPipeline& rend
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteRenderPipeline::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteRenderPipeline::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteRenderPipeline::~RemoteRenderPipeline() = default;
 
 void RemoteRenderPipeline::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteRenderPipeline::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteRenderPipeline::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteRenderPipeline::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteRenderPipeline::getBindGroupLayout(uint32_t index, WebGPUIdentifier identifier)
 {
     // "A new GPUBindGroupLayout wrapper is returned each time"
-    auto bindGroupLayout = protectedBacking()->getBindGroupLayout(index);
+    auto bindGroupLayout = protect(m_backing)->getBindGroupLayout(index);
     Ref objectHeap = m_objectHeap.get();
-    auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, objectHeap, m_streamConnection.copyRef(), protectedGPU(), identifier);
+    auto remoteBindGroupLayout = RemoteBindGroupLayout::create(bindGroupLayout, objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteBindGroupLayout);
 }
 
 void RemoteRenderPipeline::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::RenderPipeline> RemoteRenderPipeline::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteRenderPipeline::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h
@@ -74,12 +74,6 @@ private:
     RemoteRenderPipeline& operator=(RemoteRenderPipeline&&) = delete;
 
     WebCore::WebGPU::RenderPipeline& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::RenderPipeline> NODELETE protectedBacking();
-
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
-
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp
@@ -45,29 +45,24 @@ RemoteSampler::RemoteSampler(WebCore::WebGPU::Sampler& sampler, WebGPU::ObjectHe
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteSampler::~RemoteSampler() = default;
 
 void RemoteSampler::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteSampler::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteSampler::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteSampler::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTF::move(label));
-}
-
-Ref<IPC::StreamServerConnection> RemoteSampler::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h
@@ -74,7 +74,6 @@ private:
     RemoteSampler& operator=(RemoteSampler&&) = delete;
 
     WebCore::WebGPU::Sampler& backing() { return m_backing; }
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp
@@ -47,24 +47,24 @@ RemoteShaderModule::RemoteShaderModule(WebCore::WebGPU::ShaderModule& shaderModu
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteShaderModule::~RemoteShaderModule() = default;
 
 void RemoteShaderModule::destruct()
 {
-    protectedObjectHeap()->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteShaderModule::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteShaderModule::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteShaderModule::compilationInfo(CompletionHandler<void(Vector<WebGPU::CompilationMessage>&&)>&& callback)
 {
-    protectedBacking()->compilationInfo([callback = WTF::move(callback)] (Ref<WebCore::WebGPU::CompilationInfo>&& compilationMessage) mutable {
+    protect(m_backing)->compilationInfo([callback = WTF::move(callback)] (Ref<WebCore::WebGPU::CompilationInfo>&& compilationMessage) mutable {
         auto convertedMessages = compilationMessage->messages().map([] (const Ref<WebCore::WebGPU::CompilationMessage>& message) {
             return WebGPU::CompilationMessage {
                 message->message(),
@@ -81,17 +81,7 @@ void RemoteShaderModule::compilationInfo(CompletionHandler<void(Vector<WebGPU::C
 
 void RemoteShaderModule::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::ShaderModule> RemoteShaderModule::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteShaderModule::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h
@@ -77,10 +77,6 @@ private:
     RemoteShaderModule& operator=(RemoteShaderModule&&) = delete;
 
     WebCore::WebGPU::ShaderModule& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::ShaderModule> NODELETE protectedBacking();
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
-    Ref<WebGPU::ObjectHeap> protectedObjectHeap() const { return m_objectHeap; }
-    Ref<RemoteGPU> protectedGPU() const { return m_gpu; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp
@@ -74,35 +74,30 @@ void RemoteTexture::createView(const std::optional<WebGPU::TextureViewDescriptor
         MESSAGE_CHECK(resultDescriptor);
         convertedDescriptor = WTF::move(resultDescriptor);
     }
-    auto textureView = protectedBacking()->createView(convertedDescriptor);
+    auto textureView = protect(m_backing)->createView(convertedDescriptor);
     MESSAGE_CHECK(textureView);
-    auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), objectHeap, m_streamConnection.copyRef(), Ref { m_gpu.get() }, identifier);
+    auto remoteTextureView = RemoteTextureView::create(textureView.releaseNonNull(), objectHeap, protect(m_streamConnection), protect(m_gpu), identifier);
     objectHeap->addObject(identifier, remoteTextureView);
 }
 
 void RemoteTexture::destroy()
 {
-    protectedBacking()->destroy();
+    protect(m_backing)->destroy();
 }
 
 void RemoteTexture::undestroy()
 {
-    protectedBacking()->undestroy();
+    protect(m_backing)->undestroy();
 }
 
 void RemoteTexture::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteTexture::setLabel(String&& label)
 {
-    protectedBacking()->setLabel(WTF::move(label));
-}
-
-Ref<WebCore::WebGPU::Texture> RemoteTexture::protectedBacking()
-{
-    return m_backing;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h
@@ -78,7 +78,6 @@ private:
     RemoteTexture& operator=(RemoteTexture&&) = delete;
 
     WebCore::WebGPU::Texture& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::Texture> NODELETE protectedBacking();
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp
@@ -45,29 +45,24 @@ RemoteTextureView::RemoteTextureView(WebCore::WebGPU::TextureView& textureView, 
     , m_gpu(gpu)
     , m_identifier(identifier)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteTextureView::~RemoteTextureView() = default;
 
 void RemoteTextureView::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteTextureView::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteTextureView::messageReceiverName(), m_identifier.toUInt64());
 }
 
 void RemoteTextureView::setLabel(String&& label)
 {
-    Ref { m_backing }->setLabel(WTF::move(label));
-}
-
-Ref<IPC::StreamServerConnection> RemoteTextureView::protectedStreamConnection() const
-{
-    return m_streamConnection;
+    protect(m_backing)->setLabel(WTF::move(label));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h
@@ -74,7 +74,6 @@ private:
     RemoteTextureView& operator=(RemoteTextureView&&) = delete;
 
     WebCore::WebGPU::TextureView& backing() { return m_backing; }
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h
@@ -78,12 +78,7 @@ private:
     RemoteXRBinding& operator=(const RemoteXRBinding&) = delete;
     RemoteXRBinding& operator=(RemoteXRBinding&&) = delete;
 
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection();
-
     WebCore::WebGPU::XRBinding& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::XRBinding> NODELETE protectedBacking();
-
-    Ref<RemoteGPU> protectedGPU();
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp
@@ -51,35 +51,20 @@ RemoteXRProjectionLayer::RemoteXRProjectionLayer(WebCore::WebGPU::XRProjectionLa
     , m_identifier(identifier)
     , m_gpu(gpu)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteXRProjectionLayer::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteXRProjectionLayer::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteXRProjectionLayer::~RemoteXRProjectionLayer() = default;
 
-Ref<WebCore::WebGPU::XRProjectionLayer> RemoteXRProjectionLayer::protectedBacking()
-{
-    return m_backing;
-}
-
-Ref<IPC::StreamServerConnection> RemoteXRProjectionLayer::protectedStreamConnection()
-{
-    return m_streamConnection;
-}
-
-Ref<RemoteGPU> RemoteXRProjectionLayer::protectedGPU() const
-{
-    return m_gpu.get();
-}
-
 void RemoteXRProjectionLayer::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 #if PLATFORM(COCOA)
 void RemoteXRProjectionLayer::startFrame(uint64_t frameIndex, MachSendRight&& colorBuffer, MachSendRight&& depthBuffer, MachSendRight&& completionSyncEvent, uint64_t reusableTextureIndex, PlatformXR::RateMapDescription&& rateMapDescription)
 {
-    protectedBacking()->startFrame(frameIndex, WTF::move(colorBuffer), WTF::move(depthBuffer), WTF::move(completionSyncEvent), reusableTextureIndex, WTF::move(rateMapDescription));
+    protect(m_backing)->startFrame(frameIndex, WTF::move(colorBuffer), WTF::move(depthBuffer), WTF::move(completionSyncEvent), reusableTextureIndex, WTF::move(rateMapDescription));
 }
 #endif
 
@@ -89,7 +74,7 @@ void RemoteXRProjectionLayer::endFrame()
 
 void RemoteXRProjectionLayer::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteXRProjectionLayer::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteXRProjectionLayer::messageReceiverName(), m_identifier.toUInt64());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h
@@ -95,10 +95,6 @@ private:
     RemoteXRProjectionLayer& operator=(const RemoteXRProjectionLayer&) = delete;
     RemoteXRProjectionLayer& operator=(RemoteXRProjectionLayer&&) = delete;
 
-    Ref<WebCore::WebGPU::XRProjectionLayer> NODELETE protectedBacking();
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection();
-    Ref<RemoteGPU> protectedGPU() const;
-
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
     void destruct();
 #if PLATFORM(COCOA)

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h
@@ -89,10 +89,6 @@ private:
     RemoteXRSubImage& operator=(RemoteXRSubImage&&) = delete;
 
     WebCore::WebGPU::XRSubImage& backing() { return m_backing; }
-    Ref<WebCore::WebGPU::XRSubImage> NODELETE protectedBacking();
-
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection();
-    Ref<RemoteGPU> protectedGPU() const;
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;
     void destruct();

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp
@@ -47,24 +47,19 @@ RemoteXRView::RemoteXRView(WebCore::WebGPU::XRView& xrView, WebGPU::ObjectHeap& 
     , m_identifier(identifier)
     , m_gpu(gpu)
 {
-    protectedStreamConnection()->startReceivingMessages(*this, Messages::RemoteXRView::messageReceiverName(), m_identifier.toUInt64());
-}
-
-Ref<IPC::StreamServerConnection> RemoteXRView::protectedStreamConnection()
-{
-    return m_streamConnection;
+    protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteXRView::messageReceiverName(), m_identifier.toUInt64());
 }
 
 RemoteXRView::~RemoteXRView() = default;
 
 void RemoteXRView::destruct()
 {
-    Ref { m_objectHeap.get() }->removeObject(m_identifier);
+    protect(m_objectHeap)->removeObject(m_identifier);
 }
 
 void RemoteXRView::stopListeningForIPC()
 {
-    protectedStreamConnection()->stopReceivingMessages(Messages::RemoteXRView::messageReceiverName(), m_identifier.toUInt64());
+    protect(m_streamConnection)->stopReceivingMessages(Messages::RemoteXRView::messageReceiverName(), m_identifier.toUInt64());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h
@@ -87,8 +87,6 @@ private:
     RemoteXRView& operator=(const RemoteXRView&) = delete;
     RemoteXRView& operator=(RemoteXRView&&) = delete;
 
-    Ref<IPC::StreamServerConnection> NODELETE protectedStreamConnection();
-
     WebCore::WebGPU::XRView& backing() { return m_backing; }
 
     void didReceiveStreamMessage(IPC::StreamServerConnection&, IPC::Decoder&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -107,7 +107,7 @@ private:
     void endInterruptionRemote(WebCore::AudioSession::MayResume);
 
     RemoteAudioSessionProxyManager& audioSessionManager();
-    Ref<IPC::Connection> protectedConnection() const;
+    IPC::Connection& connection() const;
 
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnection;
     WebCore::AudioSession::CategoryType m_category { WebCore::AudioSession::CategoryType::None };

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp
@@ -41,7 +41,7 @@ Ref<RemoteCDMInstanceSessionProxy> RemoteCDMInstanceSessionProxy::create(WeakPtr
 {
     Ref sessionProxy = adoptRef(*new RemoteCDMInstanceSessionProxy(WTF::move(proxy), WTF::move(session), logIdentifier, identifier));
     WeakPtr<WebCore::CDMInstanceSessionClient> client = sessionProxy.get();
-    sessionProxy->protectedSession()->setClient(WTF::move(client));
+    protect(sessionProxy->m_session)->setClient(WTF::move(client));
     return sessionProxy;
 }
 
@@ -59,7 +59,7 @@ RemoteCDMInstanceSessionProxy::~RemoteCDMInstanceSessionProxy()
 void RemoteCDMInstanceSessionProxy::setLogIdentifier(uint64_t logIdentifier)
 {
 #if !RELEASE_LOG_DISABLED
-    protectedSession()->setLogIdentifier(logIdentifier);
+    protect(m_session)->setLogIdentifier(logIdentifier);
 #else
     UNUSED_PARAM(logIdentifier);
 #endif
@@ -78,7 +78,7 @@ void RemoteCDMInstanceSessionProxy::requestLicense(LicenseType type, KeyGrouping
         return;
     }
 
-    protectedSession()->requestLicense(type, keyGroupingStrategy, initDataType, initData.releaseNonNull(), [completion = WTF::move(completion)] (Ref<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, CDMInstanceSession::SuccessValue succeeded) mutable {
+    protect(m_session)->requestLicense(type, keyGroupingStrategy, initDataType, initData.releaseNonNull(), [completion = WTF::move(completion)] (Ref<SharedBuffer>&& message, const String& sessionId, bool needsIndividualization, CDMInstanceSession::SuccessValue succeeded) mutable {
         completion(WTF::move(message), sessionId, needsIndividualization, succeeded == CDMInstanceSession::Succeeded);
     });
 }
@@ -97,7 +97,7 @@ void RemoteCDMInstanceSessionProxy::updateLicense(String sessionId, LicenseType 
         return;
     }
 
-    protectedSession()->updateLicense(sessionId, type, sanitizedResponse.releaseNonNull(), [completion = WTF::move(completion)] (bool sessionClosed, std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
+    protect(m_session)->updateLicense(sessionId, type, sanitizedResponse.releaseNonNull(), [completion = WTF::move(completion)] (bool sessionClosed, std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded) mutable {
         completion(sessionClosed, WTF::move(keyStatuses), WTF::move(expirationTime), WTF::move(message), succeeded == CDMInstanceSession::Succeeded);
     });
 }
@@ -111,28 +111,28 @@ void RemoteCDMInstanceSessionProxy::loadSession(LicenseType type, String session
         return;
     }
 
-    protectedSession()->loadSession(type, *sanitizedSessionId, origin, [completion = WTF::move(completion)] (std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
+    protect(m_session)->loadSession(type, *sanitizedSessionId, origin, [completion = WTF::move(completion)] (std::optional<CDMInstanceSession::KeyStatusVector>&& keyStatuses, std::optional<double>&& expirationTime, std::optional<CDMInstanceSession::Message>&& message, CDMInstanceSession::SuccessValue succeeded, CDMInstanceSession::SessionLoadFailure failure) mutable {
         completion(WTF::move(keyStatuses), WTF::move(expirationTime), WTF::move(message), succeeded == CDMInstanceSession::Succeeded, failure);
     });
 }
 
 void RemoteCDMInstanceSessionProxy::closeSession(const String& sessionId, CloseSessionCallback&& completion)
 {
-    protectedSession()->closeSession(sessionId, [completion = WTF::move(completion)] () mutable {
+    protect(m_session)->closeSession(sessionId, [completion = WTF::move(completion)] () mutable {
         completion();
     });
 }
 
 void RemoteCDMInstanceSessionProxy::removeSessionData(const String& sessionId, LicenseType type, RemoveSessionDataCallback&& completion)
 {
-    protectedSession()->removeSessionData(sessionId, type, [completion = WTF::move(completion)] (CDMInstanceSession::KeyStatusVector&& keyStatuses, RefPtr<SharedBuffer>&& expiredSessionsData, CDMInstanceSession::SuccessValue succeeded) mutable {
+    protect(m_session)->removeSessionData(sessionId, type, [completion = WTF::move(completion)] (CDMInstanceSession::KeyStatusVector&& keyStatuses, RefPtr<SharedBuffer>&& expiredSessionsData, CDMInstanceSession::SuccessValue succeeded) mutable {
         completion(WTF::move(keyStatuses), WTF::move(expiredSessionsData), succeeded == CDMInstanceSession::Succeeded);
     });
 }
 
 void RemoteCDMInstanceSessionProxy::storeRecordOfKeyUsage(const String& sessionId)
 {
-    protectedSession()->storeRecordOfKeyUsage(sessionId);
+    protect(m_session)->storeRecordOfKeyUsage(sessionId);
 }
 
 void RemoteCDMInstanceSessionProxy::updateKeyStatuses(KeyStatusVector&& keyStatuses)

--- a/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h
@@ -87,8 +87,6 @@ private:
     void sessionIdChanged(const String&) final;
     PlatformDisplayID displayID() final { return m_displayID; }
 
-    Ref<WebCore::CDMInstanceSession> protectedSession() const { return m_session; }
-
     WeakPtr<RemoteCDMProxy> m_cdm;
     Ref<WebCore::CDMInstanceSession> m_session;
     RemoteCDMInstanceSessionIdentifier m_identifier;

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp
@@ -56,7 +56,7 @@ RemoteLegacyCDMProxy::~RemoteLegacyCDMProxy()
 
 void RemoteLegacyCDMProxy::supportsMIMEType(const String& mimeType, SupportsMIMETypeCallback&& callback)
 {
-    callback(protectedCDM()->supportsMIMEType(mimeType));
+    callback(protect(m_cdm)->supportsMIMEType(mimeType));
 }
 
 void RemoteLegacyCDMProxy::createSession(uint64_t logIdentifier, CreateSessionCallback&& callback)
@@ -68,7 +68,7 @@ void RemoteLegacyCDMProxy::createSession(uint64_t logIdentifier, CreateSessionCa
     }
 
     auto sessionIdentifier = RemoteLegacyCDMSessionIdentifier::generate();
-    Ref session = RemoteLegacyCDMSessionProxy::create(*factory, logIdentifier, sessionIdentifier, protectedCDM());
+    Ref session = RemoteLegacyCDMSessionProxy::create(*factory, logIdentifier, sessionIdentifier, protect(m_cdm));
     factory->addSession(sessionIdentifier, WTF::move(session));
     callback(WTF::move(sessionIdentifier));
 }

--- a/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h
@@ -69,8 +69,6 @@ private:
     // LegacyCDMClient
     RefPtr<WebCore::MediaPlayer> cdmMediaPlayer(const WebCore::LegacyCDM*) const final;
 
-    Ref<WebCore::LegacyCDM> protectedCDM() const { return m_cdm; }
-
     WeakPtr<RemoteLegacyCDMFactoryProxy> m_factory;
     Markable<WebCore::MediaPlayerIdentifier> m_playerId;
     Ref<WebCore::LegacyCDM> m_cdm;

--- a/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h
@@ -402,16 +402,12 @@ private:
 
 #if !RELEASE_LOG_DISABLED
     const Logger& mediaPlayerLogger() final { return m_logger; }
-    Ref<const Logger> protectedMediaPlayerLogger() const { return m_logger; }
     uint64_t mediaPlayerLogIdentifier() { return m_configuration.logIdentifier; }
     const Logger& logger() { return mediaPlayerLogger(); }
     uint64_t logIdentifier() { return mediaPlayerLogIdentifier(); }
     ASCIILiteral logClassName() const { return "RemoteMediaPlayerProxy"_s; }
     WTFLogChannel& logChannel() const;
 #endif
-
-    Ref<IPC::Connection> protectedConnection() const { return m_webProcessConnection; }
-    Ref<RemoteVideoFrameObjectHeap> NODELETE protectedVideoFrameObjectHeap() const;
 
     Vector<Ref<RemoteAudioTrackProxy>> m_audioTracks;
     Vector<Ref<RemoteVideoTrackProxy>> m_videoTracks;

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp
@@ -66,7 +66,7 @@ RemoteSourceBufferProxy::RemoteSourceBufferProxy(GPUConnectionToWebProcess& conn
     , m_remoteMediaPlayerProxy(remoteMediaPlayerProxy)
 {
     connectionToWebProcess.messageReceiverMap().addMessageReceiver(Messages::RemoteSourceBufferProxy::messageReceiverName(), m_identifier.toUInt64(), *this);
-    protectedSourceBufferPrivate()->setClient(*this);
+    protect(m_sourceBufferPrivate)->setClient(*this);
 }
 
 RemoteSourceBufferProxy::~RemoteSourceBufferProxy()
@@ -170,53 +170,53 @@ void RemoteSourceBufferProxy::append(IPC::SharedBufferReference&& buffer, Comple
         connection->connection().send(Messages::SourceBufferPrivateRemoteMessageReceiver::TakeOwnershipOfMemory(WTF::move(*handle)), m_identifier);
 
     sourceBufferPrivate->append(sharedMemory->createSharedBuffer(buffer.size()))->whenSettled(RunLoop::currentSingleton(), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)](auto&& result) mutable {
-        completionHandler(WTF::move(result), protectedSourceBufferPrivate()->timestampOffset());
+        completionHandler(WTF::move(result), protect(m_sourceBufferPrivate)->timestampOffset());
     });
 }
 
 void RemoteSourceBufferProxy::abort()
 {
-    protectedSourceBufferPrivate()->abort();
+    protect(m_sourceBufferPrivate)->abort();
 }
 
 void RemoteSourceBufferProxy::resetParserState()
 {
-    protectedSourceBufferPrivate()->resetParserState();
+    protect(m_sourceBufferPrivate)->resetParserState();
 }
 
 void RemoteSourceBufferProxy::removedFromMediaSource()
 {
-    protectedSourceBufferPrivate()->removedFromMediaSource();
+    protect(m_sourceBufferPrivate)->removedFromMediaSource();
 }
 
 void RemoteSourceBufferProxy::setMediaSourceEnded(bool isEnded)
 {
-    protectedSourceBufferPrivate()->setMediaSourceEnded(isEnded);
+    protect(m_sourceBufferPrivate)->setMediaSourceEnded(isEnded);
 }
 
 void RemoteSourceBufferProxy::setActive(bool active)
 {
-    protectedSourceBufferPrivate()->setActive(active);
+    protect(m_sourceBufferPrivate)->setActive(active);
 }
 
 void RemoteSourceBufferProxy::canSwitchToType(const ContentType& contentType, CompletionHandler<void(bool)>&& completionHandler)
 {
-    completionHandler(protectedSourceBufferPrivate()->canSwitchToType(contentType));
+    completionHandler(protect(m_sourceBufferPrivate)->canSwitchToType(contentType));
 }
 
 void RemoteSourceBufferProxy::setMode(WebCore::SourceBufferAppendMode appendMode)
 {
-    protectedSourceBufferPrivate()->setMode(appendMode);
+    protect(m_sourceBufferPrivate)->setMode(appendMode);
 }
 
 void RemoteSourceBufferProxy::startChangingType()
 {
-    protectedSourceBufferPrivate()->startChangingType();
+    protect(m_sourceBufferPrivate)->startChangingType();
 }
 
 void RemoteSourceBufferProxy::removeCodedFrames(const MediaTime& start, const MediaTime& end, const MediaTime& currentTime, CompletionHandler<void()>&& completionHandler)
 {
-    protectedSourceBufferPrivate()->removeCodedFrames(start, end, currentTime)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+    protect(m_sourceBufferPrivate)->removeCodedFrames(start, end, currentTime)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
 }
 
 void RemoteSourceBufferProxy::evictCodedFrames(uint64_t newDataSize, const MediaTime& currentTime, CompletionHandler<void(Vector<WebCore::PlatformTimeRanges>&&, WebCore::SourceBufferEvictionData&&)>&& completionHandler)
@@ -228,119 +228,119 @@ void RemoteSourceBufferProxy::evictCodedFrames(uint64_t newDataSize, const Media
 
 void RemoteSourceBufferProxy::asyncEvictCodedFrames(uint64_t newDataSize, const MediaTime& currentTime)
 {
-    protectedSourceBufferPrivate()->asyncEvictCodedFrames(newDataSize, currentTime);
+    protect(m_sourceBufferPrivate)->asyncEvictCodedFrames(newDataSize, currentTime);
 }
 
 void RemoteSourceBufferProxy::addTrackBuffer(TrackID trackId)
 {
     MESSAGE_CHECK(m_mediaDescriptions.contains(trackId));
-    protectedSourceBufferPrivate()->addTrackBuffer(trackId, m_mediaDescriptions.find(trackId)->second.ptr());
+    protect(m_sourceBufferPrivate)->addTrackBuffer(trackId, m_mediaDescriptions.find(trackId)->second.ptr());
 }
 
 void RemoteSourceBufferProxy::resetTrackBuffers()
 {
-    protectedSourceBufferPrivate()->resetTrackBuffers();
+    protect(m_sourceBufferPrivate)->resetTrackBuffers();
 }
 
 void RemoteSourceBufferProxy::clearTrackBuffers()
 {
-    protectedSourceBufferPrivate()->clearTrackBuffers();
+    protect(m_sourceBufferPrivate)->clearTrackBuffers();
 }
 
 void RemoteSourceBufferProxy::setAllTrackBuffersNeedRandomAccess()
 {
-    protectedSourceBufferPrivate()->setAllTrackBuffersNeedRandomAccess();
+    protect(m_sourceBufferPrivate)->setAllTrackBuffersNeedRandomAccess();
 }
 
 void RemoteSourceBufferProxy::reenqueueMediaIfNeeded(const MediaTime& currentMediaTime)
 {
-    protectedSourceBufferPrivate()->reenqueueMediaIfNeeded(currentMediaTime);
+    protect(m_sourceBufferPrivate)->reenqueueMediaIfNeeded(currentMediaTime);
 }
 
 void RemoteSourceBufferProxy::setGroupStartTimestamp(const MediaTime& timestamp)
 {
-    protectedSourceBufferPrivate()->setGroupStartTimestamp(timestamp);
+    protect(m_sourceBufferPrivate)->setGroupStartTimestamp(timestamp);
 }
 
 void RemoteSourceBufferProxy::setGroupStartTimestampToEndTimestamp()
 {
-    protectedSourceBufferPrivate()->setGroupStartTimestampToEndTimestamp();
+    protect(m_sourceBufferPrivate)->setGroupStartTimestampToEndTimestamp();
 }
 
 void RemoteSourceBufferProxy::setShouldGenerateTimestamps(bool shouldGenerateTimestamps)
 {
-    protectedSourceBufferPrivate()->setShouldGenerateTimestamps(shouldGenerateTimestamps);
+    protect(m_sourceBufferPrivate)->setShouldGenerateTimestamps(shouldGenerateTimestamps);
 }
 
 void RemoteSourceBufferProxy::resetTimestampOffsetInTrackBuffers()
 {
-    protectedSourceBufferPrivate()->resetTimestampOffsetInTrackBuffers();
+    protect(m_sourceBufferPrivate)->resetTimestampOffsetInTrackBuffers();
 }
 
 void RemoteSourceBufferProxy::setTimestampOffset(const MediaTime& timestampOffset)
 {
-    protectedSourceBufferPrivate()->setTimestampOffset(timestampOffset);
+    protect(m_sourceBufferPrivate)->setTimestampOffset(timestampOffset);
 }
 
 void RemoteSourceBufferProxy::setAppendWindowStart(const MediaTime& appendWindowStart)
 {
-    protectedSourceBufferPrivate()->setAppendWindowStart(appendWindowStart);
+    protect(m_sourceBufferPrivate)->setAppendWindowStart(appendWindowStart);
 }
 
 void RemoteSourceBufferProxy::setAppendWindowEnd(const MediaTime& appendWindowEnd)
 {
-    protectedSourceBufferPrivate()->setAppendWindowEnd(appendWindowEnd);
+    protect(m_sourceBufferPrivate)->setAppendWindowEnd(appendWindowEnd);
 }
 
 void RemoteSourceBufferProxy::setMaximumBufferSize(uint64_t size, CompletionHandler<void()>&& completionHandler)
 {
-    protectedSourceBufferPrivate()->setMaximumBufferSize(size)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+    protect(m_sourceBufferPrivate)->setMaximumBufferSize(size)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
 }
 
 void RemoteSourceBufferProxy::computeSeekTime(const SeekTarget& target, CompletionHandler<void(SourceBufferPrivate::ComputeSeekPromise::Result&&)>&& completionHandler)
 {
-    protectedSourceBufferPrivate()->computeSeekTime(target)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+    protect(m_sourceBufferPrivate)->computeSeekTime(target)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
 }
 
 void RemoteSourceBufferProxy::updateTrackIds(Vector<std::pair<TrackID, TrackID>>&& trackIdPairs)
 {
     if (!trackIdPairs.isEmpty())
-        protectedSourceBufferPrivate()->updateTrackIds(WTF::move(trackIdPairs));
+        protect(m_sourceBufferPrivate)->updateTrackIds(WTF::move(trackIdPairs));
 }
 
 void RemoteSourceBufferProxy::bufferedSamplesForTrackId(TrackID trackId, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&& completionHandler)
 {
-    protectedSourceBufferPrivate()->bufferedSamplesForTrackId(trackId)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+    protect(m_sourceBufferPrivate)->bufferedSamplesForTrackId(trackId)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
 }
 
 void RemoteSourceBufferProxy::enqueuedSamplesForTrackID(TrackID trackId, CompletionHandler<void(WebCore::SourceBufferPrivate::SamplesPromise::Result&&)>&& completionHandler)
 {
-    protectedSourceBufferPrivate()->enqueuedSamplesForTrackID(trackId)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
+    protect(m_sourceBufferPrivate)->enqueuedSamplesForTrackID(trackId)->whenSettled(RunLoop::currentSingleton(), WTF::move(completionHandler));
 }
 
 void RemoteSourceBufferProxy::memoryPressure(const MediaTime& currentTime)
 {
-    protectedSourceBufferPrivate()->memoryPressure(currentTime);
+    protect(m_sourceBufferPrivate)->memoryPressure(currentTime);
 }
 
 void RemoteSourceBufferProxy::minimumUpcomingPresentationTimeForTrackID(TrackID trackID, CompletionHandler<void(MediaTime)>&& completionHandler)
 {
-    completionHandler(protectedSourceBufferPrivate()->minimumUpcomingPresentationTimeForTrackID(trackID));
+    completionHandler(protect(m_sourceBufferPrivate)->minimumUpcomingPresentationTimeForTrackID(trackID));
 }
 
 void RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID(TrackID trackID, uint64_t depth)
 {
-    protectedSourceBufferPrivate()->setMaximumQueueDepthForTrackID(trackID, depth);
+    protect(m_sourceBufferPrivate)->setMaximumQueueDepthForTrackID(trackID, depth);
 }
 
 void RemoteSourceBufferProxy::detach()
 {
-    protectedSourceBufferPrivate()->detach();
+    protect(m_sourceBufferPrivate)->detach();
 }
 
 void RemoteSourceBufferProxy::attach()
 {
-    protectedSourceBufferPrivate()->attach();
+    protect(m_sourceBufferPrivate)->attach();
 }
 
 Ref<MediaPromise> RemoteSourceBufferProxy::sourceBufferPrivateDidAttach(InitializationSegment&& segment)

--- a/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h
@@ -76,7 +76,6 @@ private:
     RemoteSourceBufferProxy(GPUConnectionToWebProcess&, RemoteSourceBufferIdentifier, Ref<WebCore::SourceBufferPrivate>&&, RemoteMediaPlayerProxy&);
 
     RefPtr<IPC::Connection> connection() const;
-    Ref<WebCore::SourceBufferPrivate> protectedSourceBufferPrivate() const { return m_sourceBufferPrivate; }
 
     // SourceBufferPrivateClient
     Ref<WebCore::MediaPromise> sourceBufferPrivateDidReceiveInitializationSegment(InitializationSegment&&) final;

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp
@@ -56,7 +56,7 @@ static WorkQueue& remoteVideoFrameObjectHeapQueueSingleton()
 Ref<RemoteVideoFrameObjectHeap> RemoteVideoFrameObjectHeap::create(Ref<IPC::Connection>&& connection)
 {
     Ref heap = adoptRef(*new RemoteVideoFrameObjectHeap(WTF::move(connection)));
-    heap->protectedConnection()->addWorkQueueMessageReceiver(Messages::RemoteVideoFrameObjectHeap::messageReceiverName(), remoteVideoFrameObjectHeapQueueSingleton(), heap);
+    protect(heap->m_connection)->addWorkQueueMessageReceiver(Messages::RemoteVideoFrameObjectHeap::messageReceiverName(), remoteVideoFrameObjectHeapQueueSingleton(), heap);
     return heap;
 }
 
@@ -78,7 +78,7 @@ void RemoteVideoFrameObjectHeap::close()
         return;
 
     m_isClosed = true;
-    protectedConnection()->removeWorkQueueMessageReceiver(Messages::RemoteVideoFrameObjectHeap::messageReceiverName());
+    protect(m_connection)->removeWorkQueueMessageReceiver(Messages::RemoteVideoFrameObjectHeap::messageReceiverName());
 
 #if PLATFORM(COCOA)
     m_sharedVideoFrameWriter.disable();

--- a/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
+++ b/Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h
@@ -62,8 +62,6 @@ public:
 private:
     explicit RemoteVideoFrameObjectHeap(Ref<IPC::Connection>&&);
 
-    Ref<IPC::Connection> protectedConnection() const { return m_connection; }
-
     // IPC::MessageReceiver overrides.
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;

--- a/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
+++ b/Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm
@@ -54,7 +54,7 @@ void RemoteMediaPlayerProxy::mediaPlayerFirstVideoFrameAvailable()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
     m_layerHostingContextManager->setVideoLayerSizeIfPossible();
-    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::FirstVideoFrameAvailable(), m_id);
+    protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::FirstVideoFrameAvailable(), m_id);
 }
 
 void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
@@ -69,9 +69,9 @@ void RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged()
 #endif
 
     if (auto hostingContext = m_layerHostingContextManager->createHostingContextIfNeeded(protect(m_player)->platformLayer(), canShowWhileLocked))
-        protectedConnection()->send(Messages::MediaPlayerPrivateRemote::LayerHostingContextChanged(*hostingContext, m_layerHostingContextManager->videoLayerSize()), m_id);
+        protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::LayerHostingContextChanged(*hostingContext, m_layerHostingContextManager->videoLayerSize()), m_id);
 
-    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::RenderingModeChanged(), m_id);
+    protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::RenderingModeChanged(), m_id);
 }
 
 void RemoteMediaPlayerProxy::requestHostingContext(CompletionHandler<void(WebCore::HostingContext)>&& completionHandler)
@@ -91,8 +91,8 @@ void RemoteMediaPlayerProxy::setVideoLayerSizeFenced(const WebCore::FloatSize& s
 
 void RemoteMediaPlayerProxy::mediaPlayerOnNewVideoFrameMetadata(WebCore::VideoFrameMetadata&& metadata, RetainPtr<CVPixelBufferRef>&& buffer)
 {
-    auto properties = protectedVideoFrameObjectHeap()->add(WebCore::VideoFrameCV::create({ }, false, WebCore::VideoFrame::Rotation::None, WTF::move(buffer)));
-    protectedConnection()->send(Messages::MediaPlayerPrivateRemote::PushVideoFrameMetadata(metadata, properties), m_id);
+    auto properties = protect(m_videoFrameObjectHeap)->add(WebCore::VideoFrameCV::create({ }, false, WebCore::VideoFrame::Rotation::None, WTF::move(buffer)));
+    protect(m_webProcessConnection)->send(Messages::MediaPlayerPrivateRemote::PushVideoFrameMetadata(metadata, properties), m_id);
 }
 
 WebCore::FloatSize RemoteMediaPlayerProxy::mediaPlayerVideoLayerSize() const

--- a/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
+++ b/Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h
@@ -65,10 +65,8 @@ public:
         virtual void addMessageReceiver(IPC::ReceiverName, IPC::MessageReceiver&) = 0;
         virtual void removeMessageReceiver(IPC::ReceiverName) = 0;
         virtual IPC::Connection& connection() = 0;
-        Ref<IPC::Connection> protectedConnection() { return connection(); }
         virtual bool willStartCapture(WebCore::CaptureDevice::DeviceType, WebCore::PageIdentifier) const = 0;
         virtual Logger& logger() = 0;
-        Ref<Logger> protectedLogger() { return logger(); };
         virtual bool setCaptureAttributionString() { return true; }
         virtual const WebCore::ProcessIdentity& resourceOwner() const = 0;
 #if ENABLE(APP_PRIVACY_REPORT)

--- a/Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.cpp
@@ -88,12 +88,6 @@ void AuthenticationManager::deref() const
     return m_process->deref();
 }
 
-inline Ref<NetworkProcess> AuthenticationManager::protectedProcess() const
-{
-    ASSERT(RunLoop::isMain());
-    return m_process.get();
-}
-
 AuthenticationChallengeIdentifier AuthenticationManager::addChallengeToChallengeMap(UniqueRef<Challenge>&& challenge)
 {
     ASSERT(RunLoop::isMain());
@@ -151,7 +145,7 @@ void AuthenticationManager::didReceiveAuthenticationChallenge(PAL::SessionID ses
     std::optional<SecurityOriginData> topOriginData;
     if (topOrigin)
         topOriginData = *topOrigin;
-    protectedProcess()->send(Messages::NetworkProcessProxy::DidReceiveAuthenticationChallenge(sessionID, *pageID, topOriginData, authenticationChallenge, negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes, challengeID));
+    protect(m_process)->send(Messages::NetworkProcessProxy::DidReceiveAuthenticationChallenge(sessionID, *pageID, topOriginData, authenticationChallenge, negotiatedLegacyTLS == NegotiatedLegacyTLS::Yes, challengeID));
 }
 
 void AuthenticationManager::didReceiveAuthenticationChallenge(IPC::MessageSender& download, const WebCore::AuthenticationChallenge& authenticationChallenge, ChallengeCompletionHandler&& completionHandler)
@@ -179,7 +173,7 @@ void AuthenticationManager::completeAuthenticationChallenge(AuthenticationChalle
 
 void AuthenticationManager::negotiatedLegacyTLS(WebPageProxyIdentifier pageID) const
 {
-    protectedProcess()->send(Messages::NetworkProcessProxy::NegotiatedLegacyTLS(pageID));
+    protect(m_process)->send(Messages::NetworkProcessProxy::NegotiatedLegacyTLS(pageID));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.h
+++ b/Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.h
@@ -79,7 +79,6 @@ public:
     void negotiatedLegacyTLS(WebPageProxyIdentifier) const;
 
 private:
-    Ref<NetworkProcess> protectedProcess() const;
     struct Challenge;
 
 #if HAVE(SEC_KEY_PROXY)

--- a/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
+++ b/Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h
@@ -71,8 +71,6 @@ public:
     void notifyCookiesDidChange(PAL::SessionID);
 
 private:
-    Ref<NetworkProcess> protectedProcess();
-
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;
 

--- a/Source/WebKit/NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp
@@ -52,7 +52,7 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
         break;
     }
 
-    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protect(m_process)->storageSession(sessionID))
         storageSession->setCookieAcceptPolicy(curlPolicy);
 
     completionHandler();

--- a/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
+++ b/Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm
@@ -58,7 +58,7 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies));
 
-    CheckedPtr storageSession = protectedProcess()->storageSession(sessionID);
+    CheckedPtr storageSession = protect(m_process)->storageSession(sessionID);
     if (!storageSession)
         return completionHandler();
 

--- a/Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
+++ b/Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp
@@ -39,7 +39,7 @@ using namespace WebCore;
 
 void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionID, HTTPCookieAcceptPolicy policy, CompletionHandler<void()>&& completionHandler)
 {
-    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protect(m_process)->storageSession(sessionID))
         storageSession->setCookieAcceptPolicy(policy);
 
     completionHandler();
@@ -47,13 +47,13 @@ void WebCookieManager::platformSetHTTPCookieAcceptPolicy(PAL::SessionID sessionI
 
 void WebCookieManager::setCookiePersistentStorage(PAL::SessionID sessionID, const String& storagePath, SoupCookiePersistentStorageType storageType)
 {
-    if (CheckedPtr networkSession = protectedProcess()->networkSession(sessionID))
+    if (CheckedPtr networkSession = protect(m_process)->networkSession(sessionID))
         static_cast<NetworkSessionSoup&>(*networkSession).setCookiePersistentStorage(storagePath, storageType);
 }
 
 void WebCookieManager::replaceCookies(PAL::SessionID sessionID, const Vector<WebCore::Cookie>& cookies, CompletionHandler<void()>&& completionHandler)
 {
-    if (CheckedPtr storageSession = protectedProcess()->storageSession(sessionID))
+    if (CheckedPtr storageSession = protect(m_process)->storageSession(sessionID))
         storageSession->replaceCookies(cookies);
     completionHandler();
 }

--- a/Source/WebKit/NetworkProcess/Downloads/Download.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.cpp
@@ -145,7 +145,7 @@ void Download::didReceiveData(uint64_t bytesWritten, uint64_t totalBytesWritten,
         m_hasReceivedData = true;
     }
     
-    protectedMonitor()->downloadReceivedBytes(bytesWritten);
+    protect(m_monitor)->downloadReceivedBytes(bytesWritten);
 
 #if HAVE(MODERN_DOWNLOADPROGRESS)
     updateProgress(totalBytesWritten, totalBytesExpectedToWrite);

--- a/Source/WebKit/NetworkProcess/Downloads/Download.h
+++ b/Source/WebKit/NetworkProcess/Downloads/Download.h
@@ -97,8 +97,8 @@ public:
     void didFinish();
     void didFail(const WebCore::ResourceError&, std::span<const uint8_t> resumeData);
 
-    void applicationDidEnterBackground() { protectedMonitor()->applicationDidEnterBackground(); }
-    void applicationWillEnterForeground() { protectedMonitor()->applicationWillEnterForeground(); }
+    void applicationDidEnterBackground() { protect(m_monitor)->applicationDidEnterBackground(); }
+    void applicationWillEnterForeground() { protect(m_monitor)->applicationWillEnterForeground(); }
     DownloadManager* manager() const { return m_downloadManager.get(); }
     void clearManager() { m_downloadManager = nullptr; }
 
@@ -109,8 +109,6 @@ private:
 #if PLATFORM(COCOA)
     Download(DownloadManager&, DownloadID, NSURLSessionDownloadTask*, NetworkSession&, const String& suggestedFilename = { });
 #endif
-
-    Ref<DownloadMonitor> protectedMonitor() { return m_monitor; }
 
     // IPC::MessageSender
     IPC::Connection* messageSenderConnection() const override;

--- a/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
+++ b/Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp
@@ -124,7 +124,7 @@ void PendingDownload::willSendRedirectedRequest(WebCore::ResourceRequest&&, WebC
         completionHandler(WebCore::ResourceRequest());
         m_networkLoad->cancel();
         if (m_webProcessID && !redirectRequest.url().protocolIsJavaScript() && m_networkLoad->webFrameID() && m_networkLoad->webPageID()) {
-            if (RefPtr webProcessConnection = m_networkLoad->networkProcess()->protectedWebProcessConnection(*m_webProcessID))
+            if (RefPtr webProcessConnection = m_networkLoad->networkProcess()->webProcessConnection(*m_webProcessID))
                 webProcessConnection->loadCancelledDownloadRedirectRequestInFrame(redirectRequest, *m_networkLoad->webFrameID(), *m_networkLoad->webPageID());
         }
         return;

--- a/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp
@@ -134,7 +134,7 @@ void NetworkBroadcastChannelRegistry::removeConnection(IPC::Connection& connecti
 
 std::optional<SharedPreferencesForWebProcess> NetworkBroadcastChannelRegistry::sharedPreferencesForWebProcess(const IPC::Connection& connection) const
 {
-    RefPtr webProcessConnection = m_networkProcess->protectedWebProcessConnection(connection);
+    RefPtr webProcessConnection = m_networkProcess->webProcessConnection(connection);
     if (!webProcessConnection)
         return std::nullopt;
     return webProcessConnection->sharedPreferencesForWebProcess();

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp
@@ -63,12 +63,6 @@ void NetworkContentRuleListManager::deref() const
     m_networkProcess->deref();
 }
 
-Ref<NetworkProcess> NetworkContentRuleListManager::protectedNetworkProcess() const
-{
-    ASSERT(RunLoop::isMain());
-    return m_networkProcess.get();
-}
-
 void NetworkContentRuleListManager::contentExtensionsBackend(UserContentControllerIdentifier identifier, BackendCallback&& callback)
 {
     auto iterator = m_contentExtensionBackends.find(identifier);
@@ -79,7 +73,7 @@ void NetworkContentRuleListManager::contentExtensionsBackend(UserContentControll
     m_pendingCallbacks.ensure(identifier, [] {
         return Vector<BackendCallback> { };
     }).iterator->value.append(WTF::move(callback));
-    protect(protectedNetworkProcess()->parentProcessConnection())->send(Messages::NetworkProcessProxy::ContentExtensionRules { identifier }, 0);
+    protect(protect(m_networkProcess)->parentProcessConnection())->send(Messages::NetworkProcessProxy::ContentExtensionRules { identifier }, 0);
 }
 
 void NetworkContentRuleListManager::addContentRuleLists(UserContentControllerIdentifier identifier, Vector<std::pair<WebCompiledContentRuleListData, URL>>&& contentRuleLists)

--- a/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
+++ b/Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h
@@ -60,8 +60,6 @@ private:
     void removeAllContentRuleLists(UserContentControllerIdentifier);
     void remove(UserContentControllerIdentifier);
 
-    Ref<NetworkProcess> protectedNetworkProcess() const;
-
     HashMap<UserContentControllerIdentifier, std::unique_ptr<WebCore::ContentExtensions::ContentExtensionsBackend>> m_contentExtensionBackends;
     HashMap<UserContentControllerIdentifier, Vector<BackendCallback>> m_pendingCallbacks;
     WeakRef<NetworkProcess> m_networkProcess;

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3095,16 +3095,11 @@ NetworkConnectionToWebProcess* NetworkProcess::webProcessConnection(ProcessIdent
     return m_webProcessConnections.get(identifier);
 }
 
-RefPtr<NetworkConnectionToWebProcess> NetworkProcess::protectedWebProcessConnection(WebCore::ProcessIdentifier identifier) const
+NetworkConnectionToWebProcess* NetworkProcess::webProcessConnection(const IPC::Connection& connection) const
 {
-    return webProcessConnection(identifier);
-}
-
-RefPtr<NetworkConnectionToWebProcess> NetworkProcess::protectedWebProcessConnection(const IPC::Connection& connection) const
-{
-    for (Ref webProcessConnection : m_webProcessConnections.values()) {
+    for (auto& webProcessConnection : m_webProcessConnections.values()) {
         if (webProcessConnection->connection().uniqueID() == connection.uniqueID())
-            return webProcessConnection;
+            return webProcessConnection.ptr();
     }
     return nullptr;
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -397,8 +397,7 @@ public:
     const OptionSet<NetworkCache::CacheOption>& cacheOptions() const { return m_cacheOptions; }
 
     NetworkConnectionToWebProcess* webProcessConnection(WebCore::ProcessIdentifier) const;
-    RefPtr<NetworkConnectionToWebProcess> protectedWebProcessConnection(WebCore::ProcessIdentifier) const;
-    RefPtr<NetworkConnectionToWebProcess> protectedWebProcessConnection(const IPC::Connection&) const;
+    NetworkConnectionToWebProcess* webProcessConnection(const IPC::Connection&) const;
     WebCore::MessagePortChannelRegistry& messagePortChannelRegistry() { return m_messagePortChannelRegistry; }
 
     void setServiceWorkerFetchTimeoutForTesting(Seconds, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp
@@ -80,11 +80,6 @@ NetworkSocketChannel::~NetworkSocketChannel()
     }
 }
 
-Ref<NetworkConnectionToWebProcess> NetworkSocketChannel::protectedConnectionToWebProcess()
-{
-    return m_connectionToWebProcess.get();
-}
-
 void NetworkSocketChannel::sendString(std::span<const uint8_t> message, CompletionHandler<void()>&& callback)
 {
     protect(m_socket)->sendString(message, WTF::move(callback));
@@ -103,7 +98,7 @@ void NetworkSocketChannel::finishClosingIfPossible()
     }
     ASSERT(m_state == State::Closing);
     m_state = State::Closed;
-    protectedConnectionToWebProcess()->removeSocketChannel(m_identifier);
+    protect(m_connectionToWebProcess)->removeSocketChannel(m_identifier);
 }
 
 void NetworkSocketChannel::close(int32_t code, const String& reason)

--- a/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
+++ b/Source/WebKit/NetworkProcess/NetworkSocketChannel.h
@@ -76,8 +76,6 @@ public:
 private:
     NetworkSocketChannel(NetworkConnectionToWebProcess&, NetworkSession*, const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::StoredCredentialsPolicy);
 
-    Ref<NetworkConnectionToWebProcess> protectedConnectionToWebProcess();
-
     void didConnect(const String& subprotocol, const String& extensions);
     void didReceiveText(const String&);
     void didReceiveBinaryData(std::span<const uint8_t>);

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -262,7 +262,7 @@ void NetworkNotificationManager::getPermissionStateSync(WebCore::SecurityOriginD
 
 std::optional<SharedPreferencesForWebProcess> NetworkNotificationManager::sharedPreferencesForWebProcess(const IPC::Connection& connection) const
 {
-    RefPtr webProcessConnection = m_networkProcess->protectedWebProcessConnection(connection);
+    RefPtr webProcessConnection = m_networkProcess->webProcessConnection(connection);
     if (!webProcessConnection)
         return std::nullopt;
     return webProcessConnection->sharedPreferencesForWebProcess();

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -352,12 +352,12 @@ void PrivateClickMeasurementManager::getSignedUnlinkableTokenForDestination(Sour
 
 void PrivateClickMeasurementManager::insertPrivateClickMeasurement(PrivateClickMeasurement&& measurement, PrivateClickMeasurementAttributionType type, CompletionHandler<void()>&& completionHandler)
 {
-    protectedStore()->insertPrivateClickMeasurement(WTF::move(measurement), type, WTF::move(completionHandler));
+    protect(store())->insertPrivateClickMeasurement(WTF::move(measurement), type, WTF::move(completionHandler));
 }
 
 void PrivateClickMeasurementManager::migratePrivateClickMeasurementFromLegacyStorage(PrivateClickMeasurement&& measurement, PrivateClickMeasurementAttributionType type)
 {
-    protectedStore()->insertPrivateClickMeasurement(WTF::move(measurement), type, [] { });
+    protect(store())->insertPrivateClickMeasurement(WTF::move(measurement), type, [] { });
 }
 
 void PrivateClickMeasurementManager::setDebugModeIsEnabled(bool enabled)
@@ -462,7 +462,7 @@ void PrivateClickMeasurementManager::attribute(SourceSite&& sourceSite, Attribut
     if (!featureEnabled())
         return;
 
-    protectedStore()->attributePrivateClickMeasurement(WTF::move(sourceSite), WTF::move(destinationSite), applicationBundleIdentifier, WTF::move(attributionTriggerData), m_isRunningTest ? WebCore::PrivateClickMeasurement::IsRunningLayoutTest::Yes : WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No, [weakThis = WeakPtr { *this }] (auto attributionSecondsUntilSendData, auto debugInfo) {
+    protect(store())->attributePrivateClickMeasurement(WTF::move(sourceSite), WTF::move(destinationSite), applicationBundleIdentifier, WTF::move(attributionTriggerData), m_isRunningTest ? WebCore::PrivateClickMeasurement::IsRunningLayoutTest::Yes : WebCore::PrivateClickMeasurement::IsRunningLayoutTest::No, [weakThis = WeakPtr { *this }] (auto attributionSecondsUntilSendData, auto debugInfo) {
         WeakPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -609,7 +609,7 @@ void PrivateClickMeasurementManager::clearSentAttribution(PrivateClickMeasuremen
     if (!featureEnabled())
         return;
 
-    protectedStore()->clearSentAttribution(WTF::move(sentConversion), attributionReportEndpoint);
+    protect(store())->clearSentAttribution(WTF::move(sentConversion), attributionReportEndpoint);
 }
 
 Seconds PrivateClickMeasurementManager::randomlyBetweenFifteenAndThirtyMinutes() const
@@ -625,7 +625,7 @@ void PrivateClickMeasurementManager::firePendingAttributionRequests()
     if (!featureEnabled())
         return;
 
-    protectedStore()->allAttributedPrivateClickMeasurement([weakThis = WeakPtr { *this }] (auto&& attributions) {
+    protect(store())->allAttributedPrivateClickMeasurement([weakThis = WeakPtr { *this }] (auto&& attributions) {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
@@ -688,7 +688,7 @@ void PrivateClickMeasurementManager::clear(CompletionHandler<void()>&& completio
     if (!featureEnabled())
         return completionHandler();
 
-    protectedStore()->clearPrivateClickMeasurement(WTF::move(completionHandler));
+    protect(store())->clearPrivateClickMeasurement(WTF::move(completionHandler));
 }
 
 void PrivateClickMeasurementManager::clearForRegistrableDomain(RegistrableDomain&& domain, CompletionHandler<void()>&& completionHandler)
@@ -696,7 +696,7 @@ void PrivateClickMeasurementManager::clearForRegistrableDomain(RegistrableDomain
     if (!featureEnabled())
         return completionHandler();
 
-    protectedStore()->clearPrivateClickMeasurementForRegistrableDomain(WTF::move(domain), WTF::move(completionHandler));
+    protect(store())->clearPrivateClickMeasurementForRegistrableDomain(WTF::move(domain), WTF::move(completionHandler));
 }
 
 void PrivateClickMeasurementManager::clearExpired()
@@ -704,7 +704,7 @@ void PrivateClickMeasurementManager::clearExpired()
     if (!featureEnabled())
         return;
 
-    protectedStore()->clearExpiredPrivateClickMeasurement();
+    protect(store())->clearExpiredPrivateClickMeasurement();
 }
 
 void PrivateClickMeasurementManager::toStringForTesting(CompletionHandler<void(String)>&& completionHandler) const
@@ -712,7 +712,7 @@ void PrivateClickMeasurementManager::toStringForTesting(CompletionHandler<void(S
     if (!featureEnabled())
         return completionHandler("\nNo stored Private Click Measurement data.\n"_s);
 
-    protectedStore()->privateClickMeasurementToStringForTesting(WTF::move(completionHandler));
+    protect(store())->privateClickMeasurementToStringForTesting(WTF::move(completionHandler));
 }
 
 void PrivateClickMeasurementManager::setTokenPublicKeyURLForTesting(URL&& testURL)
@@ -743,7 +743,7 @@ void PrivateClickMeasurementManager::markAllUnattributedAsExpiredForTesting()
     if (!featureEnabled())
         return;
 
-    protectedStore()->markAllUnattributedPrivateClickMeasurementAsExpiredForTesting();
+    protect(store())->markAllUnattributedPrivateClickMeasurementAsExpiredForTesting();
 }
 
 void PrivateClickMeasurementManager::setPCMFraudPreventionValuesForTesting(String&& unlinkableToken, String&& secretToken, String&& signature, String&& keyID)
@@ -768,7 +768,7 @@ void PrivateClickMeasurementManager::markAttributedPrivateClickMeasurementsAsExp
     if (!featureEnabled())
         return completionHandler();
 
-    protectedStore()->markAttributedPrivateClickMeasurementsAsExpiredForTesting(WTF::move(completionHandler));
+    protect(store())->markAttributedPrivateClickMeasurementsAsExpiredForTesting(WTF::move(completionHandler));
 }
 
 void PrivateClickMeasurementManager::initializeStore() const
@@ -793,16 +793,6 @@ const PCM::Store& PrivateClickMeasurementManager::store() const
 {
     initializeStore();
     return *m_store;
-}
-
-Ref<PCM::Store> PrivateClickMeasurementManager::protectedStore()
-{
-    return store();
-}
-
-Ref<const PCM::Store> PrivateClickMeasurementManager::protectedStore() const
-{
-    return store();
 }
 
 void PrivateClickMeasurementManager::destroyStoreForTesting(CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
@@ -75,8 +75,6 @@ private:
 
     PCM::Store& store();
     const PCM::Store& store() const;
-    Ref<PCM::Store> protectedStore();
-    Ref<const PCM::Store> protectedStore() const;
     void initializeStore() const;
     void startTimer(Seconds);
     void getTokenPublicKey(PrivateClickMeasurement&&, WebCore::PCM::AttributionReportEndpoint, PrivateClickMeasurement::PcmDataCarried, Function<void(PrivateClickMeasurement&& attribution, const String& publicKeyBase64URL)>&&);

--- a/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
+++ b/Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp
@@ -143,7 +143,7 @@ void WebSharedWorkerServerConnection::postErrorToWorkerObject(WebCore::SharedWor
 
 std::optional<SharedPreferencesForWebProcess> WebSharedWorkerServerConnection::sharedPreferencesForWebProcess(const IPC::Connection& connection) const
 {
-    RefPtr webProcessConnection = m_networkProcess->protectedWebProcessConnection(connection);
+    RefPtr webProcessConnection = m_networkProcess->webProcessConnection(connection);
     if (!webProcessConnection)
         return std::nullopt;
     return webProcessConnection->sharedPreferencesForWebProcess();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.cpp
@@ -128,7 +128,7 @@ Cache::Cache(NetworkProcess& networkProcess, const String& storageDirectory, Ref
                 updateSpeculativeLoadManagerEnabledState();
         });
         if (shouldUseSpeculativeLoadManager())
-            m_speculativeLoadManager = makeUnique<SpeculativeLoadManager>(*this, protectedStorage());
+            m_speculativeLoadManager = makeUnique<SpeculativeLoadManager>(*this, protect(m_storage));
     }
 
     if (options.contains(CacheOption::RegisterNotify)) {
@@ -347,7 +347,7 @@ void Cache::updateSpeculativeLoadManagerEnabledState()
         m_speculativeLoadManager = nullptr;
         RELEASE_LOG(NetworkCacheSpeculativePreloading, "%p - Cache::updateSpeculativeLoadManagerEnabledState: disabling speculative loads due to low power mode or thermal change", this);
     } else if (shouldEnable && !m_speculativeLoadManager) {
-        m_speculativeLoadManager = makeUnique<SpeculativeLoadManager>(*this, protectedStorage());
+        m_speculativeLoadManager = makeUnique<SpeculativeLoadManager>(*this, protect(m_storage));
         RELEASE_LOG(NetworkCacheSpeculativePreloading, "%p - Cache::updateSpeculativeLoadManagerEnabledState: enabling speculative loads due to low power mode or thermal change", this);
     }
 }

--- a/Source/WebKit/NetworkProcess/cache/NetworkCache.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCache.h
@@ -248,8 +248,6 @@ private:
 
     std::optional<Seconds> maxAgeCap(Entry&, const WebCore::ResourceRequest&, PAL::SessionID);
 
-    Ref<Storage> protectedStorage() const { return m_storage; }
-
     const Ref<Storage> m_storage;
     const Ref<NetworkProcess> m_networkProcess;
 

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h
@@ -84,9 +84,6 @@ private:
     static bool canUsePreloadedEntry(const PreloadedEntry&, const WebCore::ResourceRequest& actualRequest);
     static bool canUsePendingPreload(const SpeculativeLoad&, const WebCore::ResourceRequest& actualRequest);
 
-    Ref<Storage> protectedStorage() const;
-    Ref<Cache> protectedCache() const;
-
     const WeakRef<Cache> m_cache;
     ThreadSafeWeakRef<Storage> m_storage;
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h
@@ -214,8 +214,6 @@ private:
     void initializeNSURLSessionsInSet(SessionSet&, NSURLSessionConfiguration *);
     SessionSet& sessionSetForPage(std::optional<WebPageProxyIdentifier>);
     const SessionSet& sessionSetForPage(std::optional<WebPageProxyIdentifier>) const;
-    Ref<SessionSet> protectedSessionSetForPage(std::optional<WebPageProxyIdentifier> identifier) { return sessionSetForPage(identifier); }
-    Ref<const SessionSet> protectedSessionSetForPage(std::optional<WebPageProxyIdentifier> identifier) const { return sessionSetForPage(identifier); }
 
     void invalidateAndCancelSessionSet(SessionSet&);
     

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1336,7 +1336,7 @@ const SessionSet& NetworkSessionCocoa::sessionSetForPage(std::optional<WebPagePr
 
 SessionWrapper& NetworkSessionCocoa::initializeEphemeralStatelessSessionIfNeeded(std::optional<WebPageProxyIdentifier> webPageProxyID, NavigatingToAppBoundDomain isNavigatingToAppBoundDomain)
 {
-    return protectedSessionSetForPage(webPageProxyID)->initializeEphemeralStatelessSessionIfNeeded(isNavigatingToAppBoundDomain, *this);
+    return protect(sessionSetForPage(webPageProxyID))->initializeEphemeralStatelessSessionIfNeeded(isNavigatingToAppBoundDomain, *this);
 }
 
 SessionWrapper& SessionSet::initializeEphemeralStatelessSessionIfNeeded(NavigatingToAppBoundDomain isNavigatingToAppBoundDomain, NetworkSessionCocoa& session)
@@ -1382,7 +1382,7 @@ SessionWrapper& NetworkSessionCocoa::sessionWrapperForTask(std::optional<WebPage
     if (CheckedPtr storageSession = networkStorageSession()) {
         auto firstParty = WebCore::RegistrableDomain(request.firstPartyForCookies());
         if (storageSession->shouldBlockThirdPartyCookiesButKeepFirstPartyCookiesFor(firstParty))
-            return protectedSessionSetForPage(webPageProxyID)->isolatedSession(storedCredentialsPolicy, firstParty, shouldBeConsideredAppBound, *this);
+            return protect(sessionSetForPage(webPageProxyID))->isolatedSession(storedCredentialsPolicy, firstParty, shouldBeConsideredAppBound, *this);
     } else
         ASSERT_NOT_REACHED();
 
@@ -1444,7 +1444,7 @@ void NetworkSessionCocoa::clearAppBoundSession()
 
 SessionWrapper& NetworkSessionCocoa::isolatedSession(WebPageProxyIdentifier webPageProxyID, WebCore::StoredCredentialsPolicy storedCredentialsPolicy, const WebCore::RegistrableDomain& firstPartyDomain, NavigatingToAppBoundDomain isNavigatingToAppBoundDomain)
 {
-    return protectedSessionSetForPage(webPageProxyID)->isolatedSession(storedCredentialsPolicy, firstPartyDomain, isNavigatingToAppBoundDomain, *this);
+    return protect(sessionSetForPage(webPageProxyID))->isolatedSession(storedCredentialsPolicy, firstPartyDomain, isNavigatingToAppBoundDomain, *this);
 }
 
 SessionWrapper& SessionSet::isolatedSession(WebCore::StoredCredentialsPolicy storedCredentialsPolicy, const WebCore::RegistrableDomain& firstPartyDomain, NavigatingToAppBoundDomain isNavigatingToAppBoundDomain, NetworkSessionCocoa& session)

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp
@@ -81,11 +81,6 @@ void BackgroundFetchStoreImpl::initializeFetches(const ServiceWorkerRegistration
     initializeFetches({ key.topOrigin(), SecurityOriginData::fromURL(key.scope()) }, WTF::move(callback));
 }
 
-RefPtr<WebCore::SWServer> BackgroundFetchStoreImpl::protectedServer()
-{
-    return m_server.get();
-}
-
 void BackgroundFetchStoreImpl::initializeFetches(const WebCore::ClientOrigin& origin, CompletionHandler<void()>&& callback)
 {
     RefPtr manager = m_manager.get();
@@ -102,7 +97,7 @@ void BackgroundFetchStoreImpl::initializeFetches(const WebCore::ClientOrigin& or
 
     addResult.iterator->value.initializationCallbacks.append(WTF::move(callback));
 
-    initializeFetchesInternal(origin, [origin, weakEngine = WeakPtr { protectedServer()->backgroundFetchEngine() }, protectedThis = Ref { *this }, manager](Vector<std::pair<RefPtr<WebCore::SharedBuffer>, String>>&& fetches) {
+    initializeFetchesInternal(origin, [origin, weakEngine = WeakPtr { protect(m_server)->backgroundFetchEngine() }, protectedThis = Ref { *this }, manager](Vector<std::pair<RefPtr<WebCore::SharedBuffer>, String>>&& fetches) {
         if (weakEngine && manager) {
             for (auto& fetch : fetches) {
                 weakEngine->addFetchFromStore(Ref { *fetch.first }->span(), [&](auto& key, auto& identifier) {
@@ -413,7 +408,7 @@ void BackgroundFetchStoreImpl::getAllBackgroundFetchIdentifiers(CompletionHandle
 
 void BackgroundFetchStoreImpl::getBackgroundFetchState(const String& backgroundFetchIdentifier, CompletionHandler<void(std::optional<BackgroundFetchState>&&)>&& callback)
 {
-    fetchInformationFromFilename(backgroundFetchIdentifier, [engine = WeakPtr { protectedServer()->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
+    fetchInformationFromFilename(backgroundFetchIdentifier, [engine = WeakPtr { protect(m_server)->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
         WeakPtr<BackgroundFetch> fetch = engine ? engine->backgroundFetch(key, identifier) : nullptr;
         if (!fetch) {
             callback({ });
@@ -426,7 +421,7 @@ void BackgroundFetchStoreImpl::getBackgroundFetchState(const String& backgroundF
 
 void BackgroundFetchStoreImpl::abortBackgroundFetch(const String& filename, CompletionHandler<void()>&& callback)
 {
-    fetchInformationFromFilename(filename, [engine = WeakPtr { protectedServer()->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
+    fetchInformationFromFilename(filename, [engine = WeakPtr { protect(m_server)->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
         if (engine && !identifier.isNull())
             engine->abortBackgroundFetch(key, identifier);
         callback();
@@ -435,7 +430,7 @@ void BackgroundFetchStoreImpl::abortBackgroundFetch(const String& filename, Comp
 
 void BackgroundFetchStoreImpl::pauseBackgroundFetch(const String& filename, CompletionHandler<void()>&& callback)
 {
-    fetchInformationFromFilename(filename, [engine = WeakPtr { protectedServer()->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
+    fetchInformationFromFilename(filename, [engine = WeakPtr { protect(m_server)->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
         if (engine && !identifier.isNull())
             engine->pauseBackgroundFetch(key, identifier);
         callback();
@@ -444,7 +439,7 @@ void BackgroundFetchStoreImpl::pauseBackgroundFetch(const String& filename, Comp
 
 void BackgroundFetchStoreImpl::resumeBackgroundFetch(const String& filename, CompletionHandler<void()>&& callback)
 {
-    fetchInformationFromFilename(filename, [engine = WeakPtr { protectedServer()->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
+    fetchInformationFromFilename(filename, [engine = WeakPtr { protect(m_server)->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
         if (engine && !identifier.isNull())
             engine->resumeBackgroundFetch(key, identifier);
         callback();
@@ -453,7 +448,7 @@ void BackgroundFetchStoreImpl::resumeBackgroundFetch(const String& filename, Com
 
 void BackgroundFetchStoreImpl::clickBackgroundFetch(const String& filename, CompletionHandler<void()>&& callback)
 {
-    fetchInformationFromFilename(filename, [engine = WeakPtr { protectedServer()->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
+    fetchInformationFromFilename(filename, [engine = WeakPtr { protect(m_server)->backgroundFetchEngine() }, callback = WTF::move(callback)](auto key, auto identifier) mutable {
         if (engine && !identifier.isNull())
             engine->clickBackgroundFetch(key, identifier);
         callback();

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
@@ -76,8 +76,6 @@ private:
     void fetchInformationFromFilename(const String&, CompletionHandler<void(const WebCore::ServiceWorkerRegistrationKey&, const String&)>&&);
     void initializeFetches(const WebCore::ClientOrigin&, CompletionHandler<void()>&&);
 
-    RefPtr<WebCore::SWServer> protectedServer();
-
     ThreadSafeWeakPtr<NetworkStorageManager> m_manager;
 
     using FetchIdentifier = std::pair<String, String>; // < service worker registration scope, background fetch identifier >

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1964,7 +1964,7 @@ void NetworkStorageManager::getAllDatabaseNamesAndVersions(IPC::Connection& conn
 
 void NetworkStorageManager::cacheStorageOpenCache(const WebCore::ClientOrigin& origin, const String& cacheName, WebCore::DOMCacheEngine::CacheIdentifierCallback&& callback)
 {
-    protect(originStorageManager(origin))->protectedCacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef())->openCache(cacheName, WTF::move(callback));
+    protect(protect(originStorageManager(origin))->cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()))->openCache(cacheName, WTF::move(callback));
 }
 
 void NetworkStorageManager::cacheStorageRemoveCache(WebCore::DOMCacheIdentifier cacheIdentifier, WebCore::DOMCacheEngine::RemoveCacheIdentifierCallback&& callback)
@@ -1982,7 +1982,7 @@ void NetworkStorageManager::cacheStorageRemoveCache(WebCore::DOMCacheIdentifier 
 
 void NetworkStorageManager::cacheStorageAllCaches(const WebCore::ClientOrigin& origin, uint64_t updateCounter, WebCore::DOMCacheEngine::CacheInfosCallback&& callback)
 {
-    protect(originStorageManager(origin))->protectedCacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef())->allCaches(updateCounter, WTF::move(callback));
+    protect(protect(originStorageManager(origin))->cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()))->allCaches(updateCounter, WTF::move(callback));
 }
 
 void NetworkStorageManager::cacheStorageReference(IPC::Connection& connection, WebCore::DOMCacheIdentifier cacheIdentifier)
@@ -2013,7 +2013,7 @@ void NetworkStorageManager::cacheStorageDereference(IPC::Connection& connection,
 
 void NetworkStorageManager::lockCacheStorage(IPC::Connection& connection, const WebCore::ClientOrigin& origin)
 {
-    protect(originStorageManager(origin))->protectedCacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef())->lockStorage(connection.uniqueID());
+    protect(protect(originStorageManager(origin))->cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()))->lockStorage(connection.uniqueID());
 }
 
 void NetworkStorageManager::unlockCacheStorage(IPC::Connection& connection, const WebCore::ClientOrigin& origin)
@@ -2076,7 +2076,7 @@ void NetworkStorageManager::cacheStorageRepresentation(CompletionHandler<void(co
                 originStrings.append(makeString("\n{ \"origin\" : { \"topOrigin\" : \""_s,
                     origin.topOrigin.toString(), "\", \"clientOrigin\": \""_s,
                     origin.clientOrigin.toString(), "\" }, \"caches\" : "_s,
-                    originStorageManager->protectedCacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef())->representationString(),
+                    protect(originStorageManager->cacheStorageManager(*m_cacheStorageRegistry, origin, m_queue.copyRef()))->representationString(),
                     '}'
                 ));
             }

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp
@@ -754,11 +754,6 @@ CacheStorageManager& OriginStorageManager::cacheStorageManager(CacheStorageRegis
     }, WTF::move(queue));
 }
 
-Ref<CacheStorageManager> OriginStorageManager::protectedCacheStorageManager(CacheStorageRegistry& registry, const WebCore::ClientOrigin& origin, Ref<WorkQueue>&& queue)
-{
-    return cacheStorageManager(registry, origin, WTF::move(queue));
-}
-
 BackgroundFetchStoreManager& OriginStorageManager::backgroundFetchManager(Ref<WorkQueue>&& queue)
 {
     return defaultBucket().backgroundFetchManager(WTF::move(queue), [quotaManager = ThreadSafeWeakPtr { this->quotaManager() }](uint64_t spaceRequested, CompletionHandler<void(bool)>&& completionHandler) mutable {

--- a/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/OriginStorageManager.h
@@ -79,7 +79,6 @@ public:
     IDBStorageManager& idbStorageManager(IDBStorageRegistry&);
     IDBStorageManager* existingIDBStorageManager();
     CacheStorageManager& cacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, Ref<WorkQueue>&&);
-    Ref<CacheStorageManager> protectedCacheStorageManager(CacheStorageRegistry&, const WebCore::ClientOrigin&, Ref<WorkQueue>&&);
     CacheStorageManager* existingCacheStorageManager();
     BackgroundFetchStoreManager& backgroundFetchManager(Ref<WTF::WorkQueue>&&);
     ServiceWorkerStorageManager& serviceWorkerStorageManager();

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp
@@ -100,7 +100,7 @@ void NetworkRTCProvider::close()
 
     protect(connection())->removeMessageReceiver(Messages::NetworkRTCProvider::messageReceiverName());
     m_connection = nullptr;
-    protectedRTCMonitor()->stopUpdating();
+    protect(m_rtcMonitor)->stopUpdating();
 
     callOnRTCNetworkThread([this, protectedThis = Ref { *this }] {
         auto sockets = std::exchange(m_sockets, { });
@@ -387,11 +387,6 @@ void NetworkRTCProvider::assertIsRTCNetworkThread()
 void NetworkRTCProvider::signalSocketIsClosed(LibWebRTCSocketIdentifier identifier)
 {
     protect(connection())->send(Messages::LibWebRTCNetwork::SignalClose(identifier, 1), 0);
-}
-
-Ref<NetworkRTCMonitor> NetworkRTCProvider::protectedRTCMonitor()
-{
-    return m_rtcMonitor;
 }
 
 std::optional<SharedPreferencesForWebProcess> NetworkRTCProvider::sharedPreferencesForWebProcess(IPC::Connection& connection)

--- a/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
+++ b/Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h
@@ -93,7 +93,7 @@ public:
     void ref() const final { ThreadSafeRefCounted::ref(); }
     void deref() const final { ThreadSafeRefCounted::deref(); }
 
-    void didReceiveNetworkRTCMonitorMessage(IPC::Connection& connection, IPC::Decoder& decoder) { protectedRTCMonitor()->didReceiveMessage(connection, decoder); }
+    void didReceiveNetworkRTCMonitorMessage(IPC::Connection& connection, IPC::Decoder& decoder) { protect(m_rtcMonitor)->didReceiveMessage(connection, decoder); }
 
     class Socket {
     public:
@@ -159,8 +159,6 @@ private:
     void signalSocketIsClosed(WebCore::LibWebRTCSocketIdentifier);
 
     void assertIsRTCNetworkThread();
-
-    Ref<NetworkRTCMonitor> protectedRTCMonitor();
 
     static constexpr size_t maxSockets { 256 };
 

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp
@@ -54,11 +54,6 @@ static WeakPtr<WebPaymentCoordinatorProxy>& activePaymentCoordinatorProxy()
     return activePaymentCoordinatorProxy.get();
 }
 
-Ref<WorkQueue> WebPaymentCoordinatorProxy::protectedCanMakePaymentsQueue() const
-{
-    return m_canMakePaymentsQueue;
-}
-
 IPC::Connection* WebPaymentCoordinatorProxy::messageSenderConnection() const
 {
     CheckedPtr client = m_client.get();

--- a/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
+++ b/Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h
@@ -132,7 +132,6 @@ public:
 
 private:
     explicit WebPaymentCoordinatorProxy(Client&);
-    Ref<WorkQueue> NODELETE protectedCanMakePaymentsQueue() const;
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) override;

--- a/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
+++ b/Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm
@@ -47,7 +47,7 @@ void WebPaymentCoordinatorProxy::platformCanMakePayments(CompletionHandler<void(
 #endif
         return completionHandler(false);
 
-    protectedCanMakePaymentsQueue()->dispatch([theClass = retainPtr(PAL::getPKPaymentAuthorizationViewControllerClassSingleton()), completionHandler = WTF::move(completionHandler)]() mutable {
+    protect(m_canMakePaymentsQueue)->dispatch([theClass = retainPtr(PAL::getPKPaymentAuthorizationViewControllerClassSingleton()), completionHandler = WTF::move(completionHandler)]() mutable {
         RunLoop::mainSingleton().dispatch([canMakePayments = [theClass canMakePayments], completionHandler = WTF::move(completionHandler)]() mutable {
             completionHandler(canMakePayments);
         });

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -427,7 +427,7 @@ public:
         return stringForURL(data.shortenedName, data.completedSource, ExtractedURLType::Image);
     }
 
-    Ref<JSON::Object> protectedRootJSONObject()
+    JSON::Object& rootJSONObject()
     {
         ASSERT(useJSONOutput());
         if (!m_rootJSONObject)
@@ -506,7 +506,7 @@ private:
             menuObject->setString("type"_s, "nativePopupMenu"_s);
             menuObject->setArray("items"_s, WTF::move(itemsArray));
 
-            if (RefPtr children = protectedRootJSONObject()->getArray("children"_s))
+            if (RefPtr children = protect(rootJSONObject())->getArray("children"_s))
                 children->pushObject(WTF::move(menuObject));
             return;
         }
@@ -523,7 +523,7 @@ private:
         if (!useJSONOutput())
             return;
 
-        protectedRootJSONObject()->setInteger("version"_s, version());
+        protect(rootJSONObject())->setInteger("version"_s, version());
     }
 
     uint32_t version() const
@@ -1399,7 +1399,7 @@ void convertToText(TextExtraction::Item&& item, TextExtractionOptions&& options,
     Ref aggregator = TextExtractionAggregator::create(WTF::move(options), WTF::move(completion));
 
     if (aggregator->useJSONOutput()) {
-        populateJSONForItem(aggregator->protectedRootJSONObject(), item, { }, aggregator);
+        populateJSONForItem(protect(aggregator->rootJSONObject()), item, { }, aggregator);
         return;
     }
 

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp
@@ -37,10 +37,10 @@ namespace WebKit::WebGPU {
 
 static WebGPUIdentifier getIdentifier(ConvertToBackingContext& convertToBacking, const WebCore::WebGPU::RenderPassColorAttachment& renderPassColorAttachment)
 {
-    if (RefPtr view = renderPassColorAttachment.protectedView().get())
+    if (RefPtr view = renderPassColorAttachment.textureView())
         return convertToBacking.convertToBacking(*view);
 
-    return convertToBacking.convertToBacking(*renderPassColorAttachment.protectedTexture().get());
+    return convertToBacking.convertToBacking(*protect(renderPassColorAttachment.texture()));
 }
 std::optional<RenderPassColorAttachment> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderPassColorAttachment& renderPassColorAttachment)
 {
@@ -48,11 +48,11 @@ std::optional<RenderPassColorAttachment> ConvertToBackingContext::convertToBacki
 
     std::optional<WebGPUIdentifier> resolveTarget;
     if (renderPassColorAttachment.resolveTarget) {
-        RefPtr textureView = renderPassColorAttachment.protectedResolveTarget().get();
+        RefPtr textureView = renderPassColorAttachment.resolveTextureView();
         if (textureView)
             resolveTarget = convertToBacking(*textureView);
         else
-            resolveTarget = convertToBacking(*renderPassColorAttachment.protectedResolveTexture());
+            resolveTarget = convertToBacking(*protect(renderPassColorAttachment.resolveTexture()));
         if (!resolveTarget)
             return std::nullopt;
     }

--- a/Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp
+++ b/Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp
@@ -39,10 +39,10 @@ namespace WebKit::WebGPU {
 
 static WebGPUIdentifier getIdentifier(ConvertToBackingContext& convertToBacking, const WebCore::WebGPU::RenderPassDepthStencilAttachment& renderPassDepthStencilAttachment)
 {
-    if (RefPtr view = renderPassDepthStencilAttachment.protectedView().get())
+    if (RefPtr view = renderPassDepthStencilAttachment.textureView())
         return convertToBacking.convertToBacking(*view);
 
-    return convertToBacking.convertToBacking(*renderPassDepthStencilAttachment.protectedTexture().get());
+    return convertToBacking.convertToBacking(*protect(renderPassDepthStencilAttachment.texture()));
 }
 std::optional<RenderPassDepthStencilAttachment> ConvertToBackingContext::convertToBacking(const WebCore::WebGPU::RenderPassDepthStencilAttachment& renderPassDepthStencilAttachment)
 {

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp
@@ -177,48 +177,48 @@ uint64_t WebPaymentCoordinator::messageSenderDestinationID() const
     return m_webPage ? m_webPage->identifier().toUInt64() : 0;
 }
 
+WebCore::PaymentCoordinator& WebPaymentCoordinator::paymentCoordinator() const
+{
+    return m_webPage->corePage()->paymentCoordinator();
+}
+
 void WebPaymentCoordinator::validateMerchant(const String& validationURLString)
 {
-    protectedPaymentCoordinator()->validateMerchant(URL { validationURLString });
+    protect(paymentCoordinator())->validateMerchant(URL { validationURLString });
 }
 
 void WebPaymentCoordinator::didAuthorizePayment(const WebCore::Payment& payment)
 {
-    protectedPaymentCoordinator()->didAuthorizePayment(payment);
+    protect(paymentCoordinator())->didAuthorizePayment(payment);
 }
 
 void WebPaymentCoordinator::didSelectShippingMethod(const WebCore::ApplePayShippingMethod& shippingMethod)
 {
-    protectedPaymentCoordinator()->didSelectShippingMethod(shippingMethod);
+    protect(paymentCoordinator())->didSelectShippingMethod(shippingMethod);
 }
 
 void WebPaymentCoordinator::didSelectShippingContact(const WebCore::PaymentContact& shippingContact)
 {
-    protectedPaymentCoordinator()->didSelectShippingContact(shippingContact);
+    protect(paymentCoordinator())->didSelectShippingContact(shippingContact);
 }
 
 void WebPaymentCoordinator::didSelectPaymentMethod(const WebCore::PaymentMethod& paymentMethod)
 {
-    protectedPaymentCoordinator()->didSelectPaymentMethod(paymentMethod);
+    protect(paymentCoordinator())->didSelectPaymentMethod(paymentMethod);
 }
 
 #if ENABLE(APPLE_PAY_COUPON_CODE)
 
 void WebPaymentCoordinator::didChangeCouponCode(String&& couponCode)
 {
-    protectedPaymentCoordinator()->didChangeCouponCode(WTF::move(couponCode));
+    protect(paymentCoordinator())->didChangeCouponCode(WTF::move(couponCode));
 }
 
 #endif // ENABLE(APPLE_PAY_COUPON_CODE)
 
 void WebPaymentCoordinator::didCancelPaymentSession(WebCore::PaymentSessionError&& sessionError)
 {
-    protectedPaymentCoordinator()->didCancelPaymentSession(WTF::move(sessionError));
-}
-
-Ref<WebCore::PaymentCoordinator> WebPaymentCoordinator::protectedPaymentCoordinator()
-{
-    return m_webPage->corePage()->paymentCoordinator();
+    protect(paymentCoordinator())->didCancelPaymentSession(WTF::move(sessionError));
 }
 
 void WebPaymentCoordinator::getSetupFeatures(const WebCore::ApplePaySetupConfiguration& configuration, const URL& url, CompletionHandler<void(Vector<Ref<WebCore::ApplePaySetupFeature>>&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
+++ b/Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h
@@ -96,6 +96,8 @@ private:
     IPC::Connection* messageSenderConnection() const final;
     uint64_t messageSenderDestinationID() const final;
 
+    WebCore::PaymentCoordinator& paymentCoordinator() const;
+
     // Message handlers.
     void validateMerchant(const String& validationURLString);
     void didAuthorizePayment(const WebCore::Payment&);
@@ -106,8 +108,6 @@ private:
     void didChangeCouponCode(String&& couponCode);
 #endif
     void didCancelPaymentSession(WebCore::PaymentSessionError&&);
-
-    Ref<WebCore::PaymentCoordinator> protectedPaymentCoordinator();
 
     using AvailablePaymentNetworksSet = HashSet<String, ASCIICaseInsensitiveHash>;
     static AvailablePaymentNetworksSet platformAvailablePaymentNetworks();

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -109,7 +109,7 @@ void WebExtensionAPIAlarms::createAlarm(NSString *name, NSDictionary *alarmInfo,
             initialInterval = repeatInterval;
     }
 
-    if (!protectedExtensionContext()->inTestingMode()) {
+    if (!protect(extensionContext())->inTestingMode()) {
         // Enforce a minimum interval outside of testing.
         initialInterval = std::max(initialInterval, webExtensionMinimumAlarmInterval);
         repeatInterval = repeatInterval ? std::max(repeatInterval, webExtensionMinimumAlarmInterval) : 0_s;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -123,7 +123,7 @@ double WebExtensionAPIDevToolsInspectedWindow::tabId(WebPage& page)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/devtools/inspectedWindow/tabId
 
-    auto result = protectedExtensionContext()->tabIdentifier(page);
+    auto result = protect(extensionContext())->tabIdentifier(page);
     return toWebAPI(result ? result.value() : WebExtensionTabConstants::NoneIdentifier);
 }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -88,7 +88,7 @@ bool WebExtensionAPIExtension::parseViewFilters(NSDictionary *filter, std::optio
 
 bool WebExtensionAPIExtension::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
+    if (protect(extensionContext())->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
     // This method was removed in manifest version 3.
@@ -110,7 +110,7 @@ JSValue *WebExtensionAPIExtension::getBackgroundPage(JSContextRef context)
 {
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/extension/getBackgroundPage
 
-    auto backgroundPage = protectedExtensionContext()->backgroundPage();
+    auto backgroundPage = protect(extensionContext())->backgroundPage();
     if (!backgroundPage)
         return toJSValue(context, JSValueMakeNull(context));
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -253,7 +253,7 @@ bool WebExtensionAPIMenus::parseCreateAndUpdateProperties(ForUpdate forUpdate, N
             return false;
         }
 
-        outClickCallback = WebExtensionCallbackHandler::create(clickCallback.context.JSGlobalContextRef, JSValueToObject(clickCallback.context.JSGlobalContextRef, clickCallback.JSValueRef, nullptr), protectedRuntime());
+        outClickCallback = WebExtensionCallbackHandler::create(clickCallback.context.JSGlobalContextRef, JSValueToObject(clickCallback.context.JSGlobalContextRef, clickCallback.JSValueRef, nullptr), protect(runtime()));
     }
 
     NSDictionary *iconDictionary;

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm
@@ -235,7 +235,7 @@ WebExtensionAPIRuntime& WebExtensionAPINamespace::runtime() const
     // Documentation: https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions/API/runtime
 
     if (!m_runtime) {
-        m_runtime = WebExtensionAPIRuntime::create(contentWorldType(), protectedExtensionContext());
+        m_runtime = WebExtensionAPIRuntime::create(contentWorldType(), protect(extensionContext()));
         m_runtime->setPropertyPath("runtime"_s, this);
     }
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -52,7 +52,7 @@ namespace WebKit {
 
 bool WebExtensionAPIStorageArea::isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*)
 {
-    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
+    if (protect(extensionContext())->isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
         return false;
 
     static NeverDestroyed<HashSet<AtomString>> syncStorageProperties { HashSet { AtomString("QUOTA_BYTES_PER_ITEM"_s), AtomString("MAX_ITEMS"_s), AtomString("MAX_WRITE_OPERATIONS_PER_HOUR"_s), AtomString("MAX_WRITE_OPERATIONS_PER_MINUTE"_s) } };

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm
@@ -42,7 +42,7 @@ namespace WebKit {
 
 bool WebExtensionAPIStorage::isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*)
 {
-    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
+    if (protect(extensionContext())->isUnsupportedAPI(propertyPath(), propertyName)) [[unlikely]]
         return false;
 
     if (propertyName == "session"_s)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -607,7 +607,7 @@ bool isValid(std::optional<WebExtensionTabIdentifier> identifier, NSString **out
 
 bool WebExtensionAPITabs::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
+    if (protect(extensionContext())->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
     static NeverDestroyed<HashSet<AtomString>> removedInManifestVersion3 { HashSet { AtomString("executeScript"_s), AtomString("getSelected"_s), AtomString("insertCSS"_s), AtomString("removeCSS"_s) } };
@@ -1057,7 +1057,7 @@ RefPtr<WebExtensionAPIPort> WebExtensionAPITabs::connect(WebFrame& frame, JSCont
         if (result)
             return;
 
-        port->setError(protectedRuntime()->reportError(result.error().createNSString().get(), globalContext.get()));
+        port->setError(protect(runtime())->reportError(result.error().createNSString().get(), globalContext.get()));
         port->disconnect();
     }, extensionContext().identifier());
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm
@@ -67,11 +67,6 @@ WebExtensionAPIWebPageRuntime& WebExtensionAPIWebPageNamespace::runtime() const
     return *m_runtime;
 }
 
-Ref<WebExtensionAPIWebPageRuntime> WebExtensionAPIWebPageNamespace::protectedRuntime() const
-{
-    return runtime();
-}
-
 WebExtensionAPITest& WebExtensionAPIWebPageNamespace::test()
 {
     // Documentation: None (Testing Only)

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -378,7 +378,7 @@ bool isValid(std::optional<WebExtensionWindowIdentifier> identifier, NSString **
 
 bool WebExtensionAPIWindows::isPropertyAllowed(const ASCIILiteral& name, WebPage*)
 {
-    if (protectedExtensionContext()->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
+    if (protect(extensionContext())->isUnsupportedAPI(propertyPath(), name)) [[unlikely]]
         return false;
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h
@@ -85,7 +85,6 @@ public:
     WebExtensionAPIAction& pageAction() { return action(); }
     WebExtensionAPIPermissions& permissions();
     WebExtensionAPIRuntime& runtime() const final;
-    Ref<WebExtensionAPIRuntime> protectedRuntime() const { return runtime(); }
     WebExtensionAPIScripting& scripting();
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
     WebExtensionAPISidePanel& sidePanel();

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h
@@ -75,10 +75,8 @@ public:
     WebExtensionContentWorldType contentWorldType() const { return m_contentWorldType; }
 
     virtual WebExtensionAPIRuntimeBase& runtime() const { return *m_runtime; }
-    Ref<WebExtensionAPIRuntimeBase> protectedRuntime() const { return runtime(); }
 
     WebExtensionContextProxy& extensionContext() const { return *m_extensionContext; }
-    Ref<WebExtensionContextProxy> protectedExtensionContext() const { return extensionContext(); }
     bool hasExtensionContext() const { return !!m_extensionContext; }
 
     const String& propertyPath() const { return m_propertyPath; }

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h
@@ -62,7 +62,6 @@ class WebExtensionAPIRuntime : public WebExtensionAPIObject, public WebExtension
 
 public:
     WebExtensionAPIRuntime& runtime() const final { return const_cast<WebExtensionAPIRuntime&>(*this); }
-    Ref<WebExtensionAPIRuntime> protectedRuntime() const { return runtime(); }
 
 #if PLATFORM(COCOA)
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
@@ -116,7 +115,6 @@ class WebExtensionAPIWebPageRuntime : public WebExtensionAPIObject, public WebEx
 
 public:
     WebExtensionAPIWebPageRuntime& runtime() const final { return const_cast<WebExtensionAPIWebPageRuntime&>(*this); }
-    Ref<WebExtensionAPIWebPageRuntime> protectedRuntime() const { return runtime(); }
 
 #if PLATFORM(COCOA)
     void sendMessage(WebPage&, WebFrame&, const String& extensionID, const String& messageJSON, NSDictionary *options, Ref<WebExtensionCallbackHandler>&&, NSString **outExceptionString);

--- a/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
+++ b/Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h
@@ -45,7 +45,6 @@ public:
     bool isPropertyAllowed(const ASCIILiteral& propertyName, WebPage*);
 
     WebExtensionAPIWebPageRuntime& runtime() const;
-    Ref<WebExtensionAPIWebPageRuntime> protectedRuntime() const;
     WebExtensionAPITest& test();
 
 private:

--- a/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm
@@ -730,7 +730,7 @@ EOF
             if ($callbackHandlerArgument && !$returnsPromiseIfNoCallback) {
                 push(@contents, <<EOF);
     if (!${callbackHandlerArgument})
-        ${callbackHandlerArgument} = toJSErrorCallbackHandler(context, impl->protectedRuntime());
+        ${callbackHandlerArgument} = toJSErrorCallbackHandler(context, protect(impl->runtime()));
 
 EOF
             }
@@ -1473,7 +1473,7 @@ sub _platformTypeConstructor
         return "toJSValue(context, $argumentName)";
     }
 
-    return "toJSCallbackHandler(context, $argumentName, impl->protectedRuntime())" if $idlTypeName eq "function" && $signature->extendedAttributes->{"CallbackHandler"};
+    return "toJSCallbackHandler(context, $argumentName, protect(impl->runtime()))" if $idlTypeName eq "function" && $signature->extendedAttributes->{"CallbackHandler"};
     return "toNSArray(context, $argumentName, $arrayType.class)" if $idlTypeName eq "array" && $arrayType;
     return "toNSArray(context, $argumentName)" if $idlTypeName eq "array";
     return "JSValueToBoolean(context, $argumentName)" if $idlTypeName eq "boolean";

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -247,8 +247,7 @@ bool GPUProcessConnection::dispatchMessage(IPC::Connection& connection, IPC::Dec
 
 #if PLATFORM(COCOA) && ENABLE(MEDIA_STREAM)
     if (decoder.messageReceiverName() == Messages::UserMediaCaptureManager::messageReceiverName()) {
-        if (RefPtr captureManager = WebProcess::singleton().supplement<UserMediaCaptureManager>())
-            captureManager->didReceiveMessageFromGPUProcess(connection, decoder);
+        WebProcess::singleton().userMediaCaptureManager().didReceiveMessageFromGPUProcess(connection, decoder);
         return true;
     }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h
@@ -80,7 +80,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void update(const WebModel::UpdateMeshDescriptor&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h
@@ -71,12 +71,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
     }
 
     void requestDevice(const WebCore::WebGPU::DeviceDescriptor&, CompletionHandler<void(RefPtr<WebCore::WebGPU::Device>&&)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h
@@ -66,7 +66,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h
@@ -70,12 +70,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h
@@ -67,17 +67,17 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
     }
     template<typename T, typename C>
     [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
+        return protect(root().streamClientConnection())->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }
 
     void mapAsync(WebCore::WebGPU::MapModeFlags, WebCore::WebGPU::Size64 offset, std::optional<WebCore::WebGPU::Size64> sizeForMap, CompletionHandler<void(bool)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h
@@ -65,7 +65,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h
@@ -65,12 +65,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
     }
 
     RefPtr<WebCore::WebGPU::RenderPassEncoder> beginRenderPass(const WebCore::WebGPU::RenderPassDescriptor&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h
@@ -84,12 +84,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
     }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h
@@ -65,7 +65,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setPipeline(const WebCore::WebGPU::ComputePipeline&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h
@@ -68,7 +68,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     Ref<WebCore::WebGPU::BindGroupLayout> getBindGroupLayout(uint32_t index) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h
@@ -70,12 +70,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T, typename C>
     [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
+        return protect(root().streamClientConnection())->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }
 
     Ref<WebCore::WebGPU::Queue> NODELETE queue() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h
@@ -66,7 +66,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -71,7 +71,6 @@ public:
     RemoteGPUProxy& root() { return *this; }
 
     IPC::StreamClientConnection& streamClientConnection() { return *m_streamConnection; }
-    Ref<IPC::StreamClientConnection> protectedStreamClientConnection() { return *m_streamConnection; }
 
     void ref() const final { return ThreadSafeRefCounted<RemoteGPUProxy>::ref(); }
     void deref() const final { return ThreadSafeRefCounted<RemoteGPUProxy>::deref(); }
@@ -106,17 +105,17 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(std::forward<T>(message), backing());
+        return protect(root().streamClientConnection())->send(std::forward<T>(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(std::forward<T>(message), backing());
+        return protect(root().streamClientConnection())->sendSync(std::forward<T>(message), backing());
     }
     template<typename T, typename C>
     [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
+        return protect(root().streamClientConnection())->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }
 
     void requestAdapter(const WebCore::WebGPU::RequestAdapterOptions&, CompletionHandler<void(RefPtr<WebCore::WebGPU::Adapter>&&)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h
@@ -66,7 +66,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h
@@ -77,7 +77,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     bool configure(const WebCore::WebGPU::CanvasConfiguration&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h
@@ -66,7 +66,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void destroy() final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h
@@ -68,12 +68,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T, typename C>
     [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
+        return protect(root().streamClientConnection())->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }
 
     void onSubmittedWorkDone(CompletionHandler<void()>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h
@@ -66,7 +66,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setPipeline(const WebCore::WebGPU::RenderPipeline&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h
@@ -66,7 +66,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h
@@ -65,7 +65,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setPipeline(const WebCore::WebGPU::RenderPipeline&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h
@@ -68,7 +68,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     Ref<WebCore::WebGPU::BindGroupLayout> getBindGroupLayout(uint32_t index) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h
@@ -66,7 +66,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h
@@ -66,12 +66,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T, typename C>
     [[nodiscard]] std::optional<IPC::StreamClientConnection::AsyncReplyID> sendWithAsyncReply(T&& message, C&& completionHandler)
     {
-        return root().protectedStreamClientConnection()->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
+        return protect(root().streamClientConnection())->sendWithAsyncReply(WTF::move(message), completionHandler, backing());
     }
 
     void compilationInfo(CompletionHandler<void(Ref<WebCore::WebGPU::CompilationInfo>&&)>&&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h
@@ -70,7 +70,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     RefPtr<WebCore::WebGPU::TextureView> createView(const std::optional<WebCore::WebGPU::TextureViewDescriptor>&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h
@@ -65,7 +65,7 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
 
     void setLabelInternal(const String&) final;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h
@@ -83,12 +83,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
     }
 
     WebGPUIdentifier m_backing;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h
@@ -90,12 +90,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
     }
 
     bool isRemoteXRProjectionLayerProxy() const final { return true; }

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h
@@ -77,12 +77,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
     }
 
     WebGPUIdentifier m_backing;

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.h
@@ -78,12 +78,12 @@ private:
     template<typename T>
     [[nodiscard]] IPC::Error send(T&& message)
     {
-        return root().protectedStreamClientConnection()->send(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->send(WTF::move(message), backing());
     }
     template<typename T>
     [[nodiscard]] IPC::Connection::SendSyncResult<T> sendSync(T&& message)
     {
-        return root().protectedStreamClientConnection()->sendSync(WTF::move(message), backing());
+        return protect(root().streamClientConnection())->sendSync(WTF::move(message), backing());
     }
 
     WebGPUIdentifier m_backing;

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp
@@ -124,7 +124,7 @@ MediaTime MediaPlayerPrivateRemote::TimeProgressEstimator::currentTimeWithLockHe
         return m_cachedMediaTime;
 
     auto calculatedCurrentTime = m_cachedMediaTime + MediaTime::createWithDouble(m_rate * (MonotonicTime::now() - m_cachedMediaTimeQueryTime).seconds());
-    calculatedCurrentTime = std::min(std::max(calculatedCurrentTime, MediaTime::zeroTime()), protectedParent()->duration());
+    calculatedCurrentTime = std::min(std::max(calculatedCurrentTime, MediaTime::zeroTime()), protect(m_parent)->duration());
     if (m_rate >= 0)
         calculatedCurrentTime = std::max(m_lastReturnedTime.value_or(calculatedCurrentTime), calculatedCurrentTime);
     else

--- a/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h
@@ -235,8 +235,6 @@ private:
         void forceUseOfCachedTimeUntilNextSetTime();
 
     private:
-        Ref<const MediaPlayerPrivateRemote> protectedParent() const { return m_parent.get(); }
-
         mutable Lock m_lock;
         std::atomic<bool> m_timeIsProgressing { false };
         MediaTime m_cachedMediaTime WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp
@@ -48,14 +48,9 @@ RemoteLegacyCDM::RemoteLegacyCDM(RemoteLegacyCDMFactory& factory, RemoteLegacyCD
 
 RemoteLegacyCDM::~RemoteLegacyCDM() = default;
 
-Ref<RemoteLegacyCDMFactory> RemoteLegacyCDM::protectedFactory() const
-{
-    return m_factory.get();
-}
-
 bool RemoteLegacyCDM::supportsMIMEType(const String& mimeType) const
 {
-    auto sendResult = protectedFactory()->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMProxy::SupportsMIMEType(mimeType), m_identifier);
+    auto sendResult = protect(m_factory)->gpuProcessConnection().connection().sendSync(Messages::RemoteLegacyCDMProxy::SupportsMIMEType(mimeType), m_identifier);
     auto [supported] = sendResult.takeReplyOr(false);
     return supported;
 }
@@ -77,7 +72,7 @@ RefPtr<WebCore::LegacyCDMSession> RemoteLegacyCDM::createSession(WebCore::Legacy
 
 void RemoteLegacyCDM::setPlayerId(std::optional<MediaPlayerIdentifier> identifier)
 {
-    protectedFactory()->gpuProcessConnection().connection().send(Messages::RemoteLegacyCDMProxy::SetPlayerId(identifier), m_identifier);
+    protect(m_factory)->gpuProcessConnection().connection().send(Messages::RemoteLegacyCDMProxy::SetPlayerId(identifier), m_identifier);
 }
 
 void RemoteLegacyCDM::ref() const

--- a/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.h
@@ -58,8 +58,6 @@ public:
     void deref() const final;
 
 private:
-    Ref<RemoteLegacyCDMFactory> protectedFactory() const;
-
     WeakRef<RemoteLegacyCDMFactory> m_factory;
     RemoteLegacyCDMIdentifier m_identifier;
 };

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp
@@ -54,11 +54,6 @@ GeolocationPermissionRequestManager::GeolocationPermissionRequestManager(WebPage
 
 GeolocationPermissionRequestManager::~GeolocationPermissionRequestManager() = default;
 
-Ref<WebPage> GeolocationPermissionRequestManager::protectedPage() const
-{
-    return m_page.get();
-}
-
 void GeolocationPermissionRequestManager::startRequestForGeolocation(Geolocation& geolocation)
 {
     RefPtr frame = geolocation.frame();
@@ -77,12 +72,12 @@ void GeolocationPermissionRequestManager::startRequestForGeolocation(Geolocation
     RefPtr webFrame = WebFrame::fromCoreFrame(*frame);
     ASSERT(webFrame);
 
-    protectedPage()->send(Messages::WebPageProxy::RequestGeolocationPermissionForFrame(geolocationID, webFrame->info()));
+    protect(m_page)->send(Messages::WebPageProxy::RequestGeolocationPermissionForFrame(geolocationID, webFrame->info()));
 }
 
 void GeolocationPermissionRequestManager::revokeAuthorizationToken(const String& authorizationToken)
 {
-    protectedPage()->send(Messages::WebPageProxy::RevokeGeolocationAuthorizationToken(authorizationToken));
+    protect(m_page)->send(Messages::WebPageProxy::RevokeGeolocationAuthorizationToken(authorizationToken));
 }
 
 void GeolocationPermissionRequestManager::cancelRequestForGeolocation(Geolocation& geolocation)

--- a/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h
@@ -61,8 +61,6 @@ private:
     IDToGeolocationMap m_idToGeolocationMap;
     GeolocationToIDMap m_geolocationToIDMap;
 
-    Ref<WebPage> protectedPage() const;
-
     WeakRef<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp
@@ -72,7 +72,7 @@ void RemoteWebInspectorUI::initialize(DebuggableInfoData&& debuggableInfo, const
     m_debuggableInfo = WTF::move(debuggableInfo);
     m_backendCommandsURL = backendCommandsURL;
 
-    protect(protectedWebPage()->corePage())->inspectorController().setInspectorFrontendClient(this);
+    protect(protect(m_page)->corePage())->inspectorController().setInspectorFrontendClient(this);
 
     m_frontendAPIDispatcher->reset();
     m_frontendAPIDispatcher->dispatchCommandWithResultAsync("setDockingUnavailable"_s, { JSON::Value::create(true) });
@@ -98,7 +98,7 @@ void RemoteWebInspectorUI::windowObjectCleared()
     if (RefPtr frontendHost = m_frontendHost)
         frontendHost->disconnectClient();
 
-    m_frontendHost = InspectorFrontendHost::create(this, protect(protectedWebPage()->corePage()).get());
+    m_frontendHost = InspectorFrontendHost::create(this, protect(protect(m_page)->corePage()).get());
     RefPtr { m_frontendHost }->addSelfToGlobalObjectInWorld(mainThreadNormalWorldSingleton());
 }
 
@@ -173,12 +173,12 @@ void RemoteWebInspectorUI::bringToFront()
 
 void RemoteWebInspectorUI::closeWindow()
 {
-    protect(protectedWebPage()->corePage())->inspectorController().setInspectorFrontendClient(nullptr);
+    protect(protect(m_page)->corePage())->inspectorController().setInspectorFrontendClient(nullptr);
 
 #if ENABLE(INSPECTOR_EXTENSIONS)
     m_extensionController = nullptr;
 #endif
-    
+
     protect(WebProcess::singleton().parentProcessConnection())->send(Messages::RemoteWebInspectorUIProxy::FrontendDidClose(), m_page->identifier());
 }
 
@@ -286,7 +286,7 @@ bool RemoteWebInspectorUI::supportsDiagnosticLogging()
 
 void RemoteWebInspectorUI::logDiagnosticEvent(const String& eventName,  const DiagnosticLoggingClient::ValueDictionary& dictionary)
 {
-    protect(protect(protectedWebPage()->corePage())->diagnosticLoggingClient())->logDiagnosticMessageWithValueDictionary(eventName, "Remote Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
+    protect(protect(protect(m_page)->corePage())->diagnosticLoggingClient())->logDiagnosticMessageWithValueDictionary(eventName, "Remote Web Inspector Frontend Diagnostics"_s, dictionary, ShouldSample::No);
 }
 
 void RemoteWebInspectorUI::setDiagnosticLoggingAvailable(bool available)
@@ -333,11 +333,6 @@ void RemoteWebInspectorUI::inspectedPageDidNavigate(const URL& newURL)
 WebCore::Page* RemoteWebInspectorUI::frontendPage()
 {
     return m_page->corePage();
-}
-
-const Ref<WebPage> RemoteWebInspectorUI::protectedWebPage()
-{
-    return m_page.get();
 }
 
 

--- a/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h
+++ b/Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h
@@ -148,7 +148,6 @@ public:
 
 private:
     explicit RemoteWebInspectorUI(WebPage&);
-    const Ref<WebPage> protectedWebPage();
 
     WeakRef<WebPage> m_page;
     const Ref<WebCore::InspectorFrontendAPIDispatcher> m_frontendAPIDispatcher;

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp
@@ -46,11 +46,6 @@ WebFrameInspectorTarget::WebFrameInspectorTarget(WebFrame& frame)
 
 WebFrameInspectorTarget::~WebFrameInspectorTarget() = default;
 
-Ref<WebFrame> WebFrameInspectorTarget::protectedFrame()
-{
-    return m_frame.get();
-}
-
 String WebFrameInspectorTarget::identifier() const
 {
     return toTargetID(m_frame->frameID());
@@ -73,7 +68,7 @@ void WebFrameInspectorTarget::disconnect()
     if (!m_channel)
         return;
 
-    if (RefPtr coreFrame = protectedFrame()->coreLocalFrame())
+    if (RefPtr coreFrame = protect(m_frame)->coreLocalFrame())
         protect(coreFrame->inspectorController())->disconnectFrontend(*m_channel);
 
     m_channel.reset();
@@ -81,7 +76,7 @@ void WebFrameInspectorTarget::disconnect()
 
 void WebFrameInspectorTarget::sendMessageToTargetBackend(const String& message)
 {
-    if (RefPtr coreFrame = protectedFrame()->coreLocalFrame())
+    if (RefPtr coreFrame = protect(m_frame)->coreLocalFrame())
         protect(coreFrame->inspectorController())->dispatchMessageFromFrontend(message);
 }
 

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.h
@@ -56,8 +56,6 @@ public:
     static String toTargetID(WebCore::FrameIdentifier);
 
 private:
-    Ref<WebFrame> protectedFrame();
-
     WeakRef<WebFrame> m_frame;
     std::unique_ptr<WebFrameInspectorTargetFrontendChannel> m_channel;
 };

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.cpp
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.cpp
@@ -43,14 +43,9 @@ WebFrameInspectorTargetFrontendChannel::WebFrameInspectorTargetFrontendChannel(W
 {
 }
 
-Ref<WebFrame> WebFrameInspectorTargetFrontendChannel::protectedFrame()
-{
-    return m_frame.get();
-}
-
 void WebFrameInspectorTargetFrontendChannel::sendMessageToFrontend(const String& message)
 {
-    if (RefPtr page = protectedFrame()->page())
+    if (RefPtr page = protect(m_frame)->page())
         page->send(Messages::WebPageProxy::SendMessageToInspectorFrontend(m_targetId, message));
 }
 

--- a/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.h
+++ b/Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.h
@@ -43,8 +43,6 @@ public:
     virtual ~WebFrameInspectorTargetFrontendChannel() = default;
 
 private:
-    Ref<WebFrame> protectedFrame();
-
     ConnectionType connectionType() const override { return m_connectionType; }
     void sendMessageToFrontend(const String& message) override;
 

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp
@@ -67,15 +67,10 @@ RemoteMediaSessionCoordinator::~RemoteMediaSessionCoordinator()
     WebProcess::singleton().removeMessageReceiver(Messages::RemoteMediaSessionCoordinator::messageReceiverName(), m_page->identifier());
 }
 
-Ref<WebPage> RemoteMediaSessionCoordinator::protectedPage() const
-{
-    return m_page.get();
-}
-
 void RemoteMediaSessionCoordinator::join(CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::Join { }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
+    protect(m_page)->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::Join { }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -92,13 +87,13 @@ void RemoteMediaSessionCoordinator::join(CompletionHandler<void(std::optional<We
 
 void RemoteMediaSessionCoordinator::leave()
 {
-    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::Leave { });
+    protect(m_page)->send(Messages::RemoteMediaSessionCoordinatorProxy::Leave { });
 }
 
 void RemoteMediaSessionCoordinator::seekTo(double time, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, time);
-    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinateSeekTo { time }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
+    protect(m_page)->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinateSeekTo { time }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -116,7 +111,7 @@ void RemoteMediaSessionCoordinator::seekTo(double time, CompletionHandler<void(s
 void RemoteMediaSessionCoordinator::play(CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinatePlay { }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
+    protect(m_page)->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinatePlay { }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -134,7 +129,7 @@ void RemoteMediaSessionCoordinator::play(CompletionHandler<void(std::optional<We
 void RemoteMediaSessionCoordinator::pause(CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinatePause { }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
+    protect(m_page)->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinatePause { }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -152,7 +147,7 @@ void RemoteMediaSessionCoordinator::pause(CompletionHandler<void(std::optional<W
 void RemoteMediaSessionCoordinator::setTrack(const String& trackIdentifier, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& callback)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    protectedPage()->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinateSetTrack { trackIdentifier }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
+    protect(m_page)->sendWithAsyncReply(Messages::RemoteMediaSessionCoordinatorProxy::CoordinateSetTrack { trackIdentifier }, [weakThis = WeakPtr { *this }, callback = WTF::move(callback)](auto&& exception) mutable {
         if (!weakThis) {
             callback(Exception { ExceptionCode::InvalidStateError });
             return;
@@ -170,25 +165,25 @@ void RemoteMediaSessionCoordinator::setTrack(const String& trackIdentifier, Comp
 void RemoteMediaSessionCoordinator::positionStateChanged(const std::optional<WebCore::MediaPositionState>& state)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER);
-    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::PositionStateChanged { state });
+    protect(m_page)->send(Messages::RemoteMediaSessionCoordinatorProxy::PositionStateChanged { state });
 }
 
 void RemoteMediaSessionCoordinator::readyStateChanged(WebCore::MediaSessionReadyState state)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, state);
-    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::ReadyStateChanged { state });
+    protect(m_page)->send(Messages::RemoteMediaSessionCoordinatorProxy::ReadyStateChanged { state });
 }
 
 void RemoteMediaSessionCoordinator::playbackStateChanged(WebCore::MediaSessionPlaybackState state)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, state);
-    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::PlaybackStateChanged { state });
+    protect(m_page)->send(Messages::RemoteMediaSessionCoordinatorProxy::PlaybackStateChanged { state });
 }
 
 void RemoteMediaSessionCoordinator::trackIdentifierChanged(const String& identifier)
 {
     ALWAYS_LOG_IF_POSSIBLE(LOGIDENTIFIER, identifier);
-    protectedPage()->send(Messages::RemoteMediaSessionCoordinatorProxy::TrackIdentifierChanged { identifier });
+    protect(m_page)->send(Messages::RemoteMediaSessionCoordinatorProxy::TrackIdentifierChanged { identifier });
 }
 
 void RemoteMediaSessionCoordinator::seekSessionToTime(double time, CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
+++ b/Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h
@@ -82,8 +82,6 @@ private:
     ASCIILiteral logClassName() const { return "RemoteMediaSessionCoordinator"_s; }
     WTFLogChannel& logChannel() const;
 
-    Ref<WebPage> protectedPage() const;
-
     WeakRef<WebPage> m_page;
     String m_identifier;
 };

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp
@@ -60,11 +60,6 @@ void UserMediaPermissionRequestManager::deref() const
     m_page->deref();
 }
 
-Ref<WebPage> UserMediaPermissionRequestManager::protectedPage() const
-{
-    return m_page.get();
-}
-
 void UserMediaPermissionRequestManager::startUserMediaRequest(UserMediaRequest& request)
 {
     RefPtr document = request.document();
@@ -100,7 +95,7 @@ void UserMediaPermissionRequestManager::sendUserMediaRequest(UserMediaRequest& u
     ASSERT(webFrame);
 
     RefPtr topLevelDocumentOrigin = userRequest.topLevelDocumentOrigin();
-    protectedPage()->send(Messages::WebPageProxy::RequestUserMediaPermissionForFrame(userRequest.identifier(), webFrame->info(), userRequest.userMediaDocumentOrigin()->data(), topLevelDocumentOrigin->data(), userRequest.request()));
+    protect(m_page)->send(Messages::WebPageProxy::RequestUserMediaPermissionForFrame(userRequest.identifier(), webFrame->info(), userRequest.userMediaDocumentOrigin()->data(), topLevelDocumentOrigin->data(), userRequest.request()));
 }
 
 void UserMediaPermissionRequestManager::cancelUserMediaRequest(UserMediaRequest& request)
@@ -165,7 +160,7 @@ void UserMediaPermissionRequestManager::enumerateMediaDevices(Document& document
         return;
     }
 
-    protectedPage()->sendWithAsyncReply(Messages::WebPageProxy::EnumerateMediaDevicesForFrame { WebFrame::fromCoreFrame(*frame)->frameID(), document.securityOrigin().data(), document.topOrigin().data() }, WTF::move(completionHandler));
+    protect(m_page)->sendWithAsyncReply(Messages::WebPageProxy::EnumerateMediaDevicesForFrame { WebFrame::fromCoreFrame(*frame)->frameID(), document.securityOrigin().data(), document.topOrigin().data() }, WTF::move(completionHandler));
 }
 
 #if USE(GSTREAMER)
@@ -201,7 +196,7 @@ UserMediaClient::DeviceChangeObserverToken UserMediaPermissionRequestManager::ad
         updateCaptureDevices(ShouldNotify::No);
         WebCore::RealtimeMediaSourceCenter::singleton().addDevicesChangedObserver(*this);
 #else
-        protectedPage()->send(Messages::WebPageProxy::BeginMonitoringCaptureDevices());
+        protect(m_page)->send(Messages::WebPageProxy::BeginMonitoringCaptureDevices());
 #endif
     }
     return identifier;
@@ -215,7 +210,7 @@ void UserMediaPermissionRequestManager::removeDeviceChangeObserver(UserMediaClie
 
 void UserMediaPermissionRequestManager::updateCaptureState(const WebCore::Document& document, bool isActive, WebCore::MediaProducerMediaCaptureKind kind, CompletionHandler<void(std::optional<WebCore::Exception>&&)>&& completionHandler)
 {
-    protectedPage()->updateCaptureState(document, isActive, kind, WTF::move(completionHandler));
+    protect(m_page)->updateCaptureState(document, isActive, kind, WTF::move(completionHandler));
 }
 
 void UserMediaPermissionRequestManager::captureDevicesChanged()

--- a/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
+++ b/Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h
@@ -77,8 +77,6 @@ private:
     // WebCore::MediaCanStartListener
     void mediaCanStart(WebCore::Document&) final;
 
-    Ref<WebPage> protectedPage() const;
-
     WeakRef<WebPage> m_page;
 
     HashMap<WebCore::UserMediaRequestIdentifier, Ref<WebCore::UserMediaRequest>> m_ongoingUserMediaRequests;

--- a/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
+++ b/Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp
@@ -85,7 +85,7 @@ void NotificationPermissionRequestManager::startRequest(const SecurityOriginData
     m_page->sendWithAsyncReply(Messages::WebPageProxy::RequestNotificationPermission(securityOrigin.toString()), [this, protectedThis = Ref { *this }, securityOrigin, permissionHandler = WTF::move(permissionHandler)](bool allowed) mutable {
 
         auto innerPermissionHandler = [this, protectedThis = Ref { *this }, securityOrigin, permissionHandler = WTF::move(permissionHandler)] (bool allowed) mutable {
-            WebProcess::singleton().protectedNotificationManager()->didUpdateNotificationDecision(securityOrigin.toString(), allowed);
+            protect(WebProcess::singleton().notificationManager())->didUpdateNotificationDecision(securityOrigin.toString(), allowed);
 
             auto permissionHandlers = m_requestsPerOrigin.take(securityOrigin);
             callPermissionHandlersWith(permissionHandlers, allowed ? Permission::Granted : Permission::Denied);
@@ -107,8 +107,8 @@ auto NotificationPermissionRequestManager::permissionLevel(const SecurityOriginD
 #if ENABLE(NOTIFICATIONS)
     if (!m_page->corePage()->settings().notificationsEnabled())
         return Permission::Denied;
-    
-    return WebProcess::singleton().protectedNotificationManager()->policyForOrigin(securityOrigin.toString());
+
+    return protect(WebProcess::singleton().notificationManager())->policyForOrigin(securityOrigin.toString());
 #else
     UNUSED_PARAM(securityOrigin);
     return Permission::Denied;
@@ -118,7 +118,7 @@ auto NotificationPermissionRequestManager::permissionLevel(const SecurityOriginD
 void NotificationPermissionRequestManager::setPermissionLevelForTesting(const String& originString, bool allowed)
 {
 #if ENABLE(NOTIFICATIONS)
-    WebProcess::singleton().protectedNotificationManager()->didUpdateNotificationDecision(originString, allowed);
+    protect(WebProcess::singleton().notificationManager())->didUpdateNotificationDecision(originString, allowed);
 #else
     UNUSED_PARAM(originString);
     UNUSED_PARAM(allowed);
@@ -128,7 +128,7 @@ void NotificationPermissionRequestManager::setPermissionLevelForTesting(const St
 void NotificationPermissionRequestManager::removeAllPermissionsForTesting()
 {
 #if ENABLE(NOTIFICATIONS)
-    WebProcess::singleton().protectedNotificationManager()->removeAllPermissionsForTesting();
+    protect(WebProcess::singleton().notificationManager())->removeAllPermissionsForTesting();
 #endif
 }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -260,7 +260,6 @@ private:
     void didInvalidateDataDetectorHighlightOverlayRects();
 
     PDFDataDetectorOverlayController& dataDetectorOverlayController() { return *m_dataDetectorOverlayController; }
-    Ref<PDFDataDetectorOverlayController> protectedDataDetectorOverlayController();
 #endif
 
     const PDFDocumentLayout& documentLayout() const { return m_documentLayout; }

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -422,11 +422,6 @@ void UnifiedPDFPlugin::enableDataDetection()
 #endif
 }
 
-Ref<PDFDataDetectorOverlayController> UnifiedPDFPlugin::protectedDataDetectorOverlayController()
-{
-    return dataDetectorOverlayController();
-}
-
 void UnifiedPDFPlugin::handleClickForDataDetectionResult(const DataDetectorElementInfo& dataDetectorElementInfo, const IntPoint& clickPointInPluginSpace)
 {
     RefPtr page = this->page();
@@ -445,7 +440,7 @@ void UnifiedPDFPlugin::didInvalidateDataDetectorHighlightOverlayRects()
 {
     auto lastKnownMousePositionInDocumentSpace = convertDown<FloatPoint>(CoordinateSpace::Plugin, CoordinateSpace::PDFDocumentLayout, lastKnownMousePositionInView());
     auto pageIndex = protect(m_presentationController)->pageIndexForDocumentPoint(lastKnownMousePositionInDocumentSpace);
-    protectedDataDetectorOverlayController()->didInvalidateHighlightOverlayRects(pageIndex);
+    protect(m_dataDetectorOverlayController)->didInvalidateHighlightOverlayRects(pageIndex);
 }
 
 #endif
@@ -1167,7 +1162,7 @@ void UnifiedPDFPlugin::didBeginMagnificationGesture()
     m_inMagnificationGesture = true;
 
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
-    protectedDataDetectorOverlayController()->hideActiveHighlightOverlay();
+    protect(m_dataDetectorOverlayController)->hideActiveHighlightOverlay();
 #endif
 }
 
@@ -2017,7 +2012,7 @@ bool UnifiedPDFPlugin::handleMouseEvent(const WebMouseEvent& event)
     }
 
 #if ENABLE(UNIFIED_PDF_DATA_DETECTION)
-    if (protectedDataDetectorOverlayController()->handleMouseEvent(event, pageIndex))
+    if (protect(m_dataDetectorOverlayController)->handleMouseEvent(event, pageIndex))
         return true;
 #endif
 

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp
@@ -73,18 +73,13 @@ WebAuthenticatorCoordinator::WebAuthenticatorCoordinator(WebPage& webPage)
 {
 }
 
-Ref<WebPage> WebAuthenticatorCoordinator::protectedPage() const
-{
-    return m_webPage.get();
-}
-
 void WebAuthenticatorCoordinator::makeCredential(const LocalFrame& frame, const PublicKeyCredentialCreationOptions& options, MediationRequirement mediation, RequestCompletionHandler&& handler)
 {
     auto webFrame = WebFrame::fromCoreFrame(frame);
     if (!webFrame)
         return;
 
-    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::MakeCredential(webFrame->frameID(), webFrame->info(), options, mediation), WTF::move(handler));
+    protect(m_webPage)->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::MakeCredential(webFrame->frameID(), webFrame->info(), options, mediation), WTF::move(handler));
 }
 
 void WebAuthenticatorCoordinator::getAssertion(const LocalFrame& frame, const PublicKeyCredentialRequestOptions& options, MediationRequirement mediation, const ScopeAndCrossOriginParent& scopeAndCrossOriginParent, RequestCompletionHandler&& handler)
@@ -93,42 +88,42 @@ void WebAuthenticatorCoordinator::getAssertion(const LocalFrame& frame, const Pu
     if (!webFrame)
         return;
 
-    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetAssertion(webFrame->frameID(), webFrame->info(), options, mediation, scopeAndCrossOriginParent.second), WTF::move(handler));
+    protect(m_webPage)->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetAssertion(webFrame->frameID(), webFrame->info(), options, mediation, scopeAndCrossOriginParent.second), WTF::move(handler));
 }
 
 void WebAuthenticatorCoordinator::isConditionalMediationAvailable(const SecurityOrigin& origin, QueryCompletionHandler&& handler)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(origin.data()), WTF::move(handler));
+    protect(m_webPage)->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::isConditionalMediationAvailable(origin.data()), WTF::move(handler));
 };
 
 void WebAuthenticatorCoordinator::isUserVerifyingPlatformAuthenticatorAvailable(const SecurityOrigin& origin, QueryCompletionHandler&& handler)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::IsUserVerifyingPlatformAuthenticatorAvailable(origin.data()), WTF::move(handler));
+    protect(m_webPage)->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::IsUserVerifyingPlatformAuthenticatorAvailable(origin.data()), WTF::move(handler));
 }
 
 void WebAuthenticatorCoordinator::cancel(CompletionHandler<void()>&& handler)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::Cancel(), WTF::move(handler));
+    protect(m_webPage)->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::Cancel(), WTF::move(handler));
 }
 
 void WebAuthenticatorCoordinator::getClientCapabilities(const SecurityOrigin& origin, CapabilitiesCompletionHandler&& handler)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetClientCapabilities(origin.data()), WTF::move(handler));
+    protect(m_webPage)->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::GetClientCapabilities(origin.data()), WTF::move(handler));
 }
 
 void WebAuthenticatorCoordinator::signalUnknownCredential(const SecurityOrigin& origin, UnknownCredentialOptions&& options, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&& handler)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::SignalUnknownCredential(origin.data(), WTF::move(options)), WTF::move(handler));
+    protect(m_webPage)->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::SignalUnknownCredential(origin.data(), WTF::move(options)), WTF::move(handler));
 }
 
 void WebAuthenticatorCoordinator::signalAllAcceptedCredentials(const SecurityOrigin& origin, AllAcceptedCredentialsOptions&& options, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&& handler)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::SignalAllAcceptedCredentials(origin.data(), WTF::move(options)), WTF::move(handler));
+    protect(m_webPage)->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::SignalAllAcceptedCredentials(origin.data(), WTF::move(options)), WTF::move(handler));
 }
 
 void WebAuthenticatorCoordinator::signalCurrentUserDetails(const SecurityOrigin& origin, CurrentUserDetailsOptions&& options, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&& handler)
 {
-    protectedPage()->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::SignalCurrentUserDetails(origin.data(), WTF::move(options)), WTF::move(handler));
+    protect(m_webPage)->sendWithAsyncReply(Messages::WebAuthenticatorCoordinatorProxy::SignalCurrentUserDetails(origin.data(), WTF::move(options)), WTF::move(handler));
 }
 
 

--- a/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h
+++ b/Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h
@@ -53,8 +53,6 @@ private:
     void signalCurrentUserDetails(const WebCore::SecurityOrigin&, WebCore::CurrentUserDetailsOptions&&, CompletionHandler<void(std::optional<WebCore::ExceptionData>)>&&) final;
     void cancel(CompletionHandler<void()>&&) final;
 
-    Ref<WebPage> protectedPage() const;
-
     WeakRef<WebPage> m_webPage;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp
@@ -44,27 +44,22 @@ WebDocumentSyncClient::WebDocumentSyncClient(WebPage& webPage)
 {
 }
 
-Ref<WebPage> WebDocumentSyncClient::protectedPage() const
-{
-    return m_page.get();
-}
-
 bool WebDocumentSyncClient::siteIsolationEnabled()
 {
-    RefPtr corePage = protectedPage()->corePage();
+    RefPtr corePage = protect(m_page)->corePage();
     return corePage ? corePage->settings().siteIsolationEnabled() : false;
 }
 
 void WebDocumentSyncClient::broadcastDocumentSyncDataToOtherProcesses(const WebCore::DocumentSyncSerializationData& data)
 {
     ASSERT(siteIsolationEnabled());
-    protectedPage()->send(Messages::WebPageProxy::BroadcastDocumentSyncData(data));
+    protect(m_page)->send(Messages::WebPageProxy::BroadcastDocumentSyncData(data));
 }
 
 void WebDocumentSyncClient::broadcastAllDocumentSyncDataToOtherProcesses(WebCore::DocumentSyncData& data)
 {
     ASSERT(siteIsolationEnabled());
-    protectedPage()->send(Messages::WebPageProxy::BroadcastAllDocumentSyncData(data));
+    protect(m_page)->send(Messages::WebPageProxy::BroadcastAllDocumentSyncData(data));
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.h
@@ -45,8 +45,6 @@ private:
     void broadcastDocumentSyncDataToOtherProcesses(const WebCore::DocumentSyncSerializationData&) final;
     void broadcastAllDocumentSyncDataToOtherProcesses(WebCore::DocumentSyncData&) final;
 
-    Ref<WebPage> protectedPage() const;
-
     const WeakRef<WebPage> m_page;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp
@@ -50,25 +50,25 @@ WebGeolocationClient::~WebGeolocationClient() = default;
 void WebGeolocationClient::geolocationDestroyed()
 {
     if (RefPtr page = m_page.get())
-        WebProcess::singleton().protectedSupplement<WebGeolocationManager>()->unregisterWebPage(*page);
+        protect(WebProcess::singleton().geolocationManager())->unregisterWebPage(*page);
 }
 
 void WebGeolocationClient::startUpdating(const String& authorizationToken, bool needsHighAccuracy)
 {
     if (RefPtr page = m_page.get())
-        WebProcess::singleton().protectedSupplement<WebGeolocationManager>()->registerWebPage(*page, authorizationToken, needsHighAccuracy);
+        protect(WebProcess::singleton().geolocationManager())->registerWebPage(*page, authorizationToken, needsHighAccuracy);
 }
 
 void WebGeolocationClient::stopUpdating()
 {
     if (RefPtr page = m_page.get())
-        WebProcess::singleton().protectedSupplement<WebGeolocationManager>()->unregisterWebPage(*page);
+        protect(WebProcess::singleton().geolocationManager())->unregisterWebPage(*page);
 }
 
 void WebGeolocationClient::setEnableHighAccuracy(bool enabled)
 {
     if (RefPtr page = m_page.get())
-        WebProcess::singleton().protectedSupplement<WebGeolocationManager>()->setEnableHighAccuracyForPage(*page, enabled);
+        protect(WebProcess::singleton().geolocationManager())->setEnableHighAccuracyForPage(*page, enabled);
 }
 
 std::optional<GeolocationPositionData> WebGeolocationClient::lastPosition()

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -364,11 +364,6 @@ void WebLocalFrameLoaderClient::dispatchDidDispatchOnloadEvents()
     webPage->injectedBundleLoaderClient().didHandleOnloadEventsForFrame(*webPage, m_frame);
 }
 
-Ref<WebCore::LocalFrame> WebLocalFrameLoaderClient::protectedLocalFrame() const
-{
-    return m_localFrame.get();
-}
-
 void WebLocalFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
 {
     RefPtr webPage = m_frame->page();
@@ -924,7 +919,7 @@ LocalFrame* WebLocalFrameLoaderClient::dispatchCreatePage(const NavigationAction
     // Just call through to the chrome client.
     WindowFeatures windowFeatures;
     windowFeatures.noopener = newFrameOpenerPolicy == NewFrameOpenerPolicy::Suppress;
-    RefPtr newPage = webPage->corePage()->chrome().createWindow(protectedLocalFrame(), { }, windowFeatures, navigationAction);
+    RefPtr newPage = webPage->corePage()->chrome().createWindow(protect(m_localFrame), { }, windowFeatures, navigationAction);
     if (!newPage)
         return nullptr;
     
@@ -1483,7 +1478,7 @@ void WebLocalFrameLoaderClient::prepareForDataSourceReplacement()
 
 Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData, ResourceRequest&& originalRequest)
 {
-    return protect(m_frame->page())->createDocumentLoader(protectedLocalFrame(), WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
+    return protect(m_frame->page())->createDocumentLoader(protect(m_localFrame), WTF::move(request), WTF::move(substituteData), WTF::move(originalRequest));
 }
 
 Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequest&& request, SubstituteData&& substituteData)
@@ -1493,7 +1488,7 @@ Ref<DocumentLoader> WebLocalFrameLoaderClient::createDocumentLoader(ResourceRequ
 
 void WebLocalFrameLoaderClient::updateCachedDocumentLoader(WebCore::DocumentLoader& loader)
 {
-    protect(m_frame->page())->updateCachedDocumentLoader(loader, protectedLocalFrame());
+    protect(m_frame->page())->updateCachedDocumentLoader(loader, protect(m_localFrame));
 }
 
 void WebLocalFrameLoaderClient::setTitle(const StringWithDirection& title, const URL& url)
@@ -1838,7 +1833,7 @@ void WebLocalFrameLoaderClient::dispatchWillDestroyGlobalObjectForDOMWindowExten
 void WebLocalFrameLoaderClient::didChangeScrollOffset()
 {
     if (RefPtr webPage = m_frame->page())
-        webPage->didChangeScrollOffsetForFrame(protectedLocalFrame());
+        webPage->didChangeScrollOffsetForFrame(protect(m_localFrame));
 }
 
 bool WebLocalFrameLoaderClient::allowScript(bool enabledPerSettings)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -286,8 +286,6 @@ private:
     void broadcastAllFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncData&) final;
     void broadcastFrameTreeSyncDataToOtherProcesses(const WebCore::FrameTreeSyncSerializationData&) final;
 
-    Ref<WebCore::LocalFrame> protectedLocalFrame() const;
-
 #if ENABLE(CONTENT_EXTENSIONS)
     void didExceedNetworkUsageThreshold();
 #endif

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h
@@ -57,8 +57,6 @@ private:
     void addObserver(WebCore::ScreenOrientationManagerObserver&) final;
     void removeObserver(WebCore::ScreenOrientationManagerObserver&) final;
 
-    Ref<WebPage> protectedPage() const;
-
     WeakRef<WebPage> m_page;
     WeakHashSet<WebCore::ScreenOrientationManagerObserver> m_observers;
     mutable std::optional<WebCore::ScreenOrientationType> m_currentOrientation;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -196,15 +196,13 @@ void WebPage::platformInitialize(const WebPageCreationParameters& parameters)
     platformInitializeAccessibility(shouldInitializeAccessibility ? ShouldInitializeNSAccessibility::Yes : ShouldInitializeNSAccessibility::No);
 
 #if ENABLE(MEDIA_STREAM)
-    if (RefPtr captureManager = WebProcess::singleton().supplement<UserMediaCaptureManager>()) {
-        captureManager->setupCaptureProcesses(parameters.shouldCaptureAudioInUIProcess, parameters.shouldCaptureAudioInGPUProcess, parameters.shouldCaptureVideoInUIProcess, parameters.shouldCaptureVideoInGPUProcess, parameters.shouldCaptureDisplayInUIProcess, parameters.shouldCaptureDisplayInGPUProcess,
+    protect(WebProcess::singleton().userMediaCaptureManager())->setupCaptureProcesses(parameters.shouldCaptureAudioInUIProcess, parameters.shouldCaptureAudioInGPUProcess, parameters.shouldCaptureVideoInUIProcess, parameters.shouldCaptureVideoInGPUProcess, parameters.shouldCaptureDisplayInUIProcess, parameters.shouldCaptureDisplayInGPUProcess,
 #if ENABLE(WEB_RTC)
-            m_page->settings().webRTCRemoteVideoFrameEnabled()
+        m_page->settings().webRTCRemoteVideoFrameEnabled()
 #else
-            false
+        false
 #endif // ENABLE(WEB_RTC)
-        );
-    }
+    );
 #endif // ENABLE(MEDIA_STREAM)
 #if USE(LIBWEBRTC)
     LibWebRTCCodecs::setCallbacks(m_page->settings().webRTCPlatformCodecsInGPUProcessEnabled(), m_page->settings().webRTCRemoteVideoFrameEnabled());

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.cpp
@@ -166,7 +166,7 @@ bool DrawingArea::supportsGPUProcessRendering()
 
 WebCore::TiledBacking* DrawingArea::mainFrameTiledBacking() const
 {
-    RefPtr frameView = protectedWebPage()->localMainFrameView();
+    RefPtr frameView = protect(m_webPage)->localMainFrameView();
     return frameView ? frameView->tiledBacking() : nullptr;
 }
 

--- a/Source/WebKit/WebProcess/WebPage/DrawingArea.h
+++ b/Source/WebKit/WebProcess/WebPage/DrawingArea.h
@@ -208,8 +208,6 @@ protected:
         return webPage->send(std::forward<T>(message), m_identifier.toUInt64(), { });
     }
 
-    Ref<WebPage> protectedWebPage() const { return m_webPage; }
-
     DrawingAreaIdentifier m_identifier;
     WeakRef<WebPage> m_webPage;
     WebCore::IntSize m_lastViewSizeForScaleToFit;

--- a/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm
@@ -248,7 +248,7 @@ void RemoteLayerTreeDrawingArea::updateRenderingWithForcedRepaint()
     if (m_isRenderingSuspended)
         return;
 
-    protect(protectedWebPage()->corePage())->forceRepaintAllFrames();
+    protect(protect(m_webPage)->corePage())->forceRepaintAllFrames();
     updateRendering();
 }
 
@@ -272,13 +272,13 @@ void RemoteLayerTreeDrawingArea::setViewExposedRect(std::optional<WebCore::Float
 {
     m_viewExposedRect = viewExposedRect;
 
-    if (RefPtr frameView = protectedWebPage()->localMainFrameView())
+    if (RefPtr frameView = protect(m_webPage)->localMainFrameView())
         frameView->setViewExposedRect(m_viewExposedRect);
 }
 
 WebCore::FloatRect RemoteLayerTreeDrawingArea::exposedContentRect() const
 {
-    RefPtr frameView = protectedWebPage()->localMainFrameView();
+    RefPtr frameView = protect(m_webPage)->localMainFrameView();
     if (!frameView)
         return FloatRect();
 
@@ -287,7 +287,7 @@ WebCore::FloatRect RemoteLayerTreeDrawingArea::exposedContentRect() const
 
 void RemoteLayerTreeDrawingArea::setExposedContentRect(const FloatRect& exposedContentRect)
 {
-    RefPtr frameView = protectedWebPage()->localMainFrameView();
+    RefPtr frameView = protect(m_webPage)->localMainFrameView();
     if (!frameView)
         return;
     if (frameView->exposedContentRect() == exposedContentRect)
@@ -441,7 +441,7 @@ void RemoteLayerTreeDrawingArea::updateRendering()
 
 void RemoteLayerTreeDrawingArea::didCompleteRenderingUpdateDisplayFlush(bool flushSucceeded)
 {
-    protectedWebPage()->didFlushLayerTreeAtTime(MonotonicTime::now(), flushSucceeded);
+    protect(m_webPage)->didFlushLayerTreeAtTime(MonotonicTime::now(), flushSucceeded);
     didCompleteRenderingUpdateDisplay();
 }
 

--- a/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm
@@ -77,7 +77,7 @@ void RemoteLayerTreeDrawingAreaMac::adjustTransientZoom(double scale, WebCore::F
 {
     LOG_WITH_STREAM(ViewGestures, stream << "RemoteLayerTreeDrawingAreaMac::adjustTransientZoom - scale " << scale << " origin " << origin);
 
-    auto totalScale = scale * protectedWebPage()->viewScaleFactor();
+    auto totalScale = scale * protect(m_webPage)->viewScaleFactor();
 
     // FIXME: Need to trigger some re-rendering here to render at the new scale, so tiles update while zooming.
 
@@ -87,7 +87,7 @@ void RemoteLayerTreeDrawingAreaMac::adjustTransientZoom(double scale, WebCore::F
 void RemoteLayerTreeDrawingAreaMac::willCommitMainFrameData(MainFrameData& data)
 {
     // FIXME: Probably need something here for PDF.
-    RefPtr frameView = protectedWebPage()->localMainFrameView();
+    RefPtr frameView = protect(m_webPage)->localMainFrameView();
     if (!frameView)
         return;
 

--- a/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm
@@ -493,7 +493,7 @@ void TiledCoreAnimationDrawingArea::setViewExposedRect(std::optional<FloatRect> 
 {
     m_viewExposedRect = viewExposedRect;
 
-    if (RefPtr frameView = protectedWebPage()->localMainFrameView())
+    if (RefPtr frameView = protect(m_webPage)->localMainFrameView())
         frameView->setViewExposedRect(m_viewExposedRect);
 }
 
@@ -681,7 +681,7 @@ void TiledCoreAnimationDrawingArea::applyTransientZoomToLayers(double scale, Flo
     if (!m_hostingLayer)
         return;
 
-    RefPtr frameView = protectedWebPage()->localMainFrameView();
+    RefPtr frameView = protect(m_webPage)->localMainFrameView();
     if (!frameView)
         return;
 

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -171,7 +171,7 @@
 #include <unistd.h>
 #endif
 
-#if PLATFORM(COCOA)
+#if ENABLE(MEDIA_STREAM)
 #include "UserMediaCaptureManager.h"
 #endif
 
@@ -324,6 +324,23 @@ WebProcess& WebProcess::singleton()
     return process.get().get();
 }
 
+WebNotificationManager& WebProcess::notificationManager()
+{
+    return *supplement<WebNotificationManager>();
+}
+
+WebGeolocationManager& WebProcess::geolocationManager()
+{
+    return *supplement<WebGeolocationManager>();
+}
+
+#if ENABLE(MEDIA_STREAM)
+UserMediaCaptureManager& WebProcess::userMediaCaptureManager()
+{
+    return *supplement<UserMediaCaptureManager>();
+}
+#endif
+
 WebProcess::WebProcess()
     : m_eventDispatcher(*this)
 #if PLATFORM(IOS_FAMILY)
@@ -446,9 +463,9 @@ void WebProcess::initializeConnection(IPC::Connection* connection)
     Ref { m_viewUpdateDispatcher }->initializeConnection(*connection);
 #endif // PLATFORM(IOS_FAMILY)
 
-    protectedWebInspectorInterruptDispatcher()->initializeConnection(*connection);
+    protect(m_webInspectorInterruptDispatcher)->initializeConnection(*connection);
 #if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
-    protectedWasmDebuggerDispatcher()->initializeConnection(*connection);
+    protect(m_wasmDebuggerDispatcher)->initializeConnection(*connection);
 #endif
 
     for (auto& supplement : m_supplements.values())
@@ -2586,11 +2603,6 @@ RemoteMediaEngineConfigurationFactory& WebProcess::mediaEngineConfigurationFacto
     return *supplement<RemoteMediaEngineConfigurationFactory>();
 }
 #endif
-
-Ref<WebNotificationManager> WebProcess::protectedNotificationManager()
-{
-    return *supplement<WebNotificationManager>();
-}
 
 RefPtr<WebTransportSession> WebProcess::webTransportSession(WebTransportSessionIdentifier identifier)
 {

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -155,9 +155,11 @@ class WebCompiledContentRuleListData;
 class WebCookieJar;
 class WebFileSystemStorageConnection;
 class WebFrame;
+class WebGeolocationManager;
 class WebLoaderStrategy;
 class WebNotificationManager;
 class WebPage;
+class UserMediaCaptureManager;
 class WebPageGroupProxy;
 class WebProcessSupplement;
 class WebTransportSession;
@@ -214,12 +216,6 @@ public:
     }
 
     template <typename T>
-    RefPtr<T> protectedSupplement()
-    {
-        return supplement<T>();
-    }
-
-    template <typename T>
     void addSupplement()
     {
         m_supplements.add(T::supplementName(), makeUnique<T>(*this));
@@ -234,6 +230,12 @@ public:
         // to find a better pattern.
         m_supplements.add(T::supplementName(), const_cast<std::unique_ptr<WebProcessSupplement>&&>(makeUniqueWithoutRefCountedCheck<T, WebProcessSupplement>(*this)));
     }
+
+    WebNotificationManager& notificationManager();
+    WebGeolocationManager& geolocationManager();
+#if ENABLE(MEDIA_STREAM)
+    UserMediaCaptureManager& userMediaCaptureManager();
+#endif
 
     // ref() & deref() do nothing since WebProcess is a singleton object.
     // This is for objects owned by the WebProcess to forward their refcounting to their owner.
@@ -283,10 +285,6 @@ public:
     void setTextCheckerState(OptionSet<TextCheckerState>);
 
     EventDispatcher& eventDispatcher() { return m_eventDispatcher; }
-    Ref<WebInspectorInterruptDispatcher> protectedWebInspectorInterruptDispatcher() { return m_webInspectorInterruptDispatcher; }
-#if ENABLE(WEBASSEMBLY_DEBUGGER) && ENABLE(REMOTE_INSPECTOR)
-    Ref<WasmDebuggerDispatcher> protectedWasmDebuggerDispatcher() { return m_wasmDebuggerDispatcher; }
-#endif
 
     NetworkProcessConnection& ensureNetworkProcessConnection();
     Ref<NetworkProcessConnection> ensureProtectedNetworkProcessConnection();
@@ -416,8 +414,6 @@ public:
     WebBroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry.get(); }
     WebCookieJar& cookieJar() { return m_cookieJar.get(); }
     WebSocketChannelManager& webSocketChannelManager() { return m_webSocketChannelManager; }
-
-    Ref<WebNotificationManager> protectedNotificationManager();
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(MACCATALYST)
     float backlightLevel() const { return m_backlightLevel; }

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp
@@ -367,12 +367,7 @@ void StorageAreaMap::incrementUseCount()
 void StorageAreaMap::decrementUseCount()
 {
     if (!--m_useCount)
-        protectedNamespace()->destroyStorageAreaMap(*this);
-}
-
-Ref<StorageNamespaceImpl> StorageAreaMap::protectedNamespace() const
-{
-    return m_namespace.get();
+        protect(m_namespace)->destroyStorageAreaMap(*this);
 }
 
 void StorageAreaMap::syncOneItem(const String& key, const String& value)

--- a/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
+++ b/Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h
@@ -109,8 +109,6 @@ private:
     void connectSync();
     void didConnect(std::optional<StorageAreaIdentifier>, HashMap<String, String>&&, uint64_t messageIdentifier);
 
-    Ref<StorageNamespaceImpl> protectedNamespace() const;
-
     uint64_t m_lastHandledMessageIdentifier { 0 };
     WeakRef<StorageNamespaceImpl> m_namespace;
     Ref<const WebCore::SecurityOrigin> m_securityOrigin;

--- a/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
+++ b/Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h
@@ -74,8 +74,6 @@ private:
     RefPtr<XRDeviceProxy> deviceByIdentifier(XRDeviceIdentifier);
     bool webXREnabled() const;
 
-    Ref<WebPage> protectedPage() const;
-
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 


### PR DESCRIPTION
#### e9d8a8871eef96aa52fbbb1d6be7d83276337c73
<pre>
Further reduce use of protected functions in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307744">https://bugs.webkit.org/show_bug.cgi?id=307744</a>

Reviewed by Anne van Kesteren.

* Source/WTF/wtf/ThreadSafeWeakPtr.h:
(WTF::protect):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUCommandEncoderImpl.cpp:
(WebCore::WebGPU::CommandEncoderImpl::beginRenderPass):
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassColorAttachment.h:
(WebCore::WebGPU::RenderPassColorAttachment::texture const):
(WebCore::WebGPU::RenderPassColorAttachment::textureView const):
(WebCore::WebGPU::RenderPassColorAttachment::resolveTexture const):
(WebCore::WebGPU::RenderPassColorAttachment::resolveTextureView const):
(WebCore::WebGPU::RenderPassColorAttachment::protectedTexture const): Deleted.
(WebCore::WebGPU::RenderPassColorAttachment::protectedView const): Deleted.
(WebCore::WebGPU::RenderPassColorAttachment::protectedResolveTexture const): Deleted.
(WebCore::WebGPU::RenderPassColorAttachment::protectedResolveTarget const): Deleted.
* Source/WebCore/Modules/WebGPU/InternalAPI/WebGPURenderPassDepthStencilAttachment.h:
(WebCore::WebGPU::RenderPassDepthStencilAttachment::texture const):
(WebCore::WebGPU::RenderPassDepthStencilAttachment::textureView const):
(WebCore::WebGPU::RenderPassDepthStencilAttachment::protectedTexture const): Deleted.
(WebCore::WebGPU::RenderPassDepthStencilAttachment::protectedView const): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::allowsExitUnderMemoryPressure const):
(WebKit::GPUConnectionToWebProcess::updateSharedPreferencesForWebProcess):
(WebKit::GPUConnectionToWebProcess::protectedLibWebRTCCodecsProxy const): Deleted.
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/graphics/ImageBufferShareableAllocator.cpp:
(WebKit::ImageBufferShareableAllocator::createPixelBuffer const):
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::destruct):
* Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.cpp:
(WebKit::ShareablePixelBuffer::protectedData const): Deleted.
* Source/WebKit/GPUProcess/graphics/ShareablePixelBuffer.h:
(WebKit::ShareablePixelBuffer::data const):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.cpp:
(WebKit::RemoteAdapter::destruct):
(WebKit::RemoteAdapter::requestDevice):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteAdapter.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.cpp:
(WebKit::RemoteBindGroup::RemoteBindGroup):
(WebKit::RemoteBindGroup::destruct):
(WebKit::RemoteBindGroup::updateExternalTextures):
(WebKit::RemoteBindGroup::stopListeningForIPC):
(WebKit::RemoteBindGroup::setLabel):
(WebKit::RemoteBindGroup::protectedBacking): Deleted.
(WebKit::RemoteBindGroup::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroup.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.cpp:
(WebKit::RemoteBindGroupLayout::RemoteBindGroupLayout):
(WebKit::RemoteBindGroupLayout::destruct):
(WebKit::RemoteBindGroupLayout::stopListeningForIPC):
(WebKit::RemoteBindGroupLayout::setLabel):
(WebKit::RemoteBindGroupLayout::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBindGroupLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.cpp:
(WebKit::RemoteBuffer::RemoteBuffer):
(WebKit::RemoteBuffer::stopListeningForIPC):
(WebKit::RemoteBuffer::mapAsync):
(WebKit::RemoteBuffer::getMappedRange):
(WebKit::RemoteBuffer::unmap):
(WebKit::RemoteBuffer::copyWithCopy):
(WebKit::RemoteBuffer::copy):
(WebKit::RemoteBuffer::destroy):
(WebKit::RemoteBuffer::destruct):
(WebKit::RemoteBuffer::setLabel):
(WebKit::RemoteBuffer::protectedBacking): Deleted.
(WebKit::RemoteBuffer::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.cpp:
(WebKit::RemoteCommandBuffer::RemoteCommandBuffer):
(WebKit::RemoteCommandBuffer::destruct):
(WebKit::RemoteCommandBuffer::stopListeningForIPC):
(WebKit::RemoteCommandBuffer::setLabel):
(WebKit::RemoteCommandBuffer::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandBuffer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.cpp:
(WebKit::RemoteCommandEncoder::destruct):
(WebKit::RemoteCommandEncoder::beginRenderPass):
(WebKit::RemoteCommandEncoder::beginComputePass):
(WebKit::RemoteCommandEncoder::copyBufferToBuffer):
(WebKit::RemoteCommandEncoder::copyBufferToTexture):
(WebKit::RemoteCommandEncoder::copyTextureToBuffer):
(WebKit::RemoteCommandEncoder::copyTextureToTexture):
(WebKit::RemoteCommandEncoder::clearBuffer):
(WebKit::RemoteCommandEncoder::pushDebugGroup):
(WebKit::RemoteCommandEncoder::popDebugGroup):
(WebKit::RemoteCommandEncoder::insertDebugMarker):
(WebKit::RemoteCommandEncoder::writeTimestamp):
(WebKit::RemoteCommandEncoder::resolveQuerySet):
(WebKit::RemoteCommandEncoder::finish):
(WebKit::RemoteCommandEncoder::setLabel):
(WebKit::RemoteCommandEncoder::protectedBacking): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCommandEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.cpp:
(WebKit::RemoteCompositorIntegration::RemoteCompositorIntegration):
(WebKit::RemoteCompositorIntegration::destruct):
(WebKit::RemoteCompositorIntegration::paintCompositedResultsToCanvas):
(WebKit::RemoteCompositorIntegration::stopListeningForIPC):
(WebKit::RemoteCompositorIntegration::recreateRenderBuffers):
(WebKit::RemoteCompositorIntegration::prepareForDisplay):
(WebKit::RemoteCompositorIntegration::updateContentsHeadroom):
(WebKit::RemoteCompositorIntegration::protectedBacking): Deleted.
(WebKit::RemoteCompositorIntegration::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteCompositorIntegration.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.cpp:
(WebKit::RemoteComputePassEncoder::RemoteComputePassEncoder):
(WebKit::RemoteComputePassEncoder::destruct):
(WebKit::RemoteComputePassEncoder::stopListeningForIPC):
(WebKit::RemoteComputePassEncoder::setPipeline):
(WebKit::RemoteComputePassEncoder::dispatch):
(WebKit::RemoteComputePassEncoder::dispatchIndirect):
(WebKit::RemoteComputePassEncoder::end):
(WebKit::RemoteComputePassEncoder::setBindGroup):
(WebKit::RemoteComputePassEncoder::pushDebugGroup):
(WebKit::RemoteComputePassEncoder::popDebugGroup):
(WebKit::RemoteComputePassEncoder::insertDebugMarker):
(WebKit::RemoteComputePassEncoder::setLabel):
(WebKit::RemoteComputePassEncoder::protectedBacking): Deleted.
(WebKit::RemoteComputePassEncoder::protectedStreamConnection const): Deleted.
(WebKit::RemoteComputePassEncoder::protectedObjectHeap const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.cpp:
(WebKit::RemoteComputePipeline::RemoteComputePipeline):
(WebKit::RemoteComputePipeline::destruct):
(WebKit::RemoteComputePipeline::stopListeningForIPC):
(WebKit::RemoteComputePipeline::getBindGroupLayout):
(WebKit::RemoteComputePipeline::setLabel):
(WebKit::RemoteComputePipeline::protectedBacking): Deleted.
(WebKit::RemoteComputePipeline::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteComputePipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.cpp:
(WebKit::RemoteDevice::destruct):
(WebKit::RemoteDevice::createXRBinding):
(WebKit::RemoteDevice::createBuffer):
(WebKit::RemoteDevice::createTexture):
(WebKit::RemoteDevice::createSampler):
(WebKit::RemoteDevice::importExternalTextureFromVideoFrame):
(WebKit::RemoteDevice::updateExternalTexture):
(WebKit::RemoteDevice::createBindGroupLayout):
(WebKit::RemoteDevice::createPipelineLayout):
(WebKit::RemoteDevice::createBindGroup):
(WebKit::RemoteDevice::createShaderModule):
(WebKit::RemoteDevice::createComputePipeline):
(WebKit::RemoteDevice::createRenderPipeline):
(WebKit::RemoteDevice::createComputePipelineAsync):
(WebKit::RemoteDevice::createRenderPipelineAsync):
(WebKit::RemoteDevice::createCommandEncoder):
(WebKit::RemoteDevice::createRenderBundleEncoder):
(WebKit::RemoteDevice::createQuerySet):
(WebKit::RemoteDevice::protectedObjectHeap const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteDevice.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.cpp:
(WebKit::RemoteExternalTexture::RemoteExternalTexture):
(WebKit::RemoteExternalTexture::destroy):
(WebKit::RemoteExternalTexture::undestroy):
(WebKit::RemoteExternalTexture::destruct):
(WebKit::RemoteExternalTexture::stopListeningForIPC):
(WebKit::RemoteExternalTexture::setLabel):
(WebKit::RemoteExternalTexture::protectedBacking): Deleted.
(WebKit::RemoteExternalTexture::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteExternalTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::initialize):
(WebKit::RemoteGPU::workQueueInitialize):
(WebKit::RemoteGPU::workQueueUninitialize):
(WebKit::RemoteGPU::isValid):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.cpp:
(WebKit::RemotePipelineLayout::RemotePipelineLayout):
(WebKit::RemotePipelineLayout::destruct):
(WebKit::RemotePipelineLayout::stopListeningForIPC):
(WebKit::RemotePipelineLayout::setLabel):
(WebKit::RemotePipelineLayout::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePipelineLayout.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.cpp:
(WebKit::RemotePresentationContext::RemotePresentationContext):
(WebKit::RemotePresentationContext::stopListeningForIPC):
(WebKit::RemotePresentationContext::configure):
(WebKit::RemotePresentationContext::unconfigure):
(WebKit::RemotePresentationContext::present):
(WebKit::RemotePresentationContext::getCurrentTexture):
(WebKit::RemotePresentationContext::protectedBacking): Deleted.
(WebKit::RemotePresentationContext::protectedObjectHeap const): Deleted.
(WebKit::RemotePresentationContext::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemotePresentationContext.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.cpp:
(WebKit::RemoteQuerySet::RemoteQuerySet):
(WebKit::RemoteQuerySet::stopListeningForIPC):
(WebKit::RemoteQuerySet::destroy):
(WebKit::RemoteQuerySet::destruct):
(WebKit::RemoteQuerySet::setLabel):
(WebKit::RemoteQuerySet::protectedBacking): Deleted.
(WebKit::RemoteQuerySet::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQuerySet.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.cpp:
(WebKit::RemoteQueue::destruct):
(WebKit::RemoteQueue::submit):
(WebKit::RemoteQueue::onSubmittedWorkDone):
(WebKit::RemoteQueue::writeBuffer):
(WebKit::RemoteQueue::writeBufferWithCopy):
(WebKit::RemoteQueue::writeTexture):
(WebKit::RemoteQueue::writeTextureWithCopy):
(WebKit::RemoteQueue::copyExternalImageToTexture):
(WebKit::RemoteQueue::setLabel):
(WebKit::RemoteQueue::protectedBacking): Deleted.
(WebKit::RemoteQueue::protectedObjectHeap const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteQueue.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.cpp:
(WebKit::RemoteRenderBundle::RemoteRenderBundle):
(WebKit::RemoteRenderBundle::destruct):
(WebKit::RemoteRenderBundle::stopListeningForIPC):
(WebKit::RemoteRenderBundle::setLabel):
(WebKit::RemoteRenderBundle::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundle.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.cpp:
(WebKit::RemoteRenderBundleEncoder::RemoteRenderBundleEncoder):
(WebKit::RemoteRenderBundleEncoder::destruct):
(WebKit::RemoteRenderBundleEncoder::stopListeningForIPC):
(WebKit::RemoteRenderBundleEncoder::setPipeline):
(WebKit::RemoteRenderBundleEncoder::setIndexBuffer):
(WebKit::RemoteRenderBundleEncoder::setVertexBuffer):
(WebKit::RemoteRenderBundleEncoder::unsetVertexBuffer):
(WebKit::RemoteRenderBundleEncoder::draw):
(WebKit::RemoteRenderBundleEncoder::drawIndexed):
(WebKit::RemoteRenderBundleEncoder::drawIndirect):
(WebKit::RemoteRenderBundleEncoder::drawIndexedIndirect):
(WebKit::RemoteRenderBundleEncoder::setBindGroup):
(WebKit::RemoteRenderBundleEncoder::pushDebugGroup):
(WebKit::RemoteRenderBundleEncoder::popDebugGroup):
(WebKit::RemoteRenderBundleEncoder::insertDebugMarker):
(WebKit::RemoteRenderBundleEncoder::finish):
(WebKit::RemoteRenderBundleEncoder::setLabel):
(WebKit::RemoteRenderBundleEncoder::protectedBacking const): Deleted.
(WebKit::RemoteRenderBundleEncoder::protectedStreamConnection const): Deleted.
(WebKit::RemoteRenderBundleEncoder::protectedObjectHeap const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderBundleEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.cpp:
(WebKit::RemoteRenderPassEncoder::destruct):
(WebKit::RemoteRenderPassEncoder::setPipeline):
(WebKit::RemoteRenderPassEncoder::setIndexBuffer):
(WebKit::RemoteRenderPassEncoder::setVertexBuffer):
(WebKit::RemoteRenderPassEncoder::unsetVertexBuffer):
(WebKit::RemoteRenderPassEncoder::draw):
(WebKit::RemoteRenderPassEncoder::drawIndexed):
(WebKit::RemoteRenderPassEncoder::drawIndirect):
(WebKit::RemoteRenderPassEncoder::drawIndexedIndirect):
(WebKit::RemoteRenderPassEncoder::setBindGroup):
(WebKit::RemoteRenderPassEncoder::pushDebugGroup):
(WebKit::RemoteRenderPassEncoder::popDebugGroup):
(WebKit::RemoteRenderPassEncoder::insertDebugMarker):
(WebKit::RemoteRenderPassEncoder::setViewport):
(WebKit::RemoteRenderPassEncoder::setScissorRect):
(WebKit::RemoteRenderPassEncoder::setBlendConstant):
(WebKit::RemoteRenderPassEncoder::setStencilReference):
(WebKit::RemoteRenderPassEncoder::beginOcclusionQuery):
(WebKit::RemoteRenderPassEncoder::endOcclusionQuery):
(WebKit::RemoteRenderPassEncoder::executeBundles):
(WebKit::RemoteRenderPassEncoder::end):
(WebKit::RemoteRenderPassEncoder::setLabel):
(WebKit::RemoteRenderPassEncoder::protectedBacking): Deleted.
(WebKit::RemoteRenderPassEncoder::protectedObjectHeap const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPassEncoder.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.cpp:
(WebKit::RemoteRenderPipeline::RemoteRenderPipeline):
(WebKit::RemoteRenderPipeline::destruct):
(WebKit::RemoteRenderPipeline::stopListeningForIPC):
(WebKit::RemoteRenderPipeline::getBindGroupLayout):
(WebKit::RemoteRenderPipeline::setLabel):
(WebKit::RemoteRenderPipeline::protectedBacking): Deleted.
(WebKit::RemoteRenderPipeline::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteRenderPipeline.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.cpp:
(WebKit::RemoteSampler::RemoteSampler):
(WebKit::RemoteSampler::destruct):
(WebKit::RemoteSampler::stopListeningForIPC):
(WebKit::RemoteSampler::setLabel):
(WebKit::RemoteSampler::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteSampler.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.cpp:
(WebKit::RemoteShaderModule::RemoteShaderModule):
(WebKit::RemoteShaderModule::destruct):
(WebKit::RemoteShaderModule::stopListeningForIPC):
(WebKit::RemoteShaderModule::compilationInfo):
(WebKit::RemoteShaderModule::setLabel):
(WebKit::RemoteShaderModule::protectedBacking): Deleted.
(WebKit::RemoteShaderModule::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteShaderModule.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.cpp:
(WebKit::RemoteTexture::createView):
(WebKit::RemoteTexture::destroy):
(WebKit::RemoteTexture::undestroy):
(WebKit::RemoteTexture::destruct):
(WebKit::RemoteTexture::setLabel):
(WebKit::RemoteTexture::protectedBacking): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTexture.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.cpp:
(WebKit::RemoteTextureView::RemoteTextureView):
(WebKit::RemoteTextureView::destruct):
(WebKit::RemoteTextureView::stopListeningForIPC):
(WebKit::RemoteTextureView::setLabel):
(WebKit::RemoteTextureView::protectedStreamConnection const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteTextureView.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.cpp:
(WebKit::RemoteXRBinding::RemoteXRBinding):
(WebKit::RemoteXRBinding::destruct):
(WebKit::RemoteXRBinding::createProjectionLayer):
(WebKit::RemoteXRBinding::getViewSubImage):
(WebKit::RemoteXRBinding::stopListeningForIPC):
(WebKit::RemoteXRBinding::protectedStreamConnection): Deleted.
(WebKit::RemoteXRBinding::protectedBacking): Deleted.
(WebKit::RemoteXRBinding::protectedGPU): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRBinding.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.cpp:
(WebKit::RemoteXRProjectionLayer::RemoteXRProjectionLayer):
(WebKit::RemoteXRProjectionLayer::destruct):
(WebKit::RemoteXRProjectionLayer::startFrame):
(WebKit::RemoteXRProjectionLayer::stopListeningForIPC):
(WebKit::RemoteXRProjectionLayer::protectedBacking): Deleted.
(WebKit::RemoteXRProjectionLayer::protectedStreamConnection): Deleted.
(WebKit::RemoteXRProjectionLayer::protectedGPU const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRProjectionLayer.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.cpp:
(WebKit::RemoteXRSubImage::RemoteXRSubImage):
(WebKit::RemoteXRSubImage::destruct):
(WebKit::RemoteXRSubImage::getColorTexture):
(WebKit::RemoteXRSubImage::getDepthTexture):
(WebKit::RemoteXRSubImage::stopListeningForIPC):
(WebKit::RemoteXRSubImage::protectedStreamConnection): Deleted.
(WebKit::RemoteXRSubImage::protectedBacking): Deleted.
(WebKit::RemoteXRSubImage::protectedGPU const): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRSubImage.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.cpp:
(WebKit::RemoteXRView::RemoteXRView):
(WebKit::RemoteXRView::destruct):
(WebKit::RemoteXRView::stopListeningForIPC):
(WebKit::RemoteXRView::protectedStreamConnection): Deleted.
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteXRView.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::connection const):
(WebKit::RemoteAudioSessionProxy::configurationChanged):
(WebKit::RemoteAudioSessionProxy::beginInterruption):
(WebKit::RemoteAudioSessionProxy::endInterruption):
(WebKit::RemoteAudioSessionProxy::protectedConnection const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.cpp:
(WebKit::RemoteCDMInstanceSessionProxy::create):
(WebKit::RemoteCDMInstanceSessionProxy::setLogIdentifier):
(WebKit::RemoteCDMInstanceSessionProxy::requestLicense):
(WebKit::RemoteCDMInstanceSessionProxy::updateLicense):
(WebKit::RemoteCDMInstanceSessionProxy::loadSession):
(WebKit::RemoteCDMInstanceSessionProxy::closeSession):
(WebKit::RemoteCDMInstanceSessionProxy::removeSessionData):
(WebKit::RemoteCDMInstanceSessionProxy::storeRecordOfKeyUsage):
* Source/WebKit/GPUProcess/media/RemoteCDMInstanceSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.cpp:
(WebKit::RemoteLegacyCDMProxy::supportsMIMEType):
(WebKit::RemoteLegacyCDMProxy::createSession):
* Source/WebKit/GPUProcess/media/RemoteLegacyCDMProxy.h:
(WebKit::RemoteLegacyCDMProxy::protectedCDM const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.cpp:
(WebKit::RemoteMediaPlayerProxy::commitAllTransactions):
(WebKit::RemoteMediaPlayerProxy::didLoadingProgress):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerNetworkStateChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerReadyStateChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerVolumeChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerMuteChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerSeeked):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerTimeChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerDurationChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRateChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerEngineFailedToLoad):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerGetRawCookies const):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerPlaybackStateChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerCharacteristicChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):
(WebKit::RemoteMediaPlayerProxy::addRemoteAudioTrackProxy):
(WebKit::RemoteMediaPlayerProxy::addRemoteVideoTrackProxy):
(WebKit::RemoteMediaPlayerProxy::addRemoteTextTrackProxy):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerDidRemoveAudioTrack):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerDidRemoveVideoTrack):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerDidRemoveTextTrack):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerResourceNotSupported):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerSizeChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerActiveSourceBuffersChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerKeyNeeded):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerInitializationDataEncountered):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerWaitingForKeyChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerCurrentPlaybackTargetIsWirelessChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerCreateResourceLoader):
(WebKit::RemoteMediaPlayerProxy::destroyResourceLoader):
(WebKit::RemoteMediaPlayerProxy::currentTimeChanged):
(WebKit::RemoteMediaPlayerProxy::videoFrameForCurrentTimeIfChanged):
(WebKit::RemoteMediaPlayerProxy::sendCachedState):
(WebKit::RemoteMediaPlayerProxy::notifyActiveSourceBuffersChanged):
(WebKit::RemoteMediaPlayerProxy::updateCachedVideoMetrics):
(WebKit::RemoteMediaPlayerProxy::sendInternalMessage):
(WebKit::RemoteMediaPlayerProxy::protectedVideoFrameObjectHeap const): Deleted.
* Source/WebKit/GPUProcess/media/RemoteMediaPlayerProxy.h:
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.cpp:
(WebKit::RemoteSourceBufferProxy::RemoteSourceBufferProxy):
(WebKit::RemoteSourceBufferProxy::append):
(WebKit::RemoteSourceBufferProxy::abort):
(WebKit::RemoteSourceBufferProxy::resetParserState):
(WebKit::RemoteSourceBufferProxy::removedFromMediaSource):
(WebKit::RemoteSourceBufferProxy::setMediaSourceEnded):
(WebKit::RemoteSourceBufferProxy::setActive):
(WebKit::RemoteSourceBufferProxy::canSwitchToType):
(WebKit::RemoteSourceBufferProxy::setMode):
(WebKit::RemoteSourceBufferProxy::startChangingType):
(WebKit::RemoteSourceBufferProxy::removeCodedFrames):
(WebKit::RemoteSourceBufferProxy::asyncEvictCodedFrames):
(WebKit::RemoteSourceBufferProxy::addTrackBuffer):
(WebKit::RemoteSourceBufferProxy::resetTrackBuffers):
(WebKit::RemoteSourceBufferProxy::clearTrackBuffers):
(WebKit::RemoteSourceBufferProxy::setAllTrackBuffersNeedRandomAccess):
(WebKit::RemoteSourceBufferProxy::reenqueueMediaIfNeeded):
(WebKit::RemoteSourceBufferProxy::setGroupStartTimestamp):
(WebKit::RemoteSourceBufferProxy::setGroupStartTimestampToEndTimestamp):
(WebKit::RemoteSourceBufferProxy::setShouldGenerateTimestamps):
(WebKit::RemoteSourceBufferProxy::resetTimestampOffsetInTrackBuffers):
(WebKit::RemoteSourceBufferProxy::setTimestampOffset):
(WebKit::RemoteSourceBufferProxy::setAppendWindowStart):
(WebKit::RemoteSourceBufferProxy::setAppendWindowEnd):
(WebKit::RemoteSourceBufferProxy::setMaximumBufferSize):
(WebKit::RemoteSourceBufferProxy::computeSeekTime):
(WebKit::RemoteSourceBufferProxy::updateTrackIds):
(WebKit::RemoteSourceBufferProxy::bufferedSamplesForTrackId):
(WebKit::RemoteSourceBufferProxy::enqueuedSamplesForTrackID):
(WebKit::RemoteSourceBufferProxy::memoryPressure):
(WebKit::RemoteSourceBufferProxy::minimumUpcomingPresentationTimeForTrackID):
(WebKit::RemoteSourceBufferProxy::setMaximumQueueDepthForTrackID):
(WebKit::RemoteSourceBufferProxy::detach):
(WebKit::RemoteSourceBufferProxy::attach):
* Source/WebKit/GPUProcess/media/RemoteSourceBufferProxy.h:
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.cpp:
(WebKit::RemoteVideoFrameObjectHeap::create):
(WebKit::RemoteVideoFrameObjectHeap::close):
* Source/WebKit/GPUProcess/media/RemoteVideoFrameObjectHeap.h:
* Source/WebKit/GPUProcess/media/cocoa/RemoteMediaPlayerProxyCocoa.mm:
(WebKit::RemoteMediaPlayerProxy::mediaPlayerFirstVideoFrameAvailable):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerRenderingModeChanged):
(WebKit::RemoteMediaPlayerProxy::mediaPlayerOnNewVideoFrameMetadata):
* Source/WebKit/GPUProcess/webrtc/RemoteAudioMediaStreamTrackRendererInternalUnitManager.cpp:
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::setShouldRegisterAsSpeakerSamplesProducer):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::start):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::stop):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitIsStarting):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::captureUnitHasStopped):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::beginAudioSessionInterruption):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::endAudioSessionInterruption):
(WebKit::RemoteAudioMediaStreamTrackRendererInternalUnitManagerUnit::protectedLocalUnit): Deleted.
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.cpp:
(WebKit::UserMediaCaptureManagerProxy::createMediaSourceForCaptureDeviceWithConstraints):
(WebKit::UserMediaCaptureManagerProxy::applyConstraints):
* Source/WebKit/GPUProcess/webrtc/UserMediaCaptureManagerProxy.h:
(WebKit::UserMediaCaptureManagerProxy::ConnectionProxy::protectedConnection): Deleted.
(WebKit::UserMediaCaptureManagerProxy::ConnectionProxy::protectedLogger): Deleted.
* Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.cpp:
(WebKit::AuthenticationManager::didReceiveAuthenticationChallenge):
(WebKit::AuthenticationManager::negotiatedLegacyTLS const):
(WebKit::AuthenticationManager::protectedProcess const): Deleted.
* Source/WebKit/NetworkProcess/Authentication/AuthenticationManager.h:
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.cpp:
(WebKit::WebCookieManager::getHostnamesWithCookies):
(WebKit::WebCookieManager::deleteCookiesForHostnames):
(WebKit::WebCookieManager::deleteAllCookies):
(WebKit::WebCookieManager::deleteCookie):
(WebKit::WebCookieManager::deleteAllCookiesModifiedSince):
(WebKit::WebCookieManager::getAllCookies):
(WebKit::WebCookieManager::getCookies):
(WebKit::WebCookieManager::setCookie):
(WebKit::WebCookieManager::setCookies):
(WebKit::WebCookieManager::notifyCookiesDidChange):
(WebKit::WebCookieManager::startObservingCookieChanges):
(WebKit::WebCookieManager::stopObservingCookieChanges):
(WebKit::WebCookieManager::setHTTPCookieAcceptPolicy):
(WebKit::WebCookieManager::getHTTPCookieAcceptPolicy):
(WebKit::WebCookieManager::protectedProcess): Deleted.
* Source/WebKit/NetworkProcess/Cookies/WebCookieManager.h:
* Source/WebKit/NetworkProcess/Cookies/curl/WebCookieManagerCurl.cpp:
(WebKit::WebCookieManager::platformSetHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/Cookies/mac/WebCookieManagerMac.mm:
(WebKit::WebCookieManager::platformSetHTTPCookieAcceptPolicy):
* Source/WebKit/NetworkProcess/Cookies/soup/WebCookieManagerSoup.cpp:
(WebKit::WebCookieManager::platformSetHTTPCookieAcceptPolicy):
(WebKit::WebCookieManager::setCookiePersistentStorage):
(WebKit::WebCookieManager::replaceCookies):
* Source/WebKit/NetworkProcess/CustomProtocols/Cocoa/LegacyCustomProtocolManagerCocoa.mm:
(LegacyCustomProtocolManager::networkProcessCreated):
(+[WKCustomProtocol canInitWithRequest:]):
(-[WKCustomProtocol initWithRequest:cachedResponse:client:]):
(-[WKCustomProtocol startLoading]):
(-[WKCustomProtocol stopLoading]):
(protectedFirstNetworkProcess): Deleted.
* Source/WebKit/NetworkProcess/Downloads/Download.cpp:
(WebKit::Download::didReceiveData):
* Source/WebKit/NetworkProcess/Downloads/Download.h:
* Source/WebKit/NetworkProcess/Downloads/PendingDownload.cpp:
(WebKit::PendingDownload::willSendRedirectedRequest):
* Source/WebKit/NetworkProcess/NetworkBroadcastChannelRegistry.cpp:
(WebKit::NetworkBroadcastChannelRegistry::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.cpp:
(WebKit::NetworkContentRuleListManager::contentExtensionsBackend):
(WebKit::NetworkContentRuleListManager::protectedNetworkProcess const): Deleted.
* Source/WebKit/NetworkProcess/NetworkContentRuleListManager.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::webProcessConnection const):
(WebKit::NetworkProcess::protectedWebProcessConnection const): Deleted.
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkSocketChannel.cpp:
(WebKit::NetworkSocketChannel::finishClosingIfPossible):
(WebKit::NetworkSocketChannel::protectedConnectionToWebProcess): Deleted.
* Source/WebKit/NetworkProcess/NetworkSocketChannel.h:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
(WebKit::PrivateClickMeasurementManager::insertPrivateClickMeasurement):
(WebKit::PrivateClickMeasurementManager::migratePrivateClickMeasurementFromLegacyStorage):
(WebKit::PrivateClickMeasurementManager::attribute):
(WebKit::PrivateClickMeasurementManager::clearSentAttribution):
(WebKit::PrivateClickMeasurementManager::firePendingAttributionRequests):
(WebKit::PrivateClickMeasurementManager::clear):
(WebKit::PrivateClickMeasurementManager::clearForRegistrableDomain):
(WebKit::PrivateClickMeasurementManager::clearExpired):
(WebKit::PrivateClickMeasurementManager::toStringForTesting const):
(WebKit::PrivateClickMeasurementManager::markAllUnattributedAsExpiredForTesting):
(WebKit::PrivateClickMeasurementManager::markAttributedPrivateClickMeasurementsAsExpiredForTesting):
(WebKit::PrivateClickMeasurementManager::protectedStore): Deleted.
(WebKit::PrivateClickMeasurementManager::protectedStore const): Deleted.
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h:
* Source/WebKit/NetworkProcess/SharedWorker/WebSharedWorkerServerConnection.cpp:
(WebKit::WebSharedWorkerServerConnection::sharedPreferencesForWebProcess const):
* Source/WebKit/NetworkProcess/cache/NetworkCache.cpp:
(WebKit::NetworkCache::Cache::Cache):
(WebKit::NetworkCache::Cache::updateSpeculativeLoadManagerEnabledState):
* Source/WebKit/NetworkProcess/cache/NetworkCache.h:
(WebKit::NetworkCache::Cache::protectedStorage const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::SpeculativeLoadManager::registerLoad):
(WebKit::NetworkCache::SpeculativeLoadManager::addPreloadedEntry):
(WebKit::NetworkCache::SpeculativeLoadManager::retrieveEntryFromStorage):
(WebKit::NetworkCache::SpeculativeLoadManager::revalidateSubresource):
(WebKit::NetworkCache::SpeculativeLoadManager::preloadEntry):
(WebKit::NetworkCache::SpeculativeLoadManager::startSpeculativeRevalidation):
(WebKit::NetworkCache::SpeculativeLoadManager::protectedCache const): Deleted.
(WebKit::NetworkCache::SpeculativeLoadManager::protectedStorage const): Deleted.
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::initializeEphemeralStatelessSessionIfNeeded):
(WebKit::NetworkSessionCocoa::sessionWrapperForTask):
(WebKit::NetworkSessionCocoa::isolatedSession):
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.cpp:
(WebKit::BackgroundFetchStoreImpl::initializeFetches):
(WebKit::BackgroundFetchStoreImpl::getBackgroundFetchState):
(WebKit::BackgroundFetchStoreImpl::abortBackgroundFetch):
(WebKit::BackgroundFetchStoreImpl::pauseBackgroundFetch):
(WebKit::BackgroundFetchStoreImpl::resumeBackgroundFetch):
(WebKit::BackgroundFetchStoreImpl::clickBackgroundFetch):
(WebKit::BackgroundFetchStoreImpl::protectedServer): Deleted.
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::cacheStorageOpenCache):
(WebKit::NetworkStorageManager::cacheStorageAllCaches):
(WebKit::NetworkStorageManager::lockCacheStorage):
(WebKit::NetworkStorageManager::cacheStorageRepresentation):
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.cpp:
(WebKit::OriginStorageManager::protectedCacheStorageManager): Deleted.
* Source/WebKit/NetworkProcess/storage/OriginStorageManager.h:
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.cpp:
(WebKit::NetworkRTCProvider::close):
(WebKit::NetworkRTCProvider::protectedRTCMonitor): Deleted.
* Source/WebKit/NetworkProcess/webrtc/NetworkRTCProvider.h:
(WebKit::NetworkRTCProvider::didReceiveNetworkRTCMonitorMessage):
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.cpp:
(WebKit::WebPaymentCoordinatorProxy::protectedCanMakePaymentsQueue const): Deleted.
* Source/WebKit/Shared/ApplePay/WebPaymentCoordinatorProxy.h:
* Source/WebKit/Shared/ApplePay/mac/WebPaymentCoordinatorProxyMac.mm:
(WebKit::WebPaymentCoordinatorProxy::platformCanMakePayments):
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
(WebKit::TextExtractionAggregator::rootJSONObject):
(WebKit::TextExtractionAggregator::addNativeMenuItemsIfNeeded):
(WebKit::TextExtractionAggregator::addVersionNumberIfNeeded):
(WebKit::convertToText):
(WebKit::TextExtractionAggregator::protectedRootJSONObject): Deleted.
* Source/WebKit/Shared/WebGPU/WebGPURenderPassColorAttachment.cpp:
(WebKit::WebGPU::getIdentifier):
(WebKit::WebGPU::ConvertToBackingContext::convertToBacking):
* Source/WebKit/Shared/WebGPU/WebGPURenderPassDepthStencilAttachment.cpp:
(WebKit::WebGPU::getIdentifier):
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.cpp:
(WebKit::WebPaymentCoordinator::paymentCoordinator const):
(WebKit::WebPaymentCoordinator::validateMerchant):
(WebKit::WebPaymentCoordinator::didAuthorizePayment):
(WebKit::WebPaymentCoordinator::didSelectShippingMethod):
(WebKit::WebPaymentCoordinator::didSelectShippingContact):
(WebKit::WebPaymentCoordinator::didSelectPaymentMethod):
(WebKit::WebPaymentCoordinator::didChangeCouponCode):
(WebKit::WebPaymentCoordinator::didCancelPaymentSession):
(WebKit::WebPaymentCoordinator::protectedPaymentCoordinator): Deleted.
* Source/WebKit/WebProcess/ApplePay/WebPaymentCoordinator.h:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
(WebKit::WebExtensionAPIAlarms::createAlarm):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
(WebKit::WebExtensionAPIDevToolsInspectedWindow::tabId):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
(WebKit::WebExtensionAPIExtension::isPropertyAllowed):
(WebKit::WebExtensionAPIExtension::getBackgroundPage):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
(WebKit::WebExtensionAPIMenus::parseCreateAndUpdateProperties):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPINamespaceCocoa.mm:
(WebKit::WebExtensionAPINamespace::runtime const):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
(WebKit::WebExtensionAPIRuntime::getBackgroundPage):
(WebKit::WebExtensionAPIRuntime::connect):
(WebKit::WebExtensionAPIRuntime::connectNative):
(WebKit::WebExtensionAPIWebPageRuntime::connect):
(WebKit::WebExtensionContextProxy::internalDispatchRuntimeMessageEvent):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
(WebKit::WebExtensionAPIStorageArea::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageCocoa.mm:
(WebKit::WebExtensionAPIStorage::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
(WebKit::WebExtensionAPITabs::isPropertyAllowed):
(WebKit::WebExtensionAPITabs::connect):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebPageNamespaceCocoa.mm:
(WebKit::WebExtensionAPIWebPageNamespace::protectedRuntime const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
(WebKit::WebExtensionAPIWindows::isPropertyAllowed):
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPINamespace.h:
(WebKit::WebExtensionAPINamespace::protectedRuntime const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIObject.h:
(WebKit::WebExtensionAPIObject::runtime const):
(WebKit::WebExtensionAPIObject::extensionContext const):
(WebKit::WebExtensionAPIObject::protectedRuntime const): Deleted.
(WebKit::WebExtensionAPIObject::protectedExtensionContext const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIRuntime.h:
(WebKit::WebExtensionAPIRuntime::protectedRuntime const): Deleted.
(WebKit::WebExtensionAPIWebPageRuntime::protectedRuntime const): Deleted.
* Source/WebKit/WebProcess/Extensions/API/WebExtensionAPIWebPageNamespace.h:
* Source/WebKit/WebProcess/Extensions/Bindings/Scripts/CodeGeneratorExtensions.pm:
(_generateImplementationFile):
(_platformTypeConstructor):
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::dispatchMessage):
* Source/WebKit/WebProcess/GPU/graphics/Model/RemoteMeshProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteAdapterProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBindGroupProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandBufferProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCommandEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteCompositorIntegrationProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteComputePipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteDeviceProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteExternalTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePipelineLayoutProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemotePresentationContextProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQuerySetProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteQueueProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderBundleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPassEncoderProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteRenderPipelineProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteSamplerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteShaderModuleProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteTextureViewProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRBindingProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRProjectionLayerProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRSubImageProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteXRViewProxy.h:
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp:
(WebKit::MediaPlayerPrivateRemote::TimeProgressEstimator::currentTimeWithLockHeld const):
* Source/WebKit/WebProcess/GPU/media/MediaPlayerPrivateRemote.h:
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.cpp:
(WebKit::RemoteLegacyCDM::supportsMIMEType const):
(WebKit::RemoteLegacyCDM::setPlayerId):
(WebKit::RemoteLegacyCDM::protectedFactory const): Deleted.
* Source/WebKit/WebProcess/GPU/media/RemoteLegacyCDM.h:
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.cpp:
(WebKit::GeolocationPermissionRequestManager::startRequestForGeolocation):
(WebKit::GeolocationPermissionRequestManager::revokeAuthorizationToken):
(WebKit::GeolocationPermissionRequestManager::protectedPage const): Deleted.
* Source/WebKit/WebProcess/Geolocation/GeolocationPermissionRequestManager.h:
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.cpp:
(WebKit::RemoteWebInspectorUI::initialize):
(WebKit::RemoteWebInspectorUI::windowObjectCleared):
(WebKit::RemoteWebInspectorUI::closeWindow):
(WebKit::RemoteWebInspectorUI::logDiagnosticEvent):
(WebKit::RemoteWebInspectorUI::protectedWebPage): Deleted.
* Source/WebKit/WebProcess/Inspector/RemoteWebInspectorUI.h:
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.cpp:
(WebKit::WebFrameInspectorTarget::disconnect):
(WebKit::WebFrameInspectorTarget::sendMessageToTargetBackend):
(WebKit::WebFrameInspectorTarget::protectedFrame): Deleted.
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTarget.h:
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.cpp:
(WebKit::WebFrameInspectorTargetFrontendChannel::sendMessageToFrontend):
(WebKit::WebFrameInspectorTargetFrontendChannel::protectedFrame): Deleted.
* Source/WebKit/WebProcess/Inspector/WebFrameInspectorTargetFrontendChannel.h:
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.cpp:
(WebKit::RemoteMediaSessionCoordinator::join):
(WebKit::RemoteMediaSessionCoordinator::leave):
(WebKit::RemoteMediaSessionCoordinator::seekTo):
(WebKit::RemoteMediaSessionCoordinator::play):
(WebKit::RemoteMediaSessionCoordinator::pause):
(WebKit::RemoteMediaSessionCoordinator::setTrack):
(WebKit::RemoteMediaSessionCoordinator::positionStateChanged):
(WebKit::RemoteMediaSessionCoordinator::readyStateChanged):
(WebKit::RemoteMediaSessionCoordinator::playbackStateChanged):
(WebKit::RemoteMediaSessionCoordinator::trackIdentifierChanged):
(WebKit::RemoteMediaSessionCoordinator::protectedPage const): Deleted.
* Source/WebKit/WebProcess/MediaSession/RemoteMediaSessionCoordinator.h:
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.cpp:
(WebKit::UserMediaPermissionRequestManager::sendUserMediaRequest):
(WebKit::UserMediaPermissionRequestManager::enumerateMediaDevices):
(WebKit::UserMediaPermissionRequestManager::addDeviceChangeObserver):
(WebKit::UserMediaPermissionRequestManager::updateCaptureState):
(WebKit::UserMediaPermissionRequestManager::protectedPage const): Deleted.
* Source/WebKit/WebProcess/MediaStream/UserMediaPermissionRequestManager.h:
* Source/WebKit/WebProcess/Notifications/NotificationPermissionRequestManager.cpp:
(WebKit::NotificationPermissionRequestManager::startRequest):
(WebKit::NotificationPermissionRequestManager::permissionLevel):
(WebKit::NotificationPermissionRequestManager::setPermissionLevelForTesting):
(WebKit::NotificationPermissionRequestManager::removeAllPermissionsForTesting):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::didInvalidateDataDetectorHighlightOverlayRects):
(WebKit::UnifiedPDFPlugin::didBeginMagnificationGesture):
(WebKit::UnifiedPDFPlugin::handleMouseEvent):
(WebKit::UnifiedPDFPlugin::protectedDataDetectorOverlayController): Deleted.
* Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.cpp:
(WebKit::WebAuthenticatorCoordinator::makeCredential):
(WebKit::WebAuthenticatorCoordinator::getAssertion):
(WebKit::WebAuthenticatorCoordinator::isConditionalMediationAvailable):
(WebKit::WebAuthenticatorCoordinator::isUserVerifyingPlatformAuthenticatorAvailable):
(WebKit::WebAuthenticatorCoordinator::cancel):
(WebKit::WebAuthenticatorCoordinator::getClientCapabilities):
(WebKit::WebAuthenticatorCoordinator::signalUnknownCredential):
(WebKit::WebAuthenticatorCoordinator::signalAllAcceptedCredentials):
(WebKit::WebAuthenticatorCoordinator::signalCurrentUserDetails):
(WebKit::WebAuthenticatorCoordinator::protectedPage const): Deleted.
* Source/WebKit/WebProcess/WebAuthentication/WebAuthenticatorCoordinator.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp:
(WebKit::WebBroadcastChannelRegistry::registerChannel):
(WebKit::WebBroadcastChannelRegistry::unregisterChannel):
(WebKit::WebBroadcastChannelRegistry::postMessage):
(WebKit::WebBroadcastChannelRegistry::networkProcessCrashed):
(WebKit::protectedNetworkProcessConnection): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.cpp:
(WebKit::WebDocumentSyncClient::siteIsolationEnabled):
(WebKit::WebDocumentSyncClient::broadcastDocumentSyncDataToOtherProcesses):
(WebKit::WebDocumentSyncClient::broadcastAllDocumentSyncDataToOtherProcesses):
(WebKit::WebDocumentSyncClient::protectedPage const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebDocumentSyncClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebGeolocationClient.cpp:
(WebKit::WebGeolocationClient::geolocationDestroyed):
(WebKit::WebGeolocationClient::startUpdating):
(WebKit::WebGeolocationClient::stopUpdating):
(WebKit::WebGeolocationClient::setEnableHighAccuracy):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchCreatePage):
(WebKit::WebLocalFrameLoaderClient::createDocumentLoader):
(WebKit::WebLocalFrameLoaderClient::updateCachedDocumentLoader):
(WebKit::WebLocalFrameLoaderClient::didChangeScrollOffset):
(WebKit::WebLocalFrameLoaderClient::protectedLocalFrame const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp:
(WebKit::WebMessagePortChannelProvider::createNewMessagePortChannel):
(WebKit::WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote):
(WebKit::WebMessagePortChannelProvider::messagePortDisentangled):
(WebKit::WebMessagePortChannelProvider::messagePortClosed):
(WebKit::WebMessagePortChannelProvider::takeAllMessagesForPort):
(WebKit::WebMessagePortChannelProvider::postMessageToRemote):
(WebKit::protectedNetworkProcessConnection): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebNotificationClient.cpp:
(WebKit::WebNotificationClient::show):
(WebKit::WebNotificationClient::cancel):
(WebKit::WebNotificationClient::notificationObjectDestroyed):
(WebKit::WebNotificationClient::requestPermission):
(WebKit::WebNotificationClient::checkPermission):
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.cpp:
(WebKit::WebScreenOrientationManager::currentOrientation):
(WebKit::WebScreenOrientationManager::lock):
(WebKit::WebScreenOrientationManager::unlock):
(WebKit::WebScreenOrientationManager::addObserver):
(WebKit::WebScreenOrientationManager::removeObserver):
(WebKit::WebScreenOrientationManager::protectedPage const): Deleted.
* Source/WebKit/WebProcess/WebCoreSupport/WebScreenOrientationManager.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::platformInitialize):
* Source/WebKit/WebProcess/WebPage/DrawingArea.cpp:
(WebKit::DrawingArea::mainFrameTiledBacking const):
* Source/WebKit/WebProcess/WebPage/DrawingArea.h:
(WebKit::DrawingArea::protectedWebPage const): Deleted.
* Source/WebKit/WebProcess/WebPage/RemoteLayerTree/RemoteLayerTreeDrawingArea.mm:
(WebKit::RemoteLayerTreeDrawingArea::updateRenderingWithForcedRepaint):
(WebKit::RemoteLayerTreeDrawingArea::setViewExposedRect):
(WebKit::RemoteLayerTreeDrawingArea::exposedContentRect const):
(WebKit::RemoteLayerTreeDrawingArea::setExposedContentRect):
(WebKit::RemoteLayerTreeDrawingArea::didCompleteRenderingUpdateDisplayFlush):
* Source/WebKit/WebProcess/WebPage/mac/RemoteLayerTreeDrawingAreaMac.mm:
(WebKit::RemoteLayerTreeDrawingAreaMac::adjustTransientZoom):
(WebKit::RemoteLayerTreeDrawingAreaMac::willCommitMainFrameData):
* Source/WebKit/WebProcess/WebPage/mac/TiledCoreAnimationDrawingArea.mm:
(WebKit::TiledCoreAnimationDrawingArea::setViewExposedRect):
(WebKit::TiledCoreAnimationDrawingArea::applyTransientZoomToLayers):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::notificationManager):
(WebKit::WebProcess::geolocationManager):
(WebKit::WebProcess::userMediaCaptureManager):
(WebKit::WebProcess::initializeConnection):
(WebKit::WebProcess::protectedNotificationManager): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.cpp:
(WebKit::StorageAreaMap::decrementUseCount):
(WebKit::StorageAreaMap::protectedNamespace const): Deleted.
* Source/WebKit/WebProcess/WebStorage/StorageAreaMap.h:
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.cpp:
(WebKit::PlatformXRSystemProxy::enumerateImmersiveXRDevices):
(WebKit::PlatformXRSystemProxy::requestPermissionOnSessionFeatures):
(WebKit::PlatformXRSystemProxy::initializeTrackingAndRendering):
(WebKit::PlatformXRSystemProxy::shutDownTrackingAndRendering):
(WebKit::PlatformXRSystemProxy::didCompleteShutdownTriggeredBySystem):
(WebKit::PlatformXRSystemProxy::requestFrame):
(WebKit::PlatformXRSystemProxy::createLayerProjection):
(WebKit::PlatformXRSystemProxy::submitFrame):
(WebKit::PlatformXRSystemProxy::requestHitTestSource):
(WebKit::PlatformXRSystemProxy::deleteHitTestSource):
(WebKit::PlatformXRSystemProxy::requestTransientInputHitTestSource):
(WebKit::PlatformXRSystemProxy::deleteTransientInputHitTestSource):
(WebKit::PlatformXRSystemProxy::protectedPage const): Deleted.
* Source/WebKit/WebProcess/XR/PlatformXRSystemProxy.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushServiceRequest::service const):
(WebPushD::PushServiceRequest::connection const):
(WebPushD::PushServiceRequest::database const):
(WebPushD::GetSubscriptionRequest::startInternal):
(WebPushD::SubscribeRequest::startImpl):
(WebPushD::UnsubscribeRequest::startInternal):
(WebPushD::PushServiceRequest::protectedService const): Deleted.
(WebPushD::PushServiceRequest::protectedConnection const): Deleted.
(WebPushD::PushServiceRequest::protectedDatabase const): Deleted.

Canonical link: <a href="https://commits.webkit.org/307464@main">https://commits.webkit.org/307464@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e4b918613fdca685c9086964b284bd60d11d6b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17181 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8741 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153172 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111112 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147465 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129768 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92025 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/12887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/618 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136493 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6456 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155485 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5311 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17033 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119114 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17071 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14257 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119472 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30622 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15310 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127669 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16655 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6077 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175790 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16391 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/45277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16455 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->