### PR TITLE
Decoding webm file with more than 2 channels will fail

### DIFF
--- a/Source/WebCore/PAL/pal/cf/CoreAudioExtras.h
+++ b/Source/WebCore/PAL/pal/cf/CoreAudioExtras.h
@@ -60,6 +60,11 @@ inline size_t allocationSize(const AudioBufferList& list)
     return offsetof(AudioBufferList, mBuffers) + sizeof(AudioBuffer) * std::max<uint32_t>(1U, list.mNumberBuffers);
 }
 
+inline size_t allocationSize(const AudioChannelLayout& layout)
+{
+    return offsetof(AudioChannelLayout, mChannelDescriptions) + sizeof(AudioChannelDescription) * std::max<uint32_t>(1U, layout.mNumberChannelDescriptions);
+}
+
 // AudioBufferList is a variable-length struct, so create on the heap with a generic new() operator
 // with a custom size, and initialize the struct manually.
 enum class ShouldZeroMemory : bool { No, Yes };
@@ -73,6 +78,20 @@ inline std::unique_ptr<AudioBufferList, WTF::SystemFree<AudioBufferList>> create
     bufferList->mNumberBuffers = bufferCount;
     ASSERT(allocationSize(*bufferList) == bufferListSize.value());
     return bufferList;
+}
+
+// AudioChannelLayout is a variable-length struct, so create on the heap with a generic new() operator
+// with a custom size, and initialize the struct manually.
+inline std::unique_ptr<AudioChannelLayout, WTF::SystemFree<AudioChannelLayout>> createAudioChannelLayout(uint32_t channelCount, ShouldZeroMemory shouldZeroMemory)
+{
+    CheckedSize channelLayoutSize = offsetof(AudioChannelLayout, mChannelDescriptions);
+    channelLayoutSize += CheckedSize { sizeof(AudioChannelDescription) } * std::max<uint32_t>(1, channelCount);
+    auto channelLayout = adoptSystemMalloc(shouldZeroMemory == ShouldZeroMemory::Yes
+        ? SystemMallocBase<AudioChannelLayout>::zeroedMalloc(channelLayoutSize.value())
+        : SystemMallocBase<AudioChannelLayout>::malloc(channelLayoutSize.value()));
+    channelLayout->mNumberChannelDescriptions = channelCount;
+    ASSERT(allocationSize(*channelLayout) == channelLayoutSize.value());
+    return channelLayout;
 }
 
 } // namespace PAL

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp
@@ -212,6 +212,7 @@ SOFT_LINK_CONSTANT_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, kCMTimebaseNotificatio
 
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMAudioFormatDescriptionCreate, OSStatus, (CFAllocatorRef allocator, const AudioStreamBasicDescription* asbd, size_t layoutSize, const AudioChannelLayout* layout, size_t magicCookieSize, const void* magicCookie, CFDictionaryRef extensions, CMAudioFormatDescriptionRef* outDesc), (allocator, asbd, layoutSize, layout, magicCookieSize, magicCookie, extensions, outDesc), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMAudioFormatDescriptionGetMagicCookie, const void*, (CMAudioFormatDescriptionRef desc, size_t* sizeOut), (desc, sizeOut), PAL_EXPORT)
+SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMAudioFormatDescriptionGetChannelLayout, const AudioChannelLayout*, (CMAudioFormatDescriptionRef desc, size_t* sizeOut), (desc, sizeOut), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMAudioFormatDescriptionGetStreamBasicDescription, const AudioStreamBasicDescription*, (CMAudioFormatDescriptionRef desc), (desc), PAL_EXPORT)
 SOFT_LINK_FUNCTION_FOR_SOURCE_WITH_EXPORT(PAL, CoreMedia, CMAudioFormatDescriptionGetRichestDecodableFormat, const AudioFormatListItem*, (CMAudioFormatDescriptionRef desc), (desc), PAL_EXPORT)
 

--- a/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
+++ b/Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h
@@ -369,6 +369,8 @@ SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMAudioFormatDescriptionCreate, OS
 #define CMAudioFormatDescriptionCreate softLink_CoreMedia_CMAudioFormatDescriptionCreate
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMAudioFormatDescriptionGetMagicCookie, const void*, (CMAudioFormatDescriptionRef desc, size_t* sizeOut), (desc, sizeOut))
 #define CMAudioFormatDescriptionGetMagicCookie softLink_CoreMedia_CMAudioFormatDescriptionGetMagicCookie
+SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMAudioFormatDescriptionGetChannelLayout, const AudioChannelLayout*, (CMAudioFormatDescriptionRef desc, size_t* sizeOut), (desc, sizeOut))
+#define CMAudioFormatDescriptionGetChannelLayout softLink_CoreMedia_CMAudioFormatDescriptionGetChannelLayout
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMAudioFormatDescriptionGetStreamBasicDescription, const AudioStreamBasicDescription*, (CMAudioFormatDescriptionRef desc), (desc))
 #define CMAudioFormatDescriptionGetStreamBasicDescription softLink_CoreMedia_CMAudioFormatDescriptionGetStreamBasicDescription
 SOFT_LINK_FUNCTION_FOR_HEADER(PAL, CoreMedia, CMAudioFormatDescriptionGetRichestDecodableFormat, const AudioFormatListItem*, (CMAudioFormatDescriptionRef desc), (desc))

--- a/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
+++ b/Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.cpp
@@ -278,6 +278,35 @@ static OSStatus passthroughInputDataCallback(AudioConverterRef, UInt32* numDataP
     return noErr;
 }
 
+static UInt32 SMPTEEquivalentLayout(UInt32 layout)
+{
+    // https://webaudio.github.io/web-audio-api/#ChannelOrdering
+    // WebAudio API requires SMPTE channel ordering. However webkit has been returning
+    // incorrectly ordered channels for as long as WebAudio has been supported and sites
+    // have adopted workaround it.
+    // To avoid breaking existing behaviour, we leave all other layouts unchanged.
+    // There are no system constants matching SMPTE, so we use the equivalent for a given channels count.
+    switch (layout) {
+    case kAudioChannelLayoutTag_Mono:
+    case kAudioChannelLayoutTag_Stereo:
+        return layout;
+    case kAudioChannelLayoutTag_Ogg_3_0:
+        return kAudioChannelLayoutTag_WAVE_3_0; // L R C
+    case kAudioChannelLayoutTag_Ogg_4_0:
+        return kAudioChannelLayoutTag_WAVE_4_0_B; // L R Rls Rrs
+    case kAudioChannelLayoutTag_Ogg_5_0:
+        return kAudioChannelLayoutTag_WAVE_5_0_B; // L R C LFE Rls Rrs
+    case kAudioChannelLayoutTag_Ogg_5_1:
+        return kAudioChannelLayoutTag_WAVE_5_1_B;
+    case kAudioChannelLayoutTag_Ogg_6_1:
+        return kAudioChannelLayoutTag_MPEG_6_1_A; // L R C LFE Ls Rs Cs
+    case kAudioChannelLayoutTag_Ogg_7_1:
+        return kAudioChannelLayoutTag_MPEG_7_1_C; // L R C LFE Ls Rs Rls Rrs
+    default:
+        return layout;
+    }
+}
+
 std::optional<size_t> AudioFileReader::decodeWebMData(AudioBufferList& bufferList, size_t numberOfFrames, const AudioStreamBasicDescription& inFormat, const AudioStreamBasicDescription& outFormat) const
 {
     AudioConverterRef converter;
@@ -298,6 +327,22 @@ std::optional<size_t> AudioFileReader::decodeWebMData(AudioBufferList& bufferLis
     const void* magicCookie = PAL::CMAudioFormatDescriptionGetMagicCookie(formatDescription.get(), &magicCookieSize);
     if (magicCookie && magicCookieSize)
         PAL::AudioConverterSetProperty(converter, kAudioConverterDecompressionMagicCookie, magicCookieSize, magicCookie);
+
+    auto setChannelLayoutIfNeeded = [&] {
+        auto* formatListItem = PAL::CMAudioFormatDescriptionGetRichestDecodableFormat(formatDescription.get());
+        if (!formatListItem)
+            return;
+        auto outputLayoutTag = SMPTEEquivalentLayout(formatListItem->mChannelLayoutTag);
+        if (outputLayoutTag == formatListItem->mChannelLayoutTag)
+            return;
+        auto inputLayout = channelLayoutFromChannelLayoutTag(formatListItem->mChannelLayoutTag);
+        auto outputLayout = channelLayoutFromChannelLayoutTag(outputLayoutTag);
+        if (!inputLayout.first || !outputLayout.first)
+            return;
+        PAL::AudioConverterSetProperty(converter, kAudioConverterInputChannelLayout, inputLayout.second, inputLayout.first.get());
+        PAL::AudioConverterSetProperty(converter, kAudioConverterOutputChannelLayout, outputLayout.second, outputLayout.first.get());
+    };
+    setChannelLayoutIfNeeded();
 
     AudioBufferListHolder decodedBufferList(inFormat.mChannelsPerFrame);
     if (!decodedBufferList) {

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <wtf/Forward.h>
 #include <wtf/RetainPtr.h>
+#include <wtf/SystemFree.h>
 #include <wtf/TZoneMalloc.h>
 
 typedef struct AudioFormatVorbisModeInfo AudioFormatVorbisModeInfo;
@@ -72,6 +73,10 @@ WEBCORE_EXPORT Vector<Ref<SharedBuffer>> getKeyIDs(CMFormatDescriptionRef);
 #endif
 
 WEBCORE_EXPORT FourCC computeBoxType(FourCC);
+
+WEBCORE_EXPORT std::pair<std::unique_ptr<AudioChannelLayout, WTF::SystemFree<AudioChannelLayout>>, size_t> channelLayoutFromChannelLayoutTag(UInt32);
+// Retrieve channel layout name string for debugging.
+WEBCORE_EXPORT String channelLayoutDescription(UInt32);
 
 class PacketDurationParser final {
     WTF_MAKE_TZONE_ALLOCATED(PacketDurationParser);

--- a/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
+++ b/Source/WebCore/platform/graphics/cocoa/CMUtilities.mm
@@ -42,6 +42,7 @@
 #import <JavaScriptCore/ArrayBuffer.h>
 #import <JavaScriptCore/DataView.h>
 #import <pal/avfoundation/MediaTimeAVFoundation.h>
+#import <pal/cf/CoreAudioExtras.h>
 #import <pal/spi/cocoa/AudioToolboxSPI.h>
 #import <wtf/Expected.h>
 #import <wtf/Scope.h>
@@ -944,6 +945,31 @@ FourCC computeBoxType(FourCC codecType)
         ASSERT_NOT_REACHED();
         return 'baad';
     }
+}
+
+std::pair<std::unique_ptr<AudioChannelLayout, WTF::SystemFree<AudioChannelLayout>>, size_t> channelLayoutFromChannelLayoutTag(UInt32 channelLayoutTag)
+{
+    if (channelLayoutTag == kAudioChannelLayoutTag_UseChannelDescriptions || channelLayoutTag == kAudioChannelLayoutTag_UseChannelBitmap) {
+        ASSERT_NOT_REACHED();
+        return { nullptr, 0 };
+    }
+
+    auto channelLayout = PAL::createAudioChannelLayout(1, PAL::ShouldZeroMemory::Yes);
+    channelLayout->mChannelLayoutTag = channelLayoutTag;
+    auto channelLayoutSize = PAL::allocationSize(*channelLayout);
+    return { WTF::move(channelLayout), channelLayoutSize };
+}
+
+String channelLayoutDescription(UInt32 channelLayoutTag)
+{
+    auto channelLayout = channelLayoutFromChannelLayoutTag(channelLayoutTag);
+    if (!channelLayout.first)
+        return { };
+    CFStringRef channelLayoutName;
+    UInt32 stringSize = sizeof(channelLayoutName);
+    if (PAL::AudioFormatGetProperty(kAudioFormatProperty_ChannelLayoutName, channelLayout.second, channelLayout.first.get(), &stringSize, &channelLayoutName))
+        return { };
+    SUPPRESS_RETAINPTR_CTOR_ADOPT return adoptCF(channelLayoutName).get(); // The caller is responsible for releasing the returned string.
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm
@@ -29,6 +29,7 @@
 #if PLATFORM(COCOA)
 
 #import "CAAudioStreamDescription.h"
+#import "CMUtilities.h"
 #import "Logging.h"
 #import "MediaUtilities.h"
 #import "PlatformMediaSessionManager.h"
@@ -99,14 +100,30 @@ static bool registerDecoderFactory(ASCIILiteral decoderName, OSType decoderType)
 
 static RefPtr<AudioInfo> createAudioInfoForFormat(OSType formatID, Vector<uint8_t>&& magicCookie)
 {
-    AudioStreamBasicDescription asbd { };
-    asbd.mFormatID = formatID;
-    uint32_t size = sizeof(asbd);
-    auto error = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, magicCookie.size(), magicCookie.span().data(), &size, &asbd);
-    if (error) {
-        RELEASE_LOG_ERROR(Media, "createAudioFormatDescriptionForFormat failed with error %d (%.4s)", error, (char *)&error);
+    AudioFormatInfo formatInfo { };
+    formatInfo.mASBD.mFormatID = formatID;
+    formatInfo.mMagicCookieSize = magicCookie.size();
+    formatInfo.mMagicCookie = magicCookie.span().data();
+    UInt32 formatListSize;
+    if (auto error = PAL::AudioFormatGetPropertyInfo(kAudioFormatProperty_FormatList, sizeof(formatInfo), &formatInfo, &formatListSize)) {
+        RELEASE_LOG_ERROR(Media, "createAudioFormatDescriptionForFormat::kAudioFormatProperty_FormatList failed with error %d (%.4s)", error, (char *)&error);
         return nullptr;
     }
+    size_t listCount = formatListSize / sizeof(AudioFormatListItem);
+    Vector<AudioFormatListItem> formatList(listCount);
+    if (auto error = PAL::AudioFormatGetProperty(kAudioFormatProperty_FormatList, sizeof(formatInfo), &formatInfo, &formatListSize, formatList.mutableSpan().data())) {
+        RELEASE_LOG_ERROR(Media, "createAudioFormatDescriptionForFormat::kAudioFormatProperty_FormatList failed with error %d (%.4s)", error, (char *)&error);
+        return nullptr;
+    }
+    UInt32 itemIndex;
+    UInt32 indexSize = sizeof(itemIndex);
+    if (auto error = PAL::AudioFormatGetProperty(kAudioFormatProperty_FirstPlayableFormatFromList, formatListSize, formatList.span().data(), &indexSize, &itemIndex)) {
+        RELEASE_LOG_ERROR(Media, "createAudioFormatDescriptionForFormat::kAudioFormatProperty_FirstPlayableFormatFromList failed with error %d (%.4s)", error, (char *)&error);
+        return nullptr;
+    }
+    AudioStreamBasicDescription asbd = formatList[itemIndex].mASBD;
+
+    RELEASE_LOG_DEBUG(Media, "createAudioFormatDescriptionForFormat for layout %s", channelLayoutDescription(formatList[itemIndex].mChannelLayoutTag).ascii().span().data());
 
     return AudioInfo::create({
         {


### PR DESCRIPTION
#### 4bf9354c493ce8d566c6deb71ee0dce97d810c22
<pre>
Decoding webm file with more than 2 channels will fail
<a href="https://bugs.webkit.org/show_bug.cgi?id=229325">https://bugs.webkit.org/show_bug.cgi?id=229325</a>
<a href="https://rdar.apple.com/82160691">rdar://82160691</a>

Reviewed by Jer Noble.

This adds support for decoding streams with multi-channels audio whenever
AudioToolbox decoder supports multi-channels audio.

For codec with an Ogg channel layout, decoded PCM channels will be re-ordered
following W3C specs (SMPTE).
For other codecs, we keep the existing behaviour of returning the codec&apos;s native
ordering as that&apos;s what webkit on cocoa platform has been doing (incorrectly)
since the start of time.

* Source/WebCore/PAL/pal/cf/CoreAudioExtras.h:
(PAL::allocationSize):
(PAL::createAudioChannelLayout):
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.cpp:
* Source/WebCore/PAL/pal/cf/CoreMediaSoftLink.h:
* Source/WebCore/platform/audio/cocoa/AudioFileReaderCocoa.mm:
(WebCore::SMPTEEquivalentLayout):
(WebCore::AudioFileReader::decodeData const):
* Source/WebCore/platform/graphics/cocoa/CMUtilities.h:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::channelLayoutFromChannelLayoutTag):
(WebCore::channelLayoutDescription):
* Source/WebCore/platform/graphics/cocoa/WebMAudioUtilitiesCocoa.mm:
(WebCore::createAudioInfoForFormat):

Canonical link: <a href="https://commits.webkit.org/308749@main">https://commits.webkit.org/308749@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f04d27ef1b709b3a648154f23ae8e3fbd1aa152

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148339 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14620 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157023 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c219f168-055c-4e37-bc4a-3a3316a6050b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150212 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114369 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9d2f334-d4cc-476d-8af0-05a9a47c4904) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16608 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133192 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95139 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f36d2088-4380-4b13-b5bd-40beaad6b123) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15721 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13527 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4459 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125333 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159356 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2490 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122398 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20823 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122618 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33344 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132915 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76984 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/18033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9660 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20440 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84225 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20172 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20317 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20226 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->