### PR TITLE
[WTF] Introduce documentation for RetainPtr and OSObjectPtr

### DIFF
--- a/Source/WTF/wtf/OSObjectPtr.h
+++ b/Source/WTF/wtf/OSObjectPtr.h
@@ -61,6 +61,35 @@ template<typename T, typename arcEnabled = ARCEnabled> struct DefaultOSObjectRet
 
 template<typename T, typename RetainTraits = DefaultOSObjectRetainTraits<T, ARCEnabled>> [[nodiscard]] OSObjectPtr<T, RetainTraits> adoptOSObject(T);
 
+/**
+ * @brief OSObjectPtr is a reference-counting smart pointer for Darwin OS object types.
+ *
+ * It extends the lifetime of the referenced object by retaining it on construction and releasing it on
+ * destruction.
+ *
+ * OSObjectPtr is used for libdispatch types (dispatch_queue_t, dispatch_source_t, dispatch_data_t,
+ * dispatch_group_t, dispatch_semaphore_t, etc.), XPC types (xpc_connection_t, xpc_object_t,
+ * xpc_endpoint_t, etc.), and Network framework types (nw_endpoint_t, nw_path_t, etc.). Each type family
+ * uses its own retain/release functions (dispatch_retain/dispatch_release, xpc_retain/xpc_release,
+ * nw_retain/nw_release, or os_retain/os_release for other types).
+ *
+ * To create an OSObjectPtr, use one of the following:
+ * @code
+ * OSObjectPtr ptr = value;            // Retains the value (increments the ref count)
+ * OSObjectPtr ptr = adoptOSObject(x); // Takes ownership without retaining
+ * @endcode
+ *
+ * Use adoptOSObject() when you receive an object that you already own (i.e., the object was returned to
+ * you with a +1 retain count). This includes objects from creation functions like dispatch_queue_create()
+ * or xpc_*_create(). Using the regular OSObjectPtr constructor instead of adoptOSObject() would add an
+ * extra retain, causing a leak when the OSObjectPtr is destroyed. Use the regular constructor when you
+ * want to add a reference to an object you don't already own.
+ *
+ * @note For Objective-C types and Core Foundation types, use RetainPtr instead of OSObjectPtr.
+ *
+ * @note OSObjectPtr is compatible with ARC (Automatic Reference Counting) and will automatically use the
+ * appropriate retain/release semantics based on the compilation mode.
+ */
 template<typename T, typename RetainTraits> class OSObjectPtr {
 public:
     using ValueType = std::remove_pointer_t<T>;


### PR DESCRIPTION
#### ef22c8ac49206993805cac7f889a9998e35fc11f
<pre>
[WTF] Introduce documentation for RetainPtr and OSObjectPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=307760">https://bugs.webkit.org/show_bug.cgi?id=307760</a>

Reviewed by Ryosuke Niwa and Geoffrey Garen.

Introduce documentation for RetainPtr and OSObjectPtr in their respective
WTF header files.

Use Doxygen format and place the comment right before the class so that
it integrates nicely with XCode&apos;s quick help.

* Source/WTF/wtf/OSObjectPtr.h:
* Source/WTF/wtf/RetainPtr.h:

Canonical link: <a href="https://commits.webkit.org/307529@main">https://commits.webkit.org/307529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e24e1ec7288c7afc112da59bd207e3b9cd92fb7c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144477 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17156 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8716 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153147 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98112 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/688c0775-ca6b-464f-91c6-4ad454b80dd9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17638 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111094 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79737 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c57337a0-dab1-4978-9df3-946a5e911230) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147440 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129748 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92007 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2f97627-d900-4f84-8c69-4992a451a72f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12876 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10628 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/593 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136468 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122382 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6435 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155460 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5286 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17008 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119092 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17046 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14238 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119452 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30667 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15286 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127648 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72549 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16630 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6057 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175765 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16366 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80409 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45271 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16575 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16430 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->