### PR TITLE
Refactor logic to check PDF display modes

### DIFF
--- a/Source/WebKit/Shared/PDFDisplayMode.h
+++ b/Source/WebKit/Shared/PDFDisplayMode.h
@@ -36,6 +36,12 @@ enum class PDFDisplayMode : uint8_t {
     TwoUpContinuous,
 };
 
+constexpr bool isSinglePagePDFDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::SinglePageDiscrete || mode == PDFDisplayMode::SinglePageContinuous; }
+constexpr bool isTwoUpPDFDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::TwoUpDiscrete || mode == PDFDisplayMode::TwoUpContinuous; }
+
+constexpr bool isScrollingPDFDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::SinglePageContinuous || mode == PDFDisplayMode::TwoUpContinuous; }
+constexpr bool isDiscretePDFDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::SinglePageDiscrete || mode == PDFDisplayMode::TwoUpDiscrete; }
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -1160,8 +1160,7 @@ static void storeAccessibilityRemoteConnectionInformation(id element, pid_t pid,
     if (!protect(page->preferences())->twoUpPDFDisplayModeSupportEnabled())
         return;
 
-    auto pdfDisplayMode = page->pdfDisplayMode();
-    BOOL isSinglePage = pdfDisplayMode == WebKit::PDFDisplayMode::SinglePageDiscrete || pdfDisplayMode == WebKit::PDFDisplayMode::SinglePageContinuous;
+    BOOL isSinglePage = WebKit::isSinglePagePDFDisplayMode(page->pdfDisplayMode());
     if (isSinglePage)
         return;
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -15391,7 +15391,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
             if (!page)
                 return;
 
-            BOOL isSinglePage = page->pdfDisplayMode() == WebKit::PDFDisplayMode::SinglePageContinuous;
+            BOOL isSinglePage = WebKit::isSinglePagePDFDisplayMode(page->pdfDisplayMode());
             BOOL isSinglePageAction = [action.identifier isEqualToString:WKPDFActionSinglePageIdentifier];
 
             if (isSinglePage == isSinglePageAction)
@@ -15403,7 +15403,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         RetainPtr singlePageAction = [UIAction actionWithTitle:WebCore::contextMenuItemPDFSinglePage().createNSString().get() image:nil identifier:WKPDFActionSinglePageIdentifier handler:actionHandler];
         RetainPtr twoPagesAction = [UIAction actionWithTitle:WebCore::contextMenuItemPDFTwoPages().createNSString().get() image:nil identifier:WKPDFActionTwoPagesIdentifier handler:actionHandler];
 
-        if (protect(strongSelf->_page)->pdfDisplayMode() == WebKit::PDFDisplayMode::SinglePageContinuous)
+        if (WebKit::isSinglePagePDFDisplayMode(protect(strongSelf->_page)->pdfDisplayMode()))
             [singlePageAction setState:UIMenuElementStateOn];
         else
             [twoPagesAction setState:UIMenuElementStateOn];

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm
@@ -98,7 +98,7 @@ void PDFDiscretePresentationController::teardown()
 
 bool PDFDiscretePresentationController::supportsDisplayMode(PDFDisplayMode mode) const
 {
-    return PDFDocumentLayout::isDiscreteDisplayMode(mode);
+    return isDiscretePDFDisplayMode(mode);
 }
 
 void PDFDiscretePresentationController::willChangeDisplayMode(PDFDisplayMode newMode)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h
@@ -111,17 +111,11 @@ public:
     void setDisplayMode(PDFDisplayMode displayMode) { m_displayMode = displayMode; }
     PDFDisplayMode displayMode() const { return m_displayMode; }
 
-    constexpr static bool isSinglePageDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::SinglePageDiscrete || mode == PDFDisplayMode::SinglePageContinuous; }
-    constexpr static bool isTwoUpDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::TwoUpDiscrete || mode == PDFDisplayMode::TwoUpContinuous; }
+    bool isSinglePageDisplayMode() const { return isSinglePagePDFDisplayMode(m_displayMode); }
+    bool isTwoUpDisplayMode() const { return isTwoUpPDFDisplayMode(m_displayMode); }
 
-    constexpr static bool isScrollingDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::SinglePageContinuous || mode == PDFDisplayMode::TwoUpContinuous; }
-    constexpr static bool isDiscreteDisplayMode(PDFDisplayMode mode) { return mode == PDFDisplayMode::SinglePageDiscrete || mode == PDFDisplayMode::TwoUpDiscrete; }
-
-    bool isSinglePageDisplayMode() const { return isSinglePageDisplayMode(m_displayMode); }
-    bool isTwoUpDisplayMode() const { return isTwoUpDisplayMode(m_displayMode); }
-
-    bool isScrollingDisplayMode() const { return isScrollingDisplayMode(m_displayMode); }
-    bool isDiscreteDisplayMode() const { return isDiscreteDisplayMode(m_displayMode); }
+    bool isScrollingDisplayMode() const { return isScrollingPDFDisplayMode(m_displayMode); }
+    bool isDiscreteDisplayMode() const { return isDiscretePDFDisplayMode(m_displayMode); }
 
     unsigned pagesPerRow() const { return isSinglePageDisplayMode() ? 1 : 2; }
 

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm
@@ -49,10 +49,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(PDFPresentationController);
 
 RefPtr<PDFPresentationController> PDFPresentationController::createForMode(PDFDisplayMode mode, UnifiedPDFPlugin& plugin)
 {
-    if (PDFDocumentLayout::isScrollingDisplayMode(mode))
+    if (isScrollingPDFDisplayMode(mode))
         return adoptRef(*new PDFScrollingPresentationController { plugin });
 
-    if (PDFDocumentLayout::isDiscreteDisplayMode(mode))
+    if (isDiscretePDFDisplayMode(mode))
         return adoptRef(*new PDFDiscretePresentationController { plugin });
 
     ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm
@@ -64,7 +64,7 @@ void PDFScrollingPresentationController::teardown()
 
 bool PDFScrollingPresentationController::supportsDisplayMode(PDFDisplayMode mode) const
 {
-    return PDFDocumentLayout::isScrollingDisplayMode(mode);
+    return isScrollingPDFDisplayMode(mode);
 }
 
 #pragma mark -


### PR DESCRIPTION
#### e4e4dc802f01766c75d9c9066c94c4b172f6bd29
<pre>
Refactor logic to check PDF display modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307764">https://bugs.webkit.org/show_bug.cgi?id=307764</a>
<a href="https://rdar.apple.com/170298190">rdar://170298190</a>

Reviewed by Abrar Rahman Protyasha.

Move helper methods to WebKit/Shared, since they will be used in both UI and Web
process code.

Deploy helper methods in UI process code instead of checking against specific
display modes.

* Source/WebKit/Shared/PDFDisplayMode.h:
(WebKit::isSinglePagePDFDisplayMode):
(WebKit::isTwoUpPDFDisplayMode):
(WebKit::isScrollingPDFDisplayMode):
(WebKit::isDiscretePDFDisplayMode):
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _updatePDFDisplayModeForHorizontalSizeClassChangeIfNeeded]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView continueContextMenuInteractionWithDataDetectors:]):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDiscretePresentationController.mm:
(WebKit::PDFDiscretePresentationController::supportsDisplayMode const):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFDocumentLayout.h:
(WebKit::PDFDocumentLayout::isSinglePageDisplayMode const):
(WebKit::PDFDocumentLayout::isTwoUpDisplayMode const):
(WebKit::PDFDocumentLayout::isScrollingDisplayMode const):
(WebKit::PDFDocumentLayout::isDiscreteDisplayMode const):
(WebKit::PDFDocumentLayout::isSinglePageDisplayMode): Deleted.
(WebKit::PDFDocumentLayout::isTwoUpDisplayMode): Deleted.
(WebKit::PDFDocumentLayout::isScrollingDisplayMode): Deleted.
(WebKit::PDFDocumentLayout::isDiscreteDisplayMode): Deleted.
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFPresentationController.mm:
(WebKit::PDFPresentationController::createForMode):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/PDFScrollingPresentationController.mm:
(WebKit::PDFScrollingPresentationController::supportsDisplayMode const):

Canonical link: <a href="https://commits.webkit.org/307480@main">https://commits.webkit.org/307480@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54bb1ce6931ccca6b29b29c4fb7244064d14ef50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153144 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5235d43d-2dbb-4a20-ae79-402adfa18493) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17047 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111088 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/473c0b22-c365-4a1e-be3b-17fc3d35b322) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147437 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13483 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1fa99da7-82b7-46a4-ae8a-c93b3ec6860e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12872 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10626 "Found 3 new API test failures: TestWebKitAPI.PermissionsAPI.GeolocationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad, TestWebKitAPI.LockdownMode.AllowedFontLoadingAPI, TestWebKitAPI.LockdownMode.NotAllowedFont (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/590 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122378 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155457 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17005 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7487 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119089 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14234 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119449 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15283 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127644 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22294 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16627 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6053 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80406 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16572 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16427 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->