### PR TITLE
Update WeakPtr / WeakRef documentation to use Doxygen

### DIFF
--- a/Source/WTF/wtf/WeakPtr.h
+++ b/Source/WTF/wtf/WeakPtr.h
@@ -26,25 +26,6 @@
 
 #pragma once
 
-// WeakPtr is a nullable weak pointer that does not prevent the referenced
-// object from being destroyed. When the referenced object is destroyed, the
-// WeakPtr automatically becomes null. Use get() to retrieve the raw pointer,
-// which will return nullptr if the object has been destroyed. Note that
-// operator->() and operator*() will safely crash (via RELEASE_ASSERT) if
-// called on a null WeakPtr.
-//
-// WeakPtr can only be used with classes that inherit from CanMakeWeakPtr or
-// CanMakeWeakPtrWithBitField (which provide the weak pointer implementation).
-//
-// If you expect the pointer to never become null during its usage, consider
-// using WeakRef instead, which provides clearer semantics and more actionable
-// crash reports when the referenced object is unexpectedly destroyed.
-//
-// Performance note: WeakPtr is often less efficient than RefPtr or CheckedPtr
-// because it involves an extra level of indirection when dereferencing (it is
-// a pointer to a pointer). This can hurt compiler optimizations. Prefer RefPtr
-// or CheckedPtr in performance sensitive code.
-
 #include <type_traits>
 #include <wtf/CanMakeWeakPtr.h>
 #include <wtf/CompactRefPtrTuple.h>
@@ -61,6 +42,28 @@ template<typename, typename, typename = DefaultWeakPtrImpl> class WeakHashMap;
 template<typename, typename = DefaultWeakPtrImpl> class WeakHashSet;
 template<typename, typename = DefaultWeakPtrImpl> class WeakListHashSet;
 
+/**
+ * @brief A nullable weak pointer that automatically becomes null when the referenced object is destroyed.
+ *
+ * WeakPtr is a nullable weak pointer that does not prevent the referenced
+ * object from being destroyed. When the referenced object is destroyed, the
+ * WeakPtr automatically becomes null. Use get() to retrieve the raw pointer,
+ * which will return nullptr if the object has been destroyed. Note that
+ * operator->() and operator*() will safely crash (via RELEASE_ASSERT) if
+ * called on a null WeakPtr.
+ *
+ * @note WeakPtr can only be used with classes that inherit from CanMakeWeakPtr or
+ * CanMakeWeakPtrWithBitField (which provide the weak pointer implementation).
+ *
+ * @note If you expect the pointer to never become null during its usage, consider
+ * using WeakRef instead, which provides clearer semantics and more actionable
+ * crash reports when the referenced object is unexpectedly destroyed.
+ *
+ * @note Performance note: WeakPtr is often less efficient than RefPtr or CheckedPtr
+ * because it involves an extra level of indirection when dereferencing (it is
+ * a pointer to a pointer). This can hurt compiler optimizations. Prefer RefPtr
+ * or CheckedPtr in performance sensitive code.
+ */
 template<typename T, typename WeakPtrImpl, typename PtrTraits> class WeakPtr {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(WeakPtr);
 public:

--- a/Source/WTF/wtf/WeakRef.h
+++ b/Source/WTF/wtf/WeakRef.h
@@ -25,27 +25,6 @@
 
 #pragma once
 
-// WeakRef is a non-nullable weak pointer that does not prevent the referenced
-// object from being destroyed. Unlike WeakPtr, WeakRef is expected to always
-// point to a valid object and will safely crash (via RELEASE_ASSERT) if you
-// dereference it or call get() after the referenced object has been destroyed.
-// This makes it useful for hardening code where a raw reference (e.g., Foo& m_foo)
-// was previously used, and where the reference is expected to remain valid for
-// the lifetime of the WeakRef.
-//
-// WeakRef can only be used with classes that inherit from CanMakeWeakPtr or
-// CanMakeWeakPtrWithBitField (which provide the weak pointer implementation).
-//
-// WeakRef is essentially a convenience wrapper around WeakPtr for cases where
-// you expect the pointer to never become null during its usage. If there is a
-// possibility that the referenced object may be destroyed while the pointer is
-// held, use WeakPtr instead.
-//
-// Performance note: WeakRef is often less efficient than Ref or CheckedRef
-// because it involves an extra level of indirection when dereferencing (it is
-// a pointer to a pointer). This can hurt compiler optimizations. Prefer Ref or
-// CheckedRef in performance sensitive code.
-
 #include <wtf/GetPtr.h>
 #include <wtf/HashTraits.h>
 #include <wtf/SingleThreadIntegralWrapper.h>
@@ -61,8 +40,17 @@ template<typename T> struct IsDeprecatedWeakRefSmartPointerException : std::fals
 
 enum class EnableWeakPtrThreadingAssertions : bool { No, Yes };
 
-// Similar to a WeakPtr but it is an error for it to become null. It is useful for hardening when replacing
-// things like `Foo& m_foo`. It is similar to CheckedRef but it generates crashes that are more actionable.
+/**
+ * @brief A non-nullable variant of WeakPtr.
+ *
+ * Unlike WeakPtr, WeakRef is expected to always point to a valid object and will
+ * safely crash (via RELEASE_ASSERT) if you dereference it or call get() after the
+ * referenced object has been destroyed. This makes it useful for hardening code
+ * where a raw reference (e.g., Foo& m_foo) was previously used, and where the
+ * reference is expected to remain valid for the lifetime of the WeakRef.
+ *
+ * @note See WeakPtr for more documentation.
+ */
 template<typename T, typename WeakPtrImpl>
 class WeakRef {
 public:


### PR DESCRIPTION
#### a8061b7209239374c68795e6102b318692f2d40f
<pre>
Update WeakPtr / WeakRef documentation to use Doxygen
<a href="https://bugs.webkit.org/show_bug.cgi?id=307769">https://bugs.webkit.org/show_bug.cgi?id=307769</a>

Reviewed by Ryosuke Niwa.

Update WeakPtr / WeakRef documentation to use Doxygen, for better
integration with Xcode quick help.

* Source/WTF/wtf/WeakPtr.h:
* Source/WTF/wtf/WeakRef.h:

Canonical link: <a href="https://commits.webkit.org/307527@main">https://commits.webkit.org/307527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/694e11597151b975dd586c75687c92b8a12a6ff1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8727 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153158 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98123 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83592879-e8fe-42c5-ab1c-aa37bda51d1a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17649 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17061 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111113 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92026 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff2cab31-d4b8-4b5d-ae67-5185e15f8129) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12881 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10642 "Found 2 new API test failures: TestWebKitAPI.PermissionsAPI.GeolocationPermissionGrantedFromPromptAndGeolocationRequestedSinceLoad, TestWebKitAPI.PermissionsAPI.GeolocationPermissionDeniedFromPromptAndGeolocationRequestedSinceLoad (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/604 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136479 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6447 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155471 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5297 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17019 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119112 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17057 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14254 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15305 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127660 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72560 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16641 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6069 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175776 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16377 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80420 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 16.4; Checked out pull request; ") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45275 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16586 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16441 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->