### PR TITLE
[YARR] Fix false negative matching Unicode regexp with mixed BMP/non-BMP character class

### DIFF
--- a/JSTests/stress/regexp-unicode-charclass-bmp-nonbmp-mixed.js
+++ b/JSTests/stress/regexp-unicode-charclass-bmp-nonbmp-mixed.js
@@ -1,0 +1,115 @@
+// This test checks that Unicode regular expressions with character classes containing
+// both BMP and non-BMP characters correctly match Char16 strings after previously
+// matching Char8 strings. A bug in optimizeAlternative caused the term order in
+// pattern.m_body to be swapped during Char8 JIT compilation; if the JIT allocation
+// subsequently failed the swapped pattern was passed to byteCodeCompilePattern,
+// causing the bytecode interpreter to misread surrogate pairs when executing against
+// Char16 strings.
+
+function shouldBe(actual, expected, description)
+{
+    if (actual !== expected)
+        throw new Error(description + ": expected " + expected + " but got " + actual);
+}
+
+function shouldMatch(re, str)
+{
+    let result = re.test(str);
+    if (!result)
+        throw new Error(re + ".test(" + JSON.stringify(str) + ") should be true but was false");
+}
+
+function shouldNotMatch(re, str)
+{
+    let result = re.test(str);
+    if (result)
+        throw new Error(re + ".test(" + JSON.stringify(str) + ") should be false but was true");
+}
+
+// Test 1: BMP + non-BMP mixed CharacterClass followed by fixed characters.
+// Char8 match first, then Char16 match (the original bug scenario).
+{
+    let re = /[a\u{10000}]bcd/u;
+    for (let i = 0; i < 100; i++) {
+        shouldMatch(re, "abcd");             // Char8: BMP char matches
+        shouldMatch(re, "\u{10000}bcd");     // Char16: non-BMP char matches
+        shouldNotMatch(re, "Xbcd");          // no match
+        shouldNotMatch(re, "\u{10001}bcd");  // different non-BMP char, no match
+    }
+}
+
+// Test 2: Char16 match first, then Char8 match (reverse order).
+{
+    let re = /[a\u{10000}]bcd/u;
+    for (let i = 0; i < 100; i++) {
+        shouldMatch(re, "\u{10000}bcd");     // Char16 first
+        shouldMatch(re, "abcd");             // Char8 second
+    }
+}
+
+// Test 3: Non-BMP character in CharacterClass with multiple BMP alternatives.
+{
+    let re = /[abc\u{10001}]xyz/u;
+    for (let i = 0; i < 100; i++) {
+        shouldMatch(re, "axyz");
+        shouldMatch(re, "bxyz");
+        shouldMatch(re, "cxyz");
+        shouldMatch(re, "\u{10001}xyz");
+        shouldNotMatch(re, "dxyz");
+        shouldNotMatch(re, "\u{10000}xyz");
+    }
+}
+
+// Test 4: Multiple non-BMP characters in CharacterClass.
+{
+    let re = /[\u{10000}\u{10001}]bcd/u;
+    for (let i = 0; i < 100; i++) {
+        shouldMatch(re, "\u{10000}bcd");
+        shouldMatch(re, "\u{10001}bcd");
+        shouldNotMatch(re, "abcd");          // BMP char not in class
+    }
+}
+
+// Test 5: BMP + non-BMP CharacterClass at end of pattern.
+{
+    let re = /abc[d\u{10000}]/u;
+    for (let i = 0; i < 100; i++) {
+        shouldMatch(re, "abcd");
+        shouldMatch(re, "abc\u{10000}");
+        shouldNotMatch(re, "abce");
+    }
+}
+
+// Test 6: Pattern with BMP + non-BMP CharacterClass preceded by fixed characters.
+{
+    let re = /abc[d\u{10000}]efg/u;
+    for (let i = 0; i < 100; i++) {
+        shouldMatch(re, "abcdefg");
+        shouldMatch(re, "abc\u{10000}efg");
+        shouldNotMatch(re, "abcXefg");
+    }
+}
+
+// Test 7: exec() returning match array with correct index.
+{
+    let re = /[a\u{10000}]bcd/u;
+    for (let i = 0; i < 100; i++) {
+        let m8 = re.exec("XabcdY");
+        shouldBe(m8[0], "abcd", "exec Char8 match string");
+        shouldBe(m8.index, 1, "exec Char8 match index");
+
+        let m16 = re.exec("X\u{10000}bcdY");
+        shouldBe(m16[0], "\u{10000}bcd", "exec Char16 match string");
+        shouldBe(m16.index, 1, "exec Char16 match index");
+    }
+}
+
+// Test 8: Inverted CharacterClass with non-BMP character.
+{
+    let re = /[^a\u{10000}]bcd/u;
+    for (let i = 0; i < 100; i++) {
+        shouldMatch(re, "Xbcd");
+        shouldNotMatch(re, "abcd");          // 'a' is in class
+        shouldNotMatch(re, "\u{10000}bcd");  // U+10000 is in class
+    }
+}


### PR DESCRIPTION
#### 9fac4e438d23d5bdf1d52a3c341876c55116387f
<pre>
[YARR] Fix false negative matching Unicode regexp with mixed BMP/non-BMP character class
<a href="https://bugs.webkit.org/show_bug.cgi?id=307774">https://bugs.webkit.org/show_bug.cgi?id=307774</a>

Reviewed by Yusuke Suzuki.

optimizeAlternative() swaps a CharacterClass term with a following
PatternCharacter term in Char8 mode even when the class contains non-BMP
characters. If JIT allocation then fails, the swapped pattern is passed to
byteCodeCompilePattern(). Executing that bytecode against a Char16 string
causes the interpreter to read a trail surrogate as errorCodePoint,
producing a false negative.

This patch fixes by restricting the Char8-mode swap to CharacterClasses
that contain only BMP characters.

Test: JSTests/stress/regexp-unicode-charclass-bmp-nonbmp-mixed.js

* JSTests/stress/regexp-unicode-charclass-bmp-nonbmp-mixed.js: Added.
(shouldBe):
(shouldMatch):
(shouldNotMatch):
(throw.new.Error):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307629@main">https://commits.webkit.org/307629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4577ee275dcbbe2e7554d8c4bcb1a8920c8a97a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17172 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153163 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98128 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17654 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17066 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111105 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79742 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13491 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92018 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12879 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10638 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/609 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136484 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122385 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6451 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155476 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5302 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17024 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7507 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119106 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17062 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14249 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119464 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30732 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15294 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127664 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72565 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16646 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6072 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/175781 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80425 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45276 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16591 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16446 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->