### PR TITLE
Unreviewed. Update safer CPP expectations for WebKitLegacy on iOS.

### DIFF
--- a/Source/WebKitLegacy/SaferCPPExpectations/ForwardDeclCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/ForwardDeclCheckerExpectations
@@ -4,4 +4,3 @@ ios/WebCoreSupport/PopupMenuIOS.h
 mac/DOM/DOMAbstractView.mm
 mac/DOM/DOMObject.mm
 [ Mac ] mac/WebView/WebView.mm
-[ iOS ] ios/WebCoreSupport/WebChromeClientIOS.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -87,7 +87,7 @@ mac/DOM/DOMWheelEvent.mm
 mac/DOM/ObjCEventListener.h
 mac/DOM/WebDOMOperations.mm
 mac/Misc/WebNSViewExtras.m
-mac/WebCoreSupport/WebChromeClient.mm
+[ Mac ] mac/WebCoreSupport/WebChromeClient.mm
 [ Mac ] mac/WebCoreSupport/WebContextMenuClient.mm
 [ Mac ] mac/WebCoreSupport/WebDragClient.mm
 mac/WebCoreSupport/WebEditorClient.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations
@@ -4,7 +4,6 @@ WebCoreSupport/SocketStreamHandleImplCFNet.cpp
 [ iOS ] ios/WebCoreSupport/WebGeolocationPrivate.h
 [ iOS ] ios/WebView/WebPDFViewIOS.mm
 [ iOS ] ios/WebView/WebPDFViewPlaceholder.h
-[ iOS ] ios/WebView/WebPDFViewPlaceholder.mm
 mac/History/BackForwardList.h
 mac/History/WebBackForwardList.h
 mac/History/WebHistory.h
@@ -39,7 +38,6 @@ mac/WebView/WebArchive.h
 mac/WebView/WebDeviceOrientation.h
 mac/WebView/WebDeviceOrientationProviderMock.h
 mac/WebView/WebDocumentLoaderMac.h
-[ iOS ] mac/WebView/WebFeature.h
 mac/WebView/WebFrame.h
 mac/WebView/WebFrameView.h
 mac/WebView/WebFrameView.mm
@@ -65,6 +63,5 @@ mac/WebView/WebTextIterator.h
 mac/WebView/WebView.h
 mac/WebView/WebView.mm
 mac/WebView/WebViewData.h
-[ iOS ] mac/WebView/WebViewPrivate.h
 [ iOS ] mac/WebView/WebViewRenderingUpdateScheduler.h
 [ Mac ] mac/WebView/WebWindowAnimation.h

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -98,6 +98,7 @@ mac/WebCoreSupport/WebGeolocationClient.mm
 [ Mac ] mac/WebCoreSupport/WebInspectorClient.mm
 mac/WebCoreSupport/WebKitFullScreenListener.mm
 mac/WebCoreSupport/WebValidationMessageClient.mm
+[ iOS ] mac/WebInspector/WebNodeHighlightView.mm
 mac/WebView/WebDeviceOrientationProviderMock.mm
 mac/WebView/WebFrame.mm
 [ Mac ] mac/WebView/WebFullScreenController.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -144,6 +144,7 @@ mac/WebCoreSupport/WebNotificationClient.mm
 mac/WebCoreSupport/WebOpenPanelResultListener.mm
 mac/WebCoreSupport/WebSecurityOrigin.mm
 mac/WebCoreSupport/WebValidationMessageClient.mm
+[ iOS ] mac/WebInspector/WebNodeHighlightView.mm
 mac/WebView/WebArchive.mm
 mac/WebView/WebDataSource.mm
 mac/WebView/WebFrame.mm

--- a/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
+++ b/Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations
@@ -11,6 +11,12 @@
 [ Mac ] mac/Panels/WebPanelAuthenticationHandler.m
 [ iOS ] mac/Storage/WebDatabaseManager.mm
 [ iOS ] mac/Storage/WebDatabaseManagerClient.mm
+[ iOS ] mac/WebCoreSupport/WebEditorClient.mm
+[ iOS ] mac/WebCoreSupport/WebFrameLoaderClient.mm
 [ iOS ] mac/WebCoreSupport/WebProgressTrackerClient.mm
 [ iOS ] mac/WebInspector/WebNodeHighlighter.mm
+[ iOS ] mac/WebView/WebFrame.mm
+[ iOS ] mac/WebView/WebFrameView.mm
+[ iOS ] mac/WebView/WebDelegateImplementationCaching.mm
 mac/WebView/WebHTMLView.mm
+[ iOS ] mac/WebView/WebView.mm


### PR DESCRIPTION
#### bfaeb17f78083c25415250d7c5abb6390a4b3a43
<pre>
Unreviewed. Update safer CPP expectations for WebKitLegacy on iOS.

* Source/WebKitLegacy/SaferCPPExpectations/ForwardDeclCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/NoUnretainedMemberCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebKitLegacy/SaferCPPExpectations/UnretainedLocalVarsCheckerExpectations:

Canonical link: <a href="https://commits.webkit.org/307453@main">https://commits.webkit.org/307453@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eee546d602627f1d470d56b97787a7022859800a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144496 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/17175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/8735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153166 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/17657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/17069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/111109 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147459 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/17657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/8735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/92022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/17657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/8735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/17657 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/8735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/155479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/17027 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/8735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/155479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/17065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/17069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/155479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/8735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72568 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22280 "Built successfully and passed tests") | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/16649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/8735 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/16449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->