### PR TITLE
AX: SVG symbols in <img src> included in VoiceOver Images web rotor

### DIFF
--- a/LayoutTests/accessibility/mac/svg-use-symbol-in-img-element-expected.txt
+++ b/LayoutTests/accessibility/mac/svg-use-symbol-in-img-element-expected.txt
@@ -1,0 +1,16 @@
+This tests that SVG symbols/use elements inside an img element are not listed in the VoiceOver images rotor.
+
+PASS: accessibilityController.accessibleElementById('img').role === 'AXRole: AXImage'
+PASS: graphicsResults.length === 1
+PASS: graphicsResults[0].role === 'AXRole: AXImage'
+PASS: graphicsResults[0].domIdentifier === 'img'
+PASS: graphicsResults.length === 2
+PASS: graphicsResults[0].domIdentifier === 'img'
+PASS: graphicsResults[1].domIdentifier === 'dynamic-img'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Text before image
+
+

--- a/LayoutTests/accessibility/mac/svg-use-symbol-in-img-element.html
+++ b/LayoutTests/accessibility/mac/svg-use-symbol-in-img-element.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="content" role="group">
+    <p>Text before image</p>
+    <img id="img" src="../resources/svg-with-use-symbol.svg" alt="SVG with symbols">
+</div>
+
+<script>
+var output = "This tests that SVG symbols/use elements inside an img element are not listed in the VoiceOver images rotor.\n\n";
+
+var searchContainer;
+function getGraphicsResults() {
+    let results = [];
+    let currentGraphic = searchContainer.uiElementForSearchPredicate(searchContainer.childAtIndex(0), /* isDirectionNext */ true, "AXGraphicSearchKey", "", /* isVisibleOnly */ false);
+    while (currentGraphic) {
+        results.push(currentGraphic);
+        currentGraphic = searchContainer.uiElementForSearchPredicate(currentGraphic, /* isDirectionNext */ true, "AXGraphicSearchKey", "", /* isVisibleOnly */ false);
+    }
+    return results;
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    searchContainer = accessibilityController.accessibleElementById("content");
+    output += expect("accessibilityController.accessibleElementById('img').role", "'AXRole: AXImage'");
+
+    var graphicsResults = getGraphicsResults();
+    // There should only be one graphic: the main img element.
+    // This critically excludes the SVG <use> elements that belong to said img element.
+    output += expect("graphicsResults.length", "1");
+    output += expect("graphicsResults[0].role", "'AXRole: AXImage'");
+    output += expect("graphicsResults[0].domIdentifier", "'img'");
+
+    // Test dynamic page update scenario: add a new img element with SVG containing use/symbol.
+    var newImg = document.createElement("img");
+    newImg.id = "dynamic-img";
+    newImg.src = "../resources/svg-with-use-symbol.svg";
+    newImg.alt = "Dynamic SVG with symbols";
+    document.getElementById("content").appendChild(newImg);
+    setTimeout(async function() {
+        await waitFor(() => accessibilityController.accessibleElementById("dynamic-img"));
+
+        graphicsResults = getGraphicsResults();
+        // There should now be exactly two graphics: the original and the new img element.
+        output += expect("graphicsResults.length", "2");
+        output += expect("graphicsResults[0].domIdentifier", "'img'");
+        output += expect("graphicsResults[1].domIdentifier", "'dynamic-img'");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/accessibility/resources/svg-with-use-symbol.svg
+++ b/LayoutTests/accessibility/resources/svg-with-use-symbol.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+    <defs>
+        <symbol id="circle-symbol" viewBox="0 0 50 50">
+            <circle cx="25" cy="25" r="20" fill="blue"/>
+        </symbol>
+        <symbol id="rect-symbol" viewBox="0 0 50 50">
+            <rect x="5" y="5" width="40" height="40" fill="red"/>
+        </symbol>
+    </defs>
+    <use href="#circle-symbol" x="0" y="0" width="50" height="50"/>
+    <use href="#rect-symbol" x="50" y="0" width="50" height="50"/>
+    <use href="#circle-symbol" x="0" y="50" width="50" height="50"/>
+    <use href="#rect-symbol" x="50" y="50" width="50" height="50"/>
+</svg>

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -503,6 +503,7 @@ public:
     bool isLink() const { return role() == AccessibilityRole::Link; };
     bool isCode() const { return role() == AccessibilityRole::Code; }
     bool isImage() const { return role() == AccessibilityRole::Image; }
+    bool isInImage() const;
     bool isImageMap() const { return role() == AccessibilityRole::ImageMap; }
     bool isVideo() const { return role() == AccessibilityRole::Video; }
     virtual bool isSecureField() const = 0;
@@ -1919,6 +1920,13 @@ inline AXCoreObject* AXCoreObject::exposedTableAncestor(bool includeSelf) const
 {
     return Accessibility::findAncestor(*this, includeSelf, [] (const auto& object) {
         return object.isExposableTable();
+    });
+}
+
+inline bool AXCoreObject::isInImage() const
+{
+    return Accessibility::findAncestor<AXCoreObject>(*this, /* includeSelf */ false, [] (const AXCoreObject& ancestor) {
+        return ancestor.role() == AccessibilityRole::Image;
     });
 }
 

--- a/Source/WebCore/accessibility/AXSearchManager.cpp
+++ b/Source/WebCore/accessibility/AXSearchManager.cpp
@@ -92,7 +92,7 @@ bool AXSearchManager::matchForSearchKeyAtIndex(Ref<AXCoreObject> axObject, const
     case AccessibilitySearchKey::Frame:
         return axObject->isWebArea();
     case AccessibilitySearchKey::Graphic:
-        return axObject->isImage();
+        return axObject->isImage() && !axObject->isInImage();
     case AccessibilitySearchKey::HeadingLevel1:
         return axObject->headingLevel() == 1;
     case AccessibilitySearchKey::HeadingLevel2:


### PR DESCRIPTION
#### 60d5c002f82a1a0cdec16395924f392da15890b4
<pre>
AX: SVG symbols in &lt;img src&gt; included in VoiceOver Images web rotor
<a href="https://bugs.webkit.org/show_bug.cgi?id=244221">https://bugs.webkit.org/show_bug.cgi?id=244221</a>
<a href="https://rdar.apple.com/98999595">rdar://98999595</a>

Reviewed by Joshua Hoffman.

When an &lt;img&gt; element references an SVG file containing &lt;use&gt; elements
(which reference &lt;symbol&gt; elements), VoiceOver&apos;s Images web rotor
incorrectly lists each symbol/use instance as a separate unnamed image
alongside the main &lt;img&gt; element.

Fix this by adding an isInImage() helper method to AXCoreObject that
checks if an accessibility object is a descendant of an image element.
Then modify the Graphic search key to exclude such descendants.

* LayoutTests/accessibility/mac/svg-use-symbol-in-img-element-expected.txt: Added.
* LayoutTests/accessibility/mac/svg-use-symbol-in-img-element.html: Added.
* LayoutTests/accessibility/resources/svg-with-use-symbol.svg: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::isInImage const):
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::matchForSearchKeyAtIndex):

Canonical link: <a href="https://commits.webkit.org/308126@main">https://commits.webkit.org/308126@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/312a10feb37deefcb11f46139645432db2aed867

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144535 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17214 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8782 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153206 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98170 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b197fb6-0146-4306-9ca9-8761bf7a3a38) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146410 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17696 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17108 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111152 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79750 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147498 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13529 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92057 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f8584fe-716d-4a64-85ac-1f4e587688c8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12913 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10669 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/651 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122420 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155518 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119157 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17066 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14288 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119502 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31026 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17104 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72607 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15326 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6109 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16688 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80467 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16424 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16633 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16488 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->