### PR TITLE
[Site Isolation] Create a class to manage the aggregated set of activities on a WebContent process tree

### DIFF
--- a/Source/WebKit/Modules/OSX_Private.modulemap
+++ b/Source/WebKit/Modules/OSX_Private.modulemap
@@ -734,6 +734,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module WKNavigationPrivateForTesting {
+    header "WKNavigationPrivateForTesting.h"
+    export *
+  }
+
   explicit module WKNavigationResponsePrivate {
     header "WKNavigationResponsePrivate.h"
     export *

--- a/Source/WebKit/Modules/iOS_Private.modulemap
+++ b/Source/WebKit/Modules/iOS_Private.modulemap
@@ -1431,6 +1431,11 @@ framework module WebKit_Private [system] {
     export *
   }
 
+  explicit module WKNavigationPrivateForTesting {
+    header "WKNavigationPrivateForTesting.h"
+    export *
+  }
+
   explicit module WKNavigationRef {
     header "WKNavigationRef.h"
     export *

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -421,6 +421,7 @@ UIProcess/ModelElementController.cpp
 UIProcess/OverrideLanguages.cpp
 UIProcess/PageClient.cpp
 UIProcess/PageLoadState.cpp
+UIProcess/ProcessActivityGroup.cpp
 UIProcess/ProcessAssertion.cpp
 UIProcess/ProcessThrottler.cpp
 UIProcess/ProvisionalFrameProxy.cpp

--- a/Source/WebKit/UIProcess/API/APINavigation.cpp
+++ b/Source/WebKit/UIProcess/API/APINavigation.cpp
@@ -42,8 +42,6 @@ namespace API {
 using namespace WebCore;
 using namespace WebKit;
 
-static constexpr Seconds navigationActivityTimeout { 30_s };
-
 SubstituteData::SubstituteData(Vector<uint8_t>&& content, const ResourceResponse& response, WebCore::SubstituteData::SessionHistoryVisibility sessionHistoryVisibility)
     : SubstituteData(WTF::move(content), response.mimeType(), response.textEncodingName(), response.url().string(), nullptr, sessionHistoryVisibility)
 {
@@ -53,7 +51,6 @@ SubstituteData::SubstituteData(Vector<uint8_t>&& content, const ResourceResponse
 Navigation::Navigation(WebCore::ProcessIdentifier processID)
     : m_navigationID(WebCore::NavigationIdentifier::generate())
     , m_processID(processID)
-    , m_clientNavigationActivity(ProcessThrottler::TimedActivity::create(navigationActivityTimeout))
 {
 }
 
@@ -61,7 +58,6 @@ Navigation::Navigation(WebCore::ProcessIdentifier processID, RefPtr<WebBackForwa
     : m_navigationID(WebCore::NavigationIdentifier::generate())
     , m_processID(processID)
     , m_reloadItem(WTF::move(currentAndTargetItem))
-    , m_clientNavigationActivity(ProcessThrottler::TimedActivity::create(navigationActivityTimeout))
 {
 }
 
@@ -72,7 +68,6 @@ Navigation::Navigation(WebCore::ProcessIdentifier processID, WebCore::ResourceRe
     , m_currentRequest(m_originalRequest)
     , m_redirectChain { m_originalRequest.url() }
     , m_fromItem(WTF::move(fromItem))
-    , m_clientNavigationActivity(ProcessThrottler::TimedActivity::create(navigationActivityTimeout))
 {
 }
 
@@ -84,7 +79,6 @@ Navigation::Navigation(WebCore::ProcessIdentifier processID, Ref<WebBackForwardL
     , m_targetFrameItem(WTF::move(targetFrameItem))
     , m_fromItem(WTF::move(fromItem))
     , m_backForwardFrameLoadType(backForwardFrameLoadType)
-    , m_clientNavigationActivity(ProcessThrottler::TimedActivity::create(navigationActivityTimeout))
 {
 }
 
@@ -216,6 +210,14 @@ WTF::String Navigation::loggingString() const
 void Navigation::setHasStorageForCurrentSite(bool hasStorageForCurrentSite)
 {
     m_hasStorageForCurrentSite = hasStorageForCurrentSite;
+}
+
+unsigned Navigation::processActivityGroupSizeForTesting() const
+{
+    if (!std::holds_alternative<Ref<WebKit::ProcessActivityGroup>>(m_clientNavigationActivity))
+        return 0;
+
+    return std::get<Ref<WebKit::ProcessActivityGroup>>(m_clientNavigationActivity)->processActivityGroupSizeForTesting();
 }
 
 } // namespace API

--- a/Source/WebKit/UIProcess/API/APINavigation.h
+++ b/Source/WebKit/UIProcess/API/APINavigation.h
@@ -29,6 +29,7 @@
 #include "APIWebsitePolicies.h"
 #include "FrameInfoData.h"
 #include "NavigationActionData.h"
+#include "ProcessActivityGroup.h"
 #include "ProcessThrottler.h"
 #include "WebBackForwardListItem.h"
 #include "WebContentMode.h"
@@ -42,6 +43,7 @@
 #include <wtf/ListHashSet.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/Ref.h>
+#include <wtf/Variant.h>
 
 namespace WebCore {
 enum class FrameLoadType : uint8_t;
@@ -171,9 +173,7 @@ public:
     const std::unique_ptr<SubstituteData>& substituteData() const LIFETIME_BOUND { return m_substituteData; }
 
     const WebCore::PrivateClickMeasurement* privateClickMeasurement() const { return m_lastNavigationAction && m_lastNavigationAction->privateClickMeasurement ? &*m_lastNavigationAction->privateClickMeasurement : nullptr; }
-
-    void setClientNavigationActivity(RefPtr<WebKit::ProcessThrottler::Activity>&& activity) { Ref { m_clientNavigationActivity }->setActivity(WTF::move(activity)); }
-
+    void setClientNavigationActivity(Variant<std::monostate, Ref<WebKit::ProcessThrottler::TimedActivity>, Ref<WebKit::ProcessActivityGroup>>&& activity) { m_clientNavigationActivity = WTF::move(activity); }
     void setIsLoadedWithNavigationShared(bool value) { m_isLoadedWithNavigationShared = value; }
     bool isLoadedWithNavigationShared() const { return m_isLoadedWithNavigationShared; }
 
@@ -207,6 +207,10 @@ public:
     WebKit::FrameState* backForwardFrameState() const { return m_backForwardFrameState.get(); }
     void setBackForwardFrameState(RefPtr<WebKit::FrameState>&& frameState) { m_backForwardFrameState = WTF::move(frameState); }
 
+    static constexpr Seconds navigationActivityTimeout { 30_s };
+
+    unsigned processActivityGroupSizeForTesting() const;
+
 private:
     Navigation(WebCore::ProcessIdentifier);
     Navigation(WebCore::ProcessIdentifier, RefPtr<WebKit::WebBackForwardListItem>&&);
@@ -231,7 +235,7 @@ private:
     std::optional<WebKit::FrameInfoData> m_originatingFrameInfo;
     WebCore::SecurityOriginData m_destinationFrameSecurityOrigin;
     WebKit::WebContentMode m_effectiveContentMode { WebKit::WebContentMode::Recommended };
-    Ref<WebKit::ProcessThrottler::TimedActivity> m_clientNavigationActivity;
+    Variant<std::monostate, Ref<WebKit::ProcessThrottler::TimedActivity>, Ref<WebKit::ProcessActivityGroup>> m_clientNavigationActivity;
     bool m_userContentExtensionsEnabled : 1 { true };
     bool m_isLoadedWithNavigationShared : 1 { false };
     bool m_requestIsFromClientInput : 1 { false };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigation.mm
@@ -60,6 +60,11 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
     return _navigation->wasUserInitiated();
 }
 
+- (unsigned)_processActivityGroupSizeForTesting
+{
+    return protect(*_navigation)->processActivityGroupSizeForTesting();
+}
+
 - (WKFrameInfo *)_initiatingFrame
 {
     auto& frameInfo = _navigation->originatingFrameInfo();

--- a/Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivateForTesting.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKNavigationPrivateForTesting.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. 
+ */
+
+#import <WebKit/WKNavigation.h>
+
+@interface WKNavigation (WKTesting)
+- (unsigned)_processActivityGroupSizeForTesting;
+@end

--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1192,6 +1192,23 @@ bool WebPageProxy::shouldForceForegroundPriorityForClientNavigation() const
     return canTakeForegroundAssertions;
 }
 
+void WebPageProxy::setClientNavigationActivity(API::Navigation& navigation)
+{
+    ASCIILiteral activityName = "Client navigation"_s;
+
+    Seconds timeout(API::Navigation::navigationActivityTimeout);
+
+    if (protect(preferences())->siteIsolationEnabled()) {
+        navigation.setClientNavigationActivity(internals().foregroundProcessActivityGroup(activityName, timeout));
+        return;
+    }
+
+    Ref legacyMainFrameProcess = m_legacyMainFrameProcess;
+    Ref timedActivity = ProcessThrottler::TimedActivity::create(timeout);
+    timedActivity->setActivity(protect(legacyMainFrameProcess->throttler())->foregroundActivity(activityName));
+    navigation.setClientNavigationActivity(WTF::move(timedActivity));
+}
+
 #if HAVE(ESIM_AUTOFILL_SYSTEM_SUPPORT)
 
 bool WebPageProxy::shouldAllowAutoFillForCellularIdentifiers() const

--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -2447,8 +2447,14 @@ void WebExtensionContext::loadBackgroundWebView()
     Ref backgroundPage = *m_backgroundWebView.get()._page;
     Ref backgroundProcess = backgroundPage->siteIsolatedProcess();
 
+    bool siteIsolationEnabled = protect(backgroundPage->preferences())->siteIsolationEnabled();
+    constexpr ASCIILiteral activityName = "Web Extension background content"_s;
+
     // Use foreground activity to keep background content responsive to events.
-    m_backgroundWebViewActivity = protect(backgroundProcess->throttler())->foregroundActivity("Web Extension background content"_s);
+    if (siteIsolationEnabled)
+        m_backgroundWebViewActivity = protect(backgroundPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
+    else
+        m_backgroundWebViewActivity = protect(backgroundProcess->throttler())->foregroundActivity(activityName);
 
     if (!protect(extension())->backgroundContentIsServiceWorker()) {
         backgroundProcess->send(Messages::WebExtensionContextProxy::SetBackgroundPageIdentifier(backgroundPage->webPageIDInMainFrameProcess()), identifier());
@@ -2475,7 +2481,7 @@ void WebExtensionContext::unloadBackgroundWebView()
 
     m_backgroundContentIsLoaded = false;
     m_unloadBackgroundWebViewTimer = nullptr;
-    m_backgroundWebViewActivity = nullptr;
+    m_backgroundWebViewActivity = { };
 
     [m_backgroundWebView _close];
     m_backgroundWebView = nil;
@@ -2999,16 +3005,23 @@ void WebExtensionContext::loadInspectorBackgroundPage(WebInspectorUIProxy& inspe
         Ref inspectorExtension = result.value();
         inspectorExtension->setClient(makeUniqueRef<InspectorExtensionClient>(inspectorExtension, *this));
 
-        Ref process = inspectorBackgroundWebView._page->legacyMainFrameProcess();
-
         // Use foreground activity to keep background content responsive to events.
-        Ref inspectorBackgroundWebViewActivity = protect(process->throttler())->foregroundActivity("Web Extension Inspector background content"_s);
+        Ref inspectorPage = *inspectorBackgroundWebView._page;
+        Ref process = inspectorPage->legacyMainFrameProcess();
+
+        Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> inspectorBackgroundWebViewActivity;
+        constexpr ASCIILiteral activityName = "Web Extension Inspector background content"_s;
+
+        if (siteIsolationEnabled)
+            inspectorBackgroundWebViewActivity = protect(inspectorPage->activityGroupContext())->foregroundProcessActivityGroup(activityName);
+        else
+            inspectorBackgroundWebViewActivity = protect(process->throttler())->foregroundActivity(activityName);
 
         InspectorContext inspectorContext {
             tab->identifier(),
             inspectorExtension.ptr(),
             inspectorBackgroundWebView,
-            inspectorBackgroundWebViewActivity.ptr()
+            WTF::move(inspectorBackgroundWebViewActivity)
         };
 
         m_inspectorContextMap.set(inspector.get(), WTF::move(inspectorContext));

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.h
@@ -32,6 +32,7 @@
 #include "APIUserScript.h"
 #include "APIUserStyleSheet.h"
 #include "MessageReceiver.h"
+#include "ProcessActivityGroup.h"
 #include "WebExtension.h"
 #include "WebExtensionAction.h"
 #include "WebExtensionAlarm.h"
@@ -77,6 +78,7 @@
 #include <wtf/RunLoop.h>
 #include <wtf/URLHash.h>
 #include <wtf/UUID.h>
+#include <wtf/Variant.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashCountedSet.h>
 #include <wtf/WeakHashMap.h>
@@ -316,7 +318,7 @@ public:
         std::optional<WebExtensionTabIdentifier> tabIdentifier;
         RefPtr<API::InspectorExtension> extension;
         RetainPtr<WKWebView> backgroundWebView;
-        RefPtr<ProcessThrottlerActivity> activity;
+        Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> activity;
     };
 #endif
 
@@ -1069,7 +1071,7 @@ private:
 
 #if PLATFORM(COCOA)
     RetainPtr<WKWebView> m_backgroundWebView;
-    RefPtr<ProcessThrottlerActivity> m_backgroundWebViewActivity;
+    Variant<std::monostate, Ref<ProcessThrottlerActivity>, Ref<ProcessActivityGroup>> m_backgroundWebViewActivity;
     RetainPtr<_WKWebExtensionContextDelegate> m_delegate;
 #endif
     RefPtr<API::Error> m_backgroundContentLoadError;

--- a/Source/WebKit/UIProcess/ProcessActivityGroup.cpp
+++ b/Source/WebKit/UIProcess/ProcessActivityGroup.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ProcessActivityGroup.h"
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(ProcessActivityGroup);
+
+Ref<ProcessActivityGroup> ProcessActivityGroup::create(ProcessActivityGroupContext& context, ASCIILiteral name, ProcessThrottlerActivityType type, std::optional<Seconds> timeout)
+{
+    return adoptRef(*new ProcessActivityGroup(context, name, type, timeout));
+}
+
+ProcessActivityGroup::ProcessActivityGroup(ProcessActivityGroupContext& context, ASCIILiteral name, ProcessThrottlerActivityType type, std::optional<Seconds> timeout)
+    : m_context(context)
+    , m_name(name)
+    , m_type(type)
+    , m_timer(RunLoop::Timer(RunLoop::mainSingleton(), "ProcessActivityGroup timer"_s, this, &ProcessActivityGroup::activityTimedOut))
+    , m_timeout(timeout)
+{
+    auto processes = context.activityTargets();
+    for (Ref process : processes)
+        m_activities.add(process->coreProcessIdentifier(), createActivity(process));
+
+    context.addProcessActivityGroup(*this);
+
+    if (m_timeout)
+        m_timer.startOneShot(*m_timeout);
+}
+
+ProcessActivityGroup::~ProcessActivityGroup()
+{
+    if (CheckedPtr context = m_context.get())
+        context->removeProcessActivityGroup(*this);
+}
+
+Ref<ProcessThrottler::Activity> ProcessActivityGroup::createActivity(WebProcessProxy& process)
+{
+    if (m_type == ProcessThrottlerActivityType::Foreground)
+        return protect(process.throttler())->foregroundActivity(m_name);
+    return protect(process.throttler())->backgroundActivity(m_name);
+}
+
+void ProcessActivityGroup::addActivityForTarget(WebProcessProxy& target)
+{
+    if (m_timeout.has_value() && !m_timer.isActive()) {
+        // The timer has fired, so we should not add new activities.
+        return;
+    }
+    m_activities.set(target.coreProcessIdentifier(), createActivity(target));
+}
+
+void ProcessActivityGroup::removeActivityForTarget(WebProcessProxy& target)
+{
+    m_activities.remove(target.coreProcessIdentifier());
+}
+
+void ProcessActivityGroup::activityTimedOut()
+{
+    m_activities.clear();
+}
+
+Ref<ProcessActivityGroup> ProcessActivityGroupContext::foregroundProcessActivityGroup(ASCIILiteral name, std::optional<Seconds> timeout)
+{
+    return ProcessActivityGroup::create(*this, name, ProcessThrottlerActivityType::Foreground, timeout);
+}
+
+void ProcessActivityGroupContext::addProcessActivityGroup(ProcessActivityGroup& activityGroup)
+{
+    m_processActivityGroups.add(activityGroup);
+}
+
+void ProcessActivityGroupContext::removeProcessActivityGroup(ProcessActivityGroup& activityGroup)
+{
+    m_processActivityGroups.remove(activityGroup);
+}
+
+void ProcessActivityGroupContext::didAddActivityTarget(WebProcessProxy& target)
+{
+    m_processActivityGroups.forEach([&](auto& activityGroup) {
+        activityGroup.addActivityForTarget(target);
+    });
+}
+
+void ProcessActivityGroupContext::didRemoveActivityTarget(WebProcessProxy& target)
+{
+    m_processActivityGroups.forEach([&](auto& activityGroup) {
+        activityGroup.removeActivityForTarget(target);
+    });
+}
+
+}

--- a/Source/WebKit/UIProcess/ProcessActivityGroup.h
+++ b/Source/WebKit/UIProcess/ProcessActivityGroup.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ProcessThrottler.h"
+#include "WebProcessProxy.h"
+
+#include <WebCore/ProcessIdentifier.h>
+#include <wtf/RunLoop.h>
+
+namespace WebKit {
+
+class ProcessActivityGroup;
+
+class ProcessActivityGroupContext
+: public CanMakeWeakPtr<ProcessActivityGroupContext>
+, public CanMakeCheckedPtr<ProcessActivityGroupContext> {
+    WTF_MAKE_TZONE_ALLOCATED(ProcessActivityGroupContext);
+    WTF_MAKE_NONCOPYABLE(ProcessActivityGroupContext);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProcessActivityGroupContext);
+public:
+    ProcessActivityGroupContext() = default;
+    virtual ~ProcessActivityGroupContext() { }
+
+    Ref<ProcessActivityGroup> foregroundProcessActivityGroup(ASCIILiteral name, std::optional<Seconds> timeout = std::nullopt);
+
+    virtual Vector<Ref<WebProcessProxy>> activityTargets() { return { }; }
+
+    void didAddActivityTarget(WebProcessProxy&);
+    void didRemoveActivityTarget(WebProcessProxy&);
+
+    void addProcessActivityGroup(ProcessActivityGroup&);
+    void removeProcessActivityGroup(ProcessActivityGroup&);
+
+private:
+    WeakHashSet<ProcessActivityGroup> m_processActivityGroups;
+};
+
+class ProcessActivityGroup : public RefCountedAndCanMakeWeakPtr<ProcessActivityGroup> {
+    WTF_MAKE_TZONE_ALLOCATED(ProcessActivityGroup);
+    WTF_MAKE_NONCOPYABLE(ProcessActivityGroup);
+public:
+    static Ref<ProcessActivityGroup> create(ProcessActivityGroupContext&, ASCIILiteral name, ProcessThrottlerActivityType, std::optional<Seconds> timeout);
+
+    ~ProcessActivityGroup();
+
+    void addActivityForTarget(WebProcessProxy&);
+    void removeActivityForTarget(WebProcessProxy&);
+
+    unsigned processActivityGroupSizeForTesting() const { return m_activities.size(); }
+
+private:
+    ProcessActivityGroup(ProcessActivityGroupContext&, ASCIILiteral name, ProcessThrottlerActivityType, std::optional<Seconds> timeout);
+
+    Ref<ProcessThrottler::Activity> createActivity(WebProcessProxy&);
+    void activityTimedOut();
+
+    WeakPtr<ProcessActivityGroupContext> m_context;
+    ASCIILiteral m_name;
+    ProcessThrottlerActivityType m_type;
+    HashMap<WebCore::ProcessIdentifier, Ref<ProcessThrottlerActivity>> m_activities;
+    RunLoop::Timer m_timer;
+    std::optional<Seconds> m_timeout;
+};
+
+}

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -105,6 +105,8 @@ RemotePageProxy::RemotePageProxy(WebPageProxy& page, WebProcessProxy& process, c
 #endif
 
     m_process->addRemotePageProxy(*this);
+
+    protectedPage->didCreateRemotePage(*this);
 }
 
 void RemotePageProxy::disconnect()
@@ -200,6 +202,8 @@ RemotePageProxy::~RemotePageProxy()
     RefPtr page = m_page.get();
     if (!page)
         return;
+
+    page->willDestroyRemotePage(*this);
 
     if (RefPtr client = page->pageClient())
         client->didStopUsingProcessForSiteIsolation(m_process);

--- a/Source/WebKit/UIProcess/RemotePageProxy.h
+++ b/Source/WebKit/UIProcess/RemotePageProxy.h
@@ -27,6 +27,7 @@
 
 #include "MessageReceiver.h"
 #include "NavigationActionData.h"
+#include "ProcessActivityGroup.h"
 #include "WebPageProxyMessageReceiverRegistration.h"
 #include "WebProcessProxy.h"
 #include <WebCore/FrameIdentifier.h>
@@ -49,6 +50,7 @@ enum class FrameLoadType : uint8_t;
 enum class HasInsecureContent : bool;
 enum class MediaProducerMediaState : uint32_t;
 enum class MouseEventPolicy : uint8_t;
+enum class ScreenOrientationType : uint8_t;
 
 class CertificateInfo;
 class ResourceResponse;

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -118,6 +118,7 @@
 #include "PlatformXRSystem.h"
 #include "PolicyDecision.h"
 #include "PrintInfo.h"
+#include "ProcessActivityGroup.h"
 #include "ProcessAssertion.h"
 #include "ProcessTerminationReason.h"
 #include "ProcessThrottler.h"
@@ -1749,7 +1750,7 @@ RefPtr<API::Navigation> WebPageProxy::launchProcessForReload()
     legacyMainFrameProcess->startResponsivenessTimer();
 
     if (shouldForceForegroundPriorityForClientNavigation())
-        navigation->setClientNavigationActivity(protect(legacyMainFrameProcess->throttler())->foregroundActivity("Client reload"_s));
+        setClientNavigationActivity(navigation);
 
     return navigation;
 }
@@ -2174,7 +2175,7 @@ RefPtr<API::Navigation> WebPageProxy::loadRequest(WebCore::ResourceRequest&& req
         navigation->markRequestAsFromClientInput();
 
     if (shouldForceForegroundPriorityForClientNavigation())
-        navigation->setClientNavigationActivity(protect(legacyMainFrameProcess().throttler())->foregroundActivity("Client navigation"_s));
+        setClientNavigationActivity(navigation);
 
 #if PLATFORM(COCOA)
     setLastNavigationWasAppInitiated(request);
@@ -2322,7 +2323,8 @@ RefPtr<API::Navigation> WebPageProxy::loadFile(const String& fileURLString, cons
     navigation->markRequestAsFromClientInput();
 
     if (shouldForceForegroundPriorityForClientNavigation())
-        navigation->setClientNavigationActivity(protect(legacyMainFrameProcess().throttler())->foregroundActivity("Client navigation"_s));
+        setClientNavigationActivity(navigation);
+
 
     Ref pageLoadState = internals().pageLoadState;
     auto transaction = pageLoadState->transaction();
@@ -2384,7 +2386,8 @@ RefPtr<API::Navigation> WebPageProxy::loadData(Ref<WebCore::SharedBuffer>&& data
     navigation->markAsFromLoadData();
 
     if (shouldForceForegroundPriorityForClientNavigation())
-        navigation->setClientNavigationActivity(protect(legacyMainFrameProcess().throttler())->foregroundActivity("Client navigation"_s));
+        setClientNavigationActivity(navigation);
+
 
     loadDataWithNavigationShared(protect(legacyMainFrameProcess()), m_webPageID, navigation, WTF::move(data), type, encoding, baseURL, userData, ShouldTreatAsContinuingLoad::No, isNavigatingToAppBoundDomain(), nullptr, shouldOpenExternalURLsPolicy, SubstituteData::SessionHistoryVisibility::Hidden);
     return navigation;
@@ -2455,7 +2458,8 @@ RefPtr<API::Navigation> WebPageProxy::loadSimulatedRequest(WebCore::ResourceRequ
     Ref navigation = m_navigationState->createSimulatedLoadWithDataNavigation(legacyMainFrameProcess().coreProcessIdentifier(), ResourceRequest(simulatedRequest), makeUnique<API::SubstituteData>(Vector(data->span()), ResourceResponse(simulatedResponse), WebCore::SubstituteData::SessionHistoryVisibility::Visible), protect(backForwardList().currentItem()));
 
     if (shouldForceForegroundPriorityForClientNavigation())
-        navigation->setClientNavigationActivity(protect(legacyMainFrameProcess().throttler())->foregroundActivity("Client navigation"_s));
+        setClientNavigationActivity(navigation);
+
 
     Ref pageLoadState = internals().pageLoadState;
     auto transaction = pageLoadState->transaction();
@@ -2626,7 +2630,8 @@ RefPtr<API::Navigation> WebPageProxy::reload(OptionSet<WebCore::ReloadOption> op
             process->startResponsivenessTimer();
 
             if (weakThis->shouldForceForegroundPriorityForClientNavigation())
-                navigation->setClientNavigationActivity(protect(process->throttler())->foregroundActivity("Client reload"_s));
+                weakThis->setClientNavigationActivity(navigation);
+
 
 #if ENABLE(SPEECH_SYNTHESIS)
             weakThis->resetSpeechSynthesizer();
@@ -7688,7 +7693,7 @@ void WebPageProxy::didFailProvisionalLoadForFrameShared(Ref<WebProcessProxy>&& p
         protectedPageLoadState->didFailProvisionalLoad(transaction);
         protectedPageClient->didFailProvisionalLoadForMainFrame();
         if (navigation)
-            navigation->setClientNavigationActivity(nullptr);
+            navigation->setClientNavigationActivity({ });
 
         callLoadCompletionHandlersIfNecessary(false);
     }
@@ -8216,7 +8221,7 @@ void WebPageProxy::didFinishLoadForFrame(IPC::Connection& connection, FrameIdent
         protectedPageClient->didFinishNavigation(navigation.get());
 
         if (navigation)
-            navigation->setClientNavigationActivity(nullptr);
+            navigation->setClientNavigationActivity({ });
 
         resetRecentCrashCountSoon();
 
@@ -8292,7 +8297,7 @@ void WebPageProxy::didFailLoadForFrame(IPC::Connection& connection, FrameIdentif
         reportPageLoadResult(error);
         protectedPageClient->didFailNavigation(navigation.get());
         if (navigation)
-            navigation->setClientNavigationActivity(nullptr);
+            navigation->setClientNavigationActivity({ });
 
         callLoadCompletionHandlersIfNecessary(false);
     }
@@ -16634,6 +16639,10 @@ bool WebPageProxy::shouldForceForegroundPriorityForClientNavigation() const
 {
     return false;
 }
+
+void WebPageProxy::setClientNavigationActivity(API::Navigation&)
+{
+}
 #endif
 
 void WebPageProxy::getProcessDisplayName(CompletionHandler<void(String&&)>&& completionHandler)
@@ -18020,6 +18029,35 @@ void WebPageProxy::takeActivitiesOnRemotePage(RemotePageProxy& remotePage)
 
     if (hasValidMainFrameNetworkActivity())
         remotePage.processActivityState().takeNetworkActivity();
+}
+
+void WebPageProxy::didCreateRemotePage(RemotePageProxy& remotePage)
+{
+    internals().didAddActivityTarget(remotePage.process());
+}
+
+void WebPageProxy::willDestroyRemotePage(RemotePageProxy& remotePage)
+{
+    internals().didRemoveActivityTarget(remotePage.process());
+}
+
+ProcessActivityGroupContext& WebPageProxy::activityGroupContext()
+{
+    return internals();
+}
+
+Vector<Ref<WebProcessProxy>> WebPageProxy::Internals::activityTargets()
+{
+    Vector<Ref<WebProcessProxy>> targets;
+
+    targets.append(Ref { page->siteIsolatedProcess() });
+
+    Ref group = protect(page)->browsingContextGroup();
+    group->forEachRemotePage(protect(page), [&](auto& remotePageProxy) {
+        targets.append(remotePageProxy.process());
+    });
+
+    return targets;
 }
 
 UniqueRef<TextExtractionAssertionScope> WebPageProxy::createTextExtractionAssertionScope()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -518,6 +518,7 @@ class PageLoadState;
 class PageLoadStateObserverBase;
 class PlatformXRSystem;
 class PlaybackSessionManagerProxy;
+class ProcessActivityGroupContext;
 class ProcessAssertion;
 class ProcessThrottlerActivity;
 class ProcessThrottlerTimedActivity;
@@ -684,6 +685,7 @@ enum class PDFDisplayMode : uint8_t;
 enum class PasteboardAccessIntent : bool;
 enum class ProcessSwapRequestedByClient : bool;
 enum class ProcessTerminationReason : uint8_t;
+enum class ProcessThrottlerActivityType : bool;
 enum class QuickLookPreviewActivity : uint8_t;
 enum class RespectSelectionAnchor : bool;
 enum class SOAuthorizationLoadPolicy : bool;
@@ -2888,6 +2890,8 @@ public:
 
     WebProcessActivityState& processActivityState() LIFETIME_BOUND { return m_mainFrameProcessActivityState; }
 
+    ProcessActivityGroupContext& activityGroupContext();
+
 #if ENABLE(WEB_PROCESS_SUSPENSION_DELAY)
     void updateWebProcessSuspensionDelay();
 #endif
@@ -2955,6 +2959,9 @@ public:
     bool hasValidNetworkActivity() const;
 
     void takeActivitiesOnRemotePage(RemotePageProxy&);
+
+    void didCreateRemotePage(RemotePageProxy&);
+    void willDestroyRemotePage(RemotePageProxy&);
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DEVICE_ORIENTATION)
     RefPtr<WebDeviceOrientationUpdateProviderProxy> NODELETE webDeviceOrientationUpdateProviderProxy();
@@ -3673,6 +3680,8 @@ private:
 
     WebProcessProxy& processForTheFrameItem(WebBackForwardListFrameItem&) const;
     Ref<FrameState> copyFrameStateForBackForwardNavigation(WebBackForwardListFrameItem&) const;
+
+    void setClientNavigationActivity(API::Navigation&);
 
     const UniqueRef<Internals> m_internals;
     Identifier m_identifier;

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -33,6 +33,7 @@
 #include "LayerTreeContext.h"
 #include "PDFDisplayMode.h"
 #include "PageLoadState.h"
+#include "ProcessActivityGroup.h"
 #include "ProcessThrottler.h"
 #include "ScrollingAccelerationCurve.h"
 #include "TextManipulationParameters.h"
@@ -229,6 +230,7 @@ struct WebPageProxy::Internals final : WebPopupMenuProxy::Client
 #if ENABLE(WIRELESS_PLAYBACK_TARGET) && !PLATFORM(IOS_FAMILY)
     , WebCore::WebMediaSessionManagerClient
 #endif
+    , ProcessActivityGroupContext
 {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(WebPageProxy);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(Internals);
@@ -247,6 +249,7 @@ public:
         WebPaymentCoordinatorProxy::Client::setDidBeginCheckedPtrDeletion();
 #endif
         WebColorPickerClient::setDidBeginCheckedPtrDeletion();
+        ProcessActivityGroupContext::setDidBeginCheckedPtrDeletion();
     }
 
 #if PLATFORM(MACCATALYST)
@@ -532,6 +535,8 @@ public:
     bool alwaysOnLoggingAllowed() const final { return protect(page)->isAlwaysOnLoggingAllowed(); }
     RetainPtr<CocoaView> platformView() const final;
 #endif
+
+    Vector<Ref<WebProcessProxy>> activityTargets() final;
 
     std::optional<WebCore::SecurityOriginData> openerOrigin;
 };

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp
@@ -83,6 +83,12 @@ void PlatformXRSystem::invalidate(InvalidationReason reason)
     invalidateImmersiveSessionState(reason == InvalidationReason::Client ? ImmersiveSessionState::SessionEndingFromSystem : ImmersiveSessionState::Idle);
 }
 
+bool PlatformXRSystem::hasActiveSession() const
+{
+    return std::holds_alternative<Ref<ProcessActivityGroup>>(m_immersiveSessionActivity)
+        || std::holds_alternative<Ref<ProcessThrottler::ForegroundActivity>>(m_immersiveSessionActivity);
+}
+
 void PlatformXRSystem::ensureImmersiveSessionActivity()
 {
     ASSERT(RunLoop::isMain());
@@ -91,10 +97,20 @@ void PlatformXRSystem::ensureImmersiveSessionActivity()
     if (!page)
         return;
 
-    if (m_immersiveSessionActivity && m_immersiveSessionActivity->isValid())
-        return;
+    const bool siteIsolationEnabled = protect(page->preferences())->siteIsolationEnabled();
+    constexpr ASCIILiteral activityName = "XR immersive session"_s;
 
-    m_immersiveSessionActivity = protect(protect(page->legacyMainFrameProcess())->throttler())->foregroundActivity("XR immersive session"_s);
+    if (siteIsolationEnabled) {
+        if (std::holds_alternative<Ref<ProcessActivityGroup>>(m_immersiveSessionActivity))
+            return;
+        m_immersiveSessionActivity = page->activityGroupContext().foregroundProcessActivityGroup(activityName);
+        return;
+    }
+
+    if (std::holds_alternative<Ref<ProcessThrottler::ForegroundActivity>>(m_immersiveSessionActivity)
+        && std::get<Ref<ProcessThrottler::ForegroundActivity>>(m_immersiveSessionActivity)->isValid())
+        return;
+    m_immersiveSessionActivity = protect(protect(page->legacyMainFrameProcess())->throttler())->foregroundActivity(activityName);
 }
 
 void PlatformXRSystem::enumerateImmersiveXRDevices(CompletionHandler<void(Vector<XRDeviceInfo>&&)>&& completionHandler)
@@ -355,7 +371,7 @@ void PlatformXRSystem::sessionDidEnd(XRDeviceIdentifier deviceIdentifier)
             return;
 
         protect(page->legacyMainFrameProcess())->send(Messages::PlatformXRSystemProxy::SessionDidEnd(deviceIdentifier), page->webPageIDInMainFrameProcess());
-        protectedThis->m_immersiveSessionActivity = nullptr;
+        protectedThis->m_immersiveSessionActivity = { };
         // If this is called when the session is running, the ending of the session is triggered by the system side
         // and we should set the state to SessionEndingFromSystem. We expect the web process to send a
         // didCompleteShutdownTriggeredBySystem message later when it has ended the XRSession, which will

--- a/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
+++ b/Source/WebKit/UIProcess/XR/PlatformXRSystem.h
@@ -29,12 +29,14 @@
 
 #include "MessageReceiver.h"
 #include "PlatformXRCoordinator.h"
+#include "ProcessActivityGroup.h"
 #include "ProcessThrottler.h"
 #include <WebCore/ExceptionData.h>
 #include <WebCore/PlatformXR.h>
 #include <WebCore/SecurityOriginData.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Variant.h>
 
 namespace WebCore {
 class SecurityOriginData;
@@ -76,7 +78,7 @@ public:
     };
     void invalidate(InvalidationReason invalidateReason = InvalidationReason::State);
 
-    bool hasActiveSession() const { return !!m_immersiveSessionActivity; }
+    bool hasActiveSession() const;
     void ensureImmersiveSessionActivity();
 
 private:
@@ -130,7 +132,7 @@ private:
     void invalidateImmersiveSessionState(ImmersiveSessionState nextSessionState = ImmersiveSessionState::Idle);
 
     WeakPtr<WebPageProxy> m_page;
-    RefPtr<ProcessThrottler::ForegroundActivity> m_immersiveSessionActivity;
+    Variant<std::monostate, Ref<ProcessThrottler::ForegroundActivity>, Ref<ProcessActivityGroup>> m_immersiveSessionActivity;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -2417,6 +2417,7 @@
 		E326E357284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */; };
 		E326F4DC2CA6C44F00182187 /* LogStream.mm in Sources */ = {isa = PBXBuildFile; fileRef = E326F4DA2CA6C44F00182187 /* LogStream.mm */; };
 		E326F4DD2CA6C44F00182187 /* LogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = E326F4D92CA6C44F00182187 /* LogStream.h */; };
+		E3301EE32F48C85500796190 /* WKNavigationPrivateForTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = E3301EE22F48C84E00796190 /* WKNavigationPrivateForTesting.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		E33E8FFD2C7FD2980002BEB3 /* UseDownloadPlaceholder.h in Headers */ = {isa = PBXBuildFile; fileRef = E33E8FFC2C7FD2980002BEB3 /* UseDownloadPlaceholder.h */; };
 		E34DAD392B753FA700FABEE2 /* ExtensionProcess.mm in Sources */ = {isa = PBXBuildFile; fileRef = E34DAD372B753FA700FABEE2 /* ExtensionProcess.mm */; };
 		E34DAD3A2B753FA700FABEE2 /* ExtensionProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = E34DAD382B753FA700FABEE2 /* ExtensionProcess.h */; };
@@ -8575,6 +8576,7 @@
 		E326E356284E580E00157372 /* AuxiliaryProcessProxyCocoa.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AuxiliaryProcessProxyCocoa.mm; sourceTree = "<group>"; };
 		E326F4D92CA6C44F00182187 /* LogStream.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LogStream.h; sourceTree = "<group>"; };
 		E326F4DA2CA6C44F00182187 /* LogStream.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = LogStream.mm; sourceTree = "<group>"; };
+		E3301EE22F48C84E00796190 /* WKNavigationPrivateForTesting.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WKNavigationPrivateForTesting.h; sourceTree = "<group>"; };
 		E33E8FFC2C7FD2980002BEB3 /* UseDownloadPlaceholder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UseDownloadPlaceholder.h; sourceTree = "<group>"; };
 		E3439B632345463A0011DE0B /* NetworkProcessConnectionInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NetworkProcessConnectionInfo.h; path = Network/NetworkProcessConnectionInfo.h; sourceTree = "<group>"; };
 		E34B110C27C46BC6006D2F2E /* libWebCoreTestShim.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libWebCoreTestShim.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -8642,6 +8644,10 @@
 		E3E6297C2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ServiceWorkerDebuggableProxy.h; sourceTree = "<group>"; };
 		E3E6297D2D5FA8F200DAE50C /* ServiceWorkerDebuggableProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ServiceWorkerDebuggableProxy.cpp; sourceTree = "<group>"; };
 		E3E84BED2AE1AA5A0091B3C2 /* ExtensionKitSPI.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExtensionKitSPI.h; sourceTree = "<group>"; };
+		E3EA8E7C2F3F61EA006CC6B3 /* SiteIsolatedActivity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SiteIsolatedActivity.h; sourceTree = "<group>"; };
+		E3EA8E7D2F3F72BD006CC6B3 /* SiteIsolatedActivity.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SiteIsolatedActivity.cpp; sourceTree = "<group>"; };
+		E3EA8F0C2F439059006CC6B3 /* ProcessActivityGroup.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ProcessActivityGroup.h; sourceTree = "<group>"; };
+		E3EA8F0D2F439059006CC6B3 /* ProcessActivityGroup.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessActivityGroup.cpp; sourceTree = "<group>"; };
 		E3EFB02C2550617C003C2F96 /* WebSystemSoundDelegate.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WebSystemSoundDelegate.cpp; sourceTree = "<group>"; };
 		E3EFB02D2550617C003C2F96 /* WebSystemSoundDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WebSystemSoundDelegate.h; sourceTree = "<group>"; };
 		E404907121DE65F70037F0DB /* ScrollingTreeFrameScrollingNodeRemoteMac.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScrollingTreeFrameScrollingNodeRemoteMac.cpp; sourceTree = "<group>"; };
@@ -12962,6 +12968,7 @@
 				1AA20D5018AD50E0005D1ED4 /* WKNavigationDelegatePrivate.h */,
 				1ABC3DF01899C6B6004F0626 /* WKNavigationInternal.h */,
 				1ACC87B91981C341003D1AF4 /* WKNavigationPrivate.h */,
+				E3301EE22F48C84E00796190 /* WKNavigationPrivateForTesting.h */,
 				1A1B0EB418A424950038481A /* WKNavigationResponse.h */,
 				1A1B0EB318A424950038481A /* WKNavigationResponse.mm */,
 				1A1B0EB718A424CD0038481A /* WKNavigationResponseInternal.h */,
@@ -15918,6 +15925,8 @@
 				F4660BC125DEF08100E86598 /* PasteboardAccessIntent.h */,
 				832ED1891E2FE13B006BA64A /* PerActivityStateCPUUsageSampler.cpp */,
 				832ED18A1E2FE13B006BA64A /* PerActivityStateCPUUsageSampler.h */,
+				E3EA8F0D2F439059006CC6B3 /* ProcessActivityGroup.cpp */,
+				E3EA8F0C2F439059006CC6B3 /* ProcessActivityGroup.h */,
 				37716A59195B910500EE8B1B /* ProcessAssertion.cpp */,
 				86F9536018FF4FD4001DB2EF /* ProcessAssertion.h */,
 				86E67A22190F411800004AB7 /* ProcessThrottler.cpp */,
@@ -15944,6 +15953,8 @@
 				7BDE98AC2F0F33140091DCA3 /* RemotePageWebDeviceOrientationUpdateProviderProxy.h */,
 				BC111B08112F5E3C00337BAB /* ResponsivenessTimer.cpp */,
 				1A30066C1110F4F70031937C /* ResponsivenessTimer.h */,
+				E3EA8E7D2F3F72BD006CC6B3 /* SiteIsolatedActivity.cpp */,
+				E3EA8E7C2F3F61EA006CC6B3 /* SiteIsolatedActivity.h */,
 				93D6B7B0255268A10058DD3A /* SpeechRecognitionPermissionManager.cpp */,
 				93D6B7B2255268A20058DD3A /* SpeechRecognitionPermissionManager.h */,
 				93D6B7AF255268A10058DD3A /* SpeechRecognitionPermissionRequest.h */,
@@ -19300,6 +19311,7 @@
 				1AA20D5118AD50E0005D1ED4 /* WKNavigationDelegatePrivate.h in Headers */,
 				1ABC3DF11899C6B6004F0626 /* WKNavigationInternal.h in Headers */,
 				1ACC87BA1981C341003D1AF4 /* WKNavigationPrivate.h in Headers */,
+				E3301EE32F48C85500796190 /* WKNavigationPrivateForTesting.h in Headers */,
 				2D3A65E31A7C3A9300CAC637 /* WKNavigationRef.h in Headers */,
 				1A1B0EB618A424950038481A /* WKNavigationResponse.h in Headers */,
 				1A1B0EB818A424CD0038481A /* WKNavigationResponseInternal.h in Headers */,

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -45,10 +45,12 @@
 #import <WebKit/WKFrameInfoPrivate.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKNavigationPrivate.h>
+#import <WebKit/WKNavigationPrivateForTesting.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKURLSchemeTaskPrivate.h>
 #import <WebKit/WKUserContentControllerPrivate.h>
+#import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WKWebpagePreferencesPrivate.h>
@@ -321,7 +323,7 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> si
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> siteIsolatedViewAndDelegate(const HTTPServer& server, CGRect rect = CGRectZero)
 {
-    return siteIsolatedViewAndDelegate(server.httpsProxyConfiguration(), rect);
+    return siteIsolatedViewAndDelegate(server.httpsProxyConfiguration(), rect, true);
 }
 
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> viewAndDelegate(const HTTPServer& server, CGRect rect = CGRectZero)
@@ -8389,5 +8391,30 @@ TEST(SiteIsolation, CrossSiteIFrameCanReceiveDeviceMotionEvents)
 }
 
 #endif // ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)
+
+TEST(SiteIsolation, ProcessActivityGroup)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://apple.com/apple'></iframe>"_s } },
+        { "/apple"_s, { "hello"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server, CGRectMake(0, 0, 800, 600));
+    bool finishedLoading { false };
+    navigationDelegate.get().didFinishNavigation = makeBlockPtr([&](WKWebView *, WKNavigation *navigation) {
+#if PLATFORM(IOS_SIMULATOR)
+        // In the Simulator, we are never taking an activity when the view is hidden and we are calling
+        // -[WKWebViewConfiguration _setClientNavigationsRunAtForegroundPriority:YES], so we disable this check.
+        EXPECT_EQ([navigation _processActivityGroupSizeForTesting], 0u);
+#else
+        EXPECT_EQ([navigation _processActivityGroupSizeForTesting], 2u);
+#endif
+        finishedLoading = true;
+    }).get();
+    [webView.get().configuration _setClientNavigationsRunAtForegroundPriority:YES];
+    [webView setHidden:YES];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    Util::run(&finishedLoading);
+}
 
 }


### PR DESCRIPTION
#### 2cf2471c5f9fc902be3815f54a79069913a8a20f
<pre>
[Site Isolation] Create a class to manage the aggregated set of activities on a WebContent process tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=307816">https://bugs.webkit.org/show_bug.cgi?id=307816</a>
<a href="https://rdar.apple.com/170326047">rdar://170326047</a>

Reviewed by Sihui Liu and Chris Dumez.

This change is introducing a new class, ProcessActivityGroup, that manages an aggregated set of activities
on a WebContent process tree. This ensures that the WebContent processes in the tree have the same activities.
When the ProcessActivityGroup is created, an activity is taken on the main frame process and all the iframe
processes. When a new iframe process is created, the same activity will be taken on it. And when an iframe
process is exiting, the associated activity will be destroyed. This can be used in suspension edge cases
where we currently are only taking an activity on the main frame process. This patch is covering some edge
cases. This is guarded behind the Site Isolation runtime flag.

New API test: SiteIsolation.ProcessActivityGroup

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::loadBackgroundWebView):
(WebKit::WebExtensionContext::loadInspectorBackgroundPage):
* Source/WebKit/UIProcess/Extensions/WebExtensionContext.h:
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::RemotePageProxy):
(WebKit::RemotePageProxy::~RemotePageProxy):
* Source/WebKit/UIProcess/SiteIsolatedActivity.cpp: Added.
(WebKit::SiteIsolatedActivity::create):
(WebKit::SiteIsolatedActivity::SiteIsolatedActivity):
(WebKit::SiteIsolatedActivity::~SiteIsolatedActivity):
(WebKit::SiteIsolatedActivity::createActivity):
(WebKit::SiteIsolatedActivity::addActivityForRemotePage):
(WebKit::SiteIsolatedActivity::removeActivityForRemotePage):
* Source/WebKit/UIProcess/SiteIsolatedActivity.h: Added.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCreateRemotePage):
(WebKit::WebPageProxy::willDestroyRemotePage):
(WebKit::WebPageProxy::siteIsolatedActivity):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/UIProcess/XR/PlatformXRSystem.cpp:
(WebKit::PlatformXRSystem::ensureImmersiveSessionActivity):
* Source/WebKit/UIProcess/XR/PlatformXRSystem.h:

Canonical link: <a href="https://commits.webkit.org/309528@main">https://commits.webkit.org/309528@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4b89350eda64e4cee16b785b61477a974283fba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/150726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/23484 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/17055 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/159448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/104160 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26b086bd-81f4-4456-951a-b77f0d57c516) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/152599 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/23916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/23687 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/116333 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/82615 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4e9a44e-4893-4314-a075-12b8c465807b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/153686 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/18445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/135218 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/97061 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d791f939-428a-4e81-89bd-7975312bb0f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/17542 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/15489 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/7296 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/127156 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/13142 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/161922 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/5043 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/14697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/124332 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/23286 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/19536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/124530 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/23274 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/134937 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/79663 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/23190 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/19604 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/11699 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/22888 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/86688 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/22600 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/22752 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/22654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->