### PR TITLE
REGRESSION (307332@main): Web process terminates due to invalid RemoteLayerTreeDrawingAreaProxy_CommitLayerTree IPC

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -198,19 +198,18 @@ private:
 enum class ScrollingStateNodeProperty : uint64_t {
     // ScrollingStateNode
     Layer                                       = 1LLU << 0,
-    ChildNodes                                  = 1LLU << 45,
     // ScrollingStateScrollingNode
-    ScrollableAreaSize                          = 1LLU << 1, // Same value as RelatedOverflowScrollingNodes, ViewportConstraints and OverflowScrollingNode
-    TotalContentsSize                           = 1LLU << 2, // Same value as LayoutConstraintData
-    ReachableContentsSize                       = 1LLU << 3,
-    ScrollPosition                              = 1LLU << 4,
-    ScrollOrigin                                = 1LLU << 5,
-    ScrollableAreaParams                        = 1LLU << 6,
+    ScrollableAreaSize                          = Layer << 1, // Same value as RelatedOverflowScrollingNodes, ViewportConstraints and OverflowScrollingNode
+    TotalContentsSize                           = ScrollableAreaSize << 1, // Same value as LayoutConstraintData
+    ReachableContentsSize                       = TotalContentsSize << 1,
+    ScrollPosition                              = ReachableContentsSize << 1,
+    ScrollOrigin                                = ScrollPosition << 1,
+    ScrollableAreaParams                        = ScrollOrigin << 1,
 #if ENABLE(SCROLLING_THREAD)
-    ReasonsForSynchronousScrolling              = 1LLU << 7,
-    RequestedScrollPosition                     = 1LLU << 8,
+    ReasonsForSynchronousScrolling              = ScrollableAreaParams << 1,
+    RequestedScrollPosition                     = ReasonsForSynchronousScrolling << 1,
 #else
-    RequestedScrollPosition                     = 1LLU << 7,
+    RequestedScrollPosition                     = ScrollableAreaParams << 1,
 #endif
     SnapOffsetsInfo                             = RequestedScrollPosition << 1,
     CurrentHorizontalSnapOffsetIndex            = SnapOffsetsInfo << 1,
@@ -220,7 +219,6 @@ enum class ScrollingStateNodeProperty : uint64_t {
     ScrolledContentsLayer                       = ScrollContainerLayer << 1,
     HorizontalScrollbarLayer                    = ScrolledContentsLayer << 1,
     VerticalScrollbarLayer                      = HorizontalScrollbarLayer << 1,
-    PainterForScrollbar                         = 1LLU << 44, // Not serialized
     ContentAreaHoverState                       = VerticalScrollbarLayer << 1,
     MouseActivityState                          = ContentAreaHoverState << 1,
     ScrollbarHoverState                         = MouseActivityState << 1,
@@ -229,9 +227,6 @@ enum class ScrollingStateNodeProperty : uint64_t {
     ScrollbarLayoutDirection                    = ScrollbarColor << 1,
     ScrollbarWidth                              = ScrollbarLayoutDirection << 1,
     UseDarkAppearanceForScrollbars              = ScrollbarWidth << 1,
-#if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
-    ScrollbarOpacity                            = 1LLU << 51, // Not serialized
-#endif
     // ScrollingStateFrameScrollingNode
     KeyboardScrollData                          = UseDarkAppearanceForScrollbars << 1,
     FrameScaleFactor                            = KeyboardScrollData << 1,
@@ -242,8 +237,6 @@ enum class ScrollingStateNodeProperty : uint64_t {
     ContentShadowLayer                          = InsetClipLayer << 1,
     HeaderHeight                                = ContentShadowLayer << 1,
     FooterHeight                                = HeaderHeight << 1,
-    HeaderLayer                                 = 1LLU << 50, // Not serialized
-    FooterLayer                                 = 1LLU << 43, // Not serialized
     BehaviorForFixedElements                    = FooterHeight << 1,
     ObscuredContentInsets                       = BehaviorForFixedElements << 1,
 #if ENABLE(BANNER_VIEW_OVERLAYS)
@@ -261,17 +254,27 @@ enum class ScrollingStateNodeProperty : uint64_t {
     MaxLayoutViewportOrigin                     = MinLayoutViewportOrigin << 1,
     OverrideVisualViewportSize                  = MaxLayoutViewportOrigin << 1,
     OverlayScrollbarsEnabled                    = OverrideVisualViewportSize << 1,
+    ChildNodes                                  = OverlayScrollbarsEnabled << 1,
     // ScrollingStatePositionedNode
-    RelatedOverflowScrollingNodes               = 1LLU << 1, // Same value as ScrollableAreaSize, ViewportConstraints and OverflowScrollingNode
-    LayoutConstraintData                        = 1LLU << 2, // Same value as TotalContentsSize
+    RelatedOverflowScrollingNodes               = ScrollableAreaSize,
+    LayoutConstraintData                        = TotalContentsSize,
     // ScrollingStateFixedNode, ScrollingStateStickyNode
-    ViewportConstraints                         = 1LLU << 1, // Same value as ScrollableAreaSize, RelatedOverflowScrollingNodes and OverflowScrollingNode
-    ViewportAnchorLayer                         = 1LLU << 2, // Same value as TotalContentsSize
+    ViewportConstraints                         = ScrollableAreaSize,
+    ViewportAnchorLayer                         = TotalContentsSize,
     // ScrollingStateOverflowScrollProxyNode
-    OverflowScrollingNode                       = 1LLU << 1, // Same value as ScrollableAreaSize, ViewportConstraints and RelatedOverflowScrollingNodes
+    OverflowScrollingNode                       = ScrollableAreaSize,
     // ScrollingStateFrameHostingNode
-    LayerHostingContextIdentifier               = 1LLU << 1,
+    LayerHostingContextIdentifier               = ScrollableAreaSize,
 
+    // The following flags are not serialized.
+    PainterForScrollbar                         = ChildNodes << 1,
+#if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
+    ScrollbarOpacity                            = PainterForScrollbar << 1,
+    HeaderLayer                                 = ScrollbarOpacity << 1,
+#else
+    HeaderLayer                                 = PainterForScrollbar << 1,
+#endif
+    FooterLayer                                 = HeaderLayer << 1,
 };
 
 class ScrollingStateNode : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ScrollingStateNode> {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -4241,7 +4241,6 @@ enum class WebCore::IncludeSecureCookies : bool;
 header: <WebCore/ScrollingStateNode.h>
 [OptionSet] enum class WebCore::ScrollingStateNodeProperty : uint64_t {
     Layer
-    ChildNodes
     ScrollableAreaSize
     TotalContentsSize
     ReachableContentsSize
@@ -4281,6 +4280,9 @@ header: <WebCore/ScrollingStateNode.h>
     FooterLayer
     BehaviorForFixedElements
     ObscuredContentInsets
+#if ENABLE(BANNER_VIEW_OVERLAYS)
+    BannerViewHeight
+#endif
     VisualViewportIsSmallerThanLayoutViewport
     AsyncFrameOrOverflowScrollingEnabled
     WheelEventGesturesBecomeNonBlocking
@@ -4297,6 +4299,7 @@ header: <WebCore/ScrollingStateNode.h>
     OverflowScrollingNode
     KeyboardScrollData
     OverlayScrollbarsEnabled
+    ChildNodes
     LayerHostingContextIdentifier
 };
 #endif


### PR DESCRIPTION
#### 0879c63cc17e57079488576bd524ee36b690614a
<pre>
REGRESSION (307332@main): Web process terminates due to invalid RemoteLayerTreeDrawingAreaProxy_CommitLayerTree IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=307817">https://bugs.webkit.org/show_bug.cgi?id=307817</a>
<a href="https://rdar.apple.com/170247986">rdar://170247986</a>

Reviewed by Lily Spiniolas.

Reorganize `ScrollingStateNodeProperty` to avoid all (unintended) overlapping enum values when
certain compile-time flags are enabled, by defining each enum value relative to the last value (or
exactly equal to one of the prior values, in the case where the overlap is intended).

Also, add `BannerViewHeight` to `WebCoreArgumentCoders.serialization.in` to ensure that it gets
properly serialized over IPC.

* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Canonical link: <a href="https://commits.webkit.org/307507@main">https://commits.webkit.org/307507@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aab25631ce4e3d45ec70f75dd94db1a0107d7a1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144559 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8813 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153230 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e4a8c381-a1d2-4549-9e88-d26e2c121ca6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17721 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17132 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111172 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65ba9805-466e-41f3-b729-4d5169c263c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147522 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13556 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92074 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26a71ddd-bbc3-4be0-bba4-e94007309581) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12936 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10683 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/675 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122447 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155542 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119180 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119520 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30651 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15342 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127728 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72631 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16712 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6128 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16657 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16512 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->