### PR TITLE
Adopt UA stylesheets in media controls instead of re-parsing them for every media element.

### DIFF
--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container-expected.txt
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container-expected.txt
@@ -3,8 +3,7 @@ Testing the MediaController has a single container for captions and media contro
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
-PASS shadowRoot.childElementCount is >= 2
-PASS shadowRoot.firstElementChild.localName is "style"
+PASS shadowRoot.childElementCount is 1
 PASS shadowRoot.lastElementChild.localName is "div"
 PASS shadowRoot.lastElementChild.className is "media-controls-container"
 PASS shadowRoot.lastElementChild.childElementCount is 2

--- a/LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container.html
+++ b/LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container.html
@@ -9,8 +9,7 @@ description("Testing the <code>MediaController</code> has a single container for
 const media = document.querySelector("video");
 const shadowRoot = window.internals.shadowRoot(media);
 
-shouldBeGreaterThanOrEqual("shadowRoot.childElementCount", "2");
-shouldBeEqualToString("shadowRoot.firstElementChild.localName", "style");
+shouldBe("shadowRoot.childElementCount", "1");
 shouldBeEqualToString("shadowRoot.lastElementChild.localName", "div");
 shouldBeEqualToString("shadowRoot.lastElementChild.className", "media-controls-container");
 

--- a/PerformanceTests/Media/AudioElementControlsCreation.html
+++ b/PerformanceTests/Media/AudioElementControlsCreation.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<script>
+    window.addEventListener('load', event => {
+        const numberOfIterations = 20;
+        const numberOfItems = 1000;
+
+        PerfTestRunner.prepareToMeasureValuesAsync({
+            customIterationCount: numberOfIterations,
+            unit: 'ms',
+            done: function () {
+                PerfTestRunner.gc();
+            }
+        });
+
+        function startIteration()
+        {
+            testGenerator = runIteration();
+            testGenerator.next();
+        }
+
+        function *runIteration()
+        {
+            var target = document.createElement('div');
+            document.body.appendChild(target);
+            var startTime = PerfTestRunner.now();
+
+            for (let i = 0; i < numberOfItems; ++i) {
+                let audio = document.createElement('audio');
+                audio.controls = true;
+                target.appendChild(audio);
+            }
+
+            if (!PerfTestRunner.measureValueAsync(PerfTestRunner.now() - startTime)) {
+                document.body.removeChild(target);
+                return;
+            }
+
+            document.body.removeChild(target);
+            target = null;
+            PerfTestRunner.gc();
+            setTimeout(startIteration, 0);
+        }
+
+        startIteration();
+    })
+</script>
+</head>
+<body></body>
+</html>

--- a/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
+++ b/Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css
@@ -23,7 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-video::-webkit-media-text-track-container {
+[useragentpart="-webkit-media-text-track-container"] {
     overflow: hidden;
     padding-bottom: 0;
     z-index: 0;
@@ -43,7 +43,7 @@ video::-webkit-media-text-track-container {
     flex: 1 1 auto;
 }
 
-video[controls]::-webkit-media-text-track-container.visible-controls-bar {
+:host(video[controls]) [useragentpart="-webkit-media-text-track-container"].visible-controls-bar {
     height: calc(100% - var(--inline-controls-bar-height) - var(--inline-controls-inside-margin));
 }
 

--- a/Source/WebCore/Modules/modern-media-controls/main.js
+++ b/Source/WebCore/Modules/modern-media-controls/main.js
@@ -25,6 +25,7 @@
 
 const MinimumSizeToShowAnyControl = 47;
 const MaximumSizeToShowSmallProminentControl = 88;
+let cachedUAStyleSheets = null;
 
 // If running outside the media element's isolated world, polyfill the MediaControlsUtils object:
 if (!window.utils) {
@@ -35,13 +36,24 @@ if (!window.utils) {
     };
 }
 
+function ensureUAStyleSheets(host)
+{
+    if (!cachedUAStyleSheets) {
+        cachedUAStyleSheets = host.shadowRootStyleSheets.map(cssText => {
+            const styleSheet = new CSSStyleSheet();
+            styleSheet.replaceSync(cssText);
+            return styleSheet;
+        });
+    }
+
+    return cachedUAStyleSheets;
+}
+
 // This is called from HTMLMediaElement::ensureMediaControls().
 function createControls(shadowRoot, media, host)
 {
-    if (host) {
-        for (let styleSheet of host.shadowRootStyleSheets)
-            shadowRoot.appendChild(document.createElement("style")).textContent = styleSheet;
-    }
+    if (host)
+        shadowRoot.adoptedStyleSheets = ensureUAStyleSheets(host);
 
     controller = new MediaController(shadowRoot, media, host);
     if (host)


### PR DESCRIPTION
#### 2ee8c675ab360120cbba8f9953a07a0dda464b80
<pre>
Adopt UA stylesheets in media controls instead of re-parsing them for every media element.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307818">https://bugs.webkit.org/show_bug.cgi?id=307818</a>
<a href="https://rdar.apple.com/170327340">rdar://170327340</a>

Reviewed by NOBODY (OOPS!).

When we insert media elements with the controls attribute into a page we will put
three style elements in the shadow tree. This causes us to re-parse the exact same
stylesheets possibly hundreds of times for documents with many media elements using
controls. Instead of doing this we can parse them once and adopt them for each element
that needs the controls styles.

This is a 45% improvement to the benchmark that is added in this PR on a M4 Max MacBook Pro.

* LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container-expected.txt:
* LayoutTests/media/modern-media-controls/media-controller/media-controller-single-container.html:
    Rebaseline since we are getting rid of the &lt;style&gt; elements.

* PerformanceTests/Media/AudioElementControlsCreation.html: Added.

* Source/WebCore/Modules/modern-media-controls/controls/text-tracks.css:
    We need these changes because of how the rules for pseudos in adopted style sheets work.

* Source/WebCore/Modules/modern-media-controls/main.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ee8c675ab360120cbba8f9953a07a0dda464b80

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144608 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17287 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98243 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146483 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17181 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111218 "Found 2 new test failures: media/track/track-cue-css.html media/track/track-user-stylesheet-override.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79762 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aef08609-8cd5-44d2-99b6-19bd2c2fc164) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147571 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13585 "Found 2 new test failures: media/track/track-user-stylesheet-override.html media/track/webvtt-ruby.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129854 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92108 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aef5aa4f-c84f-49cc-9e6a-3765ef45dec8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12962 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10718 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/724 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155591 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17139 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7622 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119221 "Found 1 new test failure: media/track/track-user-stylesheet-override.html (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17177 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14345 "Found 2 new test failures: media/track/track-user-stylesheet-override.html media/track/webvtt-ruby.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119556 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15369 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127781 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72681 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16761 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6161 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80540 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16706 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16561 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->