### PR TITLE
[AutoFill Debugging] Continue refining the `includeOffscreenPasswordFields` heuristic

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt
@@ -1,39 +1,42 @@
 -- texttree
 
-root,scrollPosition=(0,0),contentSize=[…]
-    section
-        article
-            'Article Title'
-            'January 1, 2024'
-            'This is some article content with highlighted text.'
-        form,autocomplete='on',name='signup'
-            'Sign up for our newsletter'
-            input,'checkbox',label='Remember me'
-            'Remember me'
-            input,'text',placeholder='Username',name='username',minlength=3,maxlength=20,required
-            input,'password',placeholder='Password',name='password',minlength=3,maxlength=20,required,secure
-            input,'text',placeholder='Email',pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$',name='email',required
-            input,'text',placeholder='Zip Code',pattern='[0-9]{5}',name='zipcode',minlength=5,maxlength=5
+root
+    scrollable,scrollPosition=(0,0),contentSize=[…]
+        section
+            article
+                'Article Title'
+                'January 1, 2024'
+                'This is some article content with highlighted text.'
+            form,autocomplete='on',name='signup'
+                'Sign up for our newsletter'
+                input,'checkbox',label='Remember me'
+                'Remember me'
+                input,'text',placeholder='Username',name='username',minlength=3,maxlength=20,required
+                input,'password',placeholder='Password',name='password',minlength=3,maxlength=20,required,secure
+                input,'text',placeholder='Email',pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$',name='email',required
+                input,'text',placeholder='Zip Code',pattern='[0-9]{5}',name='zipcode',minlength=5,maxlength=5
 
 -- html
 
 <body>
-    <section>
-        <article>
-            Article Title
-            January 1, 2024
-            This is some article content with highlighted text.
-        </article>
-        <form autocomplete='on' name='signup'>
-            Sign up for our newsletter
-            <input type='checkbox' label='Remember me'>
-            Remember me
-            <input type='text' placeholder='Username' name='username' minlength=3 maxlength=20 required>
-            <input type='password' placeholder='Password' name='password' minlength=3 maxlength=20 required>
-            <input type='text' placeholder='Email' pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$' name='email' required>
-            <input type='text' placeholder='Zip Code' pattern='[0-9]{5}' name='zipcode' minlength=5 maxlength=5>
-        </form>
-    </section>
+    <main>
+        <section>
+            <article>
+                Article Title
+                January 1, 2024
+                This is some article content with highlighted text.
+            </article>
+            <form autocomplete='on' name='signup'>
+                Sign up for our newsletter
+                <input type='checkbox' label='Remember me'>
+                Remember me
+                <input type='text' placeholder='Username' name='username' minlength=3 maxlength=20 required>
+                <input type='password' placeholder='Password' name='password' minlength=3 maxlength=20 required>
+                <input type='text' placeholder='Email' pattern='[a-z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,}$' name='email' required>
+                <input type='text' placeholder='Zip Code' pattern='[0-9]{5}' name='zipcode' minlength=5 maxlength=5>
+            </form>
+        </section>
+    </main>
 </body>
 
 

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html
@@ -32,6 +32,12 @@ form {
 h4 {
     margin: auto;
 }
+
+main {
+    position: fixed;
+    inset: 0;
+    overflow-y: scroll;
+}
 </style>
 <script src="../../resources/ui-helper.js"></script>
 </head>
@@ -73,13 +79,13 @@ h4 {
             <option value="apple">Apple</option>
         </select>
     </section>
+    <footer role="contentinfo">
+        <p>Footer content with <span role="img" aria-label="copyright symbol">©</span> 2024</p>
+    </footer>
+    <div role="dialog" aria-hidden="true" style="display: none;">
+        <p>This dialog is hidden and should not be extracted.</p>
+    </div>
 </main>
-<footer role="contentinfo">
-    <p>Footer content with <span role="img" aria-label="copyright symbol">©</span> 2024</p>
-</footer>
-<div role="dialog" aria-hidden="true" style="display: none;">
-    <p>This dialog is hidden and should not be extracted.</p>
-</div>
 <script>
 addEventListener("load", async () => {
     if (!window.testRunner)


### PR DESCRIPTION
#### 218be3a71acaef145b63cab6e91c129a0994aa38
<pre>
[AutoFill Debugging] Continue refining the `includeOffscreenPasswordFields` heuristic
<a href="https://bugs.webkit.org/show_bug.cgi?id=307824">https://bugs.webkit.org/show_bug.cgi?id=307824</a>
<a href="https://rdar.apple.com/170331111">rdar://170331111</a>

Reviewed by Aditya Keerthi.

Continue adjusting the `includeOffscreenPasswordFields` text extraction heuristic, by:
- Making the minimum height slightly shorter.
- Putting the form controls inside a fixed-position banner.

* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-form-controls-2.html:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::findLargeContainerAboveNode):

`wasFixed` is set for any renderer inside a fixed-position element; this causes us to extract only
the password field, in the case where it&apos;s inside a fixed element. Correct this by instead checking
whether the current renderer itself is viewport-constrained (fixed or sticky).

(WebCore::TextExtraction::findContainerNodeForDataDetectorResults):
(WebCore::TextExtraction::extractItem):

Canonical link: <a href="https://commits.webkit.org/307506@main">https://commits.webkit.org/307506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/63b46f10379c9e5655515a1df8d6dd643096599e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153244 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1eea420-1a55-46cf-9b78-0ffc58ffe149) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146448 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17735 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111189 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2fe44d30-4b7a-4318-99f2-b8f02bd52c85) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147536 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129829 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92086 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a9c9145-58dc-4bf5-997f-a22624c3cd84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12941 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10695 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/689 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122453 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6522 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155556 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17104 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119193 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17142 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14319 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119531 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30648 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15349 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127743 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16726 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6136 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16462 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80505 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16671 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16526 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->