### PR TITLE
[Swift in WebKit] Remove the has_feature(modules) check in WritingToolsSPI.h where possible

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h
@@ -32,7 +32,7 @@ DECLARE_SYSTEM_HEADER
 
 #if ENABLE(WRITING_TOOLS)
 
-#if USE(APPLE_INTERNAL_SDK) && !__has_feature(modules)
+#if USE(APPLE_INTERNAL_SDK) && (!__has_feature(modules) || HAVE(VALID_WRITING_TOOLS_MODULE))
 #import <WritingTools/WTSession_Private.h>
 #import <WritingTools/WritingTools.h>
 #else


### PR DESCRIPTION
#### deb0bd45d3a752c3cda208b5d7a0de49109028ef
<pre>
[Swift in WebKit] Remove the has_feature(modules) check in WritingToolsSPI.h where possible
<a href="https://bugs.webkit.org/show_bug.cgi?id=307770">https://bugs.webkit.org/show_bug.cgi?id=307770</a>
<a href="https://rdar.apple.com/170332820">rdar://170332820</a>

Reviewed by Wenson Hsieh.

* Source/WebCore/PAL/pal/spi/cocoa/WritingToolsSPI.h:

Canonical link: <a href="https://commits.webkit.org/307591@main">https://commits.webkit.org/307591@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/407a681dc017ae495243e29aa41e78fa2c98386a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144751 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17430 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153422 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98386 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d3f7a94-af33-4ed2-8a18-bc02b2603f42) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146626 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17913 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111301 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79791 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13661 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92196 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13035 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10791 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/867 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122552 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6657 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155734 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17282 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119304 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14431 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119633 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30700 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15441 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127899 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72824 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16904 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6252 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16640 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80683 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16849 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16704 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->