### PR TITLE
[WTF] Switch to SequesteredStack via new DeferredStack mechanism

### DIFF
--- a/Source/WTF/WTF.xcodeproj/project.pbxproj
+++ b/Source/WTF/WTF.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		0F3492D722AF431C004F85FC /* TextStreamCocoa.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0F3492D622AF42F1004F85FC /* TextStreamCocoa.mm */; };
 		0F43D8F11DB5ADDC00108FB6 /* AutomaticThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F43D8EF1DB5ADDC00108FB6 /* AutomaticThread.cpp */; };
 		0F43D8F11DB5ADDC00108FC6 /* SequesteredAutomaticThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F43D8EF1DB5ADDC00108FC6 /* SequesteredAutomaticThread.cpp */; };
+		0F43D8F11DB5ADDC00108FD6 /* StackSwitch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F43D8EF1DB5ADDC00108FD6 /* StackSwitch.cpp */; };
 		0F5BF1761F23D49A0029D91D /* Gigacage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5BF1741F23D49A0029D91D /* Gigacage.cpp */; settings = {COMPILER_FLAGS = "-O3"; }; };
 		0F60F32F1DFCBD1B00416D6C /* LockedPrintStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F60F32D1DFCBD1B00416D6C /* LockedPrintStream.cpp */; };
 		0F66B28A1DC97BAB004A1D3F /* ClockType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F66B2801DC97BAB004A1D3F /* ClockType.cpp */; };
@@ -567,6 +568,7 @@
 		DD3DC97E27A4BF8E007E5B61 /* AutomaticThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F43D8F01DB5ADDC00108FB6 /* AutomaticThread.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC97E27A4BF8E007E5BC1 /* SequesteredAutomaticThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F43D8F01DB5ADDC00108FC6 /* SequesteredAutomaticThread.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC97F27A4BF8E007E5BC1 /* StackAllocation.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4730F151A825B004123CF /* StackAllocation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		DD3DC97E27A4BF8E007E5BD1 /* StackSwitch.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F43D8F01DB5ADDC00108FD6 /* StackSwitch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC97F27A4BF8E007E5B61 /* StackBounds.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4730F151A825B004123FF /* StackBounds.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC98027A4BF8E007E5B61 /* Stopwatch.h in Headers */ = {isa = PBXBuildFile; fileRef = C4F8A93619C65EB400B2B15D /* Stopwatch.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		DD3DC98127A4BF8E007E5B61 /* StdLibExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47311151A825B004123FF /* StdLibExtras.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -1128,6 +1130,8 @@
 		0F43D8F01DB5ADDC00108FB6 /* AutomaticThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AutomaticThread.h; sourceTree = "<group>"; };
 		0F43D8EF1DB5ADDC00108FC6 /* SequesteredAutomaticThread.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SequesteredAutomaticThread.cpp; sourceTree = "<group>"; };
 		0F43D8F01DB5ADDC00108FC6 /* SequesteredAutomaticThread.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SequesteredAutomaticThread.h; sourceTree = "<group>"; };
+		0F43D8EF1DB5ADDC00108FD6 /* StackSwitch.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StackSwitch.cpp; sourceTree = "<group>"; };
+		0F43D8F01DB5ADDC00108FD6 /* StackSwitch.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StackSwitch.h; sourceTree = "<group>"; };
 		0F4570421BE5B58F0062A629 /* Dominators.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Dominators.h; sourceTree = "<group>"; };
 		0F4570441BE834410062A629 /* BubbleSort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BubbleSort.h; sourceTree = "<group>"; };
 		0F4D8C711FC1E7CE001D32AC /* SinglyLinkedListWithTail.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SinglyLinkedListWithTail.h; sourceTree = "<group>"; };
@@ -2728,6 +2732,8 @@
 				0F9DAA051FD1C37B0079C5B2 /* StackShotProfiler.h */,
 				FEDACD3B1630F83F00C69634 /* StackStats.cpp */,
 				FEDACD3C1630F83F00C69634 /* StackStats.h */,
+				0F43D8EF1DB5ADDC00108FD6 /* StackSwitch.cpp */,
+				0F43D8F01DB5ADDC00108FD6 /* StackSwitch.h */,
 				313EDEC9778E49C9BEA91CFC /* StackTrace.cpp */,
 				EF7D6CD59D8642A8A0DA86AD /* StackTrace.h */,
 				FF3997402DB044E600A58E88 /* StatisticsManager.cpp */,
@@ -3874,6 +3880,7 @@
 				DD3DC8FE27A4BF8E007E5B61 /* StackShot.h in Headers */,
 				DD3DC8A127A4BF8E007E5B61 /* StackShotProfiler.h in Headers */,
 				DD3DC97A27A4BF8E007E5B61 /* StackStats.h in Headers */,
+				DD3DC97E27A4BF8E007E5BD1 /* StackSwitch.h in Headers */,
 				DD3DC99C27A4BF8E007E5B61 /* StackTrace.h in Headers */,
 				FF3997422DB044E600A58E88 /* StatisticsManager.h in Headers */,
 				DD3DC94827A4BF8E007E5B61 /* StdFilesystem.h in Headers */,
@@ -4576,6 +4583,7 @@
 				FE35D09227DC5ECC009DFA5B /* StackCheck.cpp in Sources */,
 				FEEA4DF9216D7BE400AC0602 /* StackPointer.cpp in Sources */,
 				FEDACD3D1630F83F00C69634 /* StackStats.cpp in Sources */,
+				0F43D8F11DB5ADDC00108FD6 /* StackSwitch.cpp in Sources */,
 				3337DB9CE743410FAF076E17 /* StackTrace.cpp in Sources */,
 				FF3997412DB044E600A58E88 /* StatisticsManager.cpp in Sources */,
 				0F95B63720CB5EFD00479635 /* StringBuffer.cpp in Sources */,

--- a/Source/WTF/wtf/AutomaticThread.cpp
+++ b/Source/WTF/wtf/AutomaticThread.cpp
@@ -174,9 +174,15 @@ void AutomaticThread::start(const AbstractLocker&)
         break;
     case StackAllocationSpecification::Kind::SizeAndLocation:
         RELEASE_ASSERT(!(reinterpret_cast<uintptr_t>(stackSpec.stackSpan().data()) % pageSize()));
-        [[fallthrough]];
+        RELEASE_ASSERT(!(stackSpec.effectiveSize() % pageSize()));
+        break;
     case StackAllocationSpecification::Kind::SizeOnly:
-        RELEASE_ASSERT(!(stackSpec.sizeBytes() % pageSize()));
+        RELEASE_ASSERT(!(stackSpec.osStackSize() % pageSize()));
+        break;
+    case StackAllocationSpecification::Kind::DeferredStack:
+        RELEASE_ASSERT(!(stackSpec.osStackSize() % pageSize()));
+        RELEASE_ASSERT(!(reinterpret_cast<uintptr_t>(stackSpec.stackSpan().data()) % pageSize()));
+        RELEASE_ASSERT(!(stackSpec.effectiveSize() % pageSize()));
         break;
     }
 

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -326,6 +326,7 @@ set(WTF_PUBLIC_HEADERS
     StackShot.h
     StackShotProfiler.h
     StackStats.h
+    StackSwitch.h
     StackTrace.h
     StatisticsManager.h
     StdFilesystem.h
@@ -611,6 +612,7 @@ set(WTF_SOURCES
     StackCheck.cpp
     StackPointer.cpp
     StackStats.cpp
+    StackSwitch.cpp
     StackTrace.cpp
     StatisticsManager.cpp
     StringPrintStream.cpp

--- a/Source/WTF/wtf/SequesteredAutomaticThread.cpp
+++ b/Source/WTF/wtf/SequesteredAutomaticThread.cpp
@@ -56,7 +56,7 @@ SequesteredAutomaticThread::~SequesteredAutomaticThread()
 
 StackAllocationSpecification SequesteredAutomaticThread::stackSpecification()
 {
-    return StackAllocationSpecification::CustomStack(m_stack.span());
+    return StackAllocationSpecification::DeferredStack(m_stack.span(), 1 * MB);
 }
 
 #endif // USE(PROTECTED_JIT_STACKS)

--- a/Source/WTF/wtf/StackBounds.h
+++ b/Source/WTF/wtf/StackBounds.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <algorithm>
+#include <wtf/StackAllocation.h>
 #include <wtf/StackPointer.h>
 #include <wtf/ThreadingPrimitives.h>
 
@@ -54,6 +55,15 @@ public:
 #endif
 
     static constexpr StackBounds emptyBounds() { return StackBounds(); }
+
+    static StackBounds fromCustomStack(const StackAllocationSpecification& spec)
+    {
+        using SpecKind = StackAllocationSpecification::Kind;
+        RELEASE_ASSERT(spec.kind() == SpecKind::DeferredStack || spec.kind() == SpecKind::SizeAndLocation);
+        void* bound = spec.stackSpan().data();
+        void* origin = spec.stackOrigin();
+        return { origin, bound };
+    }
 
 #if HAVE(STACK_BOUNDS_FOR_NEW_THREAD)
     // This function is only effective for newly created threads. In some platform, it returns a bogus value for the main thread.

--- a/Source/WTF/wtf/StackSwitch.cpp
+++ b/Source/WTF/wtf/StackSwitch.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <wtf/StackSwitch.h>
+
+#include <wtf/Assertions.h>
+#include <wtf/Compiler.h>
+#include <wtf/InlineASM.h>
+#include <wtf/Threading.h>
+
+namespace WTF {
+
+// C-linkage wrapper for Thread::entryPointFinishSetup so it can be called from assembly
+extern "C" void threadEntryPointFinishSetupWrapper(void* context);
+extern "C" void threadEntryPointFinishSetupWrapper(void* context)
+{
+    Thread::entryPointFinishSetup(context);
+}
+
+#if CPU(ARM64E)
+
+// Trampoline that switches from the OS-provided stack to a custom sequestered stack.
+// Parameters:
+//   x0 = context pointer (passed as argument to Thread::entryPointFinishSetup)
+//   x1 = new stack pointer (top of stack, since stacks grow down)
+//
+// This function:
+// 1. Saves callee-saved registers on the current (OS) stack
+// 2. Switches to the new stack
+// 3. Sets up the rest of its frame (saved sp, lr) on the new stack
+// 4. Calls Thread::entryPointFinishSetup
+// 5. When function returns, restores the OS stack and all saved registers
+// 6. Returns to the original caller
+__asm__(
+    ".text" "\n"
+    ".balign 16" "\n"
+    ".globl " SYMBOL_STRING(callThreadEntryPointFinishSetupWithNewStack) "\n"
+    SYMBOL_STRING(callThreadEntryPointFinishSetupWithNewStack) ":" "\n"
+
+    // Prologue
+    "pacibsp" "\n"
+    "stp x19, x20, [sp, #-16]!" "\n"
+    // Save away old sp in callee-saved x19
+    "mov x19, sp" "\n"
+
+    // Switch to new stack: x1 contains new stack pointer)
+    "mov sp, x1" "\n"
+    // Create a proper frame on the new stack
+    // This frame chains back to the OS stack frame
+    // of our caller
+    "stp x29, x30, [sp, #-16]!" "\n"
+    "mov x29, sp" "\n"
+
+    // Call Thread::entryPointFinishSetup
+    // x0 contains the context-pointer argument
+    "bl " SYMBOL_STRING(threadEntryPointFinishSetupWrapper) "\n"
+
+    // When function returns, restore OS stack from saved register
+    "mov sp, x19" "\n" // Restore sp for OS-stack from x19
+
+    // Unwind frame and return
+    "ldp x29, x30, [sp], #16" "\n"
+    "ldp x19, x20, [sp], #16" "\n"
+    "retab" "\n"
+
+    ".previous" "\n"
+);
+
+#else // !CPU(ARM64E)
+
+IGNORE_WARNINGS_BEGIN("missing-noreturn")
+extern "C" void callThreadEntryPointFinishSetupWithNewStack(void*, void*)
+{
+    RELEASE_ASSERT_NOT_REACHED();
+}
+IGNORE_WARNINGS_END
+
+#endif // CPU(ARM64E)
+
+} // namespace WTF

--- a/Source/WTF/wtf/StackSwitch.h
+++ b/Source/WTF/wtf/StackSwitch.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/Assertions.h>
+#include <wtf/ExportMacros.h>
+#include <wtf/Platform.h>
+
+extern "C" {
+
+// Switches from the current stack to a new stack and calls Thread::entryPointFinishSetup.
+// This is used to "teleport" to a sequestered stack after thread startup.
+//
+// Parameters:
+//   newStack: Pointer to the top of the new stack (stacks grow down)
+//   context: Pointer passed as the first argument to Thread::entryPointFinishSetup
+//
+// When the function returns, this function restores the original stack
+// and returns to the caller.
+WTF_EXPORT_PRIVATE void callThreadEntryPointFinishSetupWithNewStack(void* context, void* newStack);
+
+}

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -28,11 +28,14 @@
 
 #include <bmalloc/BPlatform.h>
 #include <cstring>
+#include <wtf/Assertions.h>
 #include <wtf/DateMath.h>
 #include <wtf/Gigacage.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/PrintStream.h>
 #include <wtf/RunLoop.h>
+#include <wtf/StackAllocation.h>
+#include <wtf/StackSwitch.h>
 #include <wtf/ThreadGroup.h>
 #include <wtf/ThreadingPrimitives.h>
 #include <wtf/WTFConfig.h>
@@ -149,10 +152,11 @@ uint32_t ThreadLike::currentSequence()
 
 struct Thread::NewThreadContext : public ThreadSafeRefCounted<NewThreadContext> {
 public:
-    NewThreadContext(ASCIILiteral name, Function<void()>&& entryPoint, Ref<Thread>&& thread)
+    NewThreadContext(ASCIILiteral name, Function<void()>&& entryPoint, Ref<Thread>&& thread, StackAllocationSpecification spec)
         : name(name)
         , entryPoint(WTF::move(entryPoint))
         , thread(WTF::move(thread))
+        , stackSpec(spec)
     {
     }
 
@@ -162,6 +166,7 @@ public:
     Function<void()> entryPoint;
     Ref<Thread> thread;
     Mutex mutex;
+    StackAllocationSpecification stackSpec;
 
 #if !HAVE(STACK_BOUNDS_FOR_NEW_THREAD)
     ThreadCondition condition;
@@ -228,10 +233,32 @@ void Thread::initializeInThread()
 
 void Thread::entryPoint(NewThreadContext* newThreadContext)
 {
+    SUPPRESS_UNCOUNTED_LOCAL std::optional<void*> stackSwitchTarget { };
+    {
+        MutexLocker locker(newThreadContext->mutex);
+        if (newThreadContext->stackSpec.kind() == StackAllocationSpecification::Kind::DeferredStack) {
+            // The OS-provided stack we start on is not our 'target work stack';
+            // we need to hop over to it ourselves during initialization.
+            stackSwitchTarget = newThreadContext->stackSpec.stackOrigin();
+            RELEASE_ASSERT(*stackSwitchTarget);
+        }
+        // It's OK for us to let go of the lock between here and the next function
+        // call, as our choice of actions here should be transparent to
+        // entryPointFinishSetup either way
+    }
+
+    if (stackSwitchTarget)
+        callThreadEntryPointFinishSetupWithNewStack(newThreadContext, *stackSwitchTarget);
+    else
+        entryPointFinishSetup(newThreadContext);
+}
+
+void Thread::entryPointFinishSetup(void* newThreadContext)
+{
     Function<void()> function;
     {
         // Ref is already incremented by Thread::create.
-        Ref context = adoptRef(*newThreadContext);
+        Ref context = adoptRef(*static_cast<NewThreadContext*>(newThreadContext));
         // Block until our creating thread has completed any extra setup work, including establishing ThreadIdentifier.
         MutexLocker locker(context->mutex);
 
@@ -264,7 +291,7 @@ Ref<Thread> Thread::create(ASCIILiteral name, Function<void()>&& entryPoint, Thr
 
     Ref thread = adoptRef(*new Thread(schedulingPolicy));
 
-    Ref context = adoptRef(*new NewThreadContext { name, WTF::move(entryPoint), thread.get() });
+    Ref context = adoptRef(*new NewThreadContext { name, WTF::move(entryPoint), thread.get(), stackSpec });
     {
         MutexLocker locker(context->mutex);
         context->ref(); // Adopted by Thread::entryPoint
@@ -276,20 +303,31 @@ Ref<Thread> Thread::create(ASCIILiteral name, Function<void()>&& entryPoint, Thr
         bool success = thread->establishHandle(context.get(), stackSpec, qos, schedulingPolicy);
         RELEASE_ASSERT(success);
 
+        // If the thread is using a deferred stack, then the OS stack
+        // that newThreadStackBounds will give us is not the stack that the
+        // thread will actually spend most of its time executing on.
+        // In this case, we provide the bounds manually, with the knowledge that
+        // they will become correct once the thread transitions through the
+        // stack-switching trampoline.
+        if (stackSpec.kind() == StackAllocationSpecification::Kind::DeferredStack) {
+            thread->m_stack = StackBounds::fromCustomStack(stackSpec);
+            thread->m_savedLastStackTop = thread->stack().origin();
+        } else {
 #if HAVE(STACK_BOUNDS_FOR_NEW_THREAD)
-        thread->m_stack = StackBounds::newThreadStackBounds(thread->m_handle);
-        thread->m_savedLastStackTop = thread->stack().origin();
-        allThreads().add(thread.get()); // Must have stack bounds before adding to allThreads()
+            thread->m_stack = StackBounds::newThreadStackBounds(thread->m_handle);
+            thread->m_savedLastStackTop = thread->stack().origin();
+            allThreads().add(thread.get()); // Must have stack bounds before adding to allThreads()
 #else
-        // In platforms which do not support StackBounds::newThreadStackBounds(), we do not have a way to get stack
-        // bounds outside the target thread itself. Thus, we need to initialize thread information in the target thread
-        // and wait for completion of initialization in the caller side.
-        context->stage = NewThreadContext::Stage::EstablishedHandle;
-        while (context->stage != NewThreadContext::Stage::Initialized)
-            context->condition.wait(context->mutex);
+            // In platforms which do not support StackBounds::newThreadStackBounds(), we do not have a way to get stack
+            // bounds outside the target thread itself. Thus, we need to initialize thread information in the target thread
+            // and wait for completion of initialization in the caller side.
+            context->stage = NewThreadContext::Stage::EstablishedHandle;
+            while (context->stage != NewThreadContext::Stage::Initialized)
+                context->condition.wait(context->mutex);
 
-        // Thread::entryPoint initializes thread->m_stack and thread->m_savedLastStackTop and adds to allThreads().
+            // Thread::entryPointFinishSetup initializes thread->m_stack and thread->m_savedLastStackTop and adds to allThreads().
 #endif
+        }
     }
 
     return thread;

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -310,6 +310,7 @@ public:
 
     struct NewThreadContext;
     static void entryPoint(NewThreadContext*);
+    static void entryPointFinishSetup(void*);
     ThreadLikeAssertion threadLikeAssertion() const { return createThreadLikeAssertion(m_uid); }
 
     // Returns nullptr if thread-specific storage was not initialized.

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -319,7 +319,10 @@ bool Thread::establishHandle(NewThreadContext& context, StackAllocationSpecifica
     case StackAllocationSpecification::Kind::Default:
         break;
     case StackAllocationSpecification::Kind::SizeOnly:
-        pthread_attr_setstacksize(&attr, stackSpec.sizeBytes());
+        pthread_attr_setstacksize(&attr, stackSpec.osStackSize());
+        break;
+    case StackAllocationSpecification::Kind::DeferredStack:
+        pthread_attr_setstacksize(&attr, stackSpec.osStackSize());
         break;
     case StackAllocationSpecification::Kind::SizeAndLocation: {
         auto bounds = stackSpec.stackSpan();

--- a/Source/WTF/wtf/win/ThreadingWin.cpp
+++ b/Source/WTF/wtf/win/ThreadingWin.cpp
@@ -150,10 +150,11 @@ static unsigned __stdcall wtfThreadEntryPoint(void* data)
 bool Thread::establishHandle(NewThreadContext& data, StackAllocationSpecification stackSpec, QOS, SchedulingPolicy)
 {
     RELEASE_ASSERT(stackSpec.kind() != StackAllocationSpecification::Kind::SizeAndLocation && "Custom stacks not supported on windows");
+    RELEASE_ASSERT(stackSpec.kind() != StackAllocationSpecification::Kind::DeferredStack && "Deferred stacks not supported on windows");
     unsigned threadIdentifier = 0;
     size_t stackSize = 0;
     if (stackSpec.kind() == StackAllocationSpecification::Kind::SizeOnly)
-        stackSize = stackSpec.sizeBytes();
+        stackSize = stackSpec.osStackSize();
     unsigned initFlag = stackSize ? STACK_SIZE_PARAM_IS_A_RESERVATION : 0;
     HANDLE threadHandle = reinterpret_cast<HANDLE>(_beginthreadex(nullptr, stackSize, wtfThreadEntryPoint, &data, initFlag, &threadIdentifier));
     if (!threadHandle) {


### PR DESCRIPTION
#### 6d5322b005e5142df554852db841c860ca447b71
<pre>
[WTF] Switch to SequesteredStack via new DeferredStack mechanism
<a href="https://bugs.webkit.org/show_bug.cgi?id=307825">https://bugs.webkit.org/show_bug.cgi?id=307825</a>
<a href="https://rdar.apple.com/170333133">rdar://170333133</a>

Reviewed by Mark Lam.

It is desirable to be able to create threads whose backing stack-memory
is guarded by special memory protections. However, as we are doing this
wholly in userspace, the OS does not know to expect anything different
about the stack we pass to pthread_attr_setstack: this means that a call
to pthread_create using such a stack will necessarily fail, as the OS
does not engage the proper memory-access permissions prior to setting up
the new thread&apos;s stack.
So, what we instead want to do is be able to start a WTF::Thread with
one stack (provided by the OS, without special memory protections), then
&apos;teleport&apos; to the new protected stack via a trampoline.

What this patch does is add a new Kind to StackAllocationSpecification
which provides both a size (for the native OS stack -- we want this to
be small, as it&apos;s not going to be used for very much) and an allocation
(for the &apos;deferred&apos; stack that will be switched to during
initialization). It then makes SequesteredAutomaticThreads use this
mechanism for their protected stack.

In a subsequent patch, we will add the code to protect the special stack
and engage the proper memory protections prior to calling the
trampoline.

Canonical link: <a href="https://commits.webkit.org/307676@main">https://commits.webkit.org/307676@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9fc821379cd7c952497f2b084b6dbdb54a0b85d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145092 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153763 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18256 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111569 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98728 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78062f38-9a49-492c-94ab-00cb3f53e68a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148055 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13927 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130328 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92467 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13295 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11055 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1208 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137083 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122815 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156075 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5901 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17624 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8173 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119573 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14710 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119903 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30761 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15689 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128343 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73288 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17245 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6602 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176381 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16981 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81024 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45372 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17045 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->