### PR TITLE
[scroll-animations] WPT test `scroll-timelines/animation-with-transform.html` fails

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6355,9 +6355,6 @@ fast/repaint/absolute-position-changed.html [ Pass ImageOnlyFailure ]
 webkit.org/b/307272 fast/events/no-scroll-on-input-text-selection.html [ Failure ]
 webkit.org/b/307273 imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-default-iframe.html [ ImageOnlyFailure ]
 webkit.org/b/307519 imported/w3c/web-platform-tests/css/css-anchor-position/position-area-scrolling-004.tentative.html [ ImageOnlyFailure ]
-webkit.org/b/307785 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform.html [ ImageOnlyFailure ]
-webkit.org/b/307786 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one.html [ ImageOnlyFailure ]
-webkit.org/b/307787 imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline.html [ ImageOnlyFailure ]
 
 # affected by scroll anchoring.
 http/tests/site-isolation/mouse-events/scrolled-mainframe.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-ref.html
@@ -17,7 +17,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-animatable-interface-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-animatable-interface-expected.html
@@ -17,7 +17,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-animatable-interface.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-animatable-interface.html
@@ -22,7 +22,7 @@ interface">
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform;

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-display-none-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-display-none-expected.html
@@ -17,7 +17,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-display-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-display-none.html
@@ -21,7 +21,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform-expected.html
@@ -17,7 +17,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-changes-on-percentage-based-timeline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-changes-on-percentage-based-timeline-expected.html
@@ -17,7 +17,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-changes-on-percentage-based-timeline.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-changes-on-percentage-based-timeline.html
@@ -23,7 +23,7 @@ layout changes on percentage-based scroll offset">
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform;

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/set-current-time-before-play-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/set-current-time-before-play-expected.html
@@ -17,7 +17,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/set-current-time-before-play.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/set-current-time-before-play.html
@@ -21,7 +21,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one-expected.html
@@ -17,7 +17,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-expected.html
@@ -17,7 +17,7 @@
   }
 
   #scroller {
-    overflow: auto;
+    overflow: hidden;
     height: 100px;
     width: 100px;
     will-change: transform; /* force compositing */


### PR DESCRIPTION
#### e02eb7442f8f045fb0528d8418beea112431c36e
<pre>
[scroll-animations] WPT test `scroll-timelines/animation-with-transform.html` fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=307785">https://bugs.webkit.org/show_bug.cgi?id=307785</a>
<a href="https://rdar.apple.com/170309071">rdar://170309071</a>

Reviewed by Tim Nguyen.

Ensure all tests use `overflow: hidden` to avoid scrollbars, and their shared reference as well.
This also addresses bugs 307786 and 307787.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-animatable-interface-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-animatable-interface.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-display-none-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-display-none.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/animation-with-transform-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-changes-on-percentage-based-timeline-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/layout-changes-on-percentage-based-timeline.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/set-current-time-before-play-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/set-current-time-before-play.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-cancel-one-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/scroll-timelines/two-animations-attach-to-same-scroll-timeline-expected.html:

Canonical link: <a href="https://commits.webkit.org/307562@main">https://commits.webkit.org/307562@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9848dab356bbcb4d018b2436586fd4b2d80993bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144588 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17267 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8851 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98223 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17161 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111201 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12ded9f2-2e36-44ae-a773-22a98199d368) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13573 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129837 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92096 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/12950 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10705 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/704 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122463 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155571 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17119 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7600 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119204 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17157 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14330 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119541 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15361 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72660 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22336 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16741 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6144 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16477 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16686 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16541 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->