### PR TITLE
Enhanced <select>: only slot <button> if it's the first element child

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-parsing-expected.txt
@@ -1,4 +1,4 @@
-button  button
+  button
 
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-expected.txt
@@ -1,6 +1,6 @@
 new span two
  two two
-  two
+
 
 FAIL The <selectedcontent> element should reflect the HTML contents of the selected <option>. assert_equals: The innerHTML of <selectedcontent> should be updated in response to a form reset. expected "\n      <span class=\"one\">span</span> one\n    " but got "\n      <span class=\"two\" data-foo=\"bar\">new span</span> two\n    "
 FAIL When there are multiple <selectedcontent> elements, only the one in tree order should be kept up to date. assert_equals: Second selectedcontent should not be kept up to date. expected "" but got "two"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-mutations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-mutations-expected.txt
@@ -10,8 +10,6 @@
       two
 
 
-      option
-
 
 
       one

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt
@@ -1,4 +1,4 @@
-Dolphin
+
 
 FAIL In dialog mode the first focusable element should get focus. assert_equals: The anchor should be focused. expected Element node <a id="interactive1" href="https://www.example.com/">Elep... but got Element node <select id="target">
   <div></div>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-mutations-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/selectedcontent-mutations-expected.txt
@@ -10,8 +10,6 @@
       two
 
 
-      option
-
 
 
 

--- a/Source/WebCore/css/popover.css
+++ b/Source/WebCore/css/popover.css
@@ -11,16 +11,16 @@ dialog:popover-open {
 
 [popover] {
     position: fixed;
-    inset: 0;
     width: fit-content;
     height: fit-content;
-    margin: auto;
-    border: solid;
-    padding: 0.25em;
     overflow: auto;
 }
 
 [popover]:not(:-internal-select-popover) {
+    inset: 0;
+    margin: auto;
+    border: solid;
+    padding: 0.25em;
     color: CanvasText;
     background-color: Canvas;
 }

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -95,6 +95,11 @@ static const AtomString& buttonSlotName()
     return buttonSlot;
 }
 
+static bool isFirstElementChildButton(const Node& child)
+{
+    return is<HTMLButtonElement>(child) && !child.previousElementSibling();
+}
+
 class SelectSlotAssignment final : public NamedSlotAssignment {
 private:
     void hostChildElementDidChange(const Element&, ShadowRoot&) final;
@@ -113,13 +118,7 @@ void SelectSlotAssignment::hostChildElementDidChange(const Element& childElement
 
 const AtomString& SelectSlotAssignment::slotNameForHostChild(const Node& child) const
 {
-    // The first button child gets assigned to the button slot.
-    if (is<HTMLButtonElement>(child)) {
-        Ref select = downcast<HTMLSelectElement>(*child.parentNode());
-        if (&child == childrenOfType<HTMLButtonElement>(select).first())
-            return buttonSlotName();
-    }
-    return NamedSlotAssignment::defaultSlotName();
+    return isFirstElementChildButton(child) ? buttonSlotName() : NamedSlotAssignment::defaultSlotName();
 }
 
 // https://html.spec.whatwg.org/#dom-htmloptionscollection-length
@@ -508,7 +507,7 @@ bool HTMLSelectElement::childShouldCreateRenderer(const Node& child) const
         return is<HTMLOptionElement>(child) || is<HTMLOptGroupElement>(child) || validationMessageShadowTreeContains(child);
     if (child.isInShadowTree() && child.containingShadowRoot() == userAgentShadowRoot())
         return true;
-    if (is<HTMLButtonElement>(child) && &child == childrenOfType<HTMLButtonElement>(*this).first())
+    if (isFirstElementChildButton(child))
         return true;
     if (usesBaseAppearancePicker())
         return true;


### PR DESCRIPTION
#### 4d1e4f70bb1ea5af0a2960c650cf0473191c1990
<pre>
Enhanced &lt;select&gt;: only slot &lt;button&gt; if it&apos;s the first element child
<a href="https://bugs.webkit.org/show_bug.cgi?id=307828">https://bugs.webkit.org/show_bug.cgi?id=307828</a>

Reviewed by Tim Nguyen.

This is what the specification requires and what Chrome implements.

Together with moving some conflicting styles in popover.css this brings
html/semantics/forms/the-select-element/customizable-select/select-second-child-button.html
very close to passing. It still needs option::checkmark (bug 305894)
and a slight sizing tweak.

Canonical link: <a href="https://commits.webkit.org/307582@main">https://commits.webkit.org/307582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9659d1eea96cd1c3f6e2f989473daee7091c16a8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144781 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153452 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab4f39a4-d1fe-4aca-8d21-c797c3cc9f55) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146656 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17943 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111321 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98416 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4658047-fe8e-4dad-b98c-00840a901211) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13688 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92216 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db624d3a-61c5-4de3-8c6d-3329f9e0d032) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13061 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10815 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/897 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122576 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6684 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155764 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17312 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7764 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119325 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17359 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14457 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119653 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15463 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72854 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22345 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16934 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6279 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16670 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80713 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16879 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16734 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->