### PR TITLE
[Site Isolation] Back navigation fails when page contains iframe that navigated cross-site

### DIFF
--- a/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/back-iframe-popup.html
@@ -13,6 +13,7 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
         'navigate-to-page2': () => navigateIframeTo("back-iframe-2.html"),
+        'navigate-to-page2-cross-site-iframe': () => navigateIframeTo(crossSiteUrl("back-iframe-2.html")),
         'navigate-to-other': () => navigateTo("back-iframe-other.html"),
         back2: () => history.back(),
     },

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html
@@ -4,7 +4,7 @@
 <script src="navigation-utils.js"></script>
 <script>
 
-const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+const page = location.hostname === loopbackAddress ? "samesite" : "crosssite";
 
 window.onload = () => sendMessageToTop("load");
 window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
@@ -13,8 +13,5 @@ window.onpageshow = ()=> sendMessageToTop("pageshow", event.persisted ? "persist
 </head>
 <body>
 <h1>Iframe Page</h1>
-<script>
-document.getElementById("host").textContent = location.hostname + ":" + location.port;
-</script>
 </body>
 </html>

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html
@@ -12,7 +12,7 @@ window.onpageshow = ()=> sendMessageToOpener("pageshow", event.persisted ? "pers
 
 window.onmessage = (event) => dispatchMessage(event.data, {
     opener: {
-        'navigate-to-cross-site': () => navigateIframeTo(`http://${crossSiteHostname}:8000/navigation/resources/cross-site-iframe-nav-page.html`),
+        'navigate-to-cross-site': () => navigateIframeTo(crossSiteUrl('cross-site-iframe-nav-page.html')),
         'navigate-to-other': () => navigateTo("cross-site-iframe-nav-other.html"),
         back2: () => history.back(),
     },

--- a/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
+++ b/LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html
@@ -4,7 +4,7 @@
 <script src="navigation-utils.js"></script>
 <script>
 
-const page = location.hostname === sameSiteHostname ? "samesite" : "crosssite";
+const page = location.hostname === loopbackAddress ? "samesite" : "crosssite";
 
 window.onload = () => sendMessageToTop("load");
 window.onpageshow = () => sendMessageToTop("pageshow", event.persisted ? "persisted" : "not-persisted");
@@ -13,9 +13,5 @@ window.onpageshow = () => sendMessageToTop("pageshow", event.persisted ? "persis
 </head>
 <body>
 <h1>Iframe Page</h1>
-<p id="host"></p>
-<script>
-document.getElementById("host").textContent = location.hostname + ":" + location.port;
-</script>
 </body>
 </html>

--- a/LayoutTests/http/tests/navigation/resources/navigation-utils.js
+++ b/LayoutTests/http/tests/navigation/resources/navigation-utils.js
@@ -1,5 +1,10 @@
-const sameSiteHostname = "127.0.0.1";
-const crossSiteHostname = "localhost";
+const hostname = location.hostname;
+
+const localhost = "localhost";
+const loopbackAddress = "127.0.0.1";
+
+const sameSiteHostname = hostname;
+const crossSiteHostname = hostname === localhost ? loopbackAddress : localhost;
 
 /* `page` must be defined in embedding HTML files */
 function makeMessage(action, arg = "") {
@@ -90,4 +95,10 @@ function navigateTo(url) {
 
 function navigateIframeTo(url) {
     iframeContentWindow().location.href = url;
+}
+
+function crossSiteUrl(path) {
+    const url = new URL(path, location.href);
+    url.hostname = crossSiteHostname;
+    return url.href;
 }

--- a/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache-expected.txt
@@ -1,0 +1,21 @@
+Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Page1 loaded
+Page1 displayed first time.
+Page2 loaded
+Page2 displayed first time.
+Other page loaded
+Other page displayed.
+Page2 loaded
+PASS Page2 displayed twice.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Open a new window with back-iframe-popup.html. It has an same-site iframe with page1 loaded initially.
+Navigate iframe to cross-site page2.
+Navigate main frame to other (same-site).
+Go back. (back-iframe-popup.html with iframe showing cross-site page2)
+... and ensures the nested iframe content is correctly restored to page2.

--- a/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html
+++ b/LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html
@@ -1,0 +1,93 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true UsesBackForwardCache=false dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/navigation/resources/navigation-utils.js"></script>
+<script>
+
+description("Nested iframe history navigation works correctly with cross-site iframe when back/forward cache is disabled.");
+jsTestIsAsync = true;
+
+const page = "opener";
+var popup = null;
+
+window.onload = function() {
+    popup = window.open("/navigation/resources/back-iframe-popup.html");
+}
+
+var page1ShowCount = 0;
+var page2ShowCount = 0;
+
+window.onmessage = (event) => dispatchMessage(event.data, {
+    popup: {
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Popup should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+        },
+    },
+    page1: {
+        load: () => debug("Page1 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page1 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page1ShowCount++;
+            if (page1ShowCount == 1) {
+                debug("Page1 displayed first time.");
+                sendMessageToPopup("navigate-to-page2-cross-site-iframe");
+            } else {
+                testFailed("Page1 should be displayed only once.");
+                finishJSTest();
+            }
+        }
+    },
+    page2: {
+        load: () => debug("Page2 loaded"),
+        pageshow: ({arg}) => {
+            if (arg !== "not-persisted") {
+                testFailed("Page2 should not be loaded from back/forward cache.");
+                finishJSTest();
+                return;
+            }
+
+            page2ShowCount++;
+            if (page2ShowCount == 1) {
+                debug("Page2 displayed first time.");
+                sendMessageToPopup("navigate-to-other");
+            } else if (page2ShowCount == 2) {
+                testPassed("Page2 displayed twice.");
+                finishJSTest();
+            } else {
+                testFailed("Page2 should be displayed only twice.");
+                finishJSTest();
+            }
+        }
+    },
+    other: {
+        load: () => debug("Other page loaded"),
+        pageshow: ({arg}) => {
+            debug("Other page displayed.");
+            sendMessageToPopup("back1");
+        }
+    },
+});
+
+</script>
+</head>
+<body>
+<ul>
+    <li>Open a new window with back-iframe-popup.html. It has an same-site iframe with page1 loaded initially.</li>
+    <li>Navigate iframe to cross-site page2.</li>
+    <li>Navigate main frame to other (same-site).</li>
+    <li>Go back. (back-iframe-popup.html with iframe showing cross-site page2)</li>
+</ul>
+<p>... and ensures the nested iframe content is correctly restored to page2.</p>
+</body>
+</html>

--- a/Source/WebCore/history/HistoryItem.cpp
+++ b/Source/WebCore/history/HistoryItem.cpp
@@ -353,6 +353,14 @@ HistoryItem* HistoryItem::childItemWithDocumentSequenceNumber(long long number)
     return nullptr;
 }
 
+HistoryItem* HistoryItem::childItemForFrame(LocalFrame& frame)
+{
+    if (auto index = frame.indexInFrameTreeSiblings(); index && index.value() < m_children.size())
+        return m_children[*index].ptr();
+
+    return nullptr;
+}
+
 const Vector<Ref<HistoryItem>>& HistoryItem::children() const
 {
     return m_children;

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -164,6 +164,7 @@ public:
     WEBCORE_EXPORT HistoryItem* NODELETE childItemWithTarget(const AtomString&);
     WEBCORE_EXPORT HistoryItem* NODELETE childItemWithFrameID(FrameIdentifier);
     HistoryItem* NODELETE childItemWithDocumentSequenceNumber(long long number);
+    HistoryItem* NODELETE childItemForFrame(LocalFrame&);
     WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& NODELETE children() const;
     void clearChildren();
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1087,11 +1087,33 @@ void FrameLoader::loadURLIntoChildFrame(const URL& url, const String& referer, L
         }
     }
 
+    URL childURL { url };
+    // FIXME: This is a workaround for https://webkit.org/b/307121
+    // This logic should replace the above load once UIProcess-driven subframe loading is implemented.
+    if (m_frame->settings().siteIsolationEnabled()) {
+        if (parentItem && isBackForwardLoadType(loadType()) && !m_frame->document()->loadEventFinished()) {
+            if (RefPtr childItem = parentItem->childItemForFrame(childFrame)) {
+                // During session restoration, the child frame should be loaded normally through
+                // the frame tree restoration rather than using the history restoration path.
+                if (!childItem->wasRestoredFromSession()) {
+                    Ref childLoader = childFrame.loader();
+                    childItem->setFrameID(childFrame.frameID());
+                    childLoader->m_requestedHistoryItem = childItem;
+                    childLoader->loadDifferentDocumentItem(*childItem, nullptr, loadType(), MayAttemptCacheOnlyLoadForFormSubmissionItem, ShouldTreatAsContinuingLoad::No);
+                    return;
+                }
+
+                childItem->setWasRestoredFromSession(false);
+                childURL = URL { childItem->urlString() };
+            }
+        }
+    }
+
     RefPtr lexicalFrame = lexicalFrameFromCommonVM();
     auto initiatedByMainFrame = lexicalFrame && lexicalFrame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
 
     RefPtr document = m_frame->document();
-    FrameLoadRequest frameLoadRequest { *document, document->securityOrigin(), { URL { url } }, selfTargetFrameName(), initiatedByMainFrame };
+    FrameLoadRequest frameLoadRequest { *document, document->securityOrigin(), { WTF::move(childURL) }, selfTargetFrameName(), initiatedByMainFrame };
     frameLoadRequest.setNewFrameOpenerPolicy(NewFrameOpenerPolicy::Suppress);
     frameLoadRequest.setLockBackForwardList(LockBackForwardList::Yes);
     frameLoadRequest.setIsInitialFrameSrcLoad(true);


### PR DESCRIPTION
#### aadc37a040f63d24cb16f385c1fb774ed01030c3
<pre>
[Site Isolation] Back navigation fails when page contains iframe that navigated cross-site
<a href="https://bugs.webkit.org/show_bug.cgi?id=307121">https://bugs.webkit.org/show_bug.cgi?id=307121</a>
<a href="https://rdar.apple.com/169754535">rdar://169754535</a>

Reviewed by NOBODY (OOPS!).

When performing back navigation on a page containing an iframe that navigated cross-site,
the iframe content was incorrectly displayed.

The original code relied solely on matching frames by their uniqueName using childItemWithTarget().
When an iframe navigates cross-site, target name is not preserved across process boundaries,
causing the lookup to fail. This results in the history restoration logic falling back to the
initial page&apos;s content instead of the navigated page.

The fix implements a fallback lookup strategy using the frame&apos;s index in the frame tree when
name-based lookup fails. To minimize impact on existing behavior, the fix is only active when
Site Isolation is enabled, and only affects the specific case where a child history item exists
for the navigating frame. The fix also properly handles session restoration to avoid interfering
with the normal frame tree restoration process.

Test: http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html

* LayoutTests/http/tests/navigation/resources/back-iframe-popup.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-page.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-popup.html:
* LayoutTests/http/tests/navigation/resources/cross-site-iframe-nav-with-bfcache-page.html:
* LayoutTests/http/tests/navigation/resources/navigation-utils.js:
(crossSiteUrl):
* LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/navigation/back-iframe-cross-site-no-bf-cache.html: Added.
* Source/WebCore/history/HistoryItem.cpp:
(WebCore::HistoryItem::childItemForFrame):
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadURLIntoChildFrame):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aadc37a040f63d24cb16f385c1fb774ed01030c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146572 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155235 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99962 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148447 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19149 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112937 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80657 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9dc5653d-ae8f-406c-bee9-359c99f3d74a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149535 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93683 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1315f246-d3e3-497d-995c-b7c1bb27bfbc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14428 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12199 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2679 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124007 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9567 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157560 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/710 "Found 1 new failure in history/HistoryItem.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11001 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120946 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19048 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16004 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121150 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131319 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74863 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16788 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8229 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18667 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82417 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18397 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18547 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18455 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->