### PR TITLE
[Cocoa] Adopt -[BECapability screenCaptureWithEnvironment:]

### DIFF
--- a/Source/WebKit/Configurations/AllowedSPI.toml
+++ b/Source/WebKit/Configurations/AllowedSPI.toml
@@ -606,3 +606,10 @@ selectors = [
     { name = "_setUseVisionAlternateScrollIndicatorRendering:", class = "UIScrollView" },
 ]
 requires = ["PLATFORM_VISION"]
+
+ [[staging]]
+request = "rdar://170178645"
+selectors = [
+    { name = "screenCaptureWithEnvironment:", class = "BEProcessCapability" },
+]
+requires = ["ENABLE_EXTENSION_CAPABILITIES"]

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -238,9 +238,9 @@ private:
 #if ENABLE(EXTENSION_CAPABILITIES)
     bool setCurrentMediaEnvironment(WebCore::PageIdentifier pageIdentifier) final
     {
-        auto mediaEnvironment = m_process.get()->mediaEnvironment(pageIdentifier);
-        bool result = !mediaEnvironment.isEmpty();
-        WebCore::RealtimeMediaSourceCenter::singleton().setCurrentMediaEnvironment(WTF::move(mediaEnvironment));
+        auto mediaPlaybackEnvironment = m_process.get()->mediaPlaybackEnvironment(pageIdentifier);
+        bool result = !mediaPlaybackEnvironment.isEmpty();
+        WebCore::RealtimeMediaSourceCenter::singleton().setCurrentMediaEnvironment(WTF::move(mediaPlaybackEnvironment));
         return result;
     }
 #endif

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h
@@ -263,8 +263,10 @@ public:
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    String mediaEnvironment(WebCore::PageIdentifier);
-    void setMediaEnvironment(WebCore::PageIdentifier, const String&);
+    String mediaPlaybackEnvironment(WebCore::PageIdentifier);
+    void setMediaPlaybackEnvironment(WebCore::PageIdentifier, const String&);
+    String displayCaptureEnvironment(WebCore::PageIdentifier);
+    void setDisplayCaptureEnvironment(WebCore::PageIdentifier, const String&);
 #endif
 
 #if ENABLE(IPC_TESTING_API)
@@ -450,7 +452,8 @@ private:
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    HashMap<WebCore::PageIdentifier, String> m_mediaEnvironments;
+    HashMap<WebCore::PageIdentifier, String> m_mediaPlaybackEnvironments;
+    HashMap<WebCore::PageIdentifier, String> m_displayCaptureEnvironments;
 #endif
 
 #if ENABLE(ROUTING_ARBITRATION) && HAVE(AVAUDIO_ROUTING_ARBITER)

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in
@@ -67,7 +67,8 @@ messages -> GPUConnectionToWebProcess WantsDispatchMessage {
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    SetMediaEnvironment(WebCore::PageIdentifier pageIdentifier, String mediaEnvironment);
+    SetMediaPlaybackEnvironment(WebCore::PageIdentifier pageIdentifier, String environment);
+    SetDisplayCaptureEnvironment(WebCore::PageIdentifier pageIdentifier, String environment);
 #endif
 
 #if ENABLE(IPC_TESTING_API)

--- a/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
+++ b/Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm
@@ -111,17 +111,30 @@ void GPUConnectionToWebProcess::setTCCIdentity()
 #endif // ENABLE(APP_PRIVACY_REPORT)
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-String GPUConnectionToWebProcess::mediaEnvironment(WebCore::PageIdentifier pageIdentifier)
+String GPUConnectionToWebProcess::mediaPlaybackEnvironment(WebCore::PageIdentifier pageIdentifier)
 {
-    return m_mediaEnvironments.get(pageIdentifier);
+    return m_mediaPlaybackEnvironments.get(pageIdentifier);
 }
 
-void GPUConnectionToWebProcess::setMediaEnvironment(WebCore::PageIdentifier pageIdentifier, const String& mediaEnvironment)
+void GPUConnectionToWebProcess::setMediaPlaybackEnvironment(WebCore::PageIdentifier pageIdentifier, const String& mediaPlaybackEnvironment)
 {
-    if (mediaEnvironment.isEmpty())
-        m_mediaEnvironments.remove(pageIdentifier);
+    if (mediaPlaybackEnvironment.isEmpty())
+        m_mediaPlaybackEnvironments.remove(pageIdentifier);
     else
-        m_mediaEnvironments.set(pageIdentifier, mediaEnvironment);
+        m_mediaPlaybackEnvironments.set(pageIdentifier, mediaPlaybackEnvironment);
+}
+
+String GPUConnectionToWebProcess::displayCaptureEnvironment(WebCore::PageIdentifier pageIdentifier)
+{
+    return m_displayCaptureEnvironments.get(pageIdentifier);
+}
+
+void GPUConnectionToWebProcess::setDisplayCaptureEnvironment(WebCore::PageIdentifier pageIdentifier, const String& displayCaptureEnvironment)
+{
+    if (displayCaptureEnvironment.isEmpty())
+        m_displayCaptureEnvironments.remove(pageIdentifier);
+    else
+        m_displayCaptureEnvironments.set(pageIdentifier, displayCaptureEnvironment);
 }
 #endif
 

--- a/Source/WebKit/Platform/cocoa/MediaCapability.h
+++ b/Source/WebKit/Platform/cocoa/MediaCapability.h
@@ -47,7 +47,15 @@ class ExtensionCapabilityGrant;
 class MediaCapability final : public ExtensionCapability, public RefCountedAndCanMakeWeakPtr<MediaCapability> {
     WTF_MAKE_NONCOPYABLE(MediaCapability);
 public:
-    static Ref<MediaCapability> create(URL&&);
+    enum class Kind : uint8_t {
+        MediaPlayback,
+        CameraAndMicCapture,
+        DisplayCapture,
+    };
+
+    static Ref<MediaCapability> create(URL&&, Kind);
+
+    Kind kind() const { return m_kind; }
 
     enum class State : uint8_t {
         Inactive,
@@ -68,10 +76,11 @@ public:
     BEMediaEnvironment *platformMediaEnvironment() const { return m_mediaEnvironment.get(); }
 
 private:
-    explicit MediaCapability(URL&&);
+    explicit MediaCapability(URL&&, Kind);
 
-    State m_state { State::Inactive };
     URL m_webPageURL;
+    Kind m_kind;
+    State m_state { State::Inactive };
     RetainPtr<BEMediaEnvironment> m_mediaEnvironment;
 };
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -3341,6 +3341,7 @@ void WebPageProxy::dispatchActivityStateChange()
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     updateMediaCapability();
+    updateDisplayCaptureCapability();
 #endif
 
 #if PLATFORM(COCOA)
@@ -7820,8 +7821,10 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    if (frame->isMainFrame())
+    if (frame->isMainFrame()) {
         resetMediaCapability();
+        resetDisplayCaptureCapability();
+    }
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)
@@ -14951,6 +14954,10 @@ void WebPageProxy::updateReportedMediaCaptureState()
         if (systemAudioCaptureChanged)
             pageClient->systemAudioCaptureChanged();
     }
+
+#if ENABLE(EXTENSION_CAPABILITIES)
+    updateDisplayCaptureCapability();
+#endif
 }
 
 void WebPageProxy::videoControlsManagerDidChange()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2721,6 +2721,10 @@ public:
     const MediaCapability* mediaCapability() const;
     void resetMediaCapability();
     void updateMediaCapability();
+
+    const MediaCapability* displayCaptureCapability() const;
+    void resetDisplayCaptureCapability();
+    void updateDisplayCaptureCapability();
 #endif
 
     void requestAllTextAndRects(CompletionHandler<void(Vector<Ref<API::TextRun>>&&)>&&);
@@ -3522,6 +3526,11 @@ private:
     void deactivateMediaCapability(MediaCapability&);
     bool shouldActivateMediaCapability() const;
     bool shouldDeactivateMediaCapability() const;
+
+    void setDisplayCaptureCapability(RefPtr<MediaCapability>&&);
+    void deactivateDisplayCaptureCapability(MediaCapability&);
+    bool shouldActivateDisplayCaptureCapability() const;
+    bool shouldDeactivateDisplayCaptureCapability() const;
 #endif
 
     // These are intentionally private

--- a/Source/WebKit/UIProcess/WebPageProxyInternals.h
+++ b/Source/WebKit/UIProcess/WebPageProxyInternals.h
@@ -417,6 +417,7 @@ public:
 
 #if ENABLE(EXTENSION_CAPABILITIES)
     RefPtr<MediaCapability> mediaCapability;
+    RefPtr<MediaCapability> displayCaptureCapability;
 #endif
 
 #if ENABLE(WINDOW_PROXY_PROPERTY_ACCESS_NOTIFICATION)

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp
@@ -429,9 +429,14 @@ void GPUProcessConnection::updateMediaConfiguration(bool forceUpdate)
 }
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-void GPUProcessConnection::setMediaEnvironment(WebCore::PageIdentifier pageIdentifier, const String& mediaEnvironment)
+void GPUProcessConnection::setMediaPlaybackEnvironment(WebCore::PageIdentifier pageIdentifier, const String& environment)
 {
-    m_connection->send(Messages::GPUConnectionToWebProcess::SetMediaEnvironment(pageIdentifier, mediaEnvironment), { });
+    m_connection->send(Messages::GPUConnectionToWebProcess::SetMediaPlaybackEnvironment(pageIdentifier, environment), { });
+}
+
+void GPUProcessConnection::setDisplayCaptureEnvironment(WebCore::PageIdentifier pageIdentifier, const String& environment)
+{
+    m_connection->send(Messages::GPUConnectionToWebProcess::SetDisplayCaptureEnvironment(pageIdentifier, environment), { });
 }
 #endif
 

--- a/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
+++ b/Source/WebKit/WebProcess/GPU/GPUProcessConnection.h
@@ -110,7 +110,8 @@ public:
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    void setMediaEnvironment(WebCore::PageIdentifier, const String&);
+    void setMediaPlaybackEnvironment(WebCore::PageIdentifier, const String&);
+    void setDisplayCaptureEnvironment(WebCore::PageIdentifier, const String&);
 #endif
 
     void configureLoggingChannel(const String&, WTFLogChannelState, WTFLogLevel);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -1090,11 +1090,18 @@ URL WebPage::allowedQueryParametersForAdvancedPrivacyProtections(const URL& url)
 }
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-void WebPage::setMediaEnvironment(const String& mediaEnvironment)
+void WebPage::setMediaPlaybackEnvironment(const String& environment)
 {
-    m_mediaEnvironment = mediaEnvironment;
+    m_mediaPlaybackEnvironment = environment;
     if (RefPtr gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
-        gpuProcessConnection->setMediaEnvironment(identifier(), mediaEnvironment);
+        gpuProcessConnection->setMediaPlaybackEnvironment(identifier(), environment);
+}
+
+void WebPage::setDisplayCaptureEnvironment(const String& environment)
+{
+    m_displayCaptureEnvironment = environment;
+    if (RefPtr gpuProcessConnection = WebProcess::singleton().existingGPUProcessConnection())
+        gpuProcessConnection->setDisplayCaptureEnvironment(identifier(), environment);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1337,8 +1337,11 @@ void WebPage::gpuProcessConnectionDidBecomeAvailable(GPUProcessConnection& gpuPr
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    if (!mediaEnvironment().isEmpty())
-        gpuProcessConnection.setMediaEnvironment(identifier(), mediaEnvironment());
+    if (!mediaPlaybackEnvironment().isEmpty())
+        gpuProcessConnection.setMediaPlaybackEnvironment(identifier(), mediaPlaybackEnvironment());
+
+    if (!displayCaptureEnvironment().isEmpty())
+        gpuProcessConnection.setDisplayCaptureEnvironment(identifier(), displayCaptureEnvironment());
 #endif
 }
 
@@ -1545,7 +1548,8 @@ WebPage::~WebPage()
         completionHandler(false);
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    setMediaEnvironment({ });
+    setMediaPlaybackEnvironment({ });
+    setDisplayCaptureEnvironment({ });
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2065,8 +2065,10 @@ public:
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    const String& mediaEnvironment() const { return m_mediaEnvironment; }
-    void setMediaEnvironment(const String&);
+    const String& mediaPlaybackEnvironment() const { return m_mediaPlaybackEnvironment; }
+    void setMediaPlaybackEnvironment(const String&);
+    const String& displayCaptureEnvironment() const { return m_displayCaptureEnvironment; }
+    void setDisplayCaptureEnvironment(const String&);
 #endif
 
 #if ENABLE(WRITING_TOOLS)
@@ -3275,7 +3277,8 @@ private:
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    String m_mediaEnvironment;
+    String m_mediaPlaybackEnvironment;
+    String m_displayCaptureEnvironment;
 #endif
 
 #if ENABLE(WRITING_TOOLS)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -859,7 +859,8 @@ messages -> WebPage WantsAsyncDispatchMessage {
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)
-    SetMediaEnvironment(String mediaEnvironment)
+    SetMediaPlaybackEnvironment(String environment)
+    SetDisplayCaptureEnvironment(String environment)
 #endif
 
 #if ENABLE(WRITING_TOOLS)


### PR DESCRIPTION
#### 80b7f0b717369f584d172654f7ece217f0311de1
<pre>
[Cocoa] Adopt -[BECapability screenCaptureWithEnvironment:]
<a href="https://rdar.apple.com/170178645">rdar://170178645</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307837">https://bugs.webkit.org/show_bug.cgi?id=307837</a>

Reviewed by Eric Carlson.

MediaCapability currently wraps video playback, audio playback,
camera and microphone capture, display capture, and system capture.
We should break apart this this multi-media capability into its
constituent pieces and we&apos;re starting with display capture. Move
the functionality for display capture into a separate capability
object, and distinguish between the types of capabilities with a
new MediaCapability::Kind enum.

* Source/WebKit/Configurations/AllowedSPI.toml:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.h:
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.messages.in:
* Source/WebKit/GPUProcess/cocoa/GPUConnectionToWebProcessCocoa.mm:
(WebKit::GPUConnectionToWebProcess::mediaPlaybackEnvironment):
(WebKit::GPUConnectionToWebProcess::setMediaPlaybackEnvironment):
(WebKit::GPUConnectionToWebProcess::displayCaptureEnvironment):
(WebKit::GPUConnectionToWebProcess::setDisplayCaptureEnvironment):
(WebKit::GPUConnectionToWebProcess::mediaEnvironment): Deleted.
(WebKit::GPUConnectionToWebProcess::setMediaEnvironment): Deleted.
* Source/WebKit/Platform/cocoa/MediaCapability.h:
* Source/WebKit/Platform/cocoa/MediaCapability.mm:
(WebKit::MediaCapability::create):
(WebKit::processCapabilityForKind):
(WebKit::MediaCapability::MediaCapability):
* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::setMediaCapability):
(WebKit::WebPageProxy::resetMediaCapability):
(WebKit::WebPageProxy::displayCaptureCapability const):
(WebKit::WebPageProxy::setDisplayCaptureCapability):
(WebKit::WebPageProxy::deactivateDisplayCaptureCapability):
(WebKit::WebPageProxy::resetDisplayCaptureCapability):
(WebKit::WebPageProxy::updateDisplayCaptureCapability):
(WebKit::WebPageProxy::shouldActivateDisplayCaptureCapability const):
(WebKit::WebPageProxy::shouldDeactivateDisplayCaptureCapability const):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::dispatchActivityStateChange):
(WebKit::WebPageProxy::didCommitLoadForFrame):
(WebKit::WebPageProxy::updateReportedMediaCaptureState):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxyInternals.h:
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.cpp:
(WebKit::GPUProcessConnection::setMediaPlaybackEnvironment):
(WebKit::GPUProcessConnection::setDisplayCaptureEnvironment):
(WebKit::GPUProcessConnection::setMediaEnvironment): Deleted.
* Source/WebKit/WebProcess/GPU/GPUProcessConnection.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::setMediaPlaybackEnvironment):
(WebKit::WebPage::setDisplayCaptureEnvironment):
(WebKit::WebPage::setMediaEnvironment): Deleted.
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::gpuProcessConnectionDidBecomeAvailable):
(WebKit::WebPage::~WebPage):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:

Canonical link: <a href="https://commits.webkit.org/307549@main">https://commits.webkit.org/307549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4f3976f81674999f237bfe808ab1b5fb1dc43526

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144671 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8954 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153342 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfd9ee7e-26c0-4387-838e-9d82b46e117e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17244 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111264 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/391c406c-e756-4211-acef-c483b79c861e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147634 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13625 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129896 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92159 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eaac968d-86e4-4470-9872-c60acd772456) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13002 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10752 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/787 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122512 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155654 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119265 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/17309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14384 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119595 "Found 1 new API test failure: WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30679 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15411 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127848 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16824 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6203 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16560 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80603 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16624 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->