### PR TITLE
Make ScrollAnimation compatible with CheckedPtr

### DIFF
--- a/Source/WebCore/platform/ScrollAnimation.h
+++ b/Source/WebCore/platform/ScrollAnimation.h
@@ -28,6 +28,7 @@
 
 #include <WebCore/FloatPoint.h>
 #include <WebCore/ScrollTypes.h>
+#include <wtf/CheckedPtr.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -49,8 +50,9 @@ public:
     virtual FloatPoint scrollOffset(ScrollAnimation&) = 0;
 };
 
-class ScrollAnimation {
+class ScrollAnimation : public CanMakeThreadSafeCheckedPtr<ScrollAnimation> {
     WTF_MAKE_TZONE_ALLOCATED(ScrollAnimation);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollAnimation);
 public:
     enum class Type {
         Smooth,

--- a/Source/WebCore/platform/ScrollAnimationKeyboard.h
+++ b/Source/WebCore/platform/ScrollAnimationKeyboard.h
@@ -37,6 +37,7 @@ class TimingFunction;
 
 class ScrollAnimationKeyboard final: public ScrollAnimation {
     WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationKeyboard);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollAnimationKeyboard);
 public:
     ScrollAnimationKeyboard(ScrollAnimationClient&);
     virtual ~ScrollAnimationKeyboard();

--- a/Source/WebCore/platform/ScrollAnimationKinetic.h
+++ b/Source/WebCore/platform/ScrollAnimationKinetic.h
@@ -36,6 +36,7 @@ class PlatformWheelEvent;
 
 class ScrollAnimationKinetic final : public ScrollAnimation {
     WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationKinetic);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollAnimationKinetic);
 private:
     class PerAxisData {
     public:

--- a/Source/WebCore/platform/ScrollAnimationMomentum.h
+++ b/Source/WebCore/platform/ScrollAnimationMomentum.h
@@ -33,6 +33,7 @@ class ScrollingMomentumCalculator;
 
 class ScrollAnimationMomentum final : public ScrollAnimation {
     WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationMomentum);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollAnimationMomentum);
 public:
     ScrollAnimationMomentum(ScrollAnimationClient&);
     virtual ~ScrollAnimationMomentum();

--- a/Source/WebCore/platform/ScrollAnimationSmooth.h
+++ b/Source/WebCore/platform/ScrollAnimationSmooth.h
@@ -36,6 +36,7 @@ class TimingFunction;
 
 class ScrollAnimationSmooth final: public ScrollAnimation {
     WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationSmooth);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollAnimationSmooth);
 public:
     ScrollAnimationSmooth(ScrollAnimationClient&);
     virtual ~ScrollAnimationSmooth();

--- a/Source/WebCore/platform/ScrollingEffectsController.cpp
+++ b/Source/WebCore/platform/ScrollingEffectsController.cpp
@@ -109,7 +109,7 @@ bool ScrollingEffectsController::startKeyboardScroll(const KeyboardScroll& scrol
 
 void ScrollingEffectsController::finishKeyboardScroll(bool immediate)
 {
-    if (auto* animationKeyboard = dynamicDowncast<ScrollAnimationKeyboard>(m_currentAnimation.get()))
+    if (CheckedPtr animationKeyboard = dynamicDowncast<ScrollAnimationKeyboard>(m_currentAnimation.get()))
         animationKeyboard->finishKeyboardScroll(immediate);
 }
 
@@ -128,7 +128,7 @@ bool ScrollingEffectsController::startAnimatedScrollToDestination(FloatPoint sta
 
 bool ScrollingEffectsController::retargetAnimatedScroll(FloatPoint newDestinationOffset)
 {
-    auto* animationSmooth = dynamicDowncast<ScrollAnimationSmooth>(m_currentAnimation.get());
+    CheckedPtr animationSmooth = dynamicDowncast<ScrollAnimationSmooth>(m_currentAnimation.get());
     if (!animationSmooth)
         return false;
     
@@ -294,7 +294,7 @@ float ScrollingEffectsController::adjustedScrollDestination(ScrollEventAxis axis
 #if ENABLE(KINETIC_SCROLLING)
 bool ScrollingEffectsController::processWheelEventForKineticScrolling(const PlatformWheelEvent& event)
 {
-    if (auto* kineticAnimation = dynamicDowncast<ScrollAnimationKinetic>(m_currentAnimation.get())) {
+    if (CheckedPtr kineticAnimation = dynamicDowncast<ScrollAnimationKinetic>(m_currentAnimation.get())) {
         m_previousKineticAnimationInfo.startTime = kineticAnimation->startTime();
         m_previousKineticAnimationInfo.initialOffset = kineticAnimation->initialOffset();
         m_previousKineticAnimationInfo.initialVelocity = kineticAnimation->initialVelocity();

--- a/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
+++ b/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
@@ -33,6 +33,7 @@ namespace WebCore {
 
 class ScrollAnimationRubberBand final: public ScrollAnimation {
     WTF_MAKE_TZONE_ALLOCATED(ScrollAnimationRubberBand);
+    WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ScrollAnimationRubberBand);
 public:
     ScrollAnimationRubberBand(ScrollAnimationClient&);
     virtual ~ScrollAnimationRubberBand();

--- a/Source/WebCore/platform/mac/ScrollingEffectsController.mm
+++ b/Source/WebCore/platform/mac/ScrollingEffectsController.mm
@@ -487,12 +487,14 @@ void ScrollingEffectsController::stopRubberBanding()
 
 bool ScrollingEffectsController::startRubberBandAnimation(const FloatSize& initialVelocity, const FloatSize& initialOverscroll)
 {
-    if (m_currentAnimation)
-        m_currentAnimation->stop();
+    if (CheckedPtr currentAnimation = m_currentAnimation.get())
+        currentAnimation->stop();
 
     m_currentAnimation = makeUnique<ScrollAnimationRubberBand>(*this);
     auto targetOffset = m_client.rubberBandTargetOffset();
-    bool started = downcast<ScrollAnimationRubberBand>(*m_currentAnimation).startRubberBandAnimation(initialVelocity, initialOverscroll, targetOffset);
+
+    CheckedPtr currentAnimation = m_currentAnimation.get();
+    bool started = downcast<ScrollAnimationRubberBand>(currentAnimation.get())->startRubberBandAnimation(initialVelocity, initialOverscroll, targetOffset);
     LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController::startRubberBandAnimation() - animation " << *m_currentAnimation << " targetOffset " << targetOffset << " started " << started);
     return started;
 }
@@ -525,8 +527,8 @@ void ScrollingEffectsController::startRubberBandSnapBack()
     if (stretchAmount.isZero())
         return;
 
-    if (m_currentAnimation)
-        m_currentAnimation->stop();
+    if (CheckedPtr currentAnimation = m_currentAnimation.get())
+        currentAnimation->stop();
 
     LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingEffectsController::startRubberBandSnapBack() - stretchAmount " << stretchAmount);
     startRubberBandAnimation({ }, stretchAmount);


### PR DESCRIPTION
#### 42af18179f7ac1e4ef1d78ed9d238331ee740948
<pre>
Make ScrollAnimation compatible with CheckedPtr
<a href="https://bugs.webkit.org/show_bug.cgi?id=307838">https://bugs.webkit.org/show_bug.cgi?id=307838</a>
<a href="https://rdar.apple.com/170339530">rdar://170339530</a>

Reviewed by Ryosuke Niwa, Aditya Keerthi, and Abrar Rahman Protyasha.

Update `ScrollAnimation` to be compatible with CheckedPtr to
improve safety when downcasting (which will be performed in a later
patch.)

* Source/WebCore/platform/ScrollAnimation.h:
* Source/WebCore/platform/ScrollAnimationKeyboard.h:
* Source/WebCore/platform/ScrollAnimationKinetic.h:
* Source/WebCore/platform/ScrollAnimationMomentum.h:
* Source/WebCore/platform/ScrollAnimationSmooth.h:
* Source/WebCore/platform/ScrollingEffectsController.cpp:
(WebCore::ScrollingEffectsController::finishKeyboardScroll):
(WebCore::ScrollingEffectsController::retargetAnimatedScroll):
(WebCore::ScrollingEffectsController::processWheelEventForKineticScrolling):
* Source/WebCore/platform/mac/ScrollAnimationRubberBand.h:
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::startRubberBandAnimation):
(WebCore::ScrollingEffectsController::startRubberBandSnapBack):

Canonical link: <a href="https://commits.webkit.org/307612@main">https://commits.webkit.org/307612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7f6f0e86bc9acfaafe4ed0360f2f10a2582363b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144872 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17552 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9273 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153543 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98507 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ce289ba-da42-4261-83bc-746e282fc96a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111391 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79839 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0456fcc7-d8db-4f32-89ed-78f285d3b5c7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147835 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13755 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130096 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92286 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bba6293-36f1-4aa1-b40e-e5f032a9c5da) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13129 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10880 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/988 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122644 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6840 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155855 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7928 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119394 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17450 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119722 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30713 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15528 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72987 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17025 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6396 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16761 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80804 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16825 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->