### PR TITLE
[iOS] MediaSessionHelper::activeVideoRouteDidChange is called twice when an AirPlay route activates

### DIFF
--- a/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
+++ b/Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp
@@ -150,14 +150,14 @@ bool MediaPlayerPrivateWirelessPlayback::isCurrentPlaybackTargetWireless() const
 
 void MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget(Ref<MediaPlaybackTarget>&& playbackTarget)
 {
-    ASSERT(playbackTarget->type() == MediaPlaybackTargetType::WirelessPlayback);
     ALWAYS_LOG(LOGIDENTIFIER, playbackTarget->type());
 
     m_playbackTarget = WTF::move(playbackTarget);
 
     RefPtr route = this->route();
     if (!route) {
-        setNetworkState(MediaPlayer::NetworkState::FormatError);
+        if (is<MediaPlaybackTargetWirelessPlayback>(m_playbackTarget))
+            setNetworkState(MediaPlayer::NetworkState::FormatError);
         return;
     }
 


### PR DESCRIPTION
#### 377a419a0a7dbe929f591bfd67ef4f80c0ec3425
<pre>
[iOS] MediaSessionHelper::activeVideoRouteDidChange is called twice when an AirPlay route activates
<a href="https://bugs.webkit.org/show_bug.cgi?id=307842">https://bugs.webkit.org/show_bug.cgi?id=307842</a>
<a href="https://rdar.apple.com/170341830">rdar://170341830</a>

Reviewed by Eric Carlson.

When an AirPlay route activates and WirelessPlaybackMediaPlayerEnabled is enabled,
MediaSessionHelper learns about the new route via activeRoutesDidChange, then learns about the new
AVOutputDevice via -activeOutputDeviceDidChange:, both of which result in a call to
MediaSessionHelper::activeVideoRouteDidChange.

Resolved this in activeRoutesDidChange by eliding the call to activeVideoRouteDidChange if the
current output device is not yet an AirPlay device (or if m_playbackTarget is already configured
with the most recent active route). Resolved this in -activeOutputDeviceDidChange: by eliding the
call to activeVideoRouteDidChange if m_playbackTarget is already configured with the most recent
active route. This results in a single call to MediaSessionHelper::activeVideoRouteDidChange no
matter in which order activeRoutesDidChange and -activeOutputDeviceDidChange: are called.

Drive-by fix: removed an invalid assertion in MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget.

No new tests since this is device-specific behavior.

* Source/WebCore/platform/audio/ios/MediaSessionHelperIOS.mm:
(MediaSessionHelper::activeRoutesDidChange):
(MediaSessionHelperIOS::activeVideoRouteDidChange):
(-[WebMediaSessionHelper activeOutputDeviceDidChange:]):
* Source/WebCore/platform/graphics/MediaPlayerPrivateWirelessPlayback.cpp:
(WebCore::MediaPlayerPrivateWirelessPlayback::setWirelessPlaybackTarget):

Canonical link: <a href="https://commits.webkit.org/307566@main">https://commits.webkit.org/307566@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e79a712b72daeaf56ba960aceab378ef0f8f71ba

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17447 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9051 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153439 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23264452-b3e5-4bfe-bd7b-e5413dbf4b29) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146643 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17341 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111312 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a9e3436-1efb-457f-b947-1a293d106f00) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147731 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129964 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92207 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bc64423-ffdd-4088-b7b5-2986e976a70f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10804 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/884 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122561 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6674 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155751 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17299 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7754 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119316 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119644 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30685 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15457 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127916 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72841 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16921 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6269 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16657 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80700 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16866 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16721 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->