### PR TITLE
rename "EnhancedFullscreen" to "PictureInPicture"

### DIFF
--- a/Source/WebCore/page/ContextMenuController.cpp
+++ b/Source/WebCore/page/ContextMenuController.cpp
@@ -381,8 +381,8 @@ void ContextMenuController::contextMenuItemSelected(ContextMenuAction action, co
     case ContextMenuItemTagMediaMute:
         m_context.hitTestResult().toggleMediaMuteState();
         break;
-    case ContextMenuItemTagToggleVideoEnhancedFullscreen:
-        m_context.hitTestResult().toggleEnhancedFullscreenForVideo();
+    case ContextMenuItemTagTogglePictureInPicture:
+        m_context.hitTestResult().togglePictureInPictureForVideo();
         break;
     case ContextMenuItemTagToggleVideoViewer:
         m_context.hitTestResult().toggleVideoViewer();
@@ -1001,7 +1001,7 @@ void ContextMenuController::populate()
     ContextMenuItem ToggleVideoFullscreen(ContextMenuItemType::Action, ContextMenuItemTagToggleVideoFullscreen,
         contextMenuItemTagEnterVideoFullscreen());
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
-    ContextMenuItem ToggleVideoEnhancedFullscreen(ContextMenuItemType::Action, ContextMenuItemTagToggleVideoEnhancedFullscreen, contextMenuItemTagEnterVideoEnhancedFullscreen());
+    ContextMenuItem TogglePictureInPicture(ContextMenuItemType::Action, ContextMenuItemTagTogglePictureInPicture, contextMenuItemTagEnterPictureInPicture());
     ContextMenuItem ToggleVideoViewer(ContextMenuItemType::Action, ContextMenuItemTagToggleVideoViewer, contextMenuItemTagEnterVideoViewer());
 #endif
 
@@ -1201,7 +1201,7 @@ void ContextMenuController::populate()
             appendItem(EnterVideoFullscreen, m_contextMenu.get());
 #endif
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
-            appendItem(ToggleVideoEnhancedFullscreen, m_contextMenu.get());
+            appendItem(TogglePictureInPicture, m_contextMenu.get());
             appendItem(ToggleVideoViewer, m_contextMenu.get());
 #endif
             if (m_context.hitTestResult().isDownloadableMedia() && loader->client().canHandleRequest(ResourceRequest(WTF::move(mediaURL)))) {
@@ -1839,11 +1839,11 @@ void ContextMenuController::checkOrEnableIfNeeded(ContextMenuItem& item) const
         case ContextMenuItemTagEnterVideoFullscreen:
             shouldEnable = m_context.hitTestResult().mediaSupportsFullscreen();
             break;
-        case ContextMenuItemTagToggleVideoEnhancedFullscreen:
+        case ContextMenuItemTagTogglePictureInPicture:
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
-            item.setTitle(m_context.hitTestResult().mediaIsInEnhancedFullscreen() ? contextMenuItemTagExitVideoEnhancedFullscreen() : contextMenuItemTagEnterVideoEnhancedFullscreen());
+            item.setTitle(m_context.hitTestResult().mediaIsInPictureInPicture() ? contextMenuItemTagExitPictureInPicture() : contextMenuItemTagEnterPictureInPicture());
 #endif
-            shouldEnable = m_context.hitTestResult().mediaSupportsEnhancedFullscreen();
+            shouldEnable = m_context.hitTestResult().mediaSupportsPictureInPicture();
             break;
         case ContextMenuItemTagToggleVideoViewer:
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/platform/ContextMenuItem.cpp
+++ b/Source/WebCore/platform/ContextMenuItem.cpp
@@ -269,7 +269,7 @@ static bool isValidContextMenuAction(WebCore::ContextMenuAction action)
     case ContextMenuAction::ContextMenuItemTagToggleVideoFullscreen:
     case ContextMenuAction::ContextMenuItemTagShareMenu:
     case ContextMenuAction::ContextMenuItemTagToggleVideoViewer:
-    case ContextMenuAction::ContextMenuItemTagToggleVideoEnhancedFullscreen:
+    case ContextMenuAction::ContextMenuItemTagTogglePictureInPicture:
     case ContextMenuAction::ContextMenuItemTagLookUpImage:
     case ContextMenuAction::ContextMenuItemTagTranslate:
     case ContextMenuAction::ContextMenuItemTagWritingTools:

--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -153,7 +153,7 @@ enum ContextMenuAction {
     ContextMenuItemTagPauseAnimation,
     ContextMenuItemTagToggleVideoFullscreen,
     ContextMenuItemTagShareMenu,
-    ContextMenuItemTagToggleVideoEnhancedFullscreen,
+    ContextMenuItemTagTogglePictureInPicture,
     ContextMenuItemTagToggleVideoViewer,
     ContextMenuItemTagAddHighlightToCurrentQuickNote,
     ContextMenuItemTagAddHighlightToNewQuickNote,

--- a/Source/WebCore/platform/LocalizedStrings.h
+++ b/Source/WebCore/platform/LocalizedStrings.h
@@ -163,8 +163,8 @@ namespace WebCore {
     String contextMenuItemTagEnterVideoFullscreen();
     WEBCORE_EXPORT String contextMenuItemTagExitVideoFullscreen();
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
-    String contextMenuItemTagEnterVideoEnhancedFullscreen();
-    WEBCORE_EXPORT String contextMenuItemTagExitVideoEnhancedFullscreen();
+    String contextMenuItemTagEnterPictureInPicture();
+    WEBCORE_EXPORT String contextMenuItemTagExitPictureInPicture();
     String contextMenuItemTagEnterVideoViewer();
     WEBCORE_EXPORT String contextMenuItemTagExitVideoViewer();
 #endif

--- a/Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm
+++ b/Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm
@@ -188,12 +188,12 @@ String contextMenuItemTagChangeBack(const String& replacedString)
 }
 
 #if PLATFORM(MAC) && ENABLE(VIDEO_PRESENTATION_MODE)
-String contextMenuItemTagEnterVideoEnhancedFullscreen()
+String contextMenuItemTagEnterPictureInPicture()
 {
     return WEB_UI_STRING("Enter Picture in Picture", "menu item");
 }
 
-String contextMenuItemTagExitVideoEnhancedFullscreen()
+String contextMenuItemTagExitPictureInPicture()
 {
     return WEB_UI_STRING("Exit Picture in Picture", "menu item");
 }

--- a/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
+++ b/Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h
@@ -75,7 +75,7 @@ public:
     bool hasMode(HTMLMediaElementEnums::VideoFullscreenMode) const { return false; }
     bool pictureInPictureWasStartedWhenEnteringBackground() const { return false; }
     AVPlayerViewController *avPlayerViewController() const { return nullptr; }
-    bool isPlayingVideoInEnhancedFullscreen() const { return false; }
+    bool isPlayingVideoInPictureInPicture() const { return false; }
     std::optional<MediaPlayerIdentifier> playerIdentifier() const { return std::nullopt; }
     bool changingStandbyOnly() { return false; }
     bool returningToStandby() const { return false; }

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h
@@ -60,7 +60,7 @@ public:
     WEBCORE_EXPORT bool pictureInPictureWasStartedWhenEnteringBackground() const final;
     WEBCORE_EXPORT void setPlayerIdentifier(std::optional<MediaPlayerIdentifier>) final;
     WEBCORE_EXPORT bool mayAutomaticallyShowVideoPictureInPicture() const;
-    bool isPlayingVideoInEnhancedFullscreen() const;
+    bool isPlayingVideoInPictureInPicture() const;
     bool allowsPictureInPicturePlayback() const { return m_allowsPictureInPicturePlayback; }
     void presentFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;
     void dismissFullscreen(bool animated, Function<void(BOOL, NSError *)>&&) final;

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm
@@ -902,7 +902,7 @@ void VideoPresentationInterfaceAVKitLegacy::stopPictureInPicture()
     [m_playerViewController stopPictureInPicture];
 }
 
-bool VideoPresentationInterfaceAVKitLegacy::isPlayingVideoInEnhancedFullscreen() const
+bool VideoPresentationInterfaceAVKitLegacy::isPlayingVideoInPictureInPicture() const
 {
     return hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) && [playerController() isPlaying];
 }

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h
@@ -168,7 +168,7 @@ public:
     void willStopPictureInPicture();
     WEBCORE_EXPORT virtual void didStopPictureInPicture();
     WEBCORE_EXPORT virtual void prepareForPictureInPictureStopWithCompletionHandler(void (^)(BOOL));
-    virtual bool isPlayingVideoInEnhancedFullscreen() const = 0;
+    virtual bool isPlayingVideoInPictureInPicture() const = 0;
 
     WEBCORE_EXPORT void setMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement);
     void clearMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement);

--- a/Source/WebCore/platform/ios/VideoPresentationInterfaceTVOS.h
+++ b/Source/WebCore/platform/ios/VideoPresentationInterfaceTVOS.h
@@ -43,7 +43,7 @@ public:
     void hasVideoChanged(bool) final { }
     AVPlayerViewController *avPlayerViewController() const final { return { }; }
     bool mayAutomaticallyShowVideoPictureInPicture() const final { return false; }
-    bool isPlayingVideoInEnhancedFullscreen() const final { return false; }
+    bool isPlayingVideoInPictureInPicture() const final { return false; }
     bool pictureInPictureWasStartedWhenEnteringBackground() const final { return false; }
     
 private:

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h
@@ -105,7 +105,7 @@ public:
     WEBCORE_EXPORT void setMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement);
     WEBCORE_EXPORT void clearMode(HTMLMediaElementEnums::VideoFullscreenMode, VideoPresentationModel::ShouldNotifyMediaElement);
 
-    WEBCORE_EXPORT bool isPlayingVideoInEnhancedFullscreen() const;
+    WEBCORE_EXPORT bool isPlayingVideoInPictureInPicture() const;
 
     bool mayAutomaticallyShowVideoPictureInPicture() const { return false; }
     void applicationDidBecomeActive() { }

--- a/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
+++ b/Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm
@@ -855,7 +855,7 @@ void VideoPresentationInterfaceMac::videoDimensionsChanged(const FloatSize& vide
         [m_webVideoPresentationInterfaceObjC setVideoDimensions:videoDimensions];
 }
 
-bool VideoPresentationInterfaceMac::isPlayingVideoInEnhancedFullscreen() const
+bool VideoPresentationInterfaceMac::isPlayingVideoInPictureInPicture() const
 {
     return hasMode(WebCore::HTMLMediaElementEnums::VideoFullscreenModePictureInPicture) && [m_webVideoPresentationInterfaceObjC isPlaying];
 }

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -928,7 +928,7 @@ String HitTestResult::linkSuggestedFilename() const
     return ResourceResponse::sanitizeSuggestedFilename(urlElement->attributeWithoutSynchronization(HTMLNames::downloadAttr));
 }
 
-bool HitTestResult::mediaSupportsEnhancedFullscreen() const
+bool HitTestResult::mediaSupportsPictureInPicture() const
 {
 #if PLATFORM(MAC) && ENABLE(VIDEO) && ENABLE(VIDEO_PRESENTATION_MODE)
     if (RefPtr mediaElt = mediaElement())
@@ -937,7 +937,7 @@ bool HitTestResult::mediaSupportsEnhancedFullscreen() const
     return false;
 }
 
-bool HitTestResult::mediaIsInEnhancedFullscreen() const
+bool HitTestResult::mediaIsInPictureInPicture() const
 {
 #if PLATFORM(MAC) && ENABLE(VIDEO) && ENABLE(VIDEO_PRESENTATION_MODE)
     if (RefPtr mediaElt = mediaElement())
@@ -946,7 +946,7 @@ bool HitTestResult::mediaIsInEnhancedFullscreen() const
     return false;
 }
 
-void HitTestResult::toggleEnhancedFullscreenForVideo() const
+void HitTestResult::togglePictureInPictureForVideo() const
 {
 #if PLATFORM(MAC) && ENABLE(VIDEO) && ENABLE(VIDEO_PRESENTATION_MODE)
     RefPtr mediaElement(this->mediaElement());

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -145,9 +145,9 @@ public:
     WEBCORE_EXPORT bool mediaIsVideo() const;
     bool mediaMuted() const;
     void toggleMediaMuteState() const;
-    bool mediaSupportsEnhancedFullscreen() const;
-    bool mediaIsInEnhancedFullscreen() const;
-    void toggleEnhancedFullscreenForVideo() const;
+    bool mediaSupportsPictureInPicture() const;
+    bool mediaIsInPictureInPicture() const;
+    void togglePictureInPictureForVideo() const;
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     void pauseAnimation() const;

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceAVKit.h
@@ -51,7 +51,7 @@ private:
     // VideoPresentationInterfaceIOS overrides
     bool pictureInPictureWasStartedWhenEnteringBackground() const final { return false; }
     bool mayAutomaticallyShowVideoPictureInPicture() const final { return false; }
-    bool isPlayingVideoInEnhancedFullscreen() const final { return false; }
+    bool isPlayingVideoInPictureInPicture() const final { return false; }
     void setupFullscreen(const WebCore::FloatRect&, const WebCore::FloatSize&, UIView*, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) final;
     void hasVideoChanged(bool) final { }
     void finalizeSetup() final;

--- a/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
+++ b/Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h
@@ -57,7 +57,7 @@ private:
 
     bool pictureInPictureWasStartedWhenEnteringBackground() const final { return false; }
     bool mayAutomaticallyShowVideoPictureInPicture() const final { return false; }
-    bool isPlayingVideoInEnhancedFullscreen() const final { return false; }
+    bool isPlayingVideoInPictureInPicture() const final { return false; }
     void setupFullscreen(const WebCore::FloatRect&, const WebCore::FloatSize&, UIView*, WebCore::HTMLMediaElementEnums::VideoFullscreenMode, bool, bool, bool) final;
     void hasVideoChanged(bool) final { }
     void finalizeSetup() final;

--- a/Source/WebKit/Platform/mac/MenuUtilities.mm
+++ b/Source/WebKit/Platform/mac/MenuUtilities.mm
@@ -356,7 +356,7 @@ static std::optional<SymbolNameWithType> symbolNameWithTypeForAction(const WebCo
     }
     case WebCore::ContextMenuItemTagToggleMediaLoop:
         return { { SymbolType::Public, "arrow.2.squarepath"_s } };
-    case WebCore::ContextMenuItemTagToggleVideoEnhancedFullscreen: {
+    case WebCore::ContextMenuItemTagTogglePictureInPicture: {
         const auto symbolName =  useAlternateImage ? "pip.exit"_s : "pip.enter"_s;
         return { { SymbolType::Public, symbolName } };
     }

--- a/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
+++ b/Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h
@@ -126,7 +126,7 @@ enum {
     kWKContextMenuItemTagOpenLinkInThisWindow,
     kWKContextMenuItemTagToggleVideoFullscreen,
     kWKContextMenuItemTagShareMenu,
-    kWKContextMenuItemTagToggleVideoEnhancedFullscreen,
+    kWKContextMenuItemTagTogglePictureInPicture,
     kWKContextMenuItemTagToggleVideoViewer,
     kWKContextMenuItemTagAddHighlightToCurrentQuickNote,
     kWKContextMenuItemTagAddHighlightToNewQuickNote,

--- a/Source/WebKit/Shared/API/c/WKSharedAPICast.h
+++ b/Source/WebKit/Shared/API/c/WKSharedAPICast.h
@@ -570,8 +570,8 @@ inline WKContextMenuItemTag toAPI(WebCore::ContextMenuAction action)
         return kWKContextMenuItemTagToggleVideoFullscreen;
     case WebCore::ContextMenuItemTagEnterVideoFullscreen:
         return kWKContextMenuItemTagEnterVideoFullscreen;
-    case WebCore::ContextMenuItemTagToggleVideoEnhancedFullscreen:
-        return kWKContextMenuItemTagToggleVideoEnhancedFullscreen;
+    case WebCore::ContextMenuItemTagTogglePictureInPicture:
+        return kWKContextMenuItemTagTogglePictureInPicture;
     case WebCore::ContextMenuItemTagMediaPlayPause:
         return kWKContextMenuItemTagMediaPlayPause;
     case WebCore::ContextMenuItemTagToggleVideoViewer:
@@ -800,8 +800,8 @@ inline WebCore::ContextMenuAction toImpl(WKContextMenuItemTag tag)
         return WebCore::ContextMenuItemTagToggleVideoFullscreen;
     case kWKContextMenuItemTagEnterVideoFullscreen:
         return WebCore::ContextMenuItemTagEnterVideoFullscreen;
-    case kWKContextMenuItemTagToggleVideoEnhancedFullscreen:
-        return WebCore::ContextMenuItemTagToggleVideoEnhancedFullscreen;
+    case kWKContextMenuItemTagTogglePictureInPicture:
+        return WebCore::ContextMenuItemTagTogglePictureInPicture;
     case kWKContextMenuItemTagMediaPlayPause:
         return WebCore::ContextMenuItemTagMediaPlayPause;
     case kWKContextMenuItemTagToggleVideoViewer:

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h
@@ -77,7 +77,7 @@ WK_EXPORT void WKPageAccessibilityClearIsolatedTree(WKPageRef page);
 WK_EXPORT bool WKPageIsURLKnownHSTSHost(WKPageRef page, WKURLRef url);
 
 #if !TARGET_OS_IPHONE
-WK_EXPORT bool WKPageIsPlayingVideoInEnhancedFullscreen(WKPageRef page);
+WK_EXPORT bool WKPageIsPlayingVideoInPictureInPicture(WKPageRef page);
 #endif
 
 #ifdef __cplusplus

--- a/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
+++ b/Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm
@@ -152,9 +152,9 @@ WKWebView *WKPageGetWebView(WKPageRef page)
 }
 
 #if PLATFORM(MAC)
-bool WKPageIsPlayingVideoInEnhancedFullscreen(WKPageRef pageRef)
+bool WKPageIsPlayingVideoInPictureInPicture(WKPageRef pageRef)
 {
-    return WebKit::toProtectedImpl(pageRef)->isPlayingVideoInEnhancedFullscreen();
+    return WebKit::toProtectedImpl(pageRef)->isPlayingVideoInPictureInPicture();
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm
@@ -52,7 +52,7 @@ NSString * const _WKMenuItemIdentifierRevealImage = @"WKMenuItemIdentifierReveal
 NSString * const _WKMenuItemIdentifierSearchWeb = @"WKMenuItemIdentifierSearchWeb";
 NSString * const _WKMenuItemIdentifierShowHideMediaControls = @"WKMenuItemIdentifierShowHideMediaControls";
 NSString * const _WKMenuItemIdentifierShowHideMediaStats = @"WKMenuItemIdentifierShowHideMediaStats";
-NSString * const _WKMenuItemIdentifierToggleEnhancedFullScreen = @"WKMenuItemIdentifierToggleEnhancedFullScreen";
+NSString * const _WKMenuItemIdentifierTogglePictureInPicture = @"WKMenuItemIdentifierTogglePictureInPicture";
 NSString * const _WKMenuItemIdentifierToggleFullScreen = @"WKMenuItemIdentifierToggleFullScreen";
 NSString * const _WKMenuItemIdentifierToggleVideoViewer = @"WKMenuItemIdentifierToggleVideoViewer";
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h
@@ -50,7 +50,7 @@ WK_EXTERN NSString * const _WKMenuItemIdentifierRevealImage WK_API_AVAILABLE(mac
 WK_EXTERN NSString * const _WKMenuItemIdentifierSearchWeb WK_API_AVAILABLE(macos(10.12), ios(10.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierShowHideMediaControls WK_API_AVAILABLE(macos(10.12), ios(10.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierShowHideMediaStats WK_API_AVAILABLE(macos(13.3), ios(16.4));
-WK_EXTERN NSString * const _WKMenuItemIdentifierToggleEnhancedFullScreen WK_API_AVAILABLE(macos(10.14), ios(12.0));
+WK_EXTERN NSString * const _WKMenuItemIdentifierTogglePictureInPicture WK_API_AVAILABLE(macos(10.14), ios(12.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierToggleVideoViewer WK_API_AVAILABLE(macos(15.0), ios(18.0));
 WK_EXTERN NSString * const _WKMenuItemIdentifierToggleFullScreen WK_API_AVAILABLE(macos(10.12), ios(10.0));
 

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h
@@ -178,7 +178,7 @@ public:
 
     void requestRouteSharingPolicyAndContextUID(PlaybackSessionContextIdentifier, CompletionHandler<void(WebCore::RouteSharingPolicy, String)>&&);
 
-    bool isPlayingVideoInEnhancedFullscreen() const;
+    bool isPlayingVideoInPictureInPicture() const;
 
     RefPtr<WebCore::PlatformVideoPresentationInterface> controlsManagerInterface();
     using VideoInPictureInPictureDidChangeObserver = WTF::Observer<void(bool)>;

--- a/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
+++ b/Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm
@@ -677,10 +677,10 @@ bool VideoPresentationManagerProxy::mayAutomaticallyShowVideoPictureInPicture() 
 }
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
-bool VideoPresentationManagerProxy::isPlayingVideoInEnhancedFullscreen() const
+bool VideoPresentationManagerProxy::isPlayingVideoInPictureInPicture() const
 {
     for (auto& [model, interface] : m_contextMap.values()) {
-        if (interface->isPlayingVideoInEnhancedFullscreen())
+        if (interface->isPlayingVideoInPictureInPicture())
             return true;
     }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -14995,11 +14995,11 @@ void WebPageProxy::handleControlledElementIDResponse(const String& identifier) c
 #endif
 }
 
-bool WebPageProxy::isPlayingVideoInEnhancedFullscreen() const
+bool WebPageProxy::isPlayingVideoInPictureInPicture() const
 {
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     RefPtr videoPresentationManager = m_videoPresentationManager;
-    return videoPresentationManager && videoPresentationManager->isPlayingVideoInEnhancedFullscreen();
+    return videoPresentationManager && videoPresentationManager->isPlayingVideoInPictureInPicture();
 #else
     return false;
 #endif

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -2115,7 +2115,7 @@ public:
     bool hasActiveVideoForControlsManager() const;
     void requestControlledElementID() const;
     void handleControlledElementIDResponse(const String&) const;
-    bool isPlayingVideoInEnhancedFullscreen() const;
+    bool isPlayingVideoInPictureInPicture() const;
 
 #if PLATFORM(COCOA)
     void requestActiveNowPlayingSessionInfo(CompletionHandler<void(bool, WebCore::NowPlayingInfo&&)>&&);

--- a/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm
@@ -452,8 +452,8 @@ static void updateMenuItemImage(NSMenuItem *menuItem, const WebCore::ContextMenu
     case ContextMenuItemTagToggleMediaControls:
         useAlternateImage = title == contextMenuItemTagShowMediaControls();
         break;
-    case ContextMenuItemTagToggleVideoEnhancedFullscreen:
-        useAlternateImage = title == contextMenuItemTagExitVideoEnhancedFullscreen();
+    case ContextMenuItemTagTogglePictureInPicture:
+        useAlternateImage = title == contextMenuItemTagExitPictureInPicture();
         break;
     case ContextMenuItemTagToggleVideoFullscreen:
         useAlternateImage = title == contextMenuItemTagExitVideoFullscreen();
@@ -671,8 +671,8 @@ static RetainPtr<NSString> menuItemIdentifier(const WebCore::ContextMenuAction a
     case ContextMenuItemTagShowMediaStats:
         return _WKMenuItemIdentifierShowHideMediaStats;
 
-    case ContextMenuItemTagToggleVideoEnhancedFullscreen:
-        return _WKMenuItemIdentifierToggleEnhancedFullScreen;
+    case ContextMenuItemTagTogglePictureInPicture:
+        return _WKMenuItemIdentifierTogglePictureInPicture;
 
     case ContextMenuItemTagToggleVideoFullscreen:
         return _WKMenuItemIdentifierToggleFullScreen;

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLView.mm
@@ -412,8 +412,8 @@ static std::optional<WebCore::ContextMenuAction> toAction(NSInteger tag)
         return ContextMenuItemTagToggleMediaLoop;
     case WebMenuItemTagEnterVideoFullscreen:
         return ContextMenuItemTagEnterVideoFullscreen;
-    case WebMenuItemTagToggleVideoEnhancedFullscreen:
-        return ContextMenuItemTagToggleVideoEnhancedFullscreen;
+    case WebMenuItemTagTogglePictureInPicture:
+        return ContextMenuItemTagTogglePictureInPicture;
     case WebMenuItemTagToggleVideoViewer:
         return ContextMenuItemTagToggleVideoViewer;
     case WebMenuItemTagMediaPlayPause:
@@ -602,8 +602,8 @@ static std::optional<NSInteger> toTag(WebCore::ContextMenuAction action)
         return WebMenuItemTagToggleVideoFullscreen;
     case ContextMenuItemTagShareMenu:
         return WebMenuItemTagShareMenu;
-    case ContextMenuItemTagToggleVideoEnhancedFullscreen:
-        return WebMenuItemTagToggleVideoEnhancedFullscreen;
+    case ContextMenuItemTagTogglePictureInPicture:
+        return WebMenuItemTagTogglePictureInPicture;
     case ContextMenuItemTagToggleVideoViewer:
         return WebMenuItemTagToggleVideoViewer;
     case ContextMenuItemTagTranslate:

--- a/Source/WebKitLegacy/mac/WebView/WebUIDelegatePrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebUIDelegatePrivate.h
@@ -101,7 +101,7 @@ enum {
     WebMenuItemTagDictationAlternative,
     WebMenuItemTagToggleVideoFullscreen,
     WebMenuItemTagShareMenu,
-    WebMenuItemTagToggleVideoEnhancedFullscreen,
+    WebMenuItemTagTogglePictureInPicture,
     WebMenuItemTagToggleVideoViewer,
     WebMenuItemTagAddHighlightToCurrentQuickNote,
     WebMenuItemTagAddHighlightToNewQuickNote,


### PR DESCRIPTION
#### 299ecc359064279a709f0a6c45c48eb676d6d1d6
<pre>
rename &quot;EnhancedFullscreen&quot; to &quot;PictureInPicture&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=307846">https://bugs.webkit.org/show_bug.cgi?id=307846</a>
<a href="https://rdar.apple.com/170344170">rdar://170344170</a>

Reviewed by Tim Nguyen.

Enhanced Fullscreen was the old name for Picture in Picture. Rename all instances of &quot;EnhancedFullscreen&quot; to &quot;PictureInPicture&quot;.

No new tests. No change in behavior.

* Source/WebCore/page/ContextMenuController.cpp:
(WebCore::ContextMenuController::contextMenuItemSelected):
(WebCore::ContextMenuController::populate):
(WebCore::ContextMenuController::checkOrEnableIfNeeded const):
* Source/WebCore/platform/ContextMenuItem.cpp:
(WebCore::isValidContextMenuAction):
* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/LocalizedStrings.h:
* Source/WebCore/platform/cocoa/LocalizedStringsCocoa.mm:
(WebCore::contextMenuItemTagEnterPictureInPicture):
(WebCore::contextMenuItemTagExitPictureInPicture):
(WebCore::contextMenuItemTagEnterVideoEnhancedFullscreen): Deleted.
(WebCore::contextMenuItemTagExitVideoEnhancedFullscreen): Deleted.
* Source/WebCore/platform/graphics/cocoa/NullVideoPresentationInterface.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKit.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceAVKitLegacy.mm:
(WebCore::VideoPresentationInterfaceAVKitLegacy::isPlayingVideoInPictureInPicture const):
(WebCore::VideoPresentationInterfaceAVKitLegacy::isPlayingVideoInEnhancedFullscreen const): Deleted.
* Source/WebCore/platform/ios/VideoPresentationInterfaceIOS.h:
* Source/WebCore/platform/ios/VideoPresentationInterfaceTVOS.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.h:
* Source/WebCore/platform/mac/VideoPresentationInterfaceMac.mm:
(WebCore::VideoPresentationInterfaceMac::isPlayingVideoInPictureInPicture const):
(WebCore::VideoPresentationInterfaceMac::isPlayingVideoInEnhancedFullscreen const): Deleted.
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::mediaSupportsPictureInPicture const):
(WebCore::HitTestResult::mediaIsInPictureInPicture const):
(WebCore::HitTestResult::togglePictureInPictureForVideo const):
(WebCore::HitTestResult::mediaSupportsEnhancedFullscreen const): Deleted.
(WebCore::HitTestResult::mediaIsInEnhancedFullscreen const): Deleted.
(WebCore::HitTestResult::toggleEnhancedFullscreenForVideo const): Deleted.
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebKit/Platform/ios/VideoPresentationInterfaceLMK.h:
* Source/WebKit/Platform/mac/MenuUtilities.mm:
(WebKit::symbolNameWithTypeForAction):
* Source/WebKit/Shared/API/c/WKContextMenuItemTypes.h:
* Source/WebKit/Shared/API/c/WKSharedAPICast.h:
(WebKit::toAPI):
(WebKit::toImpl):
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.h:
* Source/WebKit/UIProcess/API/C/mac/WKPagePrivateMac.mm:
(WKPageIsPlayingVideoInPictureInPicture):
(WKPageIsPlayingVideoInEnhancedFullscreen): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiers.mm:
* Source/WebKit/UIProcess/API/Cocoa/WKMenuItemIdentifiersPrivate.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.h:
* Source/WebKit/UIProcess/Cocoa/VideoPresentationManagerProxy.mm:
(WebKit::VideoPresentationManagerProxy::isPlayingVideoInPictureInPicture const):
(WebKit::VideoPresentationManagerProxy::isPlayingVideoInEnhancedFullscreen const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::isPlayingVideoInPictureInPicture const):
(WebKit::WebPageProxy::isPlayingVideoInEnhancedFullscreen const): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/mac/WebContextMenuProxyMac.mm:
(WebKit::updateMenuItemImage):
(WebKit::menuItemIdentifier):
* Source/WebKitLegacy/mac/WebView/WebHTMLView.mm:
(toAction):
(toTag):
* Source/WebKitLegacy/mac/WebView/WebUIDelegatePrivate.h:

Canonical link: <a href="https://commits.webkit.org/307781@main">https://commits.webkit.org/307781@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/787d8d4f4c394314948cb08c9ce3f717fe333b24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145496 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18178 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/10013 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154168 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147371 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18663 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18071 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/111893 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148459 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/14266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/130710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/92794 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1615 "Failed to checkout and rebase branch from PR 58665") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/7484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156480 "Failed to checkout and rebase branch from PR 58665") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/18028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/8595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/156480 "Failed to checkout and rebase branch from PR 58665") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/156480 "Failed to checkout and rebase branch from PR 58665") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/128765 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22437 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17649 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/17386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81429 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/17449 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->