### PR TITLE
Rename ForTextEmphasisOrNot::ForTextEmphasis/NotForTextEmphasis to ForTextEmphasis::Yes/No

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -165,7 +165,7 @@ void FontCascade::update(RefPtr<FontSelector>&& fontSelector) const
     FontCache::forCurrentThread()->updateFontCascade(*this);
 }
 
-GlyphBuffer FontCascade::layoutText(CodePath codePathToUse, const TextRun& run, unsigned from, unsigned to, ForTextEmphasisOrNot forTextEmphasis, float* outWidth) const
+GlyphBuffer FontCascade::layoutText(CodePath codePathToUse, const TextRun& run, unsigned from, unsigned to, ForTextEmphasis forTextEmphasis, float* outWidth) const
 {
     if (shouldUseComplexTextController(codePathToUse))
         return layoutComplexText(run, from, to, forTextEmphasis, outWidth);
@@ -194,7 +194,7 @@ void FontCascade::drawEmphasisMarks(GraphicsContext& context, const TextRun& run
 
     unsigned destination = to.value_or(run.length());
 
-    auto glyphBuffer = layoutText(codePath(run, from, to), run, from, destination, ForTextEmphasisOrNot::ForTextEmphasis);
+    auto glyphBuffer = layoutText(codePath(run, from, to), run, from, destination, ForTextEmphasis::Yes);
     glyphBuffer.flatten();
 
     if (glyphBuffer.isEmpty())
@@ -1466,11 +1466,11 @@ float FontCascade::floatEmphasisMarkHeight(const AtomString& mark) const
     return { };
 }
 
-GlyphBuffer FontCascade::layoutSimpleText(const TextRun& run, unsigned from, unsigned to, ForTextEmphasisOrNot forTextEmphasis, float* outWidth) const
+GlyphBuffer FontCascade::layoutSimpleText(const TextRun& run, unsigned from, unsigned to, ForTextEmphasis forTextEmphasis, float* outWidth) const
 {
     GlyphBuffer glyphBuffer;
 
-    WidthIterator it(*this, run, 0, false, forTextEmphasis == ForTextEmphasisOrNot::ForTextEmphasis);
+    WidthIterator it(*this, run, 0, false, forTextEmphasis == ForTextEmphasis::Yes);
     // FIXME: Using separate glyph buffers for the prefix and the suffix is incorrect when kerning or
     // ligatures are enabled.
     GlyphBuffer localGlyphBuffer;
@@ -1505,11 +1505,11 @@ GlyphBuffer FontCascade::layoutSimpleText(const TextRun& run, unsigned from, uns
     return glyphBuffer;
 }
 
-GlyphBuffer FontCascade::layoutComplexText(const TextRun& run, unsigned from, unsigned to, ForTextEmphasisOrNot forTextEmphasis, float* outWidth) const
+GlyphBuffer FontCascade::layoutComplexText(const TextRun& run, unsigned from, unsigned to, ForTextEmphasis forTextEmphasis, float* outWidth) const
 {
     GlyphBuffer glyphBuffer;
 
-    ComplexTextController controller(*this, run, false, 0, forTextEmphasis == ForTextEmphasisOrNot::ForTextEmphasis);
+    ComplexTextController controller(*this, run, false, 0, forTextEmphasis == ForTextEmphasis::Yes);
     GlyphBuffer glyphBufferForStartingIndex;
     controller.advance(from, &glyphBufferForStartingIndex);
     float widthBeforeSegment = controller.totalAdvance().width();

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -107,7 +107,7 @@ public:
     unsigned fontSelectorVersion() const;
 
     enum class CustomFontNotReadyAction : bool { DoNotPaintIfFontNotReady, UseFallbackIfFontNotReady };
-    enum class ForTextEmphasisOrNot : bool { NotForTextEmphasis, ForTextEmphasis };
+    enum class ForTextEmphasis : bool { No, Yes };
     WEBCORE_EXPORT FloatSize drawText(GraphicsContext&, const TextRun&, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt, CustomFontNotReadyAction = CustomFontNotReadyAction::DoNotPaintIfFontNotReady) const;
     static void drawGlyphs(GraphicsContext&, const Font&, std::span<const GlyphBufferGlyph>, std::span<const GlyphBufferAdvance>, const FloatPoint&, FontSmoothingMode);
     void drawEmphasisMarks(GraphicsContext&, const TextRun&, const AtomString& mark, const FloatPoint&, unsigned from = 0, std::optional<unsigned> to = std::nullopt) const;
@@ -206,12 +206,12 @@ public:
 
     unsigned generation() const { return m_generation; }
 
-    GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis, float* outWidth = nullptr) const;
+    GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasis = ForTextEmphasis::No, float* outWidth = nullptr) const;
     void drawGlyphBuffer(GraphicsContext&, const GlyphBuffer&, FloatPoint&, CustomFontNotReadyAction) const;
 
 private:
 
-    GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis, float* outWidth = nullptr) const;
+    GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasis = ForTextEmphasis::No, float* outWidth = nullptr) const;
     void drawEmphasisMarks(GraphicsContext&, const GlyphBuffer&, const AtomString&, const FloatPoint&) const;
     int offsetForPositionForSimpleText(const TextRun&, float position, bool includePartialGlyphs) const;
     void adjustSelectionRectForSimpleText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
@@ -226,7 +226,7 @@ private:
     static constexpr bool canReturnFallbackFontsForComplexText();
     static constexpr bool canExpandAroundIdeographsInComplexText();
 
-    GlyphBuffer layoutComplexText(const TextRun&, unsigned from, unsigned to, ForTextEmphasisOrNot = ForTextEmphasisOrNot::NotForTextEmphasis, float* outWidth = nullptr) const;
+    GlyphBuffer layoutComplexText(const TextRun&, unsigned from, unsigned to, ForTextEmphasis = ForTextEmphasis::No, float* outWidth = nullptr) const;
     int offsetForPositionForComplexText(const TextRun&, float position, bool includePartialGlyphs) const;
     void adjustSelectionRectForComplexText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
 

--- a/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
+++ b/Source/WebCore/platform/graphics/FontCascadeFonts.cpp
@@ -587,7 +587,7 @@ const CachedShapedText* FontCascadeFonts::getOrCreateCachedShapedText(const Text
 
     auto codePath = fontCascade.codePath(run);
     auto width = 0.f;
-    auto glyphBuffer = fontCascade.layoutText(codePath, run, 0, run.length(), FontCascade::ForTextEmphasisOrNot::NotForTextEmphasis, &width);
+    auto glyphBuffer = fontCascade.layoutText(codePath, run, 0, run.length(), FontCascade::ForTextEmphasis::No, &width);
     glyphBuffer.flatten();
 
     cacheEntry->width = width;


### PR DESCRIPTION
#### 28941690b1c94ec6b938ffc7df1bdd8031e09fee
<pre>
Rename ForTextEmphasisOrNot::ForTextEmphasis/NotForTextEmphasis to ForTextEmphasis::Yes/No
<a href="https://bugs.webkit.org/show_bug.cgi?id=307859">https://bugs.webkit.org/show_bug.cgi?id=307859</a>
<a href="https://rdar.apple.com/170350919">rdar://170350919</a>

Reviewed by Sammy Gill.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::layoutText const):
(WebCore::FontCascade::drawEmphasisMarks const):
(WebCore::FontCascade::layoutSimpleText const):
(WebCore::FontCascade::layoutComplexText const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::getOrCreateCachedShapedText):

Canonical link: <a href="https://commits.webkit.org/307536@main">https://commits.webkit.org/307536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e628c1102dff627e35bdd7d7bda4726ee9d67e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144673 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8956 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153344 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17835 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111266 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147636 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13623 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129897 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92161 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/789 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6607 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155656 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/17204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7687 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/119269 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17243 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14387 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/119599 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30670 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/15412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127849 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16826 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6204 "Passed tests") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16626 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->