### PR TITLE
[Scroll anchoring] Fix scroll anchoring in scaled pages

### DIFF
--- a/LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-with-page-scale-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-with-page-scale-expected.txt
@@ -1,0 +1,5 @@
+PASS scroller.scrollTop is 400
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .scroller {
+            width: 300px;
+            height: 400px;
+            border: 1px solid black;
+            overflow-y: scroll;
+        }
+        .changer {
+            width: 50px;
+            height: 300px;
+            background-color: cyan;
+        }
+        body.changed .changer {
+            height: 350px;
+        }
+
+        .anchor {
+            width: 200px;
+            height: 300px;
+            background-color: green;
+        }
+        .spacer {
+            width: 50px;
+            height: 3000px;
+            background-color: silver;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        
+        let scroller;
+        window.addEventListener('load', async () => {
+            if (window.testRunner)
+                await testRunner.setPageScaleFactor(1.5, 0, 0);
+        
+            scroller = document.querySelector('.scroller');
+
+            scroller.scrollTo(0, 350);
+            await UIHelper.renderingUpdate();
+            
+            document.body.classList.add('changed');
+            
+            shouldBe('scroller.scrollTop', '400');
+            finishJSTest()
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="scroller">
+        <div class="changer"></div>
+        <div class="anchor"></div>
+        <div class="spacer"></div>
+        </div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/scroll-anchoring-with-page-scale-expected.txt
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-with-page-scale-expected.txt
@@ -1,0 +1,5 @@
+PASS window.pageYOffset is 400
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/scroll-anchoring-with-page-scale.html
+++ b/LayoutTests/fast/scrolling/scroll-anchoring-with-page-scale.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        .changer {
+            width: 50px;
+            height: 300px;
+            background-color: cyan;
+        }
+        body.changed .changer {
+            height: 350px;
+        }
+
+        .anchor {
+            width: 200px;
+            height: 300px;
+            background-color: green;
+        }
+        .spacer {
+            width: 50px;
+            height: 3000px;
+            background-color: silver;
+        }
+    </style>
+    <script src="../../resources/ui-helper.js"></script>
+    <script src="../../resources/js-test.js"></script>
+    <script>
+        jsTestIsAsync = true;
+        
+        window.addEventListener('load', async () => {
+            if (window.testRunner)
+                await testRunner.setPageScaleFactor(1.5, 0, 0);
+            
+            window.scrollTo(0, 350);
+            await UIHelper.renderingUpdate();
+            
+            document.body.classList.add('changed');
+            
+            shouldBe('window.pageYOffset', '400');
+            finishJSTest()
+        }, false);
+    </script>
+</head>
+<body>
+    <div class="changer"></div>
+    <div class="anchor"></div>
+    <div class="spacer"></div>
+    <div id="console"></div>
+</body>
+</html>

--- a/LayoutTests/fast/visual-viewport/zoomed-fixed-header-and-footer.html
+++ b/LayoutTests/fast/visual-viewport/zoomed-fixed-header-and-footer.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 
 <html>
 <head>

--- a/LayoutTests/fast/visual-viewport/zoomed-fixed.html
+++ b/LayoutTests/fast/visual-viewport/zoomed-fixed.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ CSSScrollAnchoringEnabled=false ] -->
 
 <html>
 <head>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7628,6 +7628,8 @@ imported/w3c/web-platform-tests/css/css-scroll-anchoring/zero-scroll-offset-002.
 # Requires user interaction.
 imported/w3c/web-platform-tests/css/css-scroll-anchoring/fullscreen-crash.html [ Skip ]
 
+webkit.org/b/307861 fast/scrolling/scroll-anchoring-with-page-scale.html [ Failure ]
+
 # rdar://124971386 (css-box/margin-trim/computed-margin-values layout tests failing in recursive cases)
 imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-child-with-border.html [ Pass Failure ]
 imported/w3c/web-platform-tests/css/css-box/margin-trim/computed-margin-values/block-container-block-start-self-collapsing-nested.html [ Pass Failure ]


### PR DESCRIPTION
#### 8b2e2e9fea0e4ddd61af4ddf01251c1cf93c6047
<pre>
[Scroll anchoring] Fix scroll anchoring in scaled pages
<a href="https://bugs.webkit.org/show_bug.cgi?id=307862">https://bugs.webkit.org/show_bug.cgi?id=307862</a>
<a href="https://rdar.apple.com/170352074">rdar://170352074</a>

Reviewed by Wenson Hsieh.

We have to account for page scale when computing scroll anchoring adjustments. We do so
as follow:
- use the visual viewport, so that anchor computation finds the anchor at the top of
  this viewport.
- compute absolute coords relative to the RenderView, which excludes page scale
- scale the computed offset by `frameScale` (which is page scale on the root
  frame, otherwise 1), but only for document scrolling, not overflow scrolling.

iOS is a little janky: webkit.org/b307861

Tests: fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html
       fast/scrolling/scroll-anchoring-with-page-scale.html

* LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-with-page-scale-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring-in-overflow-with-page-scale.html: Added.
* LayoutTests/fast/scrolling/scroll-anchoring-with-page-scale-expected.txt: Added.
* LayoutTests/fast/scrolling/scroll-anchoring-with-page-scale.html: Added.
* LayoutTests/fast/visual-viewport/zoomed-fixed-header-and-footer.html:
* LayoutTests/fast/visual-viewport/zoomed-fixed.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::ScrollAnchoringController::computeScrollerRelativeRects const):
(WebCore::ScrollAnchoringController::adjustScrollPositionForAnchoring):

Canonical link: <a href="https://commits.webkit.org/307577@main">https://commits.webkit.org/307577@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc4a4eb134fa42491fe3b8a59eaf36338fbadafd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144718 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9001 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153389 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98353 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146593 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17880 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111284 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79780 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147681 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13645 "layout-tests (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129927 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92179 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13019 "layout-tests (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10772 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/834 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122533 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155701 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17249 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7717 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119292 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17288 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119621 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30691 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15426 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72791 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16871 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6233 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16607 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80650 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16816 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16671 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->