### PR TITLE
[MiniBrowser] Add keyboard shortcut for New Private Window

### DIFF
--- a/Tools/MiniBrowser/mac/MainMenu.xib
+++ b/Tools/MiniBrowser/mac/MainMenu.xib
@@ -87,13 +87,14 @@
                                     <action selector="newWindow:" target="-1" id="PS4-cQ-V4Q"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="New WebKit2 Private Window" tag="2" id="Zqs-AO-XAX">
-                                <modifierMask key="keyEquivalentModifierMask"/>
+                            <menuItem title="New WebKit2 Private Window" tag="2" keyEquivalent="N" id="Zqs-AO-XAX">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>
                                     <action selector="newPrivateWindow:" target="-1" id="mf5-zi-a5R"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="New WebKit1 Editor" tag="3" keyEquivalent="N" id="jNR-Z3-YWi" userLabel="New WebKit1 Editor">
+                            <menuItem title="New WebKit1 Editor" tag="3" id="jNR-Z3-YWi" userLabel="New WebKit1 Editor">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="newEditorWindow:" target="-1" id="Nv5-c0-KRP"/>
                                 </connections>


### PR DESCRIPTION
#### d7cf33d522f8d988dae335aa1a9505aeb0b1bd7e
<pre>
[MiniBrowser] Add keyboard shortcut for New Private Window
<a href="https://bugs.webkit.org/show_bug.cgi?id=307872">https://bugs.webkit.org/show_bug.cgi?id=307872</a>
<a href="https://rdar.apple.com/170357381">rdar://170357381</a>

Reviewed by Tim Horton.

Assign CMD+SHIFT+N to open a new private browsing window in MiniBrowser,
matching the standard Safari keyboard shortcut. The shortcut was previously
assigned to &quot;New WebKit1 Editor&quot; which now has no keyboard shortcut.

* Tools/MiniBrowser/mac/MainMenu.xib:

Canonical link: <a href="https://commits.webkit.org/307570@main">https://commits.webkit.org/307570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff4e8889d04dc4eacd8d916ddbbe74a2a67c4a9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144713 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17392 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/8996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153384 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146588 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111282 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7dfecc84-1b70-430a-a610-9ef9fb548793) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147676 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13649 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; layout-tests (exception)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129924 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92177 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f311bd7-0325-45aa-b1b2-66a0b31a30b2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13023 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; layout-tests (exception)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10776 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/829 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122538 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6634 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155696 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17244 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7714 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119287 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14413 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119616 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30687 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15427 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127876 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72786 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16866 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6230 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16602 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16811 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16666 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->