### PR TITLE
Add mechanism for preserving scroll rubber banding across page loads

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -2419,6 +2419,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/ReferrerPolicy.h
     platform/RegistrableDomain.h
     platform/RemoteCommandListener.h
+    platform/RubberbandingState.h
     platform/RunLoopObserver.h
     platform/ScreenOrientationManager.h
     platform/ScreenProperties.h

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -36,6 +36,7 @@
 #include <WebCore/PlatformWheelEvent.h>
 #include <WebCore/RectEdges.h>
 #include <WebCore/Region.h>
+#include <WebCore/RubberbandingState.h>
 #include <WebCore/ScrollTypes.h>
 #include <WebCore/ScrollingCoordinatorTypes.h>
 #include <WebCore/ScrollingTreeGestureState.h>
@@ -95,6 +96,11 @@ public:
 
     bool isRubberBandInProgressForNode(std::optional<ScrollingNodeID>);
     WEBCORE_EXPORT virtual void setRubberBandingInProgressForNode(ScrollingNodeID, bool);
+
+#if HAVE(RUBBER_BANDING)
+    void setPendingMainFrameRubberbandingState(std::optional<RubberbandingState>&&) WTF_REQUIRES_LOCK(m_treeLock);
+    std::optional<RubberbandingState> takePendingMainFrameRubberbandingState() WTF_REQUIRES_LOCK(m_treeLock);
+#endif
 
     bool isUserScrollInProgressForNode(std::optional<ScrollingNodeID>);
     void setUserScrollInProgressForNode(ScrollingNodeID, bool);
@@ -359,6 +365,10 @@ private:
 
     Lock m_pendingScrollUpdatesLock;
     Vector<ScrollUpdate> m_pendingScrollUpdates WTF_GUARDED_BY_LOCK(m_pendingScrollUpdatesLock);
+
+#if HAVE(RUBBER_BANDING)
+    std::optional<RubberbandingState> m_pendingMainFrameRubberbandingState WTF_GUARDED_BY_LOCK(m_treeLock);
+#endif
 
     Lock m_lastWheelEventTimeLock;
     MonotonicTime m_lastWheelEventTime WTF_GUARDED_BY_LOCK(m_lastWheelEventTimeLock);

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp
@@ -318,6 +318,15 @@ void ScrollingTreeScrollingNode::setScrollSnapInProgress(bool isSnapping)
     scrollingTree()->setNodeScrollSnapInProgress(scrollingNodeID(), isSnapping);
 }
 
+#if HAVE(RUBBER_BANDING)
+std::optional<RubberbandingState> ScrollingTreeScrollingNode::captureRubberbandingState() const
+{
+    if (m_delegate)
+        return m_delegate->captureRubberbandingState();
+    return std::nullopt;
+}
+#endif
+
 void ScrollingTreeScrollingNode::willStartAnimatedScroll()
 {
     scrollingTree()->scrollingTreeNodeWillStartAnimatedScroll(*this);
@@ -383,6 +392,15 @@ void ScrollingTreeScrollingNode::requestKeyboardScroll(const RequestedKeyboardSc
 
 void ScrollingTreeScrollingNode::handleScrollPositionRequest(const RequestedScrollData& requestedScrollData)
 {
+#if HAVE(RUBBER_BANDING)
+    LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingTreeScrollingNode::handleScrollPositionRequest nodeID=" << scrollingNodeID() << " requestType=" << static_cast<unsigned>(requestedScrollData.requestType) << " isRubberBanding=" << scrollingTree()->isRubberBandInProgressForNode(scrollingNodeID()) << " restoredRubberbandingInProgress=" << restoredRubberbandingInProgress());
+
+    if (restoredRubberbandingInProgress()) {
+        LOG_WITH_STREAM(ScrollAnimations, stream << "ScrollingTreeScrollingNode::handleScrollPositionRequest - skipping because restored rubberbanding is in progress");
+        return;
+    }
+#endif
+
     if (requestedScrollData.requestType != ScrollRequestType::DeltaUpdate)
         stopAnimatedScroll();
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -29,6 +29,7 @@
 #if ENABLE(ASYNC_SCROLLING)
 
 #include <WebCore/IntRect.h>
+#include <WebCore/RubberbandingState.h>
 #include <WebCore/ScrollSnapOffsetsInfo.h>
 #include <WebCore/ScrollableArea.h>
 #include <WebCore/ScrollingTree.h>
@@ -85,6 +86,12 @@ public:
 
     bool isScrollSnapInProgress() const;
     void setScrollSnapInProgress(bool);
+
+#if HAVE(RUBBER_BANDING)
+    std::optional<RubberbandingState> captureRubberbandingState() const;
+    void setRestoredRubberbandingInProgress(bool inProgress) { m_restoredRubberbandingInProgress = inProgress; }
+    bool restoredRubberbandingInProgress() const { return m_restoredRubberbandingInProgress; }
+#endif
 
     virtual bool startAnimatedScrollToPosition(FloatPoint);
     virtual void stopAnimatedScroll();
@@ -223,6 +230,9 @@ private:
 #endif
     bool m_isFirstCommit { true };
     bool m_scrolledSinceLastCommit { false };
+#if HAVE(RUBBER_BANDING)
+    bool m_restoredRubberbandingInProgress { false };
+#endif
     ScrollbarRevealBehavior m_scrollbarRevealBehaviorForNextScrollbarUpdate { ScrollbarRevealBehavior::Default };
 
     LayerRepresentation m_scrollContainerLayer;

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(ASYNC_SCROLLING)
 
+#include <WebCore/RubberbandingState.h>
 #include <WebCore/ScrollingTreeScrollingNode.h>
 
 #include <wtf/TZoneMalloc.h>
@@ -62,6 +63,10 @@ public:
 
     virtual FloatPoint adjustedScrollPosition(const FloatPoint& scrollPosition) const { return scrollPosition; }
     virtual String scrollbarStateForOrientation(ScrollbarOrientation) const { return ""_s; }
+
+#if HAVE(RUBBER_BANDING)
+    virtual std::optional<RubberbandingState> captureRubberbandingState() const { return std::nullopt; }
+#endif
 
 protected:
     WEBCORE_EXPORT RefPtr<ScrollingTree> scrollingTree() const;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -61,6 +61,10 @@ public:
     bool isRubberBandInProgress() const;
     void startRubberBandSnapBack();
 
+#if HAVE(RUBBER_BANDING)
+    std::optional<RubberbandingState> captureRubberbandingState() const final;
+#endif
+
     void updateScrollbarPainters();
     void updateScrollbarLayers() final;
     
@@ -94,6 +98,10 @@ private:
     const Ref<ScrollerPairMac> m_scrollerPair;
 
     bool m_inMomentumPhase { false };
+
+#if HAVE(RUBBER_BANDING)
+    std::optional<RubberbandingState> m_pendingRubberbandingState;
+#endif
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/RubberbandingState.h
+++ b/Source/WebCore/platform/RubberbandingState.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if HAVE(RUBBER_BANDING)
+
+#include "FloatSize.h"
+#include "RectEdges.h"
+#include <wtf/MonotonicTime.h>
+
+namespace WebCore {
+
+struct RubberbandingState {
+    FloatSize initialVelocity;
+    FloatSize initialOverscroll;
+
+    MonotonicTime animationStartTime;
+    MonotonicTime captureTime;
+
+    RectEdges<bool> rubberbandingEdges;
+
+    FloatSize stretchScrollForce;
+    FloatSize momentumVelocity;
+};
+
+} // namespace WebCore
+
+#endif // HAVE(RUBBER_BANDING)

--- a/Source/WebCore/platform/ScrollAnimation.h
+++ b/Source/WebCore/platform/ScrollAnimation.h
@@ -84,6 +84,7 @@ public:
     
     FloatPoint currentOffset() const { return m_currentOffset; }
     virtual std::optional<FloatPoint> destinationOffset() const { return std::nullopt; }
+    MonotonicTime startTime() const { return m_startTime; }
 
     virtual void serviceAnimation(MonotonicTime) = 0;
 

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -30,6 +30,7 @@
 
 #include <WebCore/KeyboardScroll.h>
 #include <WebCore/RectEdges.h>
+#include <WebCore/RubberbandingState.h>
 #include <WebCore/ScrollAnimation.h>
 #include <WebCore/ScrollSnapAnimatorState.h>
 #include <WebCore/ScrollSnapOffsetsInfo.h>
@@ -199,6 +200,10 @@ public:
     void startRubberBandSnapBack();
     bool isRubberBandInProgress() const;
     RectEdges<bool> rubberBandingEdges() const { return m_rubberBandingEdges; }
+
+    std::optional<RubberbandingState> captureRubberbandingState() const;
+    bool restoreRubberbandingState(const RubberbandingState&);
+    bool shouldAttemptRubberbandingRestoration(const RubberbandingState&);
     FloatSize deltaWithAdditionalAdjustments(const FloatSize& adjustedDelta, bool);
 #endif
 
@@ -225,6 +230,7 @@ private:
     void startRubberBandAnimationIfNecessary();
 
     bool startRubberBandAnimation(const FloatSize& initialVelocity, const FloatSize& initialOverscroll);
+    bool startRubberBandAnimationWithElapsedTime(const FloatSize& initialVelocity, const FloatSize& initialOverscroll, Seconds alreadyElapsed);
     void stopRubberBandAnimation();
 
     void willStartRubberBandAnimation();

--- a/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
+++ b/Source/WebCore/platform/mac/ScrollAnimationRubberBand.h
@@ -43,6 +43,12 @@ public:
     // This is used so that rubber banding does not obscure banner view overlays.
     bool startRubberBandAnimation(const FloatSize& initialVelocity, const FloatSize& initialOverscroll, const FloatSize& targetOverscroll = { });
 
+    bool startRubberBandAnimationWithElapsedTime(const FloatSize& initialVelocity, const FloatSize& initialOverscroll, Seconds alreadyElapsed, const FloatSize& targetOverscroll = { });
+
+    const FloatSize& initialVelocity() const { return m_initialVelocity; }
+    const FloatSize& initialOverscroll() const { return m_initialOverscroll; }
+    const FloatSize& targetOverscroll() const { return m_targetOverscroll; }
+
 private:
     void updateScrollExtents() final;
     void serviceAnimation(MonotonicTime) final;

--- a/Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm
+++ b/Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm
@@ -72,6 +72,16 @@ bool ScrollAnimationRubberBand::startRubberBandAnimation(const FloatSize& initia
     return true;
 }
 
+bool ScrollAnimationRubberBand::startRubberBandAnimationWithElapsedTime(const FloatSize& initialVelocity, const FloatSize& initialOverscroll, Seconds alreadyElapsed, const FloatSize& targetOverscroll)
+{
+    m_initialVelocity = initialVelocity;
+    m_initialOverscroll = initialOverscroll;
+    m_targetOverscroll = targetOverscroll;
+
+    didStart(MonotonicTime::now() - alreadyElapsed);
+    return true;
+}
+
 bool ScrollAnimationRubberBand::retargetActiveAnimation(const FloatPoint&)
 {
     return false;


### PR DESCRIPTION
#### 0d2bd8b886d3ba2d1b6e559333aa1816c9385f63
<pre>
Add mechanism for preserving scroll rubber banding across page loads
<a href="https://bugs.webkit.org/show_bug.cgi?id=307650">https://bugs.webkit.org/show_bug.cgi?id=307650</a>
<a href="https://rdar.apple.com/170208256">rdar://170208256</a>

Reviewed by Abrar Rahman Protyasha and Simon Fraser.

Add a mechanism for preserving the scroll rubber banding across page loads
by requesting new type `RubberbandingState` from the root scrolling node
of the ScrollingTree before it is replaced with a new one. The ScrollingTree
holds onto this pending state.

In the constructor for `ScrollingTreeScrollingNodeDelegateMac`, we check
if the node is the root scrolling node, and if it is, we take the pending
`RubberbandingState` from the `ScrollingTree` and store it. In
`ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode`, we check to
see if we have a pending state, and if we do, we call
`ScrollingEffectsController::restoreRubberbandingState` which triggers
a ScrollAnimationRubberBand that uses the pending state to determine
where it should continue from, velocity, etc.

Tests will be added in a later patch.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::commitTreeStateInternal):
(WebCore::ScrollingTree::setPendingMainFrameRubberbandingState):
(WebCore::ScrollingTree::takePendingMainFrameRubberbandingState):
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.cpp:
(WebCore::ScrollingTreeScrollingNode::captureRubberbandingState const):
(WebCore::ScrollingTreeScrollingNode::handleScrollPositionRequest):
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNodeDelegate.h:
(WebCore::ScrollingTreeScrollingNodeDelegate::captureRubberbandingState const):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::ScrollingTreeScrollingNodeDelegateMac):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::updateFromStateNode):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::captureRubberbandingState const):
(WebCore::ScrollingTreeScrollingNodeDelegateMac::rubberBandingStateChanged):
* Source/WebCore/platform/RubberbandingState.h: Added.
* Source/WebCore/platform/ScrollAnimation.h:
(WebCore::ScrollAnimation::startTime const):
* Source/WebCore/platform/ScrollingEffectsController.h:
* Source/WebCore/platform/mac/ScrollAnimationRubberBand.h:
* Source/WebCore/platform/mac/ScrollAnimationRubberBand.mm:
(WebCore::ScrollAnimationRubberBand::startRubberBandAnimationWithElapsedTime):
* Source/WebCore/platform/mac/ScrollingEffectsController.mm:
(WebCore::ScrollingEffectsController::shouldAttemptRubberbandingRestoration):
(WebCore::ScrollingEffectsController::startRubberBandAnimationWithElapsedTime):
(WebCore::ScrollingEffectsController::captureRubberbandingState const):
(WebCore::ScrollingEffectsController::restoreRubberbandingState):

Canonical link: <a href="https://commits.webkit.org/307662@main">https://commits.webkit.org/307662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9c891deee5611857198286303dd28e953be06bcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144990 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153661 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98625 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee408d06-4bff-4e17-a514-43ddeb7df445) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146865 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18154 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17563 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111486 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79925 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3affd532-f68c-449a-a4da-ce37699ad109) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147953 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130203 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92382 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/333f2ee7-e4f6-4297-9824-2a7443e44c2e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13218 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10979 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1106 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122735 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6947 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155973 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17522 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8035 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119490 "Passed tests") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/144395 "Build is in progress. Recent messages:") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17568 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14622 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119818 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30753 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15617 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73167 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17143 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6500 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16879 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80922 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17088 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->