### PR TITLE
ParentalControlsURLFilter should try to request permission for URL's if possible.

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -9349,6 +9349,22 @@ WebCodecsVideoEnabled:
   richJavaScript: true
   mediaPlaybackRelated: true
 
+WebContentRestrictionsAskToEnabled:
+  type: bool
+  status: unstable
+  defaultsOverridable: true
+  humanReadableName: "Web Content Restrictions Ask To"
+  humanReadableDescription: "Enable Ask To for WebContentRestrictions"
+  condition: HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 WebContentRestrictionsTransitiveTrustEnabled:
   type: bool
   status: stable

--- a/Source/WebCore/loader/ContentFilter.cpp
+++ b/Source/WebCore/loader/ContentFilter.cpp
@@ -41,6 +41,7 @@
 #include "ParentalControlsContentFilter.h"
 #include "ScriptController.h"
 #include "SharedBuffer.h"
+#include <array>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/Ref.h>
 #include <wtf/SetForScope.h>
@@ -462,7 +463,20 @@ bool ContentFilter::isWebContentRestrictionsUnblockURL(const URL& url)
         return true;
 #endif
 
-    return url.protocolIs(ContentFilter::urlScheme()) && equalIgnoringASCIICase(url.host(), "unblock"_s);
+    if (!url.protocolIs(ContentFilter::urlScheme()))
+        return false;
+
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    static constexpr std::array validHosts { "unblock"_s, "present"_s, "ask"_s };
+#else
+    static constexpr std::array validHosts { "unblock"_s };
+#endif
+
+    for (const auto& host : validHosts) {
+        if (equalIgnoringASCIICase(url.host(), host))
+            return true;
+    }
+    return false;
 }
 
 #endif

--- a/Source/WebCore/platform/ContentFilterUnblockHandler.h
+++ b/Source/WebCore/platform/ContentFilterUnblockHandler.h
@@ -73,7 +73,7 @@ public:
 
     WEBCORE_EXPORT bool needsUIProcess() const;
     WEBCORE_EXPORT bool canHandleRequest(const ResourceRequest&) const;
-    WEBCORE_EXPORT void requestUnblockAsync(DecisionHandlerFunction&&);
+    WEBCORE_EXPORT void requestUnblockAsync(DecisionHandlerFunction&&, std::optional<URL> requestURL = std::nullopt);
     void wrapWithDecisionHandler(const DecisionHandlerFunction&);
 #if HAVE(WEBCONTENTRESTRICTIONS)
     WEBCORE_EXPORT bool needsNetworkProcess() const;

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -58,6 +58,8 @@ public:
     void isURLAllowed(const URL& mainDocumentURL, const URL&, ParentalControlsContentFilter&);
     WEBCORE_EXPORT void isURLAllowed(const URL& mainDocumentURL, const URL&, CompletionHandler<void(bool, NSData *)>&&);
     virtual void allowURL(const URL&, CompletionHandler<void(bool)>&&);
+    virtual void requestPermissionForURL(const URL&, const URL&, CompletionHandler<void(bool)>&&);
+    virtual bool canRequestPermissionForURL() { return false; }
 
 protected:
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm
@@ -238,6 +238,12 @@ void ParentalControlsURLFilter::allowURL(const ParentalControlsURLFilterParamete
     filter->allowURL(parameters.urlToAllow, WTF::move(completionHandler));
 }
 
+void ParentalControlsURLFilter::requestPermissionForURL(const URL&, const URL&, CompletionHandler<void(bool)>&&)
+{
+    // Check canRequestPermissionForURL() before invoking.
+    RELEASE_ASSERT_NOT_REACHED();
+}
+
 WCRBrowserEngineClient* ParentalControlsURLFilter::effectiveWCRBrowserEngineClient()
 {
     if (!isEnabled())

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
@@ -46,6 +46,8 @@ private:
     bool isEnabledImpl() const final;
     void isURLAllowedImpl(const URL& mainDocumentURL, const URL&, CompletionHandler<void(bool, NSData *)>&&) final;
     void allowURL(const URL&, CompletionHandler<void(bool)>&&) final;
+    void requestPermissionForURL(const URL&, const URL& referrerURL, CompletionHandler<void(bool)>&&) final;
+    bool canRequestPermissionForURL() final { return true; }
 
     BEWebContentFilter* ensureWebContentFilter();
 

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
@@ -122,6 +122,25 @@ void WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary
 #endif
 }
 
+void WebParentalControlsURLFilter::requestPermissionForURL(const URL& url, const URL& referrerURL, CompletionHandler<void(bool)>&& completionHandler)
+{
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    workQueueSingleton().dispatchSync([this, protectedThis = Ref { *this }, currentIsEnabled = isEnabled(), url = crossThreadCopy(url), referrerURL = crossThreadCopy(referrerURL), completionHandler = WTF::move(completionHandler)]() mutable {
+        if (!currentIsEnabled) {
+            callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
+                completionHandler(true);
+            });
+            return;
+        }
+        auto filter = ensureWebContentFilter();
+#if __has_include(<WebKitAdditions/BEKAdditions.h>)
+        RELEASE_LOG(Loading, "WebParentalControlsURLFilter::requestPermissionForURL starts execution");
+        MAYBE_REQUEST_PERMISSION_ASK_TO
+#endif
+    });
+#endif
+}
+
 } // namespace WebKit
 
 #endif

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -453,14 +453,20 @@ bool WebFrameProxy::didHandleContentFilterUnblockNavigation(const ResourceReques
     }
 #endif
 
+    std::optional<URL> unblockRequestURL = std::nullopt;
 #if HAVE(BROWSERENGINEKIT_WEBCONTENTFILTER) && !HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    if (page->preferences().webContentRestrictionsAskToEnabled())
+        unblockRequestURL = request.url();
+#endif
+
     WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary();
 #endif
 
     m_contentFilterUnblockHandler.requestUnblockAsync([page](bool unblocked) {
         if (unblocked)
             page->reload({ });
-    });
+    }, unblockRequestURL);
     return true;
 }
 #endif


### PR DESCRIPTION
#### d3bb55eede0164646a57cc06814de42cf72654fe
<pre>
ParentalControlsURLFilter should try to request permission for URL&apos;s if possible.
<a href="https://bugs.webkit.org/show_bug.cgi?id=307873">https://bugs.webkit.org/show_bug.cgi?id=307873</a>
<a href="https://rdar.apple.com/164138363">rdar://164138363</a>

Reviewed by Sihui Liu.

When allowing access to a URL, WebParentalControlsURLFilter can provide a referrerURL when
requesting permission for a URL. If we can&apos;t request permission for a URL, we fallback to using
the traditional code path to allow access for a URL.

No new tests needed.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/loader/ContentFilter.cpp:
(WebCore::ContentFilter::isWebContentRestrictionsUnblockURL):
* Source/WebCore/platform/ContentFilterUnblockHandler.h:
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::requestUnblockAsync):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::ParentalControlsURLFilter::requestPermissionForURL):
* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h:
* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm:
(WebKit::WebParentalControlsURLFilter::requestPermissionForURL):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didHandleContentFilterUnblockNavigation):

Canonical link: <a href="https://commits.webkit.org/307705@main">https://commits.webkit.org/307705@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af126b2ff81ed242c9178212e7ded67db3fa306d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17875 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9650 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153866 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98830 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/533e5588-4ea9-4b01-aeed-62b0376d5de2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147069 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17767 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111642 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf13608d-ddbe-42da-83a3-a94ab036c0fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148157 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130412 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92541 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/007ea4b5-1fa1-4024-855e-12804332abfe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13362 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11124 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1311 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137185 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122887 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7170 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156178 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6003 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17726 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119651 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119985 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15756 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128428 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73390 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22400 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17347 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6686 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176483 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17084 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81126 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45393 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17292 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17147 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->