### PR TITLE
AX: Eagerly dirtying relations in AXObjectCache::deferAttributeChangeIfNeeded can cause RELEASE_ASSERT to be hit

### DIFF
--- a/LayoutTests/accessibility/focus-change-id-mutation-and-removal-crash-expected.txt
+++ b/LayoutTests/accessibility/focus-change-id-mutation-and-removal-crash-expected.txt
@@ -1,0 +1,9 @@
+This test ensures we don't crash when a focusout handler moves elements from light DOM into shadow DOM while changing IDs and removing elements involved in aria relationships.
+
+PASS: input1 is focused.
+PASS: No crash after focus change with shadow DOM element moves and id mutations.
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/focus-change-id-mutation-and-removal-crash.html
+++ b/LayoutTests/accessibility/focus-change-id-mutation-and-removal-crash.html
@@ -1,0 +1,96 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<script src="../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<div id="test-content">
+    <!-- Shadow host -->
+    <div id="shadow-host"></div>
+
+    <!-- Light DOM elements that will be moved INTO shadow DOM -->
+    <div id="target-1" role="button">Light Target 1</div>
+    <div id="target-2" role="button">Light Target 2</div>
+    <div id="label-1">Light Label 1</div>
+    <div id="desc-1">Light Description 1</div>
+
+    <!-- Light DOM elements with aria relationships pointing to the above IDs -->
+    <div id="owner-1" role="group" aria-label="owner1" aria-owns="target-1"></div>
+    <div id="owner-2" role="group" aria-label="owner2" aria-owns="target-2"></div>
+    <div id="labelled-1" role="group" aria-labelledby="label-1"></div>
+    <div id="described-1" role="group" aria-describedby="desc-1"></div>
+
+    <!-- Element whose ID will change to dirty relations -->
+    <div id="changeable-id" role="group">Changeable</div>
+
+    <!-- Element that will be removed - is owned so ownerParentObject() will be called -->
+    <div id="owner-of-removed" role="group" aria-owns="to-remove">Owner of removed</div>
+    <div id="to-remove" role="button">Will be removed</div>
+
+    <!-- Focus targets -->
+    <input type="text" id="input1" onfocusout="focusoutHandler()">
+    <input type="text" id="input2">
+</div>
+
+<script>
+var output = "This test ensures we don't crash when a focusout handler moves elements from light DOM into shadow DOM while changing IDs and removing elements involved in aria relationships.\n\n";
+
+var shadowRoot = document.getElementById("shadow-host").attachShadow({ mode: "open" });
+
+function focusoutHandler() {
+    // Force layout to be clean before we start manipulating.
+    document.body.offsetHeight;
+
+    // Change an ID to dirty relations.
+    document.getElementById("changeable-id").id = "new-id";
+
+    // Move elements from light DOM into shadow DOM.
+    shadowRoot.appendChild(document.getElementById("target-1"));
+    shadowRoot.appendChild(document.getElementById("label-1"));
+
+    // Remove an element that is aria-owned.
+    document.getElementById("to-remove").remove();
+
+    // Additional ID changes and moves.
+    document.getElementById("target-2").id = "target-2-modified";
+    document.getElementById("desc-1").id = "desc-1-modified";
+    shadowRoot.appendChild(document.getElementById("desc-1-modified"));
+    shadowRoot.appendChild(document.getElementById("target-2-modified"));
+    shadowRoot.appendChild(document.getElementById("new-id"));
+}
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    touchAccessibilityTree(accessibilityController.rootElement);
+    setTimeout(async function() {
+        await UIHelper.renderingUpdate();
+
+        // Focus input1 via accessibility API
+        var axInput1 = accessibilityController.accessibleElementById("input1");
+        axInput1.takeFocus();
+
+        await waitFor(() => {
+            var focused = accessibilityController.focusedElement;
+            return focused && focused.domIdentifier === "input1";
+        });
+        output += "PASS: input1 is focused.\n";
+
+        // Focus input2 - triggers focusout handler
+        var axInput2 = accessibilityController.accessibleElementById("input2");
+        axInput2.takeFocus();
+
+        touchAccessibilityTree(accessibilityController.rootElement);
+
+        output += "PASS: No crash after focus change with shadow DOM element moves and id mutations.\n";
+        debug(output);
+        document.getElementById("test-content").style.display = "none";
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -855,6 +855,9 @@ accessibility/css-content-alt-text.html [ Skip ]
 # AXObjectCache::announce not implemented.
 accessibility/announcement-notification.html [ Skip ]
 
+# Failing since introduced.
+accessibility/focus-change-id-mutation-and-removal-crash.html [ Skip ]
+
 # AccessibilityUIElement::isInTable is not implemented.
 accessibility/table-ancestry.html [ Skip ]
 


### PR DESCRIPTION
#### b73f15088293cec470e0c2ceddd58bcd0b8480e5
<pre>
AX: Eagerly dirtying relations in AXObjectCache::deferAttributeChangeIfNeeded can cause RELEASE_ASSERT to be hit
<a href="https://bugs.webkit.org/show_bug.cgi?id=307871">https://bugs.webkit.org/show_bug.cgi?id=307871</a>
<a href="https://rdar.apple.com/170357587">rdar://170357587</a>

Reviewed by Joshua Hoffman.

It&apos;s possible for us to hit a RELEASE_ASSERT_WITH_SECURITY_IMPLICATION in TreeScopeOrderedMap::get given this sequence:

  1. An AT requests an element to be focused
  2. The page has a focus JS event handler that changes DOM IDs, moves elements with relations out of the shadow DOM, and
     removes any element.
  3. We handle the DOM ID attribute change and dirty relations in AXObjectCache::deferAttributeChangeIfNeeded
  4. We handle the node removal, which results in a call to parentObject() in AXIsolatedTree::queueNodeRemoval(),
     resulting in a call to ownerParentObject(), which tries to resolve the dirty relations.
  5. Because an element was moved out of the shadow DOM, it&apos;s treescope changed. When undirtying relations,
     TreeScopeOrderedMap::get is called, and we crash due to the treescope mismatch.

Solve this by changing AXObjectCache::deferAttributeChangeIfNeeded to never eagerly dirty relations — we will do so
in AXObjectCache::performDeferredCacheUpdate instead, which is a time when style and layout are guaranteed to be clean.

In the future, we can consider other improvements. e.g., can we simply change to eagerly updating relations in
AXObjectCache::performDeferredCacheUpdate() instead rather than updating relations lazily as we do today?

* LayoutTests/accessibility/focus-change-id-mutation-and-removal-crash-expected.txt: Added.
* LayoutTests/accessibility/focus-change-id-mutation-and-removal-crash.html: Added.
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::deferAttributeChangeIfNeeded):

Canonical link: <a href="https://commits.webkit.org/307618@main">https://commits.webkit.org/307618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5cae92096da8856fd002455e6fbafef68567949

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144836 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9237 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98471 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf6ccbbf-e307-4b2e-b3d1-f1908fcbfe72) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111367 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79821 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b40fd90e-5511-458f-a2fb-911d403a7792) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147799 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13729 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130071 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92262 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1417e019-d5a0-4cd2-83a4-9db2add59c3d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13103 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10856 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/952 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122618 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6815 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155819 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7903 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119370 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17414 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14498 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119698 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15501 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128073 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72928 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16989 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6371 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80768 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16934 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->