### PR TITLE
Unreviewed. Update safer C++ expectations for iOS.

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -114,6 +114,7 @@ wasm/WasmBBQPlan.cpp
 wasm/WasmCallee.cpp
 wasm/WasmConstExprGenerator.cpp
 wasm/WasmFaultSignalHandler.cpp
+[ iOS ] wasm/WasmFormat.h
 wasm/WasmFunctionParser.h
 wasm/WasmIPIntGenerator.cpp
 wasm/WasmIPIntPlan.cpp

--- a/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations
@@ -1,0 +1,1 @@
+[ iOS ] dom/Document.cpp


### PR DESCRIPTION
#### 29b0922cd16705e7f01cd02e679d07b5c09b7882
<pre>
Unreviewed. Update safer C++ expectations for iOS.

* Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/NoDeleteCheckerExpectations: Added.

Canonical link: <a href="https://commits.webkit.org/307557@main">https://commits.webkit.org/307557@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ff0bac9630340363a9cda164d47f986fa270ff4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144765 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/17444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/9048 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/153436 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146640 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17927 "Build is in progress. Recent messages:") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17338 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/153436 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147728 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/17927 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/129963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/153436 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/17927 "Build is in progress. Recent messages:") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10802 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/881 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136756 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/17927 "Build is in progress. Recent messages:") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/6673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155748 "Failed to checkout and rebase branch from PR 58692") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5574 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/17296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/7753 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/155748 "Failed to checkout and rebase branch from PR 58692") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/17343 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/14443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/155748 "Failed to checkout and rebase branch from PR 58692") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/127915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22333 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16918 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176053 "Built successfully") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16654 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80697 "Failed to checkout and rebase branch from PR 58692") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/45313 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16863 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/16718 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->