### PR TITLE
Fix find in page for content with -webkit-user-select: none

### DIFF
--- a/LayoutTests/editing/text-iterator/findString-selection-disabled-multiple-expected.txt
+++ b/LayoutTests/editing/text-iterator/findString-selection-disabled-multiple-expected.txt
@@ -1,0 +1,11 @@
+v_
+findme
+
+findme
+
+
+PASS find first string with selection disabled
+PASS find second string with selection disabled
+PASS find first string with selection enabled
+PASS find second string with selection enabled
+

--- a/LayoutTests/editing/text-iterator/findString-selection-disabled-multiple.html
+++ b/LayoutTests/editing/text-iterator/findString-selection-disabled-multiple.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Find multiple strings with selection disabled</title>v_
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style type="text/css">
+ .selectionDisabled { -webkit-user-select: none; }
+ .selectionEnabled { -webkit-user-select: auto; }
+</style>
+</head>
+<body>
+    <div id="container">
+        <p id="first">findme</p>
+        <p id="second">findme</p>
+    </div>
+<script>
+
+async function testFindString(disableSelection, expectedNode) {
+    container.className = disableSelection ? "selectionDisabled" : "selectionEnabled";
+
+    const result = await testRunner.findString("findme", ["WrapAround"]);
+
+    const selection = window.getSelection();
+    const range = selection.getRangeAt(0);
+    const resultNode = range.startContainer;
+    assert_equals(resultNode.parentElement, expectedNode);
+}
+
+async function runTest(disableSelection, nodeId) {
+        const expectedNode = document.getElementById(nodeId);
+        await promise_test(() => testFindString(disableSelection, expectedNode), `find ${nodeId} string with selection ${disableSelection ? "disabled" : "enabled"}`);
+}
+
+for (disableSelection of [true, false]) {
+    runTest(disableSelection, "first");
+    runTest(disableSelection, "second");
+}
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4042,7 +4042,10 @@ std::optional<SimpleRange> Editor::findString(const String& target, FindOptions 
         document->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityAutoAsVisible, LayoutOptions::TreatRevealedWhenFoundAsVisible });
         Style::PostResolutionCallbackDisabler disabler(document);
         VisibleSelection selection = document->selection().selection();
-        resultRange = rangeOfString(target, selection.firstRange(), options);
+        auto referenceRange = selection.firstRange();
+        if (!referenceRange || referenceRange->collapsed())
+            referenceRange = selection.range();
+        resultRange = rangeOfString(target, referenceRange, options);
     }
 
     if (!resultRange)
@@ -4106,7 +4109,10 @@ std::optional<SimpleRange> Editor::rangeOfString(const String& target, const std
     // If we started in the reference range and the found range exactly matches the reference range, find again.
     // Build a selection with the found range to remove collapsed whitespace.
     // Compare ranges instead of selection objects to ignore the way that the current selection was made.
-    if (startInReferenceRange && VisibleSelection(resultRange).toNormalizedRange() == referenceRange) {
+    auto resultSelection = VisibleSelection(resultRange);
+    auto normalizedRange = resultSelection.toNormalizedRange();
+    auto resultRangeForComparison = !normalizedRange || normalizedRange->collapsed() ? resultSelection.range() : normalizedRange;
+    if (startInReferenceRange && resultRangeForComparison == referenceRange) {
         searchRange = makeRangeSelectingNodeContents(document);
         start(searchRange, options) = end(*referenceRange, options);
         if (shadowTreeRoot)


### PR DESCRIPTION
#### 635808d7603e771d21ea17bccf831aa917ad5b5a
<pre>
Fix find in page for content with -webkit-user-select: none
<a href="https://rdar.apple.com/85000322">rdar://85000322</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307877">https://bugs.webkit.org/show_bug.cgi?id=307877</a>

Reviewed by Ryosuke Niwa and Megan Gardner.

The find-in-page feature relies on the selection API for finding strings. If
a string is found and it looks to be the same selection as the last found string,
it will redo the search.

The selection api will collapse user-select: none text, so when you have two matches
in a user-select: none block, both matches will be collapsed to the same point.

Because they are the same point, they look like the same selection, and the match
is skipped. To address this, I saved the start and end positions BEFORE
canonicalization, which represent the positions before adjusting to account for
user-select: none. Then, these saved points are used when comparing found strings.

* Source/WebCore/editing/Editor.cpp:
(WebCore::Editor::findString):
(WebCore::Editor::rangeOfString):
* Source/WebCore/editing/VisibleSelection.cpp:
(WebCore::VisibleSelection::rawRange const):
(WebCore::VisibleSelection::setBaseAndExtentToDeepEquivalents):
* Source/WebCore/editing/VisibleSelection.h:
(WebCore::VisibleSelection::rawStart const):
(WebCore::VisibleSelection::rawEnd const):

Canonical link: <a href="https://commits.webkit.org/308508@main">https://commits.webkit.org/308508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af18a7ac501331926e48eb34c9fd242dd8d349c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147732 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14009 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101147 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4734ddb0-115c-45af-9f7c-97b9382f6154) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113890 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/81218 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/84249d0d-5529-43ce-acce-7fb73ca5ba3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150694 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132686 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94650 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e868406f-113e-4773-899b-3a04912deb8c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15292 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13072 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3855 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10600 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158750 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1884 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12081 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121916 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122117 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31282 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20227 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132390 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76342 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17633 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9161 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19832 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83594 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19561 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19712 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->