### PR TITLE
[AppKit Gestures] Address post-commit feedback after 307491@main

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm
@@ -1962,14 +1962,14 @@ void WebPageProxy::selectPositionAtPoint(WebCore::IntPoint point, bool isInterac
     }, webPageIDInMainFrameProcess());
 }
 
-void WebPageProxy::selectTextWithGranularityAtPoint(const WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& callbackFunction)
+void WebPageProxy::selectTextWithGranularityAtPoint(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& callbackFunction)
 {
     if (!hasRunningProcess()) {
         callbackFunction();
         return;
     }
 
-    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::SelectTextWithGranularityAtPoint(point, granularity, isInteractingWithFocusedElement), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(m_legacyMainFrameProcess->throttler())->backgroundActivity("WebPageProxy::selectTextWithGranularityAtPoint"_s)] () mutable {
+    protect(legacyMainFrameProcess())->sendWithAsyncReply(Messages::WebPage::SelectTextWithGranularityAtPoint(point, granularity, isInteractingWithFocusedElement), [callbackFunction = WTF::move(callbackFunction), backgroundActivity = protect(m_legacyMainFrameProcess->throttler())->backgroundActivity("WebPageProxy::selectTextWithGranularityAtPoint"_s)] mutable {
         callbackFunction();
     }, webPageIDInMainFrameProcess());
 }

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.h
@@ -58,9 +58,6 @@ NS_SWIFT_UI_ACTOR
 - (void)continueRangeSelectionAtPoint:(NSPoint)point;
 - (void)endRangeSelectionAtPoint:(NSPoint)point;
 
-// FIXME: (rdar://170015885) Remove this declaration and its definition when possible.
-- (NSDraggingSession *)selectionManager:(NSTextSelectionManager *)selectionManager makeDraggingSessionWithGesture:(NSGestureRecognizer *)gesture;
-
 @end
 
 NS_HEADER_AUDIT_END(nullability, sendability)

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -294,19 +294,10 @@ extension WKTextSelectionController {
 
         currentRangeSelectionGranularity = granularity
 
-        let webGranularity: WebCore.TextGranularity = switch granularity {
-        case .character: .CharacterGranularity
-        case .word: .WordGranularity
-        case .line: .LineGranularity
-        case .sentence: .SentenceGranularity
-        case .paragraph: .ParagraphGranularity
-        @unknown default: .CharacterGranularity
-        }
-
         Task.immediate {
             await page.selectText(
                 at: WebCore.IntPoint(point),
-                by: webGranularity,
+                by: .init(granularity),
                 isInteractingWithFocusedElement: true // FIXME: Properly handle the case where this isn't actually true.
             )
         }
@@ -325,19 +316,10 @@ extension WKTextSelectionController {
             return
         }
 
-        let webGranularity: WebCore.TextGranularity = switch currentRangeSelectionGranularity {
-        case .character: .CharacterGranularity
-        case .word: .WordGranularity
-        case .line: .LineGranularity
-        case .sentence: .SentenceGranularity
-        case .paragraph: .ParagraphGranularity
-        @unknown default: .CharacterGranularity
-        }
-
         Task.immediate {
             await page.updateSelection(
                 withExtentPoint: WebCore.IntPoint(point),
-                by: webGranularity,
+                by: .init(currentRangeSelectionGranularity),
                 isInteractingWithFocusedElement: true, // FIXME: Properly handle the case where this isn't actually true.
                 source: .Mouse
             )
@@ -359,14 +341,19 @@ extension WKTextSelectionController {
 
         currentRangeSelectionGranularity = nil
     }
+}
 
-    @objc(selectionManager:makeDraggingSessionWithGesture:)
-    func selectionManager(
-        _ selectionManager: NSTextSelectionManager,
-        makeDraggingSessionWithGesture gesture: NSGestureRecognizer
-    ) -> NSDraggingSession {
-        // This function exists to satisfy a `respondsToSelector(_:)` check, but is never actually called.
-        fatalError("This function should never be called")
+extension WebCore.TextGranularity {
+    fileprivate init(_ value: NSTextSelection.Granularity) {
+        self =
+            switch value {
+            case .character: .CharacterGranularity
+            case .word: .WordGranularity
+            case .line: .LineGranularity
+            case .sentence: .SentenceGranularity
+            case .paragraph: .ParagraphGranularity
+            @unknown default: .CharacterGranularity
+            }
     }
 }
 

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2519,17 +2519,9 @@ std::optional<SimpleRange> WebPage::rangeForGranularityAtPoint(LocalFrame& frame
         protect(frame.selection())->selectAll();
         return std::nullopt;
     case TextGranularity::LineGranularity:
-        ASSERT_NOT_REACHED();
-        return std::nullopt;
     case TextGranularity::LineBoundary:
-        ASSERT_NOT_REACHED();
-        return std::nullopt;
     case TextGranularity::SentenceBoundary:
-        ASSERT_NOT_REACHED();
-        return std::nullopt;
     case TextGranularity::ParagraphBoundary:
-        ASSERT_NOT_REACHED();
-        return std::nullopt;
     case TextGranularity::DocumentBoundary:
         ASSERT_NOT_REACHED();
         return std::nullopt;
@@ -2538,7 +2530,7 @@ std::optional<SimpleRange> WebPage::rangeForGranularityAtPoint(LocalFrame& frame
     return std::nullopt;
 }
 
-void WebPage::setSelectionRange(const WebCore::IntPoint& point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement)
+void WebPage::setSelectionRange(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement)
 {
     updateFocusBeforeSelectingTextAtLocation(point);
 
@@ -2561,7 +2553,7 @@ void WebPage::setSelectionRange(const WebCore::IntPoint& point, WebCore::TextGra
     m_initialSelection = range;
 }
 
-void WebPage::updateSelectionWithExtentPointAndBoundary(const WebCore::IntPoint& point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, TextInteractionSource source, CompletionHandler<void(bool)>&& callback)
+void WebPage::updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, TextInteractionSource source, CompletionHandler<void(bool)>&& callback)
 {
     RefPtr frame = m_page->focusController().focusedOrMainFrame();
     if (!frame)
@@ -2608,7 +2600,7 @@ void WebPage::updateSelectionWithExtentPointAndBoundary(const WebCore::IntPoint&
     callback(selectionStart == initialSelectionStartPosition);
 }
 
-void WebPage::updateSelectionWithExtentPoint(const WebCore::IntPoint& point, bool isInteractingWithFocusedElement, RespectSelectionAnchor respectSelectionAnchor, CompletionHandler<void(bool)>&& callback)
+void WebPage::updateSelectionWithExtentPoint(WebCore::IntPoint point, bool isInteractingWithFocusedElement, RespectSelectionAnchor respectSelectionAnchor, CompletionHandler<void(bool)>&& callback)
 {
     RefPtr frame = m_page->focusController().focusedOrMainFrame();
     if (!frame)
@@ -2664,7 +2656,7 @@ void WebPage::updateSelectionWithExtentPoint(const WebCore::IntPoint& point, boo
 #endif
 }
 
-void WebPage::selectTextWithGranularityAtPoint(const WebCore::IntPoint& point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& completionHandler)
+void WebPage::selectTextWithGranularityAtPoint(WebCore::IntPoint point, WebCore::TextGranularity granularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&& completionHandler)
 {
 #if PLATFORM(IOS_FAMILY)
     if (!m_potentialTapNode) {
@@ -2674,7 +2666,7 @@ void WebPage::selectTextWithGranularityAtPoint(const WebCore::IntPoint& point, W
     }
 
     ASSERT(!m_selectionChangedHandler);
-    if (auto selectionChangedHandler = std::exchange(m_selectionChangedHandler, {}))
+    if (auto selectionChangedHandler = std::exchange(m_selectionChangedHandler, { }))
         selectionChangedHandler();
 
     m_selectionChangedHandler = [point, granularity, isInteractingWithFocusedElement, completionHandler = WTF::move(completionHandler), weakThis = WeakPtr { *this }]() mutable {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1084,12 +1084,12 @@ public:
     InteractionInformationAtPosition positionInformation(const InteractionInformationRequest&);
 
     std::optional<WebCore::SimpleRange> rangeForGranularityAtPoint(WebCore::LocalFrame&, const WebCore::IntPoint&, WebCore::TextGranularity, bool isInteractingWithFocusedElement);
-    void setSelectionRange(const WebCore::IntPoint&, WebCore::TextGranularity, bool);
+    void setSelectionRange(WebCore::IntPoint, WebCore::TextGranularity, bool);
 
     void selectPositionAtPoint(WebCore::IntPoint, bool isInteractingWithFocusedElement, CompletionHandler<void()>&&);
-    void updateSelectionWithExtentPoint(const WebCore::IntPoint&, bool isInteractingWithFocusedElement, RespectSelectionAnchor, CompletionHandler<void(bool)>&&);
-    void updateSelectionWithExtentPointAndBoundary(const WebCore::IntPoint&, WebCore::TextGranularity, bool isInteractingWithFocusedElement, TextInteractionSource, CompletionHandler<void(bool)>&&);
-    void selectTextWithGranularityAtPoint(const WebCore::IntPoint&, WebCore::TextGranularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&&);
+    void updateSelectionWithExtentPoint(WebCore::IntPoint, bool isInteractingWithFocusedElement, RespectSelectionAnchor, CompletionHandler<void(bool)>&&);
+    void updateSelectionWithExtentPointAndBoundary(WebCore::IntPoint, WebCore::TextGranularity, bool isInteractingWithFocusedElement, TextInteractionSource, CompletionHandler<void(bool)>&&);
+    void selectTextWithGranularityAtPoint(WebCore::IntPoint, WebCore::TextGranularity, bool isInteractingWithFocusedElement, CompletionHandler<void()>&&);
 #endif // PLATFORM(COCOA)
 
 #if ENABLE(TWO_PHASE_CLICKS)


### PR DESCRIPTION
#### 40507d20f50f04c200011f69eb7f97f898a028f5
<pre>
[AppKit Gestures] Address post-commit feedback after 307491@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=307885">https://bugs.webkit.org/show_bug.cgi?id=307885</a>
<a href="https://rdar.apple.com/170365759">rdar://170365759</a>

Reviewed by Abrar Rahman Protyasha.

* Source/WebKit/UIProcess/Cocoa/WebPageProxyCocoa.mm:
(WebKit::WebPageProxy::selectTextWithGranularityAtPoint):
* Source/WebKit/UIProcess/mac/WKTextSelectionController.h:
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.beginRangeSelection(at:with:)):
(WKTextSelectionController.continueRangeSelection(at:)):
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::rangeForGranularityAtPoint):
(WebKit::WebPage::setSelectionRange):
(WebKit::WebPage::updateSelectionWithExtentPointAndBoundary):
(WebKit::WebPage::updateSelectionWithExtentPoint):
(WebKit::WebPage::selectTextWithGranularityAtPoint):
* Source/WebKit/WebProcess/WebPage/WebPage.h:

Canonical link: <a href="https://commits.webkit.org/307596@main">https://commits.webkit.org/307596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3557ad816cb3f37850db53e229b7d87a5c70bb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144744 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9027 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98379 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111296 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79788 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f477e58f-4a4e-434a-b654-b905c5a4fcbb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147707 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13656 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92191 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13030 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10785 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/860 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122546 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155727 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17275 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119307 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17316 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119630 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30702 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15437 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127893 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72817 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16897 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6246 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16633 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80676 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16842 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16697 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->