### PR TITLE
Move CoreIPCNSURLRequest off of using PlistDictionary for IPC serialization

### DIFF
--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -394,10 +394,6 @@
     [Legacy] StructureParam WTF::CString.span()
 }
 
-[UnsafeWrapper] std::optional<WebKit::CoreIPCPlistDictionary> {
-    [Legacy] StructureParam WebKit::CoreIPCNSURLRequestData.protocolProperties
-}
-
 # Shared Memory
 [SafeWrapper] StructureParam WebCore::ShareableBitmapHandle.m_handle WebCore::SharedMemoryHandle
 [SafeWrapper] StructureParam IPC::StreamServerConnectionHandle.buffer WebCore::SharedMemoryHandle

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
@@ -97,12 +97,23 @@ enum class NSURLRequestFlags : int16_t {
     ShouldStartSynchronously = (1 << 12)
 };
 
+struct ProtocolProperties {
+    std::optional<bool> isTopLevelNavigation;
+    std::optional<bool> allowAllPOSTCaching;
+    std::optional<CoreIPCString> siteForCookies;
+    std::optional<CoreIPCString> cachePartitionKey;
+    std::optional<bool> wkVeryLowLoadPriority;
+    std::optional<CoreIPCNumber> fileProtocolExpectedDevice;
+    std::optional<bool> shouldSniff;
+    std::optional<bool> contentDecoderSkipURLCheck;
+};
+
 struct CoreIPCNSURLRequestData {
 
     using BodyParts = Variant<CoreIPCString, CoreIPCData>;
     using HeaderField = std::pair<String, Variant<String, Vector<String>>>;
 
-    std::optional<CoreIPCPlistDictionary> protocolProperties;
+    std::optional<ProtocolProperties> protocolProperties;
     bool isMutable { false };
     CoreIPCURL url;
     double timeout { 0 };

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
@@ -96,9 +96,20 @@ header: "CoreIPCNSURLRequest.h"
 using WebKit::CoreIPCNSURLRequestData::BodyParts = Variant<WebKit::CoreIPCString, WebKit::CoreIPCData>;
 using WebKit::CoreIPCNSURLRequestData::HeaderField = std::pair<String, Variant<String, Vector<String>>>;
 
+[CustomHeader, WebKitPlatform] struct WebKit::ProtocolProperties {
+    std::optional<bool> isTopLevelNavigation;
+    std::optional<bool> allowAllPOSTCaching;
+    std::optional<WebKit::CoreIPCString> siteForCookies;
+    std::optional<WebKit::CoreIPCString> cachePartitionKey;
+    std::optional<bool> wkVeryLowLoadPriority;
+    std::optional<WebKit::CoreIPCNumber> fileProtocolExpectedDevice;
+    std::optional<bool> shouldSniff;
+    std::optional<bool> contentDecoderSkipURLCheck;
+}
+
 header: "CoreIPCNSURLRequest.h"
 [CustomHeader, WebKitPlatform] struct WebKit::CoreIPCNSURLRequestData {
-    std::optional<WebKit::CoreIPCPlistDictionary> protocolProperties;
+    std::optional<WebKit::ProtocolProperties> protocolProperties;
     bool isMutable;
     WebKit::CoreIPCURL url;
     double timeout;


### PR DESCRIPTION
#### 930e6f1d5d028b60249d124e2aaeda4d78076d5f
<pre>
Move CoreIPCNSURLRequest off of using PlistDictionary for IPC serialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=304245">https://bugs.webkit.org/show_bug.cgi?id=304245</a>
<a href="https://rdar.apple.com/166612102">rdar://166612102</a>

Reviewed by Abrar Rahman Protyasha.

Replaces the opaque PlistDictionary in CoreIPCNSURLRequest with an
explicit breakdown of it&apos;s internal data for protocol properties.

Co-authored-by: Gavin Phillips &lt;gavin.p@apple.com&gt;

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::CoreIPCNSURLRequest):
(WebKit::CoreIPCNSURLRequest::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, NSURLRequestProtocolProperties)):

Canonical link: <a href="https://commits.webkit.org/307823@main">https://commits.webkit.org/307823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2d7de4f684e937704f2223746865fa37cfc3d7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145596 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18278 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10135 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154268 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99233 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e553a37c-b891-40aa-b5bb-68e3f7f84652) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147471 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18763 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18171 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111965 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/034b17ac-3735-4ed1-abb6-83814ba6197f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148559 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130778 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92870 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c0c77f6-028b-42ad-93e1-afa35c28bab9) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/144922 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13669 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11414 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1715 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123193 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7581 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156581 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18128 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8690 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119966 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18174 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15121 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120318 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16050 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128867 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73857 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17749 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7032 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17486 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81529 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17694 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17549 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->