### PR TITLE
Enhanced <select>: don't use native picker on iOS

### DIFF
--- a/LayoutTests/fast/forms/ios/select-base-appearance-picker-expected.txt
+++ b/LayoutTests/fast/forms/ios/select-base-appearance-picker-expected.txt
@@ -1,0 +1,19 @@
+This test verifies that base appearance selects use the in-page popover instead of the native iOS picker.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+=== Test 1: Base appearance select should use in-page popover ===
+PASS selectBase.options[0].checkVisibility() is false
+PASS selectBase.options[0].checkVisibility() is true
+PASS showingNativeMenu is false
+PASS selectBase.options[0].checkVisibility() is false
+
+=== Test 2: Auto appearance select should use native picker ===
+PASS selectAuto.options[0].checkVisibility() is false
+PASS selectAuto.options[0].checkVisibility() is false
+PASS selectAuto.options[0].checkVisibility() is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/select-base-appearance-picker.html
+++ b/LayoutTests/fast/forms/ios/select-base-appearance-picker.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+    <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+        <script src="../../../resources/js-test.js"></script>
+        <script src="../../../resources/ui-helper.js"></script>
+        <style>
+            /* Base appearance select */
+            #selectBase::picker(select) {
+                appearance: base-select;
+            }
+
+            /* Auto appearance select */
+            #selectAuto {
+                appearance: auto;
+            }
+        </style>
+    </head>
+<body>
+    <select id="selectBase">
+        <option>A</option>
+        <option>B</option>
+        <option>C</option>
+    </select>
+
+    <select id="selectAuto">
+        <option>A</option>
+        <option>B</option>
+        <option>C</option>
+    </select>
+</body>
+<script>
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("This test verifies that base appearance selects use the in-page popover instead of the native iOS picker.");
+
+    // Test 1: Base appearance select should use in-page popover
+    debug("=== Test 1: Base appearance select should use in-page popover ===");
+
+    shouldBeFalse("selectBase.options[0].checkVisibility()");
+
+    await UIHelper.activateElement(selectBase);
+
+    shouldBeTrue("selectBase.options[0].checkVisibility()");
+
+    await UIHelper.delayFor(400);
+    showingNativeMenu = await UIHelper.isShowingContextMenu();
+    shouldBeFalse("showingNativeMenu");
+
+    await UIHelper.activateElement(selectBase.options[0]);
+
+    shouldBeFalse("selectBase.options[0].checkVisibility()");
+
+    // Test 2: Auto appearance select should use native picker (not in-page popover)
+    debug("");
+    debug("=== Test 2: Auto appearance select should use native picker ===");
+
+    shouldBeFalse("selectAuto.options[0].checkVisibility()");
+
+    await UIHelper.activateElement(selectAuto);
+    await UIHelper.waitForContextMenuToShow();
+
+    shouldBeFalse("selectAuto.options[0].checkVisibility()");
+
+    await UIHelper.dismissMenu();
+    await UIHelper.waitForContextMenuToHide();
+
+    shouldBeFalse("selectAuto.options[0].checkVisibility()");
+
+    finishJSTest();
+});
+</script>
+</html>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt
@@ -51,9 +51,9 @@ PASS <option>1 (in <select multiple="">) - margin-right
 PASS <option>1 (in <select multiple="">) - margin-bottom
 PASS <option>1 (in <select multiple="">) - margin-left
 PASS <option>1 (in <select multiple="">) - padding-top
-PASS <option>1 (in <select multiple="">) - padding-right
+FAIL <option>1 (in <select multiple="">) - padding-right assert_equals: expected "0px" but got "5.5px"
 PASS <option>1 (in <select multiple="">) - padding-bottom
-PASS <option>1 (in <select multiple="">) - padding-left
+FAIL <option>1 (in <select multiple="">) - padding-left assert_equals: expected "0px" but got "5.5px"
 PASS <option>1 (in <select multiple="">) - letter-spacing
 PASS <option>1 (in <select multiple="">) - word-spacing
 PASS <option>1 (in <select multiple="">) - text-transform
@@ -73,7 +73,7 @@ PASS <option>1 (in <select multiple="">) - border-top-color
 PASS <option>1 (in <select multiple="">) - border-right-color
 PASS <option>1 (in <select multiple="">) - border-bottom-color
 PASS <option>1 (in <select multiple="">) - border-left-color
-PASS <option>1 (in <select multiple="">) - align-items
+FAIL <option>1 (in <select multiple="">) - align-items assert_equals: expected "normal" but got "center"
 FAIL <option>1 (in <select multiple="">) - white-space assert_equals: expected "normal" but got "nowrap"
 PASS <option>1 (in <select multiple="">) - color
 PASS <option>1 (in <select multiple="">) - background-color
@@ -145,9 +145,9 @@ PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-right
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-bottom
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - margin-left
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - padding-top
-PASS <option>3 (in <select multiple=""><optgroup label="2">) - padding-right
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-right assert_equals: expected "0px" but got "5.5px"
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - padding-bottom
-PASS <option>3 (in <select multiple=""><optgroup label="2">) - padding-left
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - padding-left assert_equals: expected "0px" but got "5.5px"
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - letter-spacing
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - word-spacing
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - text-transform
@@ -167,7 +167,7 @@ PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-top-color
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-right-color
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-bottom-color
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - border-left-color
-PASS <option>3 (in <select multiple=""><optgroup label="2">) - align-items
+FAIL <option>3 (in <select multiple=""><optgroup label="2">) - align-items assert_equals: expected "normal" but got "center"
 FAIL <option>3 (in <select multiple=""><optgroup label="2">) - white-space assert_equals: expected "normal" but got "nowrap"
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - color
 PASS <option>3 (in <select multiple=""><optgroup label="2">) - background-color

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt
@@ -1,5 +1,0 @@
-invoker
-
-FAIL Buttons in the popover should be rendered and should not close the popover when clicked. promise_test: Unhandled rejection with value: object "Error: element click intercepted error"
-FAIL Non-interactive content in the popover should not close the popover when clicked. assert_false: Select should be closed at the start of the test. expected false got true
-

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-anchor-regression-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-anchor-regression-expected.txt
@@ -1,4 +1,0 @@
-
-
-PASS This test passes if it does not crash.
-

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-click-drag-option.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-click-drag-option.optional-expected.txt
@@ -2,5 +2,5 @@
 
 FAIL Clicking the invoker button and dragging to an option should choose that option and close the picker. assert_equals: select.value should be changed to two after releasing the pointer on the second option. expected "two" but got "one"
 FAIL mouse: Releasing the pointer on an option positioned on top of the invoker button should not close the picker. assert_true: select should still be open after pointerUp() without moving the pointer. expected true got false
-FAIL touch: Releasing the pointer on an option positioned on top of the invoker button should not close the picker. assert_true: select should still be open after pointerUp() without moving the pointer. expected true got false
+PASS touch: Releasing the pointer on an option positioned on top of the invoker button should not close the picker.
 

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer-expected.txt
@@ -1,5 +1,5 @@
 
-PASS select can be nested inside a popover
+FAIL select can be nested inside a popover assert_true: the select should be showing expected true got false
 FAIL a popover can be nested inside select assert_true: the select should be showing expected true got false
 FAIL select can be nested inside a modal dialog assert_true: the select should be showing expected true got false
 FAIL a modal dialog can be nested inside select assert_true: the select should be showing expected true got false

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt
@@ -1,5 +1,0 @@
-
-
-PASS select should support :open pseudo selector.
-FAIL select :open and :not(:open) should invalidate correctly. assert_equals: The style rules from :open should apply when the select is open. expected "rgb(0, 128, 0)" but got "rgb(255, 0, 0)"
-

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -918,6 +918,13 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static isShowingContextMenu()
+    {
+        return new Promise(resolve => {
+            testRunner.runUIScript(`uiController.isShowingContextMenu`, result => resolve(result === "true"));
+        });
+    }
+
     static dismissMenu()
     {
         if (!this.isWebKit2())

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -1490,10 +1490,12 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
 
     if (RefPtr mouseEvent = dynamicDowncast<MouseEvent>(event); event.type() == eventNames.mousedownEvent && mouseEvent && mouseEvent->button() == MouseButton::Left) {
         focus();
-#if !PLATFORM(IOS_FAMILY)
         protect(document())->updateStyleIfNeeded();
-
+#if !PLATFORM(IOS_FAMILY)
         if (renderer() && usesMenuList()) {
+#else
+        if (usesBaseAppearancePicker()) {
+#endif
             ASSERT(usesBaseAppearancePicker() || !m_popupIsVisible);
             // Save the selection so it can be compared to the new
             // selection when we call onChange during selectOption,
@@ -1503,7 +1505,6 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
             saveLastSelection();
             showPickerInternal(); // showPickerInternal() may run JS and cause the renderer to get destroyed.
         }
-#endif
         event.setDefaultHandled();
     }
 

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -184,7 +184,7 @@ public:
     void registerSelectedContentElement();
     void unregisterSelectedContentElement();
 
-    bool usesBaseAppearancePicker() const;
+    WEBCORE_EXPORT bool usesBaseAppearancePicker() const;
     SelectPopoverElement* pickerPopoverElement() const;
     void hidePickerPopoverElement();
 

--- a/Source/WebKit/Shared/FocusedElementInformation.h
+++ b/Source/WebKit/Shared/FocusedElementInformation.h
@@ -101,6 +101,7 @@ struct FocusedElementInformation {
     bool isMultiSelect { false };
     bool isReadOnly {false };
     bool allowsUserScaling { false };
+    bool usesBaseAppearancePicker { false };
     bool allowsUserScalingIgnoringAlwaysScalable { false };
     bool insideFixedPosition { false };
     bool hasPlainText { false };

--- a/Source/WebKit/Shared/FocusedElementInformation.serialization.in
+++ b/Source/WebKit/Shared/FocusedElementInformation.serialization.in
@@ -70,6 +70,7 @@ enum class WebKit::InputType : uint8_t {
     bool isMultiSelect;
     bool isReadOnly;
     bool allowsUserScaling;
+    bool usesBaseAppearancePicker;
     bool allowsUserScalingIgnoringAlwaysScalable;
     bool insideFixedPosition;
     bool hasPlainText;

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -8306,6 +8306,10 @@ static RetainPtr<NSObject <WKFormPeripheral>> createInputPeripheralWithView(WebK
 #else
     switch (type) {
     case WebKit::InputType::Select:
+        // Don't create native iOS picker for appearance: base selects
+        if (view.focusedElementInformation.usesBaseAppearancePicker)
+            return nil;
+
         return adoptNS([[WKFormSelectControl alloc] initWithView:view]);
     case WebKit::InputType::Color:
 #if PLATFORM(APPLETV)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3061,6 +3061,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
         }
         information.selectedIndex = element->selectedIndex();
         information.isMultiSelect = element->multiple();
+        information.usesBaseAppearancePicker = element->usesBaseAppearancePicker();
     } else if (RefPtr element = dynamicDowncast<HTMLTextAreaElement>(*focusedElement)) {
         information.autocapitalizeType = element->autocapitalizeType();
         information.isAutocorrect = element->shouldAutocorrect();


### PR DESCRIPTION
#### d0d3d16a42b549d26fcb969a226d5ed6ef099a13
<pre>
Enhanced &lt;select&gt;: don&apos;t use native picker on iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=307887">https://bugs.webkit.org/show_bug.cgi?id=307887</a>
<a href="https://rdar.apple.com/170370809">rdar://170370809</a>

Reviewed by Wenson Hsieh.

`appearance: base` is meant to be consistent across platforms to avoid developer friction.

Developers who use `appearance: base` on `::picker(select)` opt-in to use the web-based picker instead of the native one.

* LayoutTests/fast/forms/ios/select-base-appearance-picker-expected.txt: Added.
* LayoutTests/fast/forms/ios/select-base-appearance-picker.html: Added.
Add test coverage.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/rendering/widgets/the-select-element/select-as-listbox-default-styles.tentative-expected.txt:
Expected &quot;regression&quot;, iOS always used menulists instead of listboxes. This now shows up because we call &quot;updateStyleIfNeeded()&quot; which makes this test reflect reality.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/button-in-popover-expected.txt: Removed.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-anchor-regression-expected.txt: Removed.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-click-drag-option.optional-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-inside-top-layer-expected.txt:
More baselines reflecting matching behavior with macOS.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-pseudo-open-expected.txt: Removed.
iOS now matches macOS behavior, the removal of these baselines match that.

* LayoutTests/resources/ui-helper.js:
(window.UIHelper.isShowingContextMenu):
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::HTMLSelectElement::menuListDefaultEventHandler):
Make the base appearance picker actually show on iOS.

* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebKit/Shared/FocusedElementInformation.h:
* Source/WebKit/Shared/FocusedElementInformation.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(createInputPeripheralWithView):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::focusedElementInformation):
Pass the base appearance state to block the native picker when necessary.

Canonical link: <a href="https://commits.webkit.org/307663@main">https://commits.webkit.org/307663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/07b594112dc75a4722468d71a05358681a168043

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17725 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9494 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153715 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac4e86bf-e3c5-43f4-9e15-32c3d6e5b027) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146919 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18208 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111529 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89e5c4c7-43e3-4300-bf35-0185604074c3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148007 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13888 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92425 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd6db56b-2cb0-4be0-a557-4a38cf8b3c6d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13259 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1160 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122777 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156027 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17576 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8124 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119532 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17622 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14670 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119860 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15664 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128294 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73240 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22380 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17197 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6565 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16933 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80976 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->