### PR TITLE
Add support for RTCIceTransport.role attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCIceTransport-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCIceTransport-expected.txt
@@ -1,7 +1,7 @@
 
 Harness Error (TIMEOUT), message = null
 
-FAIL Two connected iceTransports should have matching local/remote candidates returned assert_true: Expect RTCIceRole to be either controlling or controlled, found undefined expected true got false
+FAIL Two connected iceTransports should have matching local/remote candidates returned assert_true: Expect RTCIceComponent to be either rtp or rtcp expected true got false
 FAIL Unconnected iceTransport should have empty remote candidates and selected pair promise_test: Unhandled rejection with value: object "TypeError: iceTransport.getRemoteCandidates is not a function. (In 'iceTransport.getRemoteCandidates()', 'iceTransport.getRemoteCandidates' is undefined)"
 PASS RTCIceTransport should be in state "new" initially
 PASS RTCIceTransport should transition to "gathering" then "complete", after sLD

--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt
@@ -331,7 +331,7 @@ PASS RTCIceTransport interface object name
 PASS RTCIceTransport interface: existence and properties of interface prototype object
 PASS RTCIceTransport interface: existence and properties of interface prototype object's "constructor" property
 PASS RTCIceTransport interface: existence and properties of interface prototype object's @@unscopables property
-FAIL RTCIceTransport interface: attribute role assert_true: The prototype object must have a property "role" expected true got false
+PASS RTCIceTransport interface: attribute role
 FAIL RTCIceTransport interface: attribute component assert_true: The prototype object must have a property "component" expected true got false
 PASS RTCIceTransport interface: attribute state
 PASS RTCIceTransport interface: attribute gatheringState
@@ -345,7 +345,7 @@ PASS RTCIceTransport interface: attribute ongatheringstatechange
 PASS RTCIceTransport interface: attribute onselectedcandidatepairchange
 PASS RTCIceTransport must be primary interface of idlTestObjects.iceTransport
 PASS Stringification of idlTestObjects.iceTransport
-FAIL RTCIceTransport interface: idlTestObjects.iceTransport must inherit property "role" with the proper type assert_inherits: property "role" not found in prototype chain
+PASS RTCIceTransport interface: idlTestObjects.iceTransport must inherit property "role" with the proper type
 FAIL RTCIceTransport interface: idlTestObjects.iceTransport must inherit property "component" with the proper type assert_inherits: property "component" not found in prototype chain
 PASS RTCIceTransport interface: idlTestObjects.iceTransport must inherit property "state" with the proper type
 PASS RTCIceTransport interface: idlTestObjects.iceTransport must inherit property "gatheringState" with the proper type

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.h
@@ -62,6 +62,8 @@ public:
     RTCIceTransportState state() const { return m_transportState; }
     RTCIceGatheringState gatheringState() const { return m_gatheringState; }
 
+    RTCIceRole role() const { return m_role; }
+
     const RTCIceTransportBackend& backend() const { return m_backend.get(); }
     RefPtr<RTCPeerConnection> connection() const { return m_connection; }
 
@@ -88,6 +90,7 @@ private:
     void onStateChanged(RTCIceTransportState) final;
     void onGatheringStateChanged(RTCIceGatheringState) final;
     void onSelectedCandidatePairChanged(RefPtr<RTCIceCandidate>&&, RefPtr<RTCIceCandidate>&&) final;
+    void onRoleChanged(RTCIceRole) final;
 
     bool m_isStopped { false };
     const UniqueRef<RTCIceTransportBackend> m_backend;
@@ -95,6 +98,7 @@ private:
     RTCIceTransportState m_transportState { RTCIceTransportState::New };
     RTCIceGatheringState m_gatheringState { RTCIceGatheringState::New };
     std::optional<CandidatePair> m_selectedCandidatePair;
+    RTCIceRole m_role { RTCIceRole::Unknown };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/mediastream/RTCIceTransport.idl
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransport.idl
@@ -42,7 +42,7 @@ typedef RTCIceGatheringState IceGatheringState;
     Exposed=Window,
     SkipVTableValidation
 ] interface RTCIceTransport : EventTarget {
-    // FIXME 169662: missing readonly attribute RTCIceRole role;
+    readonly attribute RTCIceRole role;
     // FIXME 169662: missing readonly attribute RTCIceComponent component;
     readonly attribute IceTransportState state;
     readonly attribute IceGatheringState gatheringState;

--- a/Source/WebCore/Modules/mediastream/RTCIceTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/RTCIceTransportBackend.h
@@ -27,6 +27,7 @@
 #if ENABLE(WEB_RTC)
 
 #include "RTCIceGatheringState.h"
+#include "RTCIceRole.h"
 #include "RTCIceTransportState.h"
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>
 
@@ -40,6 +41,7 @@ public:
     virtual void onStateChanged(RTCIceTransportState) = 0;
     virtual void onGatheringStateChanged(RTCIceGatheringState) = 0;
     virtual void onSelectedCandidatePairChanged(RefPtr<RTCIceCandidate>&&, RefPtr<RTCIceCandidate>&&) = 0;
+    virtual void onRoleChanged(RTCIceRole) { }
 };
 
 class RTCIceTransportBackend {
@@ -49,6 +51,8 @@ public:
 
     virtual void registerClient(RTCIceTransportBackendClient&) = 0;
     virtual void unregisterClient() = 0;
+
+    virtual RTCIceRole role() const = 0;
 };
 
 inline bool operator==(const RTCIceTransportBackend& a, const RTCIceTransportBackend& b)

--- a/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.h
+++ b/Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.h
@@ -46,6 +46,7 @@ private:
     const void* backend() const final { return m_backend.ptr(); }
     void registerClient(RTCIceTransportBackendClient&) final;
     void unregisterClient() final;
+    RTCIceRole role() const final;
 
     const Ref<webrtc::IceTransportInterface> m_backend;
     const RefPtr<LibWebRTCIceTransportBackendObserver> m_observer;


### PR DESCRIPTION
#### d2e729a03fdd3b102271c85f53e298bf39938184
<pre>
Add support for RTCIceTransport.role attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=307896">https://bugs.webkit.org/show_bug.cgi?id=307896</a>
<a href="https://rdar.apple.com/170377519">rdar://170377519</a>

Reviewed by NOBODY (OOPS!).

Implement the RTCIceTransport.role attribute which returns the ICE role
(controlling, controlled, or unknown) of the transport. The role is
cached in RTCIceTransport and updated asynchronously via callbacks from
the backend, following the same pattern as state and gatheringState.

* Source/WebCore/Modules/mediastream/RTCIceTransport.cpp:
(WebCore::RTCIceTransport::RTCIceTransport): Initialize role from backend.
(WebCore::RTCIceTransport::onRoleChanged): Handle role changes.
* Source/WebCore/Modules/mediastream/RTCIceTransport.h:
(WebCore::RTCIceTransport::role const):
* Source/WebCore/Modules/mediastream/RTCIceTransport.idl:
* Source/WebCore/Modules/mediastream/RTCIceTransportBackend.h:  Add role() and
onRoleChanged() to backend interface.
(WebCore::RTCIceTransportBackendClient::onRoleChanged):
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.cpp:
(WebCore::toRTCIceRole): Convert cricket::IceRole to RTCIceRole.
(WebCore::LibWebRTCIceTransportBackendObserver::start): Send initial role.
(WebCore::LibWebRTCIceTransportBackend::role const): Return Unknown.
* Source/WebCore/Modules/mediastream/libwebrtc/LibWebRTCIceTransportBackend.h:

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCIceTransport-expected.txt: Rebaseline
* LayoutTests/imported/w3c/web-platform-tests/webrtc/idlharness.https.window-expected.txt: Progressions
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2e729a03fdd3b102271c85f53e298bf39938184

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144776 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17455 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9059 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153447 "Hash d2e729a0 for PR 58713 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98411 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc81ba8b-f618-42bd-8938-48493fb1b347) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146651 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17938 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17349 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/153447 "Hash d2e729a0 for PR 58713 does not build (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79801 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3449b3c5-bdb9-47c2-87f4-76c34bc84c15) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13685 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129972 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/153447 "Hash d2e729a0 for PR 58713 does not build (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e827b9a8-f0bd-4d16-b6ea-d801df0147df) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13058 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10812 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/892 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122572 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6682 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155759 "Hash d2e729a0 for PR 58713 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17307 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7762 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/155759 "Hash d2e729a0 for PR 58713 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14454 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/155759 "Hash d2e729a0 for PR 58713 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15456 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127924 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72849 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16929 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6277 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16665 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80708 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16874 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->