### PR TITLE
Fix GC thread terminology in comments to reflect multiple GC threads

### DIFF
--- a/Source/JavaScriptCore/heap/ReleaseHeapAccessScope.h
+++ b/Source/JavaScriptCore/heap/ReleaseHeapAccessScope.h
@@ -29,7 +29,7 @@
 
 namespace JSC {
 
-// Almost all of the VM's code runs with "heap access". This means that the GC thread believes that
+// Almost all of the VM's code runs with "heap access". This means that the GC believes that
 // the VM is messing with the heap in a way that would be unsafe for certain phases of the collector,
 // like the weak reference fixpoint, stack scanning, and changing barrier modes. However, many long
 // running operations inside the VM don't require heap access. For example, memcpying a typed array

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1065,7 +1065,7 @@ Structure* Structure::flattenDictionaryStructure(VM& vm, JSObject* object)
     WTF::storeStoreFence();
     object->setStructureIDDirectly(id());
 
-    // We need to do a writebarrier here because the GC thread might be scanning the butterfly while
+    // We need to do a writebarrier here because a GC thread might be scanning the butterfly while
     // we are shuffling properties around. See: https://bugs.webkit.org/show_bug.cgi?id=166989
     vm.writeBarrier(object);
 

--- a/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp
@@ -80,7 +80,7 @@ IDBObjectStore::~IDBObjectStore()
 
 bool IDBObjectStore::virtualHasPendingActivity() const
 {
-    // Cannot ref the transaction here since this may get called on the GC thread.
+    // Cannot ref the transaction here since this may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG return m_transaction->hasPendingActivity();
 }
 
@@ -749,11 +749,11 @@ void IDBObjectStore::visitReferencedIndexesConcurrently(Visitor& visitor) const
 {
     Locker locker { m_referencedIndexLock };
     for (auto& index : m_referencedIndexes.values()) {
-        // Cannot ref `index` here since this may get called on the GC thread.
+        // Cannot ref `index` here since this may get called on a GC thread.
         SUPPRESS_UNCOUNTED_ARG addWebCoreOpaqueRoot(visitor, index.get());
     }
     for (auto& index : m_deletedIndexes.values()) {
-        // Cannot ref `index` here since this may get called on the GC thread.
+        // Cannot ref `index` here since this may get called on a GC thread.
         SUPPRESS_UNCOUNTED_ARG addWebCoreOpaqueRoot(visitor, index.get());
     }
 }

--- a/Source/WebCore/Modules/mediasession/MediaSession.h
+++ b/Source/WebCore/Modules/mediasession/MediaSession.h
@@ -226,7 +226,7 @@ void MediaSession::visitActionHandlers(Visitor& visitor) const
     Locker lock { m_actionHandlersLock };
     for (auto& actionHandler : m_actionHandlers) {
         if (actionHandler.value) {
-            // We are not ref'ing here as this function may get called from the GC thread.
+            // We are not ref'ing here as this function may get called from a GC thread.
             SUPPRESS_UNCOUNTED_ARG actionHandler.value->visitJSFunction(visitor);
         }
     }

--- a/Source/WebCore/Modules/reporting/ReportingObserver.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.cpp
@@ -157,7 +157,7 @@ void ReportingObserver::appendQueuedReportIfCorrectType(const Ref<Report>& repor
 
 bool ReportingObserver::virtualHasPendingActivity() const
 {
-    // We cannot ref `m_reportingScope` here since this function may get called on the GC thread.
+    // We cannot ref `m_reportingScope` here since this function may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG return m_reportingScope && m_reportingScope->containsObserver(*this);
 }
 

--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -1034,7 +1034,7 @@ DEFINE_VISIT_ADDITIONAL_CHILDREN(ReadableByteStreamController);
 template<typename Visitor>
 void JSReadableByteStreamController::visitAdditionalChildren(Visitor& visitor)
 {
-    // Do not ref `wrapped()` here since this function may get called on the GC thread.
+    // Do not ref `wrapped()` here since this function may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);
 }
 

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
@@ -298,7 +298,7 @@ void ReadableStreamBYOBReader::visitAdditionalChildren(Visitor& visitor)
 template<typename Visitor>
 void JSReadableStreamBYOBReader::visitAdditionalChildren(Visitor& visitor)
 {
-    // Do not ref `wrapped()` here since this function may get called on the GC thread.
+    // Do not ref `wrapped()` here since this function may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);
 }
 

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp
@@ -94,7 +94,7 @@ DEFINE_VISIT_ADDITIONAL_CHILDREN(ReadableStreamBYOBRequest);
 template<typename Visitor>
 void JSReadableStreamBYOBRequest::visitAdditionalChildren(Visitor& visitor)
 {
-    // Do not ref `wrapped()` here since this function may get called on the GC thread.
+    // Do not ref `wrapped()` here since this function may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);
 }
 

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -391,7 +391,7 @@ void ReadableStreamDefaultReader::visitAdditionalChildren(Visitor& visitor)
 template<typename Visitor>
 void JSReadableStreamDefaultReader::visitAdditionalChildren(Visitor& visitor)
 {
-    // Do not ref `wrapped()` here since this function may get called on the GC thread.
+    // Do not ref `wrapped()` here since this function may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);
 }
 

--- a/Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp
@@ -37,7 +37,7 @@ namespace WebCore {
 template<typename Visitor>
 void JSAudioWorkletGlobalScope::visitAdditionalChildren(Visitor& visitor)
 {
-    // This function may get called on the GC thread so we cannot ref the object.
+    // This function may get called on a GC thread so we cannot ref the object.
     SUPPRESS_UNCOUNTED_ARG addWebCoreOpaqueRoot(visitor, static_cast<ScriptExecutionContext&>(wrapped()));
     SUPPRESS_UNCOUNTED_ARG wrapped().visitProcessors(visitor);
 }

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.h
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.h
@@ -68,7 +68,7 @@ public:
     DOMGuardedObjectSet& guardedObjects() WTF_REQUIRES_LOCK(m_gcLock) { return m_guardedObjects; }
     DOMConstructors& constructors() { return m_constructors; }
 
-    // No locking is necessary for call sites that do not mutate the containers and are not on the GC thread.
+    // No locking is necessary for call sites that do not mutate the containers and are not on a GC thread.
     const JSDOMStructureMap& structures() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(!Thread::mayBeGCThread()); return m_structures; }
     const DOMGuardedObjectSet& guardedObjects() const WTF_IGNORES_THREAD_SAFETY_ANALYSIS { ASSERT(!Thread::mayBeGCThread()); return m_guardedObjects; }
     const DOMConstructors& constructors() const { ASSERT(!Thread::mayBeGCThread()); return m_constructors; }

--- a/Source/WebCore/bindings/js/JSDocumentCustom.cpp
+++ b/Source/WebCore/bindings/js/JSDocumentCustom.cpp
@@ -90,7 +90,7 @@ void JSDocument::setAdoptedStyleSheets(JSC::JSGlobalObject& lexicalGlobalObject,
 template<typename Visitor>
 void JSDocument::visitAdditionalChildren(Visitor& visitor)
 {
-    // This may get called on the GC thread so we cannot ref this object.
+    // This may get called on a GC thread so we cannot ref this object.
     SUPPRESS_UNCOUNTED_ARG addWebCoreOpaqueRoot(visitor, static_cast<ScriptExecutionContext&>(wrapped()));
 }
 

--- a/Source/WebCore/bindings/js/JSNavigationCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNavigationCustom.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 template<typename Visitor>
 void JSNavigation::visitAdditionalChildren(Visitor& visitor)
 {
-    // We cannot ref the event on the GC thread.
+    // We cannot ref the event on a GC thread.
     SUPPRESS_UNCOUNTED_ARG if (auto* event = wrapped().ongoingNavigateEvent())
         addWebCoreOpaqueRoot(visitor, event);
     SUPPRESS_UNCOUNTED_ARG wrapped().visitAdditionalChildren(visitor);

--- a/Source/WebCore/bindings/js/JSNodeListCustom.cpp
+++ b/Source/WebCore/bindings/js/JSNodeListCustom.cpp
@@ -44,7 +44,7 @@ bool JSNodeListOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handl
     if (!jsNodeList->hasCustomProperties())
         return false;
 
-    // Cannot ref the node list as this gets called from the GC thread.
+    // Cannot ref the node list as this gets called from a GC thread.
     SUPPRESS_UNCOUNTED_LOCAL if (auto* liveNodeList = dynamicDowncast<LiveNodeList>(jsNodeList->wrapped())) {
         if (reason) [[unlikely]]
             *reason = "LiveNodeList owner is opaque root"_s;
@@ -52,7 +52,7 @@ bool JSNodeListOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handl
         return containsWebCoreOpaqueRoot(visitor, liveNodeList->ownerNode());
     }
 
-    // Cannot ref the node list as this gets called from the GC thread.
+    // Cannot ref the node list as this gets called from a GC thread.
     SUPPRESS_UNCOUNTED_LOCAL if (auto* childNodeList = dynamicDowncast<ChildNodeList>(jsNodeList->wrapped())) {
         if (reason) [[unlikely]]
             *reason = "ChildNodeList owner is opaque root"_s;
@@ -60,7 +60,7 @@ bool JSNodeListOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC::Unknown> handl
         return containsWebCoreOpaqueRoot(visitor, childNodeList->ownerNode());
     }
 
-    // Cannot ref the node list as this gets called from the GC thread.
+    // Cannot ref the node list as this gets called from a GC thread.
     SUPPRESS_UNCOUNTED_LOCAL if (auto* emptyNodeList = dynamicDowncast<EmptyNodeList>(jsNodeList->wrapped())) {
         if (reason) [[unlikely]]
             *reason = "EmptyNodeList owner is opaque root"_s;

--- a/Source/WebCore/bindings/js/JSReportingObserverCustom.cpp
+++ b/Source/WebCore/bindings/js/JSReportingObserverCustom.cpp
@@ -35,7 +35,7 @@ namespace WebCore {
 template <typename Visitor>
 void JSReportingObserver::visitAdditionalChildren(Visitor& visitor)
 {
-    // Do not ref `wrapped()` here since this function may get called on the GC thread.
+    // Do not ref `wrapped()` here since this function may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG wrapped().callbackConcurrently().visitJSFunction(visitor);
 }
 

--- a/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp
@@ -45,7 +45,7 @@ void JSWorkerGlobalScope::visitAdditionalChildren(Visitor& visitor)
     if (auto* navigator = wrapped().optionalNavigator())
         addWebCoreOpaqueRoot(visitor, *navigator);
 
-    // We cannot ref the object here as this may get called on the GC thread.
+    // We cannot ref the object here as this may get called on a GC thread.
     SUPPRESS_UNCOUNTED_ARG addWebCoreOpaqueRoot(visitor, static_cast<ScriptExecutionContext&>(wrapped()));
     
     // Normally JSEventTargetCustom.cpp's JSEventTarget::visitAdditionalChildren() would call this. But

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -184,7 +184,7 @@ void MutationObserver::setHasTransientRegistration(Document& document)
 
 bool MutationObserver::isReachableFromOpaqueRoots(JSC::AbstractSlotVisitor& visitor) const
 {
-    // We cannot use Ref here since this gets called on the GC thread.
+    // We cannot use Ref here since this gets called on a GC thread.
     SUPPRESS_UNCOUNTED_LOCAL for (auto& registration : m_registrations) {
         if (registration.isReachableFromOpaqueRoots(visitor))
             return true;

--- a/Source/WebCore/dom/MutationRecord.cpp
+++ b/Source/WebCore/dom/MutationRecord.cpp
@@ -48,7 +48,7 @@ static void visitNodeList(JSC::AbstractSlotVisitor& visitor, NodeList& nodeList)
     ASSERT(!nodeList.isLiveNodeList());
     unsigned length = nodeList.length();
     for (unsigned i = 0; i < length; ++i) {
-        // We cannot ref the item here as this function may get called from the GC thread.
+        // We cannot ref the item here as this function may get called from a GC thread.
         SUPPRESS_UNRETAINED_ARG addWebCoreOpaqueRoot(visitor, nodeList.item(i));
     }
 }
@@ -75,9 +75,9 @@ private:
     void visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const final
     {
         addWebCoreOpaqueRoot(visitor, m_target.get());
-        // We cannot ref m_addedNodes here as this function may get called from the GC thread.
+        // We cannot ref m_addedNodes here as this function may get called from a GC thread.
         SUPPRESS_UNRETAINED_ARG visitNodeList(visitor, m_addedNodes.get());
-        // We cannot ref m_removedNodes here as this function may get called from the GC thread.
+        // We cannot ref m_removedNodes here as this function may get called from a GC thread.
         SUPPRESS_UNRETAINED_ARG visitNodeList(visitor, m_removedNodes.get());
     }
     

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -188,7 +188,7 @@ void ScriptExecutionContext::checkConsistency() const
     for (auto& destructionObserver : m_destructionObservers)
         ASSERT(destructionObserver.scriptExecutionContext() == this);
 
-    // This can run on the GC thread.
+    // This can run on a GC thread.
     for (SUPPRESS_UNCOUNTED_LOCAL auto& activeDOMObject : m_activeDOMObjects) {
         ASSERT(activeDOMObject.scriptExecutionContext() == this);
         activeDOMObject.assertSuspendIfNeededWasCalled();
@@ -633,7 +633,7 @@ bool ScriptExecutionContext::hasPendingActivity() const
 {
     checkConsistency();
 
-    // This runs on the GC thread.
+    // This runs on a GC thread.
     for (SUPPRESS_UNCOUNTED_LOCAL auto& activeDOMObject : m_activeDOMObjects) {
         if (activeDOMObject.hasPendingActivity())
             return true;

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -169,11 +169,11 @@ InternalObserver* Subscriber::observerConcurrently()
 
 void Subscriber::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor)
 {
-    // We cannot ref `teardown` here as this may get called from the GC thread.
+    // We cannot ref `teardown` here as this may get called from a GC thread.
     SUPPRESS_UNRETAINED_ARG for (auto* teardown : teardownCallbacksConcurrently())
         teardown->visitJSFunction(visitor);
 
-    // We cannot ref the observer here as this may get called from the GC thread.
+    // We cannot ref the observer here as this may get called from a GC thread.
     SUPPRESS_UNRETAINED_ARG observerConcurrently()->visitAdditionalChildren(visitor);
 }
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -889,7 +889,7 @@ bool HTMLCanvasElement::virtualHasPendingActivity() const
 {
 #if ENABLE(WEBGL)
     if (m_hasRelevantWebGLEventListener) {
-        // This runs on the GC thread.
+        // This runs on a GC thread.
         SUPPRESS_UNCOUNTED_LOCAL auto* context = dynamicDowncast<WebGLRenderingContextBase>(m_context.get());
         // WebGL rendering context may fire contextlost / contextrestored events at any point.
         return context && !context->isContextUnrecoverablyLost();

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -645,7 +645,7 @@ HTMLMediaElement::HTMLMediaElement(const QualifiedName& tagName, Document& docum
     , m_processingPreferenceChange(false)
     , m_volumeLocked(defaultVolumeLocked())
     , m_opaqueRootProvider(WTF::Observer<WebCoreOpaqueRoot()>::create([weakThis = WeakPtr { *this }] {
-        // This gets called on the GC thread so we cannot ref `this`.
+        // This gets called on a GC thread so we cannot ref `this`.
         return weakThis->opaqueRoot();
     }))
 #if USE(AUDIO_SESSION)

--- a/Source/WebCore/html/track/TrackListBase.cpp
+++ b/Source/WebCore/html/track/TrackListBase.cpp
@@ -60,7 +60,7 @@ void TrackListBase::didMoveToNewDocument(Document& newDocument)
 
 WebCoreOpaqueRoot TrackListBase::opaqueRoot()
 {
-    // Cannot ref the observer as this gets called on the GC thread.
+    // Cannot ref the observer as this gets called on a GC thread.
     SUPPRESS_UNCOUNTED_LOCAL if (auto* rootObserver = m_opaqueRootObserver.get())
         return (*rootObserver)();
     return WebCoreOpaqueRoot { this };

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -235,7 +235,7 @@ public:
     // Testing support
     RateLimiter& rateLimiterForTesting() { return m_rateLimiter; }
 
-    NavigateEvent* ongoingNavigateEvent() { return m_ongoingNavigateEvent.get(); } // This may get called on the GC thread.
+    NavigateEvent* ongoingNavigateEvent() { return m_ongoingNavigateEvent.get(); } // This may get called on a GC thread.
     bool hasInterceptedOngoingNavigateEvent() const { return m_ongoingNavigateEvent && m_ongoingNavigateEvent->wasIntercepted(); }
 
     void updateNavigationEntry(Ref<HistoryItem>&&, ShouldCopyStateObjectFromCurrentEntry);

--- a/Source/WebCore/page/ResizeObserver.cpp
+++ b/Source/WebCore/page/ResizeObserver.cpp
@@ -174,7 +174,7 @@ void ResizeObserver::deliverObservations()
 
     // Use GCReachableRef here to make sure the targets and their JS wrappers are kept alive while we deliver.
     // It is important since m_activeObservationTargets / m_targetsWaitingForFirstObservation will get cleared and
-    // thus JSResizeObserver::visitAdditionalChildren() won't be able to visit them on the GC thread.
+    // thus JSResizeObserver::visitAdditionalChildren() won't be able to visit them on a GC thread.
     Vector<GCReachableRef<Element>> activeObservationTargets;
     Vector<GCReachableRef<Element>> targetsWaitingForFirstObservation;
     {


### PR DESCRIPTION
#### f634318089bdf19fcae7d05b01bde1175853902c
<pre>
Fix GC thread terminology in comments to reflect multiple GC threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=307897">https://bugs.webkit.org/show_bug.cgi?id=307897</a>
<a href="https://rdar.apple.com/170377922">rdar://170377922</a>

Reviewed by NOBODY (OOPS\!).

WebKit&apos;s garbage collector uses multiple parallel GC threads via
ParallelHelperPool, not a single dedicated GC thread. Update comments
throughout the codebase to use &quot;a GC thread&quot; instead of &quot;the GC thread&quot;
to accurately reflect this threading model.

No new tests since no change in behavior.

* Source/JavaScriptCore/heap/ReleaseHeapAccessScope.h:
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::flattenDictionaryStructure):
* Source/WebCore/Modules/indexeddb/IDBObjectStore.cpp:
(WebCore::IDBObjectStore::virtualHasPendingActivity const):
(WebCore::IDBObjectStore::visitReferencedIndexesConcurrently const):
* Source/WebCore/Modules/mediasession/MediaSession.h:
(WebCore::MediaSession::visitActionHandlers):
* Source/WebCore/Modules/reporting/ReportingObserver.cpp:
(WebCore::ReportingObserver::virtualHasPendingActivity const):
* Source/WebCore/Modules/streams/ReadableByteStreamController.cpp:
(WebCore::JSReadableByteStreamController::visitAdditionalChildren):
* Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp:
(WebCore::JSReadableStreamBYOBReader::visitAdditionalChildren):
* Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp:
(WebCore::JSReadableStreamBYOBRequest::visitAdditionalChildren):
* Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp:
(WebCore::JSReadableStreamDefaultReader::visitAdditionalChildren):
* Source/WebCore/bindings/js/JSAudioWorkletGlobalScopeCustom.cpp:
(WebCore::JSAudioWorkletGlobalScope::visitAdditionalChildren):
* Source/WebCore/bindings/js/JSDOMGlobalObject.h:
* Source/WebCore/bindings/js/JSDocumentCustom.cpp:
(WebCore::JSDocument::visitAdditionalChildren):
* Source/WebCore/bindings/js/JSNavigationCustom.cpp:
(WebCore::JSNavigation::visitAdditionalChildren):
* Source/WebCore/bindings/js/JSNodeListCustom.cpp:
(WebCore::JSNodeListOwner::isReachableFromOpaqueRoots):
* Source/WebCore/bindings/js/JSReportingObserverCustom.cpp:
(WebCore::JSReportingObserver::visitAdditionalChildren):
* Source/WebCore/bindings/js/JSWorkerGlobalScopeCustom.cpp:
(WebCore::JSWorkerGlobalScope::visitAdditionalChildren):
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::isReachableFromOpaqueRoots):
* Source/WebCore/dom/MutationRecord.cpp:
(WebCore::visitNodeList):
(WebCore::ChildListRecord::visitNodesConcurrently):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::checkConsistency const):
(WebCore::ScriptExecutionContext::hasPendingActivity const):
* Source/WebCore/dom/Subscriber.cpp:
(WebCore::Subscriber::visitAdditionalChildren):
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::HTMLCanvasElement::virtualHasPendingActivity const):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::HTMLMediaElement):
* Source/WebCore/html/track/TrackListBase.cpp:
(WebCore::TrackListBase::opaqueRoot):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/ResizeObserver.cpp:
(WebCore::ResizeObserver::deliverObservations):

Co-Authored-By: Claude Opus 4.6 &lt;noreply@anthropic.com&gt;
Canonical link: <a href="https://commits.webkit.org/307564@main">https://commits.webkit.org/307564@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6daf06b8ffa38823cd2343316b6440889e13d570

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [  ~~🧪 style~~](https://ews-build.webkit.org/#/builders/38/builds/144777 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/17456 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/9060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/153448 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/146652 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/17939 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/17350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/153448 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/147740 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/17939 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/9060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/153448 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/17939 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/168/builds/9060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/893 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/136768 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/17939 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/9060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/155760 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/5586 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/17308 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/9060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/155760 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/17355 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/17350 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/155760 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30684 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/9060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72850 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/16930 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/9060 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/176065 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/16666 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/80709 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/176065 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/16875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/16730 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->