### PR TITLE
Remove HTMLNames dependency for HTMLDivElement subclasses

### DIFF
--- a/Source/WebCore/html/HTMLDivElement.cpp
+++ b/Source/WebCore/html/HTMLDivElement.cpp
@@ -34,8 +34,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLDivElement);
 
 using namespace HTMLNames;
 
-HTMLDivElement::HTMLDivElement(Document& document)
-    : HTMLDivElement(divTag, document)
+HTMLDivElement::HTMLDivElement(Document& document, OptionSet<TypeFlag> typeFlags)
+    : HTMLDivElement(divTag, document, typeFlags)
 {
 }
 

--- a/Source/WebCore/html/HTMLDivElement.h
+++ b/Source/WebCore/html/HTMLDivElement.h
@@ -34,10 +34,11 @@ public:
     static Ref<HTMLDivElement> create(const QualifiedName&, Document&);
 
 protected:
-    HTMLDivElement(Document&);
-    HTMLDivElement(const QualifiedName&, Document&, OptionSet<TypeFlag> = { });
+    HTMLDivElement(Document&, OptionSet<TypeFlag> = { });
 
 private:
+    HTMLDivElement(const QualifiedName&, Document&, OptionSet<TypeFlag> = { });
+
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 };
 

--- a/Source/WebCore/html/shadow/AutoFillButtonElement.cpp
+++ b/Source/WebCore/html/shadow/AutoFillButtonElement.cpp
@@ -28,7 +28,6 @@
 
 #include "Event.h"
 #include "EventNames.h"
-#include "HTMLNames.h"
 #include "MouseEvent.h"
 #include "TextFieldInputType.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -37,15 +36,13 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(AutoFillButtonElement);
 
-using namespace HTMLNames;
-
 Ref<AutoFillButtonElement> AutoFillButtonElement::create(Document& document, AutoFillButtonOwner& owner)
 {
     return adoptRef(*new AutoFillButtonElement(document, owner));
 }
 
 AutoFillButtonElement::AutoFillButtonElement(Document& document, AutoFillButtonOwner& owner)
-    : HTMLDivElement(divTag, document)
+    : HTMLDivElement(document)
     , m_owner(owner)
 {
 }

--- a/Source/WebCore/html/shadow/AutoFillButtonElement.h
+++ b/Source/WebCore/html/shadow/AutoFillButtonElement.h
@@ -46,7 +46,7 @@ public:
 private:
     explicit AutoFillButtonElement(Document&, AutoFillButtonOwner&);
 
-    void defaultEventHandler(Event&) override;
+    void defaultEventHandler(Event&) final;
 
     AutoFillButtonOwner& m_owner;
 };

--- a/Source/WebCore/html/shadow/DataListButtonElement.cpp
+++ b/Source/WebCore/html/shadow/DataListButtonElement.cpp
@@ -28,7 +28,6 @@
 
 #include "Event.h"
 #include "EventNames.h"
-#include "HTMLNames.h"
 #include "MouseEvent.h"
 #include "StyleAppearance.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -37,15 +36,13 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DataListButtonElement);
 
-using namespace HTMLNames;
-
 Ref<DataListButtonElement> DataListButtonElement::create(Document& document, DataListButtonOwner& owner)
 {
     return adoptRef(*new DataListButtonElement(document, owner));
 }
 
 DataListButtonElement::DataListButtonElement(Document& document, DataListButtonOwner& owner)
-    : HTMLDivElement(divTag, document)
+    : HTMLDivElement(document)
     , m_owner(owner)
 {
 }

--- a/Source/WebCore/html/shadow/DataListButtonElement.h
+++ b/Source/WebCore/html/shadow/DataListButtonElement.h
@@ -50,10 +50,10 @@ public:
 private:
     explicit DataListButtonElement(Document&, DataListButtonOwner&);
 
-    bool isDataListButtonElement() const override { return true; }
+    bool isDataListButtonElement() const final { return true; }
 
-    void defaultEventHandler(Event&) override;
-    bool isDisabledFormControl() const override;
+    void defaultEventHandler(Event&) final;
+    bool isDisabledFormControl() const final;
 
     DataListButtonOwner& m_owner;
 };

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -199,7 +199,7 @@ void DateTimeEditBuilder::visitLiteral(const String& text)
 DateTimeEditElementEditControlOwner::~DateTimeEditElementEditControlOwner() = default;
 
 DateTimeEditElement::DateTimeEditElement(Document& document, DateTimeEditElementEditControlOwner& editControlOwner)
-    : HTMLDivElement(divTag, document)
+    : HTMLDivElement(document)
     , m_editControlOwner(editControlOwner)
 {
     m_placeholderDate.setToCurrentLocalTime();

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -52,7 +52,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(DateTimeFieldElement);
 DateTimeFieldElementFieldOwner::~DateTimeFieldElementFieldOwner() = default;
 
 DateTimeFieldElement::DateTimeFieldElement(Document& document, DateTimeFieldElementFieldOwner& fieldOwner)
-    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
     , m_fieldOwner(fieldOwner)
 {
 }

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.cpp
@@ -84,7 +84,7 @@ Ref<MediaControlTextTrackContainerElement> MediaControlTextTrackContainerElement
 }
 
 MediaControlTextTrackContainerElement::MediaControlTextTrackContainerElement(Document& document, HTMLMediaElement& element)
-    : HTMLDivElement(divTag, document)
+    : HTMLDivElement(document)
     , m_mediaElement(element)
 {
 }

--- a/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
+++ b/Source/WebCore/html/shadow/MediaControlTextTrackContainerElement.h
@@ -82,11 +82,11 @@ private:
     explicit MediaControlTextTrackContainerElement(Document&, HTMLMediaElement&);
 
     // Element
-    RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
+    RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 
     // TextTrackRepresentationClient
-    RefPtr<NativeImage> createTextTrackRepresentationImage() override;
-    void textTrackRepresentationBoundsChanged(const IntRect&) override;
+    RefPtr<NativeImage> createTextTrackRepresentationImage() final;
+    void textTrackRepresentationBoundsChanged(const IntRect&) final;
 
     void updateTextTrackRepresentationIfNeeded();
     void clearTextTrackRepresentation();

--- a/Source/WebCore/html/shadow/ProgressShadowElement.cpp
+++ b/Source/WebCore/html/shadow/ProgressShadowElement.cpp
@@ -32,7 +32,6 @@
 #include "ProgressShadowElement.h"
 
 #include "ContainerNodeInlines.h"
-#include "HTMLNames.h"
 #include "HTMLProgressElement.h"
 #include "RenderProgress.h"
 #include "RenderStyle+GettersInlines.h"
@@ -46,10 +45,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ProgressInnerElement);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProgressBarElement);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ProgressValueElement);
 
-using namespace HTMLNames;
-
 ProgressShadowElement::ProgressShadowElement(Document& document)
-    : HTMLDivElement(HTMLNames::divTag, document)
+    : HTMLDivElement(document)
 {
 }
 

--- a/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SelectFallbackButtonElement.cpp
@@ -47,7 +47,7 @@ Ref<SelectFallbackButtonElement> SelectFallbackButtonElement::create(Document& d
 }
 
 SelectFallbackButtonElement::SelectFallbackButtonElement(Document& document)
-    : HTMLDivElement(HTMLNames::divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -200,7 +200,7 @@ Ref<SliderThumbElement> SliderThumbElement::create(Document& document)
 }
 
 SliderThumbElement::SliderThumbElement(Document& document)
-    : HTMLDivElement(HTMLNames::divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -600,7 +600,7 @@ Ref<Element> SliderThumbElement::cloneElementWithoutAttributesAndChildren(Docume
 // --------------------------------
 
 inline SliderContainerElement::SliderContainerElement(Document& document)
-    : HTMLDivElement(HTMLNames::divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/html/shadow/SpinButtonElement.cpp
+++ b/Source/WebCore/html/shadow/SpinButtonElement.cpp
@@ -54,7 +54,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SpinButtonElement);
 using namespace HTMLNames;
 
 inline SpinButtonElement::SpinButtonElement(Document& document, SpinButtonOwner& spinButtonOwner)
-    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
     , m_spinButtonOwner(spinButtonOwner)
     , m_capturing(false)
     , m_upDownState(Indeterminate)

--- a/Source/WebCore/html/shadow/SpinButtonElement.h
+++ b/Source/WebCore/html/shadow/SpinButtonElement.h
@@ -72,9 +72,9 @@ public:
     USING_CAN_MAKE_WEAKPTR(HTMLDivElement);
 
     void step(int amount);
-    
-    bool willRespondToMouseMoveEvents() const override;
-    bool willRespondToMouseClickEventsWithEditability(Editability) const override;
+
+    bool willRespondToMouseMoveEvents() const final;
+    bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 
     // PopupOpeningObserver.
     void ref() const final { HTMLDivElement::ref(); }
@@ -83,19 +83,19 @@ public:
 private:
     SpinButtonElement(Document&, SpinButtonOwner&);
 
-    void willDetachRenderers() override;
-    bool isSpinButtonElement() const override { return true; }
-    bool isDisabledFormControl() const override;
-    bool matchesReadWritePseudoClass() const override;
-    void defaultEventHandler(Event&) override;
-    void willOpenPopup() override;
+    void willDetachRenderers() final;
+    bool isSpinButtonElement() const final { return true; }
+    bool isDisabledFormControl() const final;
+    bool matchesReadWritePseudoClass() const final;
+    void defaultEventHandler(Event&) final;
+    void willOpenPopup() final;
     void doStepAction(int);
     void startRepeatingTimer();
     void stopRepeatingTimer();
     void repeatingTimerFired();
-    void setHovered(bool, Style::InvalidationScope, HitTestRequest) override;
+    void setHovered(bool, Style::InvalidationScope, HitTestRequest) final;
     bool shouldRespondToMouseEvents() const;
-    bool isMouseFocusable() const override { return false; }
+    bool isMouseFocusable() const final { return false; }
 
     WeakPtr<SpinButtonOwner> m_spinButtonOwner;
     bool m_capturing;

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -71,7 +71,7 @@ using namespace CSS::Literals;
 using namespace HTMLNames;
 
 TextControlInnerContainer::TextControlInnerContainer(Document& document)
-    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -117,7 +117,7 @@ std::optional<Style::UnadjustedStyle> TextControlInnerContainer::resolveCustomSt
 }
 
 TextControlInnerElement::TextControlInnerElement(Document& document)
-    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -154,7 +154,7 @@ std::optional<Style::UnadjustedStyle> TextControlInnerElement::resolveCustomStyl
 // MARK: TextControlInnerTextElement
 
 inline TextControlInnerTextElement::TextControlInnerTextElement(Document& document)
-    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks )
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -219,7 +219,7 @@ std::optional<Style::UnadjustedStyle> TextControlInnerTextElement::resolveCustom
 // MARK: TextControlPlaceholderElement
 
 inline TextControlPlaceholderElement::TextControlPlaceholderElement(Document& document)
-    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -260,7 +260,7 @@ static inline bool searchFieldStyleHasExplicitlySpecifiedTextFieldAppearance(con
 }
 
 inline SearchFieldResultsButtonElement::SearchFieldResultsButtonElement(Document& document)
-    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
@@ -333,7 +333,7 @@ bool SearchFieldResultsButtonElement::willRespondToMouseClickEventsWithEditabili
 // MARK: SearchFieldCancelButtonElement
 
 inline SearchFieldCancelButtonElement::SearchFieldCancelButtonElement(Document& document)
-    : HTMLDivElement(divTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
+    : HTMLDivElement(document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 

--- a/Source/WebCore/html/shadow/TextControlInnerElements.h
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.h
@@ -42,8 +42,8 @@ public:
 
 private:
     explicit TextControlInnerContainer(Document&);
-    RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
-    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
+    RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
+    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) final;
 };
 
 class TextControlInnerElement final : public HTMLDivElement {
@@ -54,9 +54,9 @@ public:
 
 private:
     explicit TextControlInnerElement(Document&);
-    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
+    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) final;
 
-    bool isMouseFocusable() const override { return false; }
+    bool isMouseFocusable() const final { return false; }
 };
 
 class TextControlInnerTextElement final : public HTMLDivElement {
@@ -65,7 +65,7 @@ class TextControlInnerTextElement final : public HTMLDivElement {
 public:
     static Ref<TextControlInnerTextElement> create(Document&, bool isEditable);
 
-    void defaultEventHandler(Event&) override;
+    void defaultEventHandler(Event&) final;
 
     RenderTextControlInnerBlock* renderer() const;
 
@@ -79,10 +79,10 @@ private:
     void updateInnerTextElementEditabilityImpl(bool isEditable, bool initialization);
 
     explicit TextControlInnerTextElement(Document&);
-    RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
-    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
-    bool isMouseFocusable() const override { return false; }
-    bool isTextControlInnerTextElement() const override { return true; }
+    RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
+    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) final;
+    bool isMouseFocusable() const final { return false; }
+    bool isTextControlInnerTextElement() const final { return true; }
 };
 
 class TextControlPlaceholderElement final : public HTMLDivElement {
@@ -93,8 +93,8 @@ public:
 
 private:
     explicit TextControlPlaceholderElement(Document&);
-    
-    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
+
+    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) final;
 };
 
 class SearchFieldResultsButtonElement final : public HTMLDivElement {
@@ -103,18 +103,18 @@ class SearchFieldResultsButtonElement final : public HTMLDivElement {
 public:
     static Ref<SearchFieldResultsButtonElement> create(Document&);
 
-    void defaultEventHandler(Event&) override;
+    void defaultEventHandler(Event&) final;
 #if !PLATFORM(IOS_FAMILY)
-    bool willRespondToMouseClickEventsWithEditability(Editability) const override;
+    bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 #endif
 
     bool canAdjustStyleForAppearance() const { return m_canAdjustStyleForAppearance; }
 
 private:
     explicit SearchFieldResultsButtonElement(Document&);
-    bool isMouseFocusable() const override { return false; }
-    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
-    bool isSearchFieldResultsButtonElement() const override { return true; }
+    bool isMouseFocusable() const final { return false; }
+    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) final;
+    bool isSearchFieldResultsButtonElement() const final { return true; }
 
     bool m_canAdjustStyleForAppearance { true };
 };
@@ -125,15 +125,15 @@ class SearchFieldCancelButtonElement final : public HTMLDivElement {
 public:
     static Ref<SearchFieldCancelButtonElement> create(Document&);
 
-    void defaultEventHandler(Event&) override;
+    void defaultEventHandler(Event&) final;
 #if !PLATFORM(IOS_FAMILY)
-    bool willRespondToMouseClickEventsWithEditability(Editability) const override;
+    bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 #endif
 
 private:
     explicit SearchFieldCancelButtonElement(Document&);
-    bool isMouseFocusable() const override { return false; }
-    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) override;
+    bool isMouseFocusable() const final { return false; }
+    std::optional<Style::UnadjustedStyle> resolveCustomStyle(const Style::ResolutionContext&, const RenderStyle* shadowHostStyle) final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/shadow/TextPlaceholderElement.cpp
+++ b/Source/WebCore/html/shadow/TextPlaceholderElement.cpp
@@ -29,7 +29,6 @@
 #include "CSSPropertyNames.h"
 #include "CSSUnits.h"
 #include "CSSValueKeywords.h"
-#include "HTMLNames.h"
 #include "HTMLTextFormControlElement.h"
 #include "LayoutSize.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -44,7 +43,7 @@ Ref<TextPlaceholderElement> TextPlaceholderElement::create(Document& document, c
 }
 
 TextPlaceholderElement::TextPlaceholderElement(Document& document, const LayoutSize& size)
-    : HTMLDivElement { HTMLNames::divTag, document }
+    : HTMLDivElement(document)
 {
     // FIXME: Move to User Agent stylesheet. See <https://webkit.org/b/208745>.
     setInlineStyleProperty(CSSPropertyDisplay, size.width() ? CSSValueInlineBlock : CSSValueBlock);

--- a/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp
+++ b/Source/WebCore/html/shadow/YouTubeEmbedShadowElement.cpp
@@ -41,7 +41,7 @@ Ref<YouTubeEmbedShadowElement> YouTubeEmbedShadowElement::create(Document& docum
 }
 
 YouTubeEmbedShadowElement::YouTubeEmbedShadowElement(Document& document)
-    : HTMLDivElement(HTMLNames::divTag, document)
+    : HTMLDivElement(document)
 {
 }
 


### PR DESCRIPTION
#### 67d320be2f747a8adb5e66220f52d7531bf57af0
<pre>
Remove HTMLNames dependency for HTMLDivElement subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=307900">https://bugs.webkit.org/show_bug.cgi?id=307900</a>

Reviewed by Tim Nguyen.

Also switch to final on subclass methods where appropriate.

Canonical link: <a href="https://commits.webkit.org/307568@main">https://commits.webkit.org/307568@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a34fcdeb8516379580557dfc6f529cbf32985163

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17464 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9068 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153456 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff499549-f9da-4d31-a2e3-113384d4e88b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146660 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111324 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98420 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3d7dde21-e349-4da3-8b63-fa646e353fe0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147748 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/13690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129976 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92219 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/815bcc65-2d75-4e21-b65e-eddd29c7b314) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13063 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10817 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/901 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122578 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6686 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155768 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17316 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7766 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119328 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17363 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119656 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15466 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127928 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/72858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22339 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16938 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6281 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16674 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80717 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16883 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16738 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->