### PR TITLE
Add NODELETE annotations to some core DOM member functions

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -323,7 +323,6 @@ page/ElementTargetingController.cpp
 page/EventHandler.cpp
 page/FocusController.cpp
 page/FrameSnapshotting.cpp
-page/ImageOverlayController.cpp
 page/IntelligenceTextEffectsSupport.cpp
 page/InteractionRegion.cpp
 page/IntersectionObserver.cpp
@@ -472,7 +471,6 @@ rendering/RenderMultiColumnFlow.cpp
 rendering/RenderMultiColumnSet.cpp
 rendering/RenderObject.cpp
 rendering/RenderObjectNode.h
-rendering/RenderProgress.cpp
 rendering/RenderQuote.cpp
 rendering/RenderReplaced.cpp
 rendering/RenderReplica.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations
@@ -4,7 +4,6 @@ accessibility/AXObjectCache.cpp
 [ iOS ] accessibility/ios/AccessibilityObjectIOS.mm
 [ iOS ] accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
 dom/Position.cpp
-dom/TreeScope.cpp
 editing/Editing.cpp
 [ iOS ] editing/cocoa/EditorCocoa.mm
 [ iOS ] editing/ios/DictationCommandIOS.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -645,7 +645,6 @@ rendering/RenderMenuList.cpp
 rendering/RenderMultiColumnSet.cpp
 rendering/RenderObject.cpp
 rendering/RenderObjectNode.h
-rendering/RenderProgress.cpp
 rendering/RenderQuote.cpp
 rendering/RenderReplaced.cpp
 rendering/RenderReplica.cpp

--- a/Source/WebCore/dom/Attr.h
+++ b/Source/WebCore/dom/Attr.h
@@ -55,9 +55,9 @@ public:
     void attachToElement(Element&);
     void detachFromElementWithValue(const AtomString&);
 
-    const AtomString& namespaceURI() const final { return m_name.namespaceURI(); }
-    const AtomString& localName() const final { return m_name.localName(); }
-    const AtomString& prefix() const final { return m_name.prefix(); }
+    const AtomString& NODELETE namespaceURI() const final { return m_name.namespaceURI(); }
+    const AtomString& NODELETE localName() const final { return m_name.localName(); }
+    const AtomString& NODELETE prefix() const final { return m_name.prefix(); }
 
 private:
     Attr(Element&, const QualifiedName&);

--- a/Source/WebCore/dom/ContainerNode.h
+++ b/Source/WebCore/dom/ContainerNode.h
@@ -50,8 +50,8 @@ public:
     bool directChildNeedsStyleRecalc() const { return hasStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }
     void setDirectChildNeedsStyleRecalc() { setStyleFlag(NodeStyleFlag::DirectChildNeedsStyleResolution); }
 
-    WEBCORE_EXPORT unsigned countChildNodes() const;
-    WEBCORE_EXPORT Node* traverseToChildAt(unsigned) const;
+    WEBCORE_EXPORT unsigned NODELETE countChildNodes() const;
+    WEBCORE_EXPORT Node* NODELETE traverseToChildAt(unsigned) const;
 
     ExceptionOr<void> insertBefore(Node& newChild, RefPtr<Node>&& refChild);
     ExceptionOr<void> replaceChild(Node& newChild, Node& oldChild);
@@ -61,7 +61,7 @@ public:
     void replaceAll(Node*);
 
     inline ContainerNode& rootNode() const; // Defined in ContainerNodeInlines.h
-    ContainerNode& traverseToRootNode() const;
+    ContainerNode& NODELETE traverseToRootNode() const;
 
     // These methods are only used during parsing.
     // They don't send DOM mutation events or handle reparenting.
@@ -136,8 +136,8 @@ public:
 
     // From the ParentNode interface - https://dom.spec.whatwg.org/#interface-parentnode
     WEBCORE_EXPORT Ref<HTMLCollection> children();
-    WEBCORE_EXPORT Element* firstElementChild() const;
-    WEBCORE_EXPORT Element* lastElementChild() const;
+    WEBCORE_EXPORT Element* NODELETE firstElementChild() const;
+    WEBCORE_EXPORT Element* NODELETE lastElementChild() const;
     WEBCORE_EXPORT unsigned childElementCount() const;
     ExceptionOr<void> append(FixedVector<NodeOrString>&&);
     ExceptionOr<void> prepend(FixedVector<NodeOrString>&&);
@@ -178,8 +178,8 @@ private:
     void removeBetween(Node* previousChild, Node* nextChild, Node& oldChild);
     ExceptionOr<void> appendChildWithoutPreInsertionValidityCheck(Node&);
 
-    void insertBeforeCommon(Node& nextChild, Node& oldChild);
-    void appendChildCommon(Node&);
+    void NODELETE insertBeforeCommon(Node& nextChild, Node& oldChild);
+    void NODELETE appendChildCommon(Node&);
 
     void rebuildSVGExtensionsElementsIfNecessary();
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1076,7 +1076,7 @@ public:
 
     inline bool hasBrowsingContext() const; // Defined in DocumentInlines.h.
 
-    Document& contextDocument() const;
+    Document& NODELETE contextDocument() const;
     void setContextDocument(Ref<Document>&& document) { m_contextDocument = WTF::move(document); }
     
     OptionSet<ParserContentPolicy> parserContentPolicy() const { return m_parserContentPolicy; }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -209,11 +209,11 @@ public:
     WEBCORE_EXPORT void setElementAttribute(const QualifiedName& attributeName, Element* value);
     WEBCORE_EXPORT std::optional<Vector<Ref<Element>>> getElementsArrayAttributeForBindings(const QualifiedName& attributeName) const;
     WEBCORE_EXPORT void setElementsArrayAttribute(const QualifiedName& attributeName, std::optional<Vector<Ref<Element>>>&& value);
-    static bool isElementReflectionAttribute(const Settings&, const QualifiedName&);
-    static bool isElementsArrayReflectionAttribute(const QualifiedName&);
+    static bool NODELETE isElementReflectionAttribute(const Settings&, const QualifiedName&);
+    static bool NODELETE isElementsArrayReflectionAttribute(const QualifiedName&);
 
     WEBCORE_EXPORT void setUserInfo(JSC::JSGlobalObject&, JSC::JSValue);
-    WEBCORE_EXPORT String userInfo() const;
+    WEBCORE_EXPORT String NODELETE userInfo() const;
 
     // Call this to get the value of an attribute that is known not to be the style
     // attribute or one of the SVG animatable attributes.
@@ -369,10 +369,10 @@ public:
     WEBCORE_EXPORT ExceptionOr<RefPtr<Attr>> setAttributeNodeNS(Attr&);
     WEBCORE_EXPORT ExceptionOr<Ref<Attr>> removeAttributeNode(Attr&);
 
-    RefPtr<Attr> attrIfExists(const QualifiedName&);
+    RefPtr<Attr> NODELETE attrIfExists(const QualifiedName&);
     Ref<Attr> ensureAttr(const QualifiedName&);
 
-    const Vector<Ref<Attr>>& attrNodeList();
+    const Vector<Ref<Attr>>& NODELETE attrNodeList();
 
     const QualifiedName& tagQName() const { return m_tagName; }
 #if ENABLE(JIT)
@@ -386,9 +386,9 @@ public:
 
     bool hasLocalName(const AtomString& other) const { return m_tagName.localName() == other; }
 
-    const AtomString& localName() const final { return m_tagName.localName(); }
-    const AtomString& prefix() const final { return m_tagName.prefix(); }
-    const AtomString& namespaceURI() const final { return m_tagName.namespaceURI(); }
+    const AtomString& NODELETE localName() const final { return m_tagName.localName(); }
+    const AtomString& NODELETE prefix() const final { return m_tagName.prefix(); }
+    const AtomString& NODELETE namespaceURI() const final { return m_tagName.namespaceURI(); }
 
     const AtomString& localNameLowercase() const { return m_tagName.localNameLowercase(); }
 
@@ -451,8 +451,8 @@ public:
     virtual bool isReplaced(const RenderStyle* = nullptr) const { return false; }
 
     inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
-    RefPtr<ShadowRoot> shadowRootForBindings(JSC::JSGlobalObject&) const;
-    RefPtr<ShadowRoot> openOrClosedShadowRoot() const;
+    RefPtr<ShadowRoot> NODELETE shadowRootForBindings(JSC::JSGlobalObject&) const;
+    RefPtr<ShadowRoot> NODELETE openOrClosedShadowRoot() const;
     RefPtr<Element> resolveReferenceTarget() const;
     RefPtr<Element> retargetReferenceTargetForBindings(RefPtr<Element>) const;
 
@@ -467,7 +467,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&, std::optional<CustomElementRegistryKind> = std::nullopt);
     ExceptionOr<ShadowRoot&> attachDeclarativeShadow(ShadowRootMode, ShadowRootDelegatesFocus, ShadowRootClonable, ShadowRootSerializable, String referenceTarget, CustomElementRegistryKind);
 
-    WEBCORE_EXPORT ShadowRoot* userAgentShadowRoot() const;
+    WEBCORE_EXPORT ShadowRoot* NODELETE userAgentShadowRoot() const;
     WEBCORE_EXPORT ShadowRoot& ensureUserAgentShadowRoot();
     Ref<ShadowRoot> ensureProtectedUserAgentShadowRoot();
     WEBCORE_EXPORT ShadowRoot& createUserAgentShadowRoot();
@@ -478,11 +478,11 @@ public:
     void clearReactionQueueFromFailedCustomElement();
     void setIsCustomElementUpgradeCandidate();
     void enqueueToUpgrade(JSCustomElementInterface&);
-    CustomElementReactionQueue* reactionQueue() const;
+    CustomElementReactionQueue* NODELETE reactionQueue() const;
     CustomElementRegistry* customElementRegistry() const;
 
     CustomElementDefaultARIA& customElementDefaultARIA();
-    CustomElementDefaultARIA* customElementDefaultARIAIfExists() const;
+    CustomElementDefaultARIA* NODELETE customElementDefaultARIAIfExists() const;
 
     bool isInActiveChain() const { return isUserActionElement() && isUserActionElementInActiveChain(); }
     bool active() const { return isUserActionElement() && isUserActionElementActive(); }
@@ -500,7 +500,7 @@ public:
     void setHasFocusWithin(bool);
     void setHasTentativeFocus(bool);
 
-    std::optional<int> tabIndexSetExplicitly() const;
+    std::optional<int> NODELETE tabIndexSetExplicitly() const;
     bool shouldBeIgnoredInSequentialFocusNavigation() const { return defaultTabIndex() < 0 && !supportsFocus(); }
     bool hasFocusableStyle() const;
     virtual bool supportsFocus() const;
@@ -551,7 +551,7 @@ public:
     bool affectedByHasWithPositionalPseudoClass() const { return hasStyleFlag(NodeStyleFlag::AffectedByHasWithPositionalPseudoClass); }
     unsigned childIndex() const { return hasRareData() ? rareDataChildIndex() : 0; }
 
-    bool hasFlagsSetDuringStylingOfChildren() const;
+    bool NODELETE hasFlagsSetDuringStylingOfChildren() const;
 
     void setStyleAffectedByEmpty() { setStyleFlag(NodeStyleFlag::StyleAffectedByEmpty); }
     void setDescendantsAffectedByPreviousSibling() { setStyleFlag(NodeStyleFlag::DescendantsAffectedByPreviousSibling); }
@@ -633,9 +633,9 @@ public:
     virtual void finishParsingChildren();
 
     PseudoElement& ensurePseudoElement(PseudoElementType);
-    WEBCORE_EXPORT PseudoElement* beforePseudoElement() const;
-    WEBCORE_EXPORT PseudoElement* afterPseudoElement() const;
-    RefPtr<PseudoElement> pseudoElementIfExists(Style::PseudoElementIdentifier);
+    WEBCORE_EXPORT PseudoElement* NODELETE beforePseudoElement() const;
+    WEBCORE_EXPORT PseudoElement* NODELETE afterPseudoElement() const;
+    RefPtr<PseudoElement> NODELETE pseudoElementIfExists(Style::PseudoElementIdentifier);
     RefPtr<const PseudoElement> pseudoElementIfExists(Style::PseudoElementIdentifier) const;
 
     bool childNeedsShadowWalker() const;
@@ -653,7 +653,7 @@ public:
 
     WEBCORE_EXPORT DOMTokenList& classList();
 
-    SpaceSplitString partNames() const;
+    SpaceSplitString NODELETE partNames() const;
     DOMTokenList& part();
 
     DatasetDOMStringMap& dataset();
@@ -691,7 +691,7 @@ public:
     KeyframeEffectStack* keyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>&) const;
     KeyframeEffectStack& ensureKeyframeEffectStack(const std::optional<Style::PseudoElementIdentifier>&);
     bool hasKeyframeEffects(const std::optional<Style::PseudoElementIdentifier>&) const;
-    bool mayHaveKeyframeEffects() const;
+    bool NODELETE mayHaveKeyframeEffects() const;
 
     const AnimationCollection* animations(const std::optional<Style::PseudoElementIdentifier>&) const;
     bool hasCompletedTransitionForProperty(const std::optional<Style::PseudoElementIdentifier>&, const AnimatableCSSProperty&) const;
@@ -731,13 +731,13 @@ public:
     virtual void requestFullscreen(FullscreenOptions&&, RefPtr<DeferredPromise>&&);
 #endif
 
-    PopoverData* popoverData() const;
+    PopoverData* NODELETE popoverData() const;
     PopoverData& ensurePopoverData();
     void clearPopoverData();
-    bool isPopoverShowing() const;
-    PopoverState popoverState() const;
+    bool NODELETE isPopoverShowing() const;
+    PopoverState NODELETE popoverState() const;
 
-    Element* invokedPopover() const;
+    Element* NODELETE invokedPopover() const;
     void setInvokedPopover(RefPtr<Element>&&);
 
     virtual bool isValidCommandType(const CommandType) { return false; }
@@ -765,7 +765,7 @@ public:
     inline const SpaceSplitString& classNames() const;
     inline bool hasClassName(const AtomString& className) const;
 
-    ScrollPosition savedLayerScrollPosition() const;
+    ScrollPosition NODELETE savedLayerScrollPosition() const;
     void setSavedLayerScrollPosition(const ScrollPosition&);
 
     enum class EventIsDefaultPrevented : bool { No, Yes };
@@ -805,7 +805,7 @@ public:
     void clearBeforePseudoElement();
     void clearAfterPseudoElement();
     void resetComputedStyle();
-    void resetStyleRelations();
+    void NODELETE resetStyleRelations();
     void resetChildStyleRelations();
     void resetAllDescendantStyleRelations();
     void clearHoverAndActiveStatusBeforeDetachingRenderer();
@@ -848,13 +848,13 @@ public:
     void invalidateForResumingQueryContainerResolution();
     void invalidateForResumingAnchorPositionedElementResolution();
 
-    bool needsUpdateQueryContainerDependentStyle() const;
-    void clearNeedsUpdateQueryContainerDependentStyle();
+    bool NODELETE needsUpdateQueryContainerDependentStyle() const;
+    void NODELETE clearNeedsUpdateQueryContainerDependentStyle();
 
     void invalidateEventListenerRegions();
 
-    bool hasDisplayContents() const;
-    bool hasDisplayNone() const;
+    bool NODELETE hasDisplayContents() const;
+    bool NODELETE hasDisplayNone() const;
     void storeDisplayContentsOrNoneStyle(std::unique_ptr<RenderStyle>);
     void clearDisplayContentsOrNoneStyle();
 
@@ -862,20 +862,20 @@ public:
     void setAttributeEventListener(const AtomString& eventType, const QualifiedName& attributeName, const AtomString& value);
 
     virtual IntersectionObserverData& ensureIntersectionObserverData();
-    virtual IntersectionObserverData* intersectionObserverDataIfExists() const;
+    virtual IntersectionObserverData* NODELETE intersectionObserverDataIfExists() const;
 
     ResizeObserverData& ensureResizeObserverData();
-    ResizeObserverData* resizeObserverDataIfExists() const;
+    ResizeObserverData* NODELETE resizeObserverDataIfExists() const;
 
     ElementLargestContentfulPaintData& ensureLargestContentfulPaintData();
-    ElementLargestContentfulPaintData* largestContentfulPaintDataIfExists() const;
+    ElementLargestContentfulPaintData* NODELETE largestContentfulPaintDataIfExists() const;
 
-    std::optional<LayoutUnit> lastRememberedLogicalWidth() const;
-    std::optional<LayoutUnit> lastRememberedLogicalHeight() const;
+    std::optional<LayoutUnit> NODELETE lastRememberedLogicalWidth() const;
+    std::optional<LayoutUnit> NODELETE lastRememberedLogicalHeight() const;
     void setLastRememberedLogicalWidth(LayoutUnit);
-    void clearLastRememberedLogicalWidth();
+    void NODELETE clearLastRememberedLogicalWidth();
     void setLastRememberedLogicalHeight(LayoutUnit);
-    void clearLastRememberedLogicalHeight();
+    void NODELETE clearLastRememberedLogicalHeight();
 
     RefPtr<Element> findAnchorElementForLink(String& outAnchorName);
 
@@ -886,19 +886,19 @@ public:
     String debugDescription() const override;
     String attributesForDescription() const;
 
-    bool hasDuplicateAttribute() const;
-    void setHasDuplicateAttribute(bool);
+    bool NODELETE hasDuplicateAttribute() const;
+    void NODELETE setHasDuplicateAttribute(bool);
 
     virtual void updateUserAgentShadowTree() { }
 
     StylePropertyMapReadOnly& computedStyleMap();
 
     ExplicitlySetAttrElementsMap& explicitlySetAttrElementsMap();
-    ExplicitlySetAttrElementsMap* explicitlySetAttrElementsMapIfExists() const;
+    ExplicitlySetAttrElementsMap* NODELETE explicitlySetAttrElementsMapIfExists() const;
 
-    bool isRelevantToUser() const;
+    bool NODELETE isRelevantToUser() const;
 
-    std::optional<OptionSet<ContentRelevancy>> contentRelevancy() const;
+    std::optional<OptionSet<ContentRelevancy>> NODELETE contentRelevancy() const;
     void setContentRelevancy(OptionSet<ContentRelevancy>);
 
     bool hasCustomState(const AtomString& state) const;
@@ -914,7 +914,7 @@ public:
     void setViewTransitionCapturedName(const std::optional<Style::PseudoElementIdentifier>&, AtomString);
 
     double lookupCSSRandomBaseValue(const std::optional<Style::PseudoElementIdentifier>&, const CSSCalc::RandomCachingKey&) const;
-    bool hasRandomCachingKeyMap() const;
+    bool NODELETE hasRandomCachingKeyMap() const;
 
     void addShadowRoot(Ref<ShadowRoot>&&);
 
@@ -935,7 +935,7 @@ protected:
 
     static ExceptionOr<void> mergeWithNextTextNode(Text&);
 
-    StylePropertyMap* attributeStyleMap();
+    StylePropertyMap* NODELETE attributeStyleMap();
     void setAttributeStyleMap(Ref<StylePropertyMap>&&);
 
     FormAssociatedCustomElement& formAssociatedCustomElementUnsafe() const;
@@ -987,7 +987,7 @@ private:
 
     ExceptionOr<Node*> insertAdjacent(const String& where, Ref<Node>&& newChild);
 
-    bool childTypeAllowed(NodeType) const final;
+    bool NODELETE childTypeAllowed(NodeType) const final;
 
     void notifyAttributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = AttributeModificationReason::Directly);
     void parserNotifyAttributeAdded(const QualifiedName&, const AtomString& value, AttributeModificationReason = AttributeModificationReason::Directly);
@@ -1024,7 +1024,7 @@ private:
     const RenderStyle* resolveComputedStyle(ResolveComputedStyleMode = ResolveComputedStyleMode::Normal);
     const RenderStyle& resolvePseudoElementStyle(const Style::PseudoElementIdentifier&);
 
-    unsigned rareDataChildIndex() const;
+    unsigned NODELETE rareDataChildIndex() const;
 
     void createUniqueElementData();
 
@@ -1050,7 +1050,7 @@ private:
 
     void dirAttributeChanged(const AtomString& newValue);
 
-    bool hasEffectiveLangState() const;
+    bool NODELETE hasEffectiveLangState() const;
     void updateEffectiveLangState();
     void updateEffectiveLangStateFromParent();
     void setEffectiveLangStateOnOldDocumentElement();

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -93,7 +93,7 @@ public:
     inline void ref(); // Defined in EventTargetInlines.h.
     inline void deref(); // Defined in EventTargetInlines.h.
 
-    virtual enum EventTargetInterfaceType eventTargetInterface() const = 0;
+    virtual enum EventTargetInterfaceType NODELETE eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;
 
     virtual bool isPaymentRequest() const;

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -206,9 +206,9 @@ public:
     Ref<Node> cloneNode(bool deep) const;
     WEBCORE_EXPORT ExceptionOr<Ref<Node>> cloneNodeForBindings(bool deep) const;
 
-    virtual const AtomString& localName() const;
-    virtual const AtomString& namespaceURI() const;
-    virtual const AtomString& prefix() const;
+    virtual const AtomString& NODELETE localName() const;
+    virtual const AtomString& NODELETE namespaceURI() const;
+    virtual const AtomString& NODELETE prefix() const;
     virtual ExceptionOr<void> setPrefix(const AtomString&);
     WEBCORE_EXPORT ExceptionOr<void> normalize();
 
@@ -221,12 +221,12 @@ public:
     WEBCORE_EXPORT String textContent(bool convertBRsToNewlines = false) const;
     WEBCORE_EXPORT ExceptionOr<void> setTextContent(String&&);
     
-    Node* lastDescendant() const;
-    Node* firstDescendant() const;
+    Node* NODELETE lastDescendant() const;
+    Node* NODELETE firstDescendant() const;
 
     // From the NonDocumentTypeChildNode - https://dom.spec.whatwg.org/#nondocumenttypechildnode
-    WEBCORE_EXPORT Element* previousElementSibling() const;
-    WEBCORE_EXPORT Element* nextElementSibling() const;
+    WEBCORE_EXPORT Element* NODELETE previousElementSibling() const;
+    WEBCORE_EXPORT Element* NODELETE nextElementSibling() const;
 
     // From the ChildNode - https://dom.spec.whatwg.org/#childnode
     ExceptionOr<void> before(FixedVector<NodeOrString>&&);
@@ -285,8 +285,8 @@ public:
     void setNeedsSVGRendererUpdate(bool flag) { setStateFlag(StateFlag::NeedsSVGRendererUpdate, flag); }
 
     // If this node is in a shadow tree, returns its shadow host. Otherwise, returns null.
-    WEBCORE_EXPORT Element* shadowHost() const;
-    ShadowRoot* containingShadowRoot() const;
+    WEBCORE_EXPORT Element* NODELETE shadowHost() const;
+    ShadowRoot* NODELETE containingShadowRoot() const;
     inline ShadowRoot* shadowRoot() const; // Defined in ElementRareData.h
     bool isClosedShadowHidden(const Node&) const;
 
@@ -337,7 +337,7 @@ public:
     Node& getRootNode(const GetRootNodeOptions&) const;
     
     inline WebCoreOpaqueRoot opaqueRoot() const;
-    WebCoreOpaqueRoot traverseToOpaqueRoot() const;
+    WebCoreOpaqueRoot NODELETE traverseToOpaqueRoot() const;
 
     void queueTaskKeepingThisNodeAlive(TaskSource, Function<void ()>&&);
     void queueTaskToDispatchEvent(TaskSource, Ref<Event>&&);
@@ -350,11 +350,11 @@ public:
     bool selfOrPrecedingNodesAffectDirAuto() const { return hasStateFlag(StateFlag::SelfOrPrecedingNodesAffectDirAuto); }
     void setSelfOrPrecedingNodesAffectDirAuto(bool flag) { setStateFlag(StateFlag::SelfOrPrecedingNodesAffectDirAuto, flag); }
 
-    TextDirection effectiveTextDirection() const;
-    void setEffectiveTextDirection(TextDirection);
+    TextDirection NODELETE effectiveTextDirection() const;
+    void NODELETE setEffectiveTextDirection(TextDirection);
 
     bool usesEffectiveTextDirection() const { return rareDataBitfields().usesEffectiveTextDirection; }
-    void setUsesEffectiveTextDirection(bool);
+    void NODELETE setUsesEffectiveTextDirection(bool);
 
     // Returns the enclosing event parent Element (or self) that, when clicked, would trigger a navigation.
     WEBCORE_EXPORT Element* enclosingLinkEventParentOrSelf();
@@ -376,7 +376,7 @@ public:
     bool isUserActionElement() const { return hasStateFlag(StateFlag::IsUserActionElement); }
     void setUserActionElement(bool flag) { setStateFlag(StateFlag::IsUserActionElement, flag); }
 
-    bool inRenderedDocument() const;
+    bool NODELETE inRenderedDocument() const;
     bool needsStyleRecalc() const { return styleValidity() != Style::Validity::Valid || hasInvalidRenderer(); }
     Style::Validity styleValidity() const { return styleBitfields().styleValidity(); }
     bool hasInvalidRenderer() const { return hasStateFlag(StateFlag::HasInvalidRenderer); }
@@ -429,11 +429,11 @@ public:
     WEBCORE_EXPORT LayoutRect absoluteBoundingRect(bool* isReplaced);
     inline IntRect pixelSnappedAbsoluteBoundingRect(bool* isReplaced); // Defined in NodeInlines.h
 
-    WEBCORE_EXPORT unsigned computeNodeIndex() const;
+    WEBCORE_EXPORT unsigned NODELETE computeNodeIndex() const;
 
     // Returns the DOM ownerDocument attribute. This method never returns null, except in the case
     // of a Document node.
-    WEBCORE_EXPORT Document* ownerDocument() const;
+    WEBCORE_EXPORT Document* NODELETE ownerDocument() const;
 
     // Returns the document associated with this node. A document node returns itself.
     inline Document& document() const; // Defined in NodeDocument.h
@@ -600,10 +600,10 @@ public:
     void notifyMutationObserversNodeWillDetach();
 
     unsigned connectedSubframeCount() const { return rareDataBitfields().connectedSubframeCount; }
-    void incrementConnectedSubframeCount(unsigned amount = 1);
-    void decrementConnectedSubframeCount(unsigned amount = 1);
-    void updateAncestorConnectedSubframeCountForRemoval() const;
-    void updateAncestorConnectedSubframeCountForInsertion() const;
+    void NODELETE incrementConnectedSubframeCount(unsigned amount = 1);
+    void NODELETE decrementConnectedSubframeCount(unsigned amount = 1);
+    void NODELETE updateAncestorConnectedSubframeCountForRemoval() const;
+    void NODELETE updateAncestorConnectedSubframeCountForInsertion() const;
 
 #if ENABLE(JIT)
     static constexpr ptrdiff_t typeFlagsMemoryOffset() { return OBJECT_OFFSETOF(Node, m_typeBitFields); }
@@ -803,8 +803,8 @@ private:
     void trackForDebugging();
     void materializeRareData();
 
-    Vector<Ref<MutationObserverRegistration>>* mutationObserverRegistry();
-    WeakHashSet<MutationObserverRegistration>* transientMutationObserverRegistry();
+    Vector<Ref<MutationObserverRegistration>>* NODELETE mutationObserverRegistry();
+    WeakHashSet<MutationObserverRegistration>* NODELETE transientMutationObserverRegistry();
 
     void adjustStyleValidity(Style::Validity, Style::InvalidationMode);
 
@@ -837,7 +837,7 @@ private:
     CompactUniquePtrTuple<NodeRareData, uint16_t> m_rareDataWithBitfields;
 };
 
-bool connectedInSameTreeScope(const Node*, const Node*);
+bool NODELETE connectedInSameTreeScope(const Node*, const Node*);
 
 enum TreeType { Tree, ShadowIncludingTree, ComposedTree };
 template<TreeType = Tree> ContainerNode* parent(const Node&);

--- a/Source/WebCore/dom/ProcessingInstruction.h
+++ b/Source/WebCore/dom/ProcessingInstruction.h
@@ -60,7 +60,7 @@ private:
     friend class CharacterData;
     ProcessingInstruction(Document&, String&& target, String&& data);
 
-    String NODELETE nodeName() const override;
+    String nodeName() const override;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const override;
     SerializedNode serializeNode(CloningOperation) const override;
 


### PR DESCRIPTION
#### e2bc20fd62b561b8012342fbb938e1874025be98
<pre>
Add NODELETE annotations to some core DOM member functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=307901">https://bugs.webkit.org/show_bug.cgi?id=307901</a>

Reviewed by Anne van Kesteren.

Added NODELETE annotations to member functions of Node, ContainerNode, and Element.

No new tests since there should be no behavioral changes.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncheckedLocalVarsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/dom/Attr.h:
* Source/WebCore/dom/ContainerNode.h:
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/ProcessingInstruction.h:
* Source/WebCore/page/LocalDOMWindow.h:

Canonical link: <a href="https://commits.webkit.org/307615@main">https://commits.webkit.org/307615@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e814d311a3f7b620b2989d2145d9e092fb6c283

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9280 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153549 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98513 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ef4755e-393b-475d-8a9c-156e885ec1a7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146753 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17451 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111396 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79846 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/130449df-c7fd-41eb-93de-dc90eed05ea4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13758 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92291 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f96f23ea-1f40-4c24-9ca2-0b7735c9b2d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13132 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10886 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/994 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122647 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155861 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7934 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119399 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17456 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119727 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15532 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128104 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72995 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22364 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17031 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6402 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16767 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80810 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16976 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16831 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->