### PR TITLE
Add NODELETE annotations to FrameTree

### DIFF
--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -44,8 +44,8 @@ public:
 
     const AtomString& specifiedName() const { return m_specifiedName; }
     WEBCORE_EXPORT AtomString uniqueName() const;
-    WEBCORE_EXPORT void setSpecifiedName(const AtomString&);
-    WEBCORE_EXPORT void clearName();
+    WEBCORE_EXPORT void NODELETE setSpecifiedName(const AtomString&);
+    WEBCORE_EXPORT void NODELETE clearName();
     WEBCORE_EXPORT Frame* NODELETE parent() const;
 
     Frame* nextSibling() const { return m_nextSibling.get(); }
@@ -56,34 +56,34 @@ public:
     RefPtr<Frame> firstRenderedChild() const;
     RefPtr<Frame> nextRenderedSibling() const;
 
-    LocalFrame* firstLocalDescendant() const;
-    LocalFrame* nextLocalSibling() const;
+    LocalFrame* NODELETE firstLocalDescendant() const;
+    LocalFrame* NODELETE nextLocalSibling() const;
 
-    WEBCORE_EXPORT bool isDescendantOf(const Frame* ancestor) const;
+    WEBCORE_EXPORT bool NODELETE isDescendantOf(const Frame* ancestor) const;
     
-    WEBCORE_EXPORT Frame* traverseNext(const Frame* stayWithin = nullptr) const;
-    Frame* traverseNextSkippingChildren(const Frame* stayWithin = nullptr) const;
+    WEBCORE_EXPORT Frame* NODELETE traverseNext(const Frame* stayWithin = nullptr) const;
+    Frame* NODELETE traverseNextSkippingChildren(const Frame* stayWithin = nullptr) const;
     // Rendered means being the main frame or having an ownerRenderer. It may not have been parented in the Widget tree yet (see WidgetHierarchyUpdatesSuspensionScope).
     WEBCORE_EXPORT RefPtr<Frame> traverseNextRendered(const Frame* stayWithin = nullptr) const;
-    WEBCORE_EXPORT Frame* traverseNext(CanWrap, DidWrap* = nullptr) const;
-    WEBCORE_EXPORT Frame* traversePrevious(CanWrap, DidWrap* = nullptr) const;
+    WEBCORE_EXPORT Frame* NODELETE traverseNext(CanWrap, DidWrap* = nullptr) const;
+    WEBCORE_EXPORT Frame* NODELETE traversePrevious(CanWrap, DidWrap* = nullptr) const;
 
-    Frame* traverseNextInPostOrder(CanWrap) const;
+    Frame* NODELETE traverseNextInPostOrder(CanWrap) const;
 
     WEBCORE_EXPORT void appendChild(Frame&);
     void detachFromParent() { m_parent = nullptr; }
     WEBCORE_EXPORT void removeChild(Frame&);
     WEBCORE_EXPORT void replaceChild(Frame&, Frame&);
 
-    Frame* child(unsigned index) const;
-    Frame* childBySpecifiedName(const AtomString& name) const;
-    Frame* descendantByFrameID(FrameIdentifier) const;
+    Frame* NODELETE child(unsigned index) const;
+    Frame* NODELETE childBySpecifiedName(const AtomString& name) const;
+    Frame* NODELETE descendantByFrameID(FrameIdentifier) const;
     WEBCORE_EXPORT RefPtr<Frame> findByUniqueName(const AtomString&, Frame& activeFrame) const;
     WEBCORE_EXPORT RefPtr<Frame> findBySpecifiedName(const AtomString&, Frame& activeFrame) const;
-    WEBCORE_EXPORT unsigned childCount() const;
-    unsigned descendantCount() const;
-    WEBCORE_EXPORT Frame& top() const;
-    unsigned depth() const;
+    WEBCORE_EXPORT unsigned NODELETE childCount() const;
+    unsigned NODELETE descendantCount() const;
+    WEBCORE_EXPORT Frame& NODELETE top() const;
+    unsigned NODELETE depth() const;
 
     WEBCORE_EXPORT RefPtr<Frame> scopedChild(unsigned index) const;
     WEBCORE_EXPORT RefPtr<Frame> scopedChildByUniqueName(const AtomString&) const;


### PR DESCRIPTION
#### 18e5473947de68206e8cf2d41b236b3c5d110ddb
<pre>
Add NODELETE annotations to FrameTree
<a href="https://bugs.webkit.org/show_bug.cgi?id=307903">https://bugs.webkit.org/show_bug.cgi?id=307903</a>

Reviewed by Anne van Kesteren.

Added NODELETE annotations to member functions of FrameTree.

No new tests since there should be no behavioral differences.

* Source/WebCore/page/FrameTree.h:

Canonical link: <a href="https://commits.webkit.org/307581@main">https://commits.webkit.org/307581@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2a5566db8c67d58da1aa0cc3b61f733e7db8b9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153460 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbc54455-91ca-40d8-8581-fab0be139fbe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146664 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17951 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17362 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111328 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27b94d7c-c434-408c-b570-01cb1c1a74a0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147752 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13695 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/129980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92223 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b04e08f-0e30-46ef-8189-37aefac92b9b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13068 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10822 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/905 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122583 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155772 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119332 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17367 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14464 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119660 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15469 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/127932 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72862 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22344 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16942 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6285 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16678 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80721 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16887 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16742 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->