### PR TITLE
Remove single-class-element-name-based constructors

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -103,8 +103,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLModelElement);
 
 static const Seconds reloadModelDelay { 1_s };
 
-HTMLModelElement::HTMLModelElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, { TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument })
+HTMLModelElement::HTMLModelElement(Document& document)
+    : HTMLElement(modelTag, document, { TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument })
     , ActiveDOMObject(document)
     , m_readyPromise { makeUniqueRef<ReadyPromise>(*this, &HTMLModelElement::readyPromiseResolve) }
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
@@ -141,9 +141,9 @@ HTMLModelElement::~HTMLModelElement()
     deleteModelPlayer();
 }
 
-Ref<HTMLModelElement> HTMLModelElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLModelElement> HTMLModelElement::create(Document& document)
 {
-    auto model = adoptRef(*new HTMLModelElement(tagName, document));
+    Ref model = adoptRef(*new HTMLModelElement(document));
     model->suspendIfNeeded();
     return model;
 }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -76,7 +76,7 @@ class HTMLModelElement final : public HTMLElement, private CachedRawResourceClie
 public:
     USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
-    static Ref<HTMLModelElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLModelElement> create(Document&);
     virtual ~HTMLModelElement();
 
     // ActiveDOMObject.
@@ -203,7 +203,7 @@ public:
     WEBCORE_EXPORT String modelElementStateForTesting() const;
 
 private:
-    HTMLModelElement(const QualifiedName&, Document&);
+    HTMLModelElement(Document&);
 
     URL selectModelSource() const;
     void setSourceURL(const URL&);

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -91,7 +91,7 @@ void YouTubePluginReplacement::installReplacement(ShadowRoot& root)
 
     root.appendChild(embedShadowElement);
 
-    Ref iframeElement = HTMLIFrameElement::create(HTMLNames::iframeTag, document);
+    Ref iframeElement = HTMLIFrameElement::create(document);
     if (m_attributes.contains<HashTranslatorASCIILiteral>("width"_s))
         iframeElement->setAttributeWithoutSynchronization(HTMLNames::widthAttr, "100%"_s);
 

--- a/Source/WebCore/dom/DOMImplementation.cpp
+++ b/Source/WebCore/dom/DOMImplementation.cpp
@@ -144,7 +144,7 @@ Ref<HTMLDocument> DOMImplementation::createHTMLDocument(String&& title)
     document->open();
     document->write(nullptr, FixedVector<String> { "<!doctype html><html><head></head><body></body></html>"_s });
     if (!title.isNull()) {
-        auto titleElement = HTMLTitleElement::create(titleTag, document);
+        Ref titleElement = HTMLTitleElement::create(document);
         titleElement->appendChild(document->createTextNode(WTF::move(title)));
         ASSERT(document->head());
         protect(document->head())->appendChild(titleElement);

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -2516,7 +2516,7 @@ void Document::setTitle(String&& title)
     RefPtr element = documentElement();
     if (RefPtr svgElement = dynamicDowncast<SVGSVGElement>(element.get())) {
         if (!m_titleElement) {
-            Ref titleElement = SVGTitleElement::create(SVGNames::titleTag, *this);
+            Ref titleElement = SVGTitleElement::create(*this);
             m_titleElement = titleElement.copyRef();
             svgElement->insertBefore(titleElement, protect(svgElement->firstChild()));
         }
@@ -2529,7 +2529,7 @@ void Document::setTitle(String&& title)
             RefPtr headElement = head();
             if (!headElement)
                 return;
-            Ref titleElement = HTMLTitleElement::create(HTMLNames::titleTag, *this);
+            Ref titleElement = HTMLTitleElement::create(*this);
             m_titleElement = titleElement.copyRef();
             headElement->appendChild(titleElement);
         } else

--- a/Source/WebCore/dom/ImageOverlay.cpp
+++ b/Source/WebCore/dom/ImageOverlay.cpp
@@ -237,7 +237,7 @@ IntRect containerRect(HTMLElement& element)
 static void installImageOverlayStyleSheet(ShadowRoot& shadowRoot)
 {
     static MainThreadNeverDestroyed<const String> shadowStyle(StringImpl::createWithoutCopying(imageOverlayUserAgentStyleSheet));
-    Ref style = HTMLStyleElement::create(HTMLNames::styleTag, protect(shadowRoot.document()), false);
+    Ref style = HTMLStyleElement::create(protect(shadowRoot.document()));
     style->setTextContent(String { shadowStyle });
     shadowRoot.appendChild(WTF::move(style));
 }

--- a/Source/WebCore/dom/SerializedNode.cpp
+++ b/Source/WebCore/dom/SerializedNode.cpp
@@ -119,7 +119,7 @@ Ref<Node> SerializedNode::deserialize(SerializedNode&& serializedNode, WebCore::
         return result;
     }, [&] (SerializedNode::HTMLTemplateElement&& element) -> Ref<Node> {
         ASSERT(!element.shadowRoot);
-        Ref result = WebCore::HTMLTemplateElement::create(WTF::move(element.name).qualifiedName(), document);
+        Ref result = WebCore::HTMLTemplateElement::create(document);
         setAttributes(result, WTF::move(element.attributes));
         if (element.content) {
             Ref content = TemplateContentDocumentFragment::create(Ref { document.ensureTemplateDocument() }.get(), result);

--- a/Source/WebCore/dom/mac/ImageControlsMac.cpp
+++ b/Source/WebCore/dom/mac/ImageControlsMac.cpp
@@ -110,17 +110,17 @@ void createImageControls(HTMLElement& element)
 {
     Ref document = element.document();
     Ref shadowRoot = element.ensureUserAgentShadowRoot();
-    Ref controlLayer = HTMLDivElement::create(document.get());
+    Ref controlLayer = HTMLDivElement::create(document);
     controlLayer->setIdAttribute(imageControlsElementIdentifier());
     controlLayer->setAttributeWithoutSynchronization(HTMLNames::contenteditableAttr, falseAtom());
     shadowRoot->appendChild(controlLayer);
     
     static MainThreadNeverDestroyed<const String> shadowStyle(StringImpl::createWithoutCopying(imageControlsMacUserAgentStyleSheet));
-    Ref style = HTMLStyleElement::create(HTMLNames::styleTag, document.get(), false);
+    Ref style = HTMLStyleElement::create(document);
     style->setTextContent(String { shadowStyle });
     shadowRoot->appendChild(WTF::move(style));
     
-    Ref button = HTMLButtonElement::create(HTMLNames::buttonTag, protect(element.document()), nullptr);
+    Ref button = HTMLButtonElement::create(document);
     button->setIdAttribute(imageControlsButtonIdentifier());
     controlLayer->appendChild(button);
     controlLayer->setUserAgentPart(UserAgentParts::appleAttachmentControlsContainer());

--- a/Source/WebCore/dom/make_names.pl
+++ b/Source/WebCore/dom/make_names.pl
@@ -470,6 +470,17 @@ sub buildConstructorMap
     return %tagConstructorMap;
 }
 
+# Build a set of interfaces that are used by exactly one tag (single-tag interfaces).
+sub buildSingleTagInterfaces
+{
+    my %interfaceCount = ();
+    for my $elementKey (keys %allElements) {
+        next if $allElements{$elementKey}{noConstructor};
+        $interfaceCount{$allElements{$elementKey}{interfaceName}}++;
+    }
+    return map { $_ => 1 } grep { $interfaceCount{$_} == 1 } keys %interfaceCount;
+}
+
 # Helper method that print the constructor's signature avoiding
 # unneeded arguments.
 sub printConstructorSignature
@@ -491,7 +502,7 @@ sub printConstructorSignature
 # The variable names should be kept in sync with the previous method.
 sub printConstructorInterior
 {
-    my ($F, $elementKey, $interfaceName, $constructorTagName) = @_;
+    my ($F, $elementKey, $interfaceName, $constructorTagName, $singleTagInterfacesRef) = @_;
 
     # Handle media elements.
     # Note that wrapperOnlyIfMediaIsAvailable is a misnomer, because media availability
@@ -540,7 +551,15 @@ END
     }
 
     # Call the constructor with the right parameters.
-    print F "    return ${interfaceName}::create($constructorTagName, document";
+    # For single-tag interfaces, we don't need to pass the tag name.
+    my $isSingleTagInterface = $singleTagInterfacesRef->{$interfaceName};
+
+    if ($isSingleTagInterface) {
+        print F "    UNUSED_PARAM($constructorTagName);\n";
+        print F "    return ${interfaceName}::create(document";
+    } else {
+        print F "    return ${interfaceName}::create($constructorTagName, document";
+    }
     print F ", formElement" if $allElements{$elementKey}{constructorNeedsFormElement};
     print F ", createdByParser" if $allElements{$elementKey}{constructorNeedsCreatedByParser};
     print F ");\n}\n";
@@ -550,6 +569,9 @@ sub printConstructors
 {
     my ($F, $tagConstructorMapRef) = @_;
     my %tagConstructorMap = %$tagConstructorMapRef;
+
+    # Build set of single-tag interfaces.
+    my %singleTagInterfaces = buildSingleTagInterfaces();
 
     # This is to avoid generating the same constructor several times.
     my %handledInterfaces = ();
@@ -573,7 +595,7 @@ sub printConstructors
         }
 
         printConstructorSignature($F, $elementKey, $tagConstructorMap{$elementKey}, "tagName");
-        printConstructorInterior($F, $elementKey, $interfaceName, "tagName");
+        printConstructorInterior($F, $elementKey, $interfaceName, "tagName", \%singleTagInterfaces);
 
         if ($conditional) {
             print F "#endif\n";

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4891,7 +4891,7 @@ void Editor::notifyClientOfAttachmentUpdates()
 void Editor::insertAttachment(const String& identifier, std::optional<uint64_t>&& fileSize, const AtomString& fileName, const AtomString& contentType)
 {
     Ref document = this->document();
-    auto attachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, document);
+    Ref attachment = HTMLAttachmentElement::create(document);
     attachment->setUniqueIdentifier(identifier);
     attachment->updateAttributes(WTF::move(fileSize), contentType, fileName);
 

--- a/Source/WebCore/editing/cocoa/EditorCocoa.mm
+++ b/Source/WebCore/editing/cocoa/EditorCocoa.mm
@@ -460,30 +460,30 @@ void Editor::insertMultiRepresentationHEIC(const std::span<const uint8_t>& data,
     auto fallbackData = encodeData(fallbackImageForMultiRepresentationHEIC(data).get(), fallbackType, std::nullopt);
     Ref fallbackBuffer = SharedBuffer::create(WTF::move(fallbackData));
 
-    auto picture = HTMLPictureElement::create(HTMLNames::pictureTag, document);
+    Ref picture = HTMLPictureElement::create(document);
 
-    auto source = HTMLSourceElement::create(document);
+    Ref source = HTMLSourceElement::create(document);
     source->setAttributeWithoutSynchronization(HTMLNames::srcsetAttr, AtomString { DOMURL::createObjectURL(document, Blob::create(document.ptr(), primaryBuffer->copyData(), primaryType)) });
     source->setAttributeWithoutSynchronization(HTMLNames::typeAttr, AtomString { primaryType });
     picture->appendChild(WTF::move(source));
 
-    auto image = HTMLImageElement::create(document);
+    Ref image = HTMLImageElement::create(document);
     image->setAttributeWithoutSynchronization(HTMLNames::srcAttr, AtomString { DOMURL::createObjectURL(document, Blob::create(document.ptr(), fallbackBuffer->copyData(), fallbackType)) });
     if (!altText.isEmpty())
         image->setAttributeWithoutSynchronization(HTMLNames::altAttr, AtomString { altText });
     picture->appendChild(WTF::move(image));
 
-    auto fragment = document->createDocumentFragment();
+    Ref fragment = document->createDocumentFragment();
     fragment->appendChild(WTF::move(picture));
 
 #if ENABLE(ATTACHMENT_ELEMENT)
     if (DeprecatedGlobalSettings::attachmentElementEnabled()) {
-        auto primaryAttachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, document.get());
+        Ref primaryAttachment = HTMLAttachmentElement::create(document);
         auto primaryIdentifier = primaryAttachment->ensureUniqueIdentifier();
         registerAttachmentIdentifier(primaryIdentifier, "image/heic"_s, makeString(primaryIdentifier, ".heic"_s), WTF::move(primaryBuffer));
         source->setAttachmentElement(WTF::move(primaryAttachment));
 
-        auto fallbackAttachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, document.get());
+        Ref fallbackAttachment = HTMLAttachmentElement::create(document);
         auto fallbackIdentifier = fallbackAttachment->ensureUniqueIdentifier();
         registerAttachmentIdentifier(fallbackIdentifier, fallbackType, makeString(fallbackIdentifier, ".png"_s), WTF::move(fallbackBuffer));
         image->setAttachmentElement(WTF::move(fallbackAttachment));

--- a/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
+++ b/Source/WebCore/editing/cocoa/WebContentReaderCocoa.mm
@@ -254,7 +254,7 @@ static bool supportsClientSideAttachmentData(const LocalFrame& frame)
 static Ref<DocumentFragment> createFragmentForImageAttachment(LocalFrame& frame, Document& document, Ref<FragmentedSharedBuffer>&& buffer, const String& contentType, PresentationSize preferredSize)
 {
 #if ENABLE(ATTACHMENT_ELEMENT)
-    auto attachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, document);
+    Ref attachment = HTMLAttachmentElement::create(document);
     // FIXME: This fallback image name needs to be a localized string.
     constexpr ASCIILiteral defaultImageAttachmentName { "image"_s };
 
@@ -393,7 +393,7 @@ static void replaceRichContentWithAttachments(LocalFrame& frame, DocumentFragmen
             }
         }
 
-        auto attachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, fragment.document());
+        Ref attachment = HTMLAttachmentElement::create(fragment.document());
         if (supportsClientSideAttachmentData(frame)) {
             if (RefPtr image = dynamicDowncast<HTMLImageElement>(originalElement); image && contentTypeIsSuitableForInlineImageRepresentation(info.contentType)) {
                 RefPtr document = frame.document();
@@ -800,7 +800,7 @@ static String typeForAttachmentElement(const String& contentType)
 static Ref<HTMLElement> attachmentForFilePath(LocalFrame& frame, const String& path, PresentationSize preferredSize, const String& explicitContentType)
 {
     Ref document = *frame.document();
-    auto attachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, document);
+    Ref attachment = HTMLAttachmentElement::create(document);
     if (!supportsClientSideAttachmentData(frame)) {
         attachment->setFile(File::create(document.ptr(), path), HTMLAttachmentElement::UpdateDisplayAttributes::Yes);
         return attachment;
@@ -845,7 +845,7 @@ static Ref<HTMLElement> attachmentForFilePath(LocalFrame& frame, const String& p
 static Ref<HTMLElement> attachmentForData(LocalFrame& frame, FragmentedSharedBuffer& buffer, const String& contentType, const AtomString& name, PresentationSize preferredSize)
 {
     Ref document = *frame.document();
-    auto attachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, document);
+    Ref attachment = HTMLAttachmentElement::create(document);
     auto attachmentType = typeForAttachmentElement(contentType);
 
     // FIXME: We should instead ask CoreServices for a preferred name corresponding to the given content type.

--- a/Source/WebCore/editing/markup.cpp
+++ b/Source/WebCore/editing/markup.cpp
@@ -1278,7 +1278,7 @@ static void restoreAttachmentElementsInFragment(DocumentFragment& fragment)
         if (attachmentIdentifier.isEmpty())
             continue;
 
-        Ref attachment = HTMLAttachmentElement::create(HTMLNames::attachmentTag, *ownerDocument);
+        Ref attachment = HTMLAttachmentElement::create(*ownerDocument);
         attachment->setUniqueIdentifier(attachmentIdentifier);
         attachmentAssociatedElement->setAttachmentElement(WTF::move(attachment));
         element->removeAttribute(webkitattachmentidAttr);

--- a/Source/WebCore/html/FileInputType.cpp
+++ b/Source/WebCore/html/FileInputType.cpp
@@ -229,7 +229,7 @@ void FileInputType::createShadowSubtree()
     ASSERT(element()->shadowRoot());
 
     Ref element = *this->element();
-    Ref button = HTMLInputElement::create(inputTag, protect(element->document()), nullptr, false);
+    Ref button = HTMLInputElement::create(protect(element->document()), nullptr, false);
     {
         ScriptDisallowedScope::EventAllowedScope eventAllowedScopeBeforeAppend { button };
         button->setAttributeWithoutSynchronization(typeAttr, InputTypeNames::button());

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -89,11 +89,6 @@ Ref<HTMLAnchorElement> HTMLAnchorElement::create(Document& document)
     return adoptRef(*new HTMLAnchorElement(aTag, document));
 }
 
-Ref<HTMLAnchorElement> HTMLAnchorElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLAnchorElement(tagName, document));
-}
-
 HTMLAnchorElement::~HTMLAnchorElement() = default;
 
 bool HTMLAnchorElement::supportsFocus() const

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -50,7 +50,6 @@ class HTMLAnchorElement : public HTMLElement, public URLDecomposition {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLAnchorElement);
 public:
     static Ref<HTMLAnchorElement> create(Document&);
-    static Ref<HTMLAnchorElement> create(const QualifiedName&, Document&);
 
     virtual ~HTMLAnchorElement();
 

--- a/Source/WebCore/html/HTMLAreaElement.cpp
+++ b/Source/WebCore/html/HTMLAreaElement.cpp
@@ -43,17 +43,16 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLAreaElement);
 
 using namespace HTMLNames;
 
-inline HTMLAreaElement::HTMLAreaElement(const QualifiedName& tagName, Document& document)
-    : HTMLAnchorElement(tagName, document)
+inline HTMLAreaElement::HTMLAreaElement(Document& document)
+    : HTMLAnchorElement(areaTag, document)
 {
-    ASSERT(hasTagName(areaTag));
 }
 
 HTMLAreaElement::~HTMLAreaElement() = default;
 
-Ref<HTMLAreaElement> HTMLAreaElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLAreaElement> HTMLAreaElement::create(Document& document)
 {
-    return adoptRef(*new HTMLAreaElement(tagName, document));
+    return adoptRef(*new HTMLAreaElement(document));
 }
 
 void HTMLAreaElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLAreaElement.h
+++ b/Source/WebCore/html/HTMLAreaElement.h
@@ -36,7 +36,7 @@ class HTMLAreaElement final : public HTMLAnchorElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLAreaElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLAreaElement);
 public:
-    static Ref<HTMLAreaElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLAreaElement> create(Document&);
     ~HTMLAreaElement();
 
     bool isDefault() const { return m_shape == Shape::Default; }
@@ -50,9 +50,9 @@ public:
 
     // The parent map's image.
     WEBCORE_EXPORT RefPtr<HTMLImageElement> imageElement() const;
-    
+
 private:
-    HTMLAreaElement(const QualifiedName&, Document&);
+    explicit HTMLAreaElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     bool supportsFocus() const final;

--- a/Source/WebCore/html/HTMLArticleElement.cpp
+++ b/Source/WebCore/html/HTMLArticleElement.cpp
@@ -36,15 +36,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLArticleElement);
 
-Ref<HTMLArticleElement> HTMLArticleElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLArticleElement> HTMLArticleElement::create(Document& document)
 {
-    return adoptRef(*new HTMLArticleElement(tagName, document));
+    return adoptRef(*new HTMLArticleElement(document));
 }
 
-HTMLArticleElement::HTMLArticleElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLArticleElement::HTMLArticleElement(Document& document)
+    : HTMLElement(HTMLNames::articleTag, document)
 {
-    ASSERT(tagName == HTMLNames::articleTag);
 }
 
 auto HTMLArticleElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult

--- a/Source/WebCore/html/HTMLArticleElement.h
+++ b/Source/WebCore/html/HTMLArticleElement.h
@@ -33,13 +33,13 @@ class HTMLArticleElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLArticleElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLArticleElement);
 public:
-    static Ref<HTMLArticleElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLArticleElement> create(Document&);
 
 private:
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
 
-    HTMLArticleElement(const QualifiedName&, Document&);
+    explicit HTMLArticleElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -152,17 +152,16 @@ static CString compactStackTrace(StackTrace& stackTrace)
 }
 #endif // ATTACHMENT_LOG_DOCUMENT_TRAFFIC
 
-HTMLAttachmentElement::HTMLAttachmentElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLAttachmentElement::HTMLAttachmentElement(Document& document)
+    : HTMLElement(attachmentTag, document)
 {
-    ASSERT(hasTagName(attachmentTag));
 }
 
 HTMLAttachmentElement::~HTMLAttachmentElement() = default;
 
-Ref<HTMLAttachmentElement> HTMLAttachmentElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLAttachmentElement> HTMLAttachmentElement::create(Document& document)
 {
-    Ref attachment = adoptRef(*new HTMLAttachmentElement(tagName, document));
+    Ref attachment = adoptRef(*new HTMLAttachmentElement(document));
     if (document.settings().attachmentWideLayoutEnabled()) {
         ASSERT(attachment->m_implementation == Implementation::NarrowLayout);
         ASSERT(!attachment->renderer()); // Switch to wide-layout style *must* be done before renderer is created!
@@ -328,7 +327,7 @@ void HTMLAttachmentElement::ensureWideLayoutShadowTree(ShadowRoot& root)
         return;
 
     Ref document = this->document();
-    Ref style = HTMLStyleElement::create(HTMLNames::styleTag, document, false);
+    Ref style = HTMLStyleElement::create(document, false);
     style->setTextContent(shadowUserAgentStyleSheetText());
     root.appendChild(WTF::move(style));
 
@@ -534,7 +533,7 @@ String HTMLAttachmentElement::getAttachmentIdentifier(HTMLElement& element)
         return attachment->uniqueIdentifier();
 
     Ref document = element.document();
-    auto attachment = create(HTMLNames::attachmentTag, document);
+    Ref attachment = create(document);
     auto identifier = attachment->ensureUniqueIdentifier();
 
     document->registerAttachmentIdentifier(identifier, *attachmentAssociatedElement);

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -47,7 +47,7 @@ class HTMLAttachmentElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLAttachmentElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLAttachmentElement);
 public:
-    static Ref<HTMLAttachmentElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLAttachmentElement> create(Document&);
     WEBCORE_EXPORT static String getAttachmentIdentifier(HTMLElement&);
     static URL archiveResourceURL(const String&);
 
@@ -110,7 +110,7 @@ public:
 private:
     friend class AttachmentSaveEventListener;
 
-    HTMLAttachmentElement(const QualifiedName&, Document&);
+    explicit HTMLAttachmentElement(Document&);
     virtual ~HTMLAttachmentElement();
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;

--- a/Source/WebCore/html/HTMLAudioElement.cpp
+++ b/Source/WebCore/html/HTMLAudioElement.cpp
@@ -39,22 +39,21 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLAudioElement);
 
 using namespace HTMLNames;
 
-inline HTMLAudioElement::HTMLAudioElement(const QualifiedName& tagName, Document& document, bool createdByParser)
-    : HTMLMediaElement(tagName, document, createdByParser)
+inline HTMLAudioElement::HTMLAudioElement(Document& document, bool createdByParser)
+    : HTMLMediaElement(audioTag, document, createdByParser)
 {
-    ASSERT(hasTagName(audioTag));
 }
 
-Ref<HTMLAudioElement> HTMLAudioElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)
+Ref<HTMLAudioElement> HTMLAudioElement::create(Document& document, bool createdByParser)
 {
-    Ref element = adoptRef(*new HTMLAudioElement(tagName, document, createdByParser));
+    Ref element = adoptRef(*new HTMLAudioElement(document, createdByParser));
     element->suspendIfNeeded();
     return element;
 }
 
 Ref<HTMLAudioElement> HTMLAudioElement::createForLegacyFactoryFunction(Document& document, const AtomString& src)
 {
-    Ref element = create(audioTag, document, false);
+    Ref element = create(document, false);
     element->setAttributeWithoutSynchronization(preloadAttr, autoAtom());
     element->setAttributeWithoutSynchronization(srcAttr, src);
     return element;

--- a/Source/WebCore/html/HTMLAudioElement.h
+++ b/Source/WebCore/html/HTMLAudioElement.h
@@ -38,11 +38,11 @@ class HTMLAudioElement final : public HTMLMediaElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLAudioElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLAudioElement);
 public:
-    static Ref<HTMLAudioElement> create(const QualifiedName&, Document&, bool);
+    static Ref<HTMLAudioElement> create(Document&, bool createdByParser);
     static Ref<HTMLAudioElement> createForLegacyFactoryFunction(Document&, const AtomString& src);
 
 private:
-    HTMLAudioElement(const QualifiedName&, Document&, bool);
+    HTMLAudioElement(Document&, bool createdByParser);
 
     PlatformMediaSession::MediaType presentationType() const final { return PlatformMediaSession::MediaType::Audio; }
 };

--- a/Source/WebCore/html/HTMLBDIElement.cpp
+++ b/Source/WebCore/html/HTMLBDIElement.cpp
@@ -33,13 +33,13 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLBDIElement);
 
-Ref<HTMLBDIElement> HTMLBDIElement::create(const QualifiedName& name, Document& document)
+Ref<HTMLBDIElement> HTMLBDIElement::create(Document& document)
 {
-    return adoptRef(*new HTMLBDIElement(name, document));
+    return adoptRef(*new HTMLBDIElement(document));
 }
 
-HTMLBDIElement::HTMLBDIElement(const QualifiedName& name, Document& document)
-    : HTMLElement(name, document)
+HTMLBDIElement::HTMLBDIElement(Document& document)
+    : HTMLElement(HTMLNames::bdiTag, document)
 {
     setSelfOrPrecedingNodesAffectDirAuto(true);
     document.setIsDirAttributeDirty();

--- a/Source/WebCore/html/HTMLBDIElement.h
+++ b/Source/WebCore/html/HTMLBDIElement.h
@@ -28,10 +28,10 @@ class HTMLBDIElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLBDIElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLBDIElement);
 public:
-    static Ref<HTMLBDIElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLBDIElement> create(Document&);
 
 private:
-    HTMLBDIElement(const QualifiedName&, Document&);
+    explicit HTMLBDIElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLBRElement.cpp
+++ b/Source/WebCore/html/HTMLBRElement.cpp
@@ -36,20 +36,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLBRElement);
 
 using namespace HTMLNames;
 
-HTMLBRElement::HTMLBRElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLBRElement::HTMLBRElement(Document& document)
+    : HTMLElement(brTag, document)
 {
-    ASSERT(hasTagName(brTag));
 }
 
 Ref<HTMLBRElement> HTMLBRElement::create(Document& document)
 {
-    return adoptRef(*new HTMLBRElement(brTag, document));
-}
-
-Ref<HTMLBRElement> HTMLBRElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLBRElement(tagName, document));
+    return adoptRef(*new HTMLBRElement(document));
 }
 
 bool HTMLBRElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const

--- a/Source/WebCore/html/HTMLBRElement.h
+++ b/Source/WebCore/html/HTMLBRElement.h
@@ -32,12 +32,11 @@ class HTMLBRElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLBRElement);
 public:
     static Ref<HTMLBRElement> create(Document&);
-    static Ref<HTMLBRElement> create(const QualifiedName&, Document&);
 
     bool canContainRangeEndPoint() const final { return false; }
 
 private:
-    HTMLBRElement(const QualifiedName&, Document&);
+    explicit HTMLBRElement(Document&);
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;

--- a/Source/WebCore/html/HTMLBaseElement.cpp
+++ b/Source/WebCore/html/HTMLBaseElement.cpp
@@ -35,15 +35,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLBaseElement);
 
 using namespace HTMLNames;
 
-inline HTMLBaseElement::HTMLBaseElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLBaseElement::HTMLBaseElement(Document& document)
+    : HTMLElement(baseTag, document)
 {
-    ASSERT(hasTagName(baseTag));
 }
 
-Ref<HTMLBaseElement> HTMLBaseElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLBaseElement> HTMLBaseElement::create(Document& document)
 {
-    return adoptRef(*new HTMLBaseElement(tagName, document));
+    return adoptRef(*new HTMLBaseElement(document));
 }
 
 void HTMLBaseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLBaseElement.h
+++ b/Source/WebCore/html/HTMLBaseElement.h
@@ -30,12 +30,12 @@ class HTMLBaseElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLBaseElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLBaseElement);
 public:
-    static Ref<HTMLBaseElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLBaseElement> create(Document&);
 
     WEBCORE_EXPORT String href() const;
 
 private:
-    HTMLBaseElement(const QualifiedName&, Document&);
+    explicit HTMLBaseElement(Document&);
 
     AtomString target() const final;
     bool isURLAttribute(const Attribute&) const final;

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -47,20 +47,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLBodyElement);
 
 using namespace HTMLNames;
 
-HTMLBodyElement::HTMLBodyElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLBodyElement::HTMLBodyElement(Document& document)
+    : HTMLElement(bodyTag, document)
 {
-    ASSERT(hasTagName(bodyTag));
 }
 
 Ref<HTMLBodyElement> HTMLBodyElement::create(Document& document)
 {
-    return adoptRef(*new HTMLBodyElement(bodyTag, document));
-}
-
-Ref<HTMLBodyElement> HTMLBodyElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLBodyElement(tagName, document));
+    return adoptRef(*new HTMLBodyElement(document));
 }
 
 HTMLBodyElement::~HTMLBodyElement() = default;

--- a/Source/WebCore/html/HTMLBodyElement.h
+++ b/Source/WebCore/html/HTMLBodyElement.h
@@ -32,13 +32,12 @@ class HTMLBodyElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLBodyElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLBodyElement> create(Document&);
-    static Ref<HTMLBodyElement> create(const QualifiedName&, Document&);
     virtual ~HTMLBodyElement();
 
     static const AtomString& eventNameForWindowEventHandlerAttribute(const QualifiedName& attributeName);
 
 private:
-    HTMLBodyElement(const QualifiedName&, Document&);
+    explicit HTMLBodyElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -55,22 +55,16 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLButtonElement);
 
 using namespace HTMLNames;
 
-inline HTMLButtonElement::HTMLButtonElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLFormControlElement(tagName, document, form)
+inline HTMLButtonElement::HTMLButtonElement(Document& document, HTMLFormElement* form)
+    : HTMLFormControlElement(buttonTag, document, form)
     , m_type(Type::Submit)
     , m_isActivatedSubmit(false)
 {
-    ASSERT(hasTagName(buttonTag));
 }
 
-Ref<HTMLButtonElement> HTMLButtonElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLButtonElement> HTMLButtonElement::create(Document& document, HTMLFormElement* form)
 {
-    return adoptRef(*new HTMLButtonElement(tagName, document, form));
-}
-
-Ref<HTMLButtonElement> HTMLButtonElement::create(Document& document)
-{
-    return adoptRef(*new HTMLButtonElement(buttonTag, document, nullptr));
+    return adoptRef(*new HTMLButtonElement(document, form));
 }
 
 RenderPtr<RenderElement> HTMLButtonElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)

--- a/Source/WebCore/html/HTMLButtonElement.h
+++ b/Source/WebCore/html/HTMLButtonElement.h
@@ -33,8 +33,7 @@ class HTMLButtonElement final : public HTMLFormControlElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLButtonElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLButtonElement);
 public:
-    static Ref<HTMLButtonElement> create(const QualifiedName&, Document&, HTMLFormElement*);
-    static Ref<HTMLButtonElement> create(Document&);
+    static Ref<HTMLButtonElement> create(Document&, HTMLFormElement* = nullptr);
     
     const AtomString& value() const;
     const AtomString& command() const;
@@ -51,7 +50,7 @@ public:
     bool isDevolvableWidget() const override { return true; }
 
 private:
-    HTMLButtonElement(const QualifiedName& tagName, Document&, HTMLFormElement*);
+    HTMLButtonElement(Document&, HTMLFormElement*);
 
     enum class Type : uint8_t { Submit, Reset, Button };
 

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -122,24 +122,16 @@ using namespace HTMLNames;
 const int defaultWidth = 300;
 const int defaultHeight = 150;
 
-HTMLCanvasElement::HTMLCanvasElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
+HTMLCanvasElement::HTMLCanvasElement(Document& document)
+    : HTMLElement(canvasTag, document, TypeFlag::HasDidMoveToNewDocument)
     , ActiveDOMObject(document)
     , CanvasBase(IntSize(defaultWidth, defaultHeight), document)
 {
-    ASSERT(hasTagName(canvasTag));
 }
 
 Ref<HTMLCanvasElement> HTMLCanvasElement::create(Document& document)
 {
-    auto canvas = adoptRef(*new HTMLCanvasElement(canvasTag, document));
-    canvas->suspendIfNeeded();
-    return canvas;
-}
-
-Ref<HTMLCanvasElement> HTMLCanvasElement::create(const QualifiedName& tagName, Document& document)
-{
-    auto canvas = adoptRef(*new HTMLCanvasElement(tagName, document));
+    Ref canvas = adoptRef(*new HTMLCanvasElement(document));
     canvas->suspendIfNeeded();
     return canvas;
 }

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -70,7 +70,6 @@ public:
     USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
     static Ref<HTMLCanvasElement> create(Document&);
-    static Ref<HTMLCanvasElement> create(const QualifiedName&, Document&);
     virtual ~HTMLCanvasElement();
 
 
@@ -151,7 +150,7 @@ public:
     void setSizeForControllingContext(IntSize) final;
 
 private:
-    HTMLCanvasElement(const QualifiedName&, Document&);
+    explicit HTMLCanvasElement(Document&);
 
     bool isHTMLCanvasElement() const final { return true; }
 

--- a/Source/WebCore/html/HTMLDListElement.cpp
+++ b/Source/WebCore/html/HTMLDListElement.cpp
@@ -32,15 +32,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLDListElement);
 
 using namespace HTMLNames;
 
-inline HTMLDListElement::HTMLDListElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLDListElement::HTMLDListElement(Document& document)
+    : HTMLElement(dlTag, document)
 {
-    ASSERT(hasTagName(dlTag));
 }
 
-Ref<HTMLDListElement> HTMLDListElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLDListElement> HTMLDListElement::create(Document& document)
 {
-    return adoptRef(*new HTMLDListElement(tagName, document));
+    return adoptRef(*new HTMLDListElement(document));
 }
 
 }

--- a/Source/WebCore/html/HTMLDListElement.h
+++ b/Source/WebCore/html/HTMLDListElement.h
@@ -30,10 +30,10 @@ class HTMLDListElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLDListElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDListElement);
 public:
-    static Ref<HTMLDListElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLDListElement> create(Document&);
 
 private:
-    HTMLDListElement(const QualifiedName&, Document&);
+    explicit HTMLDListElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLDataElement.cpp
+++ b/Source/WebCore/html/HTMLDataElement.cpp
@@ -35,15 +35,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLDataElement);
 
 using namespace HTMLNames;
 
-Ref<HTMLDataElement> HTMLDataElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLDataElement> HTMLDataElement::create(Document& document)
 {
-    return adoptRef(*new HTMLDataElement(tagName, document));
+    return adoptRef(*new HTMLDataElement(document));
 }
 
-inline HTMLDataElement::HTMLDataElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLDataElement::HTMLDataElement(Document& document)
+    : HTMLElement(dataTag, document)
 {
-    ASSERT(hasTagName(dataTag));
 }
 
 } // namespace WebCore.

--- a/Source/WebCore/html/HTMLDataElement.h
+++ b/Source/WebCore/html/HTMLDataElement.h
@@ -33,10 +33,10 @@ class HTMLDataElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLDataElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDataElement);
 public:
-    static Ref<HTMLDataElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLDataElement> create(Document&);
 
 private:
-    HTMLDataElement(const QualifiedName&, Document&);
+    explicit HTMLDataElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLDataListElement.cpp
+++ b/Source/WebCore/html/HTMLDataListElement.cpp
@@ -45,8 +45,8 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLDataListElement);
 
-inline HTMLDataListElement::HTMLDataListElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
+inline HTMLDataListElement::HTMLDataListElement(Document& document)
+    : HTMLElement(HTMLNames::datalistTag, document, TypeFlag::HasDidMoveToNewDocument)
 {
     document.incrementDataListElementCount();
 }
@@ -56,9 +56,9 @@ HTMLDataListElement::~HTMLDataListElement()
     document().decrementDataListElementCount();
 }
 
-Ref<HTMLDataListElement> HTMLDataListElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLDataListElement> HTMLDataListElement::create(Document& document)
 {
-    return adoptRef(*new HTMLDataListElement(tagName, document));
+    return adoptRef(*new HTMLDataListElement(document));
 }
 
 void HTMLDataListElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)

--- a/Source/WebCore/html/HTMLDataListElement.h
+++ b/Source/WebCore/html/HTMLDataListElement.h
@@ -42,7 +42,7 @@ class HTMLDataListElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLDataListElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDataListElement);
 public:
-    static Ref<HTMLDataListElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLDataListElement> create(Document&);
     ~HTMLDataListElement();
 
     Ref<HTMLCollection> options();
@@ -58,7 +58,7 @@ private:
 
     void childrenChanged(const ChildChange&) final;
 
-    HTMLDataListElement(const QualifiedName&, Document&);
+    explicit HTMLDataListElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLDetailsElement.cpp
+++ b/Source/WebCore/html/HTMLDetailsElement.cpp
@@ -94,17 +94,16 @@ const AtomString& DetailsSlotAssignment::slotNameForHostChild(const Node& child)
     return NamedSlotAssignment::defaultSlotName();
 }
 
-Ref<HTMLDetailsElement> HTMLDetailsElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLDetailsElement> HTMLDetailsElement::create(Document& document)
 {
-    auto details = adoptRef(*new HTMLDetailsElement(tagName, document));
+    Ref details = adoptRef(*new HTMLDetailsElement(document));
     details->addShadowRoot(ShadowRoot::create(document, makeUnique<DetailsSlotAssignment>()));
     return details;
 }
 
-HTMLDetailsElement::HTMLDetailsElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLDetailsElement::HTMLDetailsElement(Document& document)
+    : HTMLElement(detailsTag, document)
 {
-    ASSERT(hasTagName(detailsTag));
 }
 
 HTMLDetailsElement::~HTMLDetailsElement() = default;
@@ -112,11 +111,11 @@ HTMLDetailsElement::~HTMLDetailsElement() = default;
 void HTMLDetailsElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 {
     Ref document = this->document();
-    Ref summarySlot = HTMLSlotElement::create(slotTag, document);
+    Ref summarySlot = HTMLSlotElement::create(document);
     ScriptDisallowedScope::EventAllowedScope summarySlotScope { summarySlot };
     summarySlot->setAttributeWithoutSynchronization(nameAttr, summarySlotName());
 
-    Ref defaultSummary = HTMLSummaryElement::create(summaryTag, document);
+    Ref defaultSummary = HTMLSummaryElement::create(document);
     ScriptDisallowedScope::EventAllowedScope defaultSummaryScope { defaultSummary };
     defaultSummary->appendChild(Text::create(document, defaultDetailsSummaryText()));
     m_defaultSummary = defaultSummary.get();
@@ -126,7 +125,7 @@ void HTMLDetailsElement::didAddUserAgentShadowRoot(ShadowRoot& root)
     root.appendChild(summarySlot);
     m_summarySlot = WTF::move(summarySlot);
 
-    Ref defaultSlot = HTMLSlotElement::create(slotTag, document);
+    Ref defaultSlot = HTMLSlotElement::create(document);
     ScriptDisallowedScope::EventAllowedScope defaultSlotScope { defaultSlot };
     defaultSlot->setUserAgentPart(UserAgentParts::detailsContent());
     ASSERT(!hasAttributeWithoutSynchronization(openAttr));

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -32,7 +32,7 @@ class HTMLDetailsElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLDetailsElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDetailsElement);
 public:
-    static Ref<HTMLDetailsElement> create(const QualifiedName& tagName, Document&);
+    static Ref<HTMLDetailsElement> create(Document&);
     ~HTMLDetailsElement();
 
     void toggleOpen();
@@ -44,7 +44,7 @@ public:
     bool isOpen() const;
 
 private:
-    HTMLDetailsElement(const QualifiedName&, Document&);
+    explicit HTMLDetailsElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -53,9 +53,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLDialogElement);
 
 using namespace HTMLNames;
 
-HTMLDialogElement::HTMLDialogElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLDialogElement::HTMLDialogElement(Document& document)
+    : HTMLElement(dialogTag, document)
 {
+}
+
+Ref<HTMLDialogElement> HTMLDialogElement::create(Document& document)
+{
+    return adoptRef(*new HTMLDialogElement(document));
 }
 
 ExceptionOr<void> HTMLDialogElement::show()

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -34,7 +34,7 @@ class HTMLDialogElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLDialogElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDialogElement);
 public:
-    template<typename... Args> static Ref<HTMLDialogElement> create(Args&&... args) { return adoptRef(*new HTMLDialogElement(std::forward<Args>(args)...)); }
+    static Ref<HTMLDialogElement> create(Document&);
 
     bool isOpen() const { return m_isOpen; }
 
@@ -58,7 +58,7 @@ public:
     void queueDialogToggleEventTask(ToggleState oldState, ToggleState newState, Element* source);
 
 private:
-    HTMLDialogElement(const QualifiedName&, Document&);
+    explicit HTMLDialogElement(Document&);
 
     void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;
     void setIsModal(bool newValue);

--- a/Source/WebCore/html/HTMLDirectoryElement.cpp
+++ b/Source/WebCore/html/HTMLDirectoryElement.cpp
@@ -32,15 +32,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLDirectoryElement);
 
 using namespace HTMLNames;
 
-inline HTMLDirectoryElement::HTMLDirectoryElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLDirectoryElement::HTMLDirectoryElement(Document& document)
+    : HTMLElement(dirTag, document)
 {
-    ASSERT(hasTagName(dirTag));
 }
 
-Ref<HTMLDirectoryElement> HTMLDirectoryElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLDirectoryElement> HTMLDirectoryElement::create(Document& document)
 {
-    return adoptRef(*new HTMLDirectoryElement(tagName, document));
+    return adoptRef(*new HTMLDirectoryElement(document));
 }
 
 }

--- a/Source/WebCore/html/HTMLDirectoryElement.h
+++ b/Source/WebCore/html/HTMLDirectoryElement.h
@@ -30,10 +30,10 @@ class HTMLDirectoryElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLDirectoryElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDirectoryElement);
 public:
-    static Ref<HTMLDirectoryElement> create(const QualifiedName& tagName, Document&);
+    static Ref<HTMLDirectoryElement> create(Document&);
 
 private:
-    HTMLDirectoryElement(const QualifiedName&, Document&);
+    explicit HTMLDirectoryElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLDivElement.cpp
+++ b/Source/WebCore/html/HTMLDivElement.cpp
@@ -35,24 +35,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLDivElement);
 using namespace HTMLNames;
 
 HTMLDivElement::HTMLDivElement(Document& document, OptionSet<TypeFlag> typeFlags)
-    : HTMLDivElement(divTag, document, typeFlags)
+    : HTMLElement(divTag, document, typeFlags)
 {
-}
-
-HTMLDivElement::HTMLDivElement(const QualifiedName& tagName, Document& document, OptionSet<TypeFlag> typeFlags)
-    : HTMLElement(tagName, document, typeFlags)
-{
-    ASSERT(hasTagName(divTag));
 }
 
 Ref<HTMLDivElement> HTMLDivElement::create(Document& document)
 {
-    return adoptRef(*new HTMLDivElement(divTag, document));
-}
-
-Ref<HTMLDivElement> HTMLDivElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLDivElement(tagName, document));
+    return adoptRef(*new HTMLDivElement(document));
 }
 
 void HTMLDivElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)

--- a/Source/WebCore/html/HTMLDivElement.h
+++ b/Source/WebCore/html/HTMLDivElement.h
@@ -31,7 +31,6 @@ class HTMLDivElement : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLDivElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLDivElement> create(Document&);
-    static Ref<HTMLDivElement> create(const QualifiedName&, Document&);
 
 protected:
     HTMLDivElement(Document&, OptionSet<TypeFlag> = { });

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -49,20 +49,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLEmbedElement);
 
 using namespace HTMLNames;
 
-inline HTMLEmbedElement::HTMLEmbedElement(const QualifiedName& tagName, Document& document)
-    : HTMLPlugInElement(tagName, document)
+inline HTMLEmbedElement::HTMLEmbedElement(Document& document)
+    : HTMLPlugInElement(embedTag, document)
 {
-    ASSERT(hasTagName(embedTag));
-}
-
-Ref<HTMLEmbedElement> HTMLEmbedElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLEmbedElement(tagName, document));
 }
 
 Ref<HTMLEmbedElement> HTMLEmbedElement::create(Document& document)
 {
-    return create(embedTag, document);
+    return adoptRef(*new HTMLEmbedElement(document));
 }
 
 static inline RenderWidget* findWidgetRenderer(const Node* node)

--- a/Source/WebCore/html/HTMLEmbedElement.h
+++ b/Source/WebCore/html/HTMLEmbedElement.h
@@ -31,10 +31,9 @@ class HTMLEmbedElement final : public HTMLPlugInElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLEmbedElement);
 public:
     static Ref<HTMLEmbedElement> create(Document&);
-    static Ref<HTMLEmbedElement> create(const QualifiedName&, Document&);
 
 private:
-    HTMLEmbedElement(const QualifiedName&, Document&);
+    HTMLEmbedElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;

--- a/Source/WebCore/html/HTMLFieldSetElement.cpp
+++ b/Source/WebCore/html/HTMLFieldSetElement.cpp
@@ -45,10 +45,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLFieldSetElement);
 
 using namespace HTMLNames;
 
-inline HTMLFieldSetElement::HTMLFieldSetElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLFormControlElement(tagName, document, form)
+inline HTMLFieldSetElement::HTMLFieldSetElement(Document& document, HTMLFormElement* form)
+    : HTMLFormControlElement(fieldsetTag, document, form)
 {
-    ASSERT(hasTagName(fieldsetTag));
 }
 
 HTMLFieldSetElement::~HTMLFieldSetElement()
@@ -57,9 +56,9 @@ HTMLFieldSetElement::~HTMLFieldSetElement()
         document().removeDisabledFieldsetElement();
 }
 
-Ref<HTMLFieldSetElement> HTMLFieldSetElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLFieldSetElement> HTMLFieldSetElement::create(Document& document, HTMLFormElement* form)
 {
-    return adoptRef(*new HTMLFieldSetElement(tagName, document, form));
+    return adoptRef(*new HTMLFieldSetElement(document, form));
 }
 
 bool HTMLFieldSetElement::isDisabledFormControl() const

--- a/Source/WebCore/html/HTMLFieldSetElement.h
+++ b/Source/WebCore/html/HTMLFieldSetElement.h
@@ -32,7 +32,7 @@ class HTMLFieldSetElement final : public HTMLFormControlElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLFieldSetElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFieldSetElement);
 public:
-    static Ref<HTMLFieldSetElement> create(const QualifiedName&, Document&, HTMLFormElement*);
+    static Ref<HTMLFieldSetElement> create(Document&, HTMLFormElement*);
 
     HTMLLegendElement* legend() const;
 
@@ -42,7 +42,7 @@ public:
     void removeInvalidDescendant(const HTMLElement&);
 
 private:
-    HTMLFieldSetElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLFieldSetElement(Document&, HTMLFormElement*);
     ~HTMLFieldSetElement();
 
     bool isDisabledFormControl() const final;

--- a/Source/WebCore/html/HTMLFontElement.cpp
+++ b/Source/WebCore/html/HTMLFontElement.cpp
@@ -43,15 +43,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLFontElement);
 
 using namespace HTMLNames;
 
-HTMLFontElement::HTMLFontElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLFontElement::HTMLFontElement(Document& document)
+    : HTMLElement(fontTag, document)
 {
-    ASSERT(hasTagName(fontTag));
 }
 
-Ref<HTMLFontElement> HTMLFontElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLFontElement> HTMLFontElement::create(Document& document)
 {
-    return adoptRef(*new HTMLFontElement(tagName, document));
+    return adoptRef(*new HTMLFontElement(document));
 }
 
 // http://www.whatwg.org/specs/web-apps/current-work/multipage/rendering.html#fonts-and-colors

--- a/Source/WebCore/html/HTMLFontElement.h
+++ b/Source/WebCore/html/HTMLFontElement.h
@@ -31,12 +31,12 @@ class HTMLFontElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLFontElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFontElement);
 public:
-    static Ref<HTMLFontElement> create(const QualifiedName&, Document&);
-    
+    static Ref<HTMLFontElement> create(Document&);
+
     static bool cssValueFromFontSizeNumber(const String&, CSSValueID&);
 
 private:
-    HTMLFontElement(const QualifiedName&, Document&);
+    explicit HTMLFontElement(Document&);
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -93,20 +93,14 @@ static FormRelAttributes parseFormRelAttributes(StringView string)
     return attributes;
 }
 
-HTMLFormElement::HTMLFormElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
+HTMLFormElement::HTMLFormElement(Document& document)
+    : HTMLElement(formTag, document, TypeFlag::HasDidMoveToNewDocument)
 {
-    ASSERT(hasTagName(formTag));
 }
 
 Ref<HTMLFormElement> HTMLFormElement::create(Document& document)
 {
-    return adoptRef(*new HTMLFormElement(formTag, document));
-}
-
-Ref<HTMLFormElement> HTMLFormElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLFormElement(tagName, document));
+    return adoptRef(*new HTMLFormElement(document));
 }
 
 HTMLFormElement::~HTMLFormElement()

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -46,7 +46,6 @@ class HTMLFormElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFormElement);
 public:
     static Ref<HTMLFormElement> create(Document&);
-    static Ref<HTMLFormElement> create(const QualifiedName&, Document&);
     virtual ~HTMLFormElement();
 
     Ref<HTMLFormControlsCollection> elements();
@@ -124,7 +123,7 @@ public:
     const FormSubmission::Attributes& attributes() const { return m_attributes; }
     
 private:
-    HTMLFormElement(const QualifiedName&, Document&);
+    explicit HTMLFormElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLFrameElement.cpp
+++ b/Source/WebCore/html/HTMLFrameElement.cpp
@@ -40,15 +40,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLFrameElement);
 
 using namespace HTMLNames;
 
-inline HTMLFrameElement::HTMLFrameElement(const QualifiedName& tagName, Document& document)
-    : HTMLFrameElementBase(tagName, document)
+inline HTMLFrameElement::HTMLFrameElement(Document& document)
+    : HTMLFrameElementBase(frameTag, document)
 {
-    ASSERT(hasTagName(frameTag));
 }
 
-Ref<HTMLFrameElement> HTMLFrameElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLFrameElement> HTMLFrameElement::create(Document& document)
 {
-    return adoptRef(*new HTMLFrameElement(tagName, document));
+    return adoptRef(*new HTMLFrameElement(document));
 }
 
 bool HTMLFrameElement::rendererIsNeeded(const RenderStyle& style)

--- a/Source/WebCore/html/HTMLFrameElement.h
+++ b/Source/WebCore/html/HTMLFrameElement.h
@@ -33,7 +33,7 @@ class HTMLFrameElement final : public HTMLFrameElementBase {
     WTF_MAKE_TZONE_ALLOCATED(HTMLFrameElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFrameElement);
 public:
-    static Ref<HTMLFrameElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLFrameElement> create(Document&);
 
     bool hasFrameBorder() const { return m_frameBorder; }
     bool noResize() const;
@@ -41,7 +41,7 @@ public:
     RenderFrame* renderer() const;
 
 private:
-    HTMLFrameElement(const QualifiedName&, Document&);
+    explicit HTMLFrameElement(Document&);
 
     void didAttachRenderers() final;
     bool rendererIsNeeded(const RenderStyle&) final;

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -52,8 +52,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLFrameSetElement);
 
 using namespace HTMLNames;
 
-HTMLFrameSetElement::HTMLFrameSetElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
+HTMLFrameSetElement::HTMLFrameSetElement(Document& document)
+    : HTMLElement(framesetTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
     , m_border(6)
     , m_borderSet(false)
     , m_borderColorSet(false)
@@ -61,12 +61,11 @@ HTMLFrameSetElement::HTMLFrameSetElement(const QualifiedName& tagName, Document&
     , m_frameborderSet(false)
     , m_noresize(false)
 {
-    ASSERT(hasTagName(framesetTag));
 }
 
-Ref<HTMLFrameSetElement> HTMLFrameSetElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLFrameSetElement> HTMLFrameSetElement::create(Document& document)
 {
-    return adoptRef(*new HTMLFrameSetElement(tagName, document));
+    return adoptRef(*new HTMLFrameSetElement(document));
 }
 
 bool HTMLFrameSetElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const

--- a/Source/WebCore/html/HTMLFrameSetElement.h
+++ b/Source/WebCore/html/HTMLFrameSetElement.h
@@ -37,7 +37,7 @@ class HTMLFrameSetElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLFrameSetElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLFrameSetElement);
 public:
-    static Ref<HTMLFrameSetElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLFrameSetElement> create(Document&);
 
     bool hasFrameBorder() const { return m_frameborder; }
     bool noResize() const { return m_noresize; }
@@ -58,7 +58,7 @@ public:
     bool isSupportedPropertyName(const AtomString&);
 
 private:
-    HTMLFrameSetElement(const QualifiedName&, Document&);
+    explicit HTMLFrameSetElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;

--- a/Source/WebCore/html/HTMLHRElement.cpp
+++ b/Source/WebCore/html/HTMLHRElement.cpp
@@ -39,20 +39,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLHRElement);
 
 using namespace HTMLNames;
 
-HTMLHRElement::HTMLHRElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLHRElement::HTMLHRElement(Document& document)
+    : HTMLElement(hrTag, document)
 {
-    ASSERT(hasTagName(hrTag));
 }
 
 Ref<HTMLHRElement> HTMLHRElement::create(Document& document)
 {
-    return adoptRef(*new HTMLHRElement(hrTag, document));
-}
-
-Ref<HTMLHRElement> HTMLHRElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLHRElement(tagName, document));
+    return adoptRef(*new HTMLHRElement(document));
 }
 
 auto HTMLHRElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult

--- a/Source/WebCore/html/HTMLHRElement.h
+++ b/Source/WebCore/html/HTMLHRElement.h
@@ -31,10 +31,9 @@ class HTMLHRElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLHRElement);
 public:
     static Ref<HTMLHRElement> create(Document&);
-    static Ref<HTMLHRElement> create(const QualifiedName&, Document&);
 
 private:
-    HTMLHRElement(const QualifiedName&, Document&);
+    explicit HTMLHRElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;

--- a/Source/WebCore/html/HTMLHeadElement.cpp
+++ b/Source/WebCore/html/HTMLHeadElement.cpp
@@ -34,20 +34,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLHeadElement);
 
 using namespace HTMLNames;
 
-HTMLHeadElement::HTMLHeadElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLHeadElement::HTMLHeadElement(Document& document)
+    : HTMLElement(headTag, document)
 {
-    ASSERT(hasTagName(headTag));
 }
 
 Ref<HTMLHeadElement> HTMLHeadElement::create(Document& document)
 {
-    return adoptRef(*new HTMLHeadElement(headTag, document));
-}
-
-Ref<HTMLHeadElement> HTMLHeadElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLHeadElement(tagName, document));
+    return adoptRef(*new HTMLHeadElement(document));
 }
 
 }

--- a/Source/WebCore/html/HTMLHeadElement.h
+++ b/Source/WebCore/html/HTMLHeadElement.h
@@ -32,10 +32,9 @@ class HTMLHeadElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLHeadElement);
 public:
     static Ref<HTMLHeadElement> create(Document&);
-    static Ref<HTMLHeadElement> create(const QualifiedName&, Document&);
 
 private:
-    HTMLHeadElement(const QualifiedName&, Document&);
+    explicit HTMLHeadElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLHtmlElement.cpp
+++ b/Source/WebCore/html/HTMLHtmlElement.cpp
@@ -41,20 +41,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLHtmlElement);
 
 using namespace HTMLNames;
 
-HTMLHtmlElement::HTMLHtmlElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLHtmlElement::HTMLHtmlElement(Document& document)
+    : HTMLElement(htmlTag, document)
 {
-    ASSERT(hasTagName(htmlTag));
 }
 
 Ref<HTMLHtmlElement> HTMLHtmlElement::create(Document& document)
 {
-    return adoptRef(*new HTMLHtmlElement(htmlTag, document));
-}
-
-Ref<HTMLHtmlElement> HTMLHtmlElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLHtmlElement(tagName, document));
+    return adoptRef(*new HTMLHtmlElement(document));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLHtmlElement.h
+++ b/Source/WebCore/html/HTMLHtmlElement.h
@@ -32,10 +32,9 @@ class HTMLHtmlElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLHtmlElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLHtmlElement> create(Document&);
-    static Ref<HTMLHtmlElement> create(const QualifiedName&, Document&);
 
 private:
-    HTMLHtmlElement(const QualifiedName&, Document&);
+    explicit HTMLHtmlElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -51,11 +51,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLIFrameElement);
 
 using namespace HTMLNames;
 
-inline HTMLIFrameElement::HTMLIFrameElement(const QualifiedName& tagName, Document& document)
-    : HTMLFrameElementBase(tagName, document)
+inline HTMLIFrameElement::HTMLIFrameElement(Document& document)
+    : HTMLFrameElementBase(iframeTag, document)
 {
-    ASSERT(hasTagName(iframeTag));
-
 #if ENABLE(CONTENT_EXTENSIONS)
     if (document.settings().iFrameResourceMonitoringEnabled())
         setInitiatorSourceURL(document.currentSourceURL());
@@ -64,9 +62,9 @@ inline HTMLIFrameElement::HTMLIFrameElement(const QualifiedName& tagName, Docume
 
 HTMLIFrameElement::~HTMLIFrameElement() = default;
 
-Ref<HTMLIFrameElement> HTMLIFrameElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLIFrameElement> HTMLIFrameElement::create(Document& document)
 {
-    return adoptRef(*new HTMLIFrameElement(tagName, document));
+    return adoptRef(*new HTMLIFrameElement(document));
 }
 
 int HTMLIFrameElement::defaultTabIndex() const

--- a/Source/WebCore/html/HTMLIFrameElement.h
+++ b/Source/WebCore/html/HTMLIFrameElement.h
@@ -38,7 +38,7 @@ class HTMLIFrameElement final : public HTMLFrameElementBase {
     WTF_MAKE_TZONE_ALLOCATED(HTMLIFrameElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLIFrameElement);
 public:
-    static Ref<HTMLIFrameElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLIFrameElement> create(Document&);
     ~HTMLIFrameElement();
 
     DOMTokenList& sandbox();
@@ -67,7 +67,7 @@ public:
 #endif
 
 private:
-    HTMLIFrameElement(const QualifiedName&, Document&);
+    explicit HTMLIFrameElement(Document&);
 
     int defaultTabIndex() const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -83,26 +83,18 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLImageElement);
 
 using namespace HTMLNames;
 
-HTMLImageElement::HTMLImageElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLElement(tagName, document, { TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument })
+HTMLImageElement::HTMLImageElement(Document& document, HTMLFormElement* form)
+    : HTMLElement(imgTag, document, { TypeFlag::HasCustomStyleResolveCallbacks, TypeFlag::HasDidMoveToNewDocument })
     , FormAssociatedElement(form)
     , ActiveDOMObject(document)
     , m_imageLoader(makeUniqueWithoutRefCountedCheck<HTMLImageLoader>(*this))
     , m_imageDevicePixelRatio(1.0f)
 {
-    ASSERT(hasTagName(imgTag));
 }
 
-Ref<HTMLImageElement> HTMLImageElement::create(Document& document)
+Ref<HTMLImageElement> HTMLImageElement::create(Document& document, HTMLFormElement* form)
 {
-    auto image = adoptRef(*new HTMLImageElement(imgTag, document));
-    image->suspendIfNeeded();
-    return image;
-}
-
-Ref<HTMLImageElement> HTMLImageElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-{
-    auto image = adoptRef(*new HTMLImageElement(tagName, document, form));
+    Ref image = adoptRef(*new HTMLImageElement(document, form));
     image->suspendIfNeeded();
     return image;
 }
@@ -142,7 +134,7 @@ void HTMLImageElement::formOwnerRemovedFromTree(const Node& formRoot)
 
 Ref<HTMLImageElement> HTMLImageElement::createForLegacyFactoryFunction(Document& document, std::optional<unsigned> width, std::optional<unsigned> height)
 {
-    auto image = adoptRef(*new HTMLImageElement(imgTag, document));
+    auto image = adoptRef(*new HTMLImageElement(document));
     if (width)
         image->setUnsignedIntegralAttribute(widthAttr, width.value());
     if (height)

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -60,8 +60,7 @@ class HTMLImageElement
     WTF_MAKE_TZONE_ALLOCATED(HTMLImageElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLImageElement);
 public:
-    static Ref<HTMLImageElement> create(Document&);
-    static Ref<HTMLImageElement> create(const QualifiedName&, Document&, HTMLFormElement* = nullptr);
+    static Ref<HTMLImageElement> create(Document&, HTMLFormElement* = nullptr);
     static Ref<HTMLImageElement> createForLegacyFactoryFunction(Document&, std::optional<unsigned> width, std::optional<unsigned> height);
 
     virtual ~HTMLImageElement();
@@ -173,7 +172,7 @@ public:
     Image* image() const;
 
 protected:
-    HTMLImageElement(const QualifiedName&, Document&, HTMLFormElement* = nullptr);
+    HTMLImageElement(Document&, HTMLFormElement* = nullptr);
 
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) override;
 

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -119,24 +119,23 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ListAttributeTargetObserver);
 
 static constexpr int maxSavedResults = 256;
 
-HTMLInputElement::HTMLInputElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form, CreationType creationType)
-    : HTMLTextFormControlElement(tagName, document, form)
+HTMLInputElement::HTMLInputElement(Document& document, HTMLFormElement* form, CreationType creationType)
+    : HTMLTextFormControlElement(inputTag, document, form)
     , m_parsingInProgress(creationType == CreationType::ByParser)
     // m_inputType is lazily created when constructed by the parser to avoid constructing unnecessarily a text inputType,
     // just to destroy them when the |type| attribute gets set by the parser to something else than 'text'.
     , m_inputType(creationType != CreationType::Normal ? nullptr : RefPtr { TextInputType::create(*this) })
 {
-    ASSERT(hasTagName(inputTag));
 }
 
-Ref<HTMLInputElement> HTMLInputElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form, bool createdByParser)
+Ref<HTMLInputElement> HTMLInputElement::create(Document& document, HTMLFormElement* form, bool createdByParser)
 {
-    return adoptRef(*new HTMLInputElement(tagName, document, form, createdByParser ? CreationType::ByParser : CreationType::Normal));
+    return adoptRef(*new HTMLInputElement(document, form, createdByParser ? CreationType::ByParser : CreationType::Normal));
 }
 
 Ref<Element> HTMLInputElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*) const
 {
-    return adoptRef(*new HTMLInputElement(tagQName(), document, nullptr, CreationType::ByCloning));
+    return adoptRef(*new HTMLInputElement(document, nullptr, CreationType::ByCloning));
 }
 
 HTMLImageLoader& HTMLInputElement::ensureImageLoader()

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -66,7 +66,7 @@ class HTMLInputElement final : public HTMLTextFormControlElement {
 public:
     USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
-    static Ref<HTMLInputElement> create(const QualifiedName&, Document&, HTMLFormElement*, bool createdByParser);
+    static Ref<HTMLInputElement> create(Document&, HTMLFormElement*, bool createdByParser);
     virtual ~HTMLInputElement();
 
     WEBCORE_EXPORT bool alpha();
@@ -364,7 +364,7 @@ public:
 
 private:
     enum class CreationType : uint8_t { Normal, ByParser, ByCloning };
-    HTMLInputElement(const QualifiedName&, Document&, HTMLFormElement*, CreationType);
+    HTMLInputElement(Document&, HTMLFormElement*, CreationType);
 
     void defaultEventHandler(Event&) final;
 

--- a/Source/WebCore/html/HTMLLIElement.cpp
+++ b/Source/WebCore/html/HTMLLIElement.cpp
@@ -41,20 +41,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLLIElement);
 
 using namespace HTMLNames;
 
-HTMLLIElement::HTMLLIElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLLIElement::HTMLLIElement(Document& document)
+    : HTMLElement(liTag, document)
 {
-    ASSERT(hasTagName(liTag));
 }
 
 Ref<HTMLLIElement> HTMLLIElement::create(Document& document)
 {
-    return adoptRef(*new HTMLLIElement(liTag, document));
-}
-
-Ref<HTMLLIElement> HTMLLIElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLLIElement(tagName, document));
+    return adoptRef(*new HTMLLIElement(document));
 }
 
 bool HTMLLIElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const

--- a/Source/WebCore/html/HTMLLIElement.h
+++ b/Source/WebCore/html/HTMLLIElement.h
@@ -31,10 +31,9 @@ class HTMLLIElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLLIElement);
 public:
     static Ref<HTMLLIElement> create(Document&);
-    static Ref<HTMLLIElement> create(const QualifiedName&, Document&);
 
 private:
-    HTMLLIElement(const QualifiedName&, Document&);
+    explicit HTMLLIElement(Document&);
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;

--- a/Source/WebCore/html/HTMLLabelElement.cpp
+++ b/Source/WebCore/html/HTMLLabelElement.cpp
@@ -55,20 +55,14 @@ static HTMLElement* elementForAttributeIfLabelable(const HTMLLabelElement& conte
     return nullptr;
 }
 
-inline HTMLLabelElement::HTMLLabelElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLLabelElement::HTMLLabelElement(Document& document)
+    : HTMLElement(labelTag, document)
 {
-    ASSERT(hasTagName(labelTag));
-}
-
-Ref<HTMLLabelElement> HTMLLabelElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLLabelElement(tagName, document));
 }
 
 Ref<HTMLLabelElement> HTMLLabelElement::create(Document& document)
 {
-    return adoptRef(*new HTMLLabelElement(labelTag, document));
+    return adoptRef(*new HTMLLabelElement(document));
 }
 
 RefPtr<HTMLElement> HTMLLabelElement::control() const

--- a/Source/WebCore/html/HTMLLabelElement.h
+++ b/Source/WebCore/html/HTMLLabelElement.h
@@ -32,7 +32,6 @@ class HTMLLabelElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLLabelElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLLabelElement);
 public:
-    static Ref<HTMLLabelElement> create(const QualifiedName&, Document&);
     static Ref<HTMLLabelElement> create(Document&);
 
     WEBCORE_EXPORT RefPtr<HTMLElement> control() const;
@@ -44,7 +43,7 @@ public:
     void updateLabel(TreeScope&, const AtomString& oldForAttributeValue, const AtomString& newForAttributeValue);
 
 private:
-    HTMLLabelElement(const QualifiedName&, Document&);
+    HTMLLabelElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode& parentOfInsertedTree) final;
     void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;

--- a/Source/WebCore/html/HTMLLegendElement.cpp
+++ b/Source/WebCore/html/HTMLLegendElement.cpp
@@ -36,15 +36,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLLegendElement);
 
-inline HTMLLegendElement::HTMLLegendElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLLegendElement::HTMLLegendElement(Document& document)
+    : HTMLElement(HTMLNames::legendTag, document)
 {
-    ASSERT(hasTagName(HTMLNames::legendTag));
 }
 
-Ref<HTMLLegendElement> HTMLLegendElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLLegendElement> HTMLLegendElement::create(Document& document)
 {
-    return adoptRef(*new HTMLLegendElement(tagName, document));
+    return adoptRef(*new HTMLLegendElement(document));
 }
 
 HTMLFormElement* HTMLLegendElement::form() const

--- a/Source/WebCore/html/HTMLLegendElement.h
+++ b/Source/WebCore/html/HTMLLegendElement.h
@@ -32,13 +32,13 @@ class HTMLLegendElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLLegendElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLLegendElement);
 public:
-    static Ref<HTMLLegendElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLLegendElement> create(Document&);
 
     WEBCORE_EXPORT HTMLFormElement* form() const;
     RefPtr<HTMLFormElement> formForBindings() const;
 
 private:
-    HTMLLegendElement(const QualifiedName&, Document&);
+    explicit HTMLLegendElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -115,8 +115,8 @@ void ExpectIdTargetObserver::idTargetChanged(Element& element)
         link->processInternalResourceLink(&element);
 }
 
-inline HTMLLinkElement::HTMLLinkElement(const QualifiedName& tagName, Document& document, bool createdByParser)
-    : HTMLElement(tagName, document)
+inline HTMLLinkElement::HTMLLinkElement(Document& document, bool createdByParser)
+    : HTMLElement(linkTag, document)
     , m_linkLoader(LinkLoader::create(*this))
     , m_disabledState(Unset)
     , m_loading(false)
@@ -126,12 +126,11 @@ inline HTMLLinkElement::HTMLLinkElement(const QualifiedName& tagName, Document& 
     , m_allowPrefetchLoadAndErrorForTesting(false)
     , m_pendingSheetType(PendingSheetType::Unknown)
 {
-    ASSERT(hasTagName(linkTag));
 }
 
-Ref<HTMLLinkElement> HTMLLinkElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)
+Ref<HTMLLinkElement> HTMLLinkElement::create(Document& document, bool createdByParser)
 {
-    return adoptRef(*new HTMLLinkElement(tagName, document, createdByParser));
+    return adoptRef(*new HTMLLinkElement(document, createdByParser));
 }
 
 HTMLLinkElement::~HTMLLinkElement()

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -52,7 +52,7 @@ class HTMLLinkElement final : public HTMLElement, public CachedStyleSheetClient,
 public:
     USING_CAN_MAKE_WEAKPTR(HTMLElement);
 
-    static Ref<HTMLLinkElement> create(const QualifiedName&, Document&, bool createdByParser);
+    static Ref<HTMLLinkElement> create(Document&, bool createdByParser = false);
     virtual ~HTMLLinkElement();
 
     // CachedResourceClient.
@@ -141,7 +141,7 @@ private:
 
     bool isURLAttribute(const Attribute&) const final;
 
-    HTMLLinkElement(const QualifiedName&, Document&, bool createdByParser);
+    HTMLLinkElement(Document&, bool createdByParser);
 
     void addSubresourceAttributeURLs(ListHashSet<URL>&) const final;
 

--- a/Source/WebCore/html/HTMLMapElement.cpp
+++ b/Source/WebCore/html/HTMLMapElement.cpp
@@ -40,20 +40,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLMapElement);
 
 using namespace HTMLNames;
 
-HTMLMapElement::HTMLMapElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLMapElement::HTMLMapElement(Document& document)
+    : HTMLElement(mapTag, document)
 {
-    ASSERT(hasTagName(mapTag));
 }
 
 Ref<HTMLMapElement> HTMLMapElement::create(Document& document)
 {
-    return adoptRef(*new HTMLMapElement(mapTag, document));
-}
-
-Ref<HTMLMapElement> HTMLMapElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLMapElement(tagName, document));
+    return adoptRef(*new HTMLMapElement(document));
 }
 
 HTMLMapElement::~HTMLMapElement() = default;

--- a/Source/WebCore/html/HTMLMapElement.h
+++ b/Source/WebCore/html/HTMLMapElement.h
@@ -36,18 +36,17 @@ class HTMLMapElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMapElement);
 public:
     static Ref<HTMLMapElement> create(Document&);
-    static Ref<HTMLMapElement> create(const QualifiedName&, Document&);
     virtual ~HTMLMapElement();
 
     const AtomString& getName() const { return m_name; }
 
     bool mapMouseEvent(LayoutPoint location, const LayoutSize&, HitTestResult&);
-    
+
     RefPtr<HTMLImageElement> imageElement();
     WEBCORE_EXPORT Ref<HTMLCollection> areas();
 
 private:
-    HTMLMapElement(const QualifiedName&, Document&);
+    explicit HTMLMapElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 

--- a/Source/WebCore/html/HTMLMarqueeElement.cpp
+++ b/Source/WebCore/html/HTMLMarqueeElement.cpp
@@ -46,16 +46,15 @@ using namespace HTMLNames;
 static constexpr unsigned defaultScrollAmount = 6;
 static constexpr unsigned defaultScrollDelay = 85;
 
-inline HTMLMarqueeElement::HTMLMarqueeElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
+inline HTMLMarqueeElement::HTMLMarqueeElement(Document& document)
+    : HTMLElement(marqueeTag, document, TypeFlag::HasDidMoveToNewDocument)
     , ActiveDOMObject(document)
 {
-    ASSERT(hasTagName(marqueeTag));
 }
 
-Ref<HTMLMarqueeElement> HTMLMarqueeElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLMarqueeElement> HTMLMarqueeElement::create(Document& document)
 {
-    auto marqueeElement = adoptRef(*new HTMLMarqueeElement(tagName, document));
+    Ref marqueeElement = adoptRef(*new HTMLMarqueeElement(document));
     marqueeElement->suspendIfNeeded();
     return marqueeElement;
 }

--- a/Source/WebCore/html/HTMLMarqueeElement.h
+++ b/Source/WebCore/html/HTMLMarqueeElement.h
@@ -33,7 +33,7 @@ class HTMLMarqueeElement final : public HTMLElement, public ActiveDOMObject {
     WTF_MAKE_TZONE_ALLOCATED(HTMLMarqueeElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMarqueeElement);
 public:
-    static Ref<HTMLMarqueeElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLMarqueeElement> create(Document&);
 
     // ActiveDOMObject.
     void ref() const final { HTMLElement::ref(); }
@@ -43,23 +43,23 @@ public:
 
     WEBCORE_EXPORT void start();
     WEBCORE_EXPORT void stop() final;
-    
+
     // Number of pixels to move on each scroll movement. Defaults to 6.
     WEBCORE_EXPORT unsigned scrollAmount() const;
     WEBCORE_EXPORT void setScrollAmount(unsigned);
-    
+
     // Interval between each scroll movement, in milliseconds. Defaults to 60.
     WEBCORE_EXPORT unsigned scrollDelay() const;
     WEBCORE_EXPORT void setScrollDelay(unsigned);
-    
+
     // Loop count. -1 means loop indefinitely.
     WEBCORE_EXPORT int loop() const;
     WEBCORE_EXPORT ExceptionOr<void> setLoop(int);
 
     bool hasRenderMarquee() const { return renderMarquee(); }
-    
+
 private:
-    HTMLMarqueeElement(const QualifiedName&, Document&);
+    explicit HTMLMarqueeElement(Document&);
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;

--- a/Source/WebCore/html/HTMLMenuElement.cpp
+++ b/Source/WebCore/html/HTMLMenuElement.cpp
@@ -34,15 +34,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLMenuElement);
 
 using namespace HTMLNames;
 
-inline HTMLMenuElement::HTMLMenuElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLMenuElement::HTMLMenuElement(Document& document)
+    : HTMLElement(menuTag, document)
 {
-    ASSERT(hasTagName(menuTag));
 }
 
-Ref<HTMLMenuElement> HTMLMenuElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLMenuElement> HTMLMenuElement::create(Document& document)
 {
-    return adoptRef(*new HTMLMenuElement(tagName, document));
+    return adoptRef(*new HTMLMenuElement(document));
 }
 
 }

--- a/Source/WebCore/html/HTMLMenuElement.h
+++ b/Source/WebCore/html/HTMLMenuElement.h
@@ -30,10 +30,10 @@ class HTMLMenuElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLMenuElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMenuElement);
 public:
-    static Ref<HTMLMenuElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLMenuElement> create(Document&);
 
 private:
-    HTMLMenuElement(const QualifiedName&, Document&);
+    explicit HTMLMenuElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLMetaElement.cpp
+++ b/Source/WebCore/html/HTMLMetaElement.cpp
@@ -50,20 +50,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLMetaElement);
 
 using namespace HTMLNames;
 
-inline HTMLMetaElement::HTMLMetaElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLMetaElement::HTMLMetaElement(Document& document)
+    : HTMLElement(metaTag, document)
 {
-    ASSERT(hasTagName(metaTag));
 }
 
 Ref<HTMLMetaElement> HTMLMetaElement::create(Document& document)
 {
-    return adoptRef(*new HTMLMetaElement(metaTag, document));
-}
-
-Ref<HTMLMetaElement> HTMLMetaElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLMetaElement(tagName, document));
+    return adoptRef(*new HTMLMetaElement(document));
 }
 
 #if ENABLE(DARK_MODE_CSS)

--- a/Source/WebCore/html/HTMLMetaElement.h
+++ b/Source/WebCore/html/HTMLMetaElement.h
@@ -33,7 +33,6 @@ class HTMLMetaElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMetaElement);
 public:
     static Ref<HTMLMetaElement> create(Document&);
-    static Ref<HTMLMetaElement> create(const QualifiedName&, Document&);
 
     const AtomString& content() const;
     const AtomString& httpEquiv() const;
@@ -44,7 +43,7 @@ public:
     const Color& contentColor();
 
 private:
-    HTMLMetaElement(const QualifiedName&, Document&);
+    explicit HTMLMetaElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason = AttributeModificationReason::Directly) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -47,17 +47,16 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLMeterElement);
 
 using namespace HTMLNames;
 
-HTMLMeterElement::HTMLMeterElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLMeterElement::HTMLMeterElement(Document& document)
+    : HTMLElement(meterTag, document)
 {
-    ASSERT(hasTagName(meterTag));
 }
 
 HTMLMeterElement::~HTMLMeterElement() = default;
 
-Ref<HTMLMeterElement> HTMLMeterElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLMeterElement> HTMLMeterElement::create(Document& document)
 {
-    Ref meter = adoptRef(*new HTMLMeterElement(tagName, document));
+    Ref meter = adoptRef(*new HTMLMeterElement(document));
     meter->ensureUserAgentShadowRoot();
     return meter;
 }

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -31,7 +31,7 @@ class HTMLMeterElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLMeterElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLMeterElement);
 public:
-    static Ref<HTMLMeterElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLMeterElement> create(Document&);
 
     enum GaugeRegion {
         GaugeRegionOptimum,
@@ -54,7 +54,7 @@ public:
     bool isDevolvableWidget() const override { return true; }
 
 private:
-    HTMLMeterElement(const QualifiedName&, Document&);
+    explicit HTMLMeterElement(Document&);
     virtual ~HTMLMeterElement();
 
     RenderMeter* renderMeter() const;

--- a/Source/WebCore/html/HTMLOListElement.cpp
+++ b/Source/WebCore/html/HTMLOListElement.cpp
@@ -44,20 +44,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLOListElement);
 
 using namespace HTMLNames;
 
-inline HTMLOListElement::HTMLOListElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLOListElement::HTMLOListElement(Document& document)
+    : HTMLElement(olTag, document)
 {
-    ASSERT(hasTagName(olTag));
 }
 
 Ref<HTMLOListElement> HTMLOListElement::create(Document& document)
 {
-    return adoptRef(*new HTMLOListElement(olTag, document));
-}
-
-Ref<HTMLOListElement> HTMLOListElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLOListElement(tagName, document));
+    return adoptRef(*new HTMLOListElement(document));
 }
 
 bool HTMLOListElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const

--- a/Source/WebCore/html/HTMLOListElement.h
+++ b/Source/WebCore/html/HTMLOListElement.h
@@ -31,7 +31,6 @@ class HTMLOListElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLOListElement);
 public:
     static Ref<HTMLOListElement> create(Document&);
-    static Ref<HTMLOListElement> create(const QualifiedName&, Document&);
 
     int startForBindings() const { return m_start.value_or(1); }
 
@@ -44,7 +43,7 @@ public:
     void itemCountChanged() { m_itemCount = std::nullopt; }
 
 private:
-    HTMLOListElement(const QualifiedName&, Document&);
+    explicit HTMLOListElement(Document&);
         
     WEBCORE_EXPORT unsigned itemCount() const;
 

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -63,16 +63,15 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLObjectElement);
 
 using namespace HTMLNames;
 
-inline HTMLObjectElement::HTMLObjectElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLPlugInElement(tagName, document)
+inline HTMLObjectElement::HTMLObjectElement(Document& document, HTMLFormElement* form)
+    : HTMLPlugInElement(objectTag, document)
     , FormListedElement(form)
 {
-    ASSERT(hasTagName(objectTag));
 }
 
-Ref<HTMLObjectElement> HTMLObjectElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLObjectElement> HTMLObjectElement::create(Document& document, HTMLFormElement* form)
 {
-    return adoptRef(*new HTMLObjectElement(tagName, document, form));
+    return adoptRef(*new HTMLObjectElement(document, form));
 }
 
 HTMLObjectElement::~HTMLObjectElement()

--- a/Source/WebCore/html/HTMLObjectElement.h
+++ b/Source/WebCore/html/HTMLObjectElement.h
@@ -35,7 +35,7 @@ class HTMLObjectElement final : public HTMLPlugInElement, public FormListedEleme
 public:
     USING_CAN_MAKE_WEAKPTR(HTMLPlugInElement);
 
-    static Ref<HTMLObjectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
+    static Ref<HTMLObjectElement> create(Document&, HTMLFormElement*);
 
     bool isExposed() const { return m_isExposed; }
 
@@ -54,7 +54,7 @@ public:
     using HTMLPlugInElement::deref;
 
 private:
-    HTMLObjectElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLObjectElement(Document&, HTMLFormElement*);
     ~HTMLObjectElement();
 
     int defaultTabIndex() const final;

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -44,15 +44,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLOptGroupElement);
 
 using namespace HTMLNames;
 
-inline HTMLOptGroupElement::HTMLOptGroupElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLOptGroupElement::HTMLOptGroupElement(Document& document)
+    : HTMLElement(optgroupTag, document)
 {
-    ASSERT(hasTagName(optgroupTag));
 }
 
-Ref<HTMLOptGroupElement> HTMLOptGroupElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLOptGroupElement> HTMLOptGroupElement::create(Document& document)
 {
-    return adoptRef(*new HTMLOptGroupElement(tagName, document));
+    return adoptRef(*new HTMLOptGroupElement(document));
 }
 
 auto HTMLOptGroupElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult

--- a/Source/WebCore/html/HTMLOptGroupElement.h
+++ b/Source/WebCore/html/HTMLOptGroupElement.h
@@ -33,7 +33,7 @@ class HTMLOptGroupElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLOptGroupElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLOptGroupElement);
 public:
-    static Ref<HTMLOptGroupElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLOptGroupElement> create(Document&);
 
     bool isDisabledFormControl() const final;
     WEBCORE_EXPORT HTMLSelectElement* ownerSelectElement() const;
@@ -41,7 +41,7 @@ public:
     WEBCORE_EXPORT String groupLabelText() const;
 
 private:
-    HTMLOptGroupElement(const QualifiedName&, Document&);
+    explicit HTMLOptGroupElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -60,20 +60,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLOptionElement);
 
 using namespace HTMLNames;
 
-HTMLOptionElement::HTMLOptionElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
+HTMLOptionElement::HTMLOptionElement(Document& document)
+    : HTMLElement(optionTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
-    ASSERT(hasTagName(optionTag));
 }
 
 Ref<HTMLOptionElement> HTMLOptionElement::create(Document& document)
 {
-    return adoptRef(*new HTMLOptionElement(optionTag, document));
-}
-
-Ref<HTMLOptionElement> HTMLOptionElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLOptionElement(tagName, document));
+    return adoptRef(*new HTMLOptionElement(document));
 }
 
 ExceptionOr<Ref<HTMLOptionElement>> HTMLOptionElement::createForLegacyFactoryFunction(Document& document, String&& text, const AtomString& value, bool defaultSelected, bool selected)

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -37,7 +37,6 @@ class HTMLOptionElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLOptionElement);
 public:
     static Ref<HTMLOptionElement> create(Document&);
-    static Ref<HTMLOptionElement> create(const QualifiedName&, Document&);
     static ExceptionOr<Ref<HTMLOptionElement>> createForLegacyFactoryFunction(Document&, String&& text, const AtomString& value, bool defaultSelected, bool selected);
 
     void finishParsingChildren() final;
@@ -72,7 +71,7 @@ public:
     void cloneIntoSelectedContent(HTMLSelectedContentElement&);
 
 private:
-    HTMLOptionElement(const QualifiedName&, Document&);
+    explicit HTMLOptionElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode& oldParentOfRemovedTree) final;

--- a/Source/WebCore/html/HTMLOutputElement.cpp
+++ b/Source/WebCore/html/HTMLOutputElement.cpp
@@ -44,21 +44,16 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLOutputElement);
 
-inline HTMLOutputElement::HTMLOutputElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLFormControlElement(tagName, document, form)
+inline HTMLOutputElement::HTMLOutputElement(Document& document, HTMLFormElement* form)
+    : HTMLFormControlElement(HTMLNames::outputTag, document, form)
 {
 }
 
 HTMLOutputElement::~HTMLOutputElement() = default;
 
-Ref<HTMLOutputElement> HTMLOutputElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLOutputElement> HTMLOutputElement::create(Document& document, HTMLFormElement* form)
 {
-    return adoptRef(*new HTMLOutputElement(tagName, document, form));
-}
-
-Ref<HTMLOutputElement> HTMLOutputElement::create(Document& document)
-{
-    return create(HTMLNames::outputTag, document, nullptr);
+    return adoptRef(*new HTMLOutputElement(document, form));
 }
 
 const AtomString& HTMLOutputElement::formControlType() const

--- a/Source/WebCore/html/HTMLOutputElement.h
+++ b/Source/WebCore/html/HTMLOutputElement.h
@@ -41,8 +41,7 @@ class HTMLOutputElement final : public HTMLFormControlElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLOutputElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLOutputElement);
 public:
-    static Ref<HTMLOutputElement> create(const QualifiedName&, Document&, HTMLFormElement*);
-    static Ref<HTMLOutputElement> create(Document&);
+    static Ref<HTMLOutputElement> create(Document&, HTMLFormElement* = nullptr);
     ~HTMLOutputElement();
 
     String value() const;
@@ -52,7 +51,7 @@ public:
     DOMTokenList& htmlFor();
     
 private:
-    HTMLOutputElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLOutputElement(Document&, HTMLFormElement*);
 
     bool canContainRangeEndPoint() const final { return false; }
     bool computeWillValidate() const final { return false; }

--- a/Source/WebCore/html/HTMLParagraphElement.cpp
+++ b/Source/WebCore/html/HTMLParagraphElement.cpp
@@ -35,20 +35,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLParagraphElement);
 
 using namespace HTMLNames;
 
-inline HTMLParagraphElement::HTMLParagraphElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLParagraphElement::HTMLParagraphElement(Document& document)
+    : HTMLElement(pTag, document)
 {
-    ASSERT(hasTagName(pTag));
 }
 
 Ref<HTMLParagraphElement> HTMLParagraphElement::create(Document& document)
 {
-    return adoptRef(*new HTMLParagraphElement(pTag, document));
-}
-
-Ref<HTMLParagraphElement> HTMLParagraphElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLParagraphElement(tagName, document));
+    return adoptRef(*new HTMLParagraphElement(document));
 }
 
 void HTMLParagraphElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)

--- a/Source/WebCore/html/HTMLParagraphElement.h
+++ b/Source/WebCore/html/HTMLParagraphElement.h
@@ -31,10 +31,9 @@ class HTMLParagraphElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLParagraphElement);
 public:
     static Ref<HTMLParagraphElement> create(Document&);
-    static Ref<HTMLParagraphElement> create(const QualifiedName&, Document&);
 
 private:
-    HTMLParagraphElement(const QualifiedName&, Document&);
+    explicit HTMLParagraphElement(Document&);
 
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 };

--- a/Source/WebCore/html/HTMLParamElement.cpp
+++ b/Source/WebCore/html/HTMLParamElement.cpp
@@ -32,15 +32,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLParamElement);
 
 using namespace HTMLNames;
 
-inline HTMLParamElement::HTMLParamElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLParamElement::HTMLParamElement(Document& document)
+    : HTMLElement(paramTag, document)
 {
-    ASSERT(hasTagName(paramTag));
 }
 
-Ref<HTMLParamElement> HTMLParamElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLParamElement> HTMLParamElement::create(Document& document)
 {
-    return adoptRef(*new HTMLParamElement(tagName, document));
+    return adoptRef(*new HTMLParamElement(document));
 }
 
 }

--- a/Source/WebCore/html/HTMLParamElement.h
+++ b/Source/WebCore/html/HTMLParamElement.h
@@ -30,10 +30,10 @@ class HTMLParamElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLParamElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLParamElement);
 public:
-    static Ref<HTMLParamElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLParamElement> create(Document&);
 
 private:
-    HTMLParamElement(const QualifiedName&, Document&);
+    explicit HTMLParamElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLPictureElement.cpp
+++ b/Source/WebCore/html/HTMLPictureElement.cpp
@@ -38,16 +38,16 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLPictureElement);
 
-HTMLPictureElement::HTMLPictureElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLPictureElement::HTMLPictureElement(Document& document)
+    : HTMLElement(HTMLNames::pictureTag, document)
 {
 }
 
 HTMLPictureElement::~HTMLPictureElement() = default;
 
-Ref<HTMLPictureElement> HTMLPictureElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLPictureElement> HTMLPictureElement::create(Document& document)
 {
-    return adoptRef(*new HTMLPictureElement(tagName, document));
+    return adoptRef(*new HTMLPictureElement(document));
 }
 
 void HTMLPictureElement::sourcesChanged()

--- a/Source/WebCore/html/HTMLPictureElement.h
+++ b/Source/WebCore/html/HTMLPictureElement.h
@@ -33,7 +33,7 @@ class HTMLPictureElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLPictureElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLPictureElement);
 public:
-    static Ref<HTMLPictureElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLPictureElement> create(Document&);
     virtual ~HTMLPictureElement();
 
     void sourcesChanged();
@@ -44,7 +44,7 @@ public:
 #endif
 
 private:
-    HTMLPictureElement(const QualifiedName&, Document&);
+    explicit HTMLPictureElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLProgressElement.cpp
+++ b/Source/WebCore/html/HTMLProgressElement.cpp
@@ -44,17 +44,16 @@ using namespace HTMLNames;
 const double HTMLProgressElement::IndeterminatePosition = -1;
 const double HTMLProgressElement::InvalidPosition = -2;
 
-HTMLProgressElement::HTMLProgressElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
+HTMLProgressElement::HTMLProgressElement(Document& document)
+    : HTMLElement(progressTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
-    ASSERT(hasTagName(progressTag));
 }
 
 HTMLProgressElement::~HTMLProgressElement() = default;
 
-Ref<HTMLProgressElement> HTMLProgressElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLProgressElement> HTMLProgressElement::create(Document& document)
 {
-    Ref progress = adoptRef(*new HTMLProgressElement(tagName, document));
+    Ref progress = adoptRef(*new HTMLProgressElement(document));
     progress->ensureUserAgentShadowRoot();
     return progress;
 }

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -34,7 +34,7 @@ public:
     static const double IndeterminatePosition;
     static const double InvalidPosition;
 
-    static Ref<HTMLProgressElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLProgressElement> create(Document&);
 
     double value() const;
 
@@ -46,7 +46,7 @@ public:
     bool isDevolvableWidget() const override { return true; }
 
 private:
-    HTMLProgressElement(const QualifiedName&, Document&);
+    explicit HTMLProgressElement(Document&);
     virtual ~HTMLProgressElement();
 
     bool matchesIndeterminatePseudoClass() const final;

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -45,16 +45,15 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLScriptElement);
 
 using namespace HTMLNames;
 
-inline HTMLScriptElement::HTMLScriptElement(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
-    : HTMLElement(tagName, document)
+inline HTMLScriptElement::HTMLScriptElement(Document& document, bool wasInsertedByParser, bool alreadyStarted)
+    : HTMLElement(scriptTag, document)
     , ScriptElement(*this, wasInsertedByParser, alreadyStarted)
 {
-    ASSERT(hasTagName(scriptTag));
 }
 
-Ref<HTMLScriptElement> HTMLScriptElement::create(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
+Ref<HTMLScriptElement> HTMLScriptElement::create(Document& document, bool wasInsertedByParser, bool alreadyStarted)
 {
-    return adoptRef(*new HTMLScriptElement(tagName, document, wasInsertedByParser, alreadyStarted));
+    return adoptRef(*new HTMLScriptElement(document, wasInsertedByParser, alreadyStarted));
 }
 
 bool HTMLScriptElement::isURLAttribute(const Attribute& attribute) const
@@ -287,7 +286,7 @@ bool HTMLScriptElement::isScriptPreventedByAttributes() const
 
 Ref<Element> HTMLScriptElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*) const
 {
-    return adoptRef(*new HTMLScriptElement(tagQName(), document, false, alreadyStarted()));
+    return adoptRef(*new HTMLScriptElement(document, false, alreadyStarted()));
 }
 
 String HTMLScriptElement::referrerPolicyForBindings() const

--- a/Source/WebCore/html/HTMLScriptElement.h
+++ b/Source/WebCore/html/HTMLScriptElement.h
@@ -38,7 +38,7 @@ class HTMLScriptElement final : public HTMLElement, public ScriptElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLScriptElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLScriptElement);
 public:
-    static Ref<HTMLScriptElement> create(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted = false);
+    static Ref<HTMLScriptElement> create(Document&, bool wasInsertedByParser = false, bool alreadyStarted = false);
 
     String text() const { return scriptContent(); }
     WEBCORE_EXPORT void setText(String&&);
@@ -72,7 +72,7 @@ public:
     WEBCORE_EXPORT DOMTokenList& blocking();
 
 private:
-    HTMLScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);
+    HTMLScriptElement(Document&, bool wasInsertedByParser, bool alreadyStarted);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -125,8 +125,8 @@ const AtomString& SelectSlotAssignment::slotNameForHostChild(const Node& child) 
 // https://html.spec.whatwg.org/#dom-htmloptionscollection-length
 static constexpr unsigned maxSelectItems = 100000;
 
-HTMLSelectElement::HTMLSelectElement(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
-    : HTMLFormControlElement(tagName, document, form)
+HTMLSelectElement::HTMLSelectElement(Document& document, HTMLFormElement* form)
+    : HTMLFormControlElement(selectTag, document, form)
     , m_typeAhead(this)
     , m_size(0)
     , m_lastOnChangeIndex(-1)
@@ -138,20 +138,13 @@ HTMLSelectElement::HTMLSelectElement(const QualifiedName& tagName, Document& doc
     , m_allowsNonContiguousSelection(false)
     , m_shouldRecalcListItems(false)
 {
-    ASSERT(hasTagName(selectTag));
 }
 
-Ref<HTMLSelectElement> HTMLSelectElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLSelectElement> HTMLSelectElement::create(Document& document, HTMLFormElement* form)
 {
-    ASSERT(tagName.matches(selectTag));
-    Ref select = adoptRef(*new HTMLSelectElement(tagName, document, form));
+    Ref select = adoptRef(*new HTMLSelectElement(document, form));
     select->addShadowRoot(ShadowRoot::create(document, makeUnique<SelectSlotAssignment>()));
     return select;
-}
-
-Ref<HTMLSelectElement> HTMLSelectElement::create(Document& document)
-{
-    return HTMLSelectElement::create(selectTag, document, nullptr);
 }
 
 HTMLSelectElement::~HTMLSelectElement() = default;
@@ -173,7 +166,7 @@ void HTMLSelectElement::didAddUserAgentShadowRoot(ShadowRoot& root)
 
     ScriptDisallowedScope::EventAllowedScope rootScope { root };
 
-    Ref buttonSlot = HTMLSlotElement::create(slotTag, document);
+    Ref buttonSlot = HTMLSlotElement::create(document);
     ScriptDisallowedScope::EventAllowedScope buttonSlotScope { buttonSlot };
     buttonSlot->setAttributeWithoutSynchronization(inertAttr, emptyAtom());
     buttonSlot->setAttributeWithoutSynchronization(nameAttr, buttonSlotName());
@@ -182,7 +175,7 @@ void HTMLSelectElement::didAddUserAgentShadowRoot(ShadowRoot& root)
     m_buttonSlot = WTF::move(buttonSlot);
 
     if (!document->settings().htmlEnhancedSelectEnabled()) {
-        root.appendChild(HTMLSlotElement::create(slotTag, document));
+        root.appendChild(HTMLSlotElement::create(document));
         return;
     }
 
@@ -191,7 +184,7 @@ void HTMLSelectElement::didAddUserAgentShadowRoot(ShadowRoot& root)
     popover->setAttributeWithoutSynchronization(popoverAttr, autoAtom());
     popover->setUserAgentPart(pickerSelectAtom());
 
-    popover->appendChild(HTMLSlotElement::create(slotTag, document));
+    popover->appendChild(HTMLSlotElement::create(document));
 
     root.appendChild(popover);
     m_popover = WTF::move(popover);

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -58,8 +58,7 @@ public:
     void ref() const final { HTMLFormControlElement::ref(); }
     void deref() const final { HTMLFormControlElement::deref(); }
 
-    static Ref<HTMLSelectElement> create(const QualifiedName&, Document&, HTMLFormElement*);
-    static Ref<HTMLSelectElement> create(Document&);
+    static Ref<HTMLSelectElement> create(Document&, HTMLFormElement* = nullptr);
     ~HTMLSelectElement();
 
     enum class ExcludeOptGroup : bool { No, Yes };
@@ -189,7 +188,7 @@ public:
     void hidePickerPopoverElement();
 
 protected:
-    HTMLSelectElement(const QualifiedName&, Document&, HTMLFormElement*);
+    HTMLSelectElement(Document&, HTMLFormElement*);
 
 private:
     const AtomString& formControlType() const final;

--- a/Source/WebCore/html/HTMLSelectedContentElement.cpp
+++ b/Source/WebCore/html/HTMLSelectedContentElement.cpp
@@ -42,10 +42,9 @@ using namespace HTMLNames;
 HTMLSelectedContentElement::HTMLSelectedContentElement(Document& document)
     : HTMLElement(selectedcontentTag, document, { })
 {
-    ASSERT(hasTagName(selectedcontentTag));
 }
 
-Ref<HTMLSelectedContentElement> HTMLSelectedContentElement::create(const QualifiedName&, Document& document)
+Ref<HTMLSelectedContentElement> HTMLSelectedContentElement::create(Document& document)
 {
     return adoptRef(*new HTMLSelectedContentElement(document));
 }

--- a/Source/WebCore/html/HTMLSelectedContentElement.h
+++ b/Source/WebCore/html/HTMLSelectedContentElement.h
@@ -35,7 +35,7 @@ class HTMLSelectedContentElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLSelectedContentElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSelectedContentElement);
 public:
-    static Ref<HTMLSelectedContentElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLSelectedContentElement> create(Document&);
 
     bool isDisabled() { return m_isDisabled; }
 

--- a/Source/WebCore/html/HTMLSlotElement.cpp
+++ b/Source/WebCore/html/HTMLSlotElement.cpp
@@ -47,15 +47,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLSlotElement);
 
 using namespace HTMLNames;
 
-Ref<HTMLSlotElement> HTMLSlotElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLSlotElement> HTMLSlotElement::create(Document& document)
 {
-    return adoptRef(*new HTMLSlotElement(tagName, document));
+    return adoptRef(*new HTMLSlotElement(document));
 }
 
-HTMLSlotElement::HTMLSlotElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLSlotElement::HTMLSlotElement(Document& document)
+    : HTMLElement(slotTag, document)
 {
-    ASSERT(hasTagName(slotTag));
 }
 
 HTMLSlotElement::InsertedIntoAncestorResult HTMLSlotElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLSlotElement.h
+++ b/Source/WebCore/html/HTMLSlotElement.h
@@ -35,7 +35,7 @@ class HTMLSlotElement final : public HTMLElement {
 public:
     using ElementOrText = Variant<Ref<Element>, Ref<Text>>;
 
-    static Ref<HTMLSlotElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLSlotElement> create(Document&);
 
     const Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>>* assignedNodes() const;
     struct AssignedNodesOptions {
@@ -57,7 +57,7 @@ public:
 
     void updateAccessibilityOnSlotChange() const;
 private:
-    HTMLSlotElement(const QualifiedName&, Document&);
+    explicit HTMLSlotElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLSourceElement.cpp
+++ b/Source/WebCore/html/HTMLSourceElement.cpp
@@ -54,24 +54,18 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLSourceElement);
 
 using namespace HTMLNames;
 
-inline HTMLSourceElement::HTMLSourceElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
+inline HTMLSourceElement::HTMLSourceElement(Document& document)
+    : HTMLElement(sourceTag, document, TypeFlag::HasDidMoveToNewDocument)
     , ActiveDOMObject(document)
 {
     LOG(Media, "HTMLSourceElement::HTMLSourceElement - %p", this);
-    ASSERT(hasTagName(sourceTag));
-}
-
-Ref<HTMLSourceElement> HTMLSourceElement::create(const QualifiedName& tagName, Document& document)
-{
-    auto sourceElement = adoptRef(*new HTMLSourceElement(tagName, document));
-    sourceElement->suspendIfNeeded();
-    return sourceElement;
 }
 
 Ref<HTMLSourceElement> HTMLSourceElement::create(Document& document)
 {
-    return create(sourceTag, document);
+    Ref sourceElement = adoptRef(*new HTMLSourceElement(document));
+    sourceElement->suspendIfNeeded();
+    return sourceElement;
 }
 
 Node::InsertedIntoAncestorResult HTMLSourceElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLSourceElement.h
+++ b/Source/WebCore/html/HTMLSourceElement.h
@@ -43,7 +43,6 @@ class HTMLSourceElement final
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSourceElement);
 public:
     static Ref<HTMLSourceElement> create(Document&);
-    static Ref<HTMLSourceElement> create(const QualifiedName&, Document&);
 
     // ActiveDOMObject.
     void ref() const final { HTMLElement::ref(); }
@@ -56,7 +55,7 @@ public:
     const MQ::MediaQueryList& parsedMediaAttribute(Document&) const;
 
 private:
-    HTMLSourceElement(const QualifiedName&, Document&);
+    explicit HTMLSourceElement(Document&);
     
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLSpanElement.cpp
+++ b/Source/WebCore/html/HTMLSpanElement.cpp
@@ -35,20 +35,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLSpanElement);
 
 using namespace HTMLNames;
 
-HTMLSpanElement::HTMLSpanElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLSpanElement::HTMLSpanElement(Document& document)
+    : HTMLElement(spanTag, document)
 {
-    ASSERT(hasTagName(spanTag));
 }
 
 Ref<HTMLSpanElement> HTMLSpanElement::create(Document& document)
 {
-    return adoptRef(*new HTMLSpanElement(spanTag, document));
-}
-
-Ref<HTMLSpanElement> HTMLSpanElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLSpanElement(tagName, document));
+    return adoptRef(*new HTMLSpanElement(document));
 }
 
 }

--- a/Source/WebCore/html/HTMLSpanElement.h
+++ b/Source/WebCore/html/HTMLSpanElement.h
@@ -34,10 +34,9 @@ class HTMLSpanElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSpanElement);
 public:
     static Ref<HTMLSpanElement> create(Document&);
-    static Ref<HTMLSpanElement> create(const QualifiedName&, Document&);
 
 private:
-    HTMLSpanElement(const QualifiedName&, Document&);
+    explicit HTMLSpanElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLStyleElement.cpp
+++ b/Source/WebCore/html/HTMLStyleElement.cpp
@@ -57,11 +57,10 @@ static StyleEventSender& styleLoadEventSenderSingleton()
     return sharedLoadEventSender;
 }
 
-inline HTMLStyleElement::HTMLStyleElement(const QualifiedName& tagName, Document& document, bool createdByParser)
-    : HTMLElement(tagName, document)
+inline HTMLStyleElement::HTMLStyleElement(Document& document, bool createdByParser)
+    : HTMLElement(styleTag, document)
     , m_styleSheetOwner(document, createdByParser)
 {
-    ASSERT(hasTagName(styleTag));
 }
 
 HTMLStyleElement::~HTMLStyleElement()
@@ -71,14 +70,9 @@ HTMLStyleElement::~HTMLStyleElement()
     styleLoadEventSenderSingleton().cancelEvent(*this);
 }
 
-Ref<HTMLStyleElement> HTMLStyleElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)
+Ref<HTMLStyleElement> HTMLStyleElement::create(Document& document, bool createdByParser)
 {
-    return adoptRef(*new HTMLStyleElement(tagName, document, createdByParser));
-}
-
-Ref<HTMLStyleElement> HTMLStyleElement::create(Document& document)
-{
-    return adoptRef(*new HTMLStyleElement(styleTag, document, false));
+    return adoptRef(*new HTMLStyleElement(document, createdByParser));
 }
 
 void HTMLStyleElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -39,8 +39,7 @@ class HTMLStyleElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLStyleElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLStyleElement);
 public:
-    static Ref<HTMLStyleElement> create(Document&);
-    static Ref<HTMLStyleElement> create(const QualifiedName&, Document&, bool createdByParser);
+    static Ref<HTMLStyleElement> create(Document&, bool createdByParser = false);
     virtual ~HTMLStyleElement();
 
     CSSStyleSheet* sheet() const { return m_styleSheetOwner.sheet(); }
@@ -56,7 +55,7 @@ public:
     WEBCORE_EXPORT DOMTokenList& blocking();
 
 private:
-    HTMLStyleElement(const QualifiedName&, Document&, bool createdByParser);
+    HTMLStyleElement(Document&, bool createdByParser);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLSummaryElement.cpp
+++ b/Source/WebCore/html/HTMLSummaryElement.cpp
@@ -42,15 +42,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLSummaryElement);
 
 using namespace HTMLNames;
 
-Ref<HTMLSummaryElement> HTMLSummaryElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLSummaryElement> HTMLSummaryElement::create(Document& document)
 {
-    return adoptRef(*new HTMLSummaryElement(tagName, document));
+    return adoptRef(*new HTMLSummaryElement(document));
 }
 
-HTMLSummaryElement::HTMLSummaryElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLSummaryElement::HTMLSummaryElement(Document& document)
+    : HTMLElement(summaryTag, document)
 {
-    ASSERT(hasTagName(summaryTag));
 }
 
 RefPtr<HTMLDetailsElement> HTMLSummaryElement::detailsElement() const

--- a/Source/WebCore/html/HTMLSummaryElement.h
+++ b/Source/WebCore/html/HTMLSummaryElement.h
@@ -30,13 +30,13 @@ class HTMLSummaryElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLSummaryElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLSummaryElement);
 public:
-    static Ref<HTMLSummaryElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLSummaryElement> create(Document&);
 
     bool isActiveSummary() const;
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 
 private:
-    HTMLSummaryElement(const QualifiedName&, Document&);
+    explicit HTMLSummaryElement(Document&);
 
     void defaultEventHandler(Event&) final;
 

--- a/Source/WebCore/html/HTMLTableCaptionElement.cpp
+++ b/Source/WebCore/html/HTMLTableCaptionElement.cpp
@@ -35,15 +35,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTableCaptionElement);
 
 using namespace HTMLNames;
 
-inline HTMLTableCaptionElement::HTMLTableCaptionElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLTableCaptionElement::HTMLTableCaptionElement(Document& document)
+    : HTMLElement(captionTag, document)
 {
-    ASSERT(hasTagName(captionTag));
 }
 
-Ref<HTMLTableCaptionElement> HTMLTableCaptionElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLTableCaptionElement> HTMLTableCaptionElement::create(Document& document)
 {
-    return adoptRef(*new HTMLTableCaptionElement(tagName, document));
+    return adoptRef(*new HTMLTableCaptionElement(document));
 }
 
 void HTMLTableCaptionElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)

--- a/Source/WebCore/html/HTMLTableCaptionElement.h
+++ b/Source/WebCore/html/HTMLTableCaptionElement.h
@@ -33,10 +33,10 @@ class HTMLTableCaptionElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLTableCaptionElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableCaptionElement);
 public:
-    static Ref<HTMLTableCaptionElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLTableCaptionElement> create(Document&);
 
 private:
-    HTMLTableCaptionElement(const QualifiedName&, Document&);
+    explicit HTMLTableCaptionElement(Document&);
 
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
 };

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -52,22 +52,16 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTableElement);
 
 using namespace HTMLNames;
 
-HTMLTableElement::HTMLTableElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLTableElement::HTMLTableElement(Document& document)
+    : HTMLElement(tableTag, document)
 {
-    ASSERT(hasTagName(tableTag));
 }
 
 HTMLTableElement::~HTMLTableElement() = default;
 
 Ref<HTMLTableElement> HTMLTableElement::create(Document& document)
 {
-    return adoptRef(*new HTMLTableElement(tableTag, document));
-}
-
-Ref<HTMLTableElement> HTMLTableElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLTableElement(tagName, document));
+    return adoptRef(*new HTMLTableElement(document));
 }
 
 RefPtr<HTMLTableCaptionElement> HTMLTableElement::caption() const
@@ -171,7 +165,7 @@ Ref<HTMLTableCaptionElement> HTMLTableElement::createCaption()
 {
     if (RefPtr existingCaption = caption())
         return existingCaption.releaseNonNull();
-    Ref caption = HTMLTableCaptionElement::create(captionTag, protect(document()));
+    Ref caption = HTMLTableCaptionElement::create(protect(document()));
     setCaption(caption.copyRef());
     return caption;
 }

--- a/Source/WebCore/html/HTMLTableElement.h
+++ b/Source/WebCore/html/HTMLTableElement.h
@@ -39,7 +39,6 @@ class HTMLTableElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableElement);
 public:
     static Ref<HTMLTableElement> create(Document&);
-    static Ref<HTMLTableElement> create(const QualifiedName&, Document&);
     ~HTMLTableElement();
 
     WEBCORE_EXPORT RefPtr<HTMLTableCaptionElement> caption() const;
@@ -71,7 +70,7 @@ public:
     const MutableStyleProperties* additionalGroupStyle(bool rows) const;
 
 private:
-    HTMLTableElement(const QualifiedName&, Document&);
+    explicit HTMLTableElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;

--- a/Source/WebCore/html/HTMLTableRowElement.cpp
+++ b/Source/WebCore/html/HTMLTableRowElement.cpp
@@ -45,20 +45,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTableRowElement);
 
 using namespace HTMLNames;
 
-inline HTMLTableRowElement::HTMLTableRowElement(const QualifiedName& tagName, Document& document)
-    : HTMLTablePartElement(tagName, document)
+inline HTMLTableRowElement::HTMLTableRowElement(Document& document)
+    : HTMLTablePartElement(trTag, document)
 {
-    ASSERT(hasTagName(trTag));
 }
 
 Ref<HTMLTableRowElement> HTMLTableRowElement::create(Document& document)
 {
-    return adoptRef(*new HTMLTableRowElement(trTag, document));
-}
-
-Ref<HTMLTableRowElement> HTMLTableRowElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLTableRowElement(tagName, document));
+    return adoptRef(*new HTMLTableRowElement(document));
 }
 
 static inline RefPtr<HTMLTableElement> findTable(const HTMLTableRowElement& row)

--- a/Source/WebCore/html/HTMLTableRowElement.h
+++ b/Source/WebCore/html/HTMLTableRowElement.h
@@ -35,7 +35,6 @@ class HTMLTableRowElement final : public HTMLTablePartElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTableRowElement);
 public:
     static Ref<HTMLTableRowElement> create(Document&);
-    static Ref<HTMLTableRowElement> create(const QualifiedName&, Document&);
 
     WEBCORE_EXPORT int rowIndex() const;
     void setRowIndex(int);
@@ -49,7 +48,7 @@ public:
     WEBCORE_EXPORT Ref<HTMLCollection> cells();
 
 private:
-    HTMLTableRowElement(const QualifiedName&, Document&);
+    explicit HTMLTableRowElement(Document&);
 };
 
 } // namespace

--- a/Source/WebCore/html/HTMLTableSectionElement.cpp
+++ b/Source/WebCore/html/HTMLTableSectionElement.cpp
@@ -28,7 +28,6 @@
 
 #include "ElementChildIteratorInlines.h"
 #include "GenericCachedHTMLCollection.h"
-#include "HTMLNames.h"
 #include "HTMLTableRowElement.h"
 #include "HTMLTableElement.h"
 #include "NodeList.h"
@@ -68,7 +67,7 @@ ExceptionOr<Ref<HTMLTableRowElement>> HTMLTableSectionElement::insertRow(int ind
     int numRows = children->length();
     if (index > numRows)
         return Exception { ExceptionCode::IndexSizeError };
-    Ref row = HTMLTableRowElement::create(trTag, protect(document()));
+    Ref row = HTMLTableRowElement::create(protect(document()));
     ExceptionOr<void> result;
     if (numRows == index || index == -1)
         result = appendChild(row);

--- a/Source/WebCore/html/HTMLTemplateElement.cpp
+++ b/Source/WebCore/html/HTMLTemplateElement.cpp
@@ -53,8 +53,8 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTemplateElement);
 
 using namespace HTMLNames;
 
-inline HTMLTemplateElement::HTMLTemplateElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
+inline HTMLTemplateElement::HTMLTemplateElement(Document& document)
+    : HTMLElement(templateTag, document, TypeFlag::HasDidMoveToNewDocument)
 {
 }
 
@@ -64,9 +64,9 @@ HTMLTemplateElement::~HTMLTemplateElement()
         m_content->clearHost();
 }
 
-Ref<HTMLTemplateElement> HTMLTemplateElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLTemplateElement> HTMLTemplateElement::create(Document& document)
 {
-    return adoptRef(*new HTMLTemplateElement(tagName, document));
+    return adoptRef(*new HTMLTemplateElement(document));
 }
 
 DocumentFragment* HTMLTemplateElement::contentIfAvailable() const

--- a/Source/WebCore/html/HTMLTemplateElement.h
+++ b/Source/WebCore/html/HTMLTemplateElement.h
@@ -41,7 +41,7 @@ class HTMLTemplateElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLTemplateElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTemplateElement);
 public:
-    static Ref<HTMLTemplateElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLTemplateElement> create(Document&);
     virtual ~HTMLTemplateElement();
 
     DocumentFragment& fragmentForInsertion() const;
@@ -55,7 +55,7 @@ public:
     void adoptDeserializedContent(Ref<TemplateContentDocumentFragment>&&);
 
 private:
-    HTMLTemplateElement(const QualifiedName&, Document&);
+    explicit HTMLTemplateElement(Document&);
 
     Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const final;
     SerializedNode serializeNode(CloningOperation) const override;

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -79,17 +79,16 @@ HTMLTextAreaElement::HTMLTextAreaElement(Document& document, HTMLFormElement* fo
     setFormControlValueMatchesRenderer(true);
 }
 
-Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(const QualifiedName& tagName, Document& document, HTMLFormElement* form)
+Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(Document& document, HTMLFormElement* form)
 {
-    ASSERT_UNUSED(tagName, tagName == textareaTag);
-    auto textArea = adoptRef(*new HTMLTextAreaElement(document, form));
+    Ref textArea = adoptRef(*new HTMLTextAreaElement(document, form));
     textArea->ensureUserAgentShadowRoot();
     return textArea;
 }
 
 Ref<HTMLTextAreaElement> HTMLTextAreaElement::create(Document& document)
 {
-    return create(textareaTag, document, nullptr);
+    return create(document, nullptr);
 }
 
 void HTMLTextAreaElement::didAddUserAgentShadowRoot(ShadowRoot& root)

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -37,7 +37,7 @@ class HTMLTextAreaElement final : public HTMLTextFormControlElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTextAreaElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLTextAreaElement> create(Document&);
-    static Ref<HTMLTextAreaElement> create(const QualifiedName&, Document&, HTMLFormElement*);
+    static Ref<HTMLTextAreaElement> create(Document&, HTMLFormElement*);
 
     unsigned rows() const { return m_rows; }
     WEBCORE_EXPORT void setRows(unsigned);
@@ -61,7 +61,7 @@ public:
     bool dirAutoUsesValue() const final { return true; }
 
 private:
-    HTMLTextAreaElement(Document&, HTMLFormElement*);
+    explicit HTMLTextAreaElement(Document&, HTMLFormElement*);
 
     void didAddUserAgentShadowRoot(ShadowRoot&) final;
 

--- a/Source/WebCore/html/HTMLTimeElement.cpp
+++ b/Source/WebCore/html/HTMLTimeElement.cpp
@@ -35,15 +35,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTimeElement);
 
 using namespace HTMLNames;
 
-Ref<HTMLTimeElement> HTMLTimeElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLTimeElement> HTMLTimeElement::create(Document& document)
 {
-    return adoptRef(*new HTMLTimeElement(tagName, document));
+    return adoptRef(*new HTMLTimeElement(document));
 }
 
-inline HTMLTimeElement::HTMLTimeElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLTimeElement::HTMLTimeElement(Document& document)
+    : HTMLElement(timeTag, document)
 {
-    ASSERT(hasTagName(timeTag));
 }
 
 } // namespace WebCore.

--- a/Source/WebCore/html/HTMLTimeElement.h
+++ b/Source/WebCore/html/HTMLTimeElement.h
@@ -33,10 +33,10 @@ class HTMLTimeElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLTimeElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTimeElement);
 public:
-    static Ref<HTMLTimeElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLTimeElement> create(Document&);
 
 private:
-    HTMLTimeElement(const QualifiedName&, Document&);
+    explicit HTMLTimeElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLTitleElement.cpp
+++ b/Source/WebCore/html/HTMLTitleElement.cpp
@@ -44,15 +44,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTitleElement);
 
 using namespace HTMLNames;
 
-inline HTMLTitleElement::HTMLTitleElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+inline HTMLTitleElement::HTMLTitleElement(Document& document)
+    : HTMLElement(titleTag, document)
 {
-    ASSERT(hasTagName(titleTag));
 }
 
-Ref<HTMLTitleElement> HTMLTitleElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLTitleElement> HTMLTitleElement::create(Document& document)
 {
-    return adoptRef(*new HTMLTitleElement(tagName, document));
+    return adoptRef(*new HTMLTitleElement(document));
 }
 
 Node::InsertedIntoAncestorResult HTMLTitleElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLTitleElement.h
+++ b/Source/WebCore/html/HTMLTitleElement.h
@@ -31,7 +31,7 @@ class HTMLTitleElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLTitleElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTitleElement);
 public:
-    static Ref<HTMLTitleElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLTitleElement> create(Document&);
 
     WEBCORE_EXPORT String text() const;
     WEBCORE_EXPORT void setText(String&&);
@@ -41,7 +41,7 @@ public:
     void didFinishInsertingNode() final;
 
 private:
-    HTMLTitleElement(const QualifiedName&, Document&);
+    explicit HTMLTitleElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/html/HTMLTrackElement.cpp
+++ b/Source/WebCore/html/HTMLTrackElement.cpp
@@ -63,14 +63,13 @@ static String urlForLoggingTrack(const URL& url)
 
 #endif
     
-inline HTMLTrackElement::HTMLTrackElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document, TypeFlag::HasDidMoveToNewDocument)
+inline HTMLTrackElement::HTMLTrackElement(Document& document)
+    : HTMLElement(trackTag, document, TypeFlag::HasDidMoveToNewDocument)
     , ActiveDOMObject(document)
     , m_track(LoadableTextTrack::create(*this, nullAtom(), nullAtom(), nullAtom()))
 {
     m_track->addClient(*this);
     LOG(Media, "HTMLTrackElement::HTMLTrackElement - %p", this);
-    ASSERT(hasTagName(trackTag));
 }
 
 HTMLTrackElement::~HTMLTrackElement()
@@ -78,9 +77,9 @@ HTMLTrackElement::~HTMLTrackElement()
     m_track->clearClient(*this);
 }
 
-Ref<HTMLTrackElement> HTMLTrackElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLTrackElement> HTMLTrackElement::create(Document& document)
 {
-    auto trackElement = adoptRef(*new HTMLTrackElement(tagName, document));
+    Ref trackElement = adoptRef(*new HTMLTrackElement(document));
     trackElement->suspendIfNeeded();
     return trackElement;
 }

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -41,7 +41,7 @@ class HTMLTrackElement final : public HTMLElement, public ActiveDOMObject, publi
     WTF_MAKE_TZONE_ALLOCATED(HTMLTrackElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLTrackElement);
 public:
-    static Ref<HTMLTrackElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLTrackElement> create(Document&);
 
     // ActiveDOMObject.
     void ref() const final { HTMLElement::ref(); }
@@ -71,7 +71,7 @@ public:
     void scheduleTask(Function<void(HTMLTrackElement&)>&&);
 
 private:
-    HTMLTrackElement(const QualifiedName&, Document&);
+    HTMLTrackElement(Document&);
     virtual ~HTMLTrackElement();
 
     // ActiveDOMObject.

--- a/Source/WebCore/html/HTMLUListElement.cpp
+++ b/Source/WebCore/html/HTMLUListElement.cpp
@@ -34,20 +34,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLUListElement);
 
 using namespace HTMLNames;
 
-HTMLUListElement::HTMLUListElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLUListElement::HTMLUListElement(Document& document)
+    : HTMLElement(ulTag, document)
 {
-    ASSERT(hasTagName(ulTag));
 }
 
 Ref<HTMLUListElement> HTMLUListElement::create(Document& document)
 {
-    return adoptRef(*new HTMLUListElement(ulTag, document));
-}
-
-Ref<HTMLUListElement> HTMLUListElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new HTMLUListElement(tagName, document));
+    return adoptRef(*new HTMLUListElement(document));
 }
 
 bool HTMLUListElement::hasPresentationalHintsForAttribute(const QualifiedName& name) const

--- a/Source/WebCore/html/HTMLUListElement.h
+++ b/Source/WebCore/html/HTMLUListElement.h
@@ -31,10 +31,9 @@ class HTMLUListElement final : public HTMLElement {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLUListElement);
 public:
     static Ref<HTMLUListElement> create(Document&);
-    static Ref<HTMLUListElement> create(const QualifiedName&, Document&);
 
 private:
-    HTMLUListElement(const QualifiedName&, Document&);
+    explicit HTMLUListElement(Document&);
 
     bool hasPresentationalHintsForAttribute(const QualifiedName&) const final;
     void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -89,18 +89,17 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLVideoElement);
 
 using namespace HTMLNames;
 
-inline HTMLVideoElement::HTMLVideoElement(const QualifiedName& tagName, Document& document, bool createdByParser)
-    : HTMLMediaElement(tagName, document, createdByParser)
+inline HTMLVideoElement::HTMLVideoElement(Document& document, bool createdByParser)
+    : HTMLMediaElement(videoTag, document, createdByParser)
 {
-    ASSERT(hasTagName(videoTag));
     m_defaultPosterURL = AtomString { document.settings().defaultVideoPosterURL() };
 }
 
 HTMLVideoElement::~HTMLVideoElement() = default;
 
-Ref<HTMLVideoElement> HTMLVideoElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)
+Ref<HTMLVideoElement> HTMLVideoElement::create(Document& document, bool createdByParser)
 {
-    Ref videoElement = adoptRef(*new HTMLVideoElement(tagName, document, createdByParser));
+    Ref videoElement = adoptRef(*new HTMLVideoElement(document, createdByParser));
 
 #if ENABLE(PICTURE_IN_PICTURE_API)
     HTMLVideoElementPictureInPicture::providePictureInPictureTo(videoElement);
@@ -112,7 +111,7 @@ Ref<HTMLVideoElement> HTMLVideoElement::create(const QualifiedName& tagName, Doc
 
 Ref<HTMLVideoElement> HTMLVideoElement::create(Document& document)
 {
-    return create(videoTag, document, false);
+    return create(document, false);
 }
 
 bool HTMLVideoElement::rendererIsNeeded(const RenderStyle& style)

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -51,7 +51,7 @@ class HTMLVideoElement final : public HTMLMediaElement, public Supplementable<HT
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLVideoElement);
 public:
     WEBCORE_EXPORT static Ref<HTMLVideoElement> create(Document&);
-    static Ref<HTMLVideoElement> create(const QualifiedName&, Document&, bool createdByParser);
+    static Ref<HTMLVideoElement> create(Document&, bool createdByParser);
     ~HTMLVideoElement();
 
     WEBCORE_EXPORT unsigned videoWidth() const;
@@ -151,7 +151,7 @@ public:
     void stop() final;
 
 private:
-    HTMLVideoElement(const QualifiedName&, Document&, bool createdByParser);
+    HTMLVideoElement(Document&, bool createdByParser);
 
     void scheduleResizeEvent(const FloatSize&) final;
     void scheduleResizeEventIfSizeChanged(const FloatSize&) final;

--- a/Source/WebCore/html/HTMLWBRElement.cpp
+++ b/Source/WebCore/html/HTMLWBRElement.cpp
@@ -36,15 +36,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLWBRElement);
 
 using namespace HTMLNames;
 
-Ref<HTMLWBRElement> HTMLWBRElement::create(const QualifiedName& tagName, Document& document)
+Ref<HTMLWBRElement> HTMLWBRElement::create(Document& document)
 {
-    return adoptRef(*new HTMLWBRElement(tagName, document));
+    return adoptRef(*new HTMLWBRElement(document));
 }
 
-HTMLWBRElement::HTMLWBRElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+HTMLWBRElement::HTMLWBRElement(Document& document)
+    : HTMLElement(wbrTag, document)
 {
-    ASSERT(hasTagName(wbrTag));
 }
 
 RenderPtr<RenderElement> HTMLWBRElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/html/HTMLWBRElement.h
+++ b/Source/WebCore/html/HTMLWBRElement.h
@@ -35,12 +35,12 @@ class HTMLWBRElement final : public HTMLElement {
     WTF_MAKE_TZONE_ALLOCATED(HTMLWBRElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(HTMLWBRElement);
 public:
-    static Ref<HTMLWBRElement> create(const QualifiedName&, Document&);
+    static Ref<HTMLWBRElement> create(Document&);
 
     RenderLineBreak* renderer() const;
 
 private:
-    HTMLWBRElement(const QualifiedName&, Document&);
+    explicit HTMLWBRElement(Document&);
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 };

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -110,7 +110,7 @@ public:
 
 private:
     explicit ImageDocumentElement(ImageDocument& document)
-        : HTMLImageElement(imgTag, document)
+        : HTMLImageElement(document)
         , m_imageDocument(document)
     {
     }

--- a/Source/WebCore/html/ModelDocument.cpp
+++ b/Source/WebCore/html/ModelDocument.cpp
@@ -105,18 +105,18 @@ void ModelDocumentParser::createDocumentStructure()
     auto body = HTMLBodyElement::create(document);
     rootElement->appendChild(body);
 
-    auto modelElement = HTMLModelElement::create(HTMLNames::modelTag, document);
+    Ref modelElement = HTMLModelElement::create(document);
     m_modelElement = modelElement.get();
     modelElement->setAttributeWithoutSynchronization(interactiveAttr, emptyAtom());
 
-    auto sourceElement = HTMLSourceElement::create(HTMLNames::sourceTag, document);
+    Ref sourceElement = HTMLSourceElement::create(document);
     sourceElement->setAttributeWithoutSynchronization(srcAttr, AtomString { document->url().string() });
     if (RefPtr loader = document->loader())
         sourceElement->setAttributeWithoutSynchronization(typeAttr, AtomString { loader->responseMIMEType() });
 
     modelElement->appendChild(sourceElement);
 
-    body->appendChild(modelElement);
+    body->appendChild(WTF::move(modelElement));
     document->setHasVisuallyNonEmptyCustomContent();
 
     RefPtr frame = document->frame();

--- a/Source/WebCore/html/PDFDocument.cpp
+++ b/Source/WebCore/html/PDFDocument.cpp
@@ -158,7 +158,7 @@ void PDFDocument::createDocumentStructure()
     body->setAttribute(styleAttr, "margin: 0px;height: 100vh;"_s);
     rootElement->appendChild(body);
 
-    m_iframe = HTMLIFrameElement::create(HTMLNames::iframeTag, *this);
+    m_iframe = HTMLIFrameElement::create(*this);
     m_iframe->setAttribute(srcAttr, AtomString(viewerURL));
     m_iframe->setAttribute(styleAttr, "width: 100%; height: 100%; border: 0; display: block;"_s);
 
@@ -240,7 +240,7 @@ void PDFDocument::injectStyleAndContentScript()
 
     auto* contentDocument = m_iframe->contentDocument();
     ASSERT(contentDocument->head());
-    Ref link = HTMLLinkElement::create(HTMLNames::linkTag, *contentDocument, false);
+    Ref link = HTMLLinkElement::create(*contentDocument);
     link->setAttribute(relAttr, "stylesheet"_s);
 #if PLATFORM(COCOA)
     link->setAttribute(hrefAttr, "webkit-pdfjs-viewer://pdfjs/extras/cocoa/style.css"_s);
@@ -250,7 +250,7 @@ void PDFDocument::injectStyleAndContentScript()
     contentDocument->head()->appendChild(link);
 
     ASSERT(contentDocument->body());
-    m_script = HTMLScriptElement::create(scriptTag, *contentDocument, false);
+    m_script = HTMLScriptElement::create(*contentDocument);
     ASSERT(m_listener);
     m_script->addEventListener(eventNames().loadEvent, *m_listener);
     m_script->setAttribute(srcAttr, "webkit-pdfjs-viewer://pdfjs/extras/content-script.js"_s);

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -643,7 +643,7 @@ void HTMLConstructionSite::insertScriptElement(AtomHTMLToken&& token)
     // those flags or effects thereof.
     const bool parserInserted = !m_parserContentPolicy.contains(ParserContentPolicy::DoNotMarkAlreadyStarted);
     const bool alreadyStarted = m_isParsingFragment && parserInserted;
-    auto element = HTMLScriptElement::create(scriptTag, ownerDocumentForCurrentNode(), parserInserted, alreadyStarted);
+    Ref element = HTMLScriptElement::create(ownerDocumentForCurrentNode(), parserInserted, alreadyStarted);
     setAttributes(element, token, m_parserContentPolicy);
     if (scriptingContentIsAllowed(m_parserContentPolicy))
         attachLater(protect(currentNode()), element.copyRef());

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -518,7 +518,7 @@ private:
 
             static Ref<HTMLInputElement> create(Document& document)
             {
-                return HTMLInputElement::create(HTMLNames::inputTag, document, /* form */ nullptr, /* createdByParser */ true);
+                return HTMLInputElement::create(document, /* form */ nullptr, /* createdByParser */ true);
             }
         };
 

--- a/Source/WebCore/html/shadow/SpatialImageControls.cpp
+++ b/Source/WebCore/html/shadow/SpatialImageControls.cpp
@@ -154,7 +154,7 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
         else if (imageHeight >= 490)
             paddingValue = 28;
 
-        Ref controlLayer = HTMLDivElement::create(document.get());
+        Ref controlLayer = HTMLDivElement::create(document);
         controlLayer->setIdAttribute(spatialImageControlsElementIdentifier());
         controlLayer->setAttributeWithoutSynchronization(HTMLNames::contenteditableAttr, falseAtom());
         controlLayer->setAttributeWithoutSynchronization(HTMLNames::dirAttr, isRTL ? "rtl"_s : "ltr"_s);
@@ -168,32 +168,32 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
         shadowRoot->appendChild(controlLayer);
 
         static MainThreadNeverDestroyed<const String> shadowStyle(StringImpl::createWithoutCopying(spatialImageControlsUserAgentStyleSheet));
-        Ref style = HTMLStyleElement::create(HTMLNames::styleTag, document.get(), false);
+        Ref style = HTMLStyleElement::create(document);
         style->setTextContent(String { shadowStyle });
         controlLayer->appendChild(WTF::move(style));
 
-        Ref button = HTMLButtonElement::create(HTMLNames::buttonTag, document.get(), nullptr);
+        Ref button = HTMLButtonElement::create(document);
         button->setIdAttribute(spatialImageControlsButtonIdentifier());
         button->setAttributeWithoutSynchronization(HTMLNames::aria_labelAttr, AtomString(localizedMediaControlElementString("EnterFullscreenButton"_s)));
         controlLayer->appendChild(button);
 
-        Ref backgroundBlurLayer = HTMLDivElement::create(document.get());
+        Ref backgroundBlurLayer = HTMLDivElement::create(document);
         backgroundBlurLayer->setIdAttribute("background-tint"_s);
         controlLayer->appendChild(backgroundBlurLayer);
 
-        Ref blur = HTMLDivElement::create(document.get());
+        Ref blur = HTMLDivElement::create(document);
         blur->setIdAttribute("blur"_s);
         backgroundBlurLayer->appendChild(blur);
 
-        Ref tint = HTMLDivElement::create(document.get());
+        Ref tint = HTMLDivElement::create(document);
         tint->setIdAttribute("tint"_s);
         backgroundBlurLayer->appendChild(tint);
 
-        Ref bottomGradient = HTMLDivElement::create(document.get());
+        Ref bottomGradient = HTMLDivElement::create(document);
         bottomGradient->setIdAttribute("bottom-gradient"_s);
         controlLayer->appendChild(bottomGradient);
 
-        Ref bottomLabelText = HTMLDivElement::create(document.get());
+        Ref bottomLabelText = HTMLDivElement::create(document);
         bottomLabelText->setIdAttribute("label"_s);
 #if ENABLE(PANORAMA_IMAGE_CONTROLS)
         bottomLabelText->setTextContent(isSpatialImage ? imageControlsLabelSpatial() : imageControlsLabelPanorama());
@@ -202,7 +202,7 @@ void ensureSpatialControls(HTMLImageElement& imageElement)
 #endif
         controlLayer->appendChild(bottomLabelText);
 
-        Ref glyphSpan = HTMLSpanElement::create(document.get());
+        Ref glyphSpan = HTMLSpanElement::create(document);
 #if ENABLE(PANORAMA_IMAGE_CONTROLS)
         glyphSpan->setIdAttribute(isSpatialImage ? "spatial-glyph"_s : "pano-glyph"_s);
 #else

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -519,7 +519,7 @@ void TextTrackCue::rebuildDisplayTree()
 
     if (m_fontSize) {
         if (RefPtr page = document->page()) {
-            Ref style = HTMLStyleElement::create(HTMLNames::styleTag, *document, false);
+            Ref style = HTMLStyleElement::create(*document);
             style->setTextContent(makeString(page->captionUserPreferencesStyleSheet(),
                 " ::"_s, UserAgentParts::cue(), "{font-size:"_s, m_fontSize, m_fontSizeIsImportant ? "px !important}"_s : "px}"_s));
             m_displayTree->appendChild(style);
@@ -529,7 +529,7 @@ void TextTrackCue::rebuildDisplayTree()
     if (track()) {
         if (const auto& styleSheets = track()->styleSheets()) {
             for (const auto& cssString : *styleSheets) {
-                Ref style = HTMLStyleElement::create(HTMLNames::styleTag, *document, false);
+                Ref style = HTMLStyleElement::create(*document);
                 style->setTextContent(String { cssString });
                 m_displayTree->appendChild(WTF::move(style));
             }

--- a/Source/WebCore/html/track/VTTCue.cpp
+++ b/Source/WebCore/html/track/VTTCue.cpp
@@ -282,7 +282,7 @@ Ref<VTTCue> VTTCue::create(Document& document, Ref<WebVTTCueData>&& data)
 VTTCue::VTTCue(Document& document, const MediaTime& start, const MediaTime& end, String&& content)
     : TextTrackCue(document, start, end)
     , m_content(WTF::move(content))
-    , m_cueHighlightBox(HTMLSpanElement::create(spanTag, document))
+    , m_cueHighlightBox(HTMLSpanElement::create(document))
     , m_cueBackdropBox(HTMLDivElement::create(document))
     , m_originalStartTime(MediaTime::zeroTime())
     , m_snapToLines(true)
@@ -974,14 +974,14 @@ void VTTCue::obtainCSSBoxes()
     Ref document = displayTree->document();
     if (RefPtr page = document->page()) {
         auto cssString = page->captionUserPreferencesStyleSheet();
-        Ref style = HTMLStyleElement::create(HTMLNames::styleTag, document.get(), false);
+        Ref style = HTMLStyleElement::create(document);
         style->setTextContent(WTF::move(cssString));
         displayTree->appendChild(WTF::move(style));
     }
 
     if (const auto& styleSheets = track()->styleSheets()) {
         for (const auto& cssString : *styleSheets) {
-            auto style = HTMLStyleElement::create(HTMLNames::styleTag, document.get(), false);
+            Ref style = HTMLStyleElement::create(document);
             style->setTextContent(String { cssString });
             displayTree->appendChild(WTF::move(style));
         }

--- a/Source/WebCore/mathml/MathMLFractionElement.cpp
+++ b/Source/WebCore/mathml/MathMLFractionElement.cpp
@@ -43,14 +43,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MathMLFractionElement);
 
 using namespace MathMLNames;
 
-inline MathMLFractionElement::MathMLFractionElement(const QualifiedName& tagName, Document& document)
-    : MathMLRowElement(tagName, document)
+inline MathMLFractionElement::MathMLFractionElement(Document& document)
+    : MathMLRowElement(mfracTag, document)
 {
 }
 
-Ref<MathMLFractionElement> MathMLFractionElement::create(const QualifiedName& tagName, Document& document)
+Ref<MathMLFractionElement> MathMLFractionElement::create(Document& document)
 {
-    return adoptRef(*new MathMLFractionElement(tagName, document));
+    return adoptRef(*new MathMLFractionElement(document));
 }
 
 const MathMLElement::Length& MathMLFractionElement::lineThickness()
@@ -142,7 +142,6 @@ void MathMLFractionElement::attributeChanged(const QualifiedName& name, const At
 
 RenderPtr<RenderElement> MathMLFractionElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    ASSERT(hasTagName(MathMLNames::mfracTag));
     return createRenderer<RenderMathMLFraction>(*this, WTF::move(style));
 }
 

--- a/Source/WebCore/mathml/MathMLFractionElement.h
+++ b/Source/WebCore/mathml/MathMLFractionElement.h
@@ -35,7 +35,7 @@ class MathMLFractionElement final : public MathMLRowElement {
     WTF_MAKE_TZONE_ALLOCATED(MathMLFractionElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLFractionElement);
 public:
-    static Ref<MathMLFractionElement> create(const QualifiedName& tagName, Document&);
+    static Ref<MathMLFractionElement> create(Document&);
     const Length& lineThickness();
     enum class FractionAlignment : uint8_t {
         Center,
@@ -46,7 +46,7 @@ public:
     FractionAlignment denominatorAlignment();
 
 private:
-    MathMLFractionElement(const QualifiedName& tagName, Document&);
+    explicit MathMLFractionElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool acceptsMathVariantAttribute() final { return false; };
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/mathml/MathMLMathElement.cpp
+++ b/Source/WebCore/mathml/MathMLMathElement.cpp
@@ -41,14 +41,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MathMLMathElement);
 
 using namespace MathMLNames;
 
-inline MathMLMathElement::MathMLMathElement(const QualifiedName& tagName, Document& document)
-    : MathMLRowElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
+inline MathMLMathElement::MathMLMathElement(Document& document)
+    : MathMLRowElement(mathTag, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
 }
 
-Ref<MathMLMathElement> MathMLMathElement::create(const QualifiedName& tagName, Document& document)
+Ref<MathMLMathElement> MathMLMathElement::create(Document& document)
 {
-    return adoptRef(*new MathMLMathElement(tagName, document));
+    return adoptRef(*new MathMLMathElement(document));
 }
 
 RenderPtr<RenderElement> MathMLMathElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/mathml/MathMLMathElement.h
+++ b/Source/WebCore/mathml/MathMLMathElement.h
@@ -37,10 +37,10 @@ class MathMLMathElement final : public MathMLRowElement {
     WTF_MAKE_TZONE_ALLOCATED(MathMLMathElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLMathElement);
 public:
-    static Ref<MathMLMathElement> create(const QualifiedName& tagName, Document&);
+    static Ref<MathMLMathElement> create(Document&);
 
 private:
-    MathMLMathElement(const QualifiedName& tagName, Document&);
+    explicit MathMLMathElement(Document&);
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void didAttachRenderers() final;
 

--- a/Source/WebCore/mathml/MathMLMencloseElement.cpp
+++ b/Source/WebCore/mathml/MathMLMencloseElement.cpp
@@ -40,17 +40,17 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MathMLMencloseElement);
 
 using namespace MathMLNames;
 
-MathMLMencloseElement::MathMLMencloseElement(const QualifiedName& tagName, Document& document)
-    : MathMLRowElement(tagName, document)
+MathMLMencloseElement::MathMLMencloseElement(Document& document)
+    : MathMLRowElement(mencloseTag, document)
 {
     // By default we draw a longdiv.
     clearNotations();
     addNotation(LongDiv);
 }
 
-Ref<MathMLMencloseElement> MathMLMencloseElement::create(const QualifiedName& tagName, Document& document)
+Ref<MathMLMencloseElement> MathMLMencloseElement::create(Document& document)
 {
-    return adoptRef(*new MathMLMencloseElement(tagName, document));
+    return adoptRef(*new MathMLMencloseElement(document));
 }
 
 RenderPtr<RenderElement> MathMLMencloseElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/mathml/MathMLMencloseElement.h
+++ b/Source/WebCore/mathml/MathMLMencloseElement.h
@@ -37,7 +37,7 @@ class MathMLMencloseElement final: public MathMLRowElement {
     WTF_MAKE_TZONE_ALLOCATED(MathMLMencloseElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLMencloseElement);
 public:
-    static Ref<MathMLMencloseElement> create(const QualifiedName& tagName, Document&);
+    static Ref<MathMLMencloseElement> create(Document&);
 
     enum MencloseNotationFlag {
         LongDiv = 1 << 1,
@@ -58,7 +58,7 @@ public:
     bool hasNotation(MencloseNotationFlag);
 
 private:
-    MathMLMencloseElement(const QualifiedName&, Document&);
+    explicit MathMLMencloseElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void parseNotationAttribute();

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -43,15 +43,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MathMLOperatorElement);
 using namespace MathMLNames;
 using namespace MathMLOperatorDictionary;
 
-MathMLOperatorElement::MathMLOperatorElement(const QualifiedName& tagName, Document& document)
-    : MathMLTokenElement(tagName, document)
+MathMLOperatorElement::MathMLOperatorElement(Document& document)
+    : MathMLTokenElement(moTag, document)
 {
-    ASSERT(hasTagName(MathMLNames::moTag));
 }
 
-Ref<MathMLOperatorElement> MathMLOperatorElement::create(const QualifiedName& tagName, Document& document)
+Ref<MathMLOperatorElement> MathMLOperatorElement::create(Document& document)
 {
-    return adoptRef(*new MathMLOperatorElement(tagName, document));
+    return adoptRef(*new MathMLOperatorElement(document));
 }
 
 MathMLOperatorElement::OperatorChar MathMLOperatorElement::parseOperatorChar(const String& string)

--- a/Source/WebCore/mathml/MathMLOperatorElement.h
+++ b/Source/WebCore/mathml/MathMLOperatorElement.h
@@ -36,7 +36,7 @@ class MathMLOperatorElement final : public MathMLTokenElement {
     WTF_MAKE_TZONE_ALLOCATED(MathMLOperatorElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLOperatorElement);
 public:
-    static Ref<MathMLOperatorElement> create(const QualifiedName&, Document&);
+    static Ref<MathMLOperatorElement> create(Document&);
     struct OperatorChar {
         char32_t character { 0 };
         bool isVertical { true };
@@ -54,7 +54,7 @@ public:
     const Length& maxSize();
 
 private:
-    MathMLOperatorElement(const QualifiedName&, Document&);
+    explicit MathMLOperatorElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     void childrenChanged(const ChildChange&) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/mathml/MathMLPaddedElement.cpp
+++ b/Source/WebCore/mathml/MathMLPaddedElement.cpp
@@ -41,14 +41,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MathMLPaddedElement);
 
 using namespace MathMLNames;
 
-inline MathMLPaddedElement::MathMLPaddedElement(const QualifiedName& tagName, Document& document)
-    : MathMLRowElement(tagName, document)
+inline MathMLPaddedElement::MathMLPaddedElement(Document& document)
+    : MathMLRowElement(mpaddedTag, document)
 {
 }
 
-Ref<MathMLPaddedElement> MathMLPaddedElement::create(const QualifiedName& tagName, Document& document)
+Ref<MathMLPaddedElement> MathMLPaddedElement::create(Document& document)
 {
-    return adoptRef(*new MathMLPaddedElement(tagName, document));
+    return adoptRef(*new MathMLPaddedElement(document));
 }
 
 const MathMLElement::Length& MathMLPaddedElement::width()
@@ -114,7 +114,6 @@ void MathMLPaddedElement::attributeChanged(const QualifiedName& name, const Atom
 
 RenderPtr<RenderElement> MathMLPaddedElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    ASSERT(hasTagName(MathMLNames::mpaddedTag));
     return createRenderer<RenderMathMLPadded>(*this, WTF::move(style));
 }
 

--- a/Source/WebCore/mathml/MathMLPaddedElement.h
+++ b/Source/WebCore/mathml/MathMLPaddedElement.h
@@ -35,7 +35,7 @@ class MathMLPaddedElement final : public MathMLRowElement {
     WTF_MAKE_TZONE_ALLOCATED(MathMLPaddedElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLPaddedElement);
 public:
-    static Ref<MathMLPaddedElement> create(const QualifiedName& tagName, Document&);
+    static Ref<MathMLPaddedElement> create(Document&);
     // FIXME: Pseudo-units are not supported yet (https://bugs.webkit.org/show_bug.cgi?id=85730).
     const Length& width();
     const Length& height();
@@ -43,7 +43,7 @@ public:
     const Length& lspace();
     const Length& voffset();
 private:
-    MathMLPaddedElement(const QualifiedName& tagName, Document&);
+    explicit MathMLPaddedElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 

--- a/Source/WebCore/mathml/MathMLSpaceElement.cpp
+++ b/Source/WebCore/mathml/MathMLSpaceElement.cpp
@@ -41,14 +41,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(MathMLSpaceElement);
 
 using namespace MathMLNames;
 
-MathMLSpaceElement::MathMLSpaceElement(const QualifiedName& tagName, Document& document)
-    : MathMLPresentationElement(tagName, document)
+MathMLSpaceElement::MathMLSpaceElement(Document& document)
+    : MathMLPresentationElement(mspaceTag, document)
 {
 }
 
-Ref<MathMLSpaceElement> MathMLSpaceElement::create(const QualifiedName& tagName, Document& document)
+Ref<MathMLSpaceElement> MathMLSpaceElement::create(Document& document)
 {
-    return adoptRef(*new MathMLSpaceElement(tagName, document));
+    return adoptRef(*new MathMLSpaceElement(document));
 }
 
 const MathMLElement::Length& MathMLSpaceElement::width()
@@ -96,7 +96,6 @@ void MathMLSpaceElement::attributeChanged(const QualifiedName& name, const AtomS
 
 RenderPtr<RenderElement> MathMLSpaceElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    ASSERT(hasTagName(MathMLNames::mspaceTag));
     return createRenderer<RenderMathMLSpace>(*this, WTF::move(style));
 }
 

--- a/Source/WebCore/mathml/MathMLSpaceElement.h
+++ b/Source/WebCore/mathml/MathMLSpaceElement.h
@@ -35,12 +35,12 @@ class MathMLSpaceElement final : public MathMLPresentationElement {
     WTF_MAKE_TZONE_ALLOCATED(MathMLSpaceElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(MathMLSpaceElement);
 public:
-    static Ref<MathMLSpaceElement> create(const QualifiedName& tagName, Document&);
+    static Ref<MathMLSpaceElement> create(Document&);
     const Length& width();
     const Length& height();
     const Length& depth();
 private:
-    MathMLSpaceElement(const QualifiedName& tagName, Document&);
+    explicit MathMLSpaceElement(Document&);
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -1034,7 +1034,7 @@ static Ref<Element> createFacebookFlagElement(Document& document, ASCIILiteral v
 {
     Ref text = Text::create(document, makeString("{\"require\":[[\"HasteSupportData\",\"handle\",null,[{\"gkxData\":{\""_s, value, "\":{\"result\":true,\"hash\":null}}}]]]}"_s));
 
-    Ref script = HTMLScriptElement::create(HTMLNames::scriptTag, document, false);
+    Ref script = HTMLScriptElement::create(document);
     Ref { script->dataset() }->setNamedItem("contentLen"_s, AtomString { makeString(text->length()) });
     script->appendChild(text);
 

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -52,12 +52,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAElement);
 
-inline SVGAElement::SVGAElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGAElement::SVGAElement(Document& document)
+    : SVGGraphicsElement(SVGNames::aTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
 {
-    ASSERT(hasTagName(SVGNames::aTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -67,9 +65,9 @@ inline SVGAElement::SVGAElement(const QualifiedName& tagName, Document& document
 
 SVGAElement::~SVGAElement() = default;
 
-Ref<SVGAElement> SVGAElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGAElement> SVGAElement::create(Document& document)
 {
-    return adoptRef(*new SVGAElement(tagName, document));
+    return adoptRef(*new SVGAElement(document));
 }
 
 String SVGAElement::title() const

--- a/Source/WebCore/svg/SVGAElement.h
+++ b/Source/WebCore/svg/SVGAElement.h
@@ -37,7 +37,7 @@ class SVGAElement final : public SVGGraphicsElement, public SVGURIReference {
     WTF_MAKE_TZONE_ALLOCATED(SVGAElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAElement);
 public:
-    static Ref<SVGAElement> create(const QualifiedName&, Document&);
+    static Ref<SVGAElement> create(Document&);
     ~SVGAElement();
 
     AtomString target() const final { return AtomString { m_target->currentValue() }; }
@@ -48,7 +48,7 @@ public:
     DOMTokenList& relList();
 
 private:
-    SVGAElement(const QualifiedName&, Document&);
+    explicit SVGAElement(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAElement, SVGGraphicsElement, SVGURIReference>;
 

--- a/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphDefElement.cpp
@@ -31,15 +31,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAltGlyphDefElement);
 
-inline SVGAltGlyphDefElement::SVGAltGlyphDefElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGAltGlyphDefElement::SVGAltGlyphDefElement(Document& document)
+    : SVGElement(SVGNames::altGlyphDefTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::altGlyphDefTag));
 }
 
-Ref<SVGAltGlyphDefElement> SVGAltGlyphDefElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGAltGlyphDefElement> SVGAltGlyphDefElement::create(Document& document)
 {
-    return adoptRef(*new SVGAltGlyphDefElement(tagName, document));
+    return adoptRef(*new SVGAltGlyphDefElement(document));
 }
 
 bool SVGAltGlyphDefElement::hasValidGlyphElements(Vector<String>& glyphNames) const

--- a/Source/WebCore/svg/SVGAltGlyphDefElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphDefElement.h
@@ -28,12 +28,12 @@ class SVGAltGlyphDefElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGAltGlyphDefElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAltGlyphDefElement);
 public:
-    static Ref<SVGAltGlyphDefElement> create(const QualifiedName&, Document&);
+    static Ref<SVGAltGlyphDefElement> create(Document&);
 
     bool hasValidGlyphElements(Vector<String>& glyphNames) const;
 
 private:
-    SVGAltGlyphDefElement(const QualifiedName&, Document&);
+    explicit SVGAltGlyphDefElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 };

--- a/Source/WebCore/svg/SVGAltGlyphElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphElement.cpp
@@ -37,16 +37,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAltGlyphElement);
 
-inline SVGAltGlyphElement::SVGAltGlyphElement(const QualifiedName& tagName, Document& document)
-    : SVGTextPositioningElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGAltGlyphElement::SVGAltGlyphElement(Document& document)
+    : SVGTextPositioningElement(SVGNames::altGlyphTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
 {
-    ASSERT(hasTagName(SVGNames::altGlyphTag));
 }
 
-Ref<SVGAltGlyphElement> SVGAltGlyphElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGAltGlyphElement> SVGAltGlyphElement::create(Document& document)
 {
-    return adoptRef(*new SVGAltGlyphElement(tagName, document));
+    return adoptRef(*new SVGAltGlyphElement(document));
 }
 
 ExceptionOr<void> SVGAltGlyphElement::setGlyphRef(const AtomString&)

--- a/Source/WebCore/svg/SVGAltGlyphElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphElement.h
@@ -33,7 +33,7 @@ class SVGAltGlyphElement final : public SVGTextPositioningElement, public SVGURI
     WTF_MAKE_TZONE_ALLOCATED(SVGAltGlyphElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAltGlyphElement);
 public:
-    static Ref<SVGAltGlyphElement> create(const QualifiedName&, Document&);
+    static Ref<SVGAltGlyphElement> create(Document&);
 
     const AtomString& glyphRef() const;
     ExceptionOr<void> setGlyphRef(const AtomString&);
@@ -45,7 +45,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGAltGlyphElement, SVGTextPositioningElement, SVGURIReference>;
 
 private:
-    SVGAltGlyphElement(const QualifiedName&, Document&);
+    explicit SVGAltGlyphElement(Document&);
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     bool childShouldCreateRenderer(const Node&) const override;

--- a/Source/WebCore/svg/SVGAltGlyphItemElement.cpp
+++ b/Source/WebCore/svg/SVGAltGlyphItemElement.cpp
@@ -31,15 +31,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAltGlyphItemElement);
 
-inline SVGAltGlyphItemElement::SVGAltGlyphItemElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGAltGlyphItemElement::SVGAltGlyphItemElement(Document& document)
+    : SVGElement(SVGNames::altGlyphItemTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::altGlyphItemTag));
 }
 
-Ref<SVGAltGlyphItemElement> SVGAltGlyphItemElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGAltGlyphItemElement> SVGAltGlyphItemElement::create(Document& document)
 {
-    return adoptRef(*new SVGAltGlyphItemElement(tagName, document));
+    return adoptRef(*new SVGAltGlyphItemElement(document));
 }
 
 bool SVGAltGlyphItemElement::hasValidGlyphElements(Vector<String>& glyphNames) const

--- a/Source/WebCore/svg/SVGAltGlyphItemElement.h
+++ b/Source/WebCore/svg/SVGAltGlyphItemElement.h
@@ -28,12 +28,12 @@ class SVGAltGlyphItemElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGAltGlyphItemElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAltGlyphItemElement);
 public:
-    static Ref<SVGAltGlyphItemElement> create(const QualifiedName&, Document&);
+    static Ref<SVGAltGlyphItemElement> create(Document&);
 
     bool hasValidGlyphElements(Vector<String>& glyphNames) const;
 
 private:
-    SVGAltGlyphItemElement(const QualifiedName&, Document&);
+    explicit SVGAltGlyphItemElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 };

--- a/Source/WebCore/svg/SVGAnimateElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateElement.cpp
@@ -26,21 +26,21 @@
 #include "config.h"
 #include "SVGAnimateElement.h"
 
+#include "SVGNames.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAnimateElement);
 
-SVGAnimateElement::SVGAnimateElement(const QualifiedName& tagName, Document& document)
-    : SVGAnimateElementBase(tagName, document)
+SVGAnimateElement::SVGAnimateElement(Document& document)
+    : SVGAnimateElementBase(SVGNames::animateTag, document)
 {
-    ASSERT(hasTagName(SVGNames::animateTag));
 }
 
-Ref<SVGAnimateElement> SVGAnimateElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGAnimateElement> SVGAnimateElement::create(Document& document)
 {
-    return adoptRef(*new SVGAnimateElement(tagName, document));
+    return adoptRef(*new SVGAnimateElement(document));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGAnimateElement.h
+++ b/Source/WebCore/svg/SVGAnimateElement.h
@@ -35,10 +35,10 @@ class SVGAnimateElement final : public SVGAnimateElementBase {
     WTF_MAKE_TZONE_ALLOCATED(SVGAnimateElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimateElement);
 public:
-    static Ref<SVGAnimateElement> create(const QualifiedName&, Document&);
+    static Ref<SVGAnimateElement> create(Document&);
 
 private:
-    SVGAnimateElement(const QualifiedName&, Document&);
+    explicit SVGAnimateElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGAnimateMotionElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.cpp
@@ -50,16 +50,15 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAnimateMotionElement);
     
 using namespace SVGNames;
 
-inline SVGAnimateMotionElement::SVGAnimateMotionElement(const QualifiedName& tagName, Document& document)
-    : SVGAnimationElement(tagName, document)
+inline SVGAnimateMotionElement::SVGAnimateMotionElement(Document& document)
+    : SVGAnimationElement(SVGNames::animateMotionTag, document)
 {
     setCalcMode(CalcMode::Paced);
-    ASSERT(hasTagName(animateMotionTag));
 }
 
-Ref<SVGAnimateMotionElement> SVGAnimateMotionElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGAnimateMotionElement> SVGAnimateMotionElement::create(Document& document)
 {
-    return adoptRef(*new SVGAnimateMotionElement(tagName, document));
+    return adoptRef(*new SVGAnimateMotionElement(document));
 }
 
 bool SVGAnimateMotionElement::hasValidAttributeType() const

--- a/Source/WebCore/svg/SVGAnimateMotionElement.h
+++ b/Source/WebCore/svg/SVGAnimateMotionElement.h
@@ -31,11 +31,11 @@ class SVGAnimateMotionElement final : public SVGAnimationElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGAnimateMotionElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimateMotionElement);
 public:
-    static Ref<SVGAnimateMotionElement> create(const QualifiedName&, Document&);
+    static Ref<SVGAnimateMotionElement> create(Document&);
     void updateAnimationPath();
 
 private:
-    SVGAnimateMotionElement(const QualifiedName&, Document&);
+    explicit SVGAnimateMotionElement(Document&);
 
     bool hasValidAttributeType() const override;
     bool hasValidAttributeName() const override;

--- a/Source/WebCore/svg/SVGAnimateTransformElement.cpp
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.cpp
@@ -31,16 +31,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGAnimateTransformElement);
 
-inline SVGAnimateTransformElement::SVGAnimateTransformElement(const QualifiedName& tagName, Document& document)
-    : SVGAnimateElementBase(tagName, document)
+inline SVGAnimateTransformElement::SVGAnimateTransformElement(Document& document)
+    : SVGAnimateElementBase(SVGNames::animateTransformTag, document)
     , m_type(SVGTransformValue::SVG_TRANSFORM_TRANSLATE)
 {
-    ASSERT(hasTagName(SVGNames::animateTransformTag));
 }
 
-Ref<SVGAnimateTransformElement> SVGAnimateTransformElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGAnimateTransformElement> SVGAnimateTransformElement::create(Document& document)
 {
-    return adoptRef(*new SVGAnimateTransformElement(tagName, document));
+    return adoptRef(*new SVGAnimateTransformElement(document));
 }
 
 bool SVGAnimateTransformElement::hasValidAttributeType() const

--- a/Source/WebCore/svg/SVGAnimateTransformElement.h
+++ b/Source/WebCore/svg/SVGAnimateTransformElement.h
@@ -33,12 +33,12 @@ class SVGAnimateTransformElement final : public SVGAnimateElementBase {
     WTF_MAKE_TZONE_ALLOCATED(SVGAnimateTransformElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGAnimateTransformElement);
 public:
-    static Ref<SVGAnimateTransformElement> create(const QualifiedName&, Document&);
+    static Ref<SVGAnimateTransformElement> create(Document&);
 
     SVGTransformValue::SVGTransformType transformType() const { return m_type; }
 
 private:
-    SVGAnimateTransformElement(const QualifiedName&, Document&);
+    explicit SVGAnimateTransformElement(Document&);
     
     bool hasValidAttributeType() const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/svg/SVGCircleElement.cpp
+++ b/Source/WebCore/svg/SVGCircleElement.cpp
@@ -36,11 +36,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGCircleElement);
 
-inline SVGCircleElement::SVGCircleElement(const QualifiedName& tagName, Document& document)
-    : SVGGeometryElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGCircleElement::SVGCircleElement(Document& document)
+    : SVGGeometryElement(SVGNames::circleTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::circleTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -50,9 +48,9 @@ inline SVGCircleElement::SVGCircleElement(const QualifiedName& tagName, Document
     }
 }
 
-Ref<SVGCircleElement> SVGCircleElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGCircleElement> SVGCircleElement::create(Document& document)
 {
-    return adoptRef(*new SVGCircleElement(tagName, document));
+    return adoptRef(*new SVGCircleElement(document));
 }
 
 SVGAnimatedPropertyBase* SVGCircleElement::propertyForAttribute(const QualifiedName& name) const

--- a/Source/WebCore/svg/SVGCircleElement.h
+++ b/Source/WebCore/svg/SVGCircleElement.h
@@ -31,7 +31,7 @@ class SVGCircleElement final : public SVGGeometryElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGCircleElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGCircleElement);
 public:
-    static Ref<SVGCircleElement> create(const QualifiedName&, Document&);
+    static Ref<SVGCircleElement> create(Document&);
 
     const SVGLengthValue& cx() const { return m_cx->currentValue(); }
     const SVGLengthValue& cy() const { return m_cy->currentValue(); }
@@ -46,7 +46,7 @@ public:
     SVGAnimatedPropertyBase* propertyForAttribute(const QualifiedName&) const;
 
 private:
-    SVGCircleElement(const QualifiedName&, Document&);
+    explicit SVGCircleElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -46,11 +46,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGClipPathElement);
 
-inline SVGClipPathElement::SVGClipPathElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGClipPathElement::SVGClipPathElement(Document& document)
+    : SVGGraphicsElement(SVGNames::clipPathTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::clipPathTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -58,9 +56,9 @@ inline SVGClipPathElement::SVGClipPathElement(const QualifiedName& tagName, Docu
     }
 }
 
-Ref<SVGClipPathElement> SVGClipPathElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGClipPathElement> SVGClipPathElement::create(Document& document)
 {
-    return adoptRef(*new SVGClipPathElement(tagName, document));
+    return adoptRef(*new SVGClipPathElement(document));
 }
 
 void SVGClipPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGClipPathElement.h
+++ b/Source/WebCore/svg/SVGClipPathElement.h
@@ -35,7 +35,7 @@ class SVGClipPathElement final : public SVGGraphicsElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGClipPathElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGClipPathElement);
 public:
-    static Ref<SVGClipPathElement> create(const QualifiedName&, Document&);
+    static Ref<SVGClipPathElement> create(Document&);
 
     SVGUnitTypes::SVGUnitType clipPathUnits() const { return m_clipPathUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     SVGAnimatedEnumeration& clipPathUnitsAnimated() { return m_clipPathUnits; }
@@ -47,7 +47,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGClipPathElement, SVGGraphicsElement>;
 
 private:
-    SVGClipPathElement(const QualifiedName&, Document&);
+    explicit SVGClipPathElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGCursorElement.cpp
+++ b/Source/WebCore/svg/SVGCursorElement.cpp
@@ -36,13 +36,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGCursorElement);
 
-inline SVGCursorElement::SVGCursorElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGCursorElement::SVGCursorElement(Document& document)
+    : SVGElement(SVGNames::cursorTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGTests(this)
     , SVGURIReference(this)
 {
-    ASSERT(hasTagName(SVGNames::cursorTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -51,9 +49,9 @@ inline SVGCursorElement::SVGCursorElement(const QualifiedName& tagName, Document
     }
 }
 
-Ref<SVGCursorElement> SVGCursorElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGCursorElement> SVGCursorElement::create(Document& document)
 {
-    return adoptRef(*new SVGCursorElement(tagName, document));
+    return adoptRef(*new SVGCursorElement(document));
 }
 
 SVGCursorElement::~SVGCursorElement()

--- a/Source/WebCore/svg/SVGCursorElement.h
+++ b/Source/WebCore/svg/SVGCursorElement.h
@@ -34,7 +34,7 @@ class SVGCursorElement final : public SVGElement, public SVGTests, public SVGURI
     WTF_MAKE_TZONE_ALLOCATED(SVGCursorElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGCursorElement);
 public:
-    static Ref<SVGCursorElement> create(const QualifiedName&, Document&);
+    static Ref<SVGCursorElement> create(Document&);
 
     virtual ~SVGCursorElement();
 
@@ -50,7 +50,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGCursorElement, SVGElement, SVGTests, SVGURIReference>;
 
 private:
-    SVGCursorElement(const QualifiedName&, Document&);
+    explicit SVGCursorElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGDefsElement.cpp
+++ b/Source/WebCore/svg/SVGDefsElement.cpp
@@ -34,15 +34,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGDefsElement);
 
-inline SVGDefsElement::SVGDefsElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGDefsElement::SVGDefsElement(Document& document)
+    : SVGGraphicsElement(SVGNames::defsTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::defsTag));
 }
 
-Ref<SVGDefsElement> SVGDefsElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGDefsElement> SVGDefsElement::create(Document& document)
 {
-    return adoptRef(*new SVGDefsElement(tagName, document));
+    return adoptRef(*new SVGDefsElement(document));
 }
 
 bool SVGDefsElement::isValid() const

--- a/Source/WebCore/svg/SVGDefsElement.h
+++ b/Source/WebCore/svg/SVGDefsElement.h
@@ -30,12 +30,12 @@ class SVGDefsElement final : public SVGGraphicsElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGDefsElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGDefsElement);
 public:
-    static Ref<SVGDefsElement> create(const QualifiedName&, Document&);
+    static Ref<SVGDefsElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGDefsElement, SVGGraphicsElement>;
 
 private:
-    SVGDefsElement(const QualifiedName&, Document&);
+    explicit SVGDefsElement(Document&);
 
     bool isValid() const final;
     bool supportsFocus() const final { return false; }

--- a/Source/WebCore/svg/SVGDescElement.cpp
+++ b/Source/WebCore/svg/SVGDescElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGDescElement);
 
-inline SVGDescElement::SVGDescElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGDescElement::SVGDescElement(Document& document)
+    : SVGElement(SVGNames::descTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::descTag));
 }
 
-Ref<SVGDescElement> SVGDescElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGDescElement> SVGDescElement::create(Document& document)
 {
-    return adoptRef(*new SVGDescElement(tagName, document));
+    return adoptRef(*new SVGDescElement(document));
 }
 
 String SVGDescElement::description() const

--- a/Source/WebCore/svg/SVGDescElement.h
+++ b/Source/WebCore/svg/SVGDescElement.h
@@ -29,12 +29,12 @@ class SVGDescElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGDescElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGDescElement);
 public:
-    static Ref<SVGDescElement> create(const QualifiedName&, Document&);
+    static Ref<SVGDescElement> create(Document&);
 
     String description() const;
 
 private:
-    SVGDescElement(const QualifiedName&, Document&);
+    explicit SVGDescElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
     bool supportsFocus() const final { return false; }

--- a/Source/WebCore/svg/SVGEllipseElement.cpp
+++ b/Source/WebCore/svg/SVGEllipseElement.cpp
@@ -35,11 +35,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGEllipseElement);
 
-inline SVGEllipseElement::SVGEllipseElement(const QualifiedName& tagName, Document& document)
-    : SVGGeometryElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGEllipseElement::SVGEllipseElement(Document& document)
+    : SVGGeometryElement(SVGNames::ellipseTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::ellipseTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -48,11 +46,11 @@ inline SVGEllipseElement::SVGEllipseElement(const QualifiedName& tagName, Docume
         PropertyRegistry::registerProperty<SVGNames::rxAttr, &SVGEllipseElement::m_rx>();
         PropertyRegistry::registerProperty<SVGNames::ryAttr, &SVGEllipseElement::m_ry>();
     }
-}    
+}
 
-Ref<SVGEllipseElement> SVGEllipseElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGEllipseElement> SVGEllipseElement::create(Document& document)
 {
-    return adoptRef(*new SVGEllipseElement(tagName, document));
+    return adoptRef(*new SVGEllipseElement(document));
 }
 
 void SVGEllipseElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGEllipseElement.h
+++ b/Source/WebCore/svg/SVGEllipseElement.h
@@ -31,7 +31,7 @@ class SVGEllipseElement final : public SVGGeometryElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGEllipseElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGEllipseElement);
 public:
-    static Ref<SVGEllipseElement> create(const QualifiedName&, Document&);
+    static Ref<SVGEllipseElement> create(Document&);
 
     const SVGLengthValue& cx() const { return m_cx->currentValue(); }
     const SVGLengthValue& cy() const { return m_cy->currentValue(); }
@@ -46,7 +46,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGEllipseElement, SVGGeometryElement>;
 
 private:
-    SVGEllipseElement(const QualifiedName&, Document&);
+    explicit SVGEllipseElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGFEBlendElement.cpp
+++ b/Source/WebCore/svg/SVGFEBlendElement.cpp
@@ -33,11 +33,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEBlendElement);
 
-inline SVGFEBlendElement::SVGFEBlendElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEBlendElement::SVGFEBlendElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feBlendTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feBlendTag));
-    
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -47,9 +45,9 @@ inline SVGFEBlendElement::SVGFEBlendElement(const QualifiedName& tagName, Docume
     }
 }
 
-Ref<SVGFEBlendElement> SVGFEBlendElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEBlendElement> SVGFEBlendElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEBlendElement(tagName, document));
+    return adoptRef(*new SVGFEBlendElement(document));
 }
 
 void SVGFEBlendElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEBlendElement.h
+++ b/Source/WebCore/svg/SVGFEBlendElement.h
@@ -52,7 +52,7 @@ class SVGFEBlendElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEBlendElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEBlendElement);
 public:
-    static Ref<SVGFEBlendElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEBlendElement> create(Document&);
 
     String in1() const { return m_in1->currentValue(); }
     String in2() const { return m_in2->currentValue(); }
@@ -65,7 +65,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEBlendElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEBlendElement(const QualifiedName&, Document&);
+    explicit SVGFEBlendElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -32,11 +32,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEColorMatrixElement);
 
-inline SVGFEColorMatrixElement::SVGFEColorMatrixElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEColorMatrixElement::SVGFEColorMatrixElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feColorMatrixTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feColorMatrixTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -46,9 +44,9 @@ inline SVGFEColorMatrixElement::SVGFEColorMatrixElement(const QualifiedName& tag
     }
 }
 
-Ref<SVGFEColorMatrixElement> SVGFEColorMatrixElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEColorMatrixElement> SVGFEColorMatrixElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEColorMatrixElement(tagName, document));
+    return adoptRef(*new SVGFEColorMatrixElement(document));
 }
 
 bool SVGFEColorMatrixElement::isInvalidValuesLength() const

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -68,7 +68,7 @@ class SVGFEColorMatrixElement final : public SVGFilterPrimitiveStandardAttribute
     WTF_MAKE_TZONE_ALLOCATED(SVGFEColorMatrixElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEColorMatrixElement);
 public:
-    static Ref<SVGFEColorMatrixElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEColorMatrixElement> create(Document&);
 
     String in1() const { return m_in1->currentValue(); }
     ColorMatrixType type() const { return m_type->currentValue<ColorMatrixType>(); }
@@ -81,7 +81,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEColorMatrixElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEColorMatrixElement(const QualifiedName&, Document&);
+    explicit SVGFEColorMatrixElement(Document&);
 
     bool isInvalidValuesLength() const;
 

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.cpp
@@ -36,11 +36,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEComponentTransferElement);
 
-inline SVGFEComponentTransferElement::SVGFEComponentTransferElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEComponentTransferElement::SVGFEComponentTransferElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feComponentTransferTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feComponentTransferTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -48,9 +46,9 @@ inline SVGFEComponentTransferElement::SVGFEComponentTransferElement(const Qualif
     }
 }
 
-Ref<SVGFEComponentTransferElement> SVGFEComponentTransferElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEComponentTransferElement> SVGFEComponentTransferElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEComponentTransferElement(tagName, document));
+    return adoptRef(*new SVGFEComponentTransferElement(document));
 }
 
 void SVGFEComponentTransferElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEComponentTransferElement.h
+++ b/Source/WebCore/svg/SVGFEComponentTransferElement.h
@@ -33,7 +33,7 @@ class SVGFEComponentTransferElement final : public SVGFilterPrimitiveStandardAtt
     WTF_MAKE_TZONE_ALLOCATED(SVGFEComponentTransferElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEComponentTransferElement);
 public:
-    static Ref<SVGFEComponentTransferElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEComponentTransferElement> create(Document&);
 
     String in1() const { return m_in1->currentValue(); }
     SVGAnimatedString& in1Animated() { return m_in1; }
@@ -46,7 +46,7 @@ protected:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEComponentTransferElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEComponentTransferElement(const QualifiedName&, Document&);
+    explicit SVGFEComponentTransferElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -32,11 +32,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFECompositeElement);
 
-inline SVGFECompositeElement::SVGFECompositeElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFECompositeElement::SVGFECompositeElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feCompositeTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feCompositeTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -50,9 +48,9 @@ inline SVGFECompositeElement::SVGFECompositeElement(const QualifiedName& tagName
     }
 }
 
-Ref<SVGFECompositeElement> SVGFECompositeElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFECompositeElement> SVGFECompositeElement::create(Document& document)
 {
-    return adoptRef(*new SVGFECompositeElement(tagName, document));
+    return adoptRef(*new SVGFECompositeElement(document));
 }
 
 void SVGFECompositeElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFECompositeElement.h
+++ b/Source/WebCore/svg/SVGFECompositeElement.h
@@ -77,7 +77,7 @@ class SVGFECompositeElement final : public SVGFilterPrimitiveStandardAttributes 
     WTF_MAKE_TZONE_ALLOCATED(SVGFECompositeElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFECompositeElement);
 public:
-    static Ref<SVGFECompositeElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFECompositeElement> create(Document&);
 
     String in1() const { return m_in1->currentValue(); }
     String in2() const { return m_in2->currentValue(); }
@@ -98,7 +98,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFECompositeElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFECompositeElement(const QualifiedName&, Document&);
+    explicit SVGFECompositeElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -37,11 +37,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEConvolveMatrixElement);
 
-inline SVGFEConvolveMatrixElement::SVGFEConvolveMatrixElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEConvolveMatrixElement::SVGFEConvolveMatrixElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feConvolveMatrixTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feConvolveMatrixTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -58,9 +56,9 @@ inline SVGFEConvolveMatrixElement::SVGFEConvolveMatrixElement(const QualifiedNam
     }
 }
 
-Ref<SVGFEConvolveMatrixElement> SVGFEConvolveMatrixElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEConvolveMatrixElement> SVGFEConvolveMatrixElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEConvolveMatrixElement(tagName, document));
+    return adoptRef(*new SVGFEConvolveMatrixElement(document));
 }
 
 void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.h
@@ -65,7 +65,7 @@ class SVGFEConvolveMatrixElement final : public SVGFilterPrimitiveStandardAttrib
     WTF_MAKE_TZONE_ALLOCATED(SVGFEConvolveMatrixElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEConvolveMatrixElement);
 public:
-    static Ref<SVGFEConvolveMatrixElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEConvolveMatrixElement> create(Document&);
 
     void setOrder(float orderX, float orderY);
     void setKernelUnitLength(float kernelUnitLengthX, float kernelUnitLengthY);
@@ -99,7 +99,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEConvolveMatrixElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEConvolveMatrixElement(const QualifiedName&, Document&);
+    explicit SVGFEConvolveMatrixElement(Document&);
 
     static constexpr int initialOrderValue = 3;
     static constexpr float initialDivisorValue = 1;

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -36,11 +36,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEDiffuseLightingElement);
 
-inline SVGFEDiffuseLightingElement::SVGFEDiffuseLightingElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEDiffuseLightingElement::SVGFEDiffuseLightingElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feDiffuseLightingTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feDiffuseLightingTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -51,9 +49,9 @@ inline SVGFEDiffuseLightingElement::SVGFEDiffuseLightingElement(const QualifiedN
     }
 }
 
-Ref<SVGFEDiffuseLightingElement> SVGFEDiffuseLightingElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEDiffuseLightingElement> SVGFEDiffuseLightingElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEDiffuseLightingElement(tagName, document));
+    return adoptRef(*new SVGFEDiffuseLightingElement(document));
 }
 
 void SVGFEDiffuseLightingElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
@@ -35,7 +35,7 @@ class SVGFEDiffuseLightingElement final : public SVGFilterPrimitiveStandardAttri
     WTF_MAKE_TZONE_ALLOCATED(SVGFEDiffuseLightingElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEDiffuseLightingElement);
 public:
-    static Ref<SVGFEDiffuseLightingElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEDiffuseLightingElement> create(Document&);
     void lightElementAttributeChanged(const SVGFELightElement*, const QualifiedName&);
 
     String in1() const { return m_in1->currentValue(); }
@@ -53,7 +53,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDiffuseLightingElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEDiffuseLightingElement(const QualifiedName&, Document&);
+    explicit SVGFEDiffuseLightingElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -32,11 +32,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEDisplacementMapElement);
 
-inline SVGFEDisplacementMapElement::SVGFEDisplacementMapElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEDisplacementMapElement::SVGFEDisplacementMapElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feDisplacementMapTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feDisplacementMapTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -48,9 +46,9 @@ inline SVGFEDisplacementMapElement::SVGFEDisplacementMapElement(const QualifiedN
     }
 }
 
-Ref<SVGFEDisplacementMapElement> SVGFEDisplacementMapElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEDisplacementMapElement> SVGFEDisplacementMapElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEDisplacementMapElement(tagName, document));
+    return adoptRef(*new SVGFEDisplacementMapElement(document));
 }
 
 void SVGFEDisplacementMapElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.h
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.h
@@ -67,7 +67,7 @@ class SVGFEDisplacementMapElement final : public SVGFilterPrimitiveStandardAttri
     WTF_MAKE_TZONE_ALLOCATED(SVGFEDisplacementMapElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEDisplacementMapElement);
 public:
-    static Ref<SVGFEDisplacementMapElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEDisplacementMapElement> create(Document&);
 
     static ChannelSelectorType stringToChannel(const String&);
 
@@ -86,7 +86,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDisplacementMapElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEDisplacementMapElement(const QualifiedName& tagName, Document&);
+    explicit SVGFEDisplacementMapElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEDistantLightElement.cpp
+++ b/Source/WebCore/svg/SVGFEDistantLightElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEDistantLightElement);
 
-inline SVGFEDistantLightElement::SVGFEDistantLightElement(const QualifiedName& tagName, Document& document)
-    : SVGFELightElement(tagName, document)
+inline SVGFEDistantLightElement::SVGFEDistantLightElement(Document& document)
+    : SVGFELightElement(SVGNames::feDistantLightTag, document)
 {
-    ASSERT(hasTagName(SVGNames::feDistantLightTag));
 }
 
-Ref<SVGFEDistantLightElement> SVGFEDistantLightElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEDistantLightElement> SVGFEDistantLightElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEDistantLightElement(tagName, document));
+    return adoptRef(*new SVGFEDistantLightElement(document));
 }
 
 Ref<LightSource> SVGFEDistantLightElement::lightSource() const

--- a/Source/WebCore/svg/SVGFEDistantLightElement.h
+++ b/Source/WebCore/svg/SVGFEDistantLightElement.h
@@ -28,10 +28,10 @@ class SVGFEDistantLightElement final : public SVGFELightElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEDistantLightElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEDistantLightElement);
 public:
-    static Ref<SVGFEDistantLightElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEDistantLightElement> create(Document&);
 
 private:
-    SVGFEDistantLightElement(const QualifiedName&, Document&);
+    explicit SVGFEDistantLightElement(Document&);
 
     Ref<LightSource> lightSource() const override;
 };

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -35,11 +35,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEDropShadowElement);
 
-inline SVGFEDropShadowElement::SVGFEDropShadowElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEDropShadowElement::SVGFEDropShadowElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feDropShadowTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feDropShadowTag));
-    
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -50,9 +48,9 @@ inline SVGFEDropShadowElement::SVGFEDropShadowElement(const QualifiedName& tagNa
     }
 }
 
-Ref<SVGFEDropShadowElement> SVGFEDropShadowElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEDropShadowElement> SVGFEDropShadowElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEDropShadowElement(tagName, document));
+    return adoptRef(*new SVGFEDropShadowElement(document));
 }
 
 void SVGFEDropShadowElement::setStdDeviation(float x, float y)

--- a/Source/WebCore/svg/SVGFEDropShadowElement.h
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.h
@@ -30,7 +30,7 @@ class SVGFEDropShadowElement final : public SVGFilterPrimitiveStandardAttributes
     WTF_MAKE_TZONE_ALLOCATED(SVGFEDropShadowElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEDropShadowElement);
 public:
-    static Ref<SVGFEDropShadowElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEDropShadowElement> create(Document&);
     
     void setStdDeviation(float stdDeviationX, float stdDeviationY);
 
@@ -49,7 +49,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEDropShadowElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEDropShadowElement(const QualifiedName&, Document&);
+    explicit SVGFEDropShadowElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEFloodElement.cpp
+++ b/Source/WebCore/svg/SVGFEFloodElement.cpp
@@ -34,15 +34,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEFloodElement);
 
-inline SVGFEFloodElement::SVGFEFloodElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEFloodElement::SVGFEFloodElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feFloodTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feFloodTag));
 }
 
-Ref<SVGFEFloodElement> SVGFEFloodElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEFloodElement> SVGFEFloodElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEFloodElement(tagName, document));
+    return adoptRef(*new SVGFEFloodElement(document));
 }
 
 bool SVGFEFloodElement::setFilterEffectAttribute(FilterEffect& effect, const QualifiedName& attrName)

--- a/Source/WebCore/svg/SVGFEFloodElement.h
+++ b/Source/WebCore/svg/SVGFEFloodElement.h
@@ -30,12 +30,12 @@ class SVGFEFloodElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEFloodElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFloodElement);
 public:
-    static Ref<SVGFEFloodElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEFloodElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEFloodElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEFloodElement(const QualifiedName&, Document&);
+    explicit SVGFEFloodElement(Document&);
 
     bool setFilterEffectAttribute(FilterEffect&, const QualifiedName& attrName) override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;

--- a/Source/WebCore/svg/SVGFEFuncAElement.cpp
+++ b/Source/WebCore/svg/SVGFEFuncAElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEFuncAElement);
 
-inline SVGFEFuncAElement::SVGFEFuncAElement(const QualifiedName& tagName, Document& document)
-    : SVGComponentTransferFunctionElement(tagName, document)
+inline SVGFEFuncAElement::SVGFEFuncAElement(Document& document)
+    : SVGComponentTransferFunctionElement(SVGNames::feFuncATag, document)
 {
-    ASSERT(hasTagName(SVGNames::feFuncATag));
 }
 
-Ref<SVGFEFuncAElement> SVGFEFuncAElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEFuncAElement> SVGFEFuncAElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEFuncAElement(tagName, document));
+    return adoptRef(*new SVGFEFuncAElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGFEFuncAElement.h
+++ b/Source/WebCore/svg/SVGFEFuncAElement.h
@@ -29,12 +29,12 @@ class SVGFEFuncAElement final : public SVGComponentTransferFunctionElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEFuncAElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFuncAElement);
 public:
-    static Ref<SVGFEFuncAElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEFuncAElement> create(Document&);
 
     ComponentTransferChannel channel() const final { return ComponentTransferChannel::Alpha; }
 
 private:
-    SVGFEFuncAElement(const QualifiedName&, Document&);
+    explicit SVGFEFuncAElement(Document&);
 };
 static_assert(sizeof(SVGFEFuncAElement) == sizeof(SVGComponentTransferFunctionElement));
 

--- a/Source/WebCore/svg/SVGFEFuncBElement.cpp
+++ b/Source/WebCore/svg/SVGFEFuncBElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEFuncBElement);
 
-inline SVGFEFuncBElement::SVGFEFuncBElement(const QualifiedName& tagName, Document& document)
-    : SVGComponentTransferFunctionElement(tagName, document)
+inline SVGFEFuncBElement::SVGFEFuncBElement(Document& document)
+    : SVGComponentTransferFunctionElement(SVGNames::feFuncBTag, document)
 {
-    ASSERT(hasTagName(SVGNames::feFuncBTag));
 }
 
-Ref<SVGFEFuncBElement> SVGFEFuncBElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEFuncBElement> SVGFEFuncBElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEFuncBElement(tagName, document));
+    return adoptRef(*new SVGFEFuncBElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGFEFuncBElement.h
+++ b/Source/WebCore/svg/SVGFEFuncBElement.h
@@ -28,12 +28,12 @@ class SVGFEFuncBElement final : public SVGComponentTransferFunctionElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEFuncBElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFuncBElement);
 public:
-    static Ref<SVGFEFuncBElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEFuncBElement> create(Document&);
 
     ComponentTransferChannel channel() const final { return ComponentTransferChannel::Blue; }
 
 private:
-    SVGFEFuncBElement(const QualifiedName&, Document&);
+    explicit SVGFEFuncBElement(Document&);
 };
 static_assert(sizeof(SVGFEFuncBElement) == sizeof(SVGComponentTransferFunctionElement));
 

--- a/Source/WebCore/svg/SVGFEFuncGElement.cpp
+++ b/Source/WebCore/svg/SVGFEFuncGElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEFuncGElement);
 
-inline SVGFEFuncGElement::SVGFEFuncGElement(const QualifiedName& tagName, Document& document)
-    : SVGComponentTransferFunctionElement(tagName, document)
+inline SVGFEFuncGElement::SVGFEFuncGElement(Document& document)
+    : SVGComponentTransferFunctionElement(SVGNames::feFuncGTag, document)
 {
-    ASSERT(hasTagName(SVGNames::feFuncGTag));
 }
 
-Ref<SVGFEFuncGElement> SVGFEFuncGElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEFuncGElement> SVGFEFuncGElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEFuncGElement(tagName, document));
+    return adoptRef(*new SVGFEFuncGElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGFEFuncGElement.h
+++ b/Source/WebCore/svg/SVGFEFuncGElement.h
@@ -28,12 +28,12 @@ class SVGFEFuncGElement final : public SVGComponentTransferFunctionElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEFuncGElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFuncGElement);
 public:
-    static Ref<SVGFEFuncGElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEFuncGElement> create(Document&);
 
     ComponentTransferChannel channel() const final { return ComponentTransferChannel::Green; }
 
 private:
-    SVGFEFuncGElement(const QualifiedName&, Document&);
+    explicit SVGFEFuncGElement(Document&);
 };
 static_assert(sizeof(SVGFEFuncGElement) == sizeof(SVGComponentTransferFunctionElement));
 

--- a/Source/WebCore/svg/SVGFEFuncRElement.cpp
+++ b/Source/WebCore/svg/SVGFEFuncRElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEFuncRElement);
 
-inline SVGFEFuncRElement::SVGFEFuncRElement(const QualifiedName& tagName, Document& document)
-    : SVGComponentTransferFunctionElement(tagName, document)
+inline SVGFEFuncRElement::SVGFEFuncRElement(Document& document)
+    : SVGComponentTransferFunctionElement(SVGNames::feFuncRTag, document)
 {
-    ASSERT(hasTagName(SVGNames::feFuncRTag));
 }
 
-Ref<SVGFEFuncRElement> SVGFEFuncRElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEFuncRElement> SVGFEFuncRElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEFuncRElement(tagName, document));
+    return adoptRef(*new SVGFEFuncRElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGFEFuncRElement.h
+++ b/Source/WebCore/svg/SVGFEFuncRElement.h
@@ -28,12 +28,12 @@ class SVGFEFuncRElement final : public SVGComponentTransferFunctionElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEFuncRElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEFuncRElement);
 public:
-    static Ref<SVGFEFuncRElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEFuncRElement> create(Document&);
 
     ComponentTransferChannel channel() const final { return ComponentTransferChannel::Red; }
 
 private:
-    SVGFEFuncRElement(const QualifiedName&, Document&);
+    explicit SVGFEFuncRElement(Document&);
 };
 static_assert(sizeof(SVGFEFuncRElement) == sizeof(SVGComponentTransferFunctionElement));
 

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -37,11 +37,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEGaussianBlurElement);
 
-inline SVGFEGaussianBlurElement::SVGFEGaussianBlurElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEGaussianBlurElement::SVGFEGaussianBlurElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feGaussianBlurTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feGaussianBlurTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -51,9 +49,9 @@ inline SVGFEGaussianBlurElement::SVGFEGaussianBlurElement(const QualifiedName& t
     }
 }
 
-Ref<SVGFEGaussianBlurElement> SVGFEGaussianBlurElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEGaussianBlurElement> SVGFEGaussianBlurElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEGaussianBlurElement(tagName, document));
+    return adoptRef(*new SVGFEGaussianBlurElement(document));
 }
 
 void SVGFEGaussianBlurElement::setStdDeviation(float x, float y)

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.h
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.h
@@ -32,7 +32,7 @@ class SVGFEGaussianBlurElement final : public SVGFilterPrimitiveStandardAttribut
     WTF_MAKE_TZONE_ALLOCATED(SVGFEGaussianBlurElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEGaussianBlurElement);
 public:
-    static Ref<SVGFEGaussianBlurElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEGaussianBlurElement> create(Document&);
 
     void setStdDeviation(float stdDeviationX, float stdDeviationY);
 
@@ -49,7 +49,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEGaussianBlurElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEGaussianBlurElement(const QualifiedName&, Document&);
+    explicit SVGFEGaussianBlurElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -44,12 +44,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEImageElement);
 
-inline SVGFEImageElement::SVGFEImageElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEImageElement::SVGFEImageElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feImageTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
 {
-    ASSERT(hasTagName(SVGNames::feImageTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -57,9 +55,9 @@ inline SVGFEImageElement::SVGFEImageElement(const QualifiedName& tagName, Docume
     }
 }
 
-Ref<SVGFEImageElement> SVGFEImageElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEImageElement> SVGFEImageElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEImageElement(tagName, document));
+    return adoptRef(*new SVGFEImageElement(document));
 }
 
 SVGFEImageElement::~SVGFEImageElement()

--- a/Source/WebCore/svg/SVGFEImageElement.h
+++ b/Source/WebCore/svg/SVGFEImageElement.h
@@ -33,7 +33,7 @@ class SVGFEImageElement final : public SVGFilterPrimitiveStandardAttributes, pub
     WTF_MAKE_TZONE_ALLOCATED(SVGFEImageElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEImageElement);
 public:
-    static Ref<SVGFEImageElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEImageElement> create(Document&);
 
     virtual ~SVGFEImageElement();
 
@@ -49,7 +49,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEImageElement, SVGFilterPrimitiveStandardAttributes, SVGURIReference>;
 
 private:
-    SVGFEImageElement(const QualifiedName&, Document&);
+    explicit SVGFEImageElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEMergeElement.cpp
+++ b/Source/WebCore/svg/SVGFEMergeElement.cpp
@@ -34,15 +34,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEMergeElement);
 
-inline SVGFEMergeElement::SVGFEMergeElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEMergeElement::SVGFEMergeElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feMergeTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feMergeTag));
 }
 
-Ref<SVGFEMergeElement> SVGFEMergeElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEMergeElement> SVGFEMergeElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEMergeElement(tagName, document));
+    return adoptRef(*new SVGFEMergeElement(document));
 }
 
 void SVGFEMergeElement::childrenChanged(const ChildChange& change)

--- a/Source/WebCore/svg/SVGFEMergeElement.h
+++ b/Source/WebCore/svg/SVGFEMergeElement.h
@@ -30,12 +30,12 @@ class SVGFEMergeElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEMergeElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEMergeElement);
 public:
-    static Ref<SVGFEMergeElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEMergeElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMergeElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEMergeElement(const QualifiedName&, Document&);
+    explicit SVGFEMergeElement(Document&);
 
     void childrenChanged(const ChildChange&) override;
 

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.cpp
@@ -32,11 +32,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEMergeNodeElement);
 
-inline SVGFEMergeNodeElement::SVGFEMergeNodeElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEMergeNodeElement::SVGFEMergeNodeElement(Document& document)
+    : SVGElement(SVGNames::feMergeNodeTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feMergeNodeTag));
-    
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -44,9 +42,9 @@ inline SVGFEMergeNodeElement::SVGFEMergeNodeElement(const QualifiedName& tagName
     }
 }
 
-Ref<SVGFEMergeNodeElement> SVGFEMergeNodeElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEMergeNodeElement> SVGFEMergeNodeElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEMergeNodeElement(tagName, document));
+    return adoptRef(*new SVGFEMergeNodeElement(document));
 }
 
 void SVGFEMergeNodeElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEMergeNodeElement.h
+++ b/Source/WebCore/svg/SVGFEMergeNodeElement.h
@@ -31,7 +31,7 @@ class SVGFEMergeNodeElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEMergeNodeElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEMergeNodeElement);
 public:
-    static Ref<SVGFEMergeNodeElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEMergeNodeElement> create(Document&);
 
     String in1() const { return m_in1->currentValue(); }
     SVGAnimatedString& in1Animated() { return m_in1; }
@@ -39,7 +39,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMergeNodeElement, SVGElement>;
 
 private:
-    SVGFEMergeNodeElement(const QualifiedName&, Document&);
+    explicit SVGFEMergeNodeElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -34,11 +34,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEMorphologyElement);
 
-inline SVGFEMorphologyElement::SVGFEMorphologyElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEMorphologyElement::SVGFEMorphologyElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feMorphologyTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feMorphologyTag));
-    
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -48,9 +46,9 @@ inline SVGFEMorphologyElement::SVGFEMorphologyElement(const QualifiedName& tagNa
     }
 }
 
-Ref<SVGFEMorphologyElement> SVGFEMorphologyElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEMorphologyElement> SVGFEMorphologyElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEMorphologyElement(tagName, document));
+    return adoptRef(*new SVGFEMorphologyElement(document));
 }
 
 void SVGFEMorphologyElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEMorphologyElement.h
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.h
@@ -60,7 +60,7 @@ class SVGFEMorphologyElement final : public SVGFilterPrimitiveStandardAttributes
     WTF_MAKE_TZONE_ALLOCATED(SVGFEMorphologyElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEMorphologyElement);
 public:
-    static Ref<SVGFEMorphologyElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEMorphologyElement> create(Document&);
 
     String in1() const { return m_in1->currentValue(); }
     MorphologyOperatorType svgOperator() const { return m_svgOperator->currentValue<MorphologyOperatorType>(); }
@@ -75,7 +75,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEMorphologyElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEMorphologyElement(const QualifiedName&, Document&);
+    explicit SVGFEMorphologyElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEOffsetElement.cpp
+++ b/Source/WebCore/svg/SVGFEOffsetElement.cpp
@@ -33,11 +33,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEOffsetElement);
 
-inline SVGFEOffsetElement::SVGFEOffsetElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFEOffsetElement::SVGFEOffsetElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feOffsetTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feOffsetTag));
-    
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -47,9 +45,9 @@ inline SVGFEOffsetElement::SVGFEOffsetElement(const QualifiedName& tagName, Docu
     }
 }
 
-Ref<SVGFEOffsetElement> SVGFEOffsetElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEOffsetElement> SVGFEOffsetElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEOffsetElement(tagName, document));
+    return adoptRef(*new SVGFEOffsetElement(document));
 }
 
 void SVGFEOffsetElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFEOffsetElement.h
+++ b/Source/WebCore/svg/SVGFEOffsetElement.h
@@ -30,7 +30,7 @@ class SVGFEOffsetElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEOffsetElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEOffsetElement);
 public:
-    static Ref<SVGFEOffsetElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEOffsetElement> create(Document&);
 
     String in1() const { return m_in1->currentValue(); }
     float dx() const { return m_dx->currentValue(); }
@@ -43,7 +43,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFEOffsetElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFEOffsetElement(const QualifiedName&, Document&);
+    explicit SVGFEOffsetElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFEPointLightElement.cpp
+++ b/Source/WebCore/svg/SVGFEPointLightElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFEPointLightElement);
 
-inline SVGFEPointLightElement::SVGFEPointLightElement(const QualifiedName& tagName, Document& document)
-    : SVGFELightElement(tagName, document)
+inline SVGFEPointLightElement::SVGFEPointLightElement(Document& document)
+    : SVGFELightElement(SVGNames::fePointLightTag, document)
 {
-    ASSERT(hasTagName(SVGNames::fePointLightTag));
 }
 
-Ref<SVGFEPointLightElement> SVGFEPointLightElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFEPointLightElement> SVGFEPointLightElement::create(Document& document)
 {
-    return adoptRef(*new SVGFEPointLightElement(tagName, document));
+    return adoptRef(*new SVGFEPointLightElement(document));
 }
 
 Ref<LightSource> SVGFEPointLightElement::lightSource() const

--- a/Source/WebCore/svg/SVGFEPointLightElement.h
+++ b/Source/WebCore/svg/SVGFEPointLightElement.h
@@ -28,10 +28,10 @@ class SVGFEPointLightElement final : public SVGFELightElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFEPointLightElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFEPointLightElement);
 public:
-    static Ref<SVGFEPointLightElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFEPointLightElement> create(Document&);
 
 private:
-    SVGFEPointLightElement(const QualifiedName&, Document&);
+    explicit SVGFEPointLightElement(Document&);
 
     Ref<LightSource> lightSource() const override;
 };

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -38,11 +38,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFESpecularLightingElement);
 
-inline SVGFESpecularLightingElement::SVGFESpecularLightingElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFESpecularLightingElement::SVGFESpecularLightingElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feSpecularLightingTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feSpecularLightingTag));
-    
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -54,9 +52,9 @@ inline SVGFESpecularLightingElement::SVGFESpecularLightingElement(const Qualifie
     }
 }
 
-Ref<SVGFESpecularLightingElement> SVGFESpecularLightingElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFESpecularLightingElement> SVGFESpecularLightingElement::create(Document& document)
 {
-    return adoptRef(*new SVGFESpecularLightingElement(tagName, document));
+    return adoptRef(*new SVGFESpecularLightingElement(document));
 }
 
 void SVGFESpecularLightingElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.h
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.h
@@ -33,7 +33,7 @@ class SVGFESpecularLightingElement final : public SVGFilterPrimitiveStandardAttr
     WTF_MAKE_TZONE_ALLOCATED(SVGFESpecularLightingElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFESpecularLightingElement);
 public:
-    static Ref<SVGFESpecularLightingElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFESpecularLightingElement> create(Document&);
     void lightElementAttributeChanged(const SVGFELightElement*, const QualifiedName&);
 
     String in1() const { return m_in1->currentValue(); }
@@ -53,7 +53,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFESpecularLightingElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFESpecularLightingElement(const QualifiedName&, Document&);
+    explicit SVGFESpecularLightingElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFESpotLightElement.cpp
+++ b/Source/WebCore/svg/SVGFESpotLightElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFESpotLightElement);
 
-inline SVGFESpotLightElement::SVGFESpotLightElement(const QualifiedName& tagName, Document& document)
-    : SVGFELightElement(tagName, document)
+inline SVGFESpotLightElement::SVGFESpotLightElement(Document& document)
+    : SVGFELightElement(SVGNames::feSpotLightTag, document)
 {
-    ASSERT(hasTagName(SVGNames::feSpotLightTag));
 }
 
-Ref<SVGFESpotLightElement> SVGFESpotLightElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFESpotLightElement> SVGFESpotLightElement::create(Document& document)
 {
-    return adoptRef(*new SVGFESpotLightElement(tagName, document));
+    return adoptRef(*new SVGFESpotLightElement(document));
 }
 
 Ref<LightSource> SVGFESpotLightElement::lightSource() const

--- a/Source/WebCore/svg/SVGFESpotLightElement.h
+++ b/Source/WebCore/svg/SVGFESpotLightElement.h
@@ -28,10 +28,10 @@ class SVGFESpotLightElement final : public SVGFELightElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFESpotLightElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFESpotLightElement);
 public:
-    static Ref<SVGFESpotLightElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFESpotLightElement> create(Document&);
 
 private:
-    SVGFESpotLightElement(const QualifiedName&, Document&);
+    explicit SVGFESpotLightElement(Document&);
 
     Ref<LightSource> lightSource() const override;
 };

--- a/Source/WebCore/svg/SVGFETileElement.cpp
+++ b/Source/WebCore/svg/SVGFETileElement.cpp
@@ -31,11 +31,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFETileElement);
 
-inline SVGFETileElement::SVGFETileElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFETileElement::SVGFETileElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feTileTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feTileTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -43,9 +41,9 @@ inline SVGFETileElement::SVGFETileElement(const QualifiedName& tagName, Document
     }
 }
 
-Ref<SVGFETileElement> SVGFETileElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFETileElement> SVGFETileElement::create(Document& document)
 {
-    return adoptRef(*new SVGFETileElement(tagName, document));
+    return adoptRef(*new SVGFETileElement(document));
 }
 
 void SVGFETileElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFETileElement.h
+++ b/Source/WebCore/svg/SVGFETileElement.h
@@ -30,7 +30,7 @@ class SVGFETileElement final : public SVGFilterPrimitiveStandardAttributes {
     WTF_MAKE_TZONE_ALLOCATED(SVGFETileElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFETileElement);
 public:
-    static Ref<SVGFETileElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFETileElement> create(Document&);
 
     String in1() const { return m_in1->currentValue(); }
     SVGAnimatedString& in1Animated() { return m_in1; }
@@ -38,7 +38,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETileElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFETileElement(const QualifiedName&, Document&);
+    explicit SVGFETileElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -36,11 +36,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFETurbulenceElement);
 
-inline SVGFETurbulenceElement::SVGFETurbulenceElement(const QualifiedName& tagName, Document& document)
-    : SVGFilterPrimitiveStandardAttributes(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFETurbulenceElement::SVGFETurbulenceElement(Document& document)
+    : SVGFilterPrimitiveStandardAttributes(SVGNames::feTurbulenceTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::feTurbulenceTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -52,9 +50,9 @@ inline SVGFETurbulenceElement::SVGFETurbulenceElement(const QualifiedName& tagNa
     }
 }
 
-Ref<SVGFETurbulenceElement> SVGFETurbulenceElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFETurbulenceElement> SVGFETurbulenceElement::create(Document& document)
 {
-    return adoptRef(*new SVGFETurbulenceElement(tagName, document));
+    return adoptRef(*new SVGFETurbulenceElement(document));
 }
 
 void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFETurbulenceElement.h
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.h
@@ -95,7 +95,7 @@ class SVGFETurbulenceElement final : public SVGFilterPrimitiveStandardAttributes
     WTF_MAKE_TZONE_ALLOCATED(SVGFETurbulenceElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFETurbulenceElement);
 public:
-    static Ref<SVGFETurbulenceElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFETurbulenceElement> create(Document&);
 
     float baseFrequencyX() const { return m_baseFrequencyX->currentValue(); }
     float baseFrequencyY() const { return m_baseFrequencyY->currentValue(); }
@@ -114,7 +114,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFETurbulenceElement, SVGFilterPrimitiveStandardAttributes>;
 
 private:
-    SVGFETurbulenceElement(const QualifiedName&, Document&);
+    explicit SVGFETurbulenceElement(Document&);
 
     static constexpr int initialOctavesValue = 1;
 

--- a/Source/WebCore/svg/SVGFilterElement.cpp
+++ b/Source/WebCore/svg/SVGFilterElement.cpp
@@ -43,14 +43,12 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFilterElement);
 
-inline SVGFilterElement::SVGFilterElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFilterElement::SVGFilterElement(Document& document)
+    : SVGElement(SVGNames::filterTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
 {
     // Spec: If the x/y attribute is not specified, the effect is as if a value of "-10%" were specified.
     // Spec: If the width/height attribute is not specified, the effect is as if a value of "120%" were specified.
-    ASSERT(hasTagName(SVGNames::filterTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -63,9 +61,9 @@ inline SVGFilterElement::SVGFilterElement(const QualifiedName& tagName, Document
     }
 }
 
-Ref<SVGFilterElement> SVGFilterElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFilterElement> SVGFilterElement::create(Document& document)
 {
-    return adoptRef(*new SVGFilterElement(tagName, document));
+    return adoptRef(*new SVGFilterElement(document));
 }
 
 void SVGFilterElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFilterElement.h
+++ b/Source/WebCore/svg/SVGFilterElement.h
@@ -34,7 +34,7 @@ class SVGFilterElement final : public SVGElement, public SVGURIReference {
     WTF_MAKE_TZONE_ALLOCATED(SVGFilterElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFilterElement);
 public:
-    static Ref<SVGFilterElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFilterElement> create(Document&);
 
     SVGUnitTypes::SVGUnitType filterUnits() const { return m_filterUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
     SVGUnitTypes::SVGUnitType primitiveUnits() const { return m_primitiveUnits->currentValue<SVGUnitTypes::SVGUnitType>(); }
@@ -53,7 +53,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFilterElement, SVGElement, SVGURIReference>;
 
 private:
-    SVGFilterElement(const QualifiedName&, Document&);
+    explicit SVGFilterElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGFontElement.cpp
+++ b/Source/WebCore/svg/SVGFontElement.cpp
@@ -39,15 +39,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFontElement);
 
-inline SVGFontElement::SVGFontElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFontElement::SVGFontElement(Document& document)
+    : SVGElement(SVGNames::fontTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::fontTag));
 }
 
-Ref<SVGFontElement> SVGFontElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFontElement> SVGFontElement::create(Document& document)
 {
-    return adoptRef(*new SVGFontElement(tagName, document));
+    return adoptRef(*new SVGFontElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGFontElement.h
+++ b/Source/WebCore/svg/SVGFontElement.h
@@ -44,12 +44,12 @@ class SVGFontElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFontElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontElement);
 public:
-    static Ref<SVGFontElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFontElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGFontElement, SVGElement>;
 
 private:
-    SVGFontElement(const QualifiedName&, Document&);
+    explicit SVGFontElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 };

--- a/Source/WebCore/svg/SVGFontFaceElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceElement.cpp
@@ -54,12 +54,11 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFontFaceElement);
 
 using namespace SVGNames;
 
-inline SVGFontFaceElement::SVGFontFaceElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFontFaceElement::SVGFontFaceElement(Document& document)
+    : SVGElement(font_faceTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , m_fontFaceRule(StyleRuleFontFace::create(MutableStyleProperties::create(HTMLStandardMode)))
 {
     LOG(Fonts, "SVGFontFaceElement %p ctor", this);
-    ASSERT(hasTagName(font_faceTag));
 }
 
 SVGFontFaceElement::~SVGFontFaceElement()
@@ -67,9 +66,9 @@ SVGFontFaceElement::~SVGFontFaceElement()
     LOG(Fonts, "SVGFontFaceElement %p dtor", this);
 }
 
-Ref<SVGFontFaceElement> SVGFontFaceElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFontFaceElement> SVGFontFaceElement::create(Document& document)
 {
-    return adoptRef(*new SVGFontFaceElement(tagName, document));
+    return adoptRef(*new SVGFontFaceElement(document));
 }
 
 void SVGFontFaceElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGFontFaceElement.h
+++ b/Source/WebCore/svg/SVGFontFaceElement.h
@@ -32,7 +32,7 @@ class SVGFontFaceElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFontFaceElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceElement);
 public:
-    static Ref<SVGFontFaceElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFontFaceElement> create(Document&);
 
     unsigned unitsPerEm() const;
     int xHeight() const;
@@ -53,7 +53,7 @@ public:
     StyleRuleFontFace& fontFaceRule() const { return m_fontFaceRule.get(); }
 
 private:
-    SVGFontFaceElement(const QualifiedName&, Document&);
+    explicit SVGFontFaceElement(Document&);
     ~SVGFontFaceElement();
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;

--- a/Source/WebCore/svg/SVGFontFaceFormatElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceFormatElement.cpp
@@ -32,15 +32,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFontFaceFormatElement);
     
 using namespace SVGNames;
     
-inline SVGFontFaceFormatElement::SVGFontFaceFormatElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFontFaceFormatElement::SVGFontFaceFormatElement(Document& document)
+    : SVGElement(font_face_formatTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(font_face_formatTag));
 }
 
-Ref<SVGFontFaceFormatElement> SVGFontFaceFormatElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFontFaceFormatElement> SVGFontFaceFormatElement::create(Document& document)
 {
-    return adoptRef(*new SVGFontFaceFormatElement(tagName, document));
+    return adoptRef(*new SVGFontFaceFormatElement(document));
 }
 
 void SVGFontFaceFormatElement::childrenChanged(const ChildChange& change)

--- a/Source/WebCore/svg/SVGFontFaceFormatElement.h
+++ b/Source/WebCore/svg/SVGFontFaceFormatElement.h
@@ -27,10 +27,10 @@ class SVGFontFaceFormatElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFontFaceFormatElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceFormatElement);
 public:
-    static Ref<SVGFontFaceFormatElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFontFaceFormatElement> create(Document&);
 
 private:
-    SVGFontFaceFormatElement(const QualifiedName&, Document&);
+    explicit SVGFontFaceFormatElement(Document&);
 
     void childrenChanged(const ChildChange&) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }

--- a/Source/WebCore/svg/SVGFontFaceNameElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceNameElement.cpp
@@ -30,15 +30,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFontFaceNameElement);
     
-inline SVGFontFaceNameElement::SVGFontFaceNameElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFontFaceNameElement::SVGFontFaceNameElement(Document& document)
+    : SVGElement(SVGNames::font_face_nameTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::font_face_nameTag));
 }
 
-Ref<SVGFontFaceNameElement> SVGFontFaceNameElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFontFaceNameElement> SVGFontFaceNameElement::create(Document& document)
 {
-    return adoptRef(*new SVGFontFaceNameElement(tagName, document));
+    return adoptRef(*new SVGFontFaceNameElement(document));
 }
 
 Ref<CSSFontFaceSrcLocalValue> SVGFontFaceNameElement::createSrcValue() const

--- a/Source/WebCore/svg/SVGFontFaceNameElement.h
+++ b/Source/WebCore/svg/SVGFontFaceNameElement.h
@@ -29,12 +29,12 @@ class SVGFontFaceNameElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFontFaceNameElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceNameElement);
 public:
-    static Ref<SVGFontFaceNameElement> create(const QualifiedName&, Document&);
-    
+    static Ref<SVGFontFaceNameElement> create(Document&);
+
     Ref<CSSFontFaceSrcLocalValue> createSrcValue() const;
 
 private:
-    SVGFontFaceNameElement(const QualifiedName&, Document&);
+    explicit SVGFontFaceNameElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 };

--- a/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceSrcElement.cpp
@@ -37,15 +37,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFontFaceSrcElement);
 
 using namespace SVGNames;
     
-inline SVGFontFaceSrcElement::SVGFontFaceSrcElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFontFaceSrcElement::SVGFontFaceSrcElement(Document& document)
+    : SVGElement(font_face_srcTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(font_face_srcTag));
 }
 
-Ref<SVGFontFaceSrcElement> SVGFontFaceSrcElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFontFaceSrcElement> SVGFontFaceSrcElement::create(Document& document)
 {
-    return adoptRef(*new SVGFontFaceSrcElement(tagName, document));
+    return adoptRef(*new SVGFontFaceSrcElement(document));
 }
 
 Ref<CSSValueList> SVGFontFaceSrcElement::createSrcValue() const

--- a/Source/WebCore/svg/SVGFontFaceSrcElement.h
+++ b/Source/WebCore/svg/SVGFontFaceSrcElement.h
@@ -29,13 +29,13 @@ class SVGFontFaceSrcElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGFontFaceSrcElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceSrcElement);
 public:
-    static Ref<SVGFontFaceSrcElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFontFaceSrcElement> create(Document&);
 
     Ref<CSSValueList> createSrcValue() const;
-    
+
 private:
-    SVGFontFaceSrcElement(const QualifiedName&, Document&);
-    
+    explicit SVGFontFaceSrcElement(Document&);
+
     void childrenChanged(const ChildChange&) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 };

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -40,15 +40,14 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGFontFaceUriElement);
     
 using namespace SVGNames;
     
-inline SVGFontFaceUriElement::SVGFontFaceUriElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGFontFaceUriElement::SVGFontFaceUriElement(Document& document)
+    : SVGElement(font_face_uriTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(font_face_uriTag));
 }
 
-Ref<SVGFontFaceUriElement> SVGFontFaceUriElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGFontFaceUriElement> SVGFontFaceUriElement::create(Document& document)
 {
-    return adoptRef(*new SVGFontFaceUriElement(tagName, document));
+    return adoptRef(*new SVGFontFaceUriElement(document));
 }
 
 SVGFontFaceUriElement::~SVGFontFaceUriElement()

--- a/Source/WebCore/svg/SVGFontFaceUriElement.h
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.h
@@ -31,7 +31,7 @@ class SVGFontFaceUriElement final : public SVGElement, public CachedFontClient {
     WTF_MAKE_TZONE_ALLOCATED(SVGFontFaceUriElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGFontFaceUriElement);
 public:
-    static Ref<SVGFontFaceUriElement> create(const QualifiedName&, Document&);
+    static Ref<SVGFontFaceUriElement> create(Document&);
 
     virtual ~SVGFontFaceUriElement();
 
@@ -42,7 +42,7 @@ public:
     Ref<CSSFontFaceSrcResourceValue> createSrcValue() const;
 
 private:
-    SVGFontFaceUriElement(const QualifiedName&, Document&);
+    explicit SVGFontFaceUriElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void childrenChanged(const ChildChange&) final;

--- a/Source/WebCore/svg/SVGForeignObjectElement.cpp
+++ b/Source/WebCore/svg/SVGForeignObjectElement.cpp
@@ -41,10 +41,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGForeignObjectElement);
 
-inline SVGForeignObjectElement::SVGForeignObjectElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGForeignObjectElement::SVGForeignObjectElement(Document& document)
+    : SVGGraphicsElement(SVGNames::foreignObjectTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::foreignObjectTag));
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -55,9 +54,9 @@ inline SVGForeignObjectElement::SVGForeignObjectElement(const QualifiedName& tag
     }
 }
 
-Ref<SVGForeignObjectElement> SVGForeignObjectElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGForeignObjectElement> SVGForeignObjectElement::create(Document& document)
 {
-    return adoptRef(*new SVGForeignObjectElement(tagName, document));
+    return adoptRef(*new SVGForeignObjectElement(document));
 }
 
 void SVGForeignObjectElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGForeignObjectElement.h
+++ b/Source/WebCore/svg/SVGForeignObjectElement.h
@@ -30,7 +30,7 @@ class SVGForeignObjectElement final : public SVGGraphicsElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGForeignObjectElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGForeignObjectElement);
 public:
-    static Ref<SVGForeignObjectElement> create(const QualifiedName&, Document&);
+    static Ref<SVGForeignObjectElement> create(Document&);
 
     const SVGLengthValue& x() const { return m_x->currentValue(); }
     const SVGLengthValue& y() const { return m_y->currentValue(); }
@@ -45,7 +45,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGForeignObjectElement, SVGGraphicsElement>;
 
 private:
-    SVGForeignObjectElement(const QualifiedName&, Document&);
+    explicit SVGForeignObjectElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGGElement.cpp
+++ b/Source/WebCore/svg/SVGGElement.cpp
@@ -38,20 +38,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGGElement);
 
-SVGGElement::SVGGElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+SVGGElement::SVGGElement(Document& document)
+    : SVGGraphicsElement(SVGNames::gTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::gTag));
-}
-
-Ref<SVGGElement> SVGGElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new SVGGElement(tagName, document));
 }
 
 Ref<SVGGElement> SVGGElement::create(Document& document)
 {
-    return create(SVGNames::gTag, document);
+    return adoptRef(*new SVGGElement(document));
 }
 
 RenderPtr<RenderElement> SVGGElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/svg/SVGGElement.h
+++ b/Source/WebCore/svg/SVGGElement.h
@@ -30,13 +30,12 @@ class SVGGElement final : public SVGGraphicsElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGGElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGElement);
 public:
-    static Ref<SVGGElement> create(const QualifiedName&, Document&);
     static Ref<SVGGElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGElement, SVGGraphicsElement>;
 
 private:
-    SVGGElement(const QualifiedName&, Document&);
+    explicit SVGGElement(Document&);
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
 

--- a/Source/WebCore/svg/SVGGlyphElement.cpp
+++ b/Source/WebCore/svg/SVGGlyphElement.cpp
@@ -34,15 +34,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGGlyphElement);
 
-inline SVGGlyphElement::SVGGlyphElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGGlyphElement::SVGGlyphElement(Document& document)
+    : SVGElement(SVGNames::glyphTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::glyphTag));
 }
 
-Ref<SVGGlyphElement> SVGGlyphElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGGlyphElement> SVGGlyphElement::create(Document& document)
 {
-    return adoptRef(*new SVGGlyphElement(tagName, document));
+    return adoptRef(*new SVGGlyphElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGGlyphElement.h
+++ b/Source/WebCore/svg/SVGGlyphElement.h
@@ -29,10 +29,10 @@ class SVGGlyphElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGGlyphElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGlyphElement);
 public:
-    static Ref<SVGGlyphElement> create(const QualifiedName&, Document&);
+    static Ref<SVGGlyphElement> create(Document&);
 
 private:
-    SVGGlyphElement(const QualifiedName&, Document&);
+    explicit SVGGlyphElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 };

--- a/Source/WebCore/svg/SVGGlyphRefElement.cpp
+++ b/Source/WebCore/svg/SVGGlyphRefElement.cpp
@@ -34,16 +34,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGGlyphRefElement);
 
-inline SVGGlyphRefElement::SVGGlyphRefElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGGlyphRefElement::SVGGlyphRefElement(Document& document)
+    : SVGElement(SVGNames::glyphRefTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
 {
-    ASSERT(hasTagName(SVGNames::glyphRefTag));
 }
 
-Ref<SVGGlyphRefElement> SVGGlyphRefElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGGlyphRefElement> SVGGlyphRefElement::create(Document& document)
 {
-    return adoptRef(*new SVGGlyphRefElement(tagName, document));
+    return adoptRef(*new SVGGlyphRefElement(document));
 }
 
 bool SVGGlyphRefElement::hasValidGlyphElement(String& glyphName) const

--- a/Source/WebCore/svg/SVGGlyphRefElement.h
+++ b/Source/WebCore/svg/SVGGlyphRefElement.h
@@ -30,7 +30,7 @@ class SVGGlyphRefElement final : public SVGElement, public SVGURIReference {
     WTF_MAKE_TZONE_ALLOCATED(SVGGlyphRefElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGGlyphRefElement);
 public:
-    static Ref<SVGGlyphRefElement> create(const QualifiedName&, Document&);
+    static Ref<SVGGlyphRefElement> create(Document&);
 
     bool hasValidGlyphElement(String& glyphName) const;
 
@@ -46,7 +46,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGGlyphRefElement, SVGElement, SVGURIReference>;
 
 private:
-    SVGGlyphRefElement(const QualifiedName&, Document&);
+    explicit SVGGlyphRefElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     bool rendererIsNeeded(const RenderStyle&) final { return false; }

--- a/Source/WebCore/svg/SVGHKernElement.cpp
+++ b/Source/WebCore/svg/SVGHKernElement.cpp
@@ -33,15 +33,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGHKernElement);
 
-inline SVGHKernElement::SVGHKernElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGHKernElement::SVGHKernElement(Document& document)
+    : SVGElement(SVGNames::hkernTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::hkernTag));
 }
 
-Ref<SVGHKernElement> SVGHKernElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGHKernElement> SVGHKernElement::create(Document& document)
 {
-    return adoptRef(*new SVGHKernElement(tagName, document));
+    return adoptRef(*new SVGHKernElement(document));
 }
 
 std::optional<SVGKerningPair> SVGHKernElement::buildHorizontalKerningPair() const

--- a/Source/WebCore/svg/SVGHKernElement.h
+++ b/Source/WebCore/svg/SVGHKernElement.h
@@ -29,12 +29,12 @@ class SVGHKernElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGHKernElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGHKernElement);
 public:
-    static Ref<SVGHKernElement> create(const QualifiedName&, Document&);
+    static Ref<SVGHKernElement> create(Document&);
 
     std::optional<SVGKerningPair> buildHorizontalKerningPair() const;
 
 private:
-    SVGHKernElement(const QualifiedName&, Document&);
+    explicit SVGHKernElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 };

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -45,13 +45,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGImageElement);
 
-inline SVGImageElement::SVGImageElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this), TypeFlag::HasDidMoveToNewDocument)
+inline SVGImageElement::SVGImageElement(Document& document)
+    : SVGGraphicsElement(SVGNames::imageTag, document, makeUniqueRef<PropertyRegistry>(*this), TypeFlag::HasDidMoveToNewDocument)
     , SVGURIReference(this)
     , m_imageLoader(makeUniqueRefWithoutRefCountedCheck<SVGImageLoader>(*this))
 {
-    ASSERT(hasTagName(SVGNames::imageTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -63,9 +61,9 @@ inline SVGImageElement::SVGImageElement(const QualifiedName& tagName, Document& 
     }
 }
 
-Ref<SVGImageElement> SVGImageElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGImageElement> SVGImageElement::create(Document& document)
 {
-    return adoptRef(*new SVGImageElement(tagName, document));
+    return adoptRef(*new SVGImageElement(document));
 }
 
 CachedImage* SVGImageElement::cachedImage() const

--- a/Source/WebCore/svg/SVGImageElement.h
+++ b/Source/WebCore/svg/SVGImageElement.h
@@ -32,7 +32,7 @@ class SVGImageElement final : public SVGGraphicsElement, public SVGURIReference 
     WTF_MAKE_TZONE_ALLOCATED(SVGImageElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGImageElement);
 public:
-    static Ref<SVGImageElement> create(const QualifiedName&, Document&);
+    static Ref<SVGImageElement> create(Document&);
 
     WEBCORE_EXPORT CachedImage* cachedImage() const;
     bool renderingTaintsOrigin() const;
@@ -58,7 +58,7 @@ public:
     void decode(Ref<DeferredPromise>&&);
 
 private:
-    SVGImageElement(const QualifiedName&, Document&);
+    explicit SVGImageElement(Document&);
     
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGLineElement.cpp
+++ b/Source/WebCore/svg/SVGLineElement.cpp
@@ -36,11 +36,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGLineElement);
 
-inline SVGLineElement::SVGLineElement(const QualifiedName& tagName, Document& document)
-    : SVGGeometryElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGLineElement::SVGLineElement(Document& document)
+    : SVGGeometryElement(SVGNames::lineTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::lineTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -51,9 +49,9 @@ inline SVGLineElement::SVGLineElement(const QualifiedName& tagName, Document& do
     }
 }
 
-Ref<SVGLineElement> SVGLineElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGLineElement> SVGLineElement::create(Document& document)
 {
-    return adoptRef(*new SVGLineElement(tagName, document));
+    return adoptRef(*new SVGLineElement(document));
 }
 
 void SVGLineElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGLineElement.h
+++ b/Source/WebCore/svg/SVGLineElement.h
@@ -31,7 +31,7 @@ class SVGLineElement final : public SVGGeometryElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGLineElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGLineElement);
 public:
-    static Ref<SVGLineElement> create(const QualifiedName&, Document&);
+    static Ref<SVGLineElement> create(Document&);
 
     const SVGLengthValue& x1() const { return m_x1->currentValue(); }
     const SVGLengthValue& y1() const { return m_y1->currentValue(); }
@@ -44,7 +44,7 @@ public:
     SVGAnimatedLength& y2Animated() { return m_y2; }
 
 private:
-    SVGLineElement(const QualifiedName&, Document&);
+    explicit SVGLineElement(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGLineElement, SVGGeometryElement>;
 

--- a/Source/WebCore/svg/SVGLinearGradientElement.cpp
+++ b/Source/WebCore/svg/SVGLinearGradientElement.cpp
@@ -45,12 +45,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGLinearGradientElement);
 
-inline SVGLinearGradientElement::SVGLinearGradientElement(const QualifiedName& tagName, Document& document)
-    : SVGGradientElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGLinearGradientElement::SVGLinearGradientElement(Document& document)
+    : SVGGradientElement(SVGNames::linearGradientTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
     // Spec: If the x2 attribute is not specified, the effect is as if a value of "100%" were specified.
-    ASSERT(hasTagName(SVGNames::linearGradientTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -61,9 +59,9 @@ inline SVGLinearGradientElement::SVGLinearGradientElement(const QualifiedName& t
     }
 }
 
-Ref<SVGLinearGradientElement> SVGLinearGradientElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGLinearGradientElement> SVGLinearGradientElement::create(Document& document)
 {
-    return adoptRef(*new SVGLinearGradientElement(tagName, document));
+    return adoptRef(*new SVGLinearGradientElement(document));
 }
 
 void SVGLinearGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGLinearGradientElement.h
+++ b/Source/WebCore/svg/SVGLinearGradientElement.h
@@ -33,7 +33,7 @@ class SVGLinearGradientElement final : public SVGGradientElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGLinearGradientElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGLinearGradientElement);
 public:
-    static Ref<SVGLinearGradientElement> create(const QualifiedName&, Document&);
+    static Ref<SVGLinearGradientElement> create(Document&);
 
     bool collectGradientAttributes(LinearGradientAttributes&);
 
@@ -48,7 +48,7 @@ public:
     SVGAnimatedLength& y2Animated() { return m_y2; }
 
 private:
-    SVGLinearGradientElement(const QualifiedName&, Document&);
+    explicit SVGLinearGradientElement(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGLinearGradientElement, SVGGradientElement>;
 

--- a/Source/WebCore/svg/SVGMPathElement.cpp
+++ b/Source/WebCore/svg/SVGMPathElement.cpp
@@ -33,16 +33,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGMPathElement);
 
-inline SVGMPathElement::SVGMPathElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGMPathElement::SVGMPathElement(Document& document)
+    : SVGElement(SVGNames::mpathTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
 {
-    ASSERT(hasTagName(SVGNames::mpathTag));
 }
 
-Ref<SVGMPathElement> SVGMPathElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGMPathElement> SVGMPathElement::create(Document& document)
 {
-    return adoptRef(*new SVGMPathElement(tagName, document));
+    return adoptRef(*new SVGMPathElement(document));
 }
 
 SVGMPathElement::~SVGMPathElement()

--- a/Source/WebCore/svg/SVGMPathElement.h
+++ b/Source/WebCore/svg/SVGMPathElement.h
@@ -33,7 +33,7 @@ class SVGMPathElement final : public SVGElement, public SVGURIReference {
     WTF_MAKE_TZONE_ALLOCATED(SVGMPathElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGMPathElement);
 public:
-    static Ref<SVGMPathElement> create(const QualifiedName&, Document&);
+    static Ref<SVGMPathElement> create(Document&);
 
     virtual ~SVGMPathElement();
 
@@ -44,7 +44,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMPathElement, SVGElement, SVGURIReference>;
 
 private:
-    SVGMPathElement(const QualifiedName&, Document&);
+    explicit SVGMPathElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGMarkerElement.cpp
+++ b/Source/WebCore/svg/SVGMarkerElement.cpp
@@ -38,13 +38,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGMarkerElement);
 
-inline SVGMarkerElement::SVGMarkerElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGMarkerElement::SVGMarkerElement(Document& document)
+    : SVGElement(SVGNames::markerTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGFitToViewBox(this)
 {
     // Spec: If the markerWidth/markerHeight attribute is not specified, the effect is as if a value of "3" were specified.
-    ASSERT(hasTagName(SVGNames::markerTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -57,9 +55,9 @@ inline SVGMarkerElement::SVGMarkerElement(const QualifiedName& tagName, Document
     }
 }
 
-Ref<SVGMarkerElement> SVGMarkerElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGMarkerElement> SVGMarkerElement::create(Document& document)
 {
-    return adoptRef(*new SVGMarkerElement(tagName, document));
+    return adoptRef(*new SVGMarkerElement(document));
 }
 
 AffineTransform SVGMarkerElement::viewBoxToViewTransform(float viewWidth, float viewHeight) const

--- a/Source/WebCore/svg/SVGMarkerElement.h
+++ b/Source/WebCore/svg/SVGMarkerElement.h
@@ -46,7 +46,7 @@ public:
         SVG_MARKER_ORIENT_AUTO_START_REVERSE = SVGMarkerOrientAutoStartReverse
     };
 
-    static Ref<SVGMarkerElement> create(const QualifiedName&, Document&);
+    static Ref<SVGMarkerElement> create(Document&);
 
     AffineTransform viewBoxToViewTransform(float viewWidth, float viewHeight) const;
 
@@ -74,7 +74,7 @@ public:
     void setOrientToAutoStartReverse();
 
 private:
-    SVGMarkerElement(const QualifiedName&, Document&);
+    explicit SVGMarkerElement(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMarkerElement, SVGElement, SVGFitToViewBox>;
 

--- a/Source/WebCore/svg/SVGMaskElement.cpp
+++ b/Source/WebCore/svg/SVGMaskElement.cpp
@@ -48,14 +48,12 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGMaskElement);
 
-inline SVGMaskElement::SVGMaskElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGMaskElement::SVGMaskElement(Document& document)
+    : SVGElement(SVGNames::maskTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGTests(this)
 {
     // Spec: If the x/y attribute is not specified, the effect is as if a value of "-10%" were specified.
     // Spec: If the width/height attribute is not specified, the effect is as if a value of "120%" were specified.
-    ASSERT(hasTagName(SVGNames::maskTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -68,9 +66,9 @@ inline SVGMaskElement::SVGMaskElement(const QualifiedName& tagName, Document& do
     }
 }
 
-Ref<SVGMaskElement> SVGMaskElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGMaskElement> SVGMaskElement::create(Document& document)
 {
-    return adoptRef(*new SVGMaskElement(tagName, document));
+    return adoptRef(*new SVGMaskElement(document));
 }
 
 void SVGMaskElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGMaskElement.h
+++ b/Source/WebCore/svg/SVGMaskElement.h
@@ -35,7 +35,7 @@ class SVGMaskElement final : public SVGElement, public SVGTests {
     WTF_MAKE_TZONE_ALLOCATED(SVGMaskElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGMaskElement);
 public:
-    static Ref<SVGMaskElement> create(const QualifiedName&, Document&);
+    static Ref<SVGMaskElement> create(Document&);
 
     const SVGLengthValue& x() const { return m_x->currentValue(); }
     const SVGLengthValue& y() const { return m_y->currentValue(); }
@@ -56,7 +56,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGMaskElement, SVGElement, SVGTests>;
 
 private:
-    SVGMaskElement(const QualifiedName&, Document&);
+    explicit SVGMaskElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGMetadataElement.cpp
+++ b/Source/WebCore/svg/SVGMetadataElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGMetadataElement);
 
-inline SVGMetadataElement::SVGMetadataElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGMetadataElement::SVGMetadataElement(Document& document)
+    : SVGElement(SVGNames::metadataTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::metadataTag));
 }
 
-Ref<SVGMetadataElement> SVGMetadataElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGMetadataElement> SVGMetadataElement::create(Document& document)
 {
-    return adoptRef(*new SVGMetadataElement(tagName, document));
+    return adoptRef(*new SVGMetadataElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGMetadataElement.h
+++ b/Source/WebCore/svg/SVGMetadataElement.h
@@ -29,10 +29,10 @@ class SVGMetadataElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGMetadataElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGMetadataElement);
 public:
-    static Ref<SVGMetadataElement> create(const QualifiedName&, Document&);
+    static Ref<SVGMetadataElement> create(Document&);
 
 private:
-    SVGMetadataElement(const QualifiedName&, Document&);
+    explicit SVGMetadataElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
     bool supportsFocus() const final { return false; }

--- a/Source/WebCore/svg/SVGMissingGlyphElement.cpp
+++ b/Source/WebCore/svg/SVGMissingGlyphElement.cpp
@@ -29,15 +29,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGMissingGlyphElement);
 
-inline SVGMissingGlyphElement::SVGMissingGlyphElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGMissingGlyphElement::SVGMissingGlyphElement(Document& document)
+    : SVGElement(SVGNames::missing_glyphTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::missing_glyphTag));
 }
 
-Ref<SVGMissingGlyphElement> SVGMissingGlyphElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGMissingGlyphElement> SVGMissingGlyphElement::create(Document& document)
 {
-    return adoptRef(*new SVGMissingGlyphElement(tagName, document));
+    return adoptRef(*new SVGMissingGlyphElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGMissingGlyphElement.h
+++ b/Source/WebCore/svg/SVGMissingGlyphElement.h
@@ -28,10 +28,10 @@ class SVGMissingGlyphElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGMissingGlyphElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGMissingGlyphElement);
 public:
-    static Ref<SVGMissingGlyphElement> create(const QualifiedName&, Document&);
+    static Ref<SVGMissingGlyphElement> create(Document&);
 
 private:
-    SVGMissingGlyphElement(const QualifiedName&, Document&);
+    explicit SVGMissingGlyphElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 };

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -96,11 +96,9 @@ void PathSegListCache::clear()
     m_sizeInBytes = 0;
 }
 
-inline SVGPathElement::SVGPathElement(const QualifiedName& tagName, Document& document)
-    : SVGGeometryElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGPathElement::SVGPathElement(Document& document)
+    : SVGGeometryElement(SVGNames::pathTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::pathTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -108,9 +106,9 @@ inline SVGPathElement::SVGPathElement(const QualifiedName& tagName, Document& do
     }
 }
 
-Ref<SVGPathElement> SVGPathElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGPathElement> SVGPathElement::create(Document& document)
 {
-    return adoptRef(*new SVGPathElement(tagName, document));
+    return adoptRef(*new SVGPathElement(document));
 }
 
 void SVGPathElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -37,7 +37,7 @@ class SVGPathElement final : public SVGGeometryElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGPathElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPathElement);
 public:
-    static Ref<SVGPathElement> create(const QualifiedName&, Document&);
+    static Ref<SVGPathElement> create(Document&);
 
     static Ref<SVGPathSegClosePath> createSVGPathSegClosePath() { return SVGPathSegClosePath::create(); }
     static Ref<SVGPathSegMovetoAbs> createSVGPathSegMovetoAbs(float x, float y) { return SVGPathSegMovetoAbs::create(x, y); }
@@ -109,7 +109,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPathElement, SVGGeometryElement>;
 
 private:
-    SVGPathElement(const QualifiedName&, Document&);
+    explicit SVGPathElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGPatternElement.cpp
+++ b/Source/WebCore/svg/SVGPatternElement.cpp
@@ -50,14 +50,12 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGPatternElement);
 
-inline SVGPatternElement::SVGPatternElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGPatternElement::SVGPatternElement(Document& document)
+    : SVGElement(SVGNames::patternTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGFitToViewBox(this)
     , SVGTests(this)
     , SVGURIReference(this)
 {
-    ASSERT(hasTagName(SVGNames::patternTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -71,9 +69,9 @@ inline SVGPatternElement::SVGPatternElement(const QualifiedName& tagName, Docume
     }
 }
 
-Ref<SVGPatternElement> SVGPatternElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGPatternElement> SVGPatternElement::create(Document& document)
 {
-    return adoptRef(*new SVGPatternElement(tagName, document));
+    return adoptRef(*new SVGPatternElement(document));
 }
 
 void SVGPatternElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGPatternElement.h
+++ b/Source/WebCore/svg/SVGPatternElement.h
@@ -37,7 +37,7 @@ class SVGPatternElement final : public SVGElement, public SVGFitToViewBox, publi
     WTF_MAKE_TZONE_ALLOCATED(SVGPatternElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPatternElement);
 public:
-    static Ref<SVGPatternElement> create(const QualifiedName&, Document&);
+    static Ref<SVGPatternElement> create(Document&);
 
     void collectPatternAttributes(PatternAttributes&) const;
 
@@ -60,7 +60,7 @@ public:
     SVGAnimatedTransformList& patternTransformAnimated() { return m_patternTransform; }
 
 private:
-    SVGPatternElement(const QualifiedName&, Document&);
+    explicit SVGPatternElement(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPatternElement, SVGElement, SVGFitToViewBox, SVGTests, SVGURIReference>;
 

--- a/Source/WebCore/svg/SVGPolygonElement.cpp
+++ b/Source/WebCore/svg/SVGPolygonElement.cpp
@@ -28,15 +28,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGPolygonElement);
 
-inline SVGPolygonElement::SVGPolygonElement(const QualifiedName& tagName, Document& document)
-    : SVGPolyElement(tagName, document)
+inline SVGPolygonElement::SVGPolygonElement(Document& document)
+    : SVGPolyElement(SVGNames::polygonTag, document)
 {
-    ASSERT(hasTagName(SVGNames::polygonTag));
 }
 
-Ref<SVGPolygonElement> SVGPolygonElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGPolygonElement> SVGPolygonElement::create(Document& document)
 {
-    return adoptRef(*new SVGPolygonElement(tagName, document));
+    return adoptRef(*new SVGPolygonElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGPolygonElement.h
+++ b/Source/WebCore/svg/SVGPolygonElement.h
@@ -28,10 +28,10 @@ class SVGPolygonElement final : public SVGPolyElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGPolygonElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPolygonElement);
 public:
-    static Ref<SVGPolygonElement> create(const QualifiedName&, Document&);
+    static Ref<SVGPolygonElement> create(Document&);
 
 private:
-    SVGPolygonElement(const QualifiedName&, Document&);
+    explicit SVGPolygonElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGPolylineElement.cpp
+++ b/Source/WebCore/svg/SVGPolylineElement.cpp
@@ -28,15 +28,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGPolylineElement);
 
-inline SVGPolylineElement::SVGPolylineElement(const QualifiedName& tagName, Document& document)
-    : SVGPolyElement(tagName, document)
+inline SVGPolylineElement::SVGPolylineElement(Document& document)
+    : SVGPolyElement(SVGNames::polylineTag, document)
 {
-    ASSERT(hasTagName(SVGNames::polylineTag));
 }
 
-Ref<SVGPolylineElement> SVGPolylineElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGPolylineElement> SVGPolylineElement::create(Document& document)
 {
-    return adoptRef(*new SVGPolylineElement(tagName, document));
+    return adoptRef(*new SVGPolylineElement(document));
 }
 
 }

--- a/Source/WebCore/svg/SVGPolylineElement.h
+++ b/Source/WebCore/svg/SVGPolylineElement.h
@@ -28,10 +28,10 @@ class SVGPolylineElement final : public SVGPolyElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGPolylineElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGPolylineElement);
 public:
-    static Ref<SVGPolylineElement> create(const QualifiedName&, Document&);
+    static Ref<SVGPolylineElement> create(Document&);
 
 private:
-    SVGPolylineElement(const QualifiedName&, Document&);
+    explicit SVGPolylineElement(Document&);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGRadialGradientElement.cpp
+++ b/Source/WebCore/svg/SVGRadialGradientElement.cpp
@@ -45,12 +45,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGRadialGradientElement);
 
-inline SVGRadialGradientElement::SVGRadialGradientElement(const QualifiedName& tagName, Document& document)
-    : SVGGradientElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGRadialGradientElement::SVGRadialGradientElement(Document& document)
+    : SVGGradientElement(SVGNames::radialGradientTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
     // Spec: If the cx/cy/r/fr attribute is not specified, the effect is as if a value of "50%" were specified.
-    ASSERT(hasTagName(SVGNames::radialGradientTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -63,9 +61,9 @@ inline SVGRadialGradientElement::SVGRadialGradientElement(const QualifiedName& t
     }
 }
 
-Ref<SVGRadialGradientElement> SVGRadialGradientElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGRadialGradientElement> SVGRadialGradientElement::create(Document& document)
 {
-    return adoptRef(*new SVGRadialGradientElement(tagName, document));
+    return adoptRef(*new SVGRadialGradientElement(document));
 }
 
 void SVGRadialGradientElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGRadialGradientElement.h
+++ b/Source/WebCore/svg/SVGRadialGradientElement.h
@@ -33,7 +33,7 @@ class SVGRadialGradientElement final : public SVGGradientElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGRadialGradientElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGRadialGradientElement);
 public:
-    static Ref<SVGRadialGradientElement> create(const QualifiedName&, Document&);
+    static Ref<SVGRadialGradientElement> create(Document&);
 
     bool collectGradientAttributes(RadialGradientAttributes&);
 
@@ -54,7 +54,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGRadialGradientElement, SVGGradientElement>;
 
 private:
-    SVGRadialGradientElement(const QualifiedName&, Document&);
+    explicit SVGRadialGradientElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/svg/SVGRectElement.cpp
+++ b/Source/WebCore/svg/SVGRectElement.cpp
@@ -38,11 +38,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGRectElement);
 
-inline SVGRectElement::SVGRectElement(const QualifiedName& tagName, Document& document)
-    : SVGGeometryElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGRectElement::SVGRectElement(Document& document)
+    : SVGGeometryElement(SVGNames::rectTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::rectTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -55,9 +53,9 @@ inline SVGRectElement::SVGRectElement(const QualifiedName& tagName, Document& do
     }
 }
 
-Ref<SVGRectElement> SVGRectElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGRectElement> SVGRectElement::create(Document& document)
 {
-    return adoptRef(*new SVGRectElement(tagName, document));
+    return adoptRef(*new SVGRectElement(document));
 }
 
 SVGAnimatedPropertyBase* SVGRectElement::propertyForAttribute(const QualifiedName& name) const

--- a/Source/WebCore/svg/SVGRectElement.h
+++ b/Source/WebCore/svg/SVGRectElement.h
@@ -31,7 +31,7 @@ class SVGRectElement final : public SVGGeometryElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGRectElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGRectElement);
 public:
-    static Ref<SVGRectElement> create(const QualifiedName&, Document&);
+    static Ref<SVGRectElement> create(Document&);
 
     const SVGLengthValue& x() const { return m_x->currentValue(); }
     const SVGLengthValue& y() const { return m_y->currentValue(); }
@@ -52,7 +52,7 @@ public:
     SVGAnimatedPropertyBase* propertyForAttribute(const QualifiedName&) const;
 
 private:
-    SVGRectElement(const QualifiedName&, Document&);
+    explicit SVGRectElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -67,12 +67,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGSVGElement);
 
-inline SVGSVGElement::SVGSVGElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this), TypeFlag::HasDidMoveToNewDocument)
+inline SVGSVGElement::SVGSVGElement(Document& document)
+    : SVGGraphicsElement(SVGNames::svgTag, document, makeUniqueRef<PropertyRegistry>(*this), TypeFlag::HasDidMoveToNewDocument)
     , SVGFitToViewBox(this)
     , m_timeContainer(SMILTimeContainer::create(*this))
 {
-    ASSERT(hasTagName(SVGNames::svgTag));
     document.registerForDocumentSuspensionCallbacks(*this);
 
     static bool didRegistration = false;
@@ -85,14 +84,9 @@ inline SVGSVGElement::SVGSVGElement(const QualifiedName& tagName, Document& docu
     }
 }
 
-Ref<SVGSVGElement> SVGSVGElement::create(const QualifiedName& tagName, Document& document)
-{
-    return adoptRef(*new SVGSVGElement(tagName, document));
-}
-
 Ref<SVGSVGElement> SVGSVGElement::create(Document& document)
 {
-    return create(SVGNames::svgTag, document);
+    return adoptRef(*new SVGSVGElement(document));
 }
 
 SVGSVGElement::~SVGSVGElement()

--- a/Source/WebCore/svg/SVGSVGElement.h
+++ b/Source/WebCore/svg/SVGSVGElement.h
@@ -85,7 +85,6 @@ public: // DOM
     void forceRedraw() { }
 
 public:
-    static Ref<SVGSVGElement> create(const QualifiedName&, Document&);
     static Ref<SVGSVGElement> create(Document&);
     bool scrollToFragment(StringView fragmentIdentifier);
     void resetScrollAnchor();
@@ -126,7 +125,7 @@ public:
     void inheritViewAttributes(const SVGViewElement&);
 
 private:
-    SVGSVGElement(const QualifiedName&, Document&);
+    explicit SVGSVGElement(Document&);
     virtual ~SVGSVGElement();
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -33,18 +33,17 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGScriptElement);
 
-inline SVGScriptElement::SVGScriptElement(const QualifiedName& tagName, Document& document, bool wasInsertedByParser, bool alreadyStarted)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGScriptElement::SVGScriptElement(Document& document, bool wasInsertedByParser, bool alreadyStarted)
+    : SVGElement(SVGNames::scriptTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
     , ScriptElement(*this, wasInsertedByParser, alreadyStarted)
     , m_loadEventTimer(*this, &SVGElement::loadEventTimerFired)
 {
-    ASSERT(hasTagName(SVGNames::scriptTag));
 }
 
-Ref<SVGScriptElement> SVGScriptElement::create(const QualifiedName& tagName, Document& document, bool insertedByParser)
+Ref<SVGScriptElement> SVGScriptElement::create(Document& document, bool insertedByParser)
 {
-    return adoptRef(*new SVGScriptElement(tagName, document, insertedByParser, false));
+    return adoptRef(*new SVGScriptElement(document, insertedByParser, false));
 }
 
 void SVGScriptElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
@@ -110,7 +109,7 @@ void SVGScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 }
 Ref<Element> SVGScriptElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*) const
 {
-    return adoptRef(*new SVGScriptElement(tagQName(), document, false, alreadyStarted()));
+    return adoptRef(*new SVGScriptElement(document, false, alreadyStarted()));
 }
 
 void SVGScriptElement::dispatchErrorEvent()

--- a/Source/WebCore/svg/SVGScriptElement.h
+++ b/Source/WebCore/svg/SVGScriptElement.h
@@ -33,7 +33,7 @@ class SVGScriptElement final : public SVGElement, public SVGURIReference, public
     WTF_MAKE_TZONE_ALLOCATED(SVGScriptElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGScriptElement);
 public:
-    static Ref<SVGScriptElement> create(const QualifiedName&, Document&, bool wasInsertedByParser);
+    static Ref<SVGScriptElement> create(Document&, bool wasInsertedByParser);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGScriptElement, SVGElement, SVGURIReference>;
     using SVGElement::ref;
@@ -42,7 +42,7 @@ public:
     bool async() const;
 
 private:
-    SVGScriptElement(const QualifiedName&, Document&, bool wasInsertedByParser, bool alreadyStarted);
+    SVGScriptElement(Document&, bool wasInsertedByParser, bool alreadyStarted);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGSetElement.cpp
+++ b/Source/WebCore/svg/SVGSetElement.cpp
@@ -28,16 +28,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGSetElement);
     
-inline SVGSetElement::SVGSetElement(const QualifiedName& tagName, Document& document)
-    : SVGAnimateElementBase(tagName, document)
+inline SVGSetElement::SVGSetElement(Document& document)
+    : SVGAnimateElementBase(SVGNames::setTag, document)
 {
     setAnimationMode(AnimationMode::To);
-    ASSERT(hasTagName(SVGNames::setTag));
 }
 
-Ref<SVGSetElement> SVGSetElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGSetElement> SVGSetElement::create(Document& document)
 {
-    return adoptRef(*new SVGSetElement(tagName, document));
+    return adoptRef(*new SVGSetElement(document));
 }
 
 void SVGSetElement::updateAnimationMode()

--- a/Source/WebCore/svg/SVGSetElement.h
+++ b/Source/WebCore/svg/SVGSetElement.h
@@ -29,10 +29,10 @@ class SVGSetElement final : public SVGAnimateElementBase {
     WTF_MAKE_TZONE_ALLOCATED(SVGSetElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGSetElement);
 public:
-    static Ref<SVGSetElement> create(const QualifiedName&, Document&);
+    static Ref<SVGSetElement> create(Document&);
 
 private:
-    SVGSetElement(const QualifiedName&, Document&);
+    explicit SVGSetElement(Document&);
     void updateAnimationMode() override;
 };
 

--- a/Source/WebCore/svg/SVGStopElement.cpp
+++ b/Source/WebCore/svg/SVGStopElement.cpp
@@ -36,12 +36,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGStopElement);
 
-inline SVGStopElement::SVGStopElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGStopElement::SVGStopElement(Document& document)
+    : SVGElement(SVGNames::stopTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , m_offset { SVGAnimatedNumber::create(this, 0) }
 {
-    ASSERT(hasTagName(SVGNames::stopTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -49,9 +47,9 @@ inline SVGStopElement::SVGStopElement(const QualifiedName& tagName, Document& do
     }
 }
 
-Ref<SVGStopElement> SVGStopElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGStopElement> SVGStopElement::create(Document& document)
 {
-    return adoptRef(*new SVGStopElement(tagName, document));
+    return adoptRef(*new SVGStopElement(document));
 }
 
 void SVGStopElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGStopElement.h
+++ b/Source/WebCore/svg/SVGStopElement.h
@@ -31,7 +31,7 @@ class SVGStopElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGStopElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGStopElement);
 public:
-    static Ref<SVGStopElement> create(const QualifiedName&, Document&);
+    static Ref<SVGStopElement> create(Document&);
 
     Color stopColorIncludingOpacity() const;
 
@@ -41,7 +41,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGStopElement, SVGElement>;
 
 private:
-    SVGStopElement(const QualifiedName&, Document&);
+    explicit SVGStopElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) final;

--- a/Source/WebCore/svg/SVGStyleElement.cpp
+++ b/Source/WebCore/svg/SVGStyleElement.cpp
@@ -37,12 +37,11 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGStyleElement);
 
-inline SVGStyleElement::SVGStyleElement(const QualifiedName& tagName, Document& document, bool createdByParser)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGStyleElement::SVGStyleElement(Document& document, bool createdByParser)
+    : SVGElement(SVGNames::styleTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , m_styleSheetOwner(document, createdByParser)
     , m_loadEventTimer(*this, &SVGElement::loadEventTimerFired)
 {
-    ASSERT(hasTagName(SVGNames::styleTag));
 }
 
 SVGStyleElement::~SVGStyleElement()
@@ -50,9 +49,9 @@ SVGStyleElement::~SVGStyleElement()
     m_styleSheetOwner.clearDocumentData(*this);
 }
 
-Ref<SVGStyleElement> SVGStyleElement::create(const QualifiedName& tagName, Document& document, bool createdByParser)
+Ref<SVGStyleElement> SVGStyleElement::create(Document& document, bool createdByParser)
 {
-    return adoptRef(*new SVGStyleElement(tagName, document, createdByParser));
+    return adoptRef(*new SVGStyleElement(document, createdByParser));
 }
 
 bool SVGStyleElement::disabled() const

--- a/Source/WebCore/svg/SVGStyleElement.h
+++ b/Source/WebCore/svg/SVGStyleElement.h
@@ -31,7 +31,7 @@ class SVGStyleElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGStyleElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGStyleElement);
 public:
-    static Ref<SVGStyleElement> create(const QualifiedName&, Document&, bool createdByParser);
+    static Ref<SVGStyleElement> create(Document&, bool createdByParser);
     virtual ~SVGStyleElement();
 
     CSSStyleSheet* sheet() const { return m_styleSheetOwner.sheet(); }
@@ -40,7 +40,7 @@ public:
     void setDisabled(bool);
 
 private:
-    SVGStyleElement(const QualifiedName&, Document&, bool createdByParser);
+    SVGStyleElement(Document&, bool createdByParser);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;

--- a/Source/WebCore/svg/SVGSwitchElement.cpp
+++ b/Source/WebCore/svg/SVGSwitchElement.cpp
@@ -34,15 +34,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGSwitchElement);
 
-inline SVGSwitchElement::SVGSwitchElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGSwitchElement::SVGSwitchElement(Document& document)
+    : SVGGraphicsElement(SVGNames::switchTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::switchTag));
 }
 
-Ref<SVGSwitchElement> SVGSwitchElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGSwitchElement> SVGSwitchElement::create(Document& document)
 {
-    return adoptRef(*new SVGSwitchElement(tagName, document));
+    return adoptRef(*new SVGSwitchElement(document));
 }
 
 bool SVGSwitchElement::childShouldCreateRenderer(const Node& child) const

--- a/Source/WebCore/svg/SVGSwitchElement.h
+++ b/Source/WebCore/svg/SVGSwitchElement.h
@@ -30,12 +30,12 @@ class SVGSwitchElement final : public SVGGraphicsElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGSwitchElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGSwitchElement);
 public:
-    static Ref<SVGSwitchElement> create(const QualifiedName&, Document&);
+    static Ref<SVGSwitchElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSwitchElement, SVGGraphicsElement>;
 
 private:
-    SVGSwitchElement(const QualifiedName&, Document&);
+    explicit SVGSwitchElement(Document&);
 
     bool isValid() const final { return SVGTests::isValid(); }
 

--- a/Source/WebCore/svg/SVGSymbolElement.cpp
+++ b/Source/WebCore/svg/SVGSymbolElement.cpp
@@ -34,16 +34,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGSymbolElement);
 
-inline SVGSymbolElement::SVGSymbolElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGSymbolElement::SVGSymbolElement(Document& document)
+    : SVGGraphicsElement(SVGNames::symbolTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGFitToViewBox(this)
 {
-    ASSERT(hasTagName(SVGNames::symbolTag));
 }
 
-Ref<SVGSymbolElement> SVGSymbolElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGSymbolElement> SVGSymbolElement::create(Document& document)
 {
-    return adoptRef(*new SVGSymbolElement(tagName, document));
+    return adoptRef(*new SVGSymbolElement(document));
 }
 
 void SVGSymbolElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGSymbolElement.h
+++ b/Source/WebCore/svg/SVGSymbolElement.h
@@ -31,12 +31,12 @@ class SVGSymbolElement final : public SVGGraphicsElement, public SVGFitToViewBox
     WTF_MAKE_TZONE_ALLOCATED(SVGSymbolElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGSymbolElement);
 public:
-    static Ref<SVGSymbolElement> create(const QualifiedName&, Document&);
+    static Ref<SVGSymbolElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGSymbolElement, SVGGraphicsElement, SVGFitToViewBox>;
 
 private:
-    SVGSymbolElement(const QualifiedName&, Document&);
+    explicit SVGSymbolElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;

--- a/Source/WebCore/svg/SVGTRefElement.cpp
+++ b/Source/WebCore/svg/SVGTRefElement.cpp
@@ -42,9 +42,9 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGTRefElement);
 
-Ref<SVGTRefElement> SVGTRefElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGTRefElement> SVGTRefElement::create(Document& document)
 {
-    Ref element = adoptRef(*new SVGTRefElement(tagName, document));
+    Ref element = adoptRef(*new SVGTRefElement(document));
     element->ensureUserAgentShadowRoot();
     return element;
 }
@@ -118,12 +118,11 @@ void SVGTRefTargetEventListener::handleEvent(ScriptExecutionContext&, Event& eve
         protectedTRefElement()->detachTarget();
 }
 
-inline SVGTRefElement::SVGTRefElement(const QualifiedName& tagName, Document& document)
-    : SVGTextPositioningElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGTRefElement::SVGTRefElement(Document& document)
+    : SVGTextPositioningElement(SVGNames::trefTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
     , m_targetListener(SVGTRefTargetEventListener::create(*this))
 {
-    ASSERT(hasTagName(SVGNames::trefTag));
 }
 
 SVGTRefElement::~SVGTRefElement()

--- a/Source/WebCore/svg/SVGTRefElement.h
+++ b/Source/WebCore/svg/SVGTRefElement.h
@@ -33,14 +33,14 @@ class SVGTRefElement final : public SVGTextPositioningElement, public SVGURIRefe
     WTF_MAKE_TZONE_ALLOCATED(SVGTRefElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTRefElement);
 public:
-    static Ref<SVGTRefElement> create(const QualifiedName&, Document&);
+    static Ref<SVGTRefElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTRefElement, SVGTextPositioningElement, SVGURIReference>;
 
 private:
     friend class SVGTRefTargetEventListener;
 
-    SVGTRefElement(const QualifiedName&, Document&);
+    explicit SVGTRefElement(Document&);
     virtual ~SVGTRefElement();
 
     Ref<SVGTRefTargetEventListener> protectedTargetListener() const;

--- a/Source/WebCore/svg/SVGTSpanElement.cpp
+++ b/Source/WebCore/svg/SVGTSpanElement.cpp
@@ -32,15 +32,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGTSpanElement);
 
-inline SVGTSpanElement::SVGTSpanElement(const QualifiedName& tagName, Document& document)
-    : SVGTextPositioningElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGTSpanElement::SVGTSpanElement(Document& document)
+    : SVGTextPositioningElement(SVGNames::tspanTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::tspanTag));
 }
 
-Ref<SVGTSpanElement> SVGTSpanElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGTSpanElement> SVGTSpanElement::create(Document& document)
 {
-    return adoptRef(*new SVGTSpanElement(tagName, document));
+    return adoptRef(*new SVGTSpanElement(document));
 }
 
 RenderPtr<RenderElement> SVGTSpanElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/svg/SVGTSpanElement.h
+++ b/Source/WebCore/svg/SVGTSpanElement.h
@@ -28,10 +28,10 @@ class SVGTSpanElement final : public SVGTextPositioningElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGTSpanElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTSpanElement);
 public:
-    static Ref<SVGTSpanElement> create(const QualifiedName&, Document&);
+    static Ref<SVGTSpanElement> create(Document&);
 
 private:
-    SVGTSpanElement(const QualifiedName&, Document&);
+    explicit SVGTSpanElement(Document&);
             
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     bool childShouldCreateRenderer(const Node&) const override;

--- a/Source/WebCore/svg/SVGTextElement.cpp
+++ b/Source/WebCore/svg/SVGTextElement.cpp
@@ -33,15 +33,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGTextElement);
 
-inline SVGTextElement::SVGTextElement(const QualifiedName& tagName, Document& document)
-    : SVGTextPositioningElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGTextElement::SVGTextElement(Document& document)
+    : SVGTextPositioningElement(SVGNames::textTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::textTag));
 }
 
-Ref<SVGTextElement> SVGTextElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGTextElement> SVGTextElement::create(Document& document)
 {
-    return adoptRef(*new SVGTextElement(tagName, document));
+    return adoptRef(*new SVGTextElement(document));
 }
 
 RenderPtr<RenderElement> SVGTextElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/svg/SVGTextElement.h
+++ b/Source/WebCore/svg/SVGTextElement.h
@@ -28,10 +28,10 @@ class SVGTextElement final : public SVGTextPositioningElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGTextElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTextElement);
 public:
-    static Ref<SVGTextElement> create(const QualifiedName&, Document&);
+    static Ref<SVGTextElement> create(Document&);
 
 private:
-    SVGTextElement(const QualifiedName&, Document&);
+    explicit SVGTextElement(Document&);
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) override;
     bool childShouldCreateRenderer(const Node&) const override;

--- a/Source/WebCore/svg/SVGTextPathElement.cpp
+++ b/Source/WebCore/svg/SVGTextPathElement.cpp
@@ -41,12 +41,10 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGTextPathElement);
 
-inline SVGTextPathElement::SVGTextPathElement(const QualifiedName& tagName, Document& document)
-    : SVGTextContentElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGTextPathElement::SVGTextPathElement(Document& document)
+    : SVGTextContentElement(SVGNames::textPathTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
 {
-    ASSERT(hasTagName(SVGNames::textPathTag));
-
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
         didRegistration = true;
@@ -56,9 +54,9 @@ inline SVGTextPathElement::SVGTextPathElement(const QualifiedName& tagName, Docu
     }
 }
 
-Ref<SVGTextPathElement> SVGTextPathElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGTextPathElement> SVGTextPathElement::create(Document& document)
 {
-    return adoptRef(*new SVGTextPathElement(tagName, document));
+    return adoptRef(*new SVGTextPathElement(document));
 }
 
 SVGTextPathElement::~SVGTextPathElement()

--- a/Source/WebCore/svg/SVGTextPathElement.h
+++ b/Source/WebCore/svg/SVGTextPathElement.h
@@ -112,7 +112,7 @@ public:
         TEXTPATH_SPACINGTYPE_EXACT = SVGTextPathSpacingExact
     };
 
-    static Ref<SVGTextPathElement> create(const QualifiedName&, Document&);
+    static Ref<SVGTextPathElement> create(Document&);
 
     const SVGLengthValue& startOffset() const { return m_startOffset->currentValue(); }
     SVGTextPathMethodType method() const { return m_method->currentValue<SVGTextPathMethodType>(); }
@@ -125,7 +125,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGTextPathElement, SVGTextContentElement, SVGURIReference>;
 
 private:
-    SVGTextPathElement(const QualifiedName&, Document&);
+    explicit SVGTextPathElement(Document&);
     virtual ~SVGTextPathElement();
 
     void didFinishInsertingNode() override;

--- a/Source/WebCore/svg/SVGTitleElement.cpp
+++ b/Source/WebCore/svg/SVGTitleElement.cpp
@@ -31,15 +31,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGTitleElement);
 
-inline SVGTitleElement::SVGTitleElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGTitleElement::SVGTitleElement(Document& document)
+    : SVGElement(SVGNames::titleTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::titleTag));
 }
 
-Ref<SVGTitleElement> SVGTitleElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGTitleElement> SVGTitleElement::create(Document& document)
 {
-    return adoptRef(*new SVGTitleElement(tagName, document));
+    return adoptRef(*new SVGTitleElement(document));
 }
 
 Node::InsertedIntoAncestorResult SVGTitleElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/svg/SVGTitleElement.h
+++ b/Source/WebCore/svg/SVGTitleElement.h
@@ -30,10 +30,10 @@ class SVGTitleElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGTitleElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGTitleElement);
 public:
-    static Ref<SVGTitleElement> create(const QualifiedName&, Document&);
+    static Ref<SVGTitleElement> create(Document&);
 
 private:
-    SVGTitleElement(const QualifiedName&, Document&);
+    explicit SVGTitleElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void removedFromAncestor(RemovalType, ContainerNode&) final;

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -57,13 +57,12 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGUseElement);
 
-inline SVGUseElement::SVGUseElement(const QualifiedName& tagName, Document& document)
-    : SVGGraphicsElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGUseElement::SVGUseElement(Document& document)
+    : SVGGraphicsElement(SVGNames::useTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGURIReference(this)
     , m_loadEventTimer(*this, &SVGElement::loadEventTimerFired)
 {
     ASSERT(hasCustomStyleResolveCallbacks());
-    ASSERT(hasTagName(SVGNames::useTag));
 
     static bool didRegistration = false;
     if (!didRegistration) [[unlikely]] {
@@ -75,9 +74,9 @@ inline SVGUseElement::SVGUseElement(const QualifiedName& tagName, Document& docu
     }
 }
 
-Ref<SVGUseElement> SVGUseElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGUseElement> SVGUseElement::create(Document& document)
 {
-    return adoptRef(*new SVGUseElement(tagName, document));
+    return adoptRef(*new SVGUseElement(document));
 }
 
 SVGUseElement::~SVGUseElement()

--- a/Source/WebCore/svg/SVGUseElement.h
+++ b/Source/WebCore/svg/SVGUseElement.h
@@ -36,7 +36,7 @@ class SVGUseElement final : public SVGGraphicsElement, public SVGURIReference, p
     WTF_MAKE_TZONE_ALLOCATED(SVGUseElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGUseElement);
 public:
-    static Ref<SVGUseElement> create(const QualifiedName&, Document&);
+    static Ref<SVGUseElement> create(Document&);
     virtual ~SVGUseElement();
 
     // CachedResourceClient.
@@ -64,7 +64,7 @@ public:
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGUseElement, SVGGraphicsElement, SVGURIReference>;
 
 private:
-    SVGUseElement(const QualifiedName&, Document&);
+    explicit SVGUseElement(Document&);
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) override;
     void didFinishInsertingNode() final;

--- a/Source/WebCore/svg/SVGVKernElement.cpp
+++ b/Source/WebCore/svg/SVGVKernElement.cpp
@@ -32,15 +32,14 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGVKernElement);
 
-inline SVGVKernElement::SVGVKernElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGVKernElement::SVGVKernElement(Document& document)
+    : SVGElement(SVGNames::vkernTag, document, makeUniqueRef<PropertyRegistry>(*this))
 {
-    ASSERT(hasTagName(SVGNames::vkernTag));
 }
 
-Ref<SVGVKernElement> SVGVKernElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGVKernElement> SVGVKernElement::create(Document& document)
 {
-    return adoptRef(*new SVGVKernElement(tagName, document));
+    return adoptRef(*new SVGVKernElement(document));
 }
 
 std::optional<SVGKerningPair> SVGVKernElement::buildVerticalKerningPair() const

--- a/Source/WebCore/svg/SVGVKernElement.h
+++ b/Source/WebCore/svg/SVGVKernElement.h
@@ -28,12 +28,12 @@ class SVGVKernElement final : public SVGElement {
     WTF_MAKE_TZONE_ALLOCATED(SVGVKernElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGVKernElement);
 public:
-    static Ref<SVGVKernElement> create(const QualifiedName&, Document&);
+    static Ref<SVGVKernElement> create(Document&);
 
     std::optional<SVGKerningPair> buildVerticalKerningPair() const;
 
 private:
-    SVGVKernElement(const QualifiedName&, Document&);
+    explicit SVGVKernElement(Document&);
 
     bool rendererIsNeeded(const RenderStyle&) final { return false; }
 };

--- a/Source/WebCore/svg/SVGViewElement.cpp
+++ b/Source/WebCore/svg/SVGViewElement.cpp
@@ -33,16 +33,15 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SVGViewElement);
 
-inline SVGViewElement::SVGViewElement(const QualifiedName& tagName, Document& document)
-    : SVGElement(tagName, document, makeUniqueRef<PropertyRegistry>(*this))
+inline SVGViewElement::SVGViewElement(Document& document)
+    : SVGElement(SVGNames::viewTag, document, makeUniqueRef<PropertyRegistry>(*this))
     , SVGFitToViewBox(this)
 {
-    ASSERT(hasTagName(SVGNames::viewTag));
 }
 
-Ref<SVGViewElement> SVGViewElement::create(const QualifiedName& tagName, Document& document)
+Ref<SVGViewElement> SVGViewElement::create(Document& document)
 {
-    return adoptRef(*new SVGViewElement(tagName, document));
+    return adoptRef(*new SVGViewElement(document));
 }
 
 void SVGViewElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)

--- a/Source/WebCore/svg/SVGViewElement.h
+++ b/Source/WebCore/svg/SVGViewElement.h
@@ -34,7 +34,7 @@ class SVGViewElement final : public SVGElement, public SVGFitToViewBox, public S
     WTF_MAKE_TZONE_ALLOCATED(SVGViewElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(SVGViewElement);
 public:
-    static Ref<SVGViewElement> create(const QualifiedName&, Document&);
+    static Ref<SVGViewElement> create(Document&);
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGViewElement, SVGElement, SVGFitToViewBox>;
 
@@ -43,7 +43,7 @@ public:
     void resetTargetElement() { m_targetElement = nullptr; }
 
 private:
-    SVGViewElement(const QualifiedName&, Document&);
+    explicit SVGViewElement(Document&);
 
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
     void svgAttributeChanged(const QualifiedName&) override;


### PR DESCRIPTION
#### 5998a5135f513ebf82fe35af2acf21e98f825227
<pre>
Remove single-class-element-name-based constructors
<a href="https://bugs.webkit.org/show_bug.cgi?id=307904">https://bugs.webkit.org/show_bug.cgi?id=307904</a>

Reviewed by NOBODY (OOPS!).

This improves code clarity and makes it easier to use elements
internally.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5998a5135f513ebf82fe35af2acf21e98f825227

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144791 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17470 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/9217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153462 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98426 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdc6049e-e29c-4375-b87a-5faf01f02686) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146666 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17953 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17364 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111330 "Failure limit exceed. At least found 467 new test failures: dom/xhtml/level3/core/documentadoptnode27.xhtml dom/xhtml/level3/core/nodeinsertbefore16.xhtml dom/xhtml/level3/core/nodeisdefaultnamespace09.xhtml dom/xhtml/level3/core/nodeisdefaultnamespace10.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri01.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri02.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri05.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri10.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri11.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri13.xhtml ... (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80eba559-4a63-42ee-b0f5-221272c2df8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147754 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13696 "Found 37 new test failures: dom/xhtml/level3/core/documentadoptnode27.xhtml dom/xhtml/level3/core/nodeinsertbefore16.xhtml dom/xhtml/level3/core/nodeisdefaultnamespace09.xhtml dom/xhtml/level3/core/nodeisdefaultnamespace10.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri02.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri05.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri10.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri11.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri13.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri14.xhtml ... (failure)") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/130049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92225 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac77a18e-31eb-4239-97b7-936266d0f872) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13069 "Found 5 new test failures: imported/w3c/web-platform-tests/dom/nodes/Document-createElementNS.html imported/w3c/web-platform-tests/dom/nodes/Element-tagName.html imported/w3c/web-platform-tests/domparsing/innerhtml-03.xhtml imported/w3c/web-platform-tests/html/semantics/tabular-data/the-table-element/table-insertRow.html imported/w3c/web-platform-tests/html/syntax/parsing-html-fragments/innerHTML-setter-default-namespace.xhtml (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10824 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/907 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122585 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/6793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155774 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17322 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/7881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119334 "Failure limit exceed. At least found 464 new test failures: dom/xhtml/level3/core/documentadoptnode27.xhtml dom/xhtml/level3/core/nodeinsertbefore16.xhtml dom/xhtml/level3/core/nodeisdefaultnamespace09.xhtml dom/xhtml/level3/core/nodeisdefaultnamespace10.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri01.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri02.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri05.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri10.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri11.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri13.xhtml ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17369 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14466 "Found 60 new test failures: dom/xhtml/level3/core/documentadoptnode27.xhtml dom/xhtml/level3/core/nodeinsertbefore16.xhtml dom/xhtml/level3/core/nodeisdefaultnamespace09.xhtml dom/xhtml/level3/core/nodeisdefaultnamespace10.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri01.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri02.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri05.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri10.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri11.xhtml dom/xhtml/level3/core/nodelookupnamespaceuri13.xhtml ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119662 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15472 "Passed tests") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/128051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72864 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16944 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6349 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16680 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80723 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16889 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16744 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->