### PR TITLE
SVGAnimatedNumber properties should handle attribute removal and invalid values correctly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt
@@ -1,12 +1,12 @@
 
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (invalid value) assert_equals: initial after expected 1 but got 0
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (remove)
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.slope (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.intercept (remove)
 PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.intercept (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.amplitude (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.amplitude (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.exponent (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.exponent (invalid value) assert_equals: initial after expected 1 but got 0
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.amplitude (remove)
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.amplitude (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.exponent (remove)
+PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.exponent (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.offset (remove)
 PASS SVGAnimatedNumber, initial values, SVGComponentTransferFunctionElement.prototype.offset (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFECompositeElement.prototype.k1 (remove)
@@ -25,36 +25,36 @@ PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.ker
 PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthX (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthY (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEConvolveMatrixElement.prototype.kernelUnitLengthY (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.diffuseConstant (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.diffuseConstant (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthY (invalid value) assert_equals: initial after expected 0 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.surfaceScale (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.diffuseConstant (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.diffuseConstant (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDiffuseLightingElement.prototype.kernelUnitLengthY (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEDisplacementMapElement.prototype.scale (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEDisplacementMapElement.prototype.scale (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.azimuth (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.azimuth (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.elevation (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEDistantLightElement.prototype.elevation (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (remove) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (invalid value) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (remove) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (invalid value) assert_equals: initial after expected 2 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (remove) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (invalid value) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (remove) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (invalid value) assert_equals: initial after expected 2 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationY (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusY (invalid value) assert_equals: initial after expected 0 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dx (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.dy (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEDropShadowElement.prototype.stdDeviationY (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEGaussianBlurElement.prototype.stdDeviationY (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFEMorphologyElement.prototype.radiusY (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEOffsetElement.prototype.dx (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEOffsetElement.prototype.dx (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEOffsetElement.prototype.dy (remove)
@@ -65,16 +65,16 @@ PASS SVGAnimatedNumber, initial values, SVGFEPointLightElement.prototype.y (remo
 PASS SVGAnimatedNumber, initial values, SVGFEPointLightElement.prototype.y (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFEPointLightElement.prototype.z (remove)
 PASS SVGAnimatedNumber, initial values, SVGFEPointLightElement.prototype.z (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.surfaceScale (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.surfaceScale (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularConstant (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularConstant (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularExponent (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularExponent (invalid value) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthY (invalid value) assert_equals: initial after expected 0 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.surfaceScale (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.surfaceScale (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularConstant (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularConstant (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularExponent (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.specularExponent (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpecularLightingElement.prototype.kernelUnitLengthY (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.x (remove)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.x (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.y (remove)
@@ -87,14 +87,14 @@ PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.pointsAt
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.pointsAtY (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.pointsAtZ (remove)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.pointsAtZ (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.specularExponent (remove) assert_equals: initial after expected 1 but got 0
-FAIL SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.specularExponent (invalid value) assert_equals: initial after expected 1 but got 0
+PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.specularExponent (remove)
+PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.specularExponent (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.limitingConeAngle (remove)
 PASS SVGAnimatedNumber, initial values, SVGFESpotLightElement.prototype.limitingConeAngle (invalid value)
-FAIL SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyX (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyX (invalid value) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyY (remove) assert_equals: initial after expected 0 but got 42
-FAIL SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyY (invalid value) assert_equals: initial after expected 0 but got 42
+PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyX (remove)
+PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyX (invalid value)
+PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyY (remove)
+PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.baseFrequencyY (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.seed (remove)
 PASS SVGAnimatedNumber, initial values, SVGFETurbulenceElement.prototype.seed (invalid value)
 PASS SVGAnimatedNumber, initial values, SVGGeometryElement.prototype.pathLength (remove)

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp
@@ -26,6 +26,7 @@
 #include "SVGComponentTransferFunctionElementInlines.h"
 #include "SVGFEComponentTransferElement.h"
 #include "SVGNames.h"
+#include "SVGParserUtilities.h"
 #include "SVGPropertyOwnerRegistry.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -63,19 +64,19 @@ void SVGComponentTransferFunctionElement::attributeChanged(const QualifiedName& 
         m_tableValues->baseVal()->parse(newValue);
         break;
     case AttributeNames::slopeAttr:
-        m_slope->setBaseValInternal(newValue.toFloat());
+        m_slope->setBaseValInternal(parseNumber(newValue), initialSlope);
         break;
     case AttributeNames::interceptAttr:
-        m_intercept->setBaseValInternal(newValue.toFloat());
+        m_intercept->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::amplitudeAttr:
-        m_amplitude->setBaseValInternal(newValue.toFloat());
+        m_amplitude->setBaseValInternal(parseNumber(newValue), initialAmplitude);
         break;
     case AttributeNames::exponentAttr:
-        m_exponent->setBaseValInternal(newValue.toFloat());
+        m_exponent->setBaseValInternal(parseNumber(newValue), initialExponent);
         break;
     case AttributeNames::offsetAttr:
-        m_offset->setBaseValInternal(newValue.toFloat());
+        m_offset->setBaseValInternal(parseNumber(newValue));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
+++ b/Source/WebCore/svg/SVGComponentTransferFunctionElement.h
@@ -103,12 +103,17 @@ protected:
     bool rendererIsNeeded(const RenderStyle&) override { return false; }
     
 private:
+    // FIXME: These initial values should be consolidated in a shared SVGFilterDefaults.h.
+    static constexpr float initialSlope = 1;
+    static constexpr float initialAmplitude = 1;
+    static constexpr float initialExponent = 1;
+
     const Ref<SVGAnimatedEnumeration> m_type { SVGAnimatedEnumeration::create(this, ComponentTransferType::FECOMPONENTTRANSFER_TYPE_IDENTITY) };
     const Ref<SVGAnimatedNumberList> m_tableValues { SVGAnimatedNumberList::create(this) };
-    const Ref<SVGAnimatedNumber> m_slope { SVGAnimatedNumber::create(this, 1) };
+    const Ref<SVGAnimatedNumber> m_slope { SVGAnimatedNumber::create(this, initialSlope) };
     const Ref<SVGAnimatedNumber> m_intercept { SVGAnimatedNumber::create(this) };
-    const Ref<SVGAnimatedNumber> m_amplitude { SVGAnimatedNumber::create(this, 1) };
-    const Ref<SVGAnimatedNumber> m_exponent { SVGAnimatedNumber::create(this, 1) };
+    const Ref<SVGAnimatedNumber> m_amplitude { SVGAnimatedNumber::create(this, initialAmplitude) };
+    const Ref<SVGAnimatedNumber> m_exponent { SVGAnimatedNumber::create(this, initialExponent) };
     const Ref<SVGAnimatedNumber> m_offset { SVGAnimatedNumber::create(this) };
 };
 

--- a/Source/WebCore/svg/SVGFECompositeElement.cpp
+++ b/Source/WebCore/svg/SVGFECompositeElement.cpp
@@ -25,6 +25,7 @@
 #include "FEComposite.h"
 #include "NodeName.h"
 #include "SVGNames.h"
+#include "SVGParserUtilities.h"
 #include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -71,16 +72,16 @@ void SVGFECompositeElement::attributeChanged(const QualifiedName& name, const At
         Ref { m_in2 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::k1Attr:
-        m_k1->setBaseValInternal(newValue.toFloat());
+        m_k1->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::k2Attr:
-        m_k2->setBaseValInternal(newValue.toFloat());
+        m_k2->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::k3Attr:
-        m_k3->setBaseValInternal(newValue.toFloat());
+        m_k3->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::k4Attr:
-        m_k4->setBaseValInternal(newValue.toFloat());
+        m_k4->setBaseValInternal(parseNumber(newValue));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp
@@ -107,7 +107,7 @@ void SVGFEConvolveMatrixElement::attributeChanged(const QualifiedName& name, con
         break;
     }
     case AttributeNames::biasAttr:
-        m_bias->setBaseValInternal(newValue.toFloat());
+        m_bias->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::targetXAttr:
         m_targetX->setBaseValInternal(parseInteger<unsigned>(newValue).value_or(0));

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp
@@ -63,15 +63,18 @@ void SVGFEDiffuseLightingElement::attributeChanged(const QualifiedName& name, co
         Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::surfaceScaleAttr:
-        m_surfaceScale->setBaseValInternal(newValue.toFloat());
+        m_surfaceScale->setBaseValInternal(parseNumber(newValue), initialSurfaceScale);
         break;
     case AttributeNames::diffuseConstantAttr:
-        m_diffuseConstant->setBaseValInternal(newValue.toFloat());
+        m_diffuseConstant->setBaseValInternal(parseNumber(newValue), initialDiffuseConstant);
         break;
     case AttributeNames::kernelUnitLengthAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_kernelUnitLengthX->setBaseValInternal(result->first);
             m_kernelUnitLengthY->setBaseValInternal(result->second);
+        } else {
+            m_kernelUnitLengthX->setBaseValInternal(std::nullopt);
+            m_kernelUnitLengthY->setBaseValInternal(std::nullopt);
         }
         break;
     default:

--- a/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
+++ b/Source/WebCore/svg/SVGFEDiffuseLightingElement.h
@@ -62,9 +62,13 @@ private:
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
+    // FIXME: These initial values should be consolidated in a shared SVGFilterDefaults.h.
+    static constexpr float initialDiffuseConstant = 1;
+    static constexpr float initialSurfaceScale = 1;
+
     const Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
-    const Ref<SVGAnimatedNumber> m_diffuseConstant { SVGAnimatedNumber::create(this, 1) };
-    const Ref<SVGAnimatedNumber> m_surfaceScale { SVGAnimatedNumber::create(this, 1) };
+    const Ref<SVGAnimatedNumber> m_diffuseConstant { SVGAnimatedNumber::create(this, initialDiffuseConstant) };
+    const Ref<SVGAnimatedNumber> m_surfaceScale { SVGAnimatedNumber::create(this, initialSurfaceScale) };
     const Ref<SVGAnimatedNumber> m_kernelUnitLengthX { SVGAnimatedNumber::create(this) };
     const Ref<SVGAnimatedNumber> m_kernelUnitLengthY { SVGAnimatedNumber::create(this) };
 };

--- a/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
+++ b/Source/WebCore/svg/SVGFEDisplacementMapElement.cpp
@@ -25,6 +25,7 @@
 #include "NodeName.h"
 #include "SVGFilterRenderer.h"
 #include "SVGNames.h"
+#include "SVGParserUtilities.h"
 #include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -75,7 +76,7 @@ void SVGFEDisplacementMapElement::attributeChanged(const QualifiedName& name, co
         Ref { m_in2 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::scaleAttr:
-        m_scale->setBaseValInternal(newValue.toFloat());
+        m_scale->setBaseValInternal(parseNumber(newValue));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEDropShadowElement.cpp
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.cpp
@@ -69,16 +69,19 @@ void SVGFEDropShadowElement::attributeChanged(const QualifiedName& name, const A
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_stdDeviationX->setBaseValInternal(result->first);
             m_stdDeviationY->setBaseValInternal(result->second);
+        } else {
+            m_stdDeviationX->setBaseValInternal(std::nullopt, initialStdDeviation);
+            m_stdDeviationY->setBaseValInternal(std::nullopt, initialStdDeviation);
         }
         break;
     case AttributeNames::inAttr:
         Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::dxAttr:
-        m_dx->setBaseValInternal(newValue.toFloat());
+        m_dx->setBaseValInternal(parseNumber(newValue), initialDx);
         break;
     case AttributeNames::dyAttr:
-        m_dy->setBaseValInternal(newValue.toFloat());
+        m_dy->setBaseValInternal(parseNumber(newValue), initialDy);
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFEDropShadowElement.h
+++ b/Source/WebCore/svg/SVGFEDropShadowElement.h
@@ -60,11 +60,16 @@ private:
     IntOutsets outsets(const FloatRect& targetBoundingBox, SVGUnitTypes::SVGUnitType primitiveUnits) const override;
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
+    // FIXME: These initial values should be consolidated in a shared SVGFilterDefaults.h.
+    static constexpr float initialDx = 2;
+    static constexpr float initialDy = 2;
+    static constexpr float initialStdDeviation = 2;
+
     const Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
-    const Ref<SVGAnimatedNumber> m_dx { SVGAnimatedNumber::create(this, 2) };
-    const Ref<SVGAnimatedNumber> m_dy { SVGAnimatedNumber::create(this, 2) };
-    const Ref<SVGAnimatedNumber> m_stdDeviationX { SVGAnimatedNumber::create(this, 2) };
-    const Ref<SVGAnimatedNumber> m_stdDeviationY { SVGAnimatedNumber::create(this, 2) };
+    const Ref<SVGAnimatedNumber> m_dx { SVGAnimatedNumber::create(this, initialDx) };
+    const Ref<SVGAnimatedNumber> m_dy { SVGAnimatedNumber::create(this, initialDy) };
+    const Ref<SVGAnimatedNumber> m_stdDeviationX { SVGAnimatedNumber::create(this, initialStdDeviation) };
+    const Ref<SVGAnimatedNumber> m_stdDeviationY { SVGAnimatedNumber::create(this, initialStdDeviation) };
 };
     
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
+++ b/Source/WebCore/svg/SVGFEGaussianBlurElement.cpp
@@ -70,6 +70,9 @@ void SVGFEGaussianBlurElement::attributeChanged(const QualifiedName& name, const
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_stdDeviationX->setBaseValInternal(result->first);
             m_stdDeviationY->setBaseValInternal(result->second);
+        } else {
+            m_stdDeviationX->setBaseValInternal(std::nullopt);
+            m_stdDeviationY->setBaseValInternal(std::nullopt);
         }
         break;
     case AttributeNames::inAttr:

--- a/Source/WebCore/svg/SVGFELightElement.cpp
+++ b/Source/WebCore/svg/SVGFELightElement.cpp
@@ -37,6 +37,7 @@
 #include "SVGFilterElement.h"
 #include "SVGFilterPrimitiveStandardAttributes.h"
 #include "SVGNames.h"
+#include "SVGParserUtilities.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -75,34 +76,34 @@ void SVGFELightElement::attributeChanged(const QualifiedName& name, const AtomSt
 {
     switch (name.nodeName()) {
     case AttributeNames::azimuthAttr:
-        m_azimuth->setBaseValInternal(newValue.toFloat());
+        m_azimuth->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::elevationAttr:
-        m_elevation->setBaseValInternal(newValue.toFloat());
+        m_elevation->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::xAttr:
-        m_x->setBaseValInternal(newValue.toFloat());
+        m_x->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::yAttr:
-        m_y->setBaseValInternal(newValue.toFloat());
+        m_y->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::zAttr:
-        m_z->setBaseValInternal(newValue.toFloat());
+        m_z->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::pointsAtXAttr:
-        m_pointsAtX->setBaseValInternal(newValue.toFloat());
+        m_pointsAtX->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::pointsAtYAttr:
-        m_pointsAtY->setBaseValInternal(newValue.toFloat());
+        m_pointsAtY->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::pointsAtZAttr:
-        m_pointsAtZ->setBaseValInternal(newValue.toFloat());
+        m_pointsAtZ->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::specularExponentAttr:
-        m_specularExponent->setBaseValInternal(newValue.toFloat());
+        m_specularExponent->setBaseValInternal(parseNumber(newValue), initialSpecularExponent);
         break;
     case AttributeNames::limitingConeAngleAttr:
-        m_limitingConeAngle->setBaseValInternal(newValue.toFloat());
+        m_limitingConeAngle->setBaseValInternal(parseNumber(newValue));
         break;
     default:
         break;

--- a/Source/WebCore/svg/SVGFELightElement.h
+++ b/Source/WebCore/svg/SVGFELightElement.h
@@ -70,6 +70,9 @@ private:
     void svgAttributeChanged(const QualifiedName&) override;
     void childrenChanged(const ChildChange&) override;
 
+    // FIXME: These initial values should be consolidated in a shared SVGFilterDefaults.h.
+    static constexpr float initialSpecularExponent = 1;
+
     const Ref<SVGAnimatedNumber> m_azimuth { SVGAnimatedNumber::create(this) };
     const Ref<SVGAnimatedNumber> m_elevation { SVGAnimatedNumber::create(this) };
     const Ref<SVGAnimatedNumber> m_x { SVGAnimatedNumber::create(this) };
@@ -78,7 +81,7 @@ private:
     const Ref<SVGAnimatedNumber> m_pointsAtX { SVGAnimatedNumber::create(this) };
     const Ref<SVGAnimatedNumber> m_pointsAtY { SVGAnimatedNumber::create(this) };
     const Ref<SVGAnimatedNumber> m_pointsAtZ { SVGAnimatedNumber::create(this) };
-    const Ref<SVGAnimatedNumber> m_specularExponent { SVGAnimatedNumber::create(this, 1) };
+    const Ref<SVGAnimatedNumber> m_specularExponent { SVGAnimatedNumber::create(this, initialSpecularExponent) };
     const Ref<SVGAnimatedNumber> m_limitingConeAngle { SVGAnimatedNumber::create(this) };
 };
 

--- a/Source/WebCore/svg/SVGFEMorphologyElement.cpp
+++ b/Source/WebCore/svg/SVGFEMorphologyElement.cpp
@@ -69,6 +69,9 @@ void SVGFEMorphologyElement::attributeChanged(const QualifiedName& name, const A
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_radiusX->setBaseValInternal(result->first);
             m_radiusY->setBaseValInternal(result->second);
+        } else {
+            m_radiusX->setBaseValInternal(std::nullopt);
+            m_radiusY->setBaseValInternal(std::nullopt);
         }
         break;
     default:

--- a/Source/WebCore/svg/SVGFEOffsetElement.cpp
+++ b/Source/WebCore/svg/SVGFEOffsetElement.cpp
@@ -26,6 +26,7 @@
 #include "NodeName.h"
 #include "SVGFilterRenderer.h"
 #include "SVGNames.h"
+#include "SVGParserUtilities.h"
 #include "SVGPropertyOwnerRegistry.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -56,10 +57,10 @@ void SVGFEOffsetElement::attributeChanged(const QualifiedName& name, const AtomS
 {
     switch (name.nodeName()) {
     case AttributeNames::dxAttr:
-        m_dx->setBaseValInternal(newValue.toFloat());
+        m_dx->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::dyAttr:
-        m_dy->setBaseValInternal(newValue.toFloat());
+        m_dy->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::inAttr:
         Ref { m_in1 }->setBaseValInternal(newValue);

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.cpp
@@ -66,18 +66,21 @@ void SVGFESpecularLightingElement::attributeChanged(const QualifiedName& name, c
         Ref { m_in1 }->setBaseValInternal(newValue);
         break;
     case AttributeNames::surfaceScaleAttr:
-        m_surfaceScale->setBaseValInternal(newValue.toFloat());
+        m_surfaceScale->setBaseValInternal(parseNumber(newValue), initialSurfaceScale);
         break;
     case AttributeNames::specularConstantAttr:
-        m_specularConstant->setBaseValInternal(newValue.toFloat());
+        m_specularConstant->setBaseValInternal(parseNumber(newValue), initialSpecularConstant);
         break;
     case AttributeNames::specularExponentAttr:
-        m_specularExponent->setBaseValInternal(newValue.toFloat());
+        m_specularExponent->setBaseValInternal(parseNumber(newValue), initialSpecularExponent);
         break;
     case AttributeNames::kernelUnitLengthAttr:
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_kernelUnitLengthX->setBaseValInternal(result->first);
             m_kernelUnitLengthY->setBaseValInternal(result->second);
+        } else {
+            m_kernelUnitLengthX->setBaseValInternal(std::nullopt);
+            m_kernelUnitLengthY->setBaseValInternal(std::nullopt);
         }
         break;
     default:

--- a/Source/WebCore/svg/SVGFESpecularLightingElement.h
+++ b/Source/WebCore/svg/SVGFESpecularLightingElement.h
@@ -62,10 +62,15 @@ private:
     Vector<AtomString> filterEffectInputsNames() const override { return { AtomString { in1() } }; }
     RefPtr<FilterEffect> createFilterEffect(const FilterEffectVector&, const GraphicsContext& destinationContext) const override;
 
+    // FIXME: These initial values should be consolidated in a shared SVGFilterDefaults.h.
+    static constexpr float initialSpecularConstant = 1;
+    static constexpr float initialSpecularExponent = 1;
+    static constexpr float initialSurfaceScale = 1;
+
     const Ref<SVGAnimatedString> m_in1 { SVGAnimatedString::create(this) };
-    const Ref<SVGAnimatedNumber> m_specularConstant { SVGAnimatedNumber::create(this, 1) };
-    const Ref<SVGAnimatedNumber> m_specularExponent { SVGAnimatedNumber::create(this, 1) };
-    const Ref<SVGAnimatedNumber> m_surfaceScale { SVGAnimatedNumber::create(this, 1) };
+    const Ref<SVGAnimatedNumber> m_specularConstant { SVGAnimatedNumber::create(this, initialSpecularConstant) };
+    const Ref<SVGAnimatedNumber> m_specularExponent { SVGAnimatedNumber::create(this, initialSpecularExponent) };
+    const Ref<SVGAnimatedNumber> m_surfaceScale { SVGAnimatedNumber::create(this, initialSurfaceScale) };
     const Ref<SVGAnimatedNumber> m_kernelUnitLengthX { SVGAnimatedNumber::create(this) };
     const Ref<SVGAnimatedNumber> m_kernelUnitLengthY { SVGAnimatedNumber::create(this) };
 };

--- a/Source/WebCore/svg/SVGFETurbulenceElement.cpp
+++ b/Source/WebCore/svg/SVGFETurbulenceElement.cpp
@@ -76,10 +76,13 @@ void SVGFETurbulenceElement::attributeChanged(const QualifiedName& name, const A
         if (auto result = parseNumberOptionalNumber(newValue)) {
             m_baseFrequencyX->setBaseValInternal(result->first);
             m_baseFrequencyY->setBaseValInternal(result->second);
+        } else {
+            m_baseFrequencyX->setBaseValInternal(std::nullopt);
+            m_baseFrequencyY->setBaseValInternal(std::nullopt);
         }
         break;
     case AttributeNames::seedAttr:
-        m_seed->setBaseValInternal(newValue.toFloat());
+        m_seed->setBaseValInternal(parseNumber(newValue));
         break;
     case AttributeNames::numOctavesAttr: {
         auto result = parseInteger<int>(newValue);

--- a/Source/WebCore/svg/SVGGeometryElement.cpp
+++ b/Source/WebCore/svg/SVGGeometryElement.cpp
@@ -30,6 +30,7 @@
 #include "NodeDocument.h"
 #include "RenderSVGShape.h"
 #include "SVGDocumentExtensions.h"
+#include "SVGParserUtilities.h"
 #include "SVGPathUtilities.h"
 #include "SVGPoint.h"
 #include "SVGPropertyOwnerRegistry.h"
@@ -132,7 +133,7 @@ void SVGGeometryElement::attributeChanged(const QualifiedName& name, const AtomS
 {
     if (name == SVGNames::pathLengthAttr) {
         Ref pathLength = m_pathLength;
-        pathLength->setBaseValInternal(newValue.toFloat());
+        pathLength->setBaseValInternal(parseNumber(newValue));
         if (pathLength->baseVal() < 0)
             protect(protect(document())->svgExtensions())->reportError("A negative value for path attribute <pathLength> is not allowed"_s);
     }

--- a/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
+++ b/Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h
@@ -28,6 +28,7 @@
 #include "ExceptionOr.h"
 #include "SVGAnimatedProperty.h"
 #include "SVGSharedPrimitiveProperty.h"
+#include <optional>
 
 namespace WebCore {
 
@@ -57,6 +58,7 @@ public:
 
     // Used by SVGElement::parseAttribute().
     void setBaseValInternal(const PropertyType& baseVal) { m_baseVal->setValue(baseVal); }
+    void setBaseValInternal(std::optional<PropertyType> baseVal, const PropertyType& defaultValue = PropertyType { }) requires std::is_arithmetic_v<PropertyType> { m_baseVal->setValue(baseVal.value_or(defaultValue)); }
     const PropertyType& baseVal() const LIFETIME_BOUND { return m_baseVal->value(); }
 
     // Used by SVGAttributeAnimator::progress.


### PR DESCRIPTION
#### 1b0ef2d58624dacec83c2e360999a4f36df07b53
<pre>
SVGAnimatedNumber properties should handle attribute removal and invalid values correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=303073">https://bugs.webkit.org/show_bug.cgi?id=303073</a>
<a href="https://rdar.apple.com/165378154">rdar://165378154</a>

Reviewed by NOBODY (OOPS!).

Many SVG filter elements incorrectly fall back to 0 when attribute
parsing fails because attributeChanged() used toFloat() which silently
returns 0 for empty or invalid strings.

Replace toFloat() with parseNumber() which returns std::optional.
When parsing fails, reset the property to its spec-defined initial
value instead of 0.

Each element header now declares its initial values as static constexpr
constants, following the existing SVGFEConvolveMatrixElement pattern.

These could be consolidated into a shared SVGFilterDefaults.h in the
future.

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGAnimatedNumber-initial-values-expected.txt:
* Source/WebCore/svg/SVGComponentTransferFunctionElement.cpp:
(WebCore::SVGComponentTransferFunctionElement::attributeChanged):
* Source/WebCore/svg/SVGComponentTransferFunctionElement.h:
* Source/WebCore/svg/SVGFECompositeElement.cpp:
(WebCore::SVGFECompositeElement::attributeChanged):
* Source/WebCore/svg/SVGFEConvolveMatrixElement.cpp:
(WebCore::SVGFEConvolveMatrixElement::attributeChanged):
* Source/WebCore/svg/SVGFEDiffuseLightingElement.cpp:
(WebCore::SVGFEDiffuseLightingElement::attributeChanged):
* Source/WebCore/svg/SVGFEDiffuseLightingElement.h:
* Source/WebCore/svg/SVGFEDisplacementMapElement.cpp:
(WebCore::SVGFEDisplacementMapElement::attributeChanged):
* Source/WebCore/svg/SVGFEDropShadowElement.cpp:
(WebCore::SVGFEDropShadowElement::attributeChanged):
* Source/WebCore/svg/SVGFEDropShadowElement.h:
* Source/WebCore/svg/SVGFEGaussianBlurElement.cpp:
(WebCore::SVGFEGaussianBlurElement::attributeChanged):
* Source/WebCore/svg/SVGFELightElement.cpp:
(WebCore::SVGFELightElement::attributeChanged):
* Source/WebCore/svg/SVGFELightElement.h:
* Source/WebCore/svg/SVGFEMorphologyElement.cpp:
(WebCore::SVGFEMorphologyElement::attributeChanged):
* Source/WebCore/svg/SVGFEOffsetElement.cpp:
(WebCore::SVGFEOffsetElement::attributeChanged):
* Source/WebCore/svg/SVGFESpecularLightingElement.cpp:
(WebCore::SVGFESpecularLightingElement::attributeChanged):
* Source/WebCore/svg/SVGFESpecularLightingElement.h:
* Source/WebCore/svg/SVGFETurbulenceElement.cpp:
(WebCore::SVGFETurbulenceElement::attributeChanged):
* Source/WebCore/svg/SVGGeometryElement.cpp:
(WebCore::SVGGeometryElement::attributeChanged):
* Source/WebCore/svg/properties/SVGAnimatedPrimitiveProperty.h:
(WebCore::SVGAnimatedPrimitiveProperty::setBaseValInternal):
(WebCore::SVGAnimatedPrimitiveProperty::SVGAnimatedPrimitiveProperty):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b0ef2d58624dacec83c2e360999a4f36df07b53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/155138 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/28398 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/21557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/163898 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/108691 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/157011 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/28538 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/28246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/120029 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/84800 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/158097 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/22281 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/139308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/100722 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/21366 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/19421 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/11724 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/131028 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/17150 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/166376 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/10403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/18759 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/128132 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/27942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/23459 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/128270 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/27866 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/138943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/84575 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/23132 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/15738 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/27559 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/91662 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/27137 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/27367 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/27210 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->