### PR TITLE
Convert display property to a wrapper structure and move predicates/utilities to be members

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -3802,15 +3802,15 @@ static void appendNameToStringBuilder(StringBuilder& builder, String&& text, boo
 }
 
 
-static bool displayTypeNeedsSpace(Style::DisplayType type)
+static bool displayNeedsSpace(Style::Display display)
 {
-    return type == Style::DisplayType::BlockFlow
-        || type == Style::DisplayType::InlineFlowRoot
-        || type == Style::DisplayType::InlineFlex
-        || type == Style::DisplayType::InlineGrid
-        || type == Style::DisplayType::InlineGridLanes
-        || type == Style::DisplayType::InlineTable
-        || type == Style::DisplayType::TableCell;
+    return display == Style::DisplayType::BlockFlow
+        || display == Style::DisplayType::InlineFlowRoot
+        || display == Style::DisplayType::InlineFlex
+        || display == Style::DisplayType::InlineGrid
+        || display == Style::DisplayType::InlineGridLanes
+        || display == Style::DisplayType::InlineTable
+        || display == Style::DisplayType::TableCell;
 }
 
 static bool needsSpaceFromDisplay(AccessibilityObject& axObject)
@@ -3823,7 +3823,7 @@ static bool needsSpaceFromDisplay(AccessibilityObject& axObject)
     }
 
     if (auto* style = renderer ? &downcast<RenderElement>(*renderer).style() : axObject.style())
-        return displayTypeNeedsSpace(style->display());
+        return displayNeedsSpace(style->display());
     return false;
 }
 

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -1506,7 +1506,7 @@ bool AccessibilityRenderObject::computeIsIgnored() const
     if (isStyleFormatGroup())
         return false;
 
-    switch (downcast<RenderElement>(*m_renderer).style().display()) {
+    switch (downcast<RenderElement>(*m_renderer).style().display().value) {
     case Style::DisplayType::InlineRuby:
     case Style::DisplayType::BlockRuby:
     case Style::DisplayType::RubyText:
@@ -2521,7 +2521,7 @@ AccessibilityRole AccessibilityRenderObject::determineAccessibilityRole()
     if (m_renderer->isRenderOrLegacyRenderSVGRoot())
         return AccessibilityRole::SVGRoot;
 
-    switch (downcast<RenderElement>(*m_renderer).style().display()) {
+    switch (downcast<RenderElement>(*m_renderer).style().display().value) {
     case Style::DisplayType::InlineRuby:
         return AccessibilityRole::RubyInline;
     case Style::DisplayType::RubyText:

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -556,13 +556,12 @@
             "codegen-properties": {
                 "animation-wrapper-requires-non-normalized-discrete-interpolation": true,
                 "high-priority": true,
-                "computed-style-initial-custom": true,
                 "computed-style-getter-constexpr": true,
                 "computed-style-setter-custom": true,
                 "computed-style-storage-path": ["m_nonInheritedFlags"],
                 "computed-style-storage-container": "struct",
-                "computed-style-storage-kind": "enum",
-                "computed-style-type": "Style::DisplayType",
+                "computed-style-storage-kind": "raw",
+                "computed-style-type": "Style::Display",
                 "parser-function": "consumeDisplay",
                 "parser-grammar-unused": "[ <display-outside> || <display-inside> ] | <display-listitem> | <display-internal> | <display-box> | <display-legacy> | <-webkit-display>",
                 "parser-grammar-unused-reason": "Needs support for transforming parsed input to minimal form."

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -239,7 +239,7 @@ static std::optional<SimpleRange> rangeOfStringInRange(const String& query, Simp
         Vector<Ref<Text>> textNodeList;
         // FIXME: this is O^2 since treeOrder will also do traversal, optimize.
         while (currentNode && currentNode->isDescendantOf(blockAncestor) && is_lteq(treeOrder(BoundaryPoint(*currentNode, 0), searchRange.end))) {
-            if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(currentNode->renderer()); renderElement && Style::isDisplayBlockType(renderElement->style().display()))
+            if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(currentNode->renderer()); renderElement && renderElement->style().display().isBlockType())
                 break;
 
             if (isSearchInvisible(*currentNode)) {

--- a/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveUtilities.cpp
@@ -55,7 +55,7 @@ namespace FragmentDirectiveUtilities {
 ContainerNode& nearestBlockAncestor(Node& node)
 {
     for (RefPtr currentNode = node; currentNode; currentNode = currentNode->parentNode()) {
-        if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(currentNode->renderer()); renderElement && Style::isDisplayBlockType(renderElement->style().display()))
+        if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(currentNode->renderer()); renderElement && renderElement->style().display().isBlockType())
             return downcast<ContainerNode>(*currentNode);
     }
     return node.document();

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -76,7 +76,7 @@ Ref<HTMLButtonElement> HTMLButtonElement::create(Document& document)
 RenderPtr<RenderElement> HTMLButtonElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition& position)
 {
     // https://html.spec.whatwg.org/multipage/rendering.html#button-layout
-    if (Style::isDisplayFlexibleOrGridFormattingContextBox(style.display()))
+    if (style.display().isFlexibleOrGridFormattingContextBox())
         return HTMLFormControlElement::createElementRenderer(WTF::move(style), position);
     return createRenderer<RenderButton>(*this, WTF::move(style));
 }

--- a/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp
@@ -90,7 +90,7 @@ bool InlineQuirks::inlineBoxAffectsLineBox(const InlineLevelBox& inlineLevelBox)
         // The side effect of having no marker is that in quirks mode we have to specifically check for list-item
         // and make sure it is treated as if it had content and stretched the line.
         // see LegacyInlineFlowBox c'tor.
-        return Style::isDisplayListItemType(inlineLevelBox.layoutBox().style().originalDisplay());
+        return inlineLevelBox.layoutBox().style().originalDisplay().isListItemType();
     }
     // Non-root inline boxes (e.g. <span>).
     auto& boxGeometry = formattingContext().geometryForBox(inlineLevelBox.layoutBox());

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -472,7 +472,7 @@ void InlineDisplayContentBuilder::processNonBidiContent(const LineLayoutResult& 
         CheckedRef layoutBox = lineRun.layoutBox();
 
         if (lineRun.isOpaque()) {
-            if (Style::isDisplayInlineType(layoutBox->style().originalDisplay())) {
+            if (layoutBox->style().originalDisplay().isInlineType()) {
                 formattingContext().geometryForBox(layoutBox).setTopLeft({ lineBox.logicalRect().left() + lineBox.logicalRectForRootInlineBox().left() + lineRun.logicalLeft(), lineBox.logicalRect().top() });
                 continue;
             }
@@ -803,8 +803,8 @@ void InlineDisplayContentBuilder::processBidiContent(const LineLayoutResult& lin
             hasInlineBox = hasInlineBox || (!lineRun.isBlock() && (parentDisplayBoxNodeIndex || lineRun.isInlineBoxStart() || lineRun.isLineSpanningInlineBoxStart()));
 
             if (lineRun.isOpaque()) {
-                if (Style::isDisplayInlineType(layoutBox->style().originalDisplay())) {
-                    // Note that out-of-flow handling (render tree integraton) really only needs logical coords (not even "content in inline diretion visual order").
+                if (layoutBox->style().originalDisplay().isInlineType()) {
+                    // Note that out-of-flow handling (render tree integration) really only needs logical coords (not even "content in inline direction visual order").
                     formattingContext().geometryForBox(layoutBox).setTopLeft({ lineBox.logicalRect().left() + lineBox.logicalRectForRootInlineBox().left() + lineRun.logicalLeft(), lineBox.logicalRect().top() });
                     continue;
                 }

--- a/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp
@@ -178,7 +178,7 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, RenderSt
 {
     auto adjustStyle = [&](auto& styleToAdjust) {
         // If we end up here with a box that has a table display type, just treat it as a regular block-level box.
-        if (Style::isInternalTableBox(styleToAdjust.display()) || styleToAdjust.display() == Style::DisplayType::TableCaption) {
+        if (styleToAdjust.display().isInternalTableBox() || styleToAdjust.display() == Style::DisplayType::TableCaption) {
             styleToAdjust.setDisplay(Style::DisplayType::BlockFlow);
             return;
         }
@@ -221,7 +221,7 @@ void BoxTreeUpdater::adjustStyleIfNeeded(const RenderElement& renderer, RenderSt
                     return renderInline->parent()->style().display() == Style::DisplayType::InlineRuby;
                 if (is<RenderSVGInline>(*renderInline))
                     return display == Style::DisplayType::InlineFlow;
-                return Style::isDisplayInlineType(display);
+                return display.isInlineType();
             };
             if (!isSupportedInlineDisplay())
                 styleToAdjust.setDisplay(Style::DisplayType::InlineFlow);

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp
@@ -654,7 +654,7 @@ void LineLayout::updateRenderTreePositions(const Vector<LineAdjustment>& lineAdj
             auto delta = borderBoxLogicalTopLeft - previousStaticPosition;
             auto hasStaticInlinePositioning = layoutBox->style().hasStaticInlinePosition(renderer->isHorizontalWritingMode());
 
-            if (Style::isDisplayInlineType(layoutBox->style().originalDisplay())) {
+            if (layoutBox->style().originalDisplay().isInlineType()) {
                 blockFlow->setStaticInlinePositionForChild(renderer, borderBoxLogicalTopLeft.x());
                 if (hasStaticInlinePositioning)
                     renderer->move(delta.width(), delta.height());

--- a/Source/WebCore/layout/layouttree/LayoutBox.cpp
+++ b/Source/WebCore/layout/layouttree/LayoutBox.cpp
@@ -253,7 +253,7 @@ bool Box::isInlineLevelBox() const
 {
     // Inline level elements generate inline level boxes.
     auto display = m_style.display();
-    return is<ElementBox>(*this) && 
+    return is<ElementBox>(*this) &&
           (display == Style::DisplayType::InlineFlow
         || display == Style::DisplayType::InlineFlowRoot
         || display == Style::DisplayType::InlineTable

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -532,7 +532,7 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(const Render
     }
 
     // The parent will get its own InteractionRegion.
-    if (!isOriginalMatch && !matchedElementIsGuardContainer && !isPhoto && !isInlineNonBlock && !Style::isDisplayTableOrTablePart(renderer->style().display()))
+    if (!isOriginalMatch && !matchedElementIsGuardContainer && !isPhoto && !isInlineNonBlock && !renderer->style().display().isTableOrTablePart())
         return std::nullopt;
 
     // FIXME: Consider allowing rotation / skew - rdar://127499446.

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -99,7 +99,7 @@ bool LegacyLineLayout::shouldSkipCreatingRunsForObject(RenderObject& object)
     auto& renderElement = downcast<RenderElement>(object);
     if (renderElement.isFloating())
         return true;
-    if (renderElement.isOutOfFlowPositioned() && !Style::isDisplayInlineType(renderElement.style().originalDisplay()) && !renderElement.container()->isRenderInline())
+    if (renderElement.isOutOfFlowPositioned() && !renderElement.style().originalDisplay().isInlineType() && !renderElement.container()->isRenderInline())
         return true;
     return false;
 }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -293,7 +293,7 @@ RenderBlock::~RenderBlock()
 void RenderBlock::styleWillChange(Style::Difference diff, const RenderStyle& newStyle)
 {
     const RenderStyle* oldStyle = hasInitializedStyle() ? &style() : nullptr;
-    setBlockLevelReplacedOrAtomicInline(Style::isDisplayInlineType(newStyle.display()));
+    setBlockLevelReplacedOrAtomicInline(newStyle.display().isInlineType());
     if (oldStyle) {
         removeOutOfFlowBoxesIfNeededOnStyleChange(*this, *oldStyle, newStyle);
         if (isLegend() && !oldStyle->isFloating() && newStyle.isFloating())
@@ -1302,8 +1302,8 @@ bool RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType(con
     }
 
     auto isBlockBoxWithPotentiallyScrollableOverflow = [&] {
-        return Style::isDisplayBlockType(style.display())
-            && Style::doesDisplayGenerateBlockContainer(style.display())
+        return style.display().isBlockType()
+            && style.display().doesGenerateBlockContainer()
             && hasNonVisibleOverflow()
             && style.overflowX() != Overflow::Clip
             && style.overflowX() != Overflow::Visible;
@@ -1315,7 +1315,7 @@ bool RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType(con
         || style.usedContain().contains(Style::ContainValue::Layout)
         || style.containerType() != ContainerType::Normal
         || WebCore::shouldApplyPaintContainment(style, *protect(element()))
-        || (Style::isDisplayBlockType(style.display()) && !style.blockStepSize().isNone());
+        || (style.display().isBlockType() && !style.blockStepSize().isNone());
 }
 
 bool RenderBlock::establishesIndependentFormattingContext() const
@@ -1348,7 +1348,7 @@ bool RenderBlock::createsNewFormattingContext() const
     if (isBlockContainer() && !style.alignContent().isNormal())
         return true;
     return isNonReplacedAtomicInlineLevelBox()
-        || Style::isDisplayFlexibleBoxIncludingDeprecatedOrGridFormattingContextBox(style.display())
+        || style.display().isFlexibleBoxIncludingDeprecatedOrGridFormattingContextBox()
         || isFlexItemIncludingDeprecated()
         || isRenderTable()
         || isRenderTableCell()

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -1300,7 +1300,7 @@ void RenderBlockFlow::adjustFloatingBlock(const MarginInfo& marginInfo)
 
 void RenderBlockFlow::updateStaticInlinePositionForChild(RenderBox& child, LayoutUnit logicalTop)
 {
-    if (Style::isDisplayInlineType(child.style().originalDisplay()))
+    if (child.style().originalDisplay().isInlineType())
         setStaticInlinePositionForChild(child, staticInlinePositionForOriginalDisplayInline(logicalTop));
     else
         setStaticInlinePositionForChild(child, startOffsetForContent());
@@ -1608,7 +1608,7 @@ LayoutUnit RenderBlockFlow::collapseMarginsWithChildInfo(RenderBox* child, Margi
 bool RenderBlockFlow::isChildEligibleForMarginTrim(Style::MarginTrimSide marginTrimSide, const RenderBox& child) const
 {
     ASSERT(style().marginTrim().contains(marginTrimSide));
-    if (!Style::isDisplayBlockType(child.style().display()))
+    if (!child.style().display().isBlockType())
         return false;
     // https://drafts.csswg.org/css-box-4/#margin-trim-block
     // 3.3.1. Trimming Block Container Content
@@ -4098,7 +4098,7 @@ RenderBlockFlow::InlineContentStatus RenderBlockFlow::markInlineContentDirtyForL
             if (hasParentRelativeHeightOrTop)
                 hasSimpleOutOfFlowContentOnly = false;
 
-            if (hasSimpleOutOfFlowContentOnly && Style::isDisplayInlineType(style.originalDisplay()))
+            if (hasSimpleOutOfFlowContentOnly && style.originalDisplay().isInlineType())
                 hasSimpleOutOfFlowContentOnly = hasSimpleStaticPositionForInlineLevelOutOfFlowContentByStyle;
         } else
             hasSimpleOutOfFlowContentOnly = false;
@@ -4267,7 +4267,7 @@ void RenderBlockFlow::setStaticPositionsForSimpleOutOfFlowContent()
 #ifndef NDEBUG
     ASSERT(!hasLineIfEmpty());
     for (auto walker = InlineWalker(*this); !walker.atEnd(); walker.advance()) {
-        if (Style::isDisplayInlineType(walker.current()->style().display())) {
+        if (walker.current()->style().display().isInlineType()) {
             ASSERT(hasSimpleStaticPositionForInlineLevelOutOfFlowChildrenByStyle(style()));
             break;
         }
@@ -4670,7 +4670,7 @@ RenderObject* InlineMinMaxIterator::next()
         if (is<RenderInline>(*candidate) || candidate->isRenderTextOrLineBreak() || candidate->isFloating() || candidate->isBlockLevelReplacedOrAtomicInline())
             break;
 
-        if (Style::isDisplayBlockType(candidate->style().display())) {
+        if (candidate->style().display().isBlockType()) {
             ASSERT(candidate->settings().blocksInInlineLayoutEnabled());
             break;
         }
@@ -4902,7 +4902,7 @@ void RenderBlockFlow::computeInlinePreferredLogicalWidths(LayoutUnit& minLogical
             continue;
         }
 
-        if (Style::isDisplayBlockType(child->style().display()) && !child->isFloating() && is<RenderBox>(*child)) {
+        if (child->style().display().isBlockType() && !child->isFloating() && is<RenderBox>(*child)) {
             ASSERT(settings().blocksInInlineLayoutEnabled());
 
             resetLineForForcedLineBreak();

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -421,7 +421,7 @@ void RenderBox::styleDidChange(Style::Difference diff, const RenderStyle* oldSty
     // Changing the position from/to absolute can potentially create/remove flex/grid items, as absolutely positioned
     // children of a flex/grid box are out-of-flow, and thus, not flex/grid items. This means that we need to clear
     // any override content size set by our container, because it would likely be incorrect after the style change.
-    if (isOutOfFlowPositioned() && parent() && Style::isDisplayFlexibleBoxIncludingDeprecatedOrGridFormattingContextBox(parent()->style().display()))
+    if (isOutOfFlowPositioned() && parent() && parent()->style().display().isFlexibleBoxIncludingDeprecatedOrGridFormattingContextBox())
         clearOverridingSize();
 
     if (oldStyle && oldStyle->hasOutOfFlowPosition() != style().hasOutOfFlowPosition()) {

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -221,7 +221,7 @@ void RenderBoxModelObject::updateFromStyle()
     // we only check for bits that could possibly be set to true.
     const auto& styleToUse = style();
     setHasVisibleBoxDecorations(hasVisibleBoxDecorationStyle());
-    setInline(Style::isDisplayInlineType(styleToUse.display()));
+    setInline(styleToUse.display().isInlineType());
     setPositionState(styleToUse.position());
     setHorizontalWritingMode(styleToUse.writingMode().isHorizontal());
     setPaintContainmentApplies(shouldApplyPaintContainment());

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -216,7 +216,7 @@ RenderPtr<RenderElement> RenderElement::createFor(Element& element, RenderStyle&
         }
     }
 
-    switch (style.display()) {
+    switch (style.display().value) {
     case Style::DisplayType::None:
     case Style::DisplayType::Contents:
         return nullptr;
@@ -253,10 +253,10 @@ RenderPtr<RenderElement> RenderElement::createFor(Element& element, RenderStyle&
         return createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, element, WTF::move(style));
 
     default: {
-        if (Style::isDisplayTableOrTablePart(style.display()) && rendererTypeOverride.contains(ConstructBlockLevelRendererFor::TableOrTablePart))
+        if (style.display().isTableOrTablePart() && rendererTypeOverride.contains(ConstructBlockLevelRendererFor::TableOrTablePart))
             return createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, element, WTF::move(style));
 
-        switch (style.display()) {
+        switch (style.display().value) {
         case Style::DisplayType::BlockTable:
         case Style::DisplayType::InlineTable:
             return createRenderer<RenderTable>(RenderObject::Type::Table, element, WTF::move(style));
@@ -1107,7 +1107,7 @@ void RenderElement::styleDidChange(Style::Difference diff, const RenderStyle* ol
 
     setNeedsLayoutForStyleDifference(diff, oldStyle);
 
-    if (isOutOfFlowPositioned() && oldStyle && Style::isDisplayBlockType(oldStyle->originalDisplay()) != Style::isDisplayBlockType(style().originalDisplay())) {
+    if (isOutOfFlowPositioned() && oldStyle && oldStyle->originalDisplay().isBlockType() != style().originalDisplay().isBlockType()) {
         if (CheckedPtr ancestor = RenderObject::containingBlockForPositionType(PositionType::Static, *this)) {
             ancestor->setNeedsLayout();
             ancestor->setOutOfFlowChildNeedsStaticPositionLayout();

--- a/Source/WebCore/rendering/RenderElementInlines.h
+++ b/Source/WebCore/rendering/RenderElementInlines.h
@@ -53,7 +53,7 @@ inline bool RenderElement::isBlockLevelBox() const
 
     if (renderBox->isFlexItem() || renderBox->isGridItem() || renderBox->isRenderTableCell())
         return false;
-    return Style::isDisplayBlockType(style().display());
+    return style().display().isBlockType();
 }
 
 inline bool RenderElement::isAnonymousBlock() const
@@ -74,7 +74,7 @@ inline bool RenderElement::isAnonymousBlock() const
 
 inline bool RenderElement::isBlockContainer() const
 {
-    return Style::doesDisplayGenerateBlockContainer(style().display()) && !isRenderReplaced();
+    return style().display().doesGenerateBlockContainer() && !isRenderReplaced();
 }
 
 inline bool RenderElement::isBlockBox() const

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -148,9 +148,9 @@ void RenderLayerModelObject::styleDidChange(Style::Difference diff, const Render
     // Position changes and other types of display changes are handled elsewhere.
     if ((oldStyle && isOutOfFlowPositioned() && parent() && (parent() != containingBlock()))
         && (style().position() == oldStyle->position())
-        && (Style::isDisplayInlineType(style().originalDisplay()) != Style::isDisplayInlineType(oldStyle->originalDisplay()))
-        && (Style::isDisplayBlockType(style().originalDisplay()) || Style::isDisplayInlineType(style().originalDisplay()))
-        && (Style::isDisplayBlockType(oldStyle->originalDisplay()) || Style::isDisplayInlineType(oldStyle->originalDisplay())))
+        && (style().originalDisplay().isInlineType() != oldStyle->originalDisplay().isInlineType())
+        && (style().originalDisplay().isBlockType() || style().originalDisplay().isInlineType())
+        && (oldStyle->originalDisplay().isBlockType() || oldStyle->originalDisplay().isInlineType()))
             parent()->setChildNeedsLayout();
 
     bool gainedOrLostLayer = false;

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -94,7 +94,10 @@ static Style::Difference adjustedStyleDifference(Style::Difference diff, const R
     if (diff >= Style::DifferenceResult::Layout)
         return diff;
     // FIXME: Preferably we do this at RenderStyle::changeRequiresLayout but checking against pseudo(::marker) is not sufficient.
-    auto needsLayout = oldStyle.listStylePosition() != newStyle.listStylePosition() || oldStyle.listStyleType() != newStyle.listStyleType() || Style::isDisplayInlineType(oldStyle.display()) != Style::isDisplayInlineType(newStyle.display());
+    auto needsLayout =
+           oldStyle.listStylePosition() != newStyle.listStylePosition()
+        || oldStyle.listStyleType() != newStyle.listStyleType()
+        || oldStyle.display().isInlineType() != newStyle.display().isInlineType();
     return needsLayout ? Style::DifferenceResult::Layout : diff;
 }
 

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -44,7 +44,7 @@ inline bool RenderObject::hasTransformOrPerspective() const
 inline bool RenderObject::isAtomicInlineLevelBox() const
 {
     auto display = style().display();
-    return Style::isDisplayInlineType(display)
+    return display.isInlineType()
         && !(display == Style::DisplayType::InlineFlow && !isBlockLevelReplacedOrAtomicInline());
 }
 

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -205,7 +205,7 @@ void RenderTable::willInsertTableColumn(RenderTableCol&, RenderObject*)
 
 void RenderTable::willInsertTableSection(RenderTableSection& child, RenderObject* beforeChild)
 {
-    switch (child.style().display()) {
+    switch (child.style().display().value) {
     case Style::DisplayType::TableHeaderGroup:
         resetSectionPointerIfNotBefore(m_head, beforeChild);
         if (!m_head)
@@ -1248,7 +1248,7 @@ void RenderTable::recalcSections() const
 
     // We need to get valid pointers to caption, head, foot and first body again
     for (auto* child = firstChildBox(); child; child = child->nextSiblingBox()) {
-        switch (child->style().display()) {
+        switch (child->style().display().value) {
         case Style::DisplayType::TableColumn:
         case Style::DisplayType::TableColumnGroup:
             m_hasColElements = true;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -1722,7 +1722,7 @@ void RenderTheme::adjustSliderThumbStyle(RenderStyle& style, const Element* elem
 void RenderTheme::adjustSwitchStyleDisplay(RenderStyle& style) const
 {
     // RenderTheme::adjustStyle() normalizes a bunch of display types to InlineBlock and Block.
-    switch (style.display()) {
+    switch (style.display().value) {
     case Style::DisplayType::InlineFlowRoot:
         style.setDisplayMaintainingOriginalDisplay(Style::DisplayType::InlineGrid);
         break;

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -224,7 +224,7 @@ inline std::optional<size_t> RenderStyle::usedPositionOptionIndex() const
     return m_computedStyle.usedPositionOptionIndex();
 }
 
-inline constexpr Style::DisplayType RenderStyle::originalDisplay() const
+inline constexpr Style::Display RenderStyle::originalDisplay() const
 {
     return m_computedStyle.originalDisplay();
 }
@@ -915,9 +915,9 @@ inline bool shouldApplyLayoutContainment(const RenderStyle& style, const Element
     //   if its principal box is an internal ruby box or a non-atomic inline-level box
     if (style.display() == Style::DisplayType::None || style.display() == Style::DisplayType::Contents)
         return false;
-    if (Style::isInternalTableBox(style.display()) && style.display() != Style::DisplayType::TableCell)
+    if (style.display().isInternalTableBox() && style.display() != Style::DisplayType::TableCell)
         return false;
-    if (Style::isRubyContainerOrInternalRubyBox(style.display()) || (style.display() == Style::DisplayType::InlineFlow && !element.isReplaced(&style)))
+    if (style.display().isRubyContainerOrInternalRubyBox() || (style.display() == Style::DisplayType::InlineFlow && !element.isReplaced(&style)))
         return false;
     return true;
 }
@@ -938,9 +938,9 @@ inline bool shouldApplySizeContainment(const RenderStyle& style, const Element& 
         return false;
     if (style.display() == Style::DisplayType::BlockTable || style.display() == Style::DisplayType::InlineTable)
         return false;
-    if (Style::isInternalTableBox(style.display()))
+    if (style.display().isInternalTableBox())
         return false;
-    if (Style::isRubyContainerOrInternalRubyBox(style.display()) || (style.display() == Style::DisplayType::InlineFlow && !element.isReplaced(&style)))
+    if (style.display().isRubyContainerOrInternalRubyBox() || (style.display() == Style::DisplayType::InlineFlow && !element.isReplaced(&style)))
         return false;
     return true;
 }
@@ -958,9 +958,9 @@ inline bool shouldApplyInlineSizeContainment(const RenderStyle& style, const Ele
         return false;
     if (style.display() == Style::DisplayType::BlockTable || style.display() == Style::DisplayType::InlineTable)
         return false;
-    if (Style::isInternalTableBox(style.display()))
+    if (style.display().isInternalTableBox())
         return false;
-    if (Style::isRubyContainerOrInternalRubyBox(style.display()) || (style.display() == Style::DisplayType::InlineFlow && !element.isReplaced(&style)))
+    if (style.display().isRubyContainerOrInternalRubyBox() || (style.display() == Style::DisplayType::InlineFlow && !element.isReplaced(&style)))
         return false;
     return true;
 }
@@ -987,9 +987,9 @@ inline bool shouldApplyPaintContainment(const RenderStyle& style, const Element&
     //   if its principal box is an internal ruby box or a non-atomic inline-level box
     if (style.display() == Style::DisplayType::None || style.display() == Style::DisplayType::Contents)
         return false;
-    if (Style::isInternalTableBox(style.display()) && style.display() != Style::DisplayType::TableCell)
+    if (style.display().isInternalTableBox() && style.display() != Style::DisplayType::TableCell)
         return false;
-    if (Style::isRubyContainerOrInternalRubyBox(style.display()) || (style.display() == Style::DisplayType::InlineFlow && !element.isReplaced(&style)))
+    if (style.display().isRubyContainerOrInternalRubyBox() || (style.display() == Style::DisplayType::InlineFlow && !element.isReplaced(&style)))
         return false;
     return true;
 }

--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -202,7 +202,7 @@ inline void RenderStyle::setUsedPositionOptionIndex(std::optional<size_t> index)
     m_computedStyle.setUsedPositionOptionIndex(index);
 }
 
-inline void RenderStyle::setDisplayMaintainingOriginalDisplay(Style::DisplayType display)
+inline void RenderStyle::setDisplayMaintainingOriginalDisplay(Style::Display display)
 {
     m_computedStyle.setDisplayMaintainingOriginalDisplay(display);
 }

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -106,7 +106,7 @@ std::unique_ptr<RenderStyle> RenderStyle::clonePtr(const RenderStyle& style)
     return makeUnique<RenderStyle>(style, Clone);
 }
 
-RenderStyle RenderStyle::createAnonymousStyleWithDisplay(const RenderStyle& parentStyle, Style::DisplayType display)
+RenderStyle RenderStyle::createAnonymousStyleWithDisplay(const RenderStyle& parentStyle, Style::Display display)
 {
     auto newStyle = create();
     newStyle.inheritFrom(parentStyle);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -52,7 +52,7 @@ public:
     static RenderStyle cloneIncludingPseudoElements(const RenderStyle&);
     static std::unique_ptr<RenderStyle> clonePtr(const RenderStyle&);
 
-    static RenderStyle createAnonymousStyleWithDisplay(const RenderStyle& parentStyle, Style::DisplayType);
+    static RenderStyle createAnonymousStyleWithDisplay(const RenderStyle& parentStyle, Style::Display);
     static RenderStyle createStyleInheritingFromPseudoStyle(const RenderStyle& pseudoStyle);
 
     void inheritFrom(const RenderStyle&);
@@ -164,10 +164,10 @@ public:
     inline void setIsEffectivelyTransparent(bool);
 
     // No setter. Set via `RenderStyleProperties::setDisplay()`.
-    inline constexpr Style::DisplayType originalDisplay() const;
+    inline constexpr Style::Display originalDisplay() const;
 
     // Sets the value of `display`, but leaves the value of `originalDisplay` unchanged.
-    inline void setDisplayMaintainingOriginalDisplay(Style::DisplayType);
+    inline void setDisplayMaintainingOriginalDisplay(Style::Display);
 
     inline StyleAppearance usedAppearance() const;
     inline void setUsedAppearance(StyleAppearance);

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp
@@ -240,7 +240,7 @@ void RenderTreeBuilder::Block::attachIgnoringContinuation(RenderBlock& parent, R
             Style::DisplayType::BlockGrid,
             Style::DisplayType::InlineGrid
         };
-        return m_buildsSimpleAnonymousBlocks || parentRequiresAnonymousBlock.contains(parent.style().display());
+        return m_buildsSimpleAnonymousBlocks || parentRequiresAnonymousBlock.contains(parent.style().display().value);
     };
 
     if (!shouldBuildAnonymousBlock()) {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp
@@ -44,7 +44,7 @@ RenderTreeBuilder::Ruby::Ruby(RenderTreeBuilder& builder)
 {
 }
 
-RenderStyle createAnonymousStyleForRuby(const RenderStyle& parentStyle, Style::DisplayType display)
+RenderStyle createAnonymousStyleForRuby(const RenderStyle& parentStyle, Style::Display display)
 {
     ASSERT(display == Style::DisplayType::InlineRuby || display == Style::DisplayType::RubyBase);
 
@@ -55,7 +55,7 @@ RenderStyle createAnonymousStyleForRuby(const RenderStyle& parentStyle, Style::D
     return style;
 }
 
-static RenderPtr<RenderElement> createAnonymousRendererForRuby(RenderElement& parent, Style::DisplayType display)
+static RenderPtr<RenderElement> createAnonymousRendererForRuby(RenderElement& parent, Style::Display display)
 {
     auto style = createAnonymousStyleForRuby(parent.style(), display);
     auto ruby = createRenderer<RenderInline>(RenderObject::Type::Inline, parent.document(), WTF::move(style));

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderRuby.h
@@ -46,7 +46,7 @@ private:
     RenderTreeBuilder& m_builder;
 };
 
-RenderStyle createAnonymousStyleForRuby(const RenderStyle& parentStyle, Style::DisplayType);
+RenderStyle createAnonymousStyleForRuby(const RenderStyle& parentStyle, Style::Display);
 
 }
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -157,7 +157,7 @@ static bool shouldInheritTextDecorationsInEffect(const RenderStyle& style, const
     if (isAtMediaUAShadowBoundary)
         return false;
 
-    switch (style.display()) {
+    switch (style.display().value) {
     case DisplayType::InlineFlowRoot:
     case DisplayType::InlineTable:
     case DisplayType::InlineFlex:
@@ -335,10 +335,10 @@ static bool shouldInlinifyForRuby(const RenderStyle& style, const RenderStyle& p
     return hasRubyParent && !style.hasOutOfFlowPosition() && !style.isFloating();
 }
 
-static bool hasUnsupportedRubyDisplay(DisplayType display, const Element* element)
+static bool hasUnsupportedRubyDisplay(Display display, const Element* element)
 {
     // Only allow ruby elements to have ruby display types for now.
-    switch (display) {
+    switch (display.value) {
     case DisplayType::InlineRuby:
     case DisplayType::BlockRuby:
         // Test for localName so this also allows WebVTT ruby elements.
@@ -455,7 +455,7 @@ void Adjuster::adjust(RenderStyle& style) const
             }
 
             if (element->hasTagName(legendTag))
-                style.setDisplayMaintainingOriginalDisplay(blockify(style.display()));
+                style.setDisplayMaintainingOriginalDisplay(style.display().blockified());
         }
 
         if (hasUnsupportedRubyDisplay(style.display(), m_element.get()))
@@ -468,7 +468,7 @@ void Adjuster::adjust(RenderStyle& style) const
 
         // Absolute/fixed positioned elements, floating elements and the document element need block-like outside display.
         if (style.hasOutOfFlowPosition() || style.isFloating() || (m_element && m_document->documentElement() == m_element.get()))
-            style.setDisplayMaintainingOriginalDisplay(blockify(style.display()));
+            style.setDisplayMaintainingOriginalDisplay(style.display().blockified());
 
         adjustFirstLetterStyle(style);
         adjustFirstLineStyle(style);
@@ -508,28 +508,28 @@ void Adjuster::adjust(RenderStyle& style) const
             }
         }
 
-        if (isDisplayDeprecatedFlexibleBox(style.display())) {
+        if (style.display().isDeprecatedFlexibleBox()) {
             // FIXME: Since we don't support block-flow on flexible boxes yet, disallow setting
             // of block-flow to anything other than StyleWritingMode::HorizontalTb.
             // https://bugs.webkit.org/show_bug.cgi?id=46418 - Flexible box support.
             style.setWritingMode(StyleWritingMode::HorizontalTb);
         }
 
-        if (isDisplayDeprecatedFlexibleBox(m_parentBoxStyle.display()))
+        if (m_parentBoxStyle.display().isDeprecatedFlexibleBox())
             style.setFloating(Float::None);
 
         // https://www.w3.org/TR/css-display/#transformations
         // "A parent with a grid or flex display value blockifies the box’s display type."
-        if (isDisplayFlexibleOrGridFormattingContextBox(m_parentBoxStyle.display())) {
+        if (m_parentBoxStyle.display().isFlexibleOrGridFormattingContextBox()) {
             style.setFloating(Float::None);
-            style.setDisplayMaintainingOriginalDisplay(blockify(style.display()));
+            style.setDisplayMaintainingOriginalDisplay(style.display().blockified());
         }
 
         // https://www.w3.org/TR/css-ruby-1/#anon-gen-inlinize
         if (shouldInlinifyForRuby(style, m_parentBoxStyle))
-            style.setDisplayMaintainingOriginalDisplay(inlinify(style.display()));
+            style.setDisplayMaintainingOriginalDisplay(style.display().inlinified());
         // https://drafts.csswg.org/css-ruby-1/#bidi
-        if (isRubyContainerOrInternalRubyBox(style.display()))
+        if (style.display().isRubyContainerOrInternalRubyBox())
             style.setUnicodeBidi(forceBidiIsolationForRuby(style.unicodeBidi()));
     }
 
@@ -548,7 +548,7 @@ void Adjuster::adjust(RenderStyle& style) const
         }
 
         // Make sure our z-index value is only applied if the object is positioned.
-        return style.position() == PositionType::Static && !isDisplayFlexibleOrGridFormattingContextBox(parentBoxStyle.display());
+        return style.position() == PositionType::Static && !parentBoxStyle.display().isFlexibleOrGridFormattingContextBox();
     };
 
     bool hasAutoSpecifiedZIndex = hasAutoZIndex(style, m_parentBoxStyle, m_element.get());

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -752,7 +752,7 @@ const RenderStyle* TreeResolver::parentBoxStyle() const
 
 const RenderStyle* TreeResolver::parentBoxStyleForPseudoElement(const ElementUpdate& elementUpdate) const
 {
-    switch (elementUpdate.style->display()) {
+    switch (elementUpdate.style->display().value) {
     case DisplayType::None:
         return nullptr;
     case DisplayType::Contents:

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -67,8 +67,8 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_inheritedFlags.autosizeStatus = 0;
 #endif
 
-    m_nonInheritedFlags.display = static_cast<unsigned>(ComputedStyle::initialDisplay());
-    m_nonInheritedFlags.originalDisplay = static_cast<unsigned>(ComputedStyle::initialDisplay());
+    m_nonInheritedFlags.display = ComputedStyle::initialDisplay().toRaw();
+    m_nonInheritedFlags.originalDisplay = ComputedStyle::initialDisplay().toRaw();
     m_nonInheritedFlags.overflowX = static_cast<unsigned>(ComputedStyle::initialOverflowX());
     m_nonInheritedFlags.overflowY = static_cast<unsigned>(ComputedStyle::initialOverflowY());
     m_nonInheritedFlags.clear = static_cast<unsigned>(ComputedStyle::initialClear());

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -229,9 +229,9 @@ inline std::optional<size_t> ComputedStyleBase::usedPositionOptionIndex() const
     return m_nonInheritedData->rareData->usedPositionOptionIndex;
 }
 
-inline constexpr Style::DisplayType ComputedStyleBase::originalDisplay() const
+inline constexpr Display ComputedStyleBase::originalDisplay() const
 {
-    return static_cast<Style::DisplayType>(m_nonInheritedFlags.originalDisplay);
+    return Display::fromRaw(m_nonInheritedFlags.originalDisplay);
 }
 
 inline StyleAppearance ComputedStyleBase::usedAppearance() const

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -183,9 +183,9 @@ inline void ComputedStyleBase::setUsedPositionOptionIndex(std::optional<size_t> 
     SET_NESTED(m_nonInheritedData, rareData, usedPositionOptionIndex, index);
 }
 
-inline void ComputedStyleBase::setDisplayMaintainingOriginalDisplay(DisplayType display)
+inline void ComputedStyleBase::setDisplayMaintainingOriginalDisplay(Display display)
 {
-    m_nonInheritedFlags.display = static_cast<unsigned>(display);
+    m_nonInheritedFlags.display = display.toRaw();
 }
 
 inline void ComputedStyleBase::setUsedAppearance(StyleAppearance a)

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -250,6 +250,7 @@ struct CounterIncrement;
 struct CounterReset;
 struct CounterSet;
 struct Cursor;
+struct Display;
 struct DynamicRangeLimit;
 struct Filter;
 struct FlexBasis;
@@ -538,10 +539,10 @@ public:
     inline void setIsEffectivelyTransparent(bool);
 
     // No setter. Set via `ComputedStyleProperties::setDisplay()`.
-    inline constexpr DisplayType originalDisplay() const;
+    inline constexpr Display originalDisplay() const;
 
     // Sets the value of `display`, but leaves the value of `originalDisplay` unchanged.
-    inline void setDisplayMaintainingOriginalDisplay(DisplayType);
+    inline void setDisplayMaintainingOriginalDisplay(Display);
 
     inline StyleAppearance usedAppearance() const;
     inline void setUsedAppearance(StyleAppearance);

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+InitialCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+InitialCustomInlines.h
@@ -150,10 +150,5 @@ constexpr PositionVisibility ComputedStyleProperties::initialPositionVisibility(
     return PositionVisibilityValue::AnchorsVisible;
 }
 
-constexpr DisplayType ComputedStyleProperties::initialDisplay()
-{
-    return DisplayType::InlineFlow;
-}
-
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
@@ -94,10 +94,10 @@ inline void ComputedStyleProperties::setBlendMode(BlendMode mode)
     SET(m_inheritedRareData, isInSubtreeWithBlendMode, mode != BlendMode::Normal);
 }
 
-inline void ComputedStyleProperties::setDisplay(DisplayType value)
+inline void ComputedStyleProperties::setDisplay(Display value)
 {
-    m_nonInheritedFlags.originalDisplay = static_cast<unsigned>(value);
-    m_nonInheritedFlags.display = static_cast<unsigned>(value);
+    m_nonInheritedFlags.originalDisplay = value.toRaw();
+    m_nonInheritedFlags.display = value.toRaw();
 }
 
 // FIXME: Support generating properties that have their storage spread out

--- a/Source/WebCore/style/values/display/StyleDisplay.cpp
+++ b/Source/WebCore/style/values/display/StyleDisplay.cpp
@@ -34,7 +34,7 @@ namespace Style {
 
 // MARK: - Conversion
 
-auto CSSValueConversion<DisplayType>::operator()(BuilderState& state, const CSSValue& value) -> DisplayType
+auto CSSValueConversion<Display>::operator()(BuilderState& state, const CSSValue& value) -> Display
 {
     RefPtr primitiveValue = requiredDowncast<CSSPrimitiveValue>(state, value);
     if (!primitiveValue)
@@ -118,7 +118,7 @@ auto CSSValueConversion<DisplayType>::operator()(BuilderState& state, const CSSV
 
 // MARK: - Blending
 
-auto Blending<DisplayType>::blend(DisplayType a, DisplayType b, const BlendingContext& context) -> DisplayType
+auto Blending<Display>::blend(Display a, Display b, const BlendingContext& context) -> Display
 {
     // "In general, the display property's animation type is discrete. However, similar to interpolation of
     //  visibility, during interpolation between none and any other display value, p values between 0 and 1


### PR DESCRIPTION
#### 1ff81f792f47b7e2b0415aab7e3eb1323819c402
<pre>
Convert display property to a wrapper structure and move predicates/utilities to be members
<a href="https://bugs.webkit.org/show_bug.cgi?id=307881">https://bugs.webkit.org/show_bug.cgi?id=307881</a>

Reviewed by Elika Etemad.

Add Style::Display to wrap Style::DisplayType, allowing predicates and
transformation functions to be members.

* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
* Source/WebCore/dom/FragmentDirectiveUtilities.cpp:
* Source/WebCore/html/HTMLButtonElement.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineQuirks.cpp:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationBoxTreeUpdater.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationLineLayout.cpp:
* Source/WebCore/page/InteractionRegion.cpp:
* Source/WebCore/rendering/LegacyLineLayout.cpp:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderElementInlines.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
* Source/WebCore/rendering/RenderListMarker.cpp:
* Source/WebCore/rendering/RenderObjectInlines.h:
* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTheme.cpp:
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
* Source/WebCore/rendering/style/RenderStyle+SettersInlines.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderBlock.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderRuby.h:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/StyleComputedStyleProperties+InitialCustomInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h:
* Source/WebCore/style/values/display/StyleDisplay.cpp:
* Source/WebCore/style/values/display/StyleDisplay.h:

Canonical link: <a href="https://commits.webkit.org/307604@main">https://commits.webkit.org/307604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0c55083fded29b463497004eea3a22026c113c62

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144854 "3 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9255 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153525 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98489 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146729 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18017 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17427 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111378 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79833 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147817 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92273 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13117 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/10867 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/970 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122632 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6827 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155837 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17385 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7915 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119381 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14509 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119709 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30707 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15515 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72955 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17007 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6383 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16743 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80786 "Found 1 new failure in layout/layouttree/LayoutBox.cpp") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16952 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->