### PR TITLE
[AutoFill Debugging] Interactions over disabled/readonly controls should fail with a descriptive error

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
@@ -11,10 +11,15 @@ PASS childScroller.scrollTop is 100
 PASS scrollPageError is ""
 PASS document.scrollingElement.scrollTop is 100
 PASS invalidActionError is "Failed to resolve nodeIdentifier 4294967293"
+PASS clickDisabledError is "Click target is disabled"
+PASS textInputReadonlyError is "Target is readonly"
+PASS selectDisabledMenuItemError is "Select is disabled"
+PASS readonlyField.value is "readonly"
+PASS disabledSelect.value is "Beta"
 PASS successfullyParsed is true
 
 TEST COMPLETE
-Test
+Test  Disabled
 Subject
 
 Hello world.

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -21,11 +21,18 @@
 </head>
 <body>
     <button id="test-button" aria-label="Click Me">Test</button>
+    <button id="disabled-button" aria-label="Disabled Button" disabled>Disabled</button>
     <input type="email" placeholder="Enter some text" value="foo" />
+    <input type="text" placeholder="Readonly field" value="readonly" readonly />
     <select role="menu">
         <option>One</option>
         <option selected>Two</option>
         <option>Three</option>
+    </select>
+    <select role="menu" aria-label="Disabled menu" disabled>
+        <option>Alpha</option>
+        <option selected>Beta</option>
+        <option>Gamma</option>
     </select>
     <div contenteditable="plaintext-only">
         <h3 aria-label="Heading">Subject</h3>
@@ -41,7 +48,9 @@
 
     addEventListener("load", async () => {
         textField = document.querySelector("input");
+        readonlyField = document.querySelector("input[readonly]");
         select = document.querySelector("select");
+        disabledSelect = document.querySelector("select[disabled]");
         clickCount = document.querySelector(".click-count");
         childScroller = document.querySelector(".scroller");
         document.getElementById("test-button").addEventListener("click", () => {
@@ -96,6 +105,21 @@
             nodeIdentifier: "4294967293",
         });
 
+        clickDisabledError = await UIHelper.performTextExtractionInteraction("click", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Disabled Button")
+        });
+
+        textInputReadonlyError = await UIHelper.performTextExtractionInteraction("textinput", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Readonly field"),
+            replaceAll: true,
+            text: "modified"
+        });
+
+        selectDisabledMenuItemError = await UIHelper.performTextExtractionInteraction("selectmenuitem", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Disabled menu"),
+            text: "Gamma"
+        });
+
         shouldBeEqualToString("clickError", "");
         shouldBeEqualToString("clickCount.textContent", "1");
         shouldBeEqualToString("textInputError", "");
@@ -109,6 +133,11 @@
         shouldBeEqualToString("scrollPageError", "");
         shouldBe("document.scrollingElement.scrollTop", "100");
         shouldBeEqualToString("invalidActionError", "Failed to resolve nodeIdentifier 4294967293");
+        shouldBeEqualToString("clickDisabledError", "Click target is disabled");
+        shouldBeEqualToString("textInputReadonlyError", "Target is readonly");
+        shouldBeEqualToString("selectDisabledMenuItemError", "Select is disabled");
+        shouldBeEqualToString("readonlyField.value", "readonly");
+        shouldBeEqualToString("disabledSelect.value", "Beta");
 
         finishJSTest();
     });


### PR DESCRIPTION
#### 1ef0aecdab99c95ca69374cdee56fb139d54bd49
<pre>
[AutoFill Debugging] Interactions over disabled/readonly controls should fail with a descriptive error
<a href="https://bugs.webkit.org/show_bug.cgi?id=307913">https://bugs.webkit.org/show_bug.cgi?id=307913</a>
<a href="https://rdar.apple.com/170399636">rdar://170399636</a>

Reviewed by Abrar Rahman Protyasha.

Make several interaction types fail in cases where the target node is either readonly (in the case
of text input) or disabled (in the case of clicks and selecting menu items).

* LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html:

Augment an existing layout test to cover these new cases.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::shadowHostOrSelfInclusiveParent):
(WebCore::TextExtraction::canBeEdited):
(WebCore::TextExtraction::isInDisabledFormControl):
(WebCore::TextExtraction::dispatchSimulatedClick):
(WebCore::TextExtraction::selectOptionByValue):
(WebCore::TextExtraction::focusAndInsertText):
(WebCore::TextExtraction::handleInteraction):

Canonical link: <a href="https://commits.webkit.org/307597@main">https://commits.webkit.org/307597@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfcc97ca0bbbec5b06510376c847c343b8de73b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153499 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98463 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb055c8b-d465-4f0c-a437-3452f49f0632) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111361 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79816 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a987ecf9-84a0-48b4-a8b2-7fbe2e6d6376) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147791 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13720 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130064 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92256 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6a9ad719-1a8a-43bb-882a-eb02ac717715) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13094 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10848 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/944 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122609 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6808 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155811 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17359 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119364 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17406 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14490 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119692 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30703 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15496 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128066 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72920 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16981 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6364 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16717 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80760 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16926 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->