### PR TITLE
Modernize MathMLOperatorDictionary::Form to scoped enum class

### DIFF
--- a/Source/WebCore/mathml/MathMLOperatorDictionary.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorDictionary.cpp
@@ -29,10 +29,16 @@
 #if ENABLE(MATHML)
 
 #include <array>
+#include <utility>
 
 namespace WebCore {
 
 using namespace MathMLOperatorDictionary;
+
+// Shorthand aliases for Form enum values for use in the dictionary table.
+static constexpr auto Infix = std::to_underlying(Form::Infix);
+static constexpr auto Prefix = std::to_underlying(Form::Prefix);
+static constexpr auto Postfix = std::to_underlying(Form::Postfix);
 
 typedef std::pair<char32_t, Form> Key;
 struct Entry {

--- a/Source/WebCore/mathml/MathMLOperatorDictionary.h
+++ b/Source/WebCore/mathml/MathMLOperatorDictionary.h
@@ -34,7 +34,7 @@
 namespace WebCore {
 
 namespace MathMLOperatorDictionary {
-enum Form { Infix, Prefix, Postfix };
+enum class Form : uint8_t { Infix, Prefix, Postfix };
 enum Flag {
     Accent = 0x1,
     Fence = 0x2, // This has no visual effect but allows to expose semantic information via the accessibility tree.

--- a/Source/WebCore/mathml/MathMLOperatorElement.cpp
+++ b/Source/WebCore/mathml/MathMLOperatorElement.cpp
@@ -85,20 +85,20 @@ Property MathMLOperatorElement::computeDictionaryProperty()
     const auto& value = attributeWithoutSynchronization(formAttr);
     bool explicitForm = true;
     if (value == "prefix"_s)
-        dictionaryProperty.form = Prefix;
+        dictionaryProperty.form = Form::Prefix;
     else if (value == "infix"_s)
-        dictionaryProperty.form = Infix;
+        dictionaryProperty.form = Form::Infix;
     else if (value == "postfix"_s)
-        dictionaryProperty.form = Postfix;
+        dictionaryProperty.form = Form::Postfix;
     else {
         // FIXME: We should use more advanced heuristics indicated in the specification to determine the operator form (https://bugs.webkit.org/show_bug.cgi?id=124829).
         explicitForm = false;
         if (!previousSibling() && nextSibling())
-            dictionaryProperty.form = Prefix;
+            dictionaryProperty.form = Form::Prefix;
         else if (previousSibling() && !nextSibling())
-            dictionaryProperty.form = Postfix;
+            dictionaryProperty.form = Form::Postfix;
         else
-            dictionaryProperty.form = Infix;
+            dictionaryProperty.form = Form::Infix;
     }
 
     // We then try and find an entry in the operator dictionary to override the default values.

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp
@@ -54,10 +54,10 @@ RenderPtr<RenderMathMLFencedOperator> RenderTreeBuilder::MathML::createMathMLOpe
 
 void RenderTreeBuilder::MathML::makeFences(RenderMathMLFenced& parent)
 {
-    auto openFence = createMathMLOperator(parent, parent.openingBrace(), MathMLOperatorDictionary::Prefix, MathMLOperatorDictionary::Fence);
+    auto openFence = createMathMLOperator(parent, parent.openingBrace(), MathMLOperatorDictionary::Form::Prefix, MathMLOperatorDictionary::Fence);
     m_builder.blockBuilder().attach(parent, WTF::move(openFence), parent.firstChild());
 
-    auto closeFence = createMathMLOperator(parent, parent.closingBrace(), MathMLOperatorDictionary::Postfix, MathMLOperatorDictionary::Fence);
+    auto closeFence = createMathMLOperator(parent, parent.closingBrace(), MathMLOperatorDictionary::Form::Postfix, MathMLOperatorDictionary::Fence);
     parent.setCloseFenceRenderer(*closeFence);
     m_builder.blockBuilder().attach(parent, WTF::move(closeFence), nullptr);
 }
@@ -97,7 +97,7 @@ void RenderTreeBuilder::MathML::attach(RenderMathMLFenced& parent, RenderPtr<Ren
 
             StringBuilder stringBuilder;
             stringBuilder.append(separator);
-            separatorRenderer = createMathMLOperator(parent, stringBuilder.toString(), MathMLOperatorDictionary::Infix, MathMLOperatorDictionary::Separator);
+            separatorRenderer = createMathMLOperator(parent, stringBuilder.toString(), MathMLOperatorDictionary::Form::Infix, MathMLOperatorDictionary::Separator);
         }
     }
 


### PR DESCRIPTION
#### 3508e5178b11671923b00f1793cbdb9c40bac3fc
<pre>
Modernize MathMLOperatorDictionary::Form to scoped enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=307915">https://bugs.webkit.org/show_bug.cgi?id=307915</a>
<a href="https://rdar.apple.com/170400220">rdar://170400220</a>

Reviewed by Vitor Roriz.

Convert MathMLOperatorDictionary::Form from C-style enum to
enum class : uint8_t for stronger type safety and to prevent
implicit int conversions.

* Source/WebCore/mathml/MathMLOperatorDictionary.cpp:
Add std::to_underlying aliases for dictionary table compatibility.
* Source/WebCore/mathml/MathMLOperatorDictionary.h:
* Source/WebCore/mathml/MathMLOperatorElement.cpp:
(WebCore::MathMLOperatorElement::computeDictionaryProperty):
* Source/WebCore/rendering/updating/RenderTreeBuilderMathML.cpp:
(WebCore::RenderTreeBuilder::MathML::makeFences):
(WebCore::RenderTreeBuilder::MathML::attach):

Canonical link: <a href="https://commits.webkit.org/307735@main">https://commits.webkit.org/307735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea7aebe51060db8569a82352a35677dc06edf641

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17812 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153803 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98767 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c71cecb-8d31-4fcd-80af-401140c249da) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147006 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111589 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79995 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148094 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13950 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130358 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92487 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/787161f5-71c3-441d-aa71-eb2875f957bf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13315 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11078 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1247 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7115 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156115 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17663 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119598 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17709 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14737 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119929 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30795 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15706 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128373 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73327 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17284 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6632 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17020 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81063 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17229 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17084 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->