### PR TITLE
Convert HTMLMeterElement::GaugeRegion to use a scoped enum class

### DIFF
--- a/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
+++ b/Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp
@@ -165,11 +165,11 @@ String AccessibilityProgressIndicator::gaugeRegionValueDescription() const
         return String();
 
     switch (meterElement->gaugeRegion()) {
-    case HTMLMeterElement::GaugeRegionOptimum:
+    case HTMLMeterElement::GaugeRegion::Optimum:
         return AXMeterGaugeRegionOptimumText();
-    case HTMLMeterElement::GaugeRegionSuboptimal:
+    case HTMLMeterElement::GaugeRegion::Suboptimal:
         return AXMeterGaugeRegionSuboptimalText();
-    case HTMLMeterElement::GaugeRegionEvenLessGood:
+    case HTMLMeterElement::GaugeRegion::EvenLessGood:
         return AXMeterGaugeRegionLessGoodText();
     }
 #endif

--- a/Source/WebCore/html/HTMLMeterElement.cpp
+++ b/Source/WebCore/html/HTMLMeterElement.cpp
@@ -136,27 +136,27 @@ HTMLMeterElement::GaugeRegion HTMLMeterElement::gaugeRegion() const
     if (optimumValue < lowValue) {
         // The optimum range stays under low
         if (theValue <= lowValue)
-            return GaugeRegionOptimum;
+            return GaugeRegion::Optimum;
         if (theValue <= highValue)
-            return GaugeRegionSuboptimal;
-        return GaugeRegionEvenLessGood;
+            return GaugeRegion::Suboptimal;
+        return GaugeRegion::EvenLessGood;
     }
-    
+
     if (highValue < optimumValue) {
         // The optimum range stays over high
         if (highValue <= theValue)
-            return GaugeRegionOptimum;
+            return GaugeRegion::Optimum;
         if (lowValue <= theValue)
-            return GaugeRegionSuboptimal;
-        return GaugeRegionEvenLessGood;
+            return GaugeRegion::Suboptimal;
+        return GaugeRegion::EvenLessGood;
     }
 
     // The optimum range stays between high and low.
     // According to the standard, <meter> never show GaugeRegionEvenLessGood in this case
     // because the value is never less or greater than min or max.
     if (lowValue <= theValue && theValue <= highValue)
-        return GaugeRegionOptimum;
-    return GaugeRegionSuboptimal;
+        return GaugeRegion::Optimum;
+    return GaugeRegion::Suboptimal;
 }
 
 double HTMLMeterElement::valueRatio() const
@@ -173,21 +173,20 @@ double HTMLMeterElement::valueRatio() const
 static void setValueClass(HTMLElement& element, HTMLMeterElement::GaugeRegion gaugeRegion)
 {
     switch (gaugeRegion) {
-    case HTMLMeterElement::GaugeRegionOptimum:
+    case HTMLMeterElement::GaugeRegion::Optimum:
         element.setAttribute(HTMLNames::classAttr, "optimum"_s);
         element.setUserAgentPart(UserAgentParts::webkitMeterOptimumValue());
         return;
-    case HTMLMeterElement::GaugeRegionSuboptimal:
+    case HTMLMeterElement::GaugeRegion::Suboptimal:
         element.setAttribute(HTMLNames::classAttr, "suboptimum"_s);
         element.setUserAgentPart(UserAgentParts::webkitMeterSuboptimumValue());
         return;
-    case HTMLMeterElement::GaugeRegionEvenLessGood:
+    case HTMLMeterElement::GaugeRegion::EvenLessGood:
         element.setAttribute(HTMLNames::classAttr, "even-less-good"_s);
         element.setUserAgentPart(UserAgentParts::webkitMeterEvenLessGoodValue());
         return;
-    default:
-        ASSERT_NOT_REACHED();
     }
+    ASSERT_NOT_REACHED();
 }
 
 void HTMLMeterElement::didElementStateChange()

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -33,10 +33,10 @@ class HTMLMeterElement final : public HTMLElement {
 public:
     static Ref<HTMLMeterElement> create(const QualifiedName&, Document&);
 
-    enum GaugeRegion {
-        GaugeRegionOptimum,
-        GaugeRegionSuboptimal,
-        GaugeRegionEvenLessGood
+    enum class GaugeRegion : uint8_t {
+        Optimum,
+        Suboptimal,
+        EvenLessGood
     };
 
     double min() const;

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -537,13 +537,13 @@ static void updateMeterPartForRenderer(MeterPart& meterPart, const RenderMeter& 
     MeterPart::GaugeRegion gaugeRegion;
 
     switch (element->gaugeRegion()) {
-    case HTMLMeterElement::GaugeRegionOptimum:
+    case HTMLMeterElement::GaugeRegion::Optimum:
         gaugeRegion = MeterPart::GaugeRegion::Optimum;
         break;
-    case HTMLMeterElement::GaugeRegionSuboptimal:
+    case HTMLMeterElement::GaugeRegion::Suboptimal:
         gaugeRegion = MeterPart::GaugeRegion::Suboptimal;
         break;
-    case HTMLMeterElement::GaugeRegionEvenLessGood:
+    case HTMLMeterElement::GaugeRegion::EvenLessGood:
         gaugeRegion = MeterPart::GaugeRegion::EvenLessGood;
         break;
     }

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -2929,13 +2929,13 @@ bool RenderThemeCocoa::paintMeterForVectorBasedControls(const RenderElement& ren
 
     auto colorCSSValueID = CSSValueInvalid;
     switch (element->gaugeRegion()) {
-    case HTMLMeterElement::GaugeRegionOptimum:
+    case HTMLMeterElement::GaugeRegion::Optimum:
         colorCSSValueID = CSSValueAppleSystemGreen;
         break;
-    case HTMLMeterElement::GaugeRegionSuboptimal:
+    case HTMLMeterElement::GaugeRegion::Suboptimal:
         colorCSSValueID = CSSValueAppleSystemYellow;
         break;
-    case HTMLMeterElement::GaugeRegionEvenLessGood:
+    case HTMLMeterElement::GaugeRegion::EvenLessGood:
         colorCSSValueID = CSSValueAppleSystemRed;
         break;
     }

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -1711,13 +1711,13 @@ bool RenderThemeIOS::paintMeter(const RenderElement& renderer, const PaintInfo& 
     roundedFillRect.setRect(fillRect);
 
     switch (element->gaugeRegion()) {
-    case HTMLMeterElement::GaugeRegionOptimum:
+    case HTMLMeterElement::GaugeRegion::Optimum:
         context.fillRoundedRect(roundedFillRect, systemColor(CSSValueAppleSystemGreen, styleColorOptions));
         break;
-    case HTMLMeterElement::GaugeRegionSuboptimal:
+    case HTMLMeterElement::GaugeRegion::Suboptimal:
         context.fillRoundedRect(roundedFillRect, systemColor(CSSValueAppleSystemYellow, styleColorOptions));
         break;
-    case HTMLMeterElement::GaugeRegionEvenLessGood:
+    case HTMLMeterElement::GaugeRegion::EvenLessGood:
         context.fillRoundedRect(roundedFillRect, systemColor(CSSValueAppleSystemRed, styleColorOptions));
         break;
     }


### PR DESCRIPTION
#### 51ff88782ae7447ed27fa3f938ec3dd7cdf453c4
<pre>
Convert HTMLMeterElement::GaugeRegion to use a scoped enum class
<a href="https://bugs.webkit.org/show_bug.cgi?id=307916">https://bugs.webkit.org/show_bug.cgi?id=307916</a>
<a href="https://rdar.apple.com/170400543">rdar://170400543</a>

Reviewed by Tim Nguyen.

Convert HTMLMeterElement::GaugeRegion from C-style enum to
enum class : uint8_t for stronger type safety. Remove the
redundant GaugeRegion prefix from values (GaugeRegionOptimum
becomes Optimum, etc.).

* Source/WebCore/accessibility/AccessibilityProgressIndicator.cpp:
(WebCore::AccessibilityProgressIndicator::gaugeRegionValueDescription const):
* Source/WebCore/html/HTMLMeterElement.cpp:
(WebCore::HTMLMeterElement::gaugeRegion const):
(WebCore::setValueClass):
* Source/WebCore/html/HTMLMeterElement.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::updateMeterPartForRenderer):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::RenderThemeCocoa::paintMeterForVectorBasedControls):
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
(WebCore::RenderThemeIOS::paintMeter):

Canonical link: <a href="https://commits.webkit.org/307598@main">https://commits.webkit.org/307598@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/99845f9b97588d9b3a0ef87ab29c1226cd874cab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144831 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17511 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9232 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153502 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98466 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49823d11-eb60-4639-a8b8-26bd1d224f33) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146706 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111363 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79818 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb758f07-83fe-4cb9-a3ba-fe264cd03d59) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13721 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92258 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ddcbfb2-1bc9-4e96-9f9e-a02d5c65f116) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10850 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/947 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122610 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6810 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155814 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17362 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7898 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119366 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17409 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119694 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15498 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128068 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72923 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22353 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16984 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6366 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16720 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80763 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16784 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->