### PR TITLE
Modernize ScriptRunner::ExecutionType and WebVTTNodeType to scoped enum classes

### DIFF
--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -323,11 +323,11 @@ bool ScriptElement::prepareScript(const TextPosition& scriptStartPosition)
     } else if ((isClassicExternalScript || scriptType == ScriptType::Module) && !hasAsyncAttribute() && !m_forceAsync) {
         m_willExecuteInOrder = true;
         ASSERT(m_loadableScript);
-        protect(document->scriptRunner())->queueScriptForExecution(*this, *protect(loadableScript()), ScriptRunner::IN_ORDER_EXECUTION);
+        protect(document->scriptRunner())->queueScriptForExecution(*this, *protect(loadableScript()), ScriptRunner::ExecutionType::InOrder);
     } else if (hasSourceAttribute() || scriptType == ScriptType::Module) {
         ASSERT(m_loadableScript);
         ASSERT(hasAsyncAttribute() || m_forceAsync);
-        protect(document->scriptRunner())->queueScriptForExecution(*this, *protect(loadableScript()), ScriptRunner::ASYNC_EXECUTION);
+        protect(document->scriptRunner())->queueScriptForExecution(*this, *protect(loadableScript()), ScriptRunner::ExecutionType::Async);
     } else if (!hasSourceAttribute() && m_parserInserted == ParserInserted::Yes && !document->haveStylesheetsLoaded()) {
         ASSERT(scriptType == ScriptType::Classic || scriptType == ScriptType::ImportMap || scriptType == ScriptType::SpeculationRules);
         m_willBeParserExecuted = true;

--- a/Source/WebCore/dom/ScriptRunner.cpp
+++ b/Source/WebCore/dom/ScriptRunner.cpp
@@ -80,10 +80,10 @@ void ScriptRunner::queueScriptForExecution(ScriptElement& scriptElement, Loadabl
 
     Ref pendingScript = PendingScript::create(scriptElement, loadableScript);
     switch (executionType) {
-    case ASYNC_EXECUTION:
+    case ExecutionType::Async:
         m_pendingAsyncScripts.add(pendingScript.copyRef());
         break;
-    case IN_ORDER_EXECUTION:
+    case ExecutionType::InOrder:
         m_scriptsToExecuteInOrder.append(pendingScript.copyRef());
         break;
     }

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -60,7 +60,7 @@ public:
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
     void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
-    enum ExecutionType { ASYNC_EXECUTION, IN_ORDER_EXECUTION };
+    enum class ExecutionType : uint8_t { Async, InOrder };
     void queueScriptForExecution(ScriptElement&, LoadableScript&, ExecutionType);
     bool hasPendingScripts() const { return !m_scriptsToExecuteSoon.isEmpty() || !m_scriptsToExecuteInOrder.isEmpty() || !m_pendingAsyncScripts.isEmpty(); }
     void suspend();

--- a/Source/WebCore/html/track/WebVTTElement.cpp
+++ b/Source/WebCore/html/track/WebVTTElement.cpp
@@ -49,27 +49,27 @@ static const QualifiedName& nodeTypeToTagName(WebVTTNodeType nodeType)
     static NeverDestroyed<QualifiedName> rubyTag(nullAtom(), "ruby"_s, nullAtom());
     static NeverDestroyed<QualifiedName> rtTag(nullAtom(), "rt"_s, nullAtom());
     switch (nodeType) {
-    case WebVTTNodeTypeClass:
+    case WebVTTNodeType::Class:
         return cTag;
-    case WebVTTNodeTypeItalic:
+    case WebVTTNodeType::Italic:
         return iTag;
-    case WebVTTNodeTypeLanguage:
+    case WebVTTNodeType::Language:
         return langTag;
-    case WebVTTNodeTypeBold:
+    case WebVTTNodeType::Bold:
         return bTag;
-    case WebVTTNodeTypeUnderline:
+    case WebVTTNodeType::Underline:
         return uTag;
-    case WebVTTNodeTypeRuby:
+    case WebVTTNodeType::Ruby:
         return rubyTag;
-    case WebVTTNodeTypeRubyText:
+    case WebVTTNodeType::RubyText:
         return rtTag;
-    case WebVTTNodeTypeVoice:
+    case WebVTTNodeType::Voice:
         return vTag;
-    case WebVTTNodeTypeNone:
-    default:
-        ASSERT_NOT_REACHED();
-        return cTag; // Make the compiler happy.
+    case WebVTTNodeType::None:
+        break;
     }
+    ASSERT_NOT_REACHED();
+    return cTag; // Make the compiler happy.
 }
 
 WebVTTElement::WebVTTElement(WebVTTNodeType nodeType, AtomString language, Document& document)
@@ -94,29 +94,29 @@ Ref<HTMLElement> WebVTTElement::createEquivalentHTMLElement(Document& document)
     RefPtr<HTMLElement> htmlElement;
 
     switch (m_webVTTNodeType) {
-    case WebVTTNodeTypeClass:
-    case WebVTTNodeTypeLanguage:
-    case WebVTTNodeTypeVoice:
+    case WebVTTNodeType::Class:
+    case WebVTTNodeType::Language:
+    case WebVTTNodeType::Voice:
         htmlElement = HTMLSpanElement::create(document);
         htmlElement->setAttributeWithoutSynchronization(HTMLNames::titleAttr, attributeWithoutSynchronization(voiceAttributeName()));
         htmlElement->setAttributeWithoutSynchronization(HTMLNames::langAttr, attributeWithoutSynchronization(langAttributeName()));
         break;
-    case WebVTTNodeTypeItalic:
+    case WebVTTNodeType::Italic:
         htmlElement = HTMLElement::create(HTMLNames::iTag, document);
         break;
-    case WebVTTNodeTypeBold:
+    case WebVTTNodeType::Bold:
         htmlElement = HTMLElement::create(HTMLNames::bTag, document);
         break;
-    case WebVTTNodeTypeUnderline:
+    case WebVTTNodeType::Underline:
         htmlElement = HTMLElement::create(HTMLNames::uTag, document);
         break;
-    case WebVTTNodeTypeRuby:
+    case WebVTTNodeType::Ruby:
         htmlElement = HTMLElement::create(HTMLNames::rubyTag, document);
         break;
-    case WebVTTNodeTypeRubyText:
+    case WebVTTNodeType::RubyText:
         htmlElement = HTMLElement::create(HTMLNames::rtTag, document);
         break;
-    case WebVTTNodeTypeNone:
+    case WebVTTNodeType::None:
         ASSERT_NOT_REACHED();
         break;
     }

--- a/Source/WebCore/html/track/WebVTTElement.h
+++ b/Source/WebCore/html/track/WebVTTElement.h
@@ -32,16 +32,16 @@
 
 namespace WebCore {
 
-enum WebVTTNodeType {
-    WebVTTNodeTypeNone = 0,
-    WebVTTNodeTypeClass,
-    WebVTTNodeTypeItalic,
-    WebVTTNodeTypeLanguage,
-    WebVTTNodeTypeBold,
-    WebVTTNodeTypeUnderline,
-    WebVTTNodeTypeRuby,
-    WebVTTNodeTypeRubyText,
-    WebVTTNodeTypeVoice
+enum class WebVTTNodeType : uint8_t {
+    None = 0,
+    Class,
+    Italic,
+    Language,
+    Bold,
+    Underline,
+    Ruby,
+    RubyText,
+    Voice
 };
 
 class WebVTTElement final : public Element {

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -519,7 +519,7 @@ public:
 private:
     void constructTreeFromToken(Document&);
 
-    WebVTTNodeType currentType() const { return m_typeStack.isEmpty() ? WebVTTNodeTypeNone : m_typeStack.last(); }
+    WebVTTNodeType currentType() const { return m_typeStack.isEmpty() ? WebVTTNodeType::None : m_typeStack.last(); }
 
     WebVTTToken m_token;
     Vector<WebVTTNodeType> m_typeStack;
@@ -637,28 +637,28 @@ static WebVTTNodeType tokenToNodeType(WebVTTToken& token)
     switch (token.name().length()) {
     case 1:
         if (token.name()[0] == 'c')
-            return WebVTTNodeTypeClass;
+            return WebVTTNodeType::Class;
         if (token.name()[0] == 'v')
-            return WebVTTNodeTypeVoice;
+            return WebVTTNodeType::Voice;
         if (token.name()[0] == 'b')
-            return WebVTTNodeTypeBold;
+            return WebVTTNodeType::Bold;
         if (token.name()[0] == 'i')
-            return WebVTTNodeTypeItalic;
+            return WebVTTNodeType::Italic;
         if (token.name()[0] == 'u')
-            return WebVTTNodeTypeUnderline;
+            return WebVTTNodeType::Underline;
         break;
     case 2:
         if (token.name()[0] == 'r' && token.name()[1] == 't')
-            return WebVTTNodeTypeRubyText;
+            return WebVTTNodeType::RubyText;
         break;
     case 4:
         if (token.name()[0] == 'r' && token.name()[1] == 'u' && token.name()[2] == 'b' && token.name()[3] == 'y')
-            return WebVTTNodeTypeRuby;
+            return WebVTTNodeType::Ruby;
         if (token.name()[0] == 'l' && token.name()[1] == 'a' && token.name()[2] == 'n' && token.name()[3] == 'g')
-            return WebVTTNodeTypeLanguage;
+            return WebVTTNodeType::Language;
         break;
     }
-    return WebVTTNodeTypeNone;
+    return WebVTTNodeType::None;
 }
 
 template<int width>
@@ -704,11 +704,11 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
     }
     case WebVTTTokenTypes::StartTag: {
         WebVTTNodeType nodeType = tokenToNodeType(m_token);
-        if (nodeType == WebVTTNodeTypeNone)
+        if (nodeType == WebVTTNodeType::None)
             break;
 
         // <rt> is only allowed if the current node is <ruby>.
-        if (nodeType == WebVTTNodeTypeRubyText && currentType() != WebVTTNodeTypeRuby)
+        if (nodeType == WebVTTNodeType::RubyText && currentType() != WebVTTNodeType::Ruby)
             break;
 
         auto language = !m_languageStack.isEmpty() ? m_languageStack.last() : emptyAtom();
@@ -716,9 +716,9 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
         if (!m_token.classes().isEmpty())
             child->setAttributeWithoutSynchronization(classAttr, m_token.classes());
 
-        if (nodeType == WebVTTNodeTypeVoice)
+        if (nodeType == WebVTTNodeType::Voice)
             child->setAttributeWithoutSynchronization(WebVTTElement::voiceAttributeName(), m_token.annotation());
-        else if (nodeType == WebVTTNodeTypeLanguage) {
+        else if (nodeType == WebVTTNodeType::Language) {
             m_languageStack.append(m_token.annotation());
             child->setAttributeWithoutSynchronization(WebVTTElement::langAttributeName(), m_languageStack.last());
         }
@@ -729,18 +729,18 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
     }
     case WebVTTTokenTypes::EndTag: {
         WebVTTNodeType nodeType = tokenToNodeType(m_token);
-        if (nodeType == WebVTTNodeTypeNone)
+        if (nodeType == WebVTTNodeType::None)
             break;
-        
+
         // The only non-VTTElement would be the DocumentFragment root. (Text
         // nodes and PIs will never appear as m_currentNode.)
-        if (currentType() == WebVTTNodeTypeNone)
+        if (currentType() == WebVTTNodeType::None)
             break;
 
         bool matchesCurrent = nodeType == currentType();
         if (!matchesCurrent) {
             // </ruby> auto-closes <rt>
-            if (currentType() == WebVTTNodeTypeRubyText && nodeType == WebVTTNodeTypeRuby) {
+            if (currentType() == WebVTTNodeType::RubyText && nodeType == WebVTTNodeType::Ruby) {
                 if (m_currentNode->parentNode()) {
                     m_currentNode = m_currentNode->parentNode();
                     m_typeStack.removeLast();
@@ -748,7 +748,7 @@ void WebVTTTreeBuilder::constructTreeFromToken(Document& document)
             } else
                 break;
         }
-        if (nodeType == WebVTTNodeTypeLanguage)
+        if (nodeType == WebVTTNodeType::Language)
             m_languageStack.removeLast();
         if (m_currentNode->parentNode()) {
             m_currentNode = m_currentNode->parentNode();


### PR DESCRIPTION
#### da05f14b47a08a80097be58707e0e739854a8302
<pre>
Modernize ScriptRunner::ExecutionType and WebVTTNodeType to scoped enum classes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307918">https://bugs.webkit.org/show_bug.cgi?id=307918</a>
<a href="https://rdar.apple.com/170401383">rdar://170401383</a>

Reviewed by Sammy Gill.

Convert two C-style enums to enum class : uint8_t for stronger type
safety. Update values to follow WebKit naming conventions.

ScriptRunner::ExecutionType:
- ASYNC_EXECUTION → Async
- IN_ORDER_EXECUTION → InOrder

WebVTTNodeType:
- Remove WebVTTNodeType prefix from all values
- WebVTTNodeTypeNone → None, WebVTTNodeTypeClass → Class, etc.

* Source/WebCore/dom/ScriptElement.cpp:
(WebCore::ScriptElement::prepareScript):
* Source/WebCore/dom/ScriptRunner.cpp:
(WebCore::ScriptRunner::queueScriptForExecution):
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/html/track/WebVTTElement.cpp:
(WebCore::nodeTypeToTagName):
(WebCore::WebVTTElement::createEquivalentHTMLElement):
* Source/WebCore/html/track/WebVTTElement.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTTreeBuilder::currentType const):
(WebCore::tokenToNodeType):
(WebCore::WebVTTTreeBuilder::constructTreeFromToken):

Canonical link: <a href="https://commits.webkit.org/307601@main">https://commits.webkit.org/307601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7b44e1bbff9e0ec69b1a689559fd9f70b92d03a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144833 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17513 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9234 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98468 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3a8ca18-346e-4b41-a45c-9c6facb9bd50) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146708 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/17996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111365 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79819 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5a326bd7-0f7a-48b0-9a3f-0dfade239c19) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147796 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13728 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130070 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92260 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39fae123-9c9d-45b5-ad40-ec46ceb3fad0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13102 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10854 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/949 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122617 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6814 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155816 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17364 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119368 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17411 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119696 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30705 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15500 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72925 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/16986 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6370 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16722 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80765 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16931 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16786 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->