### PR TITLE
AX: When servicing a hit test, preemptively hit-test nearby points and cache the results to make future AT hit-tests faster

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1697,6 +1697,7 @@ struct TimeoutSafeSemaphore : RefCounted<TimeoutSafeSemaphore<T>> {
     bool wait(Seconds timeout) { return semaphore.waitFor(timeout); }
 };
 
+constexpr Seconds HitTestCacheExpiration = 500_ms;
 // Timeout constants for retrieveValueFromMainThreadWithTimeoutAndDefault.
 // These are grouped by operation type to make it easier to tune timeouts.
 constexpr Seconds HitTestTimeout = 15_ms;

--- a/Source/WebCore/accessibility/AXGeometryManager.cpp
+++ b/Source/WebCore/accessibility/AXGeometryManager.cpp
@@ -33,6 +33,7 @@
 #include "AXIsolatedTree.h"
 #include "AXObjectCache.h"
 #include "Page.h"
+#include <array>
 
 #if PLATFORM(MAC)
 #include "PlatformScreen.h"
@@ -86,6 +87,8 @@ bool AXGeometryManager::cacheRectIfNeeded(AXID axID, IntRect&& rect)
     if (!rectChanged)
         return false;
 
+    invalidateHitTestCacheForID(axID);
+
     RefPtr tree = AXIsolatedTree::treeForFrameID(m_cache->frameID());
     if (!tree)
         return false;
@@ -132,16 +135,146 @@ void AXGeometryManager::scheduleRenderingUpdate()
 #if PLATFORM(MAC)
 void AXGeometryManager::initializePrimaryScreenRect()
 {
-    Locker locker { m_lock };
+    Locker locker { m_primaryScreenRectLock };
     m_primaryScreenRect = screenRectForPrimaryScreen();
 }
 
 FloatRect AXGeometryManager::primaryScreenRect()
 {
-    Locker locker { m_lock };
+    Locker locker { m_primaryScreenRectLock };
     return m_primaryScreenRect;
 }
 #endif
+
+std::optional<AXID> AXGeometryManager::cachedHitTestResult(const IntPoint& screenPoint)
+{
+    Locker locker { m_hitTestCacheLock };
+
+    static constexpr int MaxCacheRadius = 5;
+    static constexpr int MaxCacheRadiusSquared = MaxCacheRadius * MaxCacheRadius;
+
+    std::optional<AXID> closestMatch;
+    int closestDistanceSquared = INT_MAX;
+    auto now = MonotonicTime::now();
+
+    // m_hitTestCache contains a mapping of points to elements at those points.
+    // Iterate the cache to find the closest cached point to |screenPoint|.
+    // Only consider entries within MaxCacheRadius pixels, and return the
+    // element at the nearest cached point.
+    //
+    // We compare squared distances to test closeness in both x and y, and also
+    // to avoid expensive sqrt() calls.
+    //
+    // e.g., if the |screenPoint| is 3px off in the x-coordinate, and 4px off in the y-coordinate:
+    //   3² + 4² = 25 — Less than or equal to MaxCacheRadiusSquared, and thus is acceptably close.
+    // But take the case where the hit-point is 4px off in both x and y:
+    //   4² + 4² = 32 — Too far from MaxCacheRadiusSquared, so not a match.
+    for (auto& entry : m_hitTestCache) {
+        if (now > entry.expirationTime)
+            continue;
+
+        int dx = screenPoint.x() - entry.hitPoint.x();
+        int dy = screenPoint.y() - entry.hitPoint.y();
+        int distanceSquared = dx * dx + dy * dy;
+
+        if (distanceSquared <= MaxCacheRadiusSquared && distanceSquared < closestDistanceSquared) {
+            closestDistanceSquared = distanceSquared;
+            closestMatch = entry.resultID;
+        }
+    }
+
+    return closestMatch;
+}
+
+constexpr MonotonicTime hitTestExpirationTime()
+{
+    return MonotonicTime::now() + Accessibility::HitTestCacheExpiration;
+}
+
+void AXGeometryManager::cacheHitTestResult(AXID resultID, const IntPoint& hitPoint)
+{
+    Locker locker { m_hitTestCacheLock };
+
+    // Check if we already have an entry for this exact point and update it.
+    auto now = MonotonicTime::now();
+    // Also track whether any entries are expired for cleanup.
+    bool hasExpiredEntries = false;
+    for (auto& entry : m_hitTestCache) {
+        if (entry.hitPoint == hitPoint) {
+            entry.resultID = resultID;
+            entry.expirationTime = hitTestExpirationTime();
+            return;
+        }
+        if (now > entry.expirationTime)
+            hasExpiredEntries = true;
+    }
+
+    if (hasExpiredEntries) {
+        m_hitTestCache.removeAllMatching([now](const HitTestCacheEntry& entry) {
+            return now > entry.expirationTime;
+        });
+    }
+
+    // If cache is full, remove the oldest entry (first one, since we append new ones at the end).
+    if (m_hitTestCache.size() >= HitTestCacheSize)
+        m_hitTestCache.removeAt(0);
+
+    m_hitTestCache.append({ hitPoint, resultID, hitTestExpirationTime() });
+}
+
+void AXGeometryManager::expandHitTestCacheAroundPoint(const IntPoint& center, AXTreeID treeID)
+{
+    incrementProbeGeneration();
+    uint64_t capturedGeneration = currentProbeGeneration();
+
+    constexpr int ProbeDistance = 5;
+    std::array<IntPoint, 4> probePoints = {
+        IntPoint(center.x() - ProbeDistance, center.y()),
+        IntPoint(center.x() + ProbeDistance, center.y()),
+        IntPoint(center.x(), center.y() - ProbeDistance),
+        IntPoint(center.x(), center.y() + ProbeDistance),
+    };
+
+    for (const auto& probePoint : probePoints) {
+        // Skip probes with negative coordinates to avoid unnecessary main-thread trips.
+        if (probePoint.x() < 0 || probePoint.y() < 0)
+            continue;
+
+        ensureOnMainThread([weakThis = ThreadSafeWeakPtr { *this }, probePoint, capturedGeneration, treeID] {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+
+            // Check if the probe was cancelled by an assistive technology requesting
+            // a new hit-test location (which will fire new probes from a different spot).
+            if (protectedThis->currentProbeGeneration() != capturedGeneration)
+                return;
+
+            // Perform hit test.
+            if (WeakPtr cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(treeID)) {
+                auto pageRelativePoint = cache->mapScreenPointToPagePoint(probePoint);
+                RefPtr root = cache->rootWebArea();
+                if (RefPtr hitResult = root ? root->accessibilityHitTest(pageRelativePoint) : nullptr)
+                    protectedThis->cacheHitTestResult(hitResult->objectID(), probePoint);
+            }
+        });
+    }
+}
+
+void AXGeometryManager::invalidateHitTestCacheForID(AXID axID)
+{
+    Locker locker { m_hitTestCacheLock };
+
+    m_hitTestCache.removeAllMatching([axID](const HitTestCacheEntry& entry) {
+        return entry.resultID == axID;
+    });
+}
+
+void AXGeometryManager::clearHitTestCache()
+{
+    Locker locker { m_hitTestCacheLock };
+    m_hitTestCache.clear();
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -340,6 +340,7 @@ public:
 
     // Returns the root object for a specific frame.
     WEBCORE_EXPORT AXCoreObject* rootObjectForFrame(LocalFrame&);
+    AccessibilityObject* rootWebArea();
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     WEBCORE_EXPORT void setFrameInheritedState(LocalFrame&, const InheritedFrameState&);
 #endif
@@ -835,8 +836,6 @@ protected:
     LayoutRect localCaretRectForCharacterOffset(RenderObject*&, const CharacterOffset&);
     bool shouldSkipBoundary(const CharacterOffset&, const CharacterOffset&);
 private:
-    AccessibilityObject* rootWebArea();
-
     // Returns the object or nearest render-tree ancestor object that is already created (i.e.
     // retrievable by |get|, not |getOrCreate|).
     AccessibilityObject* getIncludingAncestors(RenderObject&) const;


### PR DESCRIPTION
#### 9014e0de0c569e8c335163803d0e6d61a4fd7bdf
<pre>
AX: When servicing a hit test, preemptively hit-test nearby points and cache the results to make future AT hit-tests faster
<a href="https://bugs.webkit.org/show_bug.cgi?id=307919">https://bugs.webkit.org/show_bug.cgi?id=307919</a>
<a href="https://rdar.apple.com/170401294">rdar://170401294</a>

Reviewed by Joshua Hoffman.

Certain assistive technologies (like HoverText) send very rapid hit-tests that are all close to each other (think of a
mouse moving across the screen). This commit uses this knowledge to build an optimization where when we get a hit-test
from an AT, we asynchronously also hit test nearby points and cache the results, meaning we can instantly serve follow-up
AT hit-tests for nearby points. The entries in this cache expire after a set time, and are invalidated if their object
changes its bounding box.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXGeometryManager.cpp:
(WebCore::AXGeometryManager::cacheRectIfNeeded):
(WebCore::AXGeometryManager::initializePrimaryScreenRect):
(WebCore::AXGeometryManager::primaryScreenRect):
(WebCore::AXGeometryManager::cachedHitTestResult):
(WebCore::hitTestExpirationTime):
(WebCore::AXGeometryManager::cacheHitTestResult):
(WebCore::AXGeometryManager::expandHitTestCacheAroundPoint):
(WebCore::AXGeometryManager::invalidateHitTestCacheForID):
(WebCore::AXGeometryManager::clearHitTestCache):
* Source/WebCore/accessibility/AXGeometryManager.h:
* Source/WebCore/accessibility/AXObjectCache.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::accessibilityHitTest const):
(WebCore::AXIsolatedObject::approximateHitTest const):

Canonical link: <a href="https://commits.webkit.org/307742@main">https://commits.webkit.org/307742@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c6ed8be55f8131184f413eed077510a969942b15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145304 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9779 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153976 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98941 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98b923b8-226e-4653-ac22-32404465eeac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147179 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18470 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17879 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111735 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/418b022c-c1c7-4a41-b8d7-02baf0b55cb6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148267 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92635 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b292c9ea-53c6-4f8b-b529-f07721f4ade8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13447 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11208 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1422 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122975 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156288 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17836 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8372 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119742 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17882 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120077 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30798 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15841 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128542 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73526 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17457 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6790 "Found 1 new test failure: imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html (failure)") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81236 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17402 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17257 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->