### PR TITLE
Use scoped enum classes in StepRange::StepValueShouldBe and CollapsedBorderSide

### DIFF
--- a/Source/WebCore/html/DateInputType.cpp
+++ b/Source/WebCore/html/DateInputType.cpp
@@ -51,7 +51,7 @@ using namespace HTMLNames;
 static const int dateDefaultStep = 1;
 static const int dateDefaultStepBase = 0;
 static const int dateStepScaleFactor = 86400000;
-static const StepRange::StepDescription dateStepDescription { dateDefaultStep, dateDefaultStepBase, dateStepScaleFactor, StepRange::ParsedStepValueShouldBeInteger };
+static const StepRange::StepDescription dateStepDescription { dateDefaultStep, dateDefaultStepBase, dateStepScaleFactor, StepRange::StepValueShouldBe::ParsedInteger };
 
 DateInputType::DateInputType(HTMLInputElement& element)
     : BaseDateAndTimeInputType(Type::Date, element)

--- a/Source/WebCore/html/DateTimeLocalInputType.cpp
+++ b/Source/WebCore/html/DateTimeLocalInputType.cpp
@@ -52,7 +52,7 @@ using namespace HTMLNames;
 static const int dateTimeLocalDefaultStep = 60;
 static const int dateTimeLocalDefaultStepBase = 0;
 static const int dateTimeLocalStepScaleFactor = 1000;
-static const StepRange::StepDescription dateTimeLocalStepDescription { dateTimeLocalDefaultStep, dateTimeLocalDefaultStepBase, dateTimeLocalStepScaleFactor, StepRange::ScaledStepValueShouldBeInteger };
+static const StepRange::StepDescription dateTimeLocalStepDescription { dateTimeLocalDefaultStep, dateTimeLocalDefaultStepBase, dateTimeLocalStepScaleFactor, StepRange::StepValueShouldBe::ScaledInteger };
 
 const AtomString& DateTimeLocalInputType::formControlType() const
 {

--- a/Source/WebCore/html/MonthInputType.cpp
+++ b/Source/WebCore/html/MonthInputType.cpp
@@ -55,7 +55,7 @@ using namespace HTMLNames;
 static const int monthDefaultStep = 1;
 static const int monthDefaultStepBase = 0;
 static const int monthStepScaleFactor = 1;
-static const StepRange::StepDescription monthStepDescription { monthDefaultStep, monthDefaultStepBase, monthStepScaleFactor, StepRange::ParsedStepValueShouldBeInteger };
+static const StepRange::StepDescription monthStepDescription { monthDefaultStep, monthDefaultStepBase, monthStepScaleFactor, StepRange::StepValueShouldBe::ParsedInteger };
 
 const AtomString& MonthInputType::formControlType() const
 {

--- a/Source/WebCore/html/StepRange.cpp
+++ b/Source/WebCore/html/StepRange.cpp
@@ -74,7 +74,7 @@ Decimal StepRange::acceptableError() const
 {
     // FIXME: We should use DBL_MANT_DIG instead of FLT_MANT_DIG regarding to HTML5 specification.
     static NeverDestroyed<const Decimal> twoPowerOfFloatMantissaBits(Decimal::Positive, 0, UINT64_C(1) << FLT_MANT_DIG);
-    return m_stepDescription.stepValueShouldBe == StepValueShouldBeReal ? m_step / twoPowerOfFloatMantissaBits : Decimal(0);
+    return m_stepDescription.stepValueShouldBe == StepValueShouldBe::Real ? m_step / twoPowerOfFloatMantissaBits : Decimal(0);
 }
 
 Decimal StepRange::alignValueForStep(const Decimal& currentValue, const Decimal& newValue) const
@@ -121,21 +121,19 @@ Decimal StepRange::parseStep(AnyStepHandling anyStepHandling, const StepDescript
         return stepDescription.defaultValue();
 
     switch (stepDescription.stepValueShouldBe) {
-    case StepValueShouldBeReal:
+    case StepValueShouldBe::Real:
         step *= stepDescription.stepScaleFactor;
         break;
-    case ParsedStepValueShouldBeInteger:
+    case StepValueShouldBe::ParsedInteger:
         // For date, month, and week, the parsed value should be an integer for some types.
         step = std::max(step.round(), Decimal(1));
         step *= stepDescription.stepScaleFactor;
         break;
-    case ScaledStepValueShouldBeInteger:
+    case StepValueShouldBe::ScaledInteger:
         // For datetime, datetime-local, time, the result should be an integer.
         step *= stepDescription.stepScaleFactor;
         step = std::max(step.round(), Decimal(1));
         break;
-    default:
-        ASSERT_NOT_REACHED();
     }
 
     ASSERT(step > 0);

--- a/Source/WebCore/html/StepRange.h
+++ b/Source/WebCore/html/StepRange.h
@@ -33,10 +33,10 @@ enum class RangeLimitations : bool { Valid, Invalid };
 class StepRange {
     WTF_MAKE_TZONE_ALLOCATED(StepRange);
 public:
-    enum StepValueShouldBe {
-        StepValueShouldBeReal,
-        ParsedStepValueShouldBeInteger,
-        ScaledStepValueShouldBeInteger,
+    enum class StepValueShouldBe : uint8_t {
+        Real,
+        ParsedInteger,
+        ScaledInteger,
     };
 
     struct StepDescription {
@@ -45,9 +45,9 @@ public:
         int defaultStep { 1 };
         int defaultStepBase { 0 };
         int stepScaleFactor { 1 };
-        StepValueShouldBe stepValueShouldBe { StepValueShouldBeReal };
+        StepValueShouldBe stepValueShouldBe { StepValueShouldBe::Real };
 
-        constexpr StepDescription(int defaultStep, int defaultStepBase, int stepScaleFactor, StepValueShouldBe stepValueShouldBe = StepValueShouldBeReal)
+        constexpr StepDescription(int defaultStep, int defaultStepBase, int stepScaleFactor, StepValueShouldBe stepValueShouldBe = StepValueShouldBe::Real)
             : defaultStep(defaultStep)
             , defaultStepBase(defaultStepBase)
             , stepScaleFactor(stepScaleFactor)

--- a/Source/WebCore/html/TimeInputType.cpp
+++ b/Source/WebCore/html/TimeInputType.cpp
@@ -54,7 +54,7 @@ using namespace HTMLNames;
 static const int timeDefaultStep = 60;
 static const int timeDefaultStepBase = 0;
 static const int timeStepScaleFactor = 1000;
-static const StepRange::StepDescription timeStepDescription { timeDefaultStep, timeDefaultStepBase, timeStepScaleFactor, StepRange::ScaledStepValueShouldBeInteger };
+static const StepRange::StepDescription timeStepDescription { timeDefaultStep, timeDefaultStepBase, timeStepScaleFactor, StepRange::StepValueShouldBe::ScaledInteger };
 
 TimeInputType::TimeInputType(HTMLInputElement& element)
     : BaseDateAndTimeInputType(Type::Time, element)

--- a/Source/WebCore/html/WeekInputType.cpp
+++ b/Source/WebCore/html/WeekInputType.cpp
@@ -48,7 +48,7 @@ using namespace HTMLNames;
 static const int weekDefaultStepBase = -259200000; // The first day of 1970-W01.
 static const int weekDefaultStep = 1;
 static const int weekStepScaleFactor = 604800000;
-static const StepRange::StepDescription weekStepDescription { weekDefaultStep, weekDefaultStepBase, weekStepScaleFactor, StepRange::ParsedStepValueShouldBeInteger };
+static const StepRange::StepDescription weekStepDescription { weekDefaultStep, weekDefaultStepBase, weekStepScaleFactor, StepRange::StepValueShouldBe::ParsedInteger };
 
 const AtomString& WeekInputType::formControlType() const
 {

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -772,12 +772,12 @@ CollapsedBorderValue RenderTableCell::collapsedStartBorder(IncludeBorderColorOrN
         return emptyBorder();
 
     if (table()->collapsedBordersAreValid())
-        return section()->cachedCollapsedBorder(*this, CBSStart);
+        return section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Start);
 
     CollapsedBorderValue result = computeCollapsedStartBorder(includeColor);
-    setHasEmptyCollapsedBorder(CBSStart, !result.width());
+    setHasEmptyCollapsedBorder(CollapsedBorderSide::Start, !result.width());
     if (includeColor && !m_hasEmptyCollapsedStartBorder)
-        section()->setCachedCollapsedBorder(*this, CBSStart, result);
+        section()->setCachedCollapsedBorder(*this, CollapsedBorderSide::Start, result);
     return result;
 }
 
@@ -900,12 +900,12 @@ CollapsedBorderValue RenderTableCell::collapsedEndBorder(IncludeBorderColorOrNot
         return emptyBorder();
 
     if (table()->collapsedBordersAreValid())
-        return section()->cachedCollapsedBorder(*this, CBSEnd);
+        return section()->cachedCollapsedBorder(*this, CollapsedBorderSide::End);
 
     CollapsedBorderValue result = computeCollapsedEndBorder(includeColor);
-    setHasEmptyCollapsedBorder(CBSEnd, !result.width());
+    setHasEmptyCollapsedBorder(CollapsedBorderSide::End, !result.width());
     if (includeColor && !m_hasEmptyCollapsedEndBorder)
-        section()->setCachedCollapsedBorder(*this, CBSEnd, result);
+        section()->setCachedCollapsedBorder(*this, CollapsedBorderSide::End, result);
     return result;
 }
 
@@ -1014,12 +1014,12 @@ CollapsedBorderValue RenderTableCell::collapsedBeforeBorder(IncludeBorderColorOr
         return emptyBorder();
 
     if (table()->collapsedBordersAreValid())
-        return section()->cachedCollapsedBorder(*this, CBSBefore);
+        return section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Before);
 
     CollapsedBorderValue result = computeCollapsedBeforeBorder(includeColor);
-    setHasEmptyCollapsedBorder(CBSBefore, !result.width());
+    setHasEmptyCollapsedBorder(CollapsedBorderSide::Before, !result.width());
     if (includeColor && !m_hasEmptyCollapsedBeforeBorder)
-        section()->setCachedCollapsedBorder(*this, CBSBefore, result);
+        section()->setCachedCollapsedBorder(*this, CollapsedBorderSide::Before, result);
     return result;
 }
 
@@ -1111,12 +1111,12 @@ CollapsedBorderValue RenderTableCell::collapsedAfterBorder(IncludeBorderColorOrN
         return emptyBorder();
 
     if (table()->collapsedBordersAreValid())
-        return section()->cachedCollapsedBorder(*this, CBSAfter);
+        return section()->cachedCollapsedBorder(*this, CollapsedBorderSide::After);
 
     CollapsedBorderValue result = computeCollapsedAfterBorder(includeColor);
-    setHasEmptyCollapsedBorder(CBSAfter, !result.width());
+    setHasEmptyCollapsedBorder(CollapsedBorderSide::After, !result.width());
     if (includeColor && !m_hasEmptyCollapsedAfterBorder)
-        section()->setCachedCollapsedBorder(*this, CBSAfter, result);
+        section()->setCachedCollapsedBorder(*this, CollapsedBorderSide::After, result);
     return result;
 }
 
@@ -1198,29 +1198,29 @@ CollapsedBorderValue RenderTableCell::computeCollapsedAfterBorder(IncludeBorderC
 inline CollapsedBorderValue RenderTableCell::cachedCollapsedLeftBorder(const WritingMode writingMode) const
 {
     if (writingMode.isHorizontal())
-        return writingMode.isInlineLeftToRight() ? section()->cachedCollapsedBorder(*this, CBSStart) : section()->cachedCollapsedBorder(*this, CBSEnd);
-    return writingMode.isBlockLeftToRight() ? section()->cachedCollapsedBorder(*this, CBSBefore) : section()->cachedCollapsedBorder(*this, CBSAfter);
+        return writingMode.isInlineLeftToRight() ? section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Start) : section()->cachedCollapsedBorder(*this, CollapsedBorderSide::End);
+    return writingMode.isBlockLeftToRight() ? section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Before) : section()->cachedCollapsedBorder(*this, CollapsedBorderSide::After);
 }
 
 inline CollapsedBorderValue RenderTableCell::cachedCollapsedRightBorder(const WritingMode writingMode) const
 {
     if (writingMode.isHorizontal())
-        return writingMode.isInlineLeftToRight() ? section()->cachedCollapsedBorder(*this, CBSEnd) : section()->cachedCollapsedBorder(*this, CBSStart);
-    return writingMode.isBlockLeftToRight() ? section()->cachedCollapsedBorder(*this, CBSAfter) : section()->cachedCollapsedBorder(*this, CBSBefore);
+        return writingMode.isInlineLeftToRight() ? section()->cachedCollapsedBorder(*this, CollapsedBorderSide::End) : section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Start);
+    return writingMode.isBlockLeftToRight() ? section()->cachedCollapsedBorder(*this, CollapsedBorderSide::After) : section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Before);
 }
 
 inline CollapsedBorderValue RenderTableCell::cachedCollapsedTopBorder(const WritingMode writingMode) const
 {
     if (writingMode.isHorizontal())
-        return writingMode.isBlockTopToBottom() ? section()->cachedCollapsedBorder(*this, CBSBefore) : section()->cachedCollapsedBorder(*this, CBSAfter);
-    return writingMode.isInlineTopToBottom() ? section()->cachedCollapsedBorder(*this, CBSStart) : section()->cachedCollapsedBorder(*this, CBSEnd);
+        return writingMode.isBlockTopToBottom() ? section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Before) : section()->cachedCollapsedBorder(*this, CollapsedBorderSide::After);
+    return writingMode.isInlineTopToBottom() ? section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Start) : section()->cachedCollapsedBorder(*this, CollapsedBorderSide::End);
 }
 
 inline CollapsedBorderValue RenderTableCell::cachedCollapsedBottomBorder(const WritingMode writingMode) const
 {
     if (writingMode.isHorizontal())
-        return writingMode.isBlockTopToBottom() ? section()->cachedCollapsedBorder(*this, CBSAfter) : section()->cachedCollapsedBorder(*this, CBSBefore);
-    return writingMode.isInlineTopToBottom() ? section()->cachedCollapsedBorder(*this, CBSEnd) : section()->cachedCollapsedBorder(*this, CBSStart);
+        return writingMode.isBlockTopToBottom() ? section()->cachedCollapsedBorder(*this, CollapsedBorderSide::After) : section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Before);
+    return writingMode.isInlineTopToBottom() ? section()->cachedCollapsedBorder(*this, CollapsedBorderSide::End) : section()->cachedCollapsedBorder(*this, CollapsedBorderSide::Start);
 }
 
 RectEdges<LayoutUnit> RenderTableCell::borderWidths() const

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -312,22 +312,18 @@ inline RenderTableCell* RenderTableRow::lastCell() const
 inline void RenderTableCell::setHasEmptyCollapsedBorder(CollapsedBorderSide side, bool empty) const
 {
     switch (side) {
-    case CBSAfter: {
+    case CollapsedBorderSide::After:
         m_hasEmptyCollapsedAfterBorder = empty;
         break;
-    }
-    case CBSBefore: {
+    case CollapsedBorderSide::Before:
         m_hasEmptyCollapsedBeforeBorder = empty;
         break;
-    }
-    case CBSStart: {
+    case CollapsedBorderSide::Start:
         m_hasEmptyCollapsedStartBorder = empty;
         break;
-    }
-    case CBSEnd: {
+    case CollapsedBorderSide::End:
         m_hasEmptyCollapsedEndBorder = empty;
         break;
-    }
     }
     if (empty)
         table()->collapsedEmptyBorderIsPresent();

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -34,11 +34,11 @@ namespace WebCore {
 class RenderTableCell;
 class RenderTableRow;
 
-enum CollapsedBorderSide {
-    CBSBefore,
-    CBSAfter,
-    CBSStart,
-    CBSEnd
+enum class CollapsedBorderSide : uint8_t {
+    Before,
+    After,
+    Start,
+    End
 };
 
 // Helper class for paintObject.
@@ -243,7 +243,7 @@ private:
 
     // This map holds the collapsed border values for cells with collapsed borders.
     // It is held at RenderTableSection level to spare memory consumption by table cells.
-    HashMap<std::pair<const RenderTableCell*, int>, CollapsedBorderValue > m_cellsCollapsedBorders;
+    HashMap<std::pair<const RenderTableCell*, int>, CollapsedBorderValue> m_cellsCollapsedBorders;
 
     bool m_forceSlowPaintPathWithOverflowingCell { false };
     bool m_hasMultipleCellLevels { false };


### PR DESCRIPTION
#### 6215796bd7ec31bdd7afb899f509c44f1317d188
<pre>
Use scoped enum classes in StepRange::StepValueShouldBe and CollapsedBorderSide
<a href="https://bugs.webkit.org/show_bug.cgi?id=307921">https://bugs.webkit.org/show_bug.cgi?id=307921</a>
<a href="https://rdar.apple.com/170404272">rdar://170404272</a>

Reviewed by Vitor Roriz.

Convert two more C-style enums to enum class : uint8_t for stronger
type safety. Remove redundant prefixes from values.

StepRange::StepValueShouldBe:
- StepValueShouldBeReal → Real
- ParsedStepValueShouldBeInteger → ParsedInteger
- ScaledStepValueShouldBeInteger → ScaledInteger

CollapsedBorderSide:
- CBSBefore → Before
- CBSAfter → After
- CBSStart → Start
- CBSEnd → End

No change of functionality, so no new tests added.

* Source/WebCore/html/DateInputType.cpp:
* Source/WebCore/html/DateTimeLocalInputType.cpp:
* Source/WebCore/html/MonthInputType.cpp:
* Source/WebCore/html/StepRange.cpp:
(WebCore::StepRange::acceptableError const):
(WebCore::StepRange::parseStep):
* Source/WebCore/html/StepRange.h:
(WebCore::StepRange::StepDescription::StepDescription):
* Source/WebCore/html/TimeInputType.cpp:
* Source/WebCore/html/WeekInputType.cpp:
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::RenderTableCell::collapsedStartBorder const):
(WebCore::RenderTableCell::collapsedEndBorder const):
(WebCore::RenderTableCell::collapsedBeforeBorder const):
(WebCore::RenderTableCell::collapsedAfterBorder const):
(WebCore::RenderTableCell::cachedCollapsedLeftBorder const):
(WebCore::RenderTableCell::cachedCollapsedRightBorder const):
(WebCore::RenderTableCell::cachedCollapsedTopBorder const):
(WebCore::RenderTableCell::cachedCollapsedBottomBorder const):
* Source/WebCore/rendering/RenderTableCell.h:
(WebCore::RenderTableCell::setHasEmptyCollapsedBorder const):
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::physicalBorderForDirection):
(WebCore::RenderTableSection::paintObject):
(WebCore::RenderTableSection::removeCachedCollapsedBorders):
(WebCore::RenderTableSection::setCachedCollapsedBorder):
(WebCore::RenderTableSection::cachedCollapsedBorder):
* Source/WebCore/rendering/RenderTableSection.h:

Canonical link: <a href="https://commits.webkit.org/307785@main">https://commits.webkit.org/307785@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05f7b45caa75c640d7cbfd0d241893e49c9ecd75

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98737 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93eec84f-cba7-46d8-ac49-edb3316dc048) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146976 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17674 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111570 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79982 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a221a36-6d9c-4d29-ac6f-6e1de51227dd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13941 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130334 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92468 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13306 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11062 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1217 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7091 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156084 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17633 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8179 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119576 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17679 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14718 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119906 "Found 1 new API test failure: WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/autoplay-policy (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30825 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15694 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128349 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73297 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17254 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6608 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16990 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81033 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17199 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17054 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->