### PR TITLE
[JSC] Allow RegExpTestInline for unicode patterns on 8-bit strings

### DIFF
--- a/JSTests/microbenchmarks/regexp-test-unicode-inline.js
+++ b/JSTests/microbenchmarks/regexp-test-unicode-inline.js
@@ -1,0 +1,45 @@
+// Microbenchmark for RegExp.test() with unicode flag inlining.
+// Only literal patterns are inlineable (character classes, dot, \d, and
+// ignoreCase all require callFrame which prevents inlining).
+
+function testSingleChar(s) {
+    return /x/u.test(s);
+}
+noInline(testSingleChar);
+
+function testLiteral3(s) {
+    return /abc/u.test(s);
+}
+noInline(testLiteral3);
+
+function testLiteral5(s) {
+    return /hello/u.test(s);
+}
+noInline(testLiteral5);
+
+function testLiteral8(s) {
+    return /function/u.test(s);
+}
+noInline(testLiteral8);
+
+var count = 1e5;
+
+for (var i = 0; i < count; ++i) {
+    testSingleChar("abcxdef");
+    testSingleChar("abcdef");
+}
+
+for (var i = 0; i < count; ++i) {
+    testLiteral3("xabcx");
+    testLiteral3("xyz");
+}
+
+for (var i = 0; i < count; ++i) {
+    testLiteral5("say hello world");
+    testLiteral5("xyz");
+}
+
+for (var i = 0; i < count; ++i) {
+    testLiteral8("var function foo");
+    testLiteral8("xyz");
+}

--- a/JSTests/stress/regexp-test-unicode-inline.js
+++ b/JSTests/stress/regexp-test-unicode-inline.js
@@ -1,0 +1,137 @@
+// Test that RegExp.test() with unicode flag can be inlined in DFG/FTL.
+// InlineTest always compiles for Char8 (Latin1) strings only, so surrogate pair
+// decoding is not needed and the /u flag should not prevent inlining.
+
+function testBasic(s) {
+    return /abc/u.test(s);
+}
+noInline(testBasic);
+
+function testIgnoreCase(s) {
+    return /abc/iu.test(s);
+}
+noInline(testIgnoreCase);
+
+function testWordClass(s) {
+    return /\w+/u.test(s);
+}
+noInline(testWordClass);
+
+function testDigitClass(s) {
+    return /\d+/u.test(s);
+}
+noInline(testDigitClass);
+
+function testPropertyEscape(s) {
+    return /\p{Letter}/u.test(s);
+}
+noInline(testPropertyEscape);
+
+function testDot(s) {
+    return /a.c/u.test(s);
+}
+noInline(testDot);
+
+function testWordBoundary(s) {
+    return /\bfoo\b/iu.test(s);
+}
+noInline(testWordBoundary);
+
+function testNonBMP(s) {
+    return /\u{1F600}/u.test(s);
+}
+noInline(testNonBMP);
+
+function testUnicodeSets(s) {
+    return /[a-z]/v.test(s);
+}
+noInline(testUnicodeSets);
+
+function testCharClassWithProperty(s) {
+    return /[a-z\p{Number}]/u.test(s);
+}
+noInline(testCharClassWithProperty);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    // Basic unicode pattern
+    if (!testBasic("abc"))
+        throw "Error: testBasic should match 'abc'";
+    if (!testBasic("xabcy"))
+        throw "Error: testBasic should match 'xabcy'";
+    if (testBasic("abd"))
+        throw "Error: testBasic should not match 'abd'";
+    if (testBasic(""))
+        throw "Error: testBasic should not match empty string";
+
+    // Unicode + ignoreCase
+    if (!testIgnoreCase("ABC"))
+        throw "Error: testIgnoreCase should match 'ABC'";
+    if (!testIgnoreCase("AbC"))
+        throw "Error: testIgnoreCase should match 'AbC'";
+    if (testIgnoreCase("abd"))
+        throw "Error: testIgnoreCase should not match 'abd'";
+
+    // Unicode word class
+    if (!testWordClass("hello"))
+        throw "Error: testWordClass should match 'hello'";
+    if (!testWordClass("a"))
+        throw "Error: testWordClass should match 'a'";
+    if (testWordClass("   "))
+        throw "Error: testWordClass should not match spaces";
+
+    // Unicode digit class
+    if (!testDigitClass("123"))
+        throw "Error: testDigitClass should match '123'";
+    if (testDigitClass("abc"))
+        throw "Error: testDigitClass should not match 'abc'";
+
+    // Unicode property escape
+    if (!testPropertyEscape("a"))
+        throw "Error: testPropertyEscape should match 'a'";
+    if (!testPropertyEscape("Z"))
+        throw "Error: testPropertyEscape should match 'Z'";
+    if (testPropertyEscape("1"))
+        throw "Error: testPropertyEscape should not match '1'";
+
+    // Dot in unicode mode
+    if (!testDot("abc"))
+        throw "Error: testDot should match 'abc'";
+    if (!testDot("axc"))
+        throw "Error: testDot should match 'axc'";
+    if (testDot("ac"))
+        throw "Error: testDot should not match 'ac'";
+
+    // Word boundary with unicode + ignoreCase
+    if (!testWordBoundary("foo"))
+        throw "Error: testWordBoundary should match 'foo'";
+    if (!testWordBoundary("FOO"))
+        throw "Error: testWordBoundary should match 'FOO'";
+    if (!testWordBoundary("x foo y"))
+        throw "Error: testWordBoundary should match 'x foo y'";
+    if (testWordBoundary("foobar"))
+        throw "Error: testWordBoundary should not match 'foobar'";
+
+    // Non-BMP pattern against 8-bit string should not match
+    if (testNonBMP("abc"))
+        throw "Error: testNonBMP should not match 'abc'";
+    if (testNonBMP(""))
+        throw "Error: testNonBMP should not match empty string";
+
+    // unicodeSets flag
+    if (!testUnicodeSets("a"))
+        throw "Error: testUnicodeSets should match 'a'";
+    if (!testUnicodeSets("z"))
+        throw "Error: testUnicodeSets should match 'z'";
+    if (testUnicodeSets("A"))
+        throw "Error: testUnicodeSets should not match 'A'";
+    if (testUnicodeSets("1"))
+        throw "Error: testUnicodeSets should not match '1'";
+
+    // Character class with unicode property
+    if (!testCharClassWithProperty("a"))
+        throw "Error: testCharClassWithProperty should match 'a'";
+    if (!testCharClassWithProperty("5"))
+        throw "Error: testCharClassWithProperty should match '5'";
+    if (testCharClassWithProperty("!"))
+        throw "Error: testCharClassWithProperty should not match '!'";
+}

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -1098,9 +1098,6 @@ private:
                 if (regExp->globalOrSticky())
                     return false;
 
-                if (regExp->eitherUnicode())
-                    return false;
-
                 auto jitCodeBlock = regExp->getRegExpJITCodeBlock();
                 if (!jitCodeBlock)
                     return false;

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -6706,8 +6706,6 @@ public:
                 return false;
             if (m_pattern.sticky())
                 return false;
-            if (m_pattern.eitherUnicode())
-                return false;
             if (mayCall())
                 return false;
             if (m_callFrameSizeInBytes)


### PR DESCRIPTION
#### 3dff83155cde2e11bf98371ca98b9ea00ab99b3f
<pre>
[JSC] Allow RegExpTestInline for unicode patterns on 8-bit strings
<a href="https://bugs.webkit.org/show_bug.cgi?id=307923">https://bugs.webkit.org/show_bug.cgi?id=307923</a>

Reviewed by NOBODY (OOPS!).

RegExpTestInline embeds regexp JIT code directly into DFG/FTL code,
avoiding the overhead of calling into the regexp engine. Previously,
patterns with the unicode (/u) or unicodeSets (/v) flag were
unconditionally excluded from this optimization in both YarrJIT&apos;s
canInline check and DFG&apos;s convertTestToTestInline.

This exclusion is unnecessary for the 8-bit (Latin1) compilation path.
InlineTest always compiles for Char8 only, where m_decodeSurrogatePairs
is false and mayCall() returns false, so no surrogate pair handling is
involved. The unicode flag only affects Char16 compilation (surrogate
decoding, non-BMP character handling), none of which applies to the
Char8 inline path.

This change removes the eitherUnicode() guard from both locations,
allowing unicode literal patterns like /abc/u to be inlined when
tested against 8-bit strings.

                                    TipOfTree                  Patched

regexp-test-unicode-inline        7.4819+-0.1868     ^      4.2314+-0.2148        ^ definitely 1.7682x faster

Tests: JSTests/microbenchmarks/regexp-test-unicode-inline.js
       JSTests/stress/regexp-test-unicode-inline.js

* JSTests/microbenchmarks/regexp-test-unicode-inline.js: Added.
(testSingleChar):
(testLiteral3):
(testLiteral5):
* JSTests/stress/regexp-test-unicode-inline.js: Added.
(testBasic):
(testIgnoreCase):
(testWordClass):
(testDigitClass):
(testPropertyEscape):
(testDot):
(testWordBoundary):
(testNonBMP):
(testUnicodeSets):
(testCharClassWithProperty):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dff83155cde2e11bf98371ca98b9ea00ab99b3f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9252 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153522 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98486 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111376 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147814 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13737 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130079 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92271 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13111 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10864 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/967 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136842 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122626 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6823 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155834 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5660 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17382 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119379 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14506 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119707 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15510 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128081 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72952 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17004 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6379 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176139 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16740 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80783 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45330 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16949 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16804 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->