### PR TITLE
Notify the web view when top scroll stretch changes

### DIFF
--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in
@@ -270,6 +270,9 @@ using WebKit::PageData::TransactionCallbackID = IPC::AsyncReplyID;
     Markable<WebCore::PlatformLayerIdentifier> pageScalingLayerID;
     Markable<WebCore::PlatformLayerIdentifier> scrolledContentsLayerID;
     Markable<WebCore::PlatformLayerIdentifier> mainFrameClipLayerID;
+#if ENABLE(SCROLL_STRETCH_NOTIFICATIONS)
+    uint64_t topScrollStretch;
+#endif
 #endif
 
     double pageScaleFactor;

--- a/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
+++ b/Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h
@@ -72,6 +72,9 @@ struct MainFrameData {
     Markable<WebCore::PlatformLayerIdentifier> pageScalingLayerID; // Only used for non-delegated scaling.
     Markable<WebCore::PlatformLayerIdentifier> scrolledContentsLayerID;
     Markable<WebCore::PlatformLayerIdentifier> mainFrameClipLayerID;
+#if ENABLE(SCROLL_STRETCH_NOTIFICATIONS)
+    uint64_t topScrollStretch { 0 };
+#endif
 #endif
 
     double pageScaleFactor { 1 };

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3189,6 +3189,13 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
 #endif // ENABLE(SWIFTUI)
 }
 
+#if ENABLE(SCROLL_STRETCH_NOTIFICATIONS)
+- (void)_topScrollStretchDidChange:(NSUInteger)topScrollStretch
+{
+    _impl->topScrollStretchDidChange(topScrollStretch);
+}
+#endif
+
 - (void)_updateFixedContainerEdges:(const WebCore::FixedContainerEdges&)edges
 {
     if (_fixedContainerEdges == edges)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -644,6 +644,10 @@ struct PerWebProcessState {
 - (void)_updateFixedContainerEdges:(const WebCore::FixedContainerEdges&)edges;
 - (void)_updateScrollGeometryWithContentOffset:(CGPoint)contentOffset contentSize:(CGSize)contentSize;
 
+#if ENABLE(SCROLL_STRETCH_NOTIFICATIONS)
+- (void)_topScrollStretchDidChange:(NSUInteger)topScrollStretch;
+#endif
+
 - (WKPageRef)_pageForTesting;
 - (NakedPtr<WebKit::WebPageProxy>)_page;
 - (RefPtr<WebKit::WebPageProxy>)_protectedPage;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -207,6 +207,8 @@ private:
 
     void scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID) override;
 
+    void didCommitMainFrameData(const MainFrameData&) override;
+
     void registerInsertionUndoGrouping() override;
 
     void createPDFHUD(PDFPluginIdentifier, WebCore::FrameIdentifier, const WebCore::IntRect&) override;

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -39,6 +39,7 @@
 #import "NativeWebWheelEvent.h"
 #import "NavigationState.h"
 #import "PlatformWritingToolsUtilities.h"
+#import "RemoteLayerTreeCommitBundle.h"
 #import "RemoteLayerTreeNode.h"
 #import "TextExtractionFilter.h"
 #import "UndoOrRedo.h"
@@ -803,6 +804,14 @@ void PageClientImpl::setEditableElementIsFocused(bool editableElementIsFocused)
 void PageClientImpl::scrollingNodeScrollViewDidScroll(WebCore::ScrollingNodeID)
 {
     protect(m_impl)->suppressContentRelativeChildViews(WebViewImpl::ContentRelativeChildViewsSuppressionType::TemporarilyRemove);
+}
+
+void PageClientImpl::didCommitMainFrameData(const MainFrameData& mainFrameData)
+{
+    PageClientImplCocoa::didCommitMainFrameData(mainFrameData);
+#if ENABLE(SCROLL_STRETCH_NOTIFICATIONS)
+    [webView() _topScrollStretchDidChange:mainFrameData.topScrollStretch];
+#endif
 }
 
 void PageClientImpl::willBeginViewGesture()

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -853,6 +853,9 @@ public:
     void updateBannerViewForPanGesture(NSGestureRecognizerState);
     void updateBannerViewFrame();
 #endif
+#if ENABLE(SCROLL_STRETCH_NOTIFICATIONS)
+    void topScrollStretchDidChange(uint64_t topScrollStretch);
+#endif
 
 #if ENABLE(VIDEO)
     void showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&&);
@@ -1159,6 +1162,10 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     RetainPtr<CAShapeLayer> m_bannerViewMask;
     CGFloat m_bannerViewHeight { 0 };
     bool m_canShowBannerViewOverlay { false };
+#endif
+
+#if ENABLE(SCROLL_STRETCH_NOTIFICATIONS)
+    uint64_t m_cachedTopScrollStretch { 0 };
 #endif
 
 #if HAVE(INLINE_PREDICTIONS)

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -2133,6 +2133,12 @@ void WebPage::willCommitMainFrameData(MainFrameData& data, const TransactionID& 
         m_pendingEditorStateUpdateStatus = PendingEditorStateUpdateStatus::NotScheduled;
         m_needsEditorStateVisualDataUpdate = false;
     }
+
+#if ENABLE(SCROLL_STRETCH_NOTIFICATIONS)
+    auto scrollOrigin = mainFrameView->scrollOrigin();
+    auto scrollPosition = mainFrameView->scrollPosition();
+    data.topScrollStretch = static_cast<uint64_t>(std::max(0, -scrollOrigin.y() - scrollPosition.y()));
+#endif
 }
 
 void WebPage::didFlushLayerTreeAtTime(MonotonicTime timestamp, bool flushSucceeded)


### PR DESCRIPTION
#### 267418781cf06082e70ed8a9fe349f929fca2ddb
<pre>
Notify the web view when top scroll stretch changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307922">https://bugs.webkit.org/show_bug.cgi?id=307922</a>
<a href="https://rdar.apple.com/170373141">rdar://170373141</a>

Reviewed by Abrar Rahman Protyasha.

Notify the web view when the top scroll stretch changes.
Determine whether or not top scroll stretch changed by calculating
the overflow in `WebPage::willCommitMainFrameData` and storing it
as a new property of `MainFrameData` when the overflow amount changes.
Then in `PageClientImpl::didCommitMainFrameData`, if `verticalTopStretch`
is present, call `[WKWebView _topScrollStretchDidChange:]`.

* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTree.serialization.in:
* Source/WebKit/Shared/RemoteLayerTree/RemoteLayerTreeCommitBundle.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _topScrollStretchDidChange:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didCommitMainFrameData):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::willCommitMainFrameData):

Canonical link: <a href="https://commits.webkit.org/307608@main">https://commits.webkit.org/307608@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54c48ad3dfc0c6af1a32ff9078d2b5902b7f961c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144862 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9263 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153533 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98497 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5fc4a5aa-cba5-4750-af18-9f5a40227649) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111385 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79837 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39314a5b-b9ee-456f-9919-fc5dec0a12b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130093 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92280 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e42d0818-f021-4947-841b-9e978755763a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13126 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10875 "Found 1 new API test failure: TestWebKitAPI.CSSViewportUnits.MinimumViewportInset (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/978 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155845 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119388 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17440 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119716 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/30712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15520 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128095 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/72978 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22359 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17015 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6393 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80794 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16960 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->