### PR TITLE
Refactor PDF code supporting two-phase clicks to use feature flag instead of platform guard

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -322,17 +322,22 @@ public:
     uint64_t streamedBytes() const;
     std::optional<WebCore::FrameIdentifier> rootFrameID() const final;
 
-#if PLATFORM(IOS_FAMILY)
-    virtual void setSelectionRange(WebCore::FloatPoint /* pointInRootView */, WebCore::TextGranularity) { }
-    virtual void clearSelection() { }
+#if ENABLE(TWO_PHASE_CLICKS)
     virtual std::pair<URL, WebCore::FloatRect> linkURLAndBoundsAtPoint(WebCore::FloatPoint /* pointInRootView */) const { return { }; }
     virtual std::tuple<URL, WebCore::FloatRect, RefPtr<WebCore::TextIndicator>> linkDataAtPoint(WebCore::FloatPoint /* pointInRootView */) { return { }; }
     virtual std::optional<WebCore::FloatRect> highlightRectForTapAtPoint(WebCore::FloatPoint /* pointInRootView */) const { return std::nullopt; }
-    virtual void handleSyntheticClick(WebCore::PlatformMouseEvent&&) { }
+    virtual CursorContext cursorContext(WebCore::FloatPoint /* pointInRootView */) const { return { }; }
+#if PLATFORM(IOS_FAMILY)
+    virtual void setSelectionRange(WebCore::FloatPoint /* pointInRootView */, WebCore::TextGranularity) { }
     virtual SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint /* pointInRootView */, SelectionEndpoint);
     virtual SelectionEndpoint extendInitialSelection(WebCore::FloatPoint /* pointInRootView */, WebCore::TextGranularity);
-    virtual CursorContext cursorContext(WebCore::FloatPoint /* pointInRootView */) const { return { }; }
     virtual DocumentEditingContext documentEditingContext(DocumentEditingContextRequest&&) const;
+#endif
+#endif
+
+#if ENABLE(TWO_PHASE_CLICKS)
+    virtual void handleSyntheticClick(WebCore::PlatformMouseEvent&&) { }
+    virtual void clearSelection() { }
 #endif
 
     bool populateEditorStateIfNeeded(EditorState&) const;

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h
@@ -627,19 +627,21 @@ private:
     WebCore::FloatRect pageToRootView(WebCore::FloatRect rectInPage, PDFPage *) const;
     WebCore::FloatRect pageToRootView(WebCore::FloatRect rectInPage, std::optional<PDFDocumentLayout::PageIndex>) const;
 
-#if PLATFORM(IOS_FAMILY)
-    void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity) final;
-    void clearSelection() final;
+#if ENABLE(TWO_PHASE_CLICKS)
     std::pair<URL, WebCore::FloatRect> linkURLAndBoundsForAnnotation(PDFAnnotation *) const;
     std::pair<URL, WebCore::FloatRect> linkURLAndBoundsAtPoint(WebCore::FloatPoint pointInRootView) const final;
     std::tuple<URL, WebCore::FloatRect, RefPtr<WebCore::TextIndicator>> linkDataAtPoint(WebCore::FloatPoint pointInRootView) final;
     std::optional<WebCore::FloatRect> highlightRectForTapAtPoint(WebCore::FloatPoint pointInRootView) const final;
-    void handleSyntheticClick(WebCore::PlatformMouseEvent&&) final;
+    CursorContext cursorContext(WebCore::FloatPoint pointInRootView) const final;
+#if PLATFORM(IOS_FAMILY)
+    void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity) final;
     SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint) final;
     SelectionEndpoint extendInitialSelection(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity) final;
     bool platformPopulateEditorStateIfNeeded(EditorState&) const final;
-    CursorContext cursorContext(WebCore::FloatPoint pointInRootView) const final;
     DocumentEditingContext documentEditingContext(DocumentEditingContextRequest&&) const final;
+    void resetInitialSelection();
+#endif
+#endif // ENABLE(TWO_PHASE_CLICKS)
 
 #if HAVE(PDFDOCUMENT_SELECTION_WITH_GRANULARITY)
     PDFSelection *selectionAtPoint(WebCore::FloatPoint pointInPage, PDFPage *, WebCore::TextGranularity) const;
@@ -648,8 +650,11 @@ private:
 
     PageAndPoint selectionCaretPointInPage(PDFSelection *, SelectionEndpoint) const;
     PageAndPoint selectionCaretPointInPage(SelectionEndpoint) const;
-    void resetInitialSelection();
-#endif // PLATFORM(IOS_FAMILY)
+
+#if ENABLE(TWO_PHASE_CLICKS)
+    void handleSyntheticClick(WebCore::PlatformMouseEvent&&) final;
+    void clearSelection() final;
+#endif
 
     bool shouldUseInProcessBackingStore() const;
 

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -1151,6 +1151,38 @@ void PluginView::openWithPreview(CompletionHandler<void(const String&, std::opti
     m_plugin->openWithPreview(WTF::move(completionHandler));
 }
 
+#if ENABLE(TWO_PHASE_CLICKS)
+
+std::pair<URL, FloatRect> PluginView::linkURLAndBoundsAtPoint(FloatPoint pointInRootView) const
+{
+    return m_plugin->linkURLAndBoundsAtPoint(pointInRootView);
+}
+
+std::tuple<URL, FloatRect, RefPtr<TextIndicator>> PluginView::linkDataAtPoint(FloatPoint pointInRootView)
+{
+    return m_plugin->linkDataAtPoint(pointInRootView);
+}
+
+std::optional<FloatRect> PluginView::highlightRectForTapAtPoint(FloatPoint pointInRootView) const
+{
+    return m_plugin->highlightRectForTapAtPoint(pointInRootView);
+}
+
+CursorContext PluginView::cursorContext(FloatPoint pointInRootView) const
+{
+    return m_plugin->cursorContext(pointInRootView);
+}
+
+void PluginView::clearSelection()
+{
+    m_plugin->clearSelection();
+}
+
+void PluginView::handleSyntheticClick(PlatformMouseEvent&& event)
+{
+    m_plugin->handleSyntheticClick(WTF::move(event));
+}
+
 #if PLATFORM(IOS_FAMILY)
 
 void PluginView::setSelectionRange(FloatPoint pointInRootView, TextGranularity granularity)
@@ -1173,37 +1205,9 @@ DocumentEditingContext PluginView::documentEditingContext(DocumentEditingContext
     return m_plugin->documentEditingContext(WTF::move(request));
 }
 
-void PluginView::clearSelection()
-{
-    m_plugin->clearSelection();
-}
-
-std::pair<URL, FloatRect> PluginView::linkURLAndBoundsAtPoint(FloatPoint pointInRootView) const
-{
-    return m_plugin->linkURLAndBoundsAtPoint(pointInRootView);
-}
-
-std::tuple<URL, FloatRect, RefPtr<TextIndicator>> PluginView::linkDataAtPoint(FloatPoint pointInRootView)
-{
-    return m_plugin->linkDataAtPoint(pointInRootView);
-}
-
-std::optional<FloatRect> PluginView::highlightRectForTapAtPoint(FloatPoint pointInRootView) const
-{
-    return m_plugin->highlightRectForTapAtPoint(pointInRootView);
-}
-
-void PluginView::handleSyntheticClick(PlatformMouseEvent&& event)
-{
-    m_plugin->handleSyntheticClick(WTF::move(event));
-}
-
-CursorContext PluginView::cursorContext(FloatPoint pointInRootView) const
-{
-    return m_plugin->cursorContext(pointInRootView);
-}
-
 #endif // PLATFORM(IOS_FAMILY)
+
+#endif // ENABLE(TWO_PHASE_CLICKS)
 
 bool PluginView::populateEditorStateIfNeeded(EditorState& state) const
 {

--- a/Source/WebKit/WebProcess/Plugins/PluginView.h
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.h
@@ -99,17 +99,19 @@ public:
     void mainFramePageScaleFactorDidChange();
     double pageScaleFactor() const;
     void pluginScaleFactorDidChange();
-#if PLATFORM(IOS_FAMILY)
+#if ENABLE(TWO_PHASE_CLICKS)
     std::pair<URL, WebCore::FloatRect> linkURLAndBoundsAtPoint(WebCore::FloatPoint pointInRootView) const;
     std::tuple<URL, WebCore::FloatRect, RefPtr<WebCore::TextIndicator>> linkDataAtPoint(WebCore::FloatPoint pointInRootView);
     std::optional<WebCore::FloatRect> highlightRectForTapAtPoint(WebCore::FloatPoint pointInRootView) const;
+    CursorContext cursorContext(WebCore::FloatPoint pointInRootView) const;
     void handleSyntheticClick(WebCore::PlatformMouseEvent&&);
-    void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity);
     void clearSelection();
+#if PLATFORM(IOS_FAMILY)
+    void setSelectionRange(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity);
     SelectionWasFlipped moveSelectionEndpoint(WebCore::FloatPoint pointInRootView, SelectionEndpoint);
     SelectionEndpoint extendInitialSelection(WebCore::FloatPoint pointInRootView, WebCore::TextGranularity);
-    CursorContext cursorContext(WebCore::FloatPoint pointInRootView) const;
     DocumentEditingContext documentEditingContext(DocumentEditingContextRequest&&) const;
+#endif
 #endif
 
     bool populateEditorStateIfNeeded(EditorState&) const;


### PR DESCRIPTION
#### c6cea2e84c60e501acecfe1555b8301728c9d693
<pre>
Refactor PDF code supporting two-phase clicks to use feature flag instead of platform guard
<a href="https://bugs.webkit.org/show_bug.cgi?id=307938">https://bugs.webkit.org/show_bug.cgi?id=307938</a>
<a href="https://rdar.apple.com/170419372">rdar://170419372</a>

Reviewed by Wenson Hsieh.

Generally, our PDF code that supports two-phase clicks do not have a
reason to be gated behind iOS family.

In this patch, we decouple said code from a platform guard to the
ENABLE_TWO_PHASE_CLICKS feature flag. In doing so, we also nest required
PLATFORM(IOS_FAMILY) guards inside ENABLE(TWO_PHASE_CLICKS) blocks for
iOS-specific PDF plugin functionality (selection handling,
DocumentEditingContext, EditorState). This allows shared link, highlight,
and cursor handling while not pulling in iOS text interaction infra.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
(WebKit::PDFPluginBase::cursorContext const):
(WebKit::PDFPluginBase::setSelectionRange):
(WebKit::PDFPluginBase::handleSyntheticClick):
(WebKit::PDFPluginBase::clearSelection):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.h:
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::selectionBetweenPoints const):
(WebKit::UnifiedPDFPlugin::selectionAtPoint const):
(WebKit::UnifiedPDFPlugin::selectionCaretPointInPage const):
(WebKit::UnifiedPDFPlugin::clearSelection):
(WebKit::UnifiedPDFPlugin::handleSyntheticClick):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
(WebKit::PluginView::linkURLAndBoundsAtPoint const):
(WebKit::PluginView::linkDataAtPoint):
(WebKit::PluginView::highlightRectForTapAtPoint const):
(WebKit::PluginView::cursorContext const):
(WebKit::PluginView::handleSyntheticClick):
(WebKit::PluginView::setSelectionRange):
(WebKit::PluginView::moveSelectionEndpoint):
(WebKit::PluginView::extendInitialSelection):
(WebKit::PluginView::documentEditingContext const):
* Source/WebKit/WebProcess/Plugins/PluginView.h:

Canonical link: <a href="https://commits.webkit.org/307653@main">https://commits.webkit.org/307653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6defaffe2e2a8eb988c5eb91f73d50b942189e70

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17573 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98528 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18056 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17466 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111407 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79857 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bd5a4c1-25a3-4d18-8302-3186a276bad6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147856 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13773 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92302 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/148e9dfb-660c-4d74-b470-f0ab25bc8931) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13147 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10896 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1009 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122662 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155876 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17424 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7946 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119410 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14539 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119738 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30748 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15544 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128116 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73018 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17046 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6414 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16782 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80825 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16991 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16846 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->