### PR TITLE
Remove unnecessary cast from parseDouble and remove parseHexDouble

### DIFF
--- a/Source/WTF/wtf/FastFloat.cpp
+++ b/Source/WTF/wtf/FastFloat.cpp
@@ -44,27 +44,8 @@ double parseDouble(std::span<const Latin1Character> string, size_t& parsedLength
 double parseDouble(std::span<const char16_t> string, size_t& parsedLength)
 {
     double doubleValue = 0;
-    auto stringData = spanReinterpretCast<const char16_t>(string);
-    auto result = fast_float::from_chars(std::to_address(stringData.begin()), std::to_address(stringData.end()), doubleValue, fast_float::chars_format::general | fast_float::chars_format::no_infnan | fast_float::chars_format::allow_leading_plus);
-    parsedLength = result.ptr - stringData.data();
-    return doubleValue;
-}
-
-double parseHexDouble(std::span<const Latin1Character> string, size_t& parsedLength)
-{
-    double doubleValue = 0;
-    auto stringData = byteCast<char>(string);
-    auto result = fast_float::from_chars(std::to_address(stringData.begin()), std::to_address(stringData.end()), doubleValue, fast_float::chars_format::hex | fast_float::chars_format::no_infnan | fast_float::chars_format::allow_leading_plus);
-    parsedLength = result.ptr - stringData.data();
-    return doubleValue;
-}
-
-double parseHexDouble(std::span<const char16_t> string, size_t& parsedLength)
-{
-    double doubleValue = 0;
-    auto stringData = spanReinterpretCast<const char16_t>(string);
-    auto result = fast_float::from_chars(std::to_address(stringData.begin()), std::to_address(stringData.end()), doubleValue, fast_float::chars_format::hex | fast_float::chars_format::no_infnan | fast_float::chars_format::allow_leading_plus);
-    parsedLength = result.ptr - stringData.data();
+    auto result = fast_float::from_chars(std::to_address(string.begin()), std::to_address(string.end()), doubleValue, fast_float::chars_format::general | fast_float::chars_format::no_infnan | fast_float::chars_format::allow_leading_plus);
+    parsedLength = result.ptr - string.data();
     return doubleValue;
 }
 

--- a/Source/WTF/wtf/FastFloat.h
+++ b/Source/WTF/wtf/FastFloat.h
@@ -34,7 +34,4 @@ namespace WTF {
 WTF_EXPORT_PRIVATE double parseDouble(std::span<const Latin1Character> string, size_t& parsedLength);
 WTF_EXPORT_PRIVATE double parseDouble(std::span<const char16_t> string, size_t& parsedLength);
 
-WTF_EXPORT_PRIVATE double parseHexDouble(std::span<const Latin1Character> string, size_t& parsedLength);
-WTF_EXPORT_PRIVATE double parseHexDouble(std::span<const char16_t> string, size_t& parsedLength);
-
 } // namespace WTF


### PR DESCRIPTION
#### 4865155d2fcb7cf39aad87597da8f29909d9b7f7
<pre>
Remove unnecessary cast from parseDouble and remove parseHexDouble
<a href="https://bugs.webkit.org/show_bug.cgi?id=307943">https://bugs.webkit.org/show_bug.cgi?id=307943</a>

Reviewed by Darin Adler.

parseDouble is passed a std::span&lt;const char16_t&gt; so no need to cast to
that.

Canonical link: <a href="https://commits.webkit.org/307636@main">https://commits.webkit.org/307636@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e119bf415d2d375b37c377dc438a29b52d3650d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144899 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98534 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f31f1ace-f7ee-4cbd-a760-f5ccbe6c28a3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17472 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111415 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79863 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/606bcff1-a99b-44a1-b2ef-1f6e40f5be1f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147862 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13776 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92310 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a62cf509-d09f-4f93-9be4-092ae1bae2dc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13150 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10903 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1015 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136890 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122665 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155882 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5708 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17430 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7952 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119418 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17477 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14546 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119747 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15548 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128122 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73030 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22367 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17052 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6420 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176187 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16788 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80831 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45333 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/16997 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16852 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->