### PR TITLE
Remove trivial predicates from RenderStyle

### DIFF
--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -2421,7 +2421,7 @@ void AXObjectCache::onStyleChange(RenderText& renderText, Style::Difference diff
     if (oldStyle->verticalAlign() != newStyle.verticalAlign())
         tree->queueNodeUpdate(object->objectID(), { { AXProperty::IsSuperscript, AXProperty::IsSubscript } });
 
-    if (oldStyle->hasTextShadow() != newStyle.hasTextShadow())
+    if (oldStyle->textShadow().isNone() != newStyle.textShadow().isNone())
         tree->queueNodeUpdate(object->objectID(), { AXProperty::HasTextShadow });
 
     auto oldDecor = oldStyle->textDecorationLineInEffect();

--- a/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm
@@ -242,7 +242,7 @@ bool AccessibilityObject::isSuperscript() const
 bool AccessibilityObject::hasTextShadow() const
 {
     const CheckedPtr style = this->style();
-    return style && style->hasTextShadow();
+    return style && !style->textShadow().isNone();
 }
 
 LineDecorationStyle AccessibilityObject::lineDecorationStyle() const
@@ -264,7 +264,7 @@ AttributedStringStyle AccessibilityObject::stylesForAttributedString() const
         backgroundColorFrom(*style),
         WTF::holdsAlternative<CSS::Keyword::Sub>(alignment),
         WTF::holdsAlternative<CSS::Keyword::Super>(alignment),
-        style->hasTextShadow(),
+        !style->textShadow().isNone(),
         lineDecorationStyle()
     };
 }

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -2016,7 +2016,7 @@ bool KeyframeEffect::preventsAcceleration() const
     // to an element, either through the underlying style, or through a keyframe.
     if (auto target = targetStyleable()) {
         if (auto* lastStyleChangeEventStyle = target->lastStyleChangeEventStyle()) {
-            if (lastStyleChangeEventStyle->hasOffsetPath())
+            if (!lastStyleChangeEventStyle->offsetPath().isNone())
                 return true;
         }
     }
@@ -3113,7 +3113,7 @@ void KeyframeEffect::lastStyleChangeEventStyleDidChange(const RenderStyle* previ
 #endif
 
     auto hasMotionPath = [](const RenderStyle* style) {
-        return style && style->hasOffsetPath();
+        return style && !style->offsetPath().isNone();
     };
 
     if (hasMotionPath(previousStyle) != hasMotionPath(currentStyle))

--- a/Source/WebCore/animation/WebAnimationUtilities.cpp
+++ b/Source/WebCore/animation/WebAnimationUtilities.cpp
@@ -404,7 +404,7 @@ AtomString animatablePropertyAsString(AnimatableCSSProperty property)
 
 bool styleHasDisplayTransition(const RenderStyle& style)
 {
-    if (!style.hasTransitions())
+    if (style.transitions().isInitial())
         return false;
 
     for (auto& transition : style.transitions().usedValues()) {

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -503,7 +503,7 @@ static void CallbackForContainIntrinsicSize(const Vector<Ref<ResizeObserverEntry
                 continue;
             }
             ASSERT(!isSkippedContentRoot(*box));
-            ASSERT(box->style().hasAutoLengthContainIntrinsicSize());
+            ASSERT(box->style().containIntrinsicWidth().hasAuto() || box->style().containIntrinsicHeight().hasAuto());
 
             auto contentBoxSize = entry->contentBoxSize().at(0);
             if (box->style().logicalContainIntrinsicWidth().hasAuto()) {

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -895,7 +895,7 @@ Vector<String> Element::getAttributeNames() const
 bool Element::hasFocusableStyle() const
 {
     auto isFocusableStyle = [](const RenderStyle* style) {
-        return style && style->display() != Style::DisplayType::None && style->display() != Style::DisplayType::Contents
+        return style && style->display().doesGenerateBox()
             && style->visibility() == Visibility::Visible && !style->effectiveInert()
             && (style->usedContentVisibility() != ContentVisibility::Hidden || style->contentVisibility() != ContentVisibility::Visible);
     };
@@ -3050,7 +3050,7 @@ const AtomString& Element::imageSourceURL() const
 
 bool Element::rendererIsNeeded(const RenderStyle& style)
 {
-    return style.display() != Style::DisplayType::None && style.display() != Style::DisplayType::Contents;
+    return style.display().doesGenerateBox();
 }
 
 RenderPtr<RenderElement> Element::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -181,7 +181,7 @@ RenderPtr<RenderText> Text::createTextRenderer(const RenderStyle& style)
     if (isSVGText(*this) || isSVGShadowText(*this))
         return createRenderer<RenderSVGInlineText>(*this, data());
 
-    if (style.hasTextCombine())
+    if (style.textCombine() != TextCombine::None)
         return createRenderer<RenderCombineText>(*this, data());
 
     return createRenderer<RenderText>(RenderObject::Type::Text, *this, data());

--- a/Source/WebCore/editing/DeleteSelectionCommand.cpp
+++ b/Source/WebCore/editing/DeleteSelectionCommand.cpp
@@ -96,10 +96,10 @@ static bool isSpecialHTMLElement(const Node& node)
     if (!renderer)
         return false;
 
-    if (renderer->style().display() == Style::DisplayType::BlockTable || renderer->style().display() == Style::DisplayType::InlineTable)
+    if (renderer->style().display().isTableBox())
         return true;
 
-    if (renderer->style().isFloating())
+    if (renderer->style().floating() != Float::None)
         return true;
 
     if (renderer->style().position() != PositionType::Static)

--- a/Source/WebCore/editing/ReplaceSelectionCommand.cpp
+++ b/Source/WebCore/editing/ReplaceSelectionCommand.cpp
@@ -757,7 +757,7 @@ void ReplaceSelectionCommand::removeRedundantStylesAndKeepStyleSpanInline(Insert
             // Mutate using the CSSOM wrapper so we get the same event behavior as a script.
             if (isBlock(*element))
                 element->cssomStyle().setPropertyInternal(CSSPropertyDisplay, "inline"_s, IsImportant::No);
-            if (element->renderer() && element->renderer()->style().isFloating())
+            if (element->renderer() && element->renderer()->style().floating() != Float::None)
                 element->cssomStyle().setPropertyInternal(CSSPropertyFloat, noneAtom(), IsImportant::No);
         }
     }

--- a/Source/WebCore/editing/TextManipulationController.cpp
+++ b/Source/WebCore/editing/TextManipulationController.cpp
@@ -745,7 +745,7 @@ TextManipulationController::ManipulationResult TextManipulationController::compl
                 continue;
 
             CheckedRef style = box->style();
-            if (style->width().isFixed() && style->height().isFixed() && !style->hasOutOfFlowPosition() && !style->hasClip()) {
+            if (style->width().isFixed() && style->height().isFixed() && !style->hasOutOfFlowPosition() && style->clip().isAuto()) {
                 element->setInlineStyleProperty(CSSPropertyOverflowX, CSSValueHidden);
                 element->setInlineStyleProperty(CSSPropertyOverflowY, CSSValueAuto);
             }

--- a/Source/WebCore/html/HTMLFrameSetElement.cpp
+++ b/Source/WebCore/html/HTMLFrameSetElement.cpp
@@ -148,7 +148,7 @@ void HTMLFrameSetElement::attributeChanged(const QualifiedName& name, const Atom
 
 RenderPtr<RenderElement> HTMLFrameSetElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    if (style.hasContent())
+    if (style.content().isData())
         return RenderElement::createFor(*this, WTF::move(style));
     
     return createRenderer<RenderFrameSet>(*this, WTF::move(style));

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -478,7 +478,7 @@ const AtomString& HTMLImageElement::altText() const
 
 RenderPtr<RenderElement> HTMLImageElement::createElementRenderer(RenderStyle&& style, const RenderTreePosition&)
 {
-    if (style.hasContent())
+    if (style.content().isData())
         return RenderElement::createFor(*this, WTF::move(style));
 
     return createRenderer<RenderImage>(RenderObject::Type::Image, *this, WTF::move(style), nullptr, m_imageDevicePixelRatio);
@@ -486,7 +486,7 @@ RenderPtr<RenderElement> HTMLImageElement::createElementRenderer(RenderStyle&& s
 
 bool HTMLImageElement::isReplaced(const RenderStyle* style) const
 {
-    return !style || !style->hasContent();
+    return !style || !style->content().isData();
 }
 
 bool HTMLImageElement::canStartSelection() const

--- a/Source/WebCore/layout/Verification.cpp
+++ b/Source/WebCore/layout/Verification.cpp
@@ -238,7 +238,7 @@ static bool outputMismatchingBlockBoxInformationIfNeeded(TextStream& stream, con
         if (renderTableRow && renderTableRow->table()->collapseBorders())
             return false;
         // Section borders are either collapsed or ignored. However they may produce negative padding boxes.
-        if (renderTableSection && (renderTableSection->table()->collapseBorders() || renderer.style().hasBorder()))
+        if (renderTableSection && (renderTableSection->table()->collapseBorders() || renderer.style().border().hasBorder()))
             return false;
     }
     if (!areEssentiallyEqual(frameRect, BoxGeometry::borderBoxRect(boxGeometry))) {

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -990,7 +990,7 @@ bool Line::Run::isContentfulOrHasDecoration(const Run& run, const InlineFormatti
 
 bool Line::Run::hasTextCombine() const
 {
-    return m_style.hasTextCombine();
+    return m_style.textCombine() != TextCombine::None;
 }
 
 InlineLayoutUnit Line::Run::letterSpacing() const

--- a/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp
@@ -102,7 +102,9 @@ bool InlineInvalidation::styleWillChange(const Box& layoutBox, const RenderStyle
     auto inlineItemListNeedsUpdate = [&] {
         CheckedRef oldStyle = layoutBox.style();
 
-        auto hasInlineItemTypeChanged = oldStyle->hasOutOfFlowPosition() != newStyle.hasOutOfFlowPosition() || oldStyle->isFloating() != newStyle.isFloating() || oldStyle->display() != newStyle.display();
+        auto hasInlineItemTypeChanged = oldStyle->hasOutOfFlowPosition() != newStyle.hasOutOfFlowPosition()
+            || (oldStyle->floating() != Float::None) != (newStyle.floating() != Float::None)
+            || oldStyle->display() != newStyle.display();
         if (hasInlineItemTypeChanged)
             return true;
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -397,7 +397,7 @@ bool TextUtil::mayBreakInBetween(String previousContent, const RenderStyle& prev
 unsigned TextUtil::findNextBreakablePosition(CachedLineBreakIteratorFactory& lineBreakIteratorFactory, unsigned startPosition, const RenderStyle& style)
 {
     auto wordBreak = style.wordBreak();
-    auto breakNBSP = style.autoWrap() && style.nbspMode() == NBSPMode::Space;
+    auto breakNBSP = style.textWrapMode() != TextWrapMode::NoWrap && style.nbspMode() == NBSPMode::Space;
 
     if (wordBreak == WordBreak::KeepAll) {
         if (breakNBSP)

--- a/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
+++ b/Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp
@@ -187,7 +187,7 @@ static EnumSet<FlexAvoidanceReason> canUseForFlexLayoutWithReason(const RenderFl
         if (mayHaveScrollbarOrScrollableOverflow(flexItemStyle.get()))
             ADD_REASON_AND_RETURN_IF_NEEDED(FlexItemHasUnsupportedOverflow, reasons, includeReasons);
 
-        if ((is<RenderBox>(flexItem.get()) && downcast<RenderBox>(flexItem.get()).hasIntrinsicAspectRatio()) || flexItemStyle->hasAspectRatio())
+        if ((is<RenderBox>(flexItem.get()) && downcast<RenderBox>(flexItem.get()).hasIntrinsicAspectRatio()) || flexItemStyle->aspectRatio().hasRatio())
             ADD_REASON_AND_RETURN_IF_NEEDED(FlexItemHasAspectRatio, reasons, includeReasons);
 
         auto isBaseline = !flexItemStyle->alignSelf().isAuto() ? flexItemStyle->alignSelf().isBaseline() : flexBoxStyle->alignItems().isBaseline();

--- a/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
+++ b/Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp
@@ -204,7 +204,9 @@ static bool gridItemHasValidWidth(const Style::PreferredSize& width)
 
 static bool canComputeAutomaticInlineSize(const RenderBox& gridItem, const StyleSelfAlignmentData& usedJustifySelf)
 {
-    return usedJustifySelf.position() == ItemPosition::Normal && !protect(gridItem.element())->isReplaced() && !gridItem.style().hasAspectRatio();
+    return usedJustifySelf.position() == ItemPosition::Normal
+        && !protect(gridItem.element())->isReplaced()
+        && !gridItem.style().aspectRatio().hasRatio();
 }
 
 static bool gridItemHasValidHeight(const Style::PreferredSize& height)
@@ -224,7 +226,9 @@ static bool gridItemHasValidHeight(const Style::PreferredSize& height)
 
 static bool canComputeAutomaticBlockSize(const RenderBox& gridItem, const StyleSelfAlignmentData& usedAlignSelf)
 {
-    return usedAlignSelf.position() == ItemPosition::Normal && !protect(gridItem.element())->isReplaced() && !gridItem.style().hasAspectRatio();
+    return usedAlignSelf.position() == ItemPosition::Normal
+        && !protect(gridItem.element())->isReplaced()
+        && !gridItem.style().aspectRatio().hasRatio();
 }
 
 static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& renderGrid, ReasonCollectionMode reasonCollectionMode)
@@ -508,7 +512,7 @@ static EnumSet<GridAvoidanceReason> gridLayoutAvoidanceReason(const RenderGrid& 
         if (gridItem->isOutOfFlowPositioned())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridHasOutOfFlowChild, reasons, reasonCollectionMode);
 
-        if (gridItemStyle->hasAspectRatio())
+        if (gridItemStyle->aspectRatio().hasRatio())
             ADD_REASON_AND_RETURN_IF_NEEDED(GridItemHasAspectRatio, reasons, reasonCollectionMode);
 
         if (!gridItemStyle->isOverflowVisible())

--- a/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
+++ b/Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp
@@ -219,7 +219,7 @@ void InlineContentBuilder::adjustDisplayLines(InlineContent& inlineContent, size
                     lineInkOverflowRect.unite(box.inkOverflow());
 
                 if (line.hasBlockLevelBox()) {
-                    if (hasSelfPaintingLayer || box.layoutBox().style().hasOpacity() || box.layoutBox().style().hasOutline()) {
+                    if (hasSelfPaintingLayer || !box.layoutBox().style().opacity().isOpaque() || box.layoutBox().style().hasOutline()) {
                         // See if the inline box has properties that affect block-in-inline painting.
                         inlineContent.setHasPaintedInlineLevelBoxes();
                     }

--- a/Source/WebCore/layout/layouttree/LayoutBoxInlines.h
+++ b/Source/WebCore/layout/layouttree/LayoutBoxInlines.h
@@ -51,12 +51,19 @@ inline bool Box::isListItem() const { return style().display() == Style::Display
 
 inline bool Box::isContainingBlockForFixedPosition() const
 {
-    return isInitialContainingBlock() || isLayoutContainmentBox() || style().hasTransform();
+    return isInitialContainingBlock()
+        || isLayoutContainmentBox()
+        || !style().transform().isNone()
+        || !style().offsetPath().isNone();
 }
 
 inline bool Box::isContainingBlockForOutOfFlowPosition() const
 {
-    return isInitialContainingBlock() || isPositioned() || isLayoutContainmentBox() || style().hasTransform();
+    return isInitialContainingBlock()
+        || isPositioned()
+        || isLayoutContainmentBox()
+        || !style().transform().isNone()
+        || !style().offsetPath().isNone();
 }
 
 }

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -677,8 +677,8 @@ static URL urlForElement(const Element& element)
 #endif
 
     if (CheckedPtr renderer = element.renderer()) {
-        if (auto& style = renderer->style(); style.hasBackgroundImage()) {
-            if (RefPtr image = style.backgroundLayers().usedFirst().image().tryStyleImage())
+        if (auto& backgroundLayers = renderer->style().backgroundLayers(); Style::hasImageInAnyLayer(backgroundLayers)) {
+            if (RefPtr image = backgroundLayers.usedFirst().image().tryStyleImage())
                 return image->url().resolved;
         }
     }
@@ -2093,7 +2093,7 @@ RefPtr<Image> ElementTargetingController::snapshotIgnoringVisibilityAdjustment(N
     if (!renderer)
         return { };
 
-    if (!renderer->isRenderReplaced() && !renderer->firstChild() && !renderer->style().hasBackgroundImage())
+    if (!renderer->isRenderReplaced() && !renderer->firstChild() && !Style::hasImageInAnyLayer(renderer->style().backgroundLayers()))
         return { };
 
     auto backgroundColor = frameView->baseBackgroundColor();

--- a/Source/WebCore/page/FrameSnapshotting.cpp
+++ b/Source/WebCore/page/FrameSnapshotting.cpp
@@ -182,12 +182,12 @@ RefPtr<ImageBuffer> snapshotNode(LocalFrame& frame, Node& node, SnapshotOptions&
 
 static bool styleContainsComplexBackground(const RenderStyle& style)
 {
-    return style.hasBlendMode()
-        || style.hasBackgroundImage()
+    return style.blendMode() != BlendMode::Normal
+        || Style::hasImageInAnyLayer(style.backgroundLayers())
 #if HAVE(CORE_MATERIAL)
-        || style.hasAppleVisualEffectRequiringBackdropFilter()
+        || appleVisualEffectNeedsBackdrop(style.appleVisualEffect())
 #endif
-        || style.hasBackdropFilter();
+        || !style.backdropFilter().isNone();
 }
 
 Color estimatedBackgroundColorForRange(const SimpleRange& range, const LocalFrame& frame)

--- a/Source/WebCore/page/InteractionRegion.cpp
+++ b/Source/WebCore/page/InteractionRegion.cpp
@@ -260,11 +260,11 @@ static bool hasTransparentContainerStyle(const RenderStyle& style)
 {
     return !style.hasBackground()
         && !style.hasOutline()
-        && !style.hasBoxShadow()
-        && !style.hasClipPath()
+        && style.boxShadow().isNone()
+        && style.clipPath().isNone()
         && !style.hasExplicitlySetBorderRadius()
         // No visible borders or borders that do not create a complete box.
-        && (!style.hasVisibleBorder()
+        && (!style.border().hasVisibleBorder()
             || !(style.usedBorderTopWidth() && style.usedBorderRightWidth() && style.usedBorderBottomWidth() && style.usedBorderLeftWidth()));
 }
 
@@ -510,9 +510,9 @@ std::optional<InteractionRegion> interactionRegionForRenderedRegion(const Render
 
                 return cachedImageIsPhoto(*renderImage->cachedImage());
             }();
-        } else if (regionRenderer.style().hasBackgroundImage()) {
+        } else if (auto& backgroundLayers = regionRenderer.style().backgroundLayers(); Style::hasImageInAnyLayer(backgroundLayers)) {
             isPhoto = [&]() -> bool {
-                RefPtr backgroundImage = regionRenderer.style().backgroundLayers().usedFirst().image().tryStyleImage();
+                RefPtr backgroundImage = backgroundLayers.usedFirst().image().tryStyleImage();
                 if (!backgroundImage || !backgroundImage->cachedImage())
                     return false;
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -4351,11 +4351,12 @@ LocalFrameView::ExtendedBackgroundMode LocalFrameView::calculateExtendedBackgrou
     if (!rootBackgroundRenderer)
         return ExtendedBackgroundModeNone;
 
-    if (!rootBackgroundRenderer->style().hasBackgroundImage())
+    auto& backgroundLayers = rootBackgroundRenderer->style().backgroundLayers();
+    if (!Style::hasImageInAnyLayer(backgroundLayers))
         return ExtendedBackgroundModeNone;
 
     ExtendedBackgroundMode mode = ExtendedBackgroundModeNone;
-    auto backgroundRepeat = rootBackgroundRenderer->style().backgroundLayers().usedFirst().repeat();
+    auto backgroundRepeat = backgroundLayers.usedFirst().repeat();
     if (backgroundRepeat.x() == FillRepeat::Repeat)
         mode |= ExtendedBackgroundModeHorizontal;
     if (backgroundRepeat.y() == FillRepeat::Repeat)

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -81,7 +81,7 @@ static bool isValidSampleLocation(Document& document, const IntPoint& location)
             return false;
 
         // Skip images (both `<img>` and CSS `background-image`) as they're likely not a solid color.
-        if (is<RenderImage>(renderer) || renderer->style().hasBackgroundImage())
+        if (is<RenderImage>(renderer) || Style::hasImageInAnyLayer(renderer->style().backgroundLayers()))
             return false;
 
         RefPtr element = dynamicDowncast<Element>(node.get());

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2197,7 +2197,7 @@ bool Quirks::needsHotelsAnimationQuirk(Element& element, const RenderStyle& styl
     if (!m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsHotelsAnimationQuirk))
         return false;
 
-    if (!style.hasAnimations())
+    if (style.animations().isInitial())
         return false;
 
     auto matches = Ref { element }->matches(".uitk-menu-mounted .uitk-menu-container.uitk-menu-container-autoposition.uitk-menu-container-has-intersection-root-el"_s);

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -1315,7 +1315,7 @@ static void extractRenderedTokens(Vector<TokenAndBlockOffset>& tokensAndOffsets,
 
     RefPtr frameView = renderer->view().frameView();
     auto appendReplacedContentOrBackgroundImage = [&](auto& renderer) {
-        if (!renderer.style().hasBackgroundImage() && !is<RenderReplaced>(renderer))
+        if (!Style::hasImageInAnyLayer(renderer.style().backgroundLayers()) && !is<RenderReplaced>(renderer))
             return;
 
         auto absoluteRect = renderer.absoluteBoundingBoxRect();

--- a/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
+++ b/Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp
@@ -524,7 +524,7 @@ ResolvedEmojiPolicy FontCascade::resolveEmojiPolicy(FontVariantEmoji fontVariant
 bool FontCascade::canUseGlyphDisplayList(const RenderStyle& style)
 {
     // CoreText won't call the drawImage delegate for glyphs that are invisible, even if they have an associated shadow applied to its graphic context. This would result in a glyph display list without the invisible glyph which is drawn as image and we would not draw its associated shadow. Therefore, we won't use a display list for runs that are invisible and have an associated shadow.
-    return !(style.hasTextShadow() && !style.color().isVisible());
+    return !(!style.textShadow().isNone() && !style.color().isVisible());
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/AutoTableLayout.cpp
+++ b/Source/WebCore/rendering/AutoTableLayout.cpp
@@ -78,7 +78,10 @@ void AutoTableLayout::recalcColumn(unsigned effCol)
                 if (current.inColSpan || !cell)
                     continue;
 
-                bool cellHasContent = cell->firstChild() || cell->style().hasBorder() || !Style::isKnownZero(cell->style().paddingBox()) || cell->style().hasBackground();
+                bool cellHasContent = cell->firstChild()
+                    || cell->style().border().hasBorder()
+                    || !Style::isKnownZero(cell->style().paddingBox())
+                    || cell->style().hasBackground();
                 if (cellHasContent)
                     columnLayout.emptyCellsOnly = false;
 

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -221,7 +221,7 @@ template<typename Layer> void BackgroundPainter::paintFillLayerImpl(const Color&
     auto& style = m_renderer.style();
     auto layerClip = m_overrideClip.value_or(layer.layer.clip());
 
-    bool hasRoundedBorder = style.hasBorderRadius()
+    bool hasRoundedBorder = style.border().hasBorderRadius()
         && (closedEdges.start(style.writingMode()) || closedEdges.end(style.writingMode()));
     bool clippedWithLocalScrolling = m_renderer.hasNonVisibleOverflow() && layer.layer.attachment() == FillAttachment::LocalBackground;
     bool isBorderFill = layerClip == FillBox::BorderBox;
@@ -865,12 +865,12 @@ void BackgroundPainter::paintBoxShadow(const LayoutRect& paintRect, const Render
 {
     // FIXME: Deal with border-image. Would be great to use border-image as a mask.
     GraphicsContext& context = m_paintInfo.context();
-    if (context.paintingDisabled() || !style.hasBoxShadow())
+    if (context.paintingDisabled() || style.boxShadow().isNone())
         return;
 
     const auto borderShape = BorderShape::shapeForBorderRect(style, paintRect, closedEdges);
 
-    bool hasBorderRadius = style.hasBorderRadius();
+    bool hasBorderRadius = style.border().hasBorderRadius();
     float deviceScaleFactor = document().deviceScaleFactor();
 
     bool hasOpaqueBackground = style.visitedDependentBackgroundColorApplyingColorFilter().isOpaque();
@@ -1072,7 +1072,7 @@ bool BackgroundPainter::boxShadowShouldBeAppliedToBackground(const RenderBoxMode
         return false;
 
     RefPtr image = lastBackgroundLayer.image().tryStyleImage();
-    if (image && style.hasBorderRadius())
+    if (image && style.border().hasBorderRadius())
         return false;
 
     auto applyToInlineBox = [&] {
@@ -1084,7 +1084,7 @@ bool BackgroundPainter::boxShadowShouldBeAppliedToBackground(const RenderBoxMode
             return true;
         auto& renderer = inlineBox->renderer();
         bool hasFillImage = image && image->canRender(&renderer, renderer.style().usedZoom());
-        return !hasFillImage && !renderer.style().hasBorderRadius();
+        return !hasFillImage && !renderer.style().border().hasBorderRadius();
     };
 
     if (inlineBox && !applyToInlineBox())

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -274,7 +274,7 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style
     bool innerEdgeIsRectangular = shape.innerShapeIsRectangular();
 
     paintSides(shape, {
-        style.hasBorderRadius() ? std::make_optional(style.borderRadii()) : std::nullopt,
+        style.border().hasBorderRadius() ? std::optional { style.borderRadii() } : std::nullopt,
         edges,
         decorationHasAllSolidEdges(edges),
         outerEdgeIsRectangular,

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -59,7 +59,7 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
         LayoutUnit(closedEdges.left() ? overrideBorderWidths.left() : 0_lu),
     };
 
-    if (style.hasBorderRadius()) {
+    if (style.border().hasBorderRadius()) {
         auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
         radii.scale(calcBorderRadiiConstraintScaleFor(borderRect, radii));
 
@@ -99,7 +99,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
         LayoutUnit(closedEdges.left() ? outlineWidths.left() : 0_lu),
     };
 
-    if (style.hasBorderRadius()) {
+    if (style.border().hasBorderRadius()) {
         auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
 
         auto leftOutset = std::max(borderRect.x() - outlineBoxRect.x(), 0_lu);
@@ -138,7 +138,7 @@ BorderShape BorderShape::shapeForOutsetRect(const RenderStyle& style, const Layo
 
 BorderShape BorderShape::shapeForInsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& insetRect)
 {
-    if (style.hasBorderRadius()) {
+    if (style.border().hasBorderRadius()) {
         auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), Style::ZoomNeeded { });
 
         auto leftInset = std::max(insetRect.x() - borderRect.x(), 0_lu);

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -141,7 +141,8 @@ bool isOrthogonalParent(const RenderGrid& grid, const RenderElement& parent)
 
 bool isAspectRatioBlockSizeDependentGridItem(const RenderBox& gridItem)
 {
-    return (gridItem.style().hasAspectRatio() || gridItem.hasIntrinsicAspectRatio()) && (gridItem.hasRelativeLogicalHeight() || gridItem.hasStretchedLogicalHeight());
+    return (gridItem.style().aspectRatio().hasRatio() || gridItem.hasIntrinsicAspectRatio())
+        && (gridItem.hasRelativeLogicalHeight() || gridItem.hasStretchedLogicalHeight());
 }
 
 bool isGridItemInlineSizeDependentOnBlockConstraints(const RenderBox& gridItem, const RenderGrid& parentGrid, ItemPosition gridItemAlignSelf)
@@ -168,7 +169,7 @@ bool isGridItemInlineSizeDependentOnBlockConstraints(const RenderBox& gridItem, 
 
     auto hasAspectRatioAndInlineSizeDependsOnBlockSize = [](auto& renderer) {
         auto& rendererStyle = renderer.style();
-        bool rendererHasAspectRatio = renderer.hasIntrinsicAspectRatio() || rendererStyle.hasAspectRatio();
+        bool rendererHasAspectRatio = renderer.hasIntrinsicAspectRatio() || rendererStyle.aspectRatio().hasRatio();
 
         return rendererHasAspectRatio && rendererStyle.logicalWidth().isAuto() && !rendererStyle.logicalHeight().isIntrinsicOrLegacyIntrinsicOrAuto();
     };
@@ -254,7 +255,7 @@ bool hasStretchableSizeInColumnAxis(const RenderBox& gridItem, const RenderGrid&
     if (!(gridContainer.isHorizontalWritingMode() ? gridItem.style().height().isAuto() : gridItem.style().width().isAuto()))
         return false;
 
-    if (gridItem.style().hasAspectRatio() && !gridContainer.selfAlignmentForGridItem(gridItem, LogicalBoxAxis::Block, StretchingMode::Explicit).isStretch()) {
+    if (gridItem.style().aspectRatio().hasRatio() && !gridContainer.selfAlignmentForGridItem(gridItem, LogicalBoxAxis::Block, StretchingMode::Explicit).isStretch()) {
         if (gridContainer.isHorizontalWritingMode() == gridItem.isHorizontalWritingMode()) {
             // A non-auto inline size means the same for block size (column axis size) because of the aspect ratio.
             if (!gridItem.style().logicalWidth().isAuto())
@@ -277,7 +278,7 @@ bool hasStretchableSizeInRowAxis(const RenderBox& gridItem, const RenderGrid& gr
     if (!(gridContainer.isHorizontalWritingMode() ? gridItem.style().width().isAuto() : gridItem.style().height().isAuto()))
         return false;
 
-    if (gridItem.style().hasAspectRatio() && !gridContainer.selfAlignmentForGridItem(gridItem, LogicalBoxAxis::Inline, StretchingMode::Explicit).isStretch()) {
+    if (gridItem.style().aspectRatio().hasRatio() && !gridContainer.selfAlignmentForGridItem(gridItem, LogicalBoxAxis::Inline, StretchingMode::Explicit).isStretch()) {
         if (gridContainer.isHorizontalWritingMode() != gridItem.isHorizontalWritingMode()) {
             // A non-auto inline size (column axis size) means the same for block size (row axis size) because of the aspect ratio.
             if (!gridItem.style().logicalWidth().isAuto())

--- a/Source/WebCore/rendering/InlineBoxPainter.cpp
+++ b/Source/WebCore/rendering/InlineBoxPainter.cpp
@@ -253,7 +253,7 @@ void InlineBoxPainter::paintDecorations()
 
     // :first-line cannot be used to put borders on a line. Always paint borders with our
     // non-first-line style.
-    if (m_isRootInlineBox || !renderer().style().hasVisibleBorderDecoration())
+    if (m_isRootInlineBox || !renderer().style().border().hasVisibleBorderDecoration())
         return;
 
     auto& borderImage = renderer().style().borderImage();
@@ -306,7 +306,7 @@ template<typename Layer> void InlineBoxPainter::paintFillLayer(const Color& colo
 {
     RefPtr image = fillLayer.layer.image().tryStyleImage();
     bool hasFillImage = image && image->canRender(&renderer(), renderer().style().usedZoom());
-    bool hasFillImageOrBorderRadius = hasFillImage || renderer().style().hasBorderRadius();
+    bool hasFillImageOrBorderRadius = hasFillImage || renderer().style().border().hasBorderRadius();
 
     BackgroundPainter backgroundPainter { renderer(), m_paintInfo };
 

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -115,7 +115,7 @@ void LegacyInlineFlowBox::addToLine(LegacyInlineBox* child)
         bool hasMarkers = false;
         if (auto* textBox = dynamicDowncast<LegacyInlineTextBox>(*child))
             hasMarkers = textBox->hasMarkers();
-        if (childStyle->usedLetterSpacing() < 0 || childStyle->hasTextShadow() || !childStyle->textEmphasisStyle().isNone() || childStyle->hasPositiveStrokeWidth() || hasMarkers || !childStyle->textUnderlineOffset().isAuto() || !childStyle->textDecorationThickness().isAuto() || !childStyle->textUnderlinePosition().isAuto())
+        if (childStyle->usedLetterSpacing() < 0 || !childStyle->textShadow().isNone() || !childStyle->textEmphasisStyle().isNone() || childStyle->hasPositiveStrokeWidth() || hasMarkers || !childStyle->textUnderlineOffset().isAuto() || !childStyle->textDecorationThickness().isAuto() || !childStyle->textUnderlinePosition().isAuto())
             child->clearKnownToHaveNoOverflow();
     } else if (child->boxModelObject()->hasSelfPaintingLayer())
         child->clearKnownToHaveNoOverflow();

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -100,7 +100,7 @@ void OutlinePainter::paintOutline(const RenderElement& renderer, const LayoutRec
     if (outerRect.isEmpty())
         return;
 
-    auto hasBorderRadius = styleToUse->hasBorderRadius();
+    auto hasBorderRadius = styleToUse->border().hasBorderRadius();
     auto closedEdges = RectEdges<bool> { true };
 
     auto outlineEdgeWidths = RectEdges<LayoutUnit> { outlineWidth };
@@ -269,7 +269,7 @@ void OutlinePainter::paintFocusRing(const RenderElement& renderer, const Vector<
     auto styleOptions = renderer.styleColorOptions();
     styleOptions.add(StyleColorOptions::UseSystemAppearance);
     auto focusRingColor = usePlatformFocusRingColorForOutlineStyleAuto() ? RenderTheme::singleton().focusRingColor(styleOptions) : style->visitedDependentOutlineColorApplyingColorFilter();
-    if (useShrinkWrappedFocusRingForOutlineStyleAuto() && style->hasBorderRadius()) {
+    if (useShrinkWrappedFocusRingForOutlineStyleAuto() && style->border().hasBorderRadius()) {
         auto path = pathWithShrinkWrappedRects(pixelSnappedFocusRingRects, style->border().radii, outlineOffset, style->writingMode(), deviceScaleFactor);
         if (path.isEmpty()) {
             for (auto rect : pixelSnappedFocusRingRects)

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -296,7 +296,7 @@ void RenderBlock::styleWillChange(Style::Difference diff, const RenderStyle& new
     setBlockLevelReplacedOrAtomicInline(newStyle.display().isInlineType());
     if (oldStyle) {
         removeOutOfFlowBoxesIfNeededOnStyleChange(*this, *oldStyle, newStyle);
-        if (isLegend() && !oldStyle->isFloating() && newStyle.isFloating())
+        if (isLegend() && oldStyle->floating() == Float::None && newStyle.floating() != Float::None)
             setIsExcludedFromNormalLayout(false);
     }
     RenderBox::styleWillChange(diff, newStyle);
@@ -1309,7 +1309,7 @@ bool RenderBlock::establishesIndependentFormattingContextIgnoringDisplayType(con
             && style.overflowX() != Overflow::Visible;
     };
 
-    return style.isFloating()
+    return style.floating() != Float::None
         || style.hasOutOfFlowPosition()
         || isBlockBoxWithPotentiallyScrollableOverflow()
         || style.usedContain().contains(Style::ContainValue::Layout)

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -210,7 +210,10 @@ void RenderBoxModelObject::willBeDestroyed()
 
 bool RenderBoxModelObject::hasVisibleBoxDecorationStyle() const
 {
-    return hasBackground() || style().hasVisibleBorderDecoration() || style().hasUsedAppearance() || style().hasBoxShadow();
+    return hasBackground()
+        || style().border().hasVisibleBorderDecoration()
+        || style().hasUsedAppearance()
+        || !style().boxShadow().isNone();
 }
 
 void RenderBoxModelObject::updateFromStyle()
@@ -857,7 +860,7 @@ bool RenderBoxModelObject::borderObscuresBackgroundEdge(const FloatSize& context
 
 bool RenderBoxModelObject::borderObscuresBackground() const
 {
-    if (!style().hasBorder())
+    if (!style().border().hasBorder())
         return false;
 
     // Bail if we have any border-image for now. We could look at the image alpha to improve this.

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -113,12 +113,12 @@ public:
     inline bool canContainAbsolutelyPositionedObjects(const RenderStyle* styleToUse = nullptr) const; // Defined in RenderElementStyleInlines.h.
     bool canEstablishContainingBlockWithTransform() const;
 
-    inline bool shouldApplyLayoutContainment(const RenderStyle* styleToUse = nullptr) const; // Defined in RenderElementStyleInlines.h
+    inline bool shouldApplyLayoutContainment() const; // Defined in RenderElementStyleInlines.h
     inline bool shouldApplySizeContainment() const; // Defined in RenderElementStyleInlines.h
     inline bool shouldApplyInlineSizeContainment() const; // Defined in RenderElementStyleInlines.h.
     inline bool shouldApplySizeOrInlineSizeContainment() const; // Defined in RenderElementStyleInlines.h
     inline bool shouldApplyStyleContainment() const; // Defined in RenderElementStyleInlines.h.
-    inline bool shouldApplyPaintContainment(const RenderStyle* styleToUse = nullptr) const; // Defined in RenderElementStyleInlines.h.
+    inline bool shouldApplyPaintContainment() const; // Defined in RenderElementStyleInlines.h.
     inline bool shouldApplyAnyContainment() const; // Defined in RenderElementStyleInlines.h.
 
     bool hasEligibleContainmentForSizeQuery() const;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -748,7 +748,9 @@ static bool isSVGRootWithIntrinsicAspectRatio(const RenderBox& flexItem)
 
 static bool flexItemHasAspectRatio(const RenderBox& flexItem)
 {
-    return flexItem.hasIntrinsicAspectRatio() || flexItem.style().hasAspectRatio() || isSVGRootWithIntrinsicAspectRatio(flexItem);
+    return flexItem.hasIntrinsicAspectRatio()
+        || flexItem.style().aspectRatio().hasRatio()
+        || isSVGRootWithIntrinsicAspectRatio(flexItem);
 }
 
 template<typename SizeType> std::optional<LayoutUnit> RenderFlexibleBox::computeMainAxisExtentForFlexItem(RenderBox& flexItem, const SizeType& size)
@@ -1241,7 +1243,9 @@ bool RenderFlexibleBox::flexItemHasComputableAspectRatio(const RenderBox& flexIt
 {
     if (!flexItemHasAspectRatio(flexItem))
         return false;
-    return flexItem.intrinsicSize().height() || flexItem.style().hasAspectRatio() || isSVGRootWithIntrinsicAspectRatio(flexItem);
+    return flexItem.intrinsicSize().height()
+        || flexItem.style().aspectRatio().hasRatio()
+        || isSVGRootWithIntrinsicAspectRatio(flexItem);
 }
 
 bool RenderFlexibleBox::flexItemHasComputableAspectRatioAndCrossSizeIsConsideredDefinite(const RenderBox& flexItem)

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -104,7 +104,7 @@ bool RenderGrid::isExtrinsicallySized() const
         || !participatesInBlockLayout()
         || !gridStyle.logicalHeight().isFixed()
         || !allTracksAreExtrinsicallySized()
-        || gridStyle.hasAspectRatio()
+        || gridStyle.aspectRatio().hasRatio()
         || isSubgrid()
         || isMasonry())
         return false;
@@ -1797,7 +1797,7 @@ bool RenderGrid::willStretchItem(const RenderBox& item, LogicalBoxAxis containin
 
 bool RenderGrid::aspectRatioPrefersInline(const RenderBox& gridItem, bool blockFlowIsColumnAxis)
 {
-    if (!gridItem.style().hasAspectRatio())
+    if (!gridItem.style().aspectRatio().hasRatio())
         return false;
     LogicalBoxAxis containingAxis = blockFlowIsColumnAxis ? LogicalBoxAxis::Block : LogicalBoxAxis::Inline;
     return !selfAlignmentForGridItem(gridItem, containingAxis, StretchingMode::Explicit).isStretch();

--- a/Source/WebCore/rendering/RenderImage.cpp
+++ b/Source/WebCore/rendering/RenderImage.cpp
@@ -827,7 +827,7 @@ bool RenderImage::foregroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect,
         return false;
     auto backgroundClip = style().backgroundLayers().usedFirst().clip();
     // Background paints under borders.
-    if (backgroundClip == FillBox::BorderBox && style().hasBorder() && !borderObscuresBackground())
+    if (backgroundClip == FillBox::BorderBox && style().border().hasBorder() && !borderObscuresBackground())
         return false;
     // Background shows in padding area.
     if ((backgroundClip == FillBox::BorderBox || backgroundClip == FillBox::PaddingBox) && !Style::isKnownZero(style().paddingBox()))

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -825,7 +825,6 @@ public:
     FloatPoint perspectiveOrigin() const;
     FloatPoint3D transformOriginPixelSnappedIfNeeded() const;
     inline bool preserves3D() const;
-    inline bool hasPerspective() const;
     bool has3DTransform() const { return m_transform && !m_transform->isAffine(); }
     bool hasTransformedAncestor() const { return m_hasTransformedAncestor; }
     bool participatesInPreserve3D() const;

--- a/Source/WebCore/rendering/RenderLayerInlines.h
+++ b/Source/WebCore/rendering/RenderLayerInlines.h
@@ -34,10 +34,9 @@ namespace WebCore {
 inline bool RenderLayer::canPaintTransparencyWithSetOpacity() const { return isBitmapOnly() && !hasNonOpacityTransparency() && !hasFilter(); }
 inline bool RenderLayer::hasBackdropFilter() const { return renderer().hasBackdropFilter(); }
 inline bool RenderLayer::hasFilter() const { return renderer().hasFilter(); }
-inline bool RenderLayer::hasPerspective() const { return renderer().style().hasPerspective(); }
 inline bool RenderLayer::isTransparent() const { return renderer().isTransparent() || renderer().hasMask(); }
 inline bool RenderLayer::overlapBoundsIncludeChildren() const { return hasFilter() && renderer().style().filter().hasFilterThatMovesPixels(); }
-inline bool RenderLayer::preserves3D() const { return renderer().style().preserves3D(); }
+inline bool RenderLayer::preserves3D() const { return renderer().style().usedTransformStyle3D() == TransformStyle3D::Preserve3D; }
 inline int RenderLayer::zIndex() const { return renderer().style().usedZIndex().tryValue().value_or(0).value; }
 inline Page& RenderLayer::page() const { return renderer().page(); }
 

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -165,7 +165,7 @@ void RenderLayerModelObject::styleDidChange(Style::Difference diff, const Render
         }
     } else if (layer() && layer()->parent()) {
         gainedOrLostLayer = true;
-        if (oldStyle && oldStyle->hasBlendMode())
+        if (oldStyle && oldStyle->blendMode() != BlendMode::Normal)
             layer()->willRemoveChildWithBlendMode();
         setHasTransformRelatedProperty(false); // All transform-related properties force layers, so we know we don't have one or the object doesn't support them.
         setHasSVGTransform(false); // Same reason as for setHasTransformRelatedProperty().
@@ -398,7 +398,11 @@ void RenderLayerModelObject::applySVGTransform(TransformationMatrix& transform, 
 
     // This check does not use style.hasTransformRelatedProperty() on purpose -- we only want to know if either the 'transform' property, an
     // offset path, or the individual transform operations are set (perspective / transform-style: preserve-3d are not relevant here).
-    bool hasCSSTransform = style.hasTransform() || style.hasRotate() || style.hasTranslate() || style.hasScale();
+    bool hasCSSTransform = !style.transform().isNone()
+        || !style.offsetPath().isNone()
+        || !style.rotate().isNone()
+        || !style.translate().isNone()
+        || !style.scale().isNone();
     bool hasSVGTransform = !svgTransform.isIdentity() || preApplySVGTransformMatrix || postApplySVGTransformMatrix || supplementalTransform;
 
     // Common case: 'viewBox' set on outermost <svg> element -> 'preApplySVGTransformMatrix'

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -1540,7 +1540,7 @@ bool RenderObject::shouldUseTransformFromContainer(const RenderElement* containe
         return true;
     if (hasLayer() && downcast<RenderLayerModelObject>(*this).layer()->anchorScrollAdjustment())
         return true;
-    if (containerObject && containerObject->style().hasPerspective())
+    if (containerObject && !containerObject->style().perspective().isNone())
         return containerObject == parent();
     return false;
 }
@@ -1556,8 +1556,8 @@ void RenderObject::getTransformFromContainer(const LayoutSize& offsetInContainer
 
     CheckedPtr perspectiveObject = parent();
 
-    if (perspectiveObject && perspectiveObject->hasLayer() && perspectiveObject->style().hasPerspective()) {
-        // Perpsective on the container affects us, so we have to factor it in here.
+    if (perspectiveObject && perspectiveObject->hasLayer() && !perspectiveObject->style().perspective().isNone()) {
+        // Perspective on the container affects us, so we have to factor it in here.
         ASSERT(perspectiveObject->hasLayer());
         FloatPoint perspectiveOrigin = downcast<RenderLayerModelObject>(*perspectiveObject).layer()->perspectiveOrigin();
 

--- a/Source/WebCore/rendering/RenderObjectInlines.h
+++ b/Source/WebCore/rendering/RenderObjectInlines.h
@@ -38,7 +38,7 @@ namespace WebCore {
 
 inline bool RenderObject::hasTransformOrPerspective() const
 {
-    return hasTransformRelatedProperty() && (isTransformed() || style().hasPerspective());
+    return hasTransformRelatedProperty() && (isTransformed() || !style().perspective().isNone());
 }
 
 inline bool RenderObject::isAtomicInlineLevelBox() const

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -335,7 +335,7 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     }
 
     bool completelyClippedOut = false;
-    if (style().hasBorderRadius()) {
+    if (style().border().hasBorderRadius()) {
         completelyClippedOut = size().isEmpty();
         if (!completelyClippedOut) {
             // Push a clip if we have a border radius, since we want to round the foreground content that gets painted.
@@ -348,7 +348,7 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
         if (!isSkippedContentRoot(*this))
             paintReplaced(paintInfo, adjustedPaintOffset);
 
-        if (style().hasBorderRadius())
+        if (style().border().hasBorderRadius())
             paintInfo.context().restore();
     }
         
@@ -421,7 +421,7 @@ bool RenderReplaced::hasReplacedLogicalHeight() const
         return !hasAutoHeightOrContainingBlockWithAutoHeight();
 
     if (style().logicalHeight().isIntrinsic())
-        return !style().hasAspectRatio();
+        return !style().aspectRatio().hasRatio();
 
     return false;
 }
@@ -587,7 +587,7 @@ FloatSize RenderReplaced::preferredAspectRatio() const
     auto intrinsicSize = FloatSize(intrinsicLogicalWidth(), intrinsicLogicalHeight());
     FloatSize preferredAspectRatio;
 
-    if (style().hasAspectRatio()) {
+    if (style().aspectRatio().hasRatio()) {
         preferredAspectRatio = FloatSize::narrowPrecision(style().aspectRatioLogicalWidth().value, style().aspectRatioLogicalHeight().value);
         if (style().aspectRatio().isRatio() || isVideoWithDefaultObjectSize(this))
             return preferredAspectRatio;
@@ -722,7 +722,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalWidth(ShouldComputePreferred sh
                 }();
 
                 LayoutUnit logicalHeight = computeReplacedLogicalHeight(std::optional<LayoutUnit>(estimatedUsedWidth));
-                auto boxSizing = style.hasAspectRatio() ? style.boxSizingForAspectRatio() : BoxSizing::ContentBox;
+                auto boxSizing = style.aspectRatio().hasRatio() ? style.boxSizingForAspectRatio() : BoxSizing::ContentBox;
                 return computeReplacedLogicalWidthRespectingMinMaxWidth(resolveWidthForRatio(borderAndPaddingLogicalHeight(), borderAndPaddingLogicalWidth(), logicalHeight, intrinsicRatio.aspectRatioDouble(), boxSizing), shouldComputePreferred);
             }
 
@@ -801,7 +801,7 @@ LayoutUnit RenderReplaced::computeReplacedLogicalHeight(std::optional<LayoutUnit
     if (!intrinsicRatio.isEmpty()) {
         LayoutUnit usedWidth = estimatedUsedWidth ? estimatedUsedWidth.value() : contentBoxLogicalWidth();
         BoxSizing boxSizing = BoxSizing::ContentBox;
-        if (style().hasAspectRatio())
+        if (style().aspectRatio().hasRatio())
             boxSizing = style().boxSizingForAspectRatio();
         return computeReplacedLogicalHeightRespectingMinMaxHeight(resolveHeightForRatio(borderAndPaddingLogicalWidth(), borderAndPaddingLogicalHeight(), usedWidth, intrinsicRatio.transposedSize().aspectRatioDouble(), boxSizing));
     }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -960,7 +960,7 @@ void RenderTable::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoint& p
     backgroundPainter.paintBackground(rect, bleedAvoidance);
     backgroundPainter.paintBoxShadow(rect, style(), Style::ShadowStyle::Inset);
 
-    if (style().hasVisibleBorderDecoration() && !collapseBorders())
+    if (style().border().hasVisibleBorderDecoration() && !collapseBorders())
         BorderPainter { *this, paintInfo }.paintBorder(rect, style());
 
     if (bleedAvoidance == BleedAvoidance::UseTransparencyLayer)

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -252,7 +252,7 @@ void RenderTableCell::computePreferredLogicalWidths()
     if (overridingLogicalHeight)
         setOverridingBorderBoxLogicalHeight(*overridingLogicalHeight);
 
-    if (!element() || !style().autoWrap() || !element()->hasAttributeWithoutSynchronization(nowrapAttr))
+    if (!element() || style().textWrapMode() == TextWrapMode::NoWrap || !element()->hasAttributeWithoutSynchronization(nowrapAttr))
         return;
 
     auto [ logicalWidth, usedZoom ] = styleOrColLogicalWidth();
@@ -1645,7 +1645,7 @@ void RenderTableCell::paintBoxDecorations(PaintInfo& paintInfo, const LayoutPoin
 
     backgroundPainter.paintBoxShadow(paintRect, style(), Style::ShadowStyle::Inset);
 
-    if (!style().hasBorder() || table->collapseBorders())
+    if (!style().border().hasBorder() || table->collapseBorders())
         return;
 
     BorderPainter borderPainter { *this, paintInfo };

--- a/Source/WebCore/rendering/RenderView.cpp
+++ b/Source/WebCore/rendering/RenderView.cpp
@@ -381,10 +381,10 @@ RenderElement* RenderView::rendererForRootBackground() const
 static inline bool rendererObscuresBackground(const RenderElement& rootElement)
 {
     auto& style = rootElement.style();
-    if (style.usedVisibility() != Visibility::Visible || !style.opacity().isOpaque() || style.hasTransform())
+    if (style.usedVisibility() != Visibility::Visible || !style.opacity().isOpaque() || !style.transform().isNone() || !style.offsetPath().isNone())
         return false;
 
-    if (style.hasBorderRadius())
+    if (style.border().hasBorderRadius())
         return false;
 
     if (rootElement.isComposited())

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -342,7 +342,7 @@ void RenderWidget::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     if (paintInfo.phase != PaintPhase::Foreground && !needsEventRegionContentPaint)
         return;
 
-    if (style().hasBorderRadius()) {
+    if (style().border().hasBorderRadius()) {
         LayoutRect borderRect = LayoutRect(adjustedPaintOffset, size());
 
         if (borderRect.isEmpty())
@@ -356,7 +356,7 @@ void RenderWidget::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     if (m_widget && !isSkippedContentRoot(*this))
         paintContents(paintInfo, paintOffset);
 
-    if (style().hasBorderRadius())
+    if (style().border().hasBorderRadius())
         paintInfo.context().restore();
 
     if (paintInfo.phase == PaintPhase::EventRegion || paintInfo.phase == PaintPhase::Accessibility)

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -2966,7 +2966,7 @@ bool RenderThemeCocoa::adjustListButtonStyleForVectorBasedControls(RenderStyle& 
         return false;
 
 #if PLATFORM(IOS_FAMILY)
-    if (style.hasContent() || style.hasUsedContentNone()) {
+    if (style.content().isData() || style.hasUsedContentNone()) {
         style.setLogicalWidth(11_css_px);
         return true;
     }
@@ -3039,7 +3039,7 @@ bool RenderThemeCocoa::paintListButtonForVectorBasedControls(const RenderElement
     CheckedRef style = box.style();
 
 #if PLATFORM(IOS_FAMILY)
-    if (style->hasContent() || style->hasUsedContentNone())
+    if (style->content().isData() || style->hasUsedContentNone())
         return true;
 #endif
 

--- a/Source/WebCore/rendering/ios/RenderThemeIOS.mm
+++ b/Source/WebCore/rendering/ios/RenderThemeIOS.mm
@@ -879,7 +879,7 @@ void RenderThemeIOS::adjustSearchFieldStyle(RenderStyle& style, const Element* e
     if (!element)
         return;
 
-    if (!style.hasBorder())
+    if (!style.border().hasBorder())
         return;
 
     RenderBox* box = element->renderBox();
@@ -1733,7 +1733,7 @@ bool RenderThemeIOS::paintListButton(const RenderElement& box, const PaintInfo& 
 #endif
 
     auto& style = box.style();
-    if (style.hasContent() || style.hasUsedContentNone())
+    if (style.content().isData() || style.hasUsedContentNone())
         return false;
 
     auto& context = paintInfo.context();

--- a/Source/WebCore/rendering/shapes/BoxLayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/BoxLayoutShape.cpp
@@ -68,7 +68,7 @@ LayoutRoundedRect computeRoundedRectForBoxShape(CSSBoxType box, const RenderBox&
     CheckedRef style = renderer.style();
     switch (box) {
     case CSSBoxType::MarginBox: {
-        if (!style->hasBorderRadius())
+        if (!style->border().hasBorderRadius())
             return LayoutRoundedRect(renderer.marginBoxRect(), LayoutRoundedRect::Radii());
 
         auto marginBox = renderer.marginBoxRect();

--- a/Source/WebCore/rendering/style/AutosizeStatus.cpp
+++ b/Source/WebCore/rendering/style/AutosizeStatus.cpp
@@ -100,7 +100,7 @@ auto AutosizeStatus::computeStatus(const RenderStyle& style) -> AutosizeStatus
     if (style.overflowX() == Overflow::Hidden)
         result.add(Fields::OverflowXHidden);
 
-    if (style.isFloating())
+    if (style.floating() != Float::None)
         result.add(Fields::Floating);
 
     return AutosizeStatus(result);

--- a/Source/WebCore/rendering/style/BorderData.h
+++ b/Source/WebCore/rendering/style/BorderData.h
@@ -62,6 +62,11 @@ struct BorderData {
         return radii.anyOf([](auto& corner) { return !Style::isKnownEmpty(corner); });
     }
 
+    bool hasVisibleBorderDecoration() const
+    {
+        return hasVisibleBorder() || hasBorderImage();
+    }
+
     // `BorderEdgesView` provides a `RectEdges`-like interface for efficiently working with
     // the values stored in `BorderValue` by edge. This allows `Style::ComputedStyle` code
     // generation to work as if the `border-{edge}-*`properties were stored in a `RectEdges`,

--- a/Source/WebCore/rendering/style/RenderStyle.cpp
+++ b/Source/WebCore/rendering/style/RenderStyle.cpp
@@ -284,7 +284,7 @@ bool RenderStyle::isIdempotentTextAutosizingCandidate(AutosizeStatus status) con
         return false;
     }
 
-    if (hasBackgroundImage() && backgroundLayers().usedFirst().repeat() == FillRepeat::NoRepeat)
+    if (auto& backgroundLayers = this->backgroundLayers(); Style::hasImageInAnyLayer(backgroundLayers) && backgroundLayers.usedFirst().repeat() == FillRepeat::NoRepeat)
         return false;
 
     return true;

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -452,55 +452,19 @@ public:
 
     // MARK: - has*()
 
-    inline bool hasAnimations() const;
-    inline bool hasAnimationsOrTransitions() const;
-    inline bool hasAspectRatio() const;
-    inline bool hasAutoLengthContainIntrinsicSize() const;
-    inline bool hasBackdropFilter() const;
     inline bool hasBackground() const;
-    inline bool hasBackgroundImage() const;
-    inline bool hasBlendMode() const;
-    inline bool hasBorder() const;
-    inline bool hasBorderImage() const;
-    inline bool hasBorderRadius() const;
-    inline bool hasBoxReflect() const;
-    inline bool hasBoxShadow() const;
-    inline bool hasClip() const;
-    inline bool hasClipPath() const;
-    inline bool hasContent() const;
-    inline bool hasFill() const;
-    inline bool hasFilter() const;
     inline bool hasInlineColumnAxis() const;
-    inline bool hasIsolation() const;
     inline bool hasMarkers() const;
     inline bool hasMask() const;
-    inline bool hasOffsetPath() const;
-    inline bool hasOpacity() const;
     inline bool hasOutline() const;
     inline bool hasOutlineInVisualOverflow() const;
-    inline bool hasPerspective() const;
     inline bool hasPositionedMask() const;
-    inline bool hasRotate() const;
-    inline bool hasScale() const;
     inline bool hasScrollTimelines() const;
-    inline bool hasSnapPosition() const;
-    inline bool hasStroke() const;
-    inline bool hasTextCombine() const;
-    inline bool hasTextShadow() const;
-    inline bool hasTransform() const;
-    inline bool hasTransitions() const;
-    inline bool hasTranslate() const;
     inline bool hasUsedAppearance() const;
     inline bool hasUsedContentNone() const;
     inline bool hasViewTimelines() const;
-    inline bool hasVisibleBorder() const;
-    inline bool hasVisibleBorderDecoration() const;
     inline bool hasExplicitlySetBorderRadius() const;
     inline bool hasPositiveStrokeWidth() const;
-#if HAVE(CORE_MATERIAL)
-    inline bool hasAppleVisualEffect() const;
-    inline bool hasAppleVisualEffectRequiringBackdropFilter() const;
-#endif
 
     // Whether or not a positioned element requires normal flow x/y to be computed to determine its position.
     inline bool hasStaticInlinePosition(bool horizontal) const;
@@ -513,7 +477,6 @@ public:
 
     inline bool isColumnFlexDirection() const;
     inline bool isFixedTableLayout() const;
-    inline bool isFloating() const;
     inline bool isInterCharacterRubyPosition() const;
     inline bool isOverflowVisible() const;
     inline bool isReverseFlexDirection() const;
@@ -526,7 +489,6 @@ public:
     inline bool usesLegacyScrollbarStyle() const;
     inline bool shouldPlaceVerticalScrollbarOnLeft() const;
 
-    inline bool autoWrap() const;
     inline bool preserveNewline() const;
     inline bool collapseWhiteSpace() const;
     inline bool isCollapsibleWhiteSpace(char16_t) const;
@@ -539,7 +501,6 @@ public:
     // indicates that we are transforming. The usedTransformStyle3D is not used here because in many cases (such as for deciding
     // whether or not to establish a containing block), the computed value is what matters.
     inline bool hasTransformRelatedProperty() const;
-    inline bool preserves3D() const;
     inline bool affectsTransform() const;
 
     // MARK: - Underlying ComputedStyle
@@ -552,9 +513,6 @@ private:
 
     // This constructor is used to implement the replace operation.
     RenderStyle(RenderStyle&, RenderStyle&&);
-
-    inline bool hasAutoLeftAndRight() const;
-    inline bool hasAutoTopAndBottom() const;
 
     const Style::NonInheritedData& nonInheritedData() const { return computedStyle().nonInheritedData(); }
     const Style::ComputedStyle::NonInheritedFlags& nonInheritedFlags() const { return computedStyle().nonInheritedFlags(); }
@@ -576,7 +534,6 @@ inline float applyZoom(float, const RenderStyle&);
 constexpr BorderStyle collapsedBorderStyle(BorderStyle);
 
 inline bool pseudoElementRendererIsNeeded(const RenderStyle*);
-inline bool generatesBox(const RenderStyle&);
 inline bool isNonVisibleOverflow(Overflow);
 
 inline bool isVisibleToHitTesting(const RenderStyle&, const HitTestRequest&);

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -76,7 +76,7 @@ void RenderSVGEllipse::updateShapeFromElement()
 
     m_fillBoundingBox = FloatRect(m_center.x() - m_radii.width(), m_center.y() - m_radii.height(), 2 * m_radii.width(), 2 * m_radii.height());
     m_strokeBoundingBox = m_fillBoundingBox;
-    if (style().hasStroke())
+    if (!style().stroke().isNone())
         m_strokeBoundingBox->inflate(strokeWidth() / 2);
 }
 
@@ -117,7 +117,7 @@ void RenderSVGEllipse::fillShape(GraphicsContext& context) const
 
 void RenderSVGEllipse::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
+    if (style().stroke().isNone() || !style().strokeWidth().isPossiblyPositive())
         return;
     if (hasPath()) {
         RenderSVGShape::strokeShape(context);

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -75,7 +75,7 @@ void RenderSVGPath::updateShapeFromElement()
 
 FloatRect RenderSVGPath::adjustStrokeBoundingBoxForZeroLengthLinecaps(RepaintRectCalculation, FloatRect strokeBoundingBox) const
 {
-    if (style().hasStroke()) {
+    if (!style().stroke().isNone()) {
         // FIXME: zero-length subpaths do not respect vector-effect = non-scaling-stroke.
         float strokeWidth = this->strokeWidth();
         for (auto& zeroLengthLinecapLocation : m_zeroLengthLinecapLocations) {
@@ -100,7 +100,7 @@ static void useStrokeStyleToFill(GraphicsContext& context)
 
 void RenderSVGPath::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
+    if (style().stroke().isNone() || !style().strokeWidth().isPossiblyPositive())
         return;
 
     // This happens only if the layout was never been called for this element.
@@ -117,7 +117,7 @@ bool RenderSVGPath::shapeDependentStrokeContains(const FloatPoint& point, PointC
         return true;
 
     for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i) {
-        ASSERT(style().hasStroke());
+        ASSERT(!style().stroke().isNone());
         float strokeWidth = this->strokeWidth();
         if (style().capStyle() == LineCap::Square) {
             if (zeroLengthSubpathRect(m_zeroLengthLinecapLocations[i], strokeWidth).contains(point))
@@ -136,7 +136,7 @@ bool RenderSVGPath::shouldStrokeZeroLengthSubpath() const
 {
     // Spec(11.4): Any zero length subpath shall not be stroked if the "stroke-linecap" property has a value of butt
     // but shall be stroked if the "stroke-linecap" property has a value of round or square
-    return style().hasStroke() && style().capStyle() != LineCap::Butt;
+    return !style().stroke().isNone() && style().capStyle() != LineCap::Butt;
 }
 
 Path* RenderSVGPath::zeroLengthLinecapPath(const FloatPoint& linecapPosition) const

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -88,7 +88,7 @@ void RenderSVGRect::updateShapeFromElement()
         boundingBoxSize);
 
     auto strokeBoundingBox = m_fillBoundingBox;
-    if (style->hasStroke())
+    if (!style->stroke().isNone())
         strokeBoundingBox.inflate(this->strokeWidth() / 2);
 
 #if USE(CG)
@@ -160,7 +160,7 @@ bool RenderSVGRect::definitelyHasSimpleStroke() const
 
 void RenderSVGRect::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
+    if (style().stroke().isNone() || !style().strokeWidth().isPossiblyPositive())
         return;
 
     if (hasPath()) {

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -190,7 +190,7 @@ void RenderSVGShape::fillShape(const RenderStyle& style, GraphicsContext& contex
 
 void RenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& context)
 {
-    if (!style.hasStroke() || !style.strokeWidth().isPossiblyPositive())
+    if (style.stroke().isNone() || !style.strokeWidth().isPossiblyPositive())
         return;
 
     GraphicsContextStateSaver stateSaver(context, false);
@@ -268,7 +268,7 @@ bool RenderSVGShape::isPointInFill(const FloatPoint& point)
 
 bool RenderSVGShape::isPointInStroke(const FloatPoint& point)
 {
-    if (!style().hasStroke())
+    if (style().stroke().isNone())
         return false;
 
     return shapeDependentStrokeContains(point, LocalCoordinateSpace);
@@ -311,14 +311,14 @@ bool RenderSVGShape::nodeAtPoint(const HitTestRequest& request, HitTestResult& r
         if (request.svgClipContent())
             fillRule = style().clipRule();
 
-        if (hitRules.canHitStroke && (style().hasStroke() || !hitRules.requireStroke) && strokeContains(localPoint, hitRules.requireStroke)) {
+        if (hitRules.canHitStroke && (!style().stroke().isNone() || !hitRules.requireStroke) && strokeContains(localPoint, hitRules.requireStroke)) {
             updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
             if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, strokeBoundingBox()) == HitTestProgress::Stop)
                 return true;
             return false;
         }
 
-        if ((hitRules.canHitFill && (style().hasFill() || !hitRules.requireFill) && fillContains(localPoint, hitRules.requireFill, fillRule))
+        if ((hitRules.canHitFill && (!style().fill().isNone() || !hitRules.requireFill) && fillContains(localPoint, hitRules.requireFill, fillRule))
             || (hitRules.canHitBoundingBox && m_fillBoundingBox.contains(localPoint))) {
             updateHitTestResult(result, locationInContainer.point() - toLayoutSize(adjustedLocation));
             if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, locationInContainer, m_fillBoundingBox) == HitTestProgress::Stop)
@@ -347,7 +347,7 @@ FloatRect RenderSVGShape::calculateStrokeBoundingBox() const
     ASSERT(m_path);
     FloatRect strokeBoundingBox = m_fillBoundingBox;
 
-    if (style().hasStroke()) {
+    if (!style().stroke().isNone()) {
         if (hasNonScalingStroke()) {
             AffineTransform nonScalingTransform = nonScalingStrokeTransform();
             if (std::optional<AffineTransform> inverse = nonScalingTransform.inverse()) {

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -654,8 +654,8 @@ bool RenderSVGText::nodeAtFloatPoint(const HitTestRequest& request, HitTestResul
 
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, usedPointerEvents());
     if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
-        if ((hitRules.canHitStroke && (style().hasStroke() || !hitRules.requireStroke))
-            || (hitRules.canHitFill && (style().hasFill() || !hitRules.requireFill))) {
+        if ((hitRules.canHitStroke && (!style().stroke().isNone() || !hitRules.requireStroke))
+            || (hitRules.canHitFill && (!style().fill().isNone() || !hitRules.requireFill))) {
             static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
 
             SVGVisitedRendererTracking recursionTracking(s_visitedSet);
@@ -685,8 +685,8 @@ bool RenderSVGText::nodeAtPoint(const HitTestRequest& request, HitTestResult& re
 
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, style().pointerEvents());
     if (isVisibleToHitTesting(style(), request) || !hitRules.requireVisible) {
-        if ((hitRules.canHitStroke && (style().hasStroke() || !hitRules.requireStroke))
-        || (hitRules.canHitFill && (style().hasFill() || !hitRules.requireFill))) {
+        if ((hitRules.canHitStroke && (!style().stroke().isNone() || !hitRules.requireStroke))
+        || (hitRules.canHitFill && (!style().fill().isNone() || !hitRules.requireFill))) {
             static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
 
             SVGVisitedRendererTracking recursionTracking(s_visitedSet);
@@ -723,8 +723,8 @@ bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTest
             if (!isVisibleToHitTesting(renderer.style(), request) && hitRules.requireVisible)
                 continue;
 
-            bool hitsStroke = hitRules.canHitStroke && (renderer.style().hasStroke() || !hitRules.requireStroke);
-            bool hitsFill = hitRules.canHitFill && (renderer.style().hasFill() || !hitRules.requireFill);
+            bool hitsStroke = hitRules.canHitStroke && (!renderer.style().stroke().isNone() || !hitRules.requireStroke);
+            bool hitsFill = hitRules.canHitFill && (!renderer.style().fill().isNone() || !hitRules.requireFill);
             if (!hitsStroke && !hitsFill)
                 continue;
 
@@ -929,7 +929,7 @@ void RenderSVGText::paintInlineChildren(PaintInfo& paintInfo, const LayoutPoint&
 FloatRect RenderSVGText::strokeBoundingBox() const
 {
     FloatRect strokeBoundaries = objectBoundingBox();
-    if (!style().hasStroke())
+    if (style().stroke().isNone())
         return strokeBoundaries;
 
     Ref textElement = this->textElement();

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -112,8 +112,8 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
     bool isRenderingMask = isRenderingMaskImage(*m_renderer);
     // RenderLayer takes care of root opacity.
     float opacity = (renderer.isLegacyRenderSVGRoot() || isRenderingMask) ? 1 : style.opacity().value.value;
-    bool hasBlendMode = style.hasBlendMode();
-    bool hasIsolation = style.hasIsolation();
+    bool hasBlendMode = style.blendMode() != BlendMode::Normal;
+    bool hasIsolation = style.isolation() != Isolation::Auto;
     bool isolateMaskForBlending = false;
 
     if (style.hasPositionedMask()) {

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -191,17 +191,17 @@ void SVGTextBoxPainter<TextBoxPath>::paint()
 
     auto& style = parentRenderer.style();
 
-    bool hasFill = style.hasFill();
-    bool hasVisibleStroke = style.hasStroke() && style.strokeWidth().isPossiblyPositive();
+    bool hasFill = !style.fill().isNone();
+    bool hasVisibleStroke = !style.stroke().isNone() && style.strokeWidth().isPossiblyPositive();
 
     const RenderStyle* selectionStyle = &style;
     if (hasSelection && shouldPaintSelectionHighlight) {
         selectionStyle = parentRenderer.getCachedPseudoStyle({ PseudoElementType::Selection });
         if (selectionStyle) {
             if (!hasFill)
-                hasFill = selectionStyle->hasFill();
+                hasFill = !selectionStyle->fill().isNone();
             if (!hasVisibleStroke)
-                hasVisibleStroke = selectionStyle->hasStroke() && selectionStyle->strokeWidth().isPossiblyPositive();
+                hasVisibleStroke = !selectionStyle->stroke().isNone() && selectionStyle->strokeWidth().isPossiblyPositive();
         } else
             selectionStyle = &style;
     }
@@ -456,13 +456,13 @@ void SVGTextBoxPainter<TextBoxPath>::paintDecoration(Style::TextDecorationLine d
     for (auto type : renderer().style().paintOrder()) {
         switch (type) {
         case Style::PaintType::Fill:
-            if (decorationStyle.hasFill()) {
+            if (!decorationStyle.fill().isNone()) {
                 m_paintingResourceMode = RenderSVGResourceMode::ApplyToFill;
                 paintDecorationWithStyle(decoration, fragment, *decorationRenderer);
             }
             break;
         case Style::PaintType::Stroke:
-            if (decorationStyle.hasStroke() && decorationStyle.strokeWidth().isPossiblyPositive()) {
+            if (!decorationStyle.stroke().isNone() && decorationStyle.strokeWidth().isPossiblyPositive()) {
                 m_paintingResourceMode = RenderSVGResourceMode::ApplyToStroke;
                 paintDecorationWithStyle(decoration, fragment, *decorationRenderer);
             }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp
@@ -76,7 +76,7 @@ void LegacyRenderSVGEllipse::updateShapeFromElement()
 
     m_fillBoundingBox = FloatRect(m_center.x() - m_radii.width(), m_center.y() - m_radii.height(), 2 * m_radii.width(), 2 * m_radii.height());
     m_strokeBoundingBox = m_fillBoundingBox;
-    if (style().hasStroke())
+    if (!style().stroke().isNone())
         m_strokeBoundingBox->inflate(strokeWidth() / 2);
 }
 
@@ -117,7 +117,7 @@ void LegacyRenderSVGEllipse::fillShape(GraphicsContext& context) const
 
 void LegacyRenderSVGEllipse::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
+    if (style().stroke().isNone() || !style().strokeWidth().isPossiblyPositive())
         return;
     if (hasPath()) {
         LegacyRenderSVGShape::strokeShape(context);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -91,7 +91,7 @@ FloatRect LegacyRenderSVGPath::adjustStrokeBoundingBoxForMarkersAndZeroLengthLin
             strokeBoundingBox.unite(markerRect);
     }
 
-    if (style().hasStroke()) {
+    if (!style().stroke().isNone()) {
         // FIXME: zero-length subpaths do not respect vector-effect = non-scaling-stroke.
         for (auto& zeroLengthLinecapLocation : m_zeroLengthLinecapLocations) {
             auto subpathRect = zeroLengthSubpathRect(zeroLengthLinecapLocation, strokeWidth);
@@ -115,7 +115,7 @@ static void useStrokeStyleToFill(GraphicsContext& context)
 
 void LegacyRenderSVGPath::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
+    if (style().stroke().isNone() || !style().strokeWidth().isPossiblyPositive())
         return;
 
     // This happens only if the layout was never been called for this element.
@@ -132,7 +132,7 @@ bool LegacyRenderSVGPath::shapeDependentStrokeContains(const FloatPoint& point, 
         return true;
 
     for (size_t i = 0; i < m_zeroLengthLinecapLocations.size(); ++i) {
-        ASSERT(style().hasStroke());
+        ASSERT(!style().stroke().isNone());
         float strokeWidth = this->strokeWidth();
         if (style().capStyle() == LineCap::Square) {
             if (zeroLengthSubpathRect(m_zeroLengthLinecapLocations[i], strokeWidth).contains(point))
@@ -151,7 +151,7 @@ bool LegacyRenderSVGPath::shouldStrokeZeroLengthSubpath() const
 {
     // Spec(11.4): Any zero length subpath shall not be stroked if the "stroke-linecap" property has a value of butt
     // but shall be stroked if the "stroke-linecap" property has a value of round or square
-    return style().hasStroke() && style().capStyle() != LineCap::Butt;
+    return !style().stroke().isNone() && style().capStyle() != LineCap::Butt;
 }
 
 Path* LegacyRenderSVGPath::zeroLengthLinecapPath(const FloatPoint& linecapPosition) const

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp
@@ -86,7 +86,7 @@ void LegacyRenderSVGRect::updateShapeFromElement()
         boundingBoxSize);
 
     auto strokeBoundingBox = m_fillBoundingBox;
-    if (style->hasStroke())
+    if (!style->stroke().isNone())
         strokeBoundingBox.inflate(this->strokeWidth() / 2);
 
 #if USE(CG)
@@ -123,7 +123,7 @@ void LegacyRenderSVGRect::fillShape(GraphicsContext& context) const
 
 void LegacyRenderSVGRect::strokeShape(GraphicsContext& context) const
 {
-    if (!style().hasStroke() || !style().strokeWidth().isPossiblyPositive())
+    if (style().stroke().isNone() || !style().strokeWidth().isPossiblyPositive())
         return;
 
     if (hasPath()) {

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -87,7 +87,7 @@ auto LegacyRenderSVGResourceClipper::applyResource(RenderElement& renderer, cons
 auto LegacyRenderSVGResourceClipper::pathOnlyClipping(GraphicsContext& context, const RenderElement& renderer, const AffineTransform& animatedLocalTransform, const FloatRect& objectBoundingBox, float usedZoom) -> OptionSet<ApplyResult>
 {
     // If the current clip-path gets clipped itself, we have to fall back to masking.
-    if (style().hasClipPath())
+    if (!style().clipPath().isNone())
         return { };
 
     WindRule clipRule = WindRule::NonZero;
@@ -101,7 +101,7 @@ auto LegacyRenderSVGResourceClipper::pathOnlyClipping(GraphicsContext& context, 
         if (style.display() == Style::DisplayType::None || style.usedVisibility() != Visibility::Visible)
             return false;
         // Current shape in clip-path gets clipped too. Fall back to masking.
-        if (style.hasClipPath())
+        if (!style.clipPath().isNone())
             return true;
         // Fall back to masking if there is more than one clipping path.
         if (!clipPath.isEmpty())

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp
@@ -171,7 +171,7 @@ void LegacyRenderSVGResourceContainer::markAllClientLayersForInvalidation()
 
 void LegacyRenderSVGResourceContainer::markClientForInvalidation(RenderObject& client, InvalidationMode mode)
 {
-    ASSERT(!m_clients.isEmptyIgnoringNullReferences() || client.style().hasClipPath());
+    ASSERT(!m_clients.isEmptyIgnoringNullReferences() || !client.style().clipPath().isNone());
 
     switch (mode) {
     case LayoutAndBoundariesInvalidation:

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -235,7 +235,7 @@ void LegacyRenderSVGShape::strokeShapeInternal(const RenderStyle& style, Graphic
 
 void LegacyRenderSVGShape::strokeShape(const RenderStyle& style, GraphicsContext& context)
 {
-    if (!style.hasStroke() || !style.strokeWidth().isPossiblyPositive())
+    if (style.stroke().isNone() || !style.strokeWidth().isPossiblyPositive())
         return;
 
     GraphicsContextStateSaver stateSaver(context, false);
@@ -318,7 +318,7 @@ bool LegacyRenderSVGShape::isPointInFill(const FloatPoint& point)
 
 bool LegacyRenderSVGShape::isPointInStroke(const FloatPoint& point)
 {
-    if (!style().hasStroke())
+    if (style().stroke().isNone())
         return false;
 
     return shapeDependentStrokeContains(point, LocalCoordinateSpace);
@@ -358,8 +358,8 @@ bool LegacyRenderSVGShape::nodeAtFloatPoint(const HitTestRequest& request, HitTe
         WindRule fillRule = style().fillRule();
         if (request.svgClipContent())
             fillRule = style().clipRule();
-        if ((hitRules.canHitStroke && (style().hasStroke() || !hitRules.requireStroke) && strokeContains(localPoint, hitRules.requireStroke))
-            || (hitRules.canHitFill && (style().hasFill() || !hitRules.requireFill) && fillContains(localPoint, hitRules.requireFill, fillRule))
+        if ((hitRules.canHitStroke && (!style().stroke().isNone() || !hitRules.requireStroke) && strokeContains(localPoint, hitRules.requireStroke))
+            || (hitRules.canHitFill && (!style().fill().isNone() || !hitRules.requireFill) && fillContains(localPoint, hitRules.requireFill, fillRule))
             || (hitRules.canHitBoundingBox && objectBoundingBox().contains(localPoint))) {
             updateHitTestResult(result, LayoutPoint(localPoint));
             if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, flooredLayoutPoint(localPoint)) == HitTestProgress::Stop)
@@ -386,7 +386,7 @@ FloatRect LegacyRenderSVGShape::calculateStrokeBoundingBox() const
     ASSERT(m_path);
     FloatRect strokeBoundingBox = m_fillBoundingBox;
 
-    if (style().hasStroke()) {
+    if (!style().stroke().isNone()) {
         if (hasNonScalingStroke()) {
             AffineTransform nonScalingTransform = nonScalingStrokeTransform();
             if (std::optional<AffineTransform> inverse = nonScalingTransform.inverse()) {

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -278,7 +278,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
     }
 
     if (fillAndStrokeTags().contains(tagName)) {
-        if (style.hasFill()) {
+        if (!style.fill().isNone()) {
             bool hasPendingResource = false;
             AtomString id;
             if (CheckedPtr fill = paintingResourceFromSVGPaint(treeScope, style.fill(), id, hasPendingResource))
@@ -287,7 +287,7 @@ std::unique_ptr<SVGResources> SVGResources::buildCachedResources(const RenderEle
                 treeScope->addPendingSVGResource(id, element);
         }
 
-        if (style.hasStroke()) {
+        if (!style.stroke().isNone()) {
             bool hasPendingResource = false;
             AtomString id;
             if (CheckedPtr stroke = paintingResourceFromSVGPaint(treeScope, style.stroke(), id, hasPendingResource))

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -657,9 +657,9 @@ void RenderTreeBuilder::normalizeTreeAfterStyleChange(RenderElement& renderer, R
     if (!renderer.parent())
         return;
 
-    bool wasFloating = oldStyle.isFloating();
+    bool wasFloating = oldStyle.floating() != Float::None;
     bool wasOutOfFlowPositioned = oldStyle.hasOutOfFlowPosition();
-    bool isFloating = renderer.style().isFloating();
+    bool isFloating = renderer.style().floating() != Float::None;
     bool isOutOfFlowPositioned = renderer.style().hasOutOfFlowPosition();
     bool startsAffectingParent = false;
     bool noLongerAffectsParent = false;
@@ -873,7 +873,7 @@ void RenderTreeBuilder::removeAnonymousWrappersForInlineChildrenIfNeeded(RenderE
     // if we find a continuation.
     std::optional<bool> shouldAllChildrenBeInline;
     for (auto* current = blockParent->firstChild(); current; current = current->nextSibling()) {
-        if (current->style().isFloating() || current->style().hasOutOfFlowPosition())
+        if (current->style().floating() != Float::None || current->style().hasOutOfFlowPosition())
             continue;
 
         if (!is<RenderBlock>(*current))

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -53,7 +53,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
     auto firstLetterStyle = RenderStyle::clone(*style);
 
     // If we have an initial letter drop that is >= 1, then we need to force floating to be on.
-    if (firstLetterStyle.initialLetter().drop() >= 1 && !firstLetterStyle.isFloating())
+    if (firstLetterStyle.initialLetter().drop() >= 1 && firstLetterStyle.floating() == Float::None)
         firstLetterStyle.setFloating(firstLetterStyle.writingMode().isBidiLTR() ? Float::Left : Float::Right);
 
     // We have to compute the correct font-size for the first-letter if it has an initial letter height set.
@@ -89,7 +89,7 @@ static std::optional<RenderStyle> styleForFirstLetter(const RenderElement& first
 
     firstLetterStyle.setPseudoElementIdentifier({ { PseudoElementType::FirstLetter } });
     // Force inline display (except for floating first-letters).
-    firstLetterStyle.setDisplay(firstLetterStyle.isFloating() ? Style::DisplayType::BlockFlow : Style::DisplayType::InlineFlow);
+    firstLetterStyle.setDisplay(firstLetterStyle.floating() != Float::None ? Style::DisplayType::BlockFlow : Style::DisplayType::InlineFlow);
     // CSS2 says first-letter can't be positioned.
     firstLetterStyle.setPosition(PositionType::Static);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
@@ -136,7 +136,7 @@ void RenderTreeBuilder::FormControls::updatePseudoElement(PseudoElementType type
     RenderPtr<RenderBlockFlow> pseudoElement = createRenderer<RenderBlockFlow>(RenderObject::Type::BlockFlow, document, WTF::move(pseudoElementStyle));
     pseudoElement->initializeStyle();
 
-    if (pseudoElement->style().hasContent())
+    if (pseudoElement->style().content().isData())
         RenderTreeUpdater::GeneratedContent::createContentRenderers(m_builder, *pseudoElement, pseudoElement->style(), type);
 
     m_builder.attach(renderer, WTF::move(pseudoElement));

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -482,7 +482,7 @@ void RenderTreeUpdater::updateElementRenderer(Element& element, const Style::Ele
     auto scopeExit = makeScopeExit([&] {
         if (!hasDisplayContentsOrNone) {
             auto* box = element.renderBox();
-            if (box && box->style().hasAutoLengthContainIntrinsicSize() && !isSkippedContentRoot(*box))
+            if (box && (box->style().containIntrinsicWidth().hasAuto() || box->style().containIntrinsicHeight().hasAuto()) && !isSkippedContentRoot(*box))
                 m_document->observeForContainIntrinsicSize(element);
             else
                 m_document->unobserveForContainIntrinsicSize(element);

--- a/Source/WebCore/style/AnchorPositionEvaluator.cpp
+++ b/Source/WebCore/style/AnchorPositionEvaluator.cpp
@@ -1323,7 +1323,9 @@ void AnchorPositionEvaluator::updateAnchorPositionedStateForDefaultAnchorAndPosi
 
     // `position-visibility: no-overflow` should also work for non-anchor positioned out-of-flow boxes.
     // Create an empty anchor positioning state for it so we perform the required layout interleaving.
-    auto hasPositionVisibilityNoOverflow = generatesBox(style) && style.hasOutOfFlowPosition() && style.positionVisibility().contains(PositionVisibilityValue::NoOverflow);
+    auto hasPositionVisibilityNoOverflow = style.display().doesGenerateBox()
+        && style.hasOutOfFlowPosition()
+        && style.positionVisibility().contains(PositionVisibilityValue::NoOverflow);
 
     if (!shouldResolveDefaultAnchor && !hasPositionVisibilityNoOverflow)
         return;
@@ -1367,7 +1369,7 @@ bool AnchorPositionEvaluator::isAnchorPositioned(const RenderStyle& style)
 
 bool AnchorPositionEvaluator::isStyleTimeAnchorPositioned(const RenderStyle& style)
 {
-    if (!generatesBox(style) || !style.hasOutOfFlowPosition())
+    if (!style.display().doesGenerateBox() || !style.hasOutOfFlowPosition())
         return false;
 
     return style.usesAnchorFunctions();
@@ -1375,7 +1377,7 @@ bool AnchorPositionEvaluator::isStyleTimeAnchorPositioned(const RenderStyle& sty
 
 bool AnchorPositionEvaluator::isLayoutTimeAnchorPositioned(const RenderStyle& style)
 {
-    if (!generatesBox(style) || !style.hasOutOfFlowPosition())
+    if (!style.display().doesGenerateBox() || !style.hasOutOfFlowPosition())
         return false;
 
     if (!style.positionArea().isNone())

--- a/Source/WebCore/style/StyleChange.cpp
+++ b/Source/WebCore/style/StyleChange.cpp
@@ -55,7 +55,8 @@ OptionSet<Change> determineChanges(const RenderStyle& s1, const RenderStyle& s2)
         if (s1.columnSpan() != ColumnSpan::All)
             return false;
         // Spanning in ignored for floating and out-of-flow boxes.
-        return s1.isFloating() != s2.isFloating() || s1.hasOutOfFlowPosition() != s2.hasOutOfFlowPosition();
+        return (s1.floating() != Float::None) != (s2.floating() != Float::None)
+            || s1.hasOutOfFlowPosition() != s2.hasOutOfFlowPosition();
     };
 
     auto needsRendererUpdate = [&] {
@@ -69,7 +70,7 @@ OptionSet<Change> determineChanges(const RenderStyle& s1, const RenderStyle& s2)
             return true;
         // When text-combine is on, we use RenderCombineText, otherwise RenderText.
         // https://bugs.webkit.org/show_bug.cgi?id=55069
-        if (s1.hasTextCombine() != s2.hasTextCombine())
+        if ((s1.textCombine() != TextCombine::None) != (s2.textCombine() != TextCombine::None))
             return true;
         if (s1.content() != s2.content())
             return true;

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -2156,7 +2156,7 @@ inline void ExtractorCustom::extractBorderImageWidthSerialization(ExtractorState
 
 inline Ref<CSSValue> ExtractorCustom::extractTransform(ExtractorState& state)
 {
-    if (!state.style.hasTransform())
+    if (state.style.transform().isNone() && state.style.offsetPath().isNone())
         return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
     if (state.renderer)
@@ -2173,7 +2173,7 @@ inline Ref<CSSValue> ExtractorCustom::extractTransform(ExtractorState& state)
 
 inline void ExtractorCustom::extractTransformSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
 {
-    if (!state.style.hasTransform()) {
+    if (state.style.transform().isNone() && state.style.offsetPath().isNone()) {
         serializationForCSS(builder, context, state.style, CSS::Keyword::None { });
         return;
     }
@@ -2934,7 +2934,7 @@ inline RefPtr<CSSValue> ExtractorCustom::extractOffsetShorthand(ExtractorState& 
     bool nonInitialDistance = state.style.offsetDistance() != ComputedStyle::initialOffsetDistance();
     bool nonInitialRotate = state.style.offsetRotate() != ComputedStyle::initialOffsetRotate();
 
-    if (state.style.hasOffsetPath() || nonInitialDistance || nonInitialRotate)
+    if (!state.style.offsetPath().isNone() || nonInitialDistance || nonInitialRotate)
         innerList.append(createCSSValue(state.pool, state.style, state.style.offsetPath()));
 
     if (nonInitialDistance)

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -405,7 +405,7 @@ void Styleable::updateCSSAnimations(const RenderStyle* currentStyle, const Rende
 
     auto& currentAnimationList = newStyle.animations();
     auto& previousAnimationList = keyframeEffectStack.cssAnimationList();
-    if (!element.hasPendingKeyframesUpdate(pseudoElementIdentifier) && previousAnimationList && !previousAnimationList->isInitial() && newStyle.hasAnimations() && *previousAnimationList == newStyle.animations() && !animationListContainsNewlyValidAnimation(newStyle.animations()))
+    if (!element.hasPendingKeyframesUpdate(pseudoElementIdentifier) && previousAnimationList && !previousAnimationList->isInitial() && !newStyle.animations().isInitial() && *previousAnimationList == newStyle.animations() && !animationListContainsNewlyValidAnimation(newStyle.animations()))
         return;
 
     CSSAnimationCollection newAnimations;
@@ -777,7 +777,7 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
 
     // In case this element is newly getting a "display: none" we need to cancel all of its transitions and disregard new ones,
     // unless it will transition the "display" property itself.
-    if (currentStyle.hasTransitions() && currentStyle.display() != Style::DisplayType::None && newStyle.display() == Style::DisplayType::None && !styleHasDisplayTransition(newStyle)) {
+    if (!currentStyle.transitions().isInitial() && currentStyle.display() != Style::DisplayType::None && newStyle.display() == Style::DisplayType::None && !styleHasDisplayTransition(newStyle)) {
         if (hasRunningTransitions()) {
             auto runningTransitions = ensureRunningTransitionsByProperty();
             for (const auto& cssTransitionsByAnimatableCSSPropertyMapItem : runningTransitions)

--- a/Source/WebCore/style/values/display/StyleDisplay.h
+++ b/Source/WebCore/style/values/display/StyleDisplay.h
@@ -88,6 +88,7 @@ struct Display {
 
     constexpr bool isBlockType() const;
     constexpr bool isInlineType() const;
+    constexpr bool isTableBox() const;
     constexpr bool isTableOrTablePart() const;
     constexpr bool isInternalTableBox() const;
     constexpr bool isRubyContainerOrInternalRubyBox() const;
@@ -100,6 +101,7 @@ struct Display {
     constexpr bool isFlexibleOrGridFormattingContextBox() const;
     constexpr bool isFlexibleBoxIncludingDeprecatedOrGridFormattingContextBox() const;
     constexpr bool doesGenerateBlockContainer() const;
+    constexpr bool doesGenerateBox() const;
 
     constexpr bool operator==(const Display&) const = default;
     constexpr bool operator==(DisplayType other) const { return value == other; }
@@ -240,6 +242,12 @@ constexpr bool Display::isInlineType() const
         || value == DisplayType::RubyText;
 }
 
+constexpr bool Display::isTableBox() const
+{
+    return value == DisplayType::BlockTable
+        || value == DisplayType::InlineTable;
+}
+
 constexpr bool Display::isTableOrTablePart() const
 {
     return value == DisplayType::BlockTable
@@ -329,6 +337,12 @@ constexpr bool Display::doesGenerateBlockContainer() const
         || value == DisplayType::InlineFlowRoot
         || value == DisplayType::TableCell
         || value == DisplayType::TableCaption;
+}
+
+constexpr bool Display::doesGenerateBox() const
+{
+    return value != DisplayType::Contents
+        && value != DisplayType::None;
 }
 
 // MARK: - Conversion

--- a/Source/WebCore/svg/SVGClipPathElement.cpp
+++ b/Source/WebCore/svg/SVGClipPathElement.cpp
@@ -27,7 +27,7 @@
 #include "Document.h"
 #include "ImageBuffer.h"
 #include "LegacyRenderSVGResourceClipper.h"
-#include "RenderElementInlines.h"
+#include "RenderElementStyleInlines.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGResourceClipper.h"
 #include "RenderSVGText.h"
@@ -118,7 +118,7 @@ RenderPtr<RenderElement> SVGClipPathElement::createElementRenderer(RenderStyle&&
 RefPtr<SVGGraphicsElement> SVGClipPathElement::shouldApplyPathClipping() const
 {
     // If the current clip-path gets clipped itself, we have to fall back to masking.
-    if (renderer() && renderer()->style().hasClipPath())
+    if (renderer() && renderer()->hasClipPath())
         return nullptr;
 
     auto rendererRequiresMaskClipping = [](auto& renderer) -> bool {
@@ -129,7 +129,7 @@ RefPtr<SVGGraphicsElement> SVGClipPathElement::shouldApplyPathClipping() const
         if (style.display() == Style::DisplayType::None || style.usedVisibility() != Visibility::Visible)
             return false;
         // Current shape in clip-path gets clipped too. Fall back to masking.
-        return style.hasClipPath();
+        return renderer.hasClipPath();
     };
 
     RefPtr<SVGGraphicsElement> useGraphicsElement;

--- a/Source/WebCore/svg/SVGGraphicsElement.cpp
+++ b/Source/WebCore/svg/SVGGraphicsElement.cpp
@@ -97,10 +97,10 @@ AffineTransform SVGGraphicsElement::animatedLocalTransform() const
 
     CheckedPtr renderer = this->renderer();
     CheckedPtr style = renderer ? &renderer->style() : nullptr;
-    bool hasSpecifiedTransform = style && style->hasTransform();
+    bool hasSpecifiedTransform = style && (!style->transform().isNone() || !style->offsetPath().isNone());
 
     // Honor any of the transform-related CSS properties if set.
-    if (hasSpecifiedTransform || (style && (style->hasTranslate() || style->hasScale() || style->hasRotate()))) {
+    if (hasSpecifiedTransform || (style && (!style->translate().isNone() || !style->scale().isNone() || !style->rotate().isNone()))) {
         // Note: objectBoundingBox is an emptyRect for elements like pattern or clipPath.
         // See the "Object bounding box units" section of http://dev.w3.org/csswg/css3-transforms/
         auto transform = Style::TransformResolver::computeTransform(*style, TransformOperationData(renderer->transformReferenceBoxRect(), renderer.get()));


### PR DESCRIPTION
#### f8a81e5c0a749fee15a9067a4f6ec06095d8e175
<pre>
Remove trivial predicates from RenderStyle
<a href="https://bugs.webkit.org/show_bug.cgi?id=307907">https://bugs.webkit.org/show_bug.cgi?id=307907</a>

Reviewed by Alan Baradlay.

Remove trivial predicates from RenderStyle, further reducing its interface surface
area and making transitioning more to Style::ComputedStyle possible.

This also has the benefit of often making the calling code more clear, as some
of the predicates (like hasTransform()) were a little more than they seemed.

* Source/WebCore/accessibility/AXObjectCache.cpp:
* Source/WebCore/accessibility/cocoa/AccessibilityObjectCocoa.mm:
* Source/WebCore/animation/KeyframeEffect.cpp:
* Source/WebCore/animation/WebAnimationUtilities.cpp:
* Source/WebCore/dom/Document.cpp:
* Source/WebCore/dom/Element.cpp:
* Source/WebCore/dom/Text.cpp:
* Source/WebCore/editing/DeleteSelectionCommand.cpp:
* Source/WebCore/editing/ReplaceSelectionCommand.cpp:
* Source/WebCore/editing/TextManipulationController.cpp:
* Source/WebCore/html/HTMLFrameSetElement.cpp:
* Source/WebCore/html/HTMLImageElement.cpp:
* Source/WebCore/layout/Verification.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
* Source/WebCore/layout/formattingContexts/inline/invalidation/InlineInvalidation.cpp:
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
* Source/WebCore/layout/integration/LayoutIntegrationCoverage.cpp:
* Source/WebCore/layout/integration/grid/LayoutIntegrationGridCoverage.cpp:
* Source/WebCore/layout/integration/inline/LayoutIntegrationInlineContentBuilder.cpp:
* Source/WebCore/layout/layouttree/LayoutBoxInlines.h:
* Source/WebCore/page/ElementTargetingController.cpp:
* Source/WebCore/page/FrameSnapshotting.cpp:
* Source/WebCore/page/InteractionRegion.cpp:
* Source/WebCore/page/LocalFrameView.cpp:
* Source/WebCore/page/PageColorSampler.cpp:
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
* Source/WebCore/platform/graphics/coretext/FontCascadeCoreText.cpp:
* Source/WebCore/rendering/AutoTableLayout.cpp:
* Source/WebCore/rendering/BackgroundPainter.cpp:
* Source/WebCore/rendering/BorderPainter.cpp:
* Source/WebCore/rendering/BorderShape.cpp:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
* Source/WebCore/rendering/InlineBoxPainter.cpp:
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
* Source/WebCore/rendering/OutlinePainter.cpp:
* Source/WebCore/rendering/RenderBlock.cpp:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
* Source/WebCore/rendering/RenderBox.cpp:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
* Source/WebCore/rendering/RenderElement.cpp:
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderElementStyleInlines.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
* Source/WebCore/rendering/RenderGrid.cpp:
* Source/WebCore/rendering/RenderImage.cpp:
* Source/WebCore/rendering/RenderLayer.cpp:
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
* Source/WebCore/rendering/RenderLayerInlines.h:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
* Source/WebCore/rendering/RenderObject.cpp:
* Source/WebCore/rendering/RenderObjectInlines.h:
* Source/WebCore/rendering/RenderReplaced.cpp:
* Source/WebCore/rendering/RenderTable.cpp:
* Source/WebCore/rendering/RenderTableCell.cpp:
* Source/WebCore/rendering/RenderText.cpp:
* Source/WebCore/rendering/RenderView.cpp:
* Source/WebCore/rendering/RenderWidget.cpp:
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
* Source/WebCore/rendering/ios/RenderThemeIOS.mm:
* Source/WebCore/rendering/shapes/BoxLayoutShape.cpp:
* Source/WebCore/rendering/style/AutosizeStatus.cpp:
* Source/WebCore/rendering/style/BorderData.h:
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
* Source/WebCore/rendering/style/RenderStyle.cpp:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/svg/RenderSVGEllipse.cpp:
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.cpp:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp:
* Source/WebCore/rendering/updating/RenderTreeUpdater.cpp:
* Source/WebCore/style/AnchorPositionEvaluator.cpp:
* Source/WebCore/style/StyleAdjuster.cpp:
* Source/WebCore/style/StyleChange.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/StyleTreeResolver.cpp:
* Source/WebCore/style/Styleable.cpp:
* Source/WebCore/style/values/display/StyleDisplay.h:
* Source/WebCore/svg/SVGClipPathElement.cpp:
* Source/WebCore/svg/SVGGraphicsElement.cpp:

Canonical link: <a href="https://commits.webkit.org/307628@main">https://commits.webkit.org/307628@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73f1d063cccbeefdef413ec7256c39f6178f2245

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144916 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17596 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98551 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18079 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111427 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79877 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13789 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92322 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13163 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10918 "Found 1 new API test failure: TestWebKitAPI.HistoryDelegate.NonpersistentDataStoreDoesNotSendHistoryEvents (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1032 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122678 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6878 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155899 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17447 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119430 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17494 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119759 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30731 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15567 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128136 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73069 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17069 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6434 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16805 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80848 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17014 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16869 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->