### PR TITLE
DecompressionStream should output valid data before throwing for extra trailing bytes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL decompressing deflate input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing gzip input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing deflate-raw input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing brotli input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
+PASS decompressing deflate input with extra pad should still give the output
+PASS decompressing gzip input with extra pad should still give the output
+PASS decompressing deflate-raw input with extra pad should still give the output
+PASS decompressing brotli input with extra pad should still give the output
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.serviceworker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL decompressing deflate input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing gzip input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing deflate-raw input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing brotli input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
+PASS decompressing deflate input with extra pad should still give the output
+PASS decompressing gzip input with extra pad should still give the output
+PASS decompressing deflate-raw input with extra pad should still give the output
+PASS decompressing brotli input with extra pad should still give the output
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.sharedworker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL decompressing deflate input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing gzip input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing deflate-raw input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing brotli input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
+PASS decompressing deflate input with extra pad should still give the output
+PASS decompressing gzip input with extra pad should still give the output
+PASS decompressing deflate-raw input with extra pad should still give the output
+PASS decompressing brotli input with extra pad should still give the output
 

--- a/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL decompressing deflate input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing gzip input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing deflate-raw input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing brotli input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
+PASS decompressing deflate input with extra pad should still give the output
+PASS decompressing gzip input with extra pad should still give the output
+PASS decompressing deflate-raw input with extra pad should still give the output
+PASS decompressing brotli input with extra pad should still give the output
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL decompressing deflate input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing gzip input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing deflate-raw input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
+PASS decompressing deflate input with extra pad should still give the output
+PASS decompressing gzip input with extra pad should still give the output
+PASS decompressing deflate-raw input with extra pad should still give the output
 FAIL decompressing brotli input with extra pad should still give the output promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.serviceworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.serviceworker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL decompressing deflate input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing gzip input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing deflate-raw input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
+PASS decompressing deflate input with extra pad should still give the output
+PASS decompressing gzip input with extra pad should still give the output
+PASS decompressing deflate-raw input with extra pad should still give the output
 FAIL decompressing brotli input with extra pad should still give the output promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.sharedworker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.sharedworker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL decompressing deflate input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing gzip input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing deflate-raw input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
+PASS decompressing deflate input with extra pad should still give the output
+PASS decompressing gzip input with extra pad should still give the output
+PASS decompressing deflate-raw input with extra pad should still give the output
 FAIL decompressing brotli input with extra pad should still give the output promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.worker-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.worker-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL decompressing deflate input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing gzip input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
-FAIL decompressing deflate-raw input with extra pad should still give the output promise_test: Unhandled rejection with value: object "TypeError: Extra bytes past the end."
+PASS decompressing deflate input with extra pad should still give the output
+PASS decompressing gzip input with extra pad should still give the output
+PASS decompressing deflate-raw input with extra pad should still give the output
 FAIL decompressing brotli input with extra pad should still give the output promise_test: Unhandled rejection with value: object "NotSupportedError: Unsupported algorithm"
 

--- a/Source/WebCore/Modules/compression/DecompressionStream.js
+++ b/Source/WebCore/Modules/compression/DecompressionStream.js
@@ -60,6 +60,9 @@ function initializeDecompressionStream(format)
                 const controller = @getByIdDirectPrivate(transformStream, "controller");
                 @transformStreamDefaultControllerEnqueue(controller, buffer);
             }
+
+            if (decoder.@didDetectExtraBytes())
+                return @promiseReject(@Promise, @makeTypeError("Extra bytes past the end."));
         } catch (e) {
             return @promiseReject(@Promise, @makeTypeError(e.message));
         }

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.h
@@ -47,6 +47,7 @@ public:
 
     ExceptionOr<RefPtr<Uint8Array>> decode(const BufferSource&&);
     ExceptionOr<RefPtr<Uint8Array>> flush();
+    bool didDetectExtraBytes() const { return m_didDetectExtraBytes; }
 
 private:
     bool didInflateFinish(int) const;
@@ -73,6 +74,7 @@ private:
     const size_t maxAllocationSize = 1073741824; // 1GB
 
     bool m_didFinish { false };
+    bool m_didDetectExtraBytes { false };
     const Formats::CompressionFormat m_format;
 
     // TODO: convert to using variant

--- a/Source/WebCore/Modules/compression/DecompressionStreamDecoder.idl
+++ b/Source/WebCore/Modules/compression/DecompressionStreamDecoder.idl
@@ -32,4 +32,5 @@
 
     [PrivateIdentifier] Uint8Array? decode(BufferSource chunk);
     [PrivateIdentifier] Uint8Array? flush();
+    [PrivateIdentifier] boolean didDetectExtraBytes();
 };

--- a/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
+++ b/Source/WebCore/bindings/js/WebCoreBuiltinNames.h
@@ -616,6 +616,7 @@ namespace WebCore {
     macro(crossOriginIsolated) \
     macro(customElements) \
     macro(decode) \
+    macro(didDetectExtraBytes) \
     macro(disturbed) \
     macro(document) \
     macro(encode) \


### PR DESCRIPTION
#### 61a06dede8c655c1be0145ba1ed49fb23b89d339
<pre>
DecompressionStream should output valid data before throwing for extra trailing bytes
<a href="https://bugs.webkit.org/show_bug.cgi?id=307952">https://bugs.webkit.org/show_bug.cgi?id=307952</a>
<a href="https://rdar.apple.com/170439927">rdar://170439927</a>

Reviewed by Youenn Fablet.

Per the Compression Streams spec, when decompressing data with extra trailing bytes
after the end of the compressed stream, the decompressor must:
1. Enqueue the valid decompressed output first
2. Then throw a TypeError

Previously, WebKit threw immediately upon detecting extra bytes, discarding the
valid output.

* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.worker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.serviceworker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.sharedworker-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/compression/decompression-extra-input.any.worker-expected.txt:
* Source/WebCore/Modules/compression/DecompressionStream.js:
(initializeDecompressionStream):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.cpp:
(WebCore::DecompressionStreamDecoder::flush):
(WebCore::DecompressionStreamDecoder::didInflateContainExtraBytes const):
(WebCore::didInflateIncompleteInput):
(WebCore::DecompressionStreamDecoder::decompressZlib):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.h:
(WebCore::DecompressionStreamDecoder::didDetectExtraBytes const):
* Source/WebCore/Modules/compression/DecompressionStreamDecoder.idl:
* Source/WebCore/Modules/compression/cocoa/DecompressionStreamDecoderCocoa.mm:
(WebCore::DecompressionStreamDecoder::decompressAppleCompressionFramework):
* Source/WebCore/bindings/js/WebCoreBuiltinNames.h:

Canonical link: <a href="https://commits.webkit.org/307650@main">https://commits.webkit.org/307650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35267c184264b1a5087914450c6c799095af4c2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145013 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17693 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9451 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153684 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98649 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d05071b-ba6c-4923-91d9-9edaab2d384a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146888 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18177 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111508 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79944 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22147f3c-6f39-49db-8d08-c85834dd7974) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147976 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13869 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130253 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92404 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13241 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11003 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1129 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6998 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155996 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17545 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8086 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119512 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17591 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119840 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30744 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15640 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128256 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73204 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17166 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6542 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16902 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80945 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17111 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16966 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->