### PR TITLE
[AutoFill Debugging] [URL Shortening] Image file extensions sometimes contain extra text

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt
@@ -29,6 +29,7 @@ root
 		image,src='image2.gif',alt='Image with high entropy name 2'
 		image,src='image2.gif',alt='Image with high entropy name (duplicate)'
 		image,src='image.png',alt='Image with high entropy name, no extension'
+		image,src='image.jpg',alt='File extension with trailing text'
 
 -- markdown
 
@@ -58,5 +59,6 @@ root
 ![Image with high entropy name 2](image2.gif)
 ![Image with high entropy name \(duplicate\)](image2.gif)
 ![Image with high entropy name, no extension](image.png)
+![File extension with trailing text](image.jpg)
 
 

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html
@@ -61,6 +61,7 @@ a, img {
         <img src="https://assets.example.com/70a27eafd353.gif" alt="Image with high entropy name 2">
         <img src="https://assets.example.com/70a27eafd353.gif" alt="Image with high entropy name (duplicate)">
         <img src="https://assets.example.com/21e0397d-ed0b77b86272" alt="Image with high entropy name, no extension">
+        <img src="https://assets.example.com/6539472cv17d.jpg;canvasHeight=130;canvasWidth=130" alt="File extension with trailing text">
     </section>
 </main>
 


### PR DESCRIPTION
#### fb64ee67225a761ab3aa59d0be573bed55958632
<pre>
[AutoFill Debugging] [URL Shortening] Image file extensions sometimes contain extra text
<a href="https://bugs.webkit.org/show_bug.cgi?id=307953">https://bugs.webkit.org/show_bug.cgi?id=307953</a>
<a href="https://rdar.apple.com/170436339">rdar://170436339</a>

Reviewed by Abrar Rahman Protyasha.

Make a small adjustment to URL shortening, in the case of image source URLs — strip out any part of
the file extension, after and including the first non-alphanumeric character. This changes a URL
like &quot;<a href="https://www.example.com/assets/6539472cv17d.jpg">https://www.example.com/assets/6539472cv17d.jpg</a>;canvasHeight=130;canvasWidth=130&quot; from
`image.jpg;canvasHeight=130;canvasWidth=130` into just `image.jpg`.

* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-shorten-urls.html:

Augment a layout test to exercise this change.

* Source/WebCore/platform/StringEntropyHelpers.cpp:
(WebCore::StringEntropyHelpers::lowEntropyLastPathComponent):

Canonical link: <a href="https://commits.webkit.org/307633@main">https://commits.webkit.org/307633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e62fdcc2654668681cbe015e6d2b5afe215a771

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144945 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9347 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153616 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98580 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22fdcb56-86dd-4730-90d6-b1f6f5c3f1b4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146820 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18109 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17518 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111449 "Found 1 new test failure: fast/mediastream/stream-switch.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79898 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/044b4b9f-9dbe-4665-a558-ff6425dbbeba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147908 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13815 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130156 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92345 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a39b0c3c-85f3-44dd-82d8-b81ab1614c4c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13189 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10943 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1061 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122704 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155928 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119455 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17523 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14586 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119783 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30736 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15589 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128158 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73105 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17098 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6456 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80877 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17043 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16898 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->