### PR TITLE
Sync `fetch/range` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: fetch
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any-expected.txt
@@ -1,5 +1,6 @@
 
 PASS A simple blob range request.
+PASS A blob range request with no type.
 PASS A blob range request with no end.
 PASS A blob range request with no start.
 PASS A simple blob range request with whitespace.

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.js
@@ -11,6 +11,15 @@ const supportedBlobRange = [
     result: "Hello, World!",
   },
   {
+    name: "A blob range request with no type.",
+    data: ["A simple Hello, World! example"],
+    type: undefined,
+    range: "bytes=9-21",
+    content_length: 13,
+    content_range: "bytes 9-21/30",
+    result: "Hello, World!",
+  },
+  {
     name: "A blob range request with no end.",
     data: ["Range with no end"],
     type: "text/plain",
@@ -201,7 +210,7 @@ supportedBlobRange.forEach(({ name, data, type, range, content_length, content_r
     });
     assert_equals(resp.status, 206, "HTTP status is 206");
     assert_equals(resp.type, "basic", "response type is basic");
-    assert_equals(resp.headers.get("Content-Type"), type, "Content-Type is " + resp.headers.get("Content-Type"));
+    assert_equals(resp.headers.get("Content-Type"), type || "", "Content-Type is " + resp.headers.get("Content-Type"));
     assert_equals(resp.headers.get("Content-Length"), content_length.toString(), "Content-Length is " + resp.headers.get("Content-Length"));
     assert_equals(resp.headers.get("Content-Range"), content_range, "Content-Range is " + resp.headers.get("Content-Range"));
     const text = await resp.text();

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.worker-expected.txt
@@ -1,5 +1,6 @@
 
 PASS A simple blob range request.
+PASS A blob range request with no type.
 PASS A blob range request with no end.
 PASS A blob range request with no start.
 PASS A simple blob range request with whitespace.

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/cache-revalidate-construct-range-response-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/cache-revalidate-construct-range-response-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Range request after cache revalidation with 200 OK response should succeed
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/cache-revalidate-construct-range-response.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/cache-revalidate-construct-range-response.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta name="timeout" content="long">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+
+promise_test(async t => {
+    const url = new URL('resources/video-with-aged-proxy-cache.py', location.href);
+    const response_1 = await fetch(url.toString());
+    assert_equals(response_1.status, 200, 'Initial fetch should succeed with 200');
+    const response_1_blob = await response_1.blob();
+    assert_equals(response_1_blob.size, 80666, 'Initial fetch should get full content');
+    const response_2 = await fetch(url.toString(), {
+        headers: {'Range': 'bytes=0-99'}
+    });
+    const response_2_blob = await response_2.blob();
+    assert_equals(response_2.status, 206, 'Range fetch after cache revalidation should succeed with 206');
+    assert_equals(response_2_blob.size, 100, 'Range fetch after cache revalidation should get partial content');
+}, `Range request after cache revalidation with 200 OK response should succeed`);
+
+</script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/general.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/general.any.js
@@ -88,10 +88,7 @@ promise_test(async () => {
     });
 
     const response = await fetch(stashTakeURL);
-
-    assert_regexp_match(await response.json(),
-                        /.*\bidentity\b.*/,
-                        `Expect identity accept-encoding if range header is ${JSON.stringify(rangeHeader)}`);
+    assert_equals(await response.json(), 'identity', `Expect identity accept-encoding if range header is ${JSON.stringify(rangeHeader)}`);
   }
 }, `Fetch with range header will be sent with Accept-Encoding: identity`);
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/video-with-aged-proxy-cache.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/video-with-aged-proxy-cache.py
@@ -1,0 +1,64 @@
+import re
+import os
+import json
+from wptserve.utils import isomorphic_decode
+
+ENTITY_TAG = b'"sine440-v1"'
+# There should be two requests made to this resource:
+# 1. A request fetch the whole video. This request should receive a
+#    200 Success response with a aged header of value more
+#    than 24 hours in the past, simulating an aged proxy cache.
+# 2.a A subsequent request with a Range header to revalidate the cached content.
+#    This request should include an If-Modified-Since / If-Not-Match header
+#    and should response with a 304 Not Modified response.
+# 2.b A subsequent request with a Range header to fetch a range of the video.
+#    But without Http-Cache revalidation related header.
+#    This request should receive a 206 Partial Content response with the
+#    requested range of the video.
+
+def main(request, response):
+    path = os.path.join(request.doc_root, u"media", "sine440.mp3")
+    total_size = os.path.getsize(path)
+    if_modified_since = request.headers.get(b'If-Modified-Since')
+    if_none_match = request.headers.get(b'If-Not-Match')
+    range_header = request.headers.get(b'Range')
+    range_header_match = range_header and re.search(r'^bytes=(\d*)-(\d*)$', isomorphic_decode(range_header))
+
+    if range_header_match:
+        start, end = range_header_match.groups()
+        start = int(start or 0)
+        end = int(end or total_size)
+        status = 206
+    elif if_modified_since or if_none_match:
+        status = 304
+        start = 0
+        end = 0
+    else:
+        status = 200
+        start = 0
+        end = total_size
+
+    response.status = status
+    headers = []
+    if status == 200:
+        headers.append((b"Age", b"86400"))
+        headers.append((b"Expires", b"Wed, 21 Oct 2015 07:28:00 GMT"))
+        headers.append((b"Last-Modified", b"Wed, 21 Oct 2015 07:28:00 GMT"))
+        headers.append((b"ETag", ENTITY_TAG))
+        video_file = open(path, "rb")
+        video_file.seek(start)
+        content = video_file.read(end)
+    elif status == 206:
+        headers.append((b"Content-Range", b"bytes %d-%d/%d" % (start, end, total_size)))
+        headers.append((b"Accept-Ranges", b"bytes"))
+        headers.append((b"ETag", ENTITY_TAG))
+        video_file = open(path, "rb")
+        video_file.seek(start)
+        end = min(end+1, total_size)
+        content = video_file.read(end-start)
+    else:
+        content = b""
+    headers.append((b"Content-Length", str(end - start)))
+    headers.append((b"Content-Type", b"audio/mp3"))
+
+    return status, headers, content

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/w3c-import.log
@@ -21,4 +21,5 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/range-sw.js
 /LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/stash-take.py
 /LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/utils.js
+/LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/video-with-aged-proxy-cache.py
 /LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/video-with-range.py

--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/range/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/range/w3c-import.log
@@ -14,7 +14,9 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/fetch/range/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.js
+/LayoutTests/imported/w3c/web-platform-tests/fetch/range/cache-revalidate-construct-range-response.html
 /LayoutTests/imported/w3c/web-platform-tests/fetch/range/data.any.js
 /LayoutTests/imported/w3c/web-platform-tests/fetch/range/general.any.js
 /LayoutTests/imported/w3c/web-platform-tests/fetch/range/general.window.js

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -3080,6 +3080,9 @@
     "imported/w3c/web-platform-tests/fetch/metadata/tools/templates/window-location.sub.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/fetch/range/cache-revalidate-construct-range-response.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/fetch/range/non-matching-range-response.html": [
         "slow"
     ],


### PR DESCRIPTION
#### 4c207becc3ac8f847ef27fff21091782c011b883
<pre>
Sync `fetch/range` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=307958">https://bugs.webkit.org/show_bug.cgi?id=307958</a>
<a href="https://rdar.apple.com/170441555">rdar://170441555</a>

Reviewed by Tim Nguyen and Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/65aa223f9ec654eeac89b9a30aec6d670fc484f5">https://github.com/web-platform-tests/wpt/commit/65aa223f9ec654eeac89b9a30aec6d670fc484f5</a>

* LayoutTests/imported/w3c/web-platform-tests/fetch/range/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.js:
(supportedBlobRange.forEach):
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/blob.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/cache-revalidate-construct-range-response-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/cache-revalidate-construct-range-response.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/general.any.js:
(promise_test.async const):
(promise_test):
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/video-with-aged-proxy-cache.py: Added.
(main):
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/resources/w3c-import.log:
* LayoutTests/imported/w3c/web-platform-tests/fetch/range/w3c-import.log:
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/307631@main">https://commits.webkit.org/307631@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08a0889c9dd441053df27e994531bdb53bb28f8a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9340 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153609 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98573 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/302b0fde-dc12-4178-a592-cdcbfbfc9105) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18102 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17511 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111444 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79892 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147901 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130153 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92340 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de798232-0bcb-429e-b79b-0ad7bcec5f98) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13183 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10937 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1054 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122698 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6897 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155921 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17469 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119450 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14580 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119778 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30733 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15581 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128155 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73095 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17091 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6453 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16827 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17036 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16891 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->