### PR TITLE
[YARR] Fix out-of-bounds table access in JIT case-insensitive backreference matching

### DIFF
--- a/JSTests/stress/regexp-backreference-ignorecase-non-ascii-folding.js
+++ b/JSTests/stress/regexp-backreference-ignorecase-non-ascii-folding.js
@@ -1,0 +1,78 @@
+// JIT case-insensitive backreference must not use latin1CanonicalizationTable
+// for non-ASCII characters. When the captured character is non-ASCII (e.g.,
+// U+212A KELVIN SIGN) but the input character is ASCII (e.g., 'K'), the JIT
+// fast path incorrectly accessed the table out of bounds.
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error((message ? message + ": " : "") + "expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// U+212A KELVIN SIGN folds to 'K' (U+004B) under Unicode case folding.
+// The backreference \1 should match 'K' when ignoreCase and unicode flags are set.
+// This was returning false in JIT due to out-of-bounds table access.
+
+// Test 1: Kelvin sign captured, backreference matches ASCII 'K'
+for (let i = 0; i < 100; i++) {
+    let result = /(\u212a)\1/iu.test("\u212aK");
+    shouldBe(result, true, "Test 1: /(\\u212a)\\1/iu.test('\\u212aK')");
+}
+
+// Test 2: ASCII 'K' captured, backreference matches Kelvin sign
+for (let i = 0; i < 100; i++) {
+    let result = /(K)\1/iu.test("K\u212a");
+    shouldBe(result, true, "Test 2: /(K)\\1/iu.test('K\\u212a')");
+}
+
+// Test 3: Kelvin sign captured, backreference matches lowercase 'k'
+for (let i = 0; i < 100; i++) {
+    let result = /(\u212a)\1/iu.test("\u212ak");
+    shouldBe(result, true, "Test 3: /(\\u212a)\\1/iu.test('\\u212ak')");
+}
+
+// U+017F LATIN SMALL LETTER LONG S folds to 's' (U+0073) under Unicode case folding.
+// Test 4: Long S captured, backreference matches ASCII 's'
+for (let i = 0; i < 100; i++) {
+    let result = /(\u017f)\1/iu.test("\u017fs");
+    shouldBe(result, true, "Test 4: /(\\u017f)\\1/iu.test('\\u017fs')");
+}
+
+// Test 5: Long S captured, backreference matches ASCII 'S'
+for (let i = 0; i < 100; i++) {
+    let result = /(\u017f)\1/iu.test("\u017fS");
+    shouldBe(result, true, "Test 5: /(\\u017f)\\1/iu.test('\\u017fS')");
+}
+
+// Test 6: ASCII 'S' captured, backreference matches Long S
+for (let i = 0; i < 100; i++) {
+    let result = /(S)\1/iu.test("S\u017f");
+    shouldBe(result, true, "Test 6: /(S)\\1/iu.test('S\\u017f')");
+}
+
+// Test 7: Kelvin sign self-match (both captured and backreference are U+212A)
+for (let i = 0; i < 100; i++) {
+    let result = /(\u212a)\1/iu.test("\u212a\u212a");
+    shouldBe(result, true, "Test 7: /(\\u212a)\\1/iu.test('\\u212a\\u212a')");
+}
+
+// Test 8: Verify exec() returns correct match
+for (let i = 0; i < 100; i++) {
+    let match = /(\u212a)\1/iu.exec("\u212aK");
+    shouldBe(match !== null, true, "Test 8: match should not be null");
+    shouldBe(match[0], "\u212aK", "Test 8: full match");
+    shouldBe(match[1], "\u212a", "Test 8: capture group");
+}
+
+// Test 9: Non-matching case still correctly fails
+for (let i = 0; i < 100; i++) {
+    let result = /(\u212a)\1/iu.test("\u212aX");
+    shouldBe(result, false, "Test 9: /(\\u212a)\\1/iu.test('\\u212aX') should not match");
+}
+
+// Test 10: Without unicode flag - UCS2 mode.
+// In non-Unicode mode, case folding uses simple toUpperCase which does NOT
+// equate U+212A (Kelvin sign) with 'K'. So this should NOT match.
+for (let i = 0; i < 100; i++) {
+    let result = /(\u212a)\1/i.test("\u212aK");
+    shouldBe(result, false, "Test 10: /(\\u212a)\\1/i.test('\\u212aK') should not match without u flag");
+}


### PR DESCRIPTION
#### b2d8670b72c1e13f59548d808923f709291eb509
<pre>
[YARR] Fix out-of-bounds table access in JIT case-insensitive backreference matching
<a href="https://bugs.webkit.org/show_bug.cgi?id=307961">https://bugs.webkit.org/show_bug.cgi?id=307961</a>

Reviewed by Yusuke Suzuki.

In 16-bit case-insensitive backreference matching, the JIT ASCII fast path
only checked whether the input character was &lt;= 127 before indexing into
latin1CanonicalizationTable (256 entries). It did not check the pattern
character (the character read from the captured group). When the captured
character is non-ASCII (e.g., U+212A KELVIN SIGN) but the input character
is ASCII (e.g., &apos;K&apos;), this results in an out-of-bounds read from the table
and a false negative match.

Fix by checking that both the input character and the pattern character are
ASCII before taking the table lookup fast path. If either is non-ASCII,
fall through to the areCanonicallyEquivalent slow path which correctly
handles the full Unicode case folding.

Test: JSTests/stress/regexp-backreference-ignorecase-non-ascii-folding.js

* JSTests/stress/regexp-backreference-ignorecase-non-ascii-folding.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307793@main">https://commits.webkit.org/307793@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9111057de450051e52d68e016765381dae82f9f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18228 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154218 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18713 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18121 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111926 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14293 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/130738 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92830 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1665 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137537 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7518 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156531 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6355 "Built successfully and passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/18078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/8629 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/119932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120277 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30830 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128800 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/17699 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176836 "Built successfully") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/17436 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45437 "Passed tests") | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17499 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->