### PR TITLE
[YARR] Fix word boundary assertion corrupting position with surrogate pairs in bytecode interpreter

### DIFF
--- a/JSTests/stress/yarr-word-boundary-surrogate-pair.js
+++ b/JSTests/stress/yarr-word-boundary-surrogate-pair.js
@@ -1,0 +1,41 @@
+//@ runDefault("--useRegExpJIT=false")
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${String(expected)} but got: ${String(actual)}`);
+}
+
+// \B (non-word-boundary) followed by dot should match a supplementary character
+// at the start of the string because the boundary between two non-word characters
+// is a non-word-boundary.
+{
+    let result = /\B./u.exec("\u{10000}\u{10000}");
+    shouldBe(result !== null, true);
+    shouldBe(result[0], "\u{10000}");
+    shouldBe(result.index, 0);
+}
+
+// \b (word-boundary) should not match between two supplementary non-word characters.
+{
+    let result = /\b./u.exec("\u{10000}\u{10000}");
+    shouldBe(result, null);
+}
+
+// \B with supplementary characters mixed with ASCII word characters.
+{
+    let result = /\B./u.exec("a\u{10000}");
+    shouldBe(result, null);
+}
+
+// \b at the start before a supplementary non-word character should not match.
+{
+    let result = /\b/u.exec("\u{10000}");
+    shouldBe(result, null);
+}
+
+// \B at the start before a supplementary non-word character should match.
+{
+    let result = /\B/u.exec("\u{10000}");
+    shouldBe(result !== null, true);
+    shouldBe(result.index, 0);
+}

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -709,10 +709,10 @@ public:
 
         auto boundaryCharacterClass = term.ignoreCase() ? pattern->ignoreCaseWordcharCharacterClass : pattern->wordcharCharacterClass;
 
-        bool prevIsWordchar = !input.atStart(inputOffset) && testCharacterClass(boundaryCharacterClass, input.readChecked(inputOffset + 1));
+        bool prevIsWordchar = !input.atStart(inputOffset) && testCharacterClass(boundaryCharacterClass, input.readCheckedDontAdvance(inputOffset + 1));
         bool readIsWordchar;
         if (inputOffset)
-            readIsWordchar = !input.atEnd(inputOffset) && testCharacterClass(boundaryCharacterClass, input.readChecked(inputOffset));
+            readIsWordchar = !input.atEnd(inputOffset) && testCharacterClass(boundaryCharacterClass, input.readCheckedDontAdvance(inputOffset));
         else
             readIsWordchar = !input.atEnd() && testCharacterClass(boundaryCharacterClass, input.read());
 


### PR DESCRIPTION
#### 7f53c2a455abfe907a1fdeae7edf579e04e519cf
<pre>
[YARR] Fix word boundary assertion corrupting position with surrogate pairs in bytecode interpreter
<a href="https://bugs.webkit.org/show_bug.cgi?id=307962">https://bugs.webkit.org/show_bug.cgi?id=307962</a>

Reviewed by Yusuke Suzuki.

matchAssertionWordBoundary() used readChecked() to test whether adjacent
characters are word characters. readChecked() has a side effect: when it
reads a surrogate pair, it calls next() which advances pos by one. This
corrupts the input position for subsequent matching operations.

For example, /\B./u.exec(&quot;\u{10000}\u{10000}&quot;) incorrectly returned null
because after \B read U+10000 (a surrogate pair), pos was advanced, causing
the dot to read from the trail surrogate position and get errorCodePoint.

The fix replaces readChecked() with readCheckedDontAdvance(), which decodes
surrogate pairs without advancing pos. This is consistent with how
matchAssertionBOL() and matchAssertionEOL() already handle their reads.

This bug only affects the bytecode interpreter (--useRegExpJIT=false) since
the JIT compiler generates different code for word boundary assertions.

Test: JSTests/stress/yarr-word-boundary-surrogate-pair.js

* JSTests/stress/yarr-word-boundary-surrogate-pair.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::matchAssertionWordBoundary):

Canonical link: <a href="https://commits.webkit.org/307677@main">https://commits.webkit.org/307677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89759fe74897d06fde6c3e7cc8e203a25983b48c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17629 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153620 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98584 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18113 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17522 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111454 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79903 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147912 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13822 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10948 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1065 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136940 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6909 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155932 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5758 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17480 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119460 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17527 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14591 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119788 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30762 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15588 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73110 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17102 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6464 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176237 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16838 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80881 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45339 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17047 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16902 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->