### PR TITLE
[YARR] Fix false negative matching Unicode regexp with inverted character class

### DIFF
--- a/JSTests/stress/yarr-jit-optimize-alternative-inverted-char-class.js
+++ b/JSTests/stress/yarr-jit-optimize-alternative-inverted-char-class.js
@@ -1,0 +1,32 @@
+//@ requireOptions("--useExecutableAllocationFuzz=true", "--fireExecutableAllocationFuzzAtOrAfter=1")
+
+// Regression test for optimizeAlternative swapping an inverted character class
+// with a fixed character in Char8 mode. [^a] is BMP-only in its class data, but
+// being inverted it can match non-BMP characters (variable width in UTF-16).
+// When JIT allocation fails and falls back to bytecode with the already-swapped
+// pattern, executing against a Char16 string can cause surrogate pair misreads.
+
+function shouldBe(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+// Force Char8 compilation first (Latin1 string), then test with Char16 string
+// containing a non-BMP character. The non-BMP character \u{10000} is encoded as
+// the surrogate pair \uD800\uDC00 in UTF-16.
+
+var re = /[^a]bcd/u;
+
+// Char8 path: Latin1 string triggers Char8 JIT compilation (which does the swap)
+var result8 = re.exec("xbcd");
+shouldBe(result8[0], "xbcd", "Char8 match");
+
+// Char16 path: String with non-BMP character forces Char16 execution.
+// \u{10000} is not 'a', so [^a] should match it, followed by "bcd".
+var result16 = re.exec("\u{10000}bcd");
+shouldBe(result16 !== null, true, "Char16 match should not be null");
+shouldBe(result16[0], "\u{10000}bcd", "Char16 match with non-BMP character");
+
+// Additional test: ensure [^a] does NOT match 'a'
+var resultNoMatch = re.exec("abcd");
+shouldBe(resultNoMatch, null, "should not match 'a' followed by bcd");


### PR DESCRIPTION
#### 6219e9ebc052202ebec9b0edf8dea908752d2c44
<pre>
[YARR] Fix false negative matching Unicode regexp with inverted character class
<a href="https://bugs.webkit.org/show_bug.cgi?id=307964">https://bugs.webkit.org/show_bug.cgi?id=307964</a>

Reviewed by Yusuke Suzuki.

optimizeAlternative() swaps a CharacterClass term with a following
PatternCharacter term in Char8 mode even when the class is inverted. An
inverted class like [^a] has BMP-only class data so hasNonBMPCharacters()
returns false, but being inverted it can match any non-BMP character. If
JIT allocation then fails, the swapped pattern is passed to
byteCodeCompilePattern(). Executing that bytecode against a Char16 string
causes the interpreter to misread surrogate pairs, producing a false
negative.

This patch fixes by restricting the swap to non-inverted CharacterClasses.

Test: JSTests/stress/yarr-jit-optimize-alternative-inverted-char-class.js

* JSTests/stress/yarr-jit-optimize-alternative-inverted-char-class.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307639@main">https://commits.webkit.org/307639@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ef4ac2178e6681f207ff977763442e12bd445e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/144953 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9356 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153624 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98588 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18117 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17526 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111458 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79905 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13821 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130164 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92354 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13195 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10951 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1069 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/136944 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122710 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6908 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155936 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5762 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17484 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/7996 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119464 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17531 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14594 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119792 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30738 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15593 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73115 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17106 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6463 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176241 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16842 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80885 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45340 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17051 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16906 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->