### PR TITLE
REGRESSION (227123@main): [ iOS ] fast/scrolling/ios/programmatic-scroll-while-zoomed.html and fast/scrolling/ios/autoscroll-input-when-very-zoomed.html are Failing

### DIFF
--- a/LayoutTests/fast/scrolling/ios/autoscroll-input-when-very-zoomed.html
+++ b/LayoutTests/fast/scrolling/ios/autoscroll-input-when-very-zoomed.html
@@ -22,7 +22,7 @@
         await UIHelper.activateElementAndWaitForInputSession(document.getElementById('editable'));
 
         await UIHelper.immediateZoomToScale(3.284);
-        await UIHelper.immediateScrollTo(390, 500);
+        await UIHelper.immediateScrollTo(350, 500);
 
         await Promise.all([UIHelper.ensureVisibleContentRectUpdate(), UIHelper.ensureStablePresentationUpdate()]);
 
@@ -85,7 +85,7 @@ the first text input so that the input element in is visible again, but should n
 scroll more than once, as it should be visible after the first scroll. On iPad, the
 input should not scroll at all, as the iPad is larger and should not need to scroll
 for the input element to be visible. The test results should reflect these expectations.
-<div id="testArea"><input id="editable" type="text" value="Test text"></input></div>
+<div id="testArea"><input id="editable" type="text" value="Test text"></div>
 </body>
 </html>
 

--- a/LayoutTests/fast/scrolling/ios/programmatic-scroll-while-zoomed-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/programmatic-scroll-while-zoomed-expected.txt
@@ -1,13 +1,13 @@
-PASS window.pageXOffset is 53
-PASS window.pageYOffset is 91
-PASS window.visualViewport.pageLeft is 53
-PASS window.visualViewport.pageTop is 91
+PASS window.pageXOffset is 65
+PASS window.pageYOffset is 133
+PASS window.visualViewport.pageLeft is 65
+PASS window.visualViewport.pageTop is 133
 
 scrolling to 0,0
-PASS window.pageXOffset is 53
-PASS window.pageYOffset is 91
-PASS window.visualViewport.pageLeft is 53
-PASS window.visualViewport.pageTop is 91
+PASS window.pageXOffset is 65
+PASS window.pageYOffset is 133
+PASS window.visualViewport.pageLeft is 65
+PASS window.visualViewport.pageTop is 133
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/scrolling/ios/programmatic-scroll-while-zoomed.html
+++ b/LayoutTests/fast/scrolling/ios/programmatic-scroll-while-zoomed.html
@@ -5,15 +5,22 @@
     <style>
         body {
             overflow: hidden;
+            height: 1000px;
         }
 
         .contents {
             width: 100%;
             height: 100%;
         }
+        
+        /* Prevent output from affecting the document size */
+        #console {
+            height: 10em;
+            overflow: clip;
+        }
     </style>
     <script src="../../../resources/ui-helper.js"></script>
-    <script src="../../../resources/js-test-pre.js"></script>
+    <script src="../../../resources/js-test.js"></script>
     <script>
         jsTestIsAsync = true;
 
@@ -21,13 +28,14 @@
             if (!window.testRunner)
                 return;
 
-            await UIHelper.immediateZoomToScale(1.5);
+            await UIHelper.zoomToScale(1.5);
+            await UIHelper.renderingUpdate();
             
-            shouldBe('window.pageXOffset', '53');
-            shouldBe('window.pageYOffset', '91');
+            shouldBe('window.pageXOffset', '65');
+            shouldBe('window.pageYOffset', '133');
 
-            shouldBe('window.visualViewport.pageLeft', '53');
-            shouldBe('window.visualViewport.pageTop', '91');
+            shouldBe('window.visualViewport.pageLeft', '65');
+            shouldBe('window.visualViewport.pageTop', '133');
 
             await Promise.all([UIHelper.ensureVisibleContentRectUpdate(), UIHelper.ensureStablePresentationUpdate()]);
 
@@ -37,11 +45,11 @@
 
             await Promise.all([UIHelper.ensureVisibleContentRectUpdate(), UIHelper.ensureStablePresentationUpdate()]);
 
-            shouldBe('window.pageXOffset', '53');
-            shouldBe('window.pageYOffset', '91');
+            shouldBe('window.pageXOffset', '65');
+            shouldBe('window.pageYOffset', '133');
 
-            shouldBe('window.visualViewport.pageLeft', '53');
-            shouldBe('window.visualViewport.pageTop', '91');
+            shouldBe('window.visualViewport.pageLeft', '65');
+            shouldBe('window.visualViewport.pageTop', '133');
 
             finishJSTest();
         }
@@ -50,8 +58,7 @@
     </script>
 </head>
 <body>
-    <div class="contents">
-    </div>
-    <script src="../../../resources/js-test-post.js"></script>
+    <div class="contents"></div>
+    <div id="console"></div>
 </body>
 </html>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6444,8 +6444,6 @@ webkit.org/b/214512 imported/w3c/web-platform-tests/css/geometry/DOMMatrix2DInit
 webkit.org/b/230959 fast/scrolling/ios/click-events-after-long-press-during-momentum-scroll-in-overflow.html [ Pass Timeout ]
 webkit.org/b/230959 fast/scrolling/ios/click-events-after-long-press-during-momentum-scroll-in-main-frame.html [ Pass Timeout ]
 
-webkit.org/b/214598 fast/scrolling/ios/autoscroll-input-when-very-zoomed.html [ Pass Failure ]
-
 webkit.org/b/231603 fast/scrolling/ios/reconcile-layer-position-recursive.html [ Pass Failure ]
 
 webkit.org/b/231641 fast/scrolling/ios/scroll-snap-with-momentum-scroll-in-overflow-scroll-area.html [ Pass Failure ]
@@ -7374,8 +7372,6 @@ webkit.org/b/214730 [ Debug ] imported/w3c/web-platform-tests/webrtc/RTCCertific
 webkit.org/b/214730 [ Debug ] imported/w3c/web-platform-tests/webrtc/RTCCertificate.html [ Skip ]
 webkit.org/b/214730 [ Debug ] imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-generateCertificate.html [ Skip ]
 webkit.org/b/214730 [ Debug ] imported/w3c/web-platform-tests/webrtc/RTCSctpTransport-constructor.html [ Skip ]
-
-webkit.org/b/214358 fast/scrolling/ios/programmatic-scroll-while-zoomed.html [ Pass Failure ]
 
 webkit.org/b/214736 imported/w3c/web-platform-tests/css/css-flexbox/align-self-014.html [ Pass Timeout ]
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -55,6 +55,8 @@
 - (NSString *)_uiViewTreeAsTextForViewWithLayerID:(unsigned long long)layerID;
 - (NSString *)_uiViewTreeAsTextForView:(UIView *)view;
 
+- (void)_setZoomScaleForTesting:(CGFloat)scale animated:(BOOL)animated;
+
 - (void)keyboardAccessoryBarNext;
 - (void)keyboardAccessoryBarPrevious;
 - (void)dismissFormAccessoryView;

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -59,6 +59,16 @@ static void dumpSeparatedLayerProperties(TextStream&, CALayer *) { }
 
 @implementation WKWebView (WKTestingIOS)
 
+- (void)_setZoomScaleForTesting:(CGFloat)scale animated:(BOOL)animated
+{
+    // We have to pretend this is user-originated zooming to avoid WebPage::viewportConfigurationChanged() resetting back to the initial scale.
+    _page->willStartUserTriggeredZooming();
+    [self.scrollView setZoomScale:scale animated:animated];
+    // For animated zooms, didEndUserTriggeredZooming() is always called from -[WKWebView scrollViewDidEndZooming:withView:atScale:].
+    if (!animated)
+        _page->didEndUserTriggeredZooming();
+}
+
 - (void)_requestTextInputContextsInRect:(CGRect)rect completionHandler:(void (^)(NSArray<_WKTextInputContext *> *))completionHandler
 {
     // Adjust returned bounding rects to be in WKWebView coordinates.

--- a/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
+++ b/Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm
@@ -369,7 +369,7 @@ IGNORE_WARNINGS_END
     }
 
     self.zoomToScaleCompletionHandler = completionHandler;
-    [self.scrollView setZoomScale:scale animated:animated];
+    [self _setZoomScaleForTesting:scale animated:animated];
 }
 
 - (void)_keyboardWillHide

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -264,6 +264,11 @@ void UIScriptControllerIOS::doAfterNextVisibleContentRectAndStablePresentationUp
     }).get()];
 }
 
+void UIScriptControllerIOS::immediateZoomToScale(double scale)
+{
+    [webView() zoomToScale:scale animated:NO completionHandler:nil];
+}
+
 void UIScriptControllerIOS::zoomToScale(double scale, JSValueRef callback)
 {
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
@@ -839,11 +844,6 @@ void UIScriptControllerIOS::immediateScrollElementAtContentPointToOffset(long x,
     UIView *hitView = [contentView hitTest:CGPointMake(x, y) withEvent:nil];
     UIScrollView *enclosingScrollView = enclosingScrollViewIncludingSelf(hitView);
     [enclosingScrollView setContentOffset:CGPointMake(xScrollOffset, yScrollOffset)];
-}
-
-void UIScriptControllerIOS::immediateZoomToScale(double scale)
-{
-    [webView().scrollView setZoomScale:scale animated:NO];
 }
 
 void UIScriptControllerIOS::keyboardAccessoryBarNext()


### PR DESCRIPTION
#### d7bc6b73ffbc2d5036bbfb89dee95a8c63331a22
<pre>
REGRESSION (<a href="https://commits.webkit.org/227123@main">227123@main</a>): [ iOS ] fast/scrolling/ios/programmatic-scroll-while-zoomed.html and fast/scrolling/ios/autoscroll-input-when-very-zoomed.html are Failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=214358">https://bugs.webkit.org/show_bug.cgi?id=214358</a>
<a href="https://rdar.apple.com/65609413">rdar://65609413</a>

Reviewed by NOBODY (OOPS!).

These two tests were failing because when calling `UIHelper.immediateZoomToScale()` sometimes the zoom
level is set back to one, and other reasons.

`WebPage::viewportConfigurationChanged()` consults `m_userHasChangedPageScaleFactor`, and if not set, it
sets the zoom back to the initial zoom; that caused any test using `immediateZoomToScale()` that also
changes the document size (e.g. as a side effect of producing output) to fail.

Fix by implementing `[WKWebView _setZoomScaleForTesting:animated:]` which calls `willStartUserTriggeredZooming()`/
`didEndUserTriggeredZooming()` so that the zoom behaves as if user-initiated, and call this from
`-[TestRunnerWKWebView zoomToScale:animated:completionHandler:]`.

However, even with these fixes, `immediateZoomToScale` is flakey (webkit.org/307996), so change
`programmatic-scroll-while-zoomed.html` to use `zoomToScale`.

Also tweak the tests to behave the way they were originally written.

* LayoutTests/fast/scrolling/ios/autoscroll-input-when-very-zoomed.html:
* LayoutTests/fast/scrolling/ios/programmatic-scroll-while-zoomed-expected.txt:
* LayoutTests/fast/scrolling/ios/programmatic-scroll-while-zoomed.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _setZoomScaleForTesting:animated:]):
* Tools/WebKitTestRunner/cocoa/TestRunnerWKWebView.mm:
(-[TestRunnerWKWebView zoomToScale:animated:completionHandler:]): Call `_setZoomScaleForTesting:animated:`
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::immediateZoomToScale): Just moved.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7bc6b73ffbc2d5036bbfb89dee95a8c63331a22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145045 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9496 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153716 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98681 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146920 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17618 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111547 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79965 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148008 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13895 "Found unexpected failure with change (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130288 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92432 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13266 "Exiting early after 10 failures. 14 tests run. 2 flakes") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11029 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1161 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122785 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156028 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17577 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8127 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119538 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17623 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14673 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119866 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15667 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128297 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73241 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17198 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6567 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16934 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80977 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17143 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16998 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->