### PR TITLE
[scroll-animations] WPT test `css/scroll-timeline-paused-animations.html` fails

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt
@@ -1,4 +1,4 @@
 
 PASS Test that the scroll animation is paused
-FAIL Test that the scroll animation is paused by updating animation-play-state assert_equals: Current time preserved when pause-pending. expected "200px" but got "50px"
+PASS Test that the scroll animation is paused by updating animation-play-state
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-paused-animations-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-paused-animations-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Test that a scroll-driven animation can be paused by updating animation-play-state
+

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-paused-animations.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-paused-animations.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<title>View timeline with paused animations</title>
+<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1">
+<link rel="help" href="https://drafts.csswg.org/scroll-animations-1/#view-notation">
+<link rel="help" href="https://drafts.csswg.org/css-animations/#animation-play-state">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/scroll-animations/scroll-timelines/testcommon.js"></script>
+<script src="/css/css-animations/support/testcommon.js"></script>
+<script src="support/testcommon.js"></script>
+<style>
+  @keyframes anim {
+    from { z-index: 0; }
+    to { z-index: 100; }
+  }
+
+  #scroller {
+    overflow: auto;
+    width: 100px;
+    height: 100px;
+  }
+
+  .padding {
+      height: 150px;
+  }
+
+  #target {
+    height: 50px;
+    z-index: -1;
+    animation: anim 1s linear;
+    animation-timeline: view();
+  }
+</style>
+
+<div id=scroller>
+  <div class="padding"></div> <!-- [0px, 150px]  -->
+  <div id="target"></div> <!-- [150px, 200px] -->
+  <div class="padding"></div> <!-- [200px, 350px]  -->
+</div>
+
+<script>
+  setup(assert_implements_animation_timeline);
+
+  async function scrollTop(e, value) {
+    e.scrollTop = value;
+    await waitForNextFrame();
+  }
+
+  promise_test(async (t) => {
+    const animation = target.getAnimations()[0];
+    await animation.ready;
+
+    assert_equals(getComputedStyle(target).zIndex, '-1', 'Initial state');
+
+    await scrollTop(scroller, 125);
+    assert_equals(getComputedStyle(target).zIndex, '50', 'Animation applies after scrolling');
+
+    target.style.animationPlayState = 'paused';
+    assert_equals(animation.playState, 'paused');
+    assert_equals(getComputedStyle(target).zIndex, '50', 'Current time is preserved when pause-pending');
+    assert_true(animation.pending, 'Pending state after changing animationPlayState');
+
+    await animation.ready;
+    assert_equals(getComputedStyle(target).zIndex, '50', 'Current time is preserved when paused');
+
+    await scrollTop(scroller, 150);
+    assert_equals(getComputedStyle(target).zIndex, '50', 'Current time is preserved when scrolling while paused');
+  }, 'Test that a scroll-driven animation can be paused by updating animation-play-state');
+</script>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt
@@ -1,0 +1,6 @@
+
+Harness Error (TIMEOUT), message = null
+
+PASS Test that the scroll animation is paused
+TIMEOUT Test that the scroll animation is paused by updating animation-play-state Test timed out
+

--- a/Source/WebCore/animation/ScrollTimeline.cpp
+++ b/Source/WebCore/animation/ScrollTimeline.cpp
@@ -114,6 +114,7 @@ ScrollTimeline::ScrollTimeline(const AtomString& name, ScrollAxis axis)
 {
     m_axis = axis;
     m_name = name;
+    m_isStyleOriginated = true;
 }
 
 ScrollTimeline::ScrollTimeline(Scroller scroller, ScrollAxis axis)
@@ -121,6 +122,7 @@ ScrollTimeline::ScrollTimeline(Scroller scroller, ScrollAxis axis)
 {
     m_axis = axis;
     m_scroller = scroller;
+    m_isStyleOriginated = true;
 }
 
 RefPtr<Element> ScrollTimeline::bindingsSource() const
@@ -403,6 +405,11 @@ void ScrollTimeline::animationTimingDidChange(WebAnimation& animation)
 
     if (RefPtr page = protect(source->element.document())->page())
         page->scheduleRenderingUpdate(RenderingUpdateStep::Animations);
+}
+
+bool ScrollTimeline::matchesAnonymousScrollFunctionForSource(const Style::ScrollFunction& scrollFunction, const Styleable& source) const
+{
+    return m_isStyleOriginated && m_name.isEmpty() && m_scroller == scrollFunction->scroller && m_axis == scrollFunction->axis && m_source.styleable() == source;
 }
 
 #if ENABLE(THREADED_ANIMATIONS)

--- a/Source/WebCore/animation/ScrollTimeline.h
+++ b/Source/WebCore/animation/ScrollTimeline.h
@@ -30,6 +30,7 @@
 #include <WebCore/RenderStyleConstants.h>
 #include <WebCore/ScrollAxis.h>
 #include <WebCore/ScrollTimelineOptions.h>
+#include <WebCore/StyleScrollFunction.h>
 #include <WebCore/Styleable.h>
 #include <wtf/Ref.h>
 #include <wtf/WeakHashSet.h>
@@ -63,6 +64,8 @@ public:
     void setName(const AtomString& name) { m_name = name; }
 
     bool isInactiveStyleOriginatedTimeline() const { return m_isInactiveStyleOriginatedTimeline; }
+
+    bool matchesAnonymousScrollFunctionForSource(const Style::ScrollFunction&, const Styleable&) const;
 
     AnimationTimeline::ShouldUpdateAnimationsAndSendEvents documentWillUpdateAnimationsAndSendEvents() override;
     void updateCurrentTimeIfStale();
@@ -102,6 +105,7 @@ protected:
     static ScrollableArea* scrollableAreaForSourceRenderer(const RenderElement*, Document&);
     ResolvedScrollDirection resolvedScrollDirection() const;
     void sourceMetricsDidChange();
+    bool isStyleOriginated() const { return m_isStyleOriginated; }
 
 #if ENABLE(THREADED_ANIMATIONS)
     void scheduleAcceleratedRepresentationUpdate();
@@ -137,6 +141,7 @@ private:
     WeakPtr<Element, WeakPtrImplWithEventTargetData> m_timelineScopeElement;
     CurrentTimeData m_cachedCurrentTimeData { };
     bool m_isInactiveStyleOriginatedTimeline { false };
+    bool m_isStyleOriginated { false };
 };
 
 WTF::TextStream& operator<<(WTF::TextStream&, const ScrollTimeline&);

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -629,6 +629,11 @@ Ref<CSSNumericValue> ViewTimeline::endOffset() const
     return CSSNumericFactory::px(computeTimelineData().rangeEnd);
 }
 
+bool ViewTimeline::matchesAnonymousViewFunctionForSubject(const Style::ViewFunction& viewFunction, const Styleable& subject) const
+{
+    return isStyleOriginated() && name().isEmpty() && m_insets == viewFunction->insets && axis() == viewFunction->axis && m_subject.styleable() == subject;
+}
+
 WTF::TextStream& operator<<(WTF::TextStream& ts, const StickinessAdjustmentData& stickiness)
 {
     ts << "[ TopOrLeftAdjustment: "_s << stickiness.stickyTopOrLeftAdjustment << ", TopOrLeftLocation: "_s << stickiness.topOrLeftAdjustmentLocation << ", BottomOrRightAdjustment: "_s << stickiness.stickyBottomOrRightAdjustment << ", BottomOrRightLocation: "_s << stickiness.bottomOrRightAdjustmentLocation << " ]"_s;

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -28,6 +28,7 @@
 #include <WebCore/CSSNumericValue.h>
 #include <WebCore/CSSPrimitiveValue.h>
 #include <WebCore/ScrollTimeline.h>
+#include <WebCore/StyleViewFunction.h>
 #include <WebCore/StyleViewTimelineInsets.h>
 #include <WebCore/Styleable.h>
 #include <WebCore/ViewTimelineOptions.h>
@@ -96,6 +97,8 @@ public:
     std::pair<WebAnimationTime, WebAnimationTime> intervalForAttachmentRange(const Style::SingleAnimationRange&) const final;
     std::pair<double, double> offsetIntervalForAttachmentRange(const Style::SingleAnimationRange&) const;
     std::pair<double, double> offsetIntervalForTimelineRangeName(Style::SingleAnimationRangeName) const;
+
+    bool matchesAnonymousViewFunctionForSubject(const Style::ViewFunction&, const Styleable&) const;
 
 private:
     ScrollTimeline::Data computeTimelineData(UseCachedCurrentTime = UseCachedCurrentTime::Yes) const final;

--- a/Source/WebCore/animation/WebAnimation.h
+++ b/Source/WebCore/animation/WebAnimation.h
@@ -200,11 +200,13 @@ protected:
     virtual void animationDidFinish();
     WebAnimationTime zeroTime() const;
 
+    enum class AutoRewind : bool { No, Yes };
+    ExceptionOr<void> play(AutoRewind);
+
 private:
     enum class DidSeek : bool { No, Yes };
     enum class SynchronouslyNotify : bool { No, Yes };
     enum class RespectHoldTime : bool { No, Yes };
-    enum class AutoRewind : bool { No, Yes };
     enum class TimeToRunPendingTask : uint8_t { NotScheduled, ASAP, WhenReady };
 
     void timingDidChange(DidSeek, SynchronouslyNotify, Silently = Silently::No);
@@ -217,7 +219,6 @@ private:
     void finishNotificationSteps();
     bool hasPendingPauseTask() const { return m_timeToRunPendingPauseTask != TimeToRunPendingTask::NotScheduled; }
     bool hasPendingPlayTask() const { return m_timeToRunPendingPlayTask != TimeToRunPendingTask::NotScheduled; }
-    ExceptionOr<void> play(AutoRewind);
     void runPendingPauseTask();
     void runPendingPlayTask();
     void resetPendingTasks();


### PR DESCRIPTION
#### a770c443fc9e6d3563244a316e7920011425dae2
<pre>
[scroll-animations] WPT test `css/scroll-timeline-paused-animations.html` fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=307782">https://bugs.webkit.org/show_bug.cgi?id=307782</a>
<a href="https://rdar.apple.com/170309012">rdar://170309012</a>

Reviewed by Anne van Kesteren.

There were two issues that prevented us from passing the subtest that checks that pausing
a CSS Animation by setting the CSS property `animation-play-state` dynamically would successfully
pause a scroll-driven animation:

1. in `syncStyleOriginatedTimeline()`, which is called when a style update changes CSS
   properties related to animations, we would reset the animation&apos;s timeline when the `scroll()`
   notation was used because the equality check in `WebAnimation::setTimeline()` would fail as
   indeed a new `ScrollTimeline` instanced was created. We now have a method to check whether
   a `scroll()` notation would indeed yield a new timeline and avoid setting the timeline in
   case it would not.

2. in `syncPropertiesWithBackingAnimation()`, which is also called when a style update
   changes CSS properties related to animations, we would fail to pause an animation when
   `animation-play-state` was set to `paused` if the animation was not running, as for instance
   when it is finished as in this test. We now pause animations as long as it&apos;s not idle.

The behavior caught in 1 was not tested for view timelines, so we added a new test and a similar
function for the view timeline notation.

Test: imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-paused-animations.html

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-paused-animations-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-paused-animations.html: Added.
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-paused-animations-expected.txt: Added.
* Source/WebCore/animation/CSSAnimation.cpp:
(WebCore::CSSAnimation::syncPropertiesWithBackingAnimation):
(WebCore::CSSAnimation::syncStyleOriginatedTimeline):
* Source/WebCore/animation/ScrollTimeline.cpp:
(WebCore::ScrollTimeline::ScrollTimeline):
(WebCore::ScrollTimeline::matchesAnonymousScrollFunctionForSource const):
* Source/WebCore/animation/ScrollTimeline.h:
(WebCore::ScrollTimeline::isStyleOriginated const):
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::matchesAnonymousViewFunctionForSubject const):
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/animation/WebAnimation.h:
(WebCore::WebAnimation::hasPendingPlayTask const):

Canonical link: <a href="https://commits.webkit.org/307645@main">https://commits.webkit.org/307645@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/daecdbb47dce53ac9fd96aaa25f3ebee6257f71d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145006 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17686 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9434 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153677 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98642 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/988cb560-d00e-4c6e-a72f-74dc33060857) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17579 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111501 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79938 "Failed to checkout and rebase branch from PR 58784") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4141d434-c1df-4d0d-8f56-db00e852abac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13862 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130241 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92397 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85940efa-c00b-4da2-b2b2-4ae0258161a1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13234 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/10997 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1122 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155989 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17538 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119505 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14640 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119833 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15636 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128243 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73190 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22372 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17159 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6531 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16895 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80938 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16959 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->