### PR TITLE
RTCPeerConnection.addIceCandidate should reject when connection is closed

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate-expected.txt
@@ -1,40 +1,38 @@
 
-Harness Error (TIMEOUT), message = null
-
 PASS Add ICE candidate before setting remote description should reject with InvalidStateError
-TIMEOUT addIceCandidate after close should reject with InvalidStateError Test timed out
-NOTRUN addIceCandidate({"candidate":"","sdpMid":null,"sdpMLineIndex":null}) works
-NOTRUN addIceCandidate({"candidate":"","sdpMid":null,"sdpMLineIndex":null}) adds a=end-of-candidates to both m-sections
-NOTRUN addIceCandidate(undefined) works
-NOTRUN addIceCandidate(undefined) adds a=end-of-candidates to both m-sections
-NOTRUN addIceCandidate(null) works
-NOTRUN addIceCandidate(null) adds a=end-of-candidates to both m-sections
-NOTRUN addIceCandidate({}) works
-NOTRUN addIceCandidate({}) adds a=end-of-candidates to both m-sections
-NOTRUN addIceCandidate({}) in stable should work, and add a=end-of-candidates to both m-sections
-NOTRUN addIceCandidate({usernameFragment: usernameFragment1, sdpMid: sdpMid1}) should work, and add a=end-of-candidates to the first m-section
-NOTRUN addIceCandidate({usernameFragment: usernameFragment2, sdpMLineIndex: 1}) should work, and add a=end-of-candidates to the first m-section
-NOTRUN addIceCandidate({usernameFragment: "no such ufrag"}) should not work
-NOTRUN Add ICE candidate after setting remote description should succeed
-NOTRUN Add ICE candidate with RTCIceCandidate should succeed
-NOTRUN Add candidate with only valid sdpMid should succeed
-NOTRUN Add candidate with only valid sdpMid and RTCIceCandidate should succeed
-NOTRUN Add candidate with only valid sdpMLineIndex should succeed
-NOTRUN addIceCandidate with first sdpMid and sdpMLineIndex add candidate to first media stream
-NOTRUN addIceCandidate with second sdpMid and sdpMLineIndex should add candidate to second media stream
-NOTRUN Add candidate for first media stream with null usernameFragment should add candidate to first media stream
-NOTRUN Adding multiple candidates should add candidates to their corresponding media stream
-NOTRUN Add with empty candidate string (end of candidates) should succeed
-NOTRUN Add candidate with both sdpMid and sdpMLineIndex manually set to null should reject with TypeError
-NOTRUN addIceCandidate with a candidate and neither sdpMid nor sdpMLineIndex should reject with TypeError
-NOTRUN Add candidate with only valid candidate string should reject with TypeError
-NOTRUN Add candidate with invalid candidate string and both sdpMid and sdpMLineIndex null should reject with TypeError
-NOTRUN Add candidate with invalid sdpMid should reject with OperationError
-NOTRUN Add candidate with invalid sdpMLineIndex should reject with OperationError
-NOTRUN Invalid sdpMLineIndex should be ignored if valid sdpMid is provided
-NOTRUN Add candidate for media stream 2 with null usernameFragment should succeed
-NOTRUN Add candidate with invalid usernameFragment should reject with OperationError
-NOTRUN Add candidate with invalid candidate string should reject with OperationError
-NOTRUN Add candidate with sdpMid belonging to different usernameFragment should reject with OperationError
-NOTRUN addIceCandidate should not recognize relayProtocol or url
+PASS addIceCandidate after close should reject with InvalidStateError
+PASS addIceCandidate({"candidate":"","sdpMid":null,"sdpMLineIndex":null}) works
+FAIL addIceCandidate({"candidate":"","sdpMid":null,"sdpMLineIndex":null}) adds a=end-of-candidates to both m-sections assert_true: Expect candidate line to be found between media lines m=audio and m=video expected true got false
+PASS addIceCandidate(undefined) works
+FAIL addIceCandidate(undefined) adds a=end-of-candidates to both m-sections assert_true: Expect candidate line to be found between media lines m=audio and m=video expected true got false
+PASS addIceCandidate(null) works
+FAIL addIceCandidate(null) adds a=end-of-candidates to both m-sections assert_true: Expect candidate line to be found between media lines m=audio and m=video expected true got false
+PASS addIceCandidate({}) works
+FAIL addIceCandidate({}) adds a=end-of-candidates to both m-sections assert_true: Expect candidate line to be found between media lines m=audio and m=video expected true got false
+FAIL addIceCandidate({}) in stable should work, and add a=end-of-candidates to both m-sections assert_true: Expect candidate line to be found between media lines m=audio and m=video expected true got false
+FAIL addIceCandidate({usernameFragment: usernameFragment1, sdpMid: sdpMid1}) should work, and add a=end-of-candidates to the first m-section assert_true: Expect candidate line to be found between media lines m=audio and m=video expected true got false
+FAIL addIceCandidate({usernameFragment: usernameFragment2, sdpMLineIndex: 1}) should work, and add a=end-of-candidates to the first m-section assert_true: expected true got false
+FAIL addIceCandidate({usernameFragment: "no such ufrag"}) should not work assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Add ICE candidate after setting remote description should succeed
+PASS Add ICE candidate with RTCIceCandidate should succeed
+PASS Add candidate with only valid sdpMid should succeed
+PASS Add candidate with only valid sdpMid and RTCIceCandidate should succeed
+PASS Add candidate with only valid sdpMLineIndex should succeed
+PASS addIceCandidate with first sdpMid and sdpMLineIndex add candidate to first media stream
+PASS addIceCandidate with second sdpMid and sdpMLineIndex should add candidate to second media stream
+PASS Add candidate for first media stream with null usernameFragment should add candidate to first media stream
+PASS Adding multiple candidates should add candidates to their corresponding media stream
+FAIL Add with empty candidate string (end of candidates) should succeed assert_true: Expect candidate line to be found between media lines m=audio and m=video expected true got false
+PASS Add candidate with both sdpMid and sdpMLineIndex manually set to null should reject with TypeError
+PASS addIceCandidate with a candidate and neither sdpMid nor sdpMLineIndex should reject with TypeError
+PASS Add candidate with only valid candidate string should reject with TypeError
+PASS Add candidate with invalid candidate string and both sdpMid and sdpMLineIndex null should reject with TypeError
+PASS Add candidate with invalid sdpMid should reject with OperationError
+PASS Add candidate with invalid sdpMLineIndex should reject with OperationError
+PASS Invalid sdpMLineIndex should be ignored if valid sdpMid is provided
+PASS Add candidate for media stream 2 with null usernameFragment should succeed
+FAIL Add candidate with invalid usernameFragment should reject with OperationError assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS Add candidate with invalid candidate string should reject with OperationError
+FAIL Add candidate with sdpMid belonging to different usernameFragment should reject with OperationError assert_unreached: Should have rejected: undefined Reached unreachable code
+PASS addIceCandidate should not recognize relayProtocol or url
 

--- a/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
+++ b/Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp
@@ -588,6 +588,9 @@ void PeerConnectionBackend::setRemoteDescriptionFailed(Exception&& exception)
 void PeerConnectionBackend::iceGatheringStateChanged(RTCIceGatheringState state)
 {
     ActiveDOMObject::queueTaskKeepingObjectAlive(protectedPeerConnection().get(), TaskSource::Networking, [this, protectedThis = Ref { *this }, state](auto& peerConnection) {
+        if (peerConnection.isClosed())
+            return;
+
         if (state == RTCIceGatheringState::Complete) {
             doneGatheringCandidates();
             return;

--- a/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp
@@ -484,9 +484,6 @@ void RTCPeerConnection::addIceCandidate(Candidate&& rtcCandidate, Ref<DeferredPr
         return;
     }
 
-    if (isClosed())
-        return;
-
     chainOperation(WTF::move(promise), [this, candidate = WTF::move(candidate)](Ref<DeferredPromise>&& promise) mutable {
         protectedBackend()->addIceCandidate(candidate.get(), [protectedThis = Ref { *this }, promise = DOMPromiseDeferred<void>(WTF::move(promise))](auto&& result) mutable {
             if (protectedThis->isClosed())


### PR DESCRIPTION
#### 2f05f731f91c81311380119b3e201fb54e48372e
<pre>
RTCPeerConnection.addIceCandidate should reject when connection is closed
<a href="https://rdar.apple.com/170470988">rdar://170470988</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307980">https://bugs.webkit.org/show_bug.cgi?id=307980</a>

Reviewed by Brandon Stewart.

As per spec, we need to reject the promise with InvalidStateError in case of adding an ice candidate to a peer connection.
We just have to remove the early return check since chainOperation handles already this case.
We also add an early return if peer connection is closed to not send a candidate event, as per spec, as this can cause some flakinesses in imported/w3c/web-platform-tests/webrtc/rtp-stats-lifetime.https.html.

* LayoutTests/imported/w3c/web-platform-tests/webrtc/RTCPeerConnection-addIceCandidate-expected.txt:
* Source/WebCore/Modules/mediastream/PeerConnectionBackend.cpp:
(WebCore::PeerConnectionBackend::iceGatheringStateChanged):
* Source/WebCore/Modules/mediastream/RTCPeerConnection.cpp:
(WebCore::RTCPeerConnection::addIceCandidate):

Canonical link: <a href="https://commits.webkit.org/307702@main">https://commits.webkit.org/307702@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a04bc3f1160c9ae03234483d83432b173edc090b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145198 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17879 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98834 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac5bee89-f1e1-48be-a6bb-1b466640df23) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18362 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111645 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0314dc0-c7fe-4a0f-b9e0-a52a1ef2af71) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148161 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130416 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92544 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/352402a1-d29c-454e-a10a-d6afda15afb0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13363 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11126 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1315 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7174 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156182 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17730 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8262 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119654 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14793 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119988 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30776 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15753 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73394 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17351 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6690 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81130 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17296 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17151 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->