### PR TITLE
[scroll-animations] WPT test `css/view-timeline-range-animation.html` fails

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt
@@ -15,5 +15,5 @@ PASS Animation with ranges [exit-crossing 20px, exit-crossing 80px]
 PASS Animation with ranges [contain 20px, contain calc(100px - 10%)]
 PASS Animation with ranges [exit 2em, exit 8em]
 PASS Animation with ranges [exit 2em, exit 8em] (scoped)
-FAIL Animation with ranges [scroll 100px, scroll 800px] assert_equals: expected "50" but got "0"
+PASS Animation with ranges [scroll 100px, scroll 800px]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Getting and setting the animation range assert_equals: rangeStart set to scroll 10% expected (string) "scroll" but got (undefined) undefined
+PASS Getting and setting the animation range
 

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -314,6 +314,7 @@ void ViewTimeline::cacheCurrentTime()
 
         auto scrollDirection = resolvedScrollDirection();
         float scrollOffset = scrollDirection.isVertical ? sourceScrollableArea->scrollOffset().y() : sourceScrollableArea->scrollOffset().x();
+        float maxScrollOffset = scrollDirection.isVertical ? sourceScrollableArea->maximumScrollOffset().y() : sourceScrollableArea->maximumScrollOffset().x();
         float scrollContainerSize = scrollDirection.isVertical ? sourceScrollableArea->visibleHeight() : sourceScrollableArea->visibleWidth();
 
         // https://drafts.csswg.org/scroll-animations-1/#view-timelines-ranges
@@ -399,6 +400,7 @@ void ViewTimeline::cacheCurrentTime()
 
         return {
             scrollOffset,
+            maxScrollOffset,
             scrollContainerSize,
             subjectOffset,
             subjectSize,
@@ -504,6 +506,8 @@ std::pair<double, double> ViewTimeline::intervalForTimelineRangeName(const Scrol
         case Style::SingleAnimationRangeName::Cover:
         case Style::SingleAnimationRangeName::EntryCrossing:
             return data.rangeStart;
+        case Style::SingleAnimationRangeName::Scroll:
+            return 0.0;
         case Style::SingleAnimationRangeName::Entry:
             // https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-entry
             // 0% is equivalent to 0% of the cover range.
@@ -530,6 +534,8 @@ std::pair<double, double> ViewTimeline::intervalForTimelineRangeName(const Scrol
         case Style::SingleAnimationRangeName::Cover:
         case Style::SingleAnimationRangeName::ExitCrossing:
             return data.rangeEnd;
+        case Style::SingleAnimationRangeName::Scroll:
+            return m_cachedCurrentTimeData.maxScrollOffset;
         case Style::SingleAnimationRangeName::Exit:
             // https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-exit
             // 100% is equivalent to 100% of the cover range.

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -112,6 +112,7 @@ private:
 
     struct CurrentTimeData {
         float scrollOffset { 0 };
+        float maxScrollOffset { 0 };
         float scrollContainerSize { 0 };
         float subjectOffset { 0 };
         float subjectSize { 0 };

--- a/Source/WebCore/css/CSSKeyframeRule.cpp
+++ b/Source/WebCore/css/CSSKeyframeRule.cpp
@@ -52,6 +52,8 @@ void StyleRuleKeyframe::Key::writeToString(StringBuilder& str) const
         str.append("exit "_s);
     else if (rangeName == CSSValueExitCrossing)
         str.append("exit-crossing "_s);
+    else if (rangeName == CSSValueScroll)
+        str.append("scroll "_s);
     str.append(offset * 100, '%');
 }
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -2046,7 +2046,8 @@
                 "entry",
                 "exit",
                 "entry-crossing",
-                "exit-crossing"
+                "exit-crossing",
+                "scroll"
             ],
             "codegen-properties": {
                 "coordinated-value-list-property": true,
@@ -2072,7 +2073,8 @@
                 "entry",
                 "exit",
                 "entry-crossing",
-                "exit-crossing"
+                "exit-crossing",
+                "scroll"
             ],
             "codegen-properties": {
                 "coordinated-value-list-property": true,
@@ -15152,7 +15154,7 @@
             }
         },
         "<timeline-range-name>": {
-            "grammar": "cover | contain | entry | exit | entry-crossing | exit-crossing",
+            "grammar": "cover | contain | entry | exit | entry-crossing | exit-crossing | scroll",
             "exported": true,
             "specification": {
                 "category": "scroll-animations",

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -1090,6 +1090,7 @@ entry
 exit
 entry-crossing
 exit-crossing
+// scroll
 
 //
 // CSS_PROP_ZOOM

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
@@ -44,7 +44,7 @@ namespace CSSPropertyParserHelpers {
 
 bool isAnimationRangeKeyword(CSSValueID id)
 {
-    return identMatches<CSSValueNormal, CSSValueCover, CSSValueContain, CSSValueEntry, CSSValueExit, CSSValueEntryCrossing, CSSValueExitCrossing>(id);
+    return identMatches<CSSValueNormal, CSSValueCover, CSSValueContain, CSSValueEntry, CSSValueExit, CSSValueEntryCrossing, CSSValueExitCrossing, CSSValueScroll>(id);
 }
 
 RefPtr<CSSValue> consumeAnimationTimelineScroll(CSSParserTokenRange& range, CSS::PropertyParserState&)

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
@@ -112,6 +112,8 @@ template<typename Edge> static Edge convertSingleAnimationRangeEdge(BuilderState
             return CSS::Keyword::EntryCrossing { };
         case CSSValueExitCrossing:
             return CSS::Keyword::ExitCrossing { };
+        case CSSValueScroll:
+            return CSS::Keyword::Scroll { };
         default:
             break;
         }
@@ -138,6 +140,8 @@ template<typename Edge> static Edge convertSingleAnimationRangeEdge(BuilderState
         return { CSS::Keyword::EntryCrossing { }, WTF::move(offset) };
     case CSSValueExitCrossing:
         return { CSS::Keyword::ExitCrossing { }, WTF::move(offset) };
+    case CSSValueScroll:
+        return { CSS::Keyword::Scroll { }, WTF::move(offset) };
     default:
         break;
     }
@@ -174,6 +178,8 @@ template<typename Edge> static std::optional<Edge> deprecatedConvertSingleAnimat
             return { CSS::Keyword::EntryCrossing { } };
         case CSSValueExitCrossing:
             return { CSS::Keyword::ExitCrossing { } };
+        case CSSValueScroll:
+            return { CSS::Keyword::Scroll { } };
         default:
             break;
         }
@@ -210,6 +216,8 @@ template<typename Edge> static std::optional<Edge> deprecatedConvertSingleAnimat
         return { { CSS::Keyword::EntryCrossing { }, WTF::move(offset) } };
     case CSSValueExitCrossing:
         return { { CSS::Keyword::ExitCrossing { }, WTF::move(offset) } };
+    case CSSValueScroll:
+        return { { CSS::Keyword::Scroll { }, WTF::move(offset) } };
     default:
         break;
     }

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRange.h
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRange.h
@@ -83,6 +83,10 @@ struct SingleAnimationRangeEdge {
         : SingleAnimationRangeEdge { Name::ExitCrossing, WTF::move(offset) }
     {
     }
+    SingleAnimationRangeEdge(CSS::Keyword::Scroll, std::optional<Offset>&& offset = std::nullopt)
+        : SingleAnimationRangeEdge { Name::Scroll, WTF::move(offset) }
+    {
+    }
 
     bool isNormal() const { return m_name == Name::Normal; }
 
@@ -113,6 +117,8 @@ struct SingleAnimationRangeEdge {
             return visitPredefinedNamedRange(CSS::Keyword::EntryCrossing { });
         case Name::ExitCrossing:
             return visitPredefinedNamedRange(CSS::Keyword::ExitCrossing { });
+        case Name::Scroll:
+            return visitPredefinedNamedRange(CSS::Keyword::Scroll { });
         }
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.cpp
@@ -49,6 +49,8 @@ SingleAnimationRangeName convertCSSValueIDToSingleAnimationRangeName(CSSValueID 
         return SingleAnimationRangeName::EntryCrossing;
     case CSSValueExitCrossing:
         return SingleAnimationRangeName::ExitCrossing;
+    case CSSValueScroll:
+        return SingleAnimationRangeName::Scroll;
     default:
         ASSERT_NOT_REACHED();
         return SingleAnimationRangeName::Normal;
@@ -72,6 +74,8 @@ CSSValueID convertSingleAnimationRangeNameToCSSValueID(SingleAnimationRangeName 
         return CSSValueEntryCrossing;
     case SingleAnimationRangeName::ExitCrossing:
         return CSSValueExitCrossing;
+    case SingleAnimationRangeName::Scroll:
+        return CSSValueScroll;
     case SingleAnimationRangeName::Omitted:
         return CSSValueInvalid;
     }
@@ -98,6 +102,8 @@ String convertSingleAnimationRangeNameToRangeString(SingleAnimationRangeName ran
         return "entry-crossing"_s;
     case SingleAnimationRangeName::ExitCrossing:
         return "exit-crossing"_s;
+    case SingleAnimationRangeName::Scroll:
+        return "scroll"_s;
     }
     ASSERT_NOT_REACHED();
     return "normal"_s;
@@ -118,6 +124,8 @@ SingleAnimationRangeName convertRangeStringToSingleTimelineRangeName(const Strin
         return Style::SingleAnimationRangeName::EntryCrossing;
     if (rangeString == "exit-crossing"_s)
         return Style::SingleAnimationRangeName::ExitCrossing;
+    if (rangeString == "scroll"_s)
+        return Style::SingleAnimationRangeName::Scroll;
     return Style::SingleAnimationRangeName::Normal;
 }
 

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.h
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.h
@@ -32,15 +32,16 @@ enum CSSValueID : uint16_t;
 
 namespace Style {
 
-// <timeline-range-name> = cover | contain | entry | exit | entry-crossing | exit-crossing
+// <timeline-range-name> = cover | contain | entry | exit | entry-crossing | exit-crossing | scroll
 // https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-cover
 // https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-contain
 // https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-entry
 // https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-exit
 // https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-entry-crossing
 // https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-exit-crossing
+// https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-scroll
 
-enum class SingleAnimationRangeName : uint8_t { Normal, Omitted, Cover, Contain, Entry, Exit, EntryCrossing, ExitCrossing };
+enum class SingleAnimationRangeName : uint8_t { Normal, Omitted, Cover, Contain, Entry, Exit, EntryCrossing, ExitCrossing, Scroll };
 
 CSSValueID convertSingleAnimationRangeNameToCSSValueID(SingleAnimationRangeName);
 SingleAnimationRangeName convertCSSValueIDToSingleAnimationRangeName(CSSValueID);


### PR DESCRIPTION
#### 2f996eab6888d712777297ffa81baed237c5b8b9
<pre>
[scroll-animations] WPT test `css/view-timeline-range-animation.html` fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=307784">https://bugs.webkit.org/show_bug.cgi?id=307784</a>
<a href="https://rdar.apple.com/170308965">rdar://170308965</a>

Reviewed by Simon Fraser and Sam Weinig.

An additional `scroll` view progress timeline range [0] was introduced to represents &quot;the
full range of the scroll container on which the view progress timeline is defined&quot;. So we
add support for this which makes two scroll-animations WPT tests pass.

This also addresses bug 307791.

[0] <a href="https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-scroll">https://drafts.csswg.org/scroll-animations-1/#valdef-animation-timeline-range-scroll</a>

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-range-animation-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/view-timeline-get-set-range-expected.txt:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::cacheCurrentTime):
(WebCore::ViewTimeline::intervalForTimelineRangeName const):
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/css/CSSKeyframeRule.cpp:
(WebCore::StyleRuleKeyframe::Key::writeToString const):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/CSSValueKeywords.in:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp:
(WebCore::CSSPropertyParserHelpers::isAnimationRangeKeyword):
* Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp:
(WebCore::Style::convertSingleAnimationRangeEdge):
(WebCore::Style::deprecatedConvertSingleAnimationRangeEdge):
* Source/WebCore/style/values/animations/StyleSingleAnimationRange.h:
(WebCore::Style::SingleAnimationRangeEdge::SingleAnimationRangeEdge):
(WebCore::Style::SingleAnimationRangeEdge::switchOn const):
* Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.cpp:
(WebCore::Style::convertCSSValueIDToSingleAnimationRangeName):
(WebCore::Style::convertSingleAnimationRangeNameToCSSValueID):
(WebCore::Style::convertSingleAnimationRangeNameToRangeString):
(WebCore::Style::convertRangeStringToSingleTimelineRangeName):
* Source/WebCore/style/values/animations/StyleSingleAnimationRangeName.h:

Canonical link: <a href="https://commits.webkit.org/307648@main">https://commits.webkit.org/307648@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9737e44f1653a98a3c44cd4174f801e2fab85bf7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98648 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48e64254-5ced-45cc-ada0-f5995cba4b10) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146887 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18176 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17585 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111507 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79945 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/70829196-e825-4b97-a564-0e3f3ed85169) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/147975 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13868 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130247 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92403 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9aa90cd4-463b-4384-aee1-6b2b803a1156) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13240 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11002 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1128 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122757 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/6992 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/155995 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17544 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8080 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119511 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17590 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14645 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119839 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15639 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73203 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22374 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17165 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6536 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16901 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80944 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16965 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->