### PR TITLE
[scroll-animations] WPT test `view-timelines/contain-alignment.html` fails

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt
@@ -2,5 +2,5 @@
 
 
 
-FAIL Stability of animated elements aligned to the bounds of a contain region assert_equals: a: Mismatched background color expected "rgb(0, 254, 0)" but got "rgb(136, 136, 136)"
+PASS Stability of animated elements aligned to the bounds of a contain region
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html
@@ -6,7 +6,7 @@
 
 @keyframes bg {
   from { background-color:  rgb(254, 0, 0); }
-  to { background-color: rgb(0 254, 0); }
+  to { background-color: rgb(0, 254, 0); }
 }
 .item {
   flex-grow: 1;

--- a/Source/WebCore/animation/ViewTimeline.cpp
+++ b/Source/WebCore/animation/ViewTimeline.cpp
@@ -421,6 +421,17 @@ void ViewTimeline::cacheCurrentTime()
         sourceMetricsDidChange();
 }
 
+WebAnimationTime ViewTimeline::epsilon() const
+{
+    if (!m_cachedCurrentTimeData.subjectSize)
+        return WebAnimationTime::fromPercentage(0);
+    // The metrics reported for the subject and scroll container can be the subject of multiple conversions
+    // along the way, so we compute a percentage value that can be used in WebAnimation::currentTime() to round
+    // values around the 0% and 100% thresholds. To that end, we'll allow for a 0.1pt tolerance.
+    float pointTolerance = 0.1;
+    return WebAnimationTime::fromPercentage(pointTolerance / m_cachedCurrentTimeData.subjectSize * 100);
+}
+
 AnimationTimeline::ShouldUpdateAnimationsAndSendEvents ViewTimeline::documentWillUpdateAnimationsAndSendEvents()
 {
     cacheCurrentTime();

--- a/Source/WebCore/animation/ViewTimeline.h
+++ b/Source/WebCore/animation/ViewTimeline.h
@@ -99,6 +99,7 @@ public:
     std::pair<double, double> offsetIntervalForTimelineRangeName(Style::SingleAnimationRangeName) const;
 
     bool matchesAnonymousViewFunctionForSubject(const Style::ViewFunction&, const Styleable&) const;
+    WebAnimationTime epsilon() const;
 
 private:
     ScrollTimeline::Data computeTimelineData(UseCachedCurrentTime = UseCachedCurrentTime::Yes) const final;


### PR DESCRIPTION
#### 915bfc026f21b43a2290cb38d640c1ac1a7ea191
<pre>
[scroll-animations] WPT test `view-timelines/contain-alignment.html` fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=307788">https://bugs.webkit.org/show_bug.cgi?id=307788</a>
<a href="https://rdar.apple.com/170309501">rdar://170309501</a>

Reviewed by Anne van Kesteren.

This test uses a flex layout to locate three items at the boundaries and in the middle of of a &quot;contain&quot; region.
The computed locations of the items vary depending on the browsers and in our case it would yield a time just
under 0% for one of the extremities that caused an unresolved progress instead of a `0` value.

We address this by adding a way to round the current time of animations associated with a view timeline by querying
the view timeline for an epsilon value computed as 0.1pt compared to the extent of the subject size. We do this
rounding for values just below 0% and just above 100%.

We also fix an egregious error in the test where it missed a comma in the `rgb()` color provided in the `to` keyframe
which caused WebKit to not blend the color as expected and fail assertions.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/view-timelines/contain-alignment.html:
* Source/WebCore/animation/ViewTimeline.cpp:
(WebCore::ViewTimeline::epsilon const):
* Source/WebCore/animation/ViewTimeline.h:
* Source/WebCore/animation/WebAnimation.cpp:
(WebCore::WebAnimation::currentTime const):

Canonical link: <a href="https://commits.webkit.org/307693@main">https://commits.webkit.org/307693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f4aafc831ec4043e272a98a98059b969a2fd8db8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145041 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17722 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9490 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98677 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8c7a273-d081-4a50-9d82-6ff8c070d780) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/146916 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17614 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111530 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79961 "2 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148004 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130281 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92426 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8278f09b-08d5-4d07-882a-c9c9bb405b49) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13261 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11025 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1157 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122779 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7031 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156024 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17573 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8119 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119533 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17619 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14669 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119861 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15662 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128289 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73237 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22395 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17194 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6561 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16930 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/80973 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17139 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/16994 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->