### PR TITLE
Fix findString-selection-disabled.html

### DIFF
--- a/LayoutTests/editing/text-iterator/findString-selection-disabled-expected.txt
+++ b/LayoutTests/editing/text-iterator/findString-selection-disabled-expected.txt
@@ -1,40 +1,14 @@
-Searching for 'e' in 'Some sample text that can be searched' with selection enabled:
-PASS testRunner.findString('e', []) is true
 
-Searching for 'o' in 'Some sample text that can be searched' with selection enabled:
-PASS testRunner.findString('o', []) is true
-
-Searching for 'y' in 'Some sample text that can be searched' with selection enabled:
-PASS testRunner.findString('y', []) is false
-
-Searching for 't t' in 'Some sample text that can be searched' with selection enabled:
-PASS testRunner.findString('t t', []) is true
-
-Searching for 'mount' in 'insurmountable mountain' with selection enabled:
-PASS testRunner.findString('mount', []) is true
-
-Searching for 'Wally' in 'insurmountable mountain' with selection enabled:
-PASS testRunner.findString('Wally', []) is false
-
-Searching for 'e' in 'Some sample text that can be searched' with selection disabled:
-PASS testRunner.findString('e', []) is true
-
-Searching for 'o' in 'Some sample text that can be searched' with selection disabled:
-PASS testRunner.findString('o', []) is true
-
-Searching for 'y' in 'Some sample text that can be searched' with selection disabled:
-PASS testRunner.findString('y', []) is false
-
-Searching for 't t' in 'Some sample text that can be searched' with selection disabled:
-PASS testRunner.findString('t t', []) is true
-
-Searching for 'mount' in 'insurmountable mountain' with selection disabled:
-PASS testRunner.findString('mount', []) is true
-
-Searching for 'Wally' in 'insurmountable mountain' with selection disabled:
-PASS testRunner.findString('Wally', []) is false
-
-PASS successfullyParsed is true
-
-TEST COMPLETE
+PASS find "e" in "Some sample text that can be searched" with selection disabled
+PASS find "o" in "Some sample text that can be searched" with selection disabled
+PASS find "y" in "Some sample text that can be searched" with selection disabled
+PASS find "t t" in "Some sample text that can be searched" with selection disabled
+PASS find "mount" in "insurmountable mountain" with selection disabled
+PASS find "Wally" in "insurmountable mountain" with selection disabled
+PASS find "e" in "Some sample text that can be searched" with selection enabled
+PASS find "o" in "Some sample text that can be searched" with selection enabled
+PASS find "y" in "Some sample text that can be searched" with selection enabled
+PASS find "t t" in "Some sample text that can be searched" with selection enabled
+PASS find "mount" in "insurmountable mountain" with selection enabled
+PASS find "Wally" in "insurmountable mountain" with selection enabled
 

--- a/LayoutTests/editing/text-iterator/findString-selection-disabled.html
+++ b/LayoutTests/editing/text-iterator/findString-selection-disabled.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
+<title>Find string with selection disabled</title>
 <meta charset="utf-8">
-<script src="../../resources/js-test-pre.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
 <style type="text/css">
  .selectionDisabled { -webkit-user-select: none; }
  .selectionEnabled { -webkit-user-select: auto; }
@@ -10,49 +12,40 @@
 </head>
 <body>
 <div id="container"></div>
-<pre id="console" style="visibility: hidden;"></pre>
 <script>
-function log(message)
-{
-    document.getElementById("console").appendChild(document.createTextNode(message + "\n"));
-}
 
-function testFindString(text, target, disableSelection, expected)
-{
-    var selectionStatus = disableSelection ? "selection disabled:" : "selection enabled:";
-    log("Searching for '" + target + "' in '" + text + "' with " + selectionStatus);
-
-    var container = document.getElementById("container");
+async function testFindString(text, target, expected, disableSelection) {
+    const container = document.getElementById("container");
     container.innerText = text;
-    document.body.offsetTop;
-
     container.className = disableSelection ? "selectionDisabled" : "selectionEnabled";
 
-    shouldBe("testRunner.findString('" + target + "', [])", expected);
+    const result = await testRunner.findString(target, []);
+    assert_equals(result, expected);
 
     container.innerText = "";
-    log("");
 }
 
-if (!window.testRunner)
-    testFailed('This test requires the testRunner object');
-else {
-    for (i = 0; i < 2; i++) {
-        var disableSelection = (i == 1);
+async function runTest(text, target, expected, disableSelection) {
+    await promise_test(() => testFindString(text, target, expected, disableSelection), `find "${target}" in "${text}" with selection ${disableSelection ? "disabled" : "enabled"}`);
+}
 
-        testFindString("Some sample text that can be searched", "e", disableSelection, "true");
-        testFindString("Some sample text that can be searched", "o", disableSelection, "true");
-        testFindString("Some sample text that can be searched", "y", disableSelection, "false");
-        testFindString("Some sample text that can be searched", "t t", disableSelection, "true");
-        testFindString("insurmountable mountain", "mount", disableSelection, "true");
-        testFindString("insurmountable mountain", "Wally", disableSelection, "false");
+const text1 = "Some sample text that can be searched";
+const text2 = "insurmountable mountain";
+const testData = [
+    { text: text1, target: "e" },
+    { text: text1, target: "o" },
+    { text: text1, target: "y" },
+    { text: text1, target: "t t" },
+    { text: text2, target: "mount" },
+    { text: text2, target: "Wally" },
+];
+
+for (disableSelection of [true, false]) {
+    for (data of testData) {
+        runTest(data.text, data.target, data.text.includes(data.target), disableSelection);
     }
 }
 
-document.getElementById("console").style.removeProperty("visibility");
-
-var successfullyParsed = true;
 </script>
-<script src="../../resources/js-test-post.js"></script>
 </body>
 </html>

--- a/LayoutTests/platform/wk2/TestExpectations
+++ b/LayoutTests/platform/wk2/TestExpectations
@@ -139,10 +139,6 @@ editing/pasteboard/drag-files-to-editable-element-as-URLs.html [ Skip ]
 # https://bugs.webkit.org/show_bug.cgi?id=63806
 http/tests/cache/history-only-cached-subresource-loads-max-age-https.html
 
-# Frame::findString does nothing on pages that prevent selection
-# https://bugs.webkit.org/show_bug.cgi?id=40361
-editing/text-iterator/findString-selection-disabled.html
-
 # WebKitTestRunner needs to implement testRunner.closeIdleLocalStorageDatabases().
 # https://bugs.webkit.org/show_bug.cgi?id=103861
 storage/domstorage/localstorage/close-idle-localstorage-databases-immediately.html

--- a/Source/WebKit/WebProcess/WebPage/FindController.cpp
+++ b/Source/WebKit/WebProcess/WebPage/FindController.cpp
@@ -497,7 +497,8 @@ void FindController::didFindString()
 
     CheckedRef selection = selectedFrame->selection();
     selection->revealSelection();
-    revealClosedDetailsAndHiddenUntilFoundAncestors(*protect(selection->selection().start().anchorNode()));
+    if (RefPtr anchorNode = selection->selection().start().anchorNode())
+        revealClosedDetailsAndHiddenUntilFoundAncestors(*anchorNode);
 }
 
 void FindController::didHideFindIndicator()

--- a/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm
@@ -185,7 +185,8 @@ void FindController::didFindString()
     // text, so we reveal the text at the center of the viewport.
     // FIXME: Find a better way to estimate the obscured area (https://webkit.org/b/183889).
     selection->revealSelection({ SelectionRevealMode::RevealUpToMainFrame, ScrollAlignment::alignCenterAlways, WebCore::RevealExtentOption::DoNotRevealExtent });
-    revealClosedDetailsAndHiddenUntilFoundAncestors(*protect(selection->selection().start().anchorNode()));
+    if (RefPtr anchorNode = selection->selection().start().anchorNode())
+        revealClosedDetailsAndHiddenUntilFoundAncestors(*anchorNode);
 }
 
 void FindController::didFailToFindString()


### PR DESCRIPTION
#### 487f2fe9339813961cbaba40b45bf1cf308ae3db
<pre>
Fix findString-selection-disabled.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=307998">https://bugs.webkit.org/show_bug.cgi?id=307998</a>
<a href="https://rdar.apple.com/170493000">rdar://170493000</a>

Reviewed by Aditya Keerthi.

findString-selection-disabled.html was expecting testRunner.findString
to return a bool, but it returns a promise. I changed the expected return
typed and updated the test to use the test harness.

* LayoutTests/editing/text-iterator/findString-selection-disabled-expected.txt:
* LayoutTests/editing/text-iterator/findString-selection-disabled.html:
* LayoutTests/platform/wk2/TestExpectations:
* Source/WebKit/WebProcess/WebPage/FindController.cpp:
(WebKit::FindController::didFindString):
* Source/WebKit/WebProcess/WebPage/ios/FindControllerIOS.mm:
(WebKit::FindController::didFindString):

Canonical link: <a href="https://commits.webkit.org/307699@main">https://commits.webkit.org/307699@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/04fb1cd2ec9db8ceaad28f6e1387218e915af743

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17844 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9619 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153835 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98799 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44ecaae6-b5f7-499c-8371-4e8454f25177) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18327 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dca9d591-6b2f-46de-8357-2f42e80210d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148126 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13984 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130382 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92514 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13344 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11101 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1280 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156147 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17695 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8228 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119624 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17741 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14763 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119958 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30775 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15729 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128398 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73359 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17316 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6656 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17053 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17261 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17116 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->