### PR TITLE
Introduce TextShapingResult as result for layout*Text functions

### DIFF
--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -2877,14 +2877,14 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     auto& fontCascade = this->fontProxy()->fontCascade();
     auto& fontMetrics = fontProxy()->metricsOfPrimaryFont();
 
-    const CachedShapedText* cachedShapedText = nullptr;
+    const TextShapingResult* cachedShapedText = nullptr;
     if (canUseCachedShapedText(textRun)) {
         RefPtr fonts = fontCascade.fonts();
         ASSERT(fonts);
         cachedShapedText = fonts->getOrCreateCachedShapedText(textRun, fontCascade);
     }
 
-    float fontWidth = (cachedShapedText && cachedShapedText->glyphBuffer) ? cachedShapedText->width : fontCascade.width(textRun);
+    float fontWidth = cachedShapedText ? cachedShapedText->width : fontCascade.width(textRun);
 
     bool useMaxWidth = maxWidth && maxWidth.value() < fontWidth;
     float width = useMaxWidth ? maxWidth.value() : fontWidth;
@@ -2905,8 +2905,8 @@ void CanvasRenderingContext2DBase::drawTextUnchecked(const TextRun& textRun, dou
     auto& fontProxy = *this->fontProxy();
 
     auto drawText = [&](GraphicsContext& context, const FloatPoint& point) {
-        if (cachedShapedText && cachedShapedText->glyphBuffer) {
-            const auto& glyphBuffer = *cachedShapedText->glyphBuffer;
+        if (cachedShapedText) {
+            const auto& glyphBuffer = cachedShapedText->glyphBuffer;
             if (!glyphBuffer.isEmpty()) {
                 FloatPoint startPoint = point + WebCore::size(glyphBuffer.initialAdvance());
                 fontCascade.drawGlyphBuffer(context, glyphBuffer, startPoint, FontCascade::CustomFontNotReadyAction::UseFallbackIfFontNotReady);

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -81,6 +81,13 @@ public:
     void operator()(TextLayout*) const;
 };
 
+struct TextShapingResult {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(TextShapingResult);
+public:
+    float width { 0.f };
+    GlyphBuffer glyphBuffer;
+};
+
 class FontCascade final : public CanMakeWeakPtr<FontCascade>, public CanMakeCheckedPtr<FontCascade, WTF::DefaultedOperatorEqual::No, WTF::CheckedPtrDeleteCheckException::Yes> {
     WTF_MAKE_TZONE_ALLOCATED(FontCascade);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FontCascade);
@@ -206,12 +213,12 @@ public:
 
     unsigned generation() const { return m_generation; }
 
-    GlyphBuffer layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasis = ForTextEmphasis::No, float* outWidth = nullptr) const;
+    TextShapingResult layoutText(CodePath, const TextRun&, unsigned from, unsigned to, ForTextEmphasis = ForTextEmphasis::No) const;
     void drawGlyphBuffer(GraphicsContext&, const GlyphBuffer&, FloatPoint&, CustomFontNotReadyAction) const;
 
 private:
 
-    GlyphBuffer layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasis = ForTextEmphasis::No, float* outWidth = nullptr) const;
+    TextShapingResult layoutSimpleText(const TextRun&, unsigned from, unsigned to, ForTextEmphasis = ForTextEmphasis::No) const;
     void drawEmphasisMarks(GraphicsContext&, const GlyphBuffer&, const AtomString&, const FloatPoint&) const;
     int offsetForPositionForSimpleText(const TextRun&, float position, bool includePartialGlyphs) const;
     void adjustSelectionRectForSimpleText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
@@ -226,7 +233,7 @@ private:
     static constexpr bool canReturnFallbackFontsForComplexText();
     static constexpr bool canExpandAroundIdeographsInComplexText();
 
-    GlyphBuffer layoutComplexText(const TextRun&, unsigned from, unsigned to, ForTextEmphasis = ForTextEmphasis::No, float* outWidth = nullptr) const;
+    TextShapingResult layoutComplexText(const TextRun&, unsigned from, unsigned to, ForTextEmphasis = ForTextEmphasis::No) const;
     int offsetForPositionForComplexText(const TextRun&, float position, bool includePartialGlyphs) const;
     void adjustSelectionRectForComplexText(const TextRun&, LayoutRect& selectionRect, unsigned from, unsigned to) const;
 


### PR DESCRIPTION
#### e1708f08916433fc8060af1c4bfacdebc23c4cdf
<pre>
Introduce TextShapingResult as result for layout*Text functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308000">https://bugs.webkit.org/show_bug.cgi?id=308000</a>
<a href="https://rdar.apple.com/170493502">rdar://170493502</a>

Reviewed by Elika Etemad.

Refactor layoutText and related functions to return TextShapingResult
instead of using out-parameter. This is a better pattern now that
layoutText result is not only a glyph buffer. With that, we can also
align the returned type with what&apos;s stored in the CachedShapedText,
avoiding an intermediary wrapper.

* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::CanvasRenderingContext2DBase::drawTextUnchecked):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::layoutText const):
(WebCore::FontCascade::drawText const):
(WebCore::FontCascade::drawEmphasisMarks const):
(WebCore::FontCascade::displayListForTextRun const):
(WebCore::FontCascade::layoutSimpleText const):
(WebCore::FontCascade::layoutComplexText const):
(WebCore::FontCascade::lineSegmentsForIntersectionsWithRect const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontCascadeFonts.cpp:
(WebCore::FontCascadeFonts::getOrCreateCachedShapedText):
* Source/WebCore/platform/graphics/FontCascadeFonts.h:

Canonical link: <a href="https://commits.webkit.org/307707@main">https://commits.webkit.org/307707@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8766f09aed17918ef0f85c330ff6944794b9828

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145171 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17852 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98807 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2105df8-55eb-4c0f-8ed6-b4e22d3e36a1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111624 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80010 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0cd5d1c0-ac11-4996-8474-af5aab7aeb0b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148134 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13987 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130389 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92522 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dec06180-b093-47a7-98e4-6d23e3cceb4e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11109 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1288 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122870 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7147 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156155 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17703 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8235 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119630 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17749 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14772 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119964 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30778 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15737 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128405 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73367 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17324 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6663 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17061 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81103 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17124 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->