### PR TITLE
Fix sources-fallback-codecs.html

### DIFF
--- a/LayoutTests/media/sources-fallback-codecs.html
+++ b/LayoutTests/media/sources-fallback-codecs.html
@@ -63,21 +63,21 @@
 
         <video id='v1' controls oncanplaythrough='onCanPlayThrough()' onerror='onError(event)'>
             <source onerror='onError(event)' type="video/mp4" src="content/test.mp4"/>
-            <source onerror='onError(event)' type="video/ogg" src="content/test.ogv"/>
+            <source onerror='onError(event)' type="image/png" src="content/abe.png"/>
         </video>
 
         <video id='v2' controls oncanplaythrough='onCanPlayThrough()' onerror='onError(event)'>
-            <source onerror='onError(event)' type="video/ogg" src="content/test.ogv"/>
+            <source onerror='onError(event)' type="image/png" src="content/abe.png"/>
             <source onerror='onError(event)' type="video/mp4" src="content/test.mp4"/>
         </video>
 
         <audio id='a1' controls oncanplaythrough='onCanPlayThrough()' onerror='onError(event)'>
             <source onerror='onError(event)' type="audio/wav" src="content/test.wav"/>
-            <source onerror='onError(event)' type="audio/ogg" src="content/test.oga"/>
+            <source onerror='onError(event)' type="image/png" src="content/abe.png"/>
         </audio>
 
         <audio id='a2' controls oncanplaythrough='onCanPlayThrough()' onerror='onError(event)'>
-            <source onerror='onError(event)' type="audio/ogg" src="content/test.oga"/>
+            <source onerror='onError(event)' type="image/png" src="content/abe.png"/>
             <source onerror='onError(event)' type="audio/wav" src="content/test.wav"/>
         </audio>
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -7970,9 +7970,6 @@ imported/w3c/web-platform-tests/css/CSS2/stacking-context/composite-change-after
 
 webkit.org/b/288518 fast/text/emoji-num-glyphs.html [ Failure ]
 
-# rdar://148254605 (REGRESSION (iOS 18.4): media/sources-fallback-codecs.html is constantly failing.)
-media/sources-fallback-codecs.html [ Failure ]
-
 webkit.org/b/294142 fast/canvas/webgl/gl-teximage.html [ Failure ]
 
 webkit.org/b/294152 http/tests/misc/timer-vs-loading.html [ Timeout ]


### PR DESCRIPTION
#### a927dcb53a6d556a75a63e57389fef80094ae5d5
<pre>
Fix sources-fallback-codecs.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=308003">https://bugs.webkit.org/show_bug.cgi?id=308003</a>
<a href="https://rdar.apple.com/148254605">rdar://148254605</a>

Reviewed by Jean-Yves Avenard.

media/sources-fallback-codecs.html was constantly failing. The test assumed that .oga files
were not supported, but support was added recently, so the test fails.

I fixed this by changing the source tag from a .oga to a .png, which will never be playable
in an audio tag.

The test also assumes that .ogv files are not supported. This works fine, but I changed the source
tags to .png there as well, so the test will continue to work if .ogv files are supported in the
future.

* LayoutTests/media/sources-fallback-codecs.html:
* LayoutTests/platform/ios/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/307678@main">https://commits.webkit.org/307678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8f00642abf950986525e1eb1edce232d1d99849

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145078 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17759 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98714 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5618ff1-9006-46db-a99e-26d23054e1ad) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18242 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111553 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/79974 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0766af71-9bc7-4f33-8310-c2cec0dba791) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148041 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130310 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b996f4fe-0d8b-449c-b749-69af8049c8af) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13283 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11046 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1194 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122803 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7062 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156061 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17610 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8150 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17656 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14698 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119888 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30763 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15679 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128320 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73274 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17231 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6584 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16967 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17176 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17031 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->