### PR TITLE
harmonize codepath for Image transcoding for input and drag/drop

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp
@@ -67,8 +67,14 @@ static String transcodeImage(const String& path, const String& destinationUTI, c
 
     // It is important to add the appropriate file extension to the temporary file path.
     // The File object depends solely on the extension to know the MIME type of the file.
+    // Extract the original filename (without extension) to preserve it in the transcoded file.
+    auto originalFilename = FileSystem::pathFileName(path);
+    auto dotPosition = originalFilename.reverseFind('.');
+    auto baseName = (dotPosition != notFound) ? originalFilename.left(dotPosition) : originalFilename;
+    if (baseName.isEmpty())
+        baseName = "image"_s;
     auto suffix = makeString('.', destinationExtension);
-    auto [destinationPath, destinationFileHandle] = FileSystem::openTemporaryFile("tempImage"_s, suffix);
+    auto [destinationPath, destinationFileHandle] = FileSystem::openTemporaryFile(baseName, suffix);
     if (!destinationFileHandle) {
         RELEASE_LOG_ERROR(Images, "transcodeImage: Destination image could not be created: %s %s\n", path.utf8().data(), destinationUTI.utf8().data());
         return nullString();


### PR DESCRIPTION
#### 60bd2f4eece7ae20392044a2dd65b13709c3bb38
<pre>
harmonize codepath for Image transcoding for input and drag/drop
<a href="https://bugs.webkit.org/show_bug.cgi?id=292350">https://bugs.webkit.org/show_bug.cgi?id=292350</a>
<a href="https://rdar.apple.com/150401192">rdar://150401192</a>

Reviewed by Wenson Hsieh.

When users drag HEIC/F images onto custom drop zones (divs with ondrop handlers),
websites received raw HEIC/F files they couldn&apos;t process.
This patch adds automatic HEIC/HEIF to JPEG transcoding in
WebPasteboardProxyCocoa.mm for macOS (getPasteboardPathnamesForType)
and iOS (allPasteboardItemInfo, informationForItemAtIndex).
The transcoding runs asynchronously on a shared background queue to avoid
blocking the UI, then notifies NetworkProcess to grant file access for the
transcoded images. ImageUtilitiesCG.cpp was also updated to preserve original
filenames during transcoding (IMG_0229.HEIC → IMG_0229.jpg).

* Source/WebCore/platform/graphics/cg/ImageUtilitiesCG.cpp:
(WebCore::transcodeImage):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::getPasteboardPathnamesForType):
(WebKit::findHEICPathsForTranscoding):
(WebKit::WebPasteboardProxy::allPasteboardItemInfo):
(WebKit::WebPasteboardProxy::informationForItemAtIndex):

Canonical link: <a href="https://commits.webkit.org/307797@main">https://commits.webkit.org/307797@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/446124a9989e5cc202d8bb791941c8b6dd7f6036

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18184 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10020 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154174 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99139 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147377 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18669 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18077 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111899 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148465 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130716 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92800 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13597 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11360 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1621 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123138 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7490 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156486 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18034 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8601 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119904 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15060 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120245 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30831 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15996 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128771 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73763 "The change is no longer eligible for processing.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17655 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6973 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17392 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81435 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17600 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17455 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->