### PR TITLE
Remove advanced privacy protection condition for blockable requests

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -347,7 +347,6 @@ bool NetworkLoadChecker::shouldBlockForTrackingPolicy(const ResourceRequest& req
     if (!m_webPageProxyID)
         return false;
 
-    bool needsAdvancedPrivacyProtections = false;
     bool mayBlock = false;
     if (RefPtr networkResourceLoader = m_networkResourceLoader.get()) {
         mayBlock = networkResourceLoader->parameters().mayBlockNetworkRequest;
@@ -355,11 +354,9 @@ bool NetworkLoadChecker::shouldBlockForTrackingPolicy(const ResourceRequest& req
             LOAD_CHECKER_RELEASE_LOG("shouldBlockForTrackingPolicy - Blocked non-script load by tracking protections");
             return true;
         }
-
-        needsAdvancedPrivacyProtections = networkResourceLoader->parameters().advancedPrivacyProtections.contains(WebCore::AdvancedPrivacyProtections::BaselineProtections);
     }
     if (CheckedPtr networkSession = m_networkProcess->networkSession(m_sessionID)) {
-        if (networkSession->shouldBlockRequestForTrackingPolicyAndUpdatePolicy(request, *m_webPageProxyID, mayBlock, needsAdvancedPrivacyProtections)) {
+        if (networkSession->shouldBlockRequestForTrackingPolicyAndUpdatePolicy(request, *m_webPageProxyID, mayBlock)) {
             LOAD_CHECKER_RELEASE_LOG("shouldBlockForTrackingPolicy - Blocked by tracking protections");
             return true;
         }

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -317,10 +317,10 @@ bool NetworkSession::isTrackingPreventionEnabled() const
     return !!m_resourceLoadStatistics;
 }
 
-bool NetworkSession::isRequestBlockable(const WebCore::ResourceRequest& request, bool needsAdvancedPrivacyProtections)
+bool NetworkSession::isRequestBlockable(const WebCore::ResourceRequest& request)
 {
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    return WebKit::isRequestBlockable(request, needsAdvancedPrivacyProtections);
+    return WebKit::isRequestBlockable(request);
 #else
     return false;
 #endif
@@ -342,9 +342,9 @@ IsKnownCrossSiteTracker NetworkSession::isResourceFromKnownCrossSiteTracker(cons
     return isRequestToKnownCrossSiteTracker(request);
 }
 
-bool NetworkSession::shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const WebCore::ResourceRequest& request, WebPageProxyIdentifier webPageID, bool mayBlockScriptLoad, bool needsAdvancedPrivacyProtections)
+bool NetworkSession::shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const WebCore::ResourceRequest& request, WebPageProxyIdentifier webPageID, bool mayBlockScriptLoad)
 {
-    if (!mayBlockScriptLoad && !isRequestBlockable(request, needsAdvancedPrivacyProtections))
+    if (!mayBlockScriptLoad && !isRequestBlockable(request))
         return false;
     auto it = m_trackerBlockingPolicyByPageIdentifier.find(webPageID);
     if (it == m_trackerBlockingPolicyByPageIdentifier.end())

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -144,8 +144,8 @@ public:
     bool isTrackingPreventionEnabled() const;
     static WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore::ResourceRequest&);
     static WebCore::IsKnownCrossSiteTracker isResourceFromKnownCrossSiteTracker(const URL& firstParty, const URL& resource);
-    static bool isRequestBlockable(const WebCore::ResourceRequest&, bool needsAdvancedPrivacyProtections);
-    bool shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const WebCore::ResourceRequest&, WebPageProxyIdentifier, bool mayBlockScriptLoad, bool needsAdvancedPrivacyProtections);
+    static bool isRequestBlockable(const WebCore::ResourceRequest&);
+    bool shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const WebCore::ResourceRequest&, WebPageProxyIdentifier, bool mayBlockScriptLoad);
     void deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
     void registrableDomainsWithWebsiteData(OptionSet<WebsiteDataType>, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
     bool enableResourceLoadStatisticsLogTestingEvent() const { return m_enableResourceLoadStatisticsLogTestingEvent; }

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -63,7 +63,7 @@ enum class RestrictedOpenerType : uint8_t;
 void configureForAdvancedPrivacyProtections(NSURLSession *);
 bool isKnownTrackerAddressOrDomain(StringView host);
 WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore::ResourceRequest&);
-bool isRequestBlockable(const WebCore::ResourceRequest&, bool);
+bool isRequestBlockable(const WebCore::ResourceRequest&);
 bool isTaintedScriptURLBlockable(const URL&);
 void requestLinkDecorationFilteringData(CompletionHandler<void(Vector<WebCore::LinkDecorationFilteringData>&&)>&&);
 

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -764,7 +764,7 @@ WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore:
     return request.isThirdParty() && isKnownTrackerAddressOrDomain(request.url().host()) ? WebCore::IsKnownCrossSiteTracker::Yes : WebCore::IsKnownCrossSiteTracker::No;
 }
 
-bool isRequestBlockable(const WebCore::ResourceRequest& request, bool needsAdvancedPrivacyProtections)
+bool isRequestBlockable(const WebCore::ResourceRequest& request)
 {
     TrackerAddressLookupInfo::populateIfNeeded();
     TrackerDomainLookupInfo::populateIfNeeded();
@@ -774,9 +774,7 @@ bool isRequestBlockable(const WebCore::ResourceRequest& request, bool needsAdvan
         return true;
 
     if (auto info = TrackerDomainLookupInfo::find(domain.string()); info.owner().length()) {
-        if (info.canBlock() == TrackerDomainLookupInfo::CanBlock::No)
-            return false;
-        return needsAdvancedPrivacyProtections || info.canBlock() == TrackerDomainLookupInfo::CanBlock::WithDefaultProtections;
+        return info.canBlock() == TrackerDomainLookupInfo::CanBlock::WithDefaultProtections;
     }
     return false;
 }
@@ -790,7 +788,7 @@ bool isTaintedScriptURLBlockable(const URL& url)
 void configureForAdvancedPrivacyProtections(NSURLSession *) { }
 bool isKnownTrackerAddressOrDomain(StringView) { return false; }
 WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore::ResourceRequest&) { return WebCore::IsKnownCrossSiteTracker::No; }
-bool isRequestBlockable(const WebCore::ResourceRequest&, bool) { return false; }
+bool isRequestBlockable(const WebCore::ResourceRequest&) { return false; }
 bool isTaintedScriptURLBlockable(const URL&) { return false; }
 
 #endif

--- a/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp
+++ b/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp
@@ -119,6 +119,9 @@ bool ScriptTrackingPrivacyFilter::shouldBlockRequest(const URL& url, const WebCo
 #endif
 
     auto categoryFlag = WebCore::scriptCategoryAsFlag(ScriptTrackingPrivacyCategory::NetworkRequests);
+    if (!m_categoriesWithAllowedHosts.contains(categoryFlag))
+        return true;
+
     auto result = lookup(url, topOrigin);
     return result.foundMatch && !result.allowedCategories.contains(categoryFlag);
 }


### PR DESCRIPTION
#### 7345301751fee6b570c512f68fcc2efe145312c7
<pre>
Remove advanced privacy protection condition for blockable requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=308008">https://bugs.webkit.org/show_bug.cgi?id=308008</a>
<a href="https://rdar.apple.com/170489913">rdar://170489913</a>

Reviewed by Charlie Wolfe.

Currently, requests are blockable if we have advanced privacy protections
enabled, or if a particular domain is annotated as being blockable with default
privacy protections. This change relaxes the first condition, so we only block
requests if that is web compatible.

This patch also adds an early return when none of the NetworkRequest category
is never allowed.

Covered by existing tests.

* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::shouldBlockForTrackingPolicy):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::isRequestBlockable):
(WebKit::NetworkSession::shouldBlockRequestForTrackingPolicyAndUpdatePolicy):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::isRequestBlockable):
* Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp:
(WebKit::ScriptTrackingPrivacyFilter::shouldBlockRequest):

Canonical link: <a href="https://commits.webkit.org/307706@main">https://commits.webkit.org/307706@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0c245a7ea310edb8d68331de4beb67f6683c6f2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17790 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98745 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51ffa6e7-f128-494f-a268-84ba7b95e513) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18273 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111577 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/79986 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/498d75a0-87e4-4bd8-b072-e9b9f08c38cd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148072 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13932 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92475 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae3d2295-e58c-4333-b03e-f27f6d5475e5) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11064 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1225 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156093 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17641 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8186 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119583 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14721 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119914 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15699 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128356 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73305 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22401 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17262 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6615 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/16998 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81041 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17207 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17062 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->