### PR TITLE
Improve isTaintedScriptURLBlockable when ADVANCED_PRIVACY_PROTECTIONS and TRACKER_NETWORK_REQUEST_BLOCKING isn't defined

### DIFF
--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -56,6 +56,8 @@ enum class IsKnownCrossSiteTracker : bool;
 
 namespace WebKit {
 
+bool isTaintedScriptURLBlockable(const URL&);
+
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
 
 enum class RestrictedOpenerType : uint8_t;
@@ -64,7 +66,6 @@ void configureForAdvancedPrivacyProtections(NSURLSession *);
 bool isKnownTrackerAddressOrDomain(StringView host);
 WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore::ResourceRequest&);
 bool isRequestBlockable(const WebCore::ResourceRequest&, bool);
-bool isTaintedScriptURLBlockable(const URL&);
 void requestLinkDecorationFilteringData(CompletionHandler<void(Vector<WebCore::LinkDecorationFilteringData>&&)>&&);
 
 class ListDataObserver : public RefCountedAndCanMakeWeakPtr<ListDataObserver> {

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -783,7 +783,8 @@ bool isRequestBlockable(const WebCore::ResourceRequest& request, bool needsAdvan
 
 bool isTaintedScriptURLBlockable(const URL& url)
 {
-    return IS_REQUEST_UNCONDITIONALLY_BLOCKABLE(WebCore::RegistrableDomain { url });
+    WebCore::RegistrableDomain domain { url };
+    return domain == "tainted.example" || IS_REQUEST_UNCONDITIONALLY_BLOCKABLE(domain);
 }
 #else
 
@@ -948,4 +949,8 @@ void ConsistentPrivacyQuirkController::didUpdateCachedListData()
 
 } // namespace WebKit
 
+#else
+namespace WebKit {
+bool isTaintedScriptURLBlockable(const URL&) { return false; }
+}
 #endif // ENABLE(ADVANCED_PRIVACY_PROTECTIONS)

--- a/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp
+++ b/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp
@@ -29,7 +29,7 @@
 #include <WebCore/RegistrableDomain.h>
 #include <WebCore/SecurityOrigin.h>
 
-#if ENABLE(TRACKER_NETWORK_REQUEST_BLOCKING)
+#if PLATFORM(COCOA)
 #include "WebPrivacyHelpers.h"
 #endif
 
@@ -96,7 +96,7 @@ bool ScriptTrackingPrivacyFilter::shouldAllowAccess(const URL& url, const WebCor
     if (url.isEmpty())
         return false;
 
-#if ENABLE(TRACKER_NETWORK_REQUEST_BLOCKING) && ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+#if PLATFORM(COCOA)
     if (category == WebCore::ScriptTrackingPrivacyCategory::NetworkRequests && !isTaintedScriptURLBlockable(url))
         return true;
 #endif
@@ -113,7 +113,7 @@ bool ScriptTrackingPrivacyFilter::shouldBlockRequest(const URL& url, const WebCo
     if (url.isEmpty())
         return true;
 
-#if ENABLE(TRACKER_NETWORK_REQUEST_BLOCKING) && ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+#if PLATFORM(COCOA)
     if (!isTaintedScriptURLBlockable(url))
         return false;
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm
@@ -248,7 +248,7 @@ static constexpr auto simpleIndexHTML = R"markup(
             <script src="test://top-domain.org/script.js"></script>
         </head>
         <body>
-            <script src="test://tainted.net/script.js"></script>
+            <script src="test://tainted.example/script.js"></script>
             <script src="test://pure.com/script.js"></script>
         </body>
     </html>
@@ -279,7 +279,7 @@ static constexpr auto formFieldIndexHTML = R"markup(
             <select name="selectField" id="selectField">
                 <option value="Primary"></option>
             </select>
-            <script src="test://tainted.net/script.js"></script>
+            <script src="test://tainted.example/script.js"></script>
             <script src="test://pure.com/script.js"></script>
         </body>
     </html>
@@ -290,12 +290,12 @@ TEST(ScriptTrackingPrivacyTests, Referrer)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html", @{
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://pure.com/script.js" : @"window.referrerForPureScript = document.referrer;",
-        @"test://tainted.net/script.js" : @"window.referrerForTaintedScript = document.referrer;"
+        @"test://tainted.example/script.js" : @"window.referrerForTaintedScript = document.referrer;"
     });
 
     EXPECT_WK_STREQ("https://webkit.org/", [webView stringByEvaluatingJavaScript:@"window.referrerForPureScript"]);
@@ -307,12 +307,12 @@ TEST(ScriptTrackingPrivacyTests, QueryParameters)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html?uid=Hv9U23Hfco08", @{
         @"test://top-domain.org/index.html?uid=Hv9U23Hfco08" : simpleIndexHTML.createNSString().autorelease(),
         @"test://pure.com/script.js" : @"window.urlForPureScript = document.URL;",
-        @"test://tainted.net/script.js" : @"window.urlForTaintedScript = document.URL;"
+        @"test://tainted.example/script.js" : @"window.urlForTaintedScript = document.URL;"
     });
 
     EXPECT_WK_STREQ("test://top-domain.org/index.html?uid=Hv9U23Hfco08", [webView stringByEvaluatingJavaScript:@"window.urlForPureScript"]);
@@ -324,7 +324,7 @@ TEST(ScriptTrackingPrivacyTests, ConsistentQueryParameters)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    auto simpleConsistentIndexHTML = makeStringByReplacingAll(simpleIndexHTML, "tainted.net"_s, "consistentQueryParameterFiltering.internal"_s);
+    auto simpleConsistentIndexHTML = makeStringByReplacingAll(simpleIndexHTML, "tainted.example"_s, "consistentQueryParameterFiltering.internal"_s);
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html?uid=Hv9U23Hfco08", @{
         @"test://top-domain.org/index.html?uid=Hv9U23Hfco08" : simpleConsistentIndexHTML.createNSString().autorelease(),
@@ -341,7 +341,7 @@ TEST(ScriptTrackingPrivacyTests, Canvas2D)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     NSString *addHashScriptSource = @"fullCanvasHash().then(hash => {"
         "    if (window.hashes)"
@@ -354,7 +354,7 @@ TEST(ScriptTrackingPrivacyTests, Canvas2D)
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://top-domain.org/script.js" : getBundleResourceAsText(@"canvas-fingerprinting", @"js"),
         @"test://pure.com/script.js" : addHashScriptSource,
-        @"test://tainted.net/script.js" : addHashScriptSource,
+        @"test://tainted.example/script.js" : addHashScriptSource,
     });
 
     RetainPtr<NSArray> hashes;
@@ -374,7 +374,7 @@ TEST(ScriptTrackingPrivacyTests, AudioSamples)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     NSString *addHashScriptSource = @"testOscillatorCompressorAnalyzer().then(hash => {"
         "    if (window.hashes)"
@@ -387,7 +387,7 @@ TEST(ScriptTrackingPrivacyTests, AudioSamples)
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://top-domain.org/script.js" : getBundleResourceAsText(@"audio-fingerprinting", @"js"),
         @"test://pure.com/script.js" : addHashScriptSource,
-        @"test://tainted.net/script.js" : addHashScriptSource,
+        @"test://tainted.example/script.js" : addHashScriptSource,
     });
 
     RetainPtr<NSArray> hashes;
@@ -407,7 +407,7 @@ TEST(ScriptTrackingPrivacyTests, ScreenMetrics)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 #if PLATFORM(IOS_FAMILY)
     IPadUserInterfaceSwizzler userInterfaceSwizzler;
 #endif
@@ -426,7 +426,7 @@ TEST(ScriptTrackingPrivacyTests, ScreenMetrics)
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html", uiDelegate.get(), @{
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://pure.com/script.js" : @"window.pureInfo = { screenX, screenY, 'screen.width': screen.width, 'screen.height': screen.height, outerWidth, outerHeight }",
-        @"test://tainted.net/script.js" : @"window.taintedInfo = { screenX, screenY, 'screen.width': screen.width, 'screen.height': screen.height, outerWidth, outerHeight }"
+        @"test://tainted.example/script.js" : @"window.taintedInfo = { screenX, screenY, 'screen.width': screen.width, 'screen.height': screen.height, outerWidth, outerHeight }"
     });
 
     NSDictionary<NSString *, NSNumber *> *pureInfo = [webView objectByEvaluatingJavaScript:@"window.pureInfo"];
@@ -452,7 +452,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptWrittenCookies)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto makeScriptSource = ^(NSString *pureOrTainted) {
         return [NSString stringWithFormat:@"(function () {"
@@ -464,7 +464,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptWrittenCookies)
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(nil, @{
         @"test://pure.com/script.js" : makeScriptSource(@"pure"),
-        @"test://tainted.net/script.js" : makeScriptSource(@"tainted"),
+        @"test://tainted.example/script.js" : makeScriptSource(@"tainted"),
     }, nil, _WKWebsiteNetworkConnectionIntegrityPolicyEnabled);
 
     RetainPtr dataStore = [[webView configuration] websiteDataStore];
@@ -506,7 +506,7 @@ TEST(ScriptTrackingPrivacyTests, LocalStorage)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto makeScriptSource = ^(NSString *pureOrTainted) {
         return [NSString stringWithFormat:@"localStorage.setItem('%@', 'foo'); window.%@Item = localStorage.getItem('%@')", pureOrTainted, pureOrTainted, pureOrTainted];
@@ -514,7 +514,7 @@ TEST(ScriptTrackingPrivacyTests, LocalStorage)
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(nil, @{
         @"test://pure.com/script.js" : makeScriptSource(@"pure"),
-        @"test://tainted.net/script.js" : makeScriptSource(@"tainted"),
+        @"test://tainted.example/script.js" : makeScriptSource(@"tainted"),
     }, nil, _WKWebsiteNetworkConnectionIntegrityPolicyEnabled);
 
     RetainPtr dataStore = [[webView configuration] websiteDataStore];
@@ -533,13 +533,13 @@ TEST(ScriptTrackingPrivacyTests, HardwareConcurrency)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto computeHardwareConcurrency = [] {
         RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html", @{
             @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
             @"test://pure.com/script.js" : @"window.pureValue = navigator.hardwareConcurrency",
-            @"test://tainted.net/script.js" : @"window.taintedValue = navigator.hardwareConcurrency",
+            @"test://tainted.example/script.js" : @"window.taintedValue = navigator.hardwareConcurrency",
         });
 
         return std::pair {
@@ -563,13 +563,13 @@ TEST(ScriptTrackingPrivacyTests, SpeechSynthesisGetVoices)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html", @{
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://top-domain.org/script.js" : @"internals.enableMockSpeechSynthesizer()",
         @"test://pure.com/script.js" : @"window.pureNumberOfVoices = speechSynthesis.getVoices().length",
-        @"test://tainted.net/script.js" : @"window.taintedNumberOfVoices = speechSynthesis.getVoices().length",
+        @"test://tainted.example/script.js" : @"window.taintedNumberOfVoices = speechSynthesis.getVoices().length",
     });
 
     auto pureNumberOfVoices = [[webView objectByEvaluatingJavaScript:@"window.pureNumberOfVoices"] unsignedIntValue];
@@ -584,7 +584,7 @@ TEST(ScriptTrackingPrivacyTests, DirectFormFieldAccess)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     const auto expectedPureValue = [](const auto& field) {
         if (field == "dateField"_s)
@@ -628,7 +628,7 @@ TEST(ScriptTrackingPrivacyTests, DirectFormFieldAccess)
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html", @{
         @"test://top-domain.org/index.html" : formFieldIndexHTML.createNSString().autorelease(),
         @"test://pure.com/script.js" : makeScriptSource(@"pure"),
-        @"test://tainted.net/script.js" : makeScriptSource(@"tainted"),
+        @"test://tainted.example/script.js" : makeScriptSource(@"tainted"),
     }, @"https://webkit.org", _WKWebsiteNetworkConnectionIntegrityPolicyEnabled);
 
     Vector formFields { {
@@ -714,7 +714,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptAccessCategories)
         return;
 
     FingerprintingScriptsRequestSwizzler swizzler {
-        @[ @"tainted.net" ],
+        @[ @"tainted.example" ],
         { WPScriptAccessCategoryFormControls | WPScriptAccessCategoryQueryParameters }
     };
 
@@ -729,7 +729,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptAccessCategories)
         @"test://top-domain.org/index.html" : formFieldIndexHTML.createNSString().autorelease(),
         @"test://top-domain.org/script.js" : @"internals.enableMockSpeechSynthesizer()",
         @"test://pure.com/script.js" : makeTestScript(@"pure"),
-        @"test://tainted.net/script.js" : makeTestScript(@"tainted"),
+        @"test://tainted.example/script.js" : makeTestScript(@"tainted"),
     }, nil, _WKWebsiteNetworkConnectionIntegrityPolicyEnabled);
 
     RetainPtr pureTextFieldValue = [webView stringByEvaluatingJavaScript:@"window.pureTextFieldValue"];
@@ -751,7 +751,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptAccessCategoriesAppendTaintedInlineScript
         return;
 
     FingerprintingScriptsRequestSwizzler swizzler {
-        @[ @"tainted.net" ],
+        @[ @"tainted.example" ],
         { WPScriptAccessCategoryFormControls | WPScriptAccessCategoryQueryParameters }
     };
 
@@ -761,7 +761,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptAccessCategoriesAppendTaintedInlineScript
             <head><script src="test://top-domain.org/script.js"></script></head>
             <body>
                 <input type="text" id="textField" value="textFieldValue">
-                <script src="test://tainted.net/script.js"></script>
+                <script src="test://tainted.example/script.js"></script>
             </body>
         </html>
     )markup"_s;
@@ -775,7 +775,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptAccessCategoriesAppendTaintedInlineScript
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html", @{
         @"test://top-domain.org/index.html" : testHTML.createNSString().autorelease(),
         @"test://top-domain.org/script.js" : @"internals.enableMockSpeechSynthesizer()",
-        @"test://tainted.net/script.js" : taintedAppendScript,
+        @"test://tainted.example/script.js" : taintedAppendScript,
     }, nil, _WKWebsiteNetworkConnectionIntegrityPolicyEnabled);
 
     EXPECT_EQ([[webView objectByEvaluatingJavaScript:@"window.appendedNumberOfVoices"] intValue], 0);
@@ -788,7 +788,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptAccessCategoriesWithTimeout)
         return;
 
     FingerprintingScriptsRequestSwizzler swizzler {
-        @[ @"tainted.net" ],
+        @[ @"tainted.example" ],
         { WPScriptAccessCategoryFormControls | WPScriptAccessCategoryQueryParameters }
     };
 
@@ -798,7 +798,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptAccessCategoriesWithTimeout)
             <head><script src="test://top-domain.org/script.js"></script></head>
             <body>
                 <input type="text" id="textField" value="textFieldValue">
-                <script src="test://tainted.net/script.js"></script>
+                <script src="test://tainted.example/script.js"></script>
             </body>
         </html>
     )markup"_s;
@@ -813,7 +813,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptAccessCategoriesWithTimeout)
     RetainPtr webView = setUpWebViewForFingerprintingTests(@"test://top-domain.org/index.html", @{
         @"test://top-domain.org/index.html" : testHTML.createNSString().autorelease(),
         @"test://top-domain.org/script.js" : @"internals.enableMockSpeechSynthesizer()",
-        @"test://tainted.net/script.js" : taintedTimeoutScript,
+        @"test://tainted.example/script.js" : taintedTimeoutScript,
     }, nil, _WKWebsiteNetworkConnectionIntegrityPolicyEnabled);
 
     Util::waitForConditionWithLogging([&] -> bool {
@@ -829,7 +829,7 @@ TEST(ScriptTrackingPrivacyTests, FetchBlocked)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto makeFetchScript = ^(NSString *pureOrTainted) {
         return [NSString stringWithFormat:@"(async function() {"
@@ -847,7 +847,7 @@ TEST(ScriptTrackingPrivacyTests, FetchBlocked)
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://top-domain.org/data.json" : @"{\"value\": 42}",
         @"test://pure.com/script.js" : makeFetchScript(@"pure"),
-        @"test://tainted.net/script.js" : makeFetchScript(@"tainted"),
+        @"test://tainted.example/script.js" : makeFetchScript(@"tainted"),
     });
 
     Util::waitForConditionWithLogging([&] -> bool {
@@ -867,7 +867,7 @@ TEST(ScriptTrackingPrivacyTests, XHRBlocked)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto makeXHRScript = ^(NSString *pureOrTainted) {
         return [NSString stringWithFormat:@"(function() {"
@@ -891,7 +891,7 @@ TEST(ScriptTrackingPrivacyTests, XHRBlocked)
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://top-domain.org/data.json" : @"{\"value\": 42}",
         @"test://pure.com/script.js" : makeXHRScript(@"pure"),
-        @"test://tainted.net/script.js" : makeXHRScript(@"tainted"),
+        @"test://tainted.example/script.js" : makeXHRScript(@"tainted"),
     });
 
     Util::waitForConditionWithLogging([&] -> bool {
@@ -911,7 +911,7 @@ TEST(ScriptTrackingPrivacyTests, SyncXHRBlocked)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto makeSyncXHRScript = ^(NSString *pureOrTainted) {
         return [NSString stringWithFormat:@"(function() {"
@@ -930,7 +930,7 @@ TEST(ScriptTrackingPrivacyTests, SyncXHRBlocked)
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://top-domain.org/data.json" : @"{\"value\": 42}",
         @"test://pure.com/script.js" : makeSyncXHRScript(@"pure"),
-        @"test://tainted.net/script.js" : makeSyncXHRScript(@"tainted"),
+        @"test://tainted.example/script.js" : makeSyncXHRScript(@"tainted"),
     });
 
     RetainPtr pureSyncXHRResult = [webView stringByEvaluatingJavaScript:@"window.pureSyncXHRResult"];
@@ -945,7 +945,7 @@ TEST(ScriptTrackingPrivacyTests, ImgElementLoadBlocked)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto makeImgElement = ^(NSString *pureOrTainted) {
         return [NSString stringWithFormat:@"(function() {"
@@ -960,7 +960,7 @@ TEST(ScriptTrackingPrivacyTests, ImgElementLoadBlocked)
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://top-domain.org/test.jpg" : getBundleResourceAsEncodedString(@"test", @"jpg"),
         @"test://pure.com/script.js" : makeImgElement(@"pure"),
-        @"test://tainted.net/script.js" : makeImgElement(@"tainted"),
+        @"test://tainted.example/script.js" : makeImgElement(@"tainted"),
     });
 
     TestWebKitAPI::Util::spinRunLoop(100);
@@ -977,7 +977,7 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequentFetch)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto server = HTTPServer(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
@@ -989,7 +989,7 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequentFetch)
                 String script = makeStringByReplacingAll(
                     "async function doFetch() {"
                     "  try {"
-                    "    const response = await fetch('http://tainted.net/data.json', { 'mode': 'no-cors' });"
+                    "    const response = await fetch('http://tainted.example/data.json', { 'mode': 'no-cors' });"
                     "    const data = await response.text();"
                     "    window.%@FetchResult = 'success: ' + data;"
                     "  } catch (e) {"
@@ -1048,7 +1048,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptElementLoadBlocked)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto makeScriptElement = ^(NSString *pureOrTainted) {
         return [NSString stringWithFormat:@"(function() {"
@@ -1064,7 +1064,7 @@ TEST(ScriptTrackingPrivacyTests, ScriptElementLoadBlocked)
         @"test://top-domain.org/index.html" : simpleIndexHTML.createNSString().autorelease(),
         @"test://top-domain.org/script2.js" : @"",
         @"test://pure.com/script.js" : makeScriptElement(@"pure"),
-        @"test://tainted.net/script.js" : makeScriptElement(@"tainted"),
+        @"test://tainted.example/script.js" : makeScriptElement(@"tainted"),
     });
 
     TestWebKitAPI::Util::spinRunLoop(100);
@@ -1081,7 +1081,7 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequentElement)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto server = HTTPServer(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
@@ -1098,7 +1098,7 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequentElement)
                     "  let script = document.createElement(\"script\");"
                     "  script.onload = () => { window.%%LoadResult = 'success'; };"
                     "  script.onerror = () => { window.%%LoadResult = 'error'; };"
-                    "  script.src = \"http://tainted.net/script2.js\";"
+                    "  script.src = \"http://tainted.example/script2.js\";"
                     "  document.body.appendChild(script);"
                     "}"
                     "(function() {"
@@ -1153,7 +1153,7 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequent2Element)
     if (!supportsFingerprintingScriptRequests())
         return;
 
-    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.net" ] };
+    FingerprintingScriptsRequestSwizzler swizzler { @[ @"tainted.example" ] };
 
     auto server = HTTPServer(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
         while (1) {
@@ -1170,7 +1170,7 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequent2Element)
                     "  let script1 = document.createElement(\"script\");"
                     "  script1.onload = () => { window.%%LoadResult1 = 'success'; };"
                     "  script1.onerror = () => { window.%%LoadResult1 = 'error'; };"
-                    "  script1.src = \"http://tainted.net/script2.js\";"
+                    "  script1.src = \"http://tainted.example/script2.js\";"
                     "  document.body.appendChild(script1);"
                     "  let script2 = document.createElement(\"script\");"
                     "  script2.onload = () => { window.%%LoadResult2 = 'success'; };"


### PR DESCRIPTION
#### d0bd5b24d0d4cb28c69784f4b7789ae885e997d0
<pre>
Improve isTaintedScriptURLBlockable when ADVANCED_PRIVACY_PROTECTIONS and TRACKER_NETWORK_REQUEST_BLOCKING isn&apos;t defined
<a href="https://bugs.webkit.org/show_bug.cgi?id=308012">https://bugs.webkit.org/show_bug.cgi?id=308012</a>
<a href="https://rdar.apple.com/170510641">rdar://170510641</a>

Reviewed by Pascoe.

This patch provides a default implementation of
WebKit::isTaintedScriptURLBlockable when ADVANCED_PRIVACY_PROTECTIONS isn&apos;t
defined, and checked against a testing domain when
TRACKER_NETWORK_REQUEST_BLOCKING isn&apos;t defined. This implementation uses
tainted.example because it is not a registrable domain (therefore safe to use
in production). As such, I am changing all of the API tests to use
tainted.example instead of tainted.net.

* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::isTaintedScriptURLBlockable):
* Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp:
(WebKit::ScriptTrackingPrivacyFilter::shouldAllowAccess):
(WebKit::ScriptTrackingPrivacyFilter::shouldBlockRequest):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm:
(TestWebKitAPI::(ScriptTrackingPrivacyTests, Referrer)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, QueryParameters)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ConsistentQueryParameters)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, Canvas2D)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, AudioSamples)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ScreenMetrics)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ScriptWrittenCookies)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, LocalStorage)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, HardwareConcurrency)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, SpeechSynthesisGetVoices)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, DirectFormFieldAccess)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ScriptAccessCategories)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ScriptAccessCategoriesAppendTaintedInlineScript)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ScriptAccessCategoriesWithTimeout)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, FetchBlocked)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, XHRBlocked)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, SyncXHRBlocked)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ImgElementLoadBlocked)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, BlockSubsequentFetch)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, ScriptElementLoadBlocked)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, BlockSubsequentElement)):
(TestWebKitAPI::(ScriptTrackingPrivacyTests, BlockSubsequent2Element)):

Canonical link: <a href="https://commits.webkit.org/307771@main">https://commits.webkit.org/307771@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d078a1a0d572c37d9db8d3949cd58ad73dac895

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145441 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18123 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9944 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99078 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a04bb117-f901-4b7e-a0bd-fe08b7aa6254) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18607 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18016 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111850 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f3fb186e-b62e-470d-9887-0b9ac65c2230) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148404 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14217 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92751 "Found 1 new API test failure: WPE/TestMultiprocess:/webkit/WebKitWebView/multiprocess-create-ready-close (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aab814e7-1004-44c5-b36c-2393aef7728b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13553 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11315 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1559 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123089 "Passed tests") | [⏳ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156425 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8530 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119856 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15006 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120196 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30814 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15951 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128698 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73692 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17594 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17331 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81373 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17539 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->