### PR TITLE
pgo-profile should be able to decompress profiles

### DIFF
--- a/Tools/Scripts/pgo-profile
+++ b/Tools/Scripts/pgo-profile
@@ -131,6 +131,14 @@ def compress_parser(subparsers, parent_parser):
     parser.set_defaults(func=compress)
     return parser
 
+def decompress_parser(subparsers, parent_parser):
+    parser = subparsers.add_parser('decompress', parents=[parent_parser],
+                                   help='Decompress *.profdata files so that they can be checked in.')
+    parser.add_argument('--input', help='Path to the directory containing the input *.profdata.compressed files.')
+    parser.add_argument('--output', help='Path to the directory where the output will be placed.')
+    parser.set_defaults(func=decompress)
+    return parser
+
 
 def compress(args):
     out = assert_directory(args.output)
@@ -147,6 +155,21 @@ def compress(args):
         compress_process.check_returncode()
         logger.info(f'{lib} is successfully compressed')
 
+def decompress(args):
+    out = assert_directory(args.output)
+    input_directory = assert_directory(args.input)
+
+    for lib in PROFILED_DYLIBS:
+        logger.info(f'Decompressing {lib}')
+        input_file = os.path.join(input_directory, f'{lib}.profdata.compressed')
+        output_file = os.path.join(out, f'{lib}.profdata')
+
+        compress_process = LLVMProfileData.decompress(input_file, output_file)
+        logger.info(f'stdout: {compress_process.stdout}')
+        logger.info(f'stderr: {compress_process.stderr}')
+        compress_process.check_returncode()
+        logger.info(f'{lib} is successfully compressed')
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(prog='pgo-profile')
@@ -157,6 +180,7 @@ if __name__ == '__main__':
     summarize_parser(subparsers, verbose_parser)
     combine_parser(subparsers, verbose_parser)
     compress_parser(subparsers, verbose_parser)
+    decompress_parser(subparsers, verbose_parser)
 
     args = parser.parse_args()
     if args.verbose:

--- a/Tools/Scripts/webkitpy/llvm_profile_utils.py
+++ b/Tools/Scripts/webkitpy/llvm_profile_utils.py
@@ -131,6 +131,12 @@ class LLVMProfileData:
         return subprocess.run(['/usr/bin/compression_tool', '-encode', '-i', input_profile, '-o', output_file,
                                '-a', 'lzfse'], capture_output=True, check=True, text=True)
 
+    @classmethod
+    def decompress(cls, input_profile, output_file):
+        subprocess.run(['/usr/bin/touch', output_file], check=True)
+        return subprocess.run(['/usr/bin/compression_tool', '-decode', '-i', input_profile, '-o', output_file,
+                               '-a', 'lzfse'], capture_output=True, check=True, text=True)
+
 
 def merge_raw_profiles_in_directory_by_prefixes(prefix_list, input_directory, output_directory=None,
                                                 input_suffix='.profraw', output_suffix='.profdata'):


### PR DESCRIPTION
#### 3d1b67e7633f8a8928e51f34445abc9de28a05b5
<pre>
pgo-profile should be able to decompress profiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=308010">https://bugs.webkit.org/show_bug.cgi?id=308010</a>
<a href="https://rdar.apple.com/170509801">rdar://170509801</a>

Reviewed by Jonathan Bedard.

Add a decompress option similar to existing compress option.

* Tools/Scripts/pgo-profile:
(compress_parser):
(decompress_parser):
(compress):
(decompress):
* Tools/Scripts/webkitpy/llvm_profile_utils.py:
(LLVMProfileData.compress):
(LLVMProfileData):
(LLVMProfileData.decompress):

Canonical link: <a href="https://commits.webkit.org/308060@main">https://commits.webkit.org/308060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e1ac22d1934d1b83165d7c164b122bc1ea1ed4d4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145316 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17998 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98953 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5ab7701-0f74-4e83-927e-2b401327e018) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147191 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17891 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111741 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80086 "Exiting early after 60 failures. 15387 tests run. 60 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b37bce92-7486-431d-b901-b5ac69609bf7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14107 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130525 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92642 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc7d1a3d-e0ed-443b-9b08-273dd5b55172) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/144642 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13454 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11214 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1434 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122981 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156300 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119747 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17848 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14896 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120084 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30985 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128547 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73538 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6794 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17469 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17206 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17269 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->