### PR TITLE
[WTF] Refactor StackSwitch to accomodate multiple trampolines

### DIFF
--- a/Source/WTF/wtf/StackSwitch.cpp
+++ b/Source/WTF/wtf/StackSwitch.cpp
@@ -33,69 +33,72 @@
 
 namespace WTF {
 
-// C-linkage wrapper for Thread::entryPointFinishSetup so it can be called from assembly
-extern "C" void threadEntryPointFinishSetupWrapper(void* context);
-extern "C" void threadEntryPointFinishSetupWrapper(void* context)
-{
-    Thread::entryPointFinishSetup(context);
-}
+// C-linkage wrappers for target functions so they can be called from assembly
+#define DEFINE_STACK_SWITCH_WRAPPER(trampolineName, argType, argName, callExpression) \
+    extern "C" void trampolineName##Wrapper(argType argName); \
+    extern "C" void trampolineName##Wrapper(argType argName) \
+    { \
+        callExpression; \
+    }
+
+WTF_FOR_EACH_STACK_SWITCH_TRAMPOLINE(DEFINE_STACK_SWITCH_WRAPPER)
+#undef DEFINE_STACK_SWITCH_WRAPPER
 
 #if CPU(ARM64E)
 
 // Trampoline that switches from the OS-provided stack to a custom sequestered stack.
 // Parameters:
-//   x0 = context pointer (passed as argument to Thread::entryPointFinishSetup)
+//   x0 = context pointer (passed as argument to target function, or 'this' pointer for member functions)
 //   x1 = new stack pointer (top of stack, since stacks grow down)
 //
 // This function:
 // 1. Saves callee-saved registers on the current (OS) stack
 // 2. Switches to the new stack
 // 3. Sets up the rest of its frame (saved sp, lr) on the new stack
-// 4. Calls Thread::entryPointFinishSetup
+// 4. Calls the target function via its wrapper
 // 5. When function returns, restores the OS stack and all saved registers
 // 6. Returns to the original caller
-__asm__(
-    ".text" "\n"
-    ".balign 16" "\n"
-    ".globl " SYMBOL_STRING(callThreadEntryPointFinishSetupWithNewStack) "\n"
-    SYMBOL_STRING(callThreadEntryPointFinishSetupWithNewStack) ":" "\n"
+#define DEFINE_STACK_SWITCH_TRAMPOLINE_ARM64E(trampolineName, argType, argName, callExpression) \
+    __asm__( \
+        ".text" "\n" \
+        ".balign 16" "\n" \
+        ".globl " SYMBOL_STRING(trampolineName) "\n" \
+        SYMBOL_STRING(trampolineName) ":" "\n" \
+        \
+        "pacibsp" "\n" \
+        "stp x19, x20, [sp, #-16]!" "\n" \
+        "mov x19, sp" "\n" \
+        \
+        "mov sp, x1" "\n" \
+        "stp x29, x30, [sp, #-16]!" "\n" \
+        "mov x29, sp" "\n" \
+        \
+        "bl " SYMBOL_STRING(trampolineName##Wrapper) "\n" \
+        \
+        "mov sp, x19" "\n" \
+        "ldp x29, x30, [sp], #16" "\n" \
+        "ldp x19, x20, [sp], #16" "\n" \
+        "retab" "\n" \
+        \
+        ".previous" "\n" \
+    );
 
-    // Prologue
-    "pacibsp" "\n"
-    "stp x19, x20, [sp, #-16]!" "\n"
-    // Save away old sp in callee-saved x19
-    "mov x19, sp" "\n"
-
-    // Switch to new stack: x1 contains new stack pointer)
-    "mov sp, x1" "\n"
-    // Create a proper frame on the new stack
-    // This frame chains back to the OS stack frame
-    // of our caller
-    "stp x29, x30, [sp, #-16]!" "\n"
-    "mov x29, sp" "\n"
-
-    // Call Thread::entryPointFinishSetup
-    // x0 contains the context-pointer argument
-    "bl " SYMBOL_STRING(threadEntryPointFinishSetupWrapper) "\n"
-
-    // When function returns, restore OS stack from saved register
-    "mov sp, x19" "\n" // Restore sp for OS-stack from x19
-
-    // Unwind frame and return
-    "ldp x29, x30, [sp], #16" "\n"
-    "ldp x19, x20, [sp], #16" "\n"
-    "retab" "\n"
-
-    ".previous" "\n"
-);
+WTF_FOR_EACH_STACK_SWITCH_TRAMPOLINE(DEFINE_STACK_SWITCH_TRAMPOLINE_ARM64E)
+#undef DEFINE_STACK_SWITCH_TRAMPOLINE_ARM64E
 
 #else // !CPU(ARM64E)
 
 IGNORE_WARNINGS_BEGIN("missing-noreturn")
-extern "C" void callThreadEntryPointFinishSetupWithNewStack(void*, void*)
-{
-    RELEASE_ASSERT_NOT_REACHED();
-}
+
+#define DEFINE_STACK_SWITCH_STUB(trampolineName, argType, argName, callExpression) \
+    extern "C" void trampolineName(argType, void*) \
+    { \
+        RELEASE_ASSERT_NOT_REACHED(); \
+    }
+
+WTF_FOR_EACH_STACK_SWITCH_TRAMPOLINE(DEFINE_STACK_SWITCH_STUB)
+#undef DEFINE_STACK_SWITCH_STUB
+
 IGNORE_WARNINGS_END
 
 #endif // CPU(ARM64E)

--- a/Source/WTF/wtf/StackSwitch.h
+++ b/Source/WTF/wtf/StackSwitch.h
@@ -29,17 +29,30 @@
 #include <wtf/ExportMacros.h>
 #include <wtf/Platform.h>
 
+// List of all stack-switching trampolines.
+// Each trampoline switches from the current stack to a new stack and calls a target function.
+// This is used to "teleport" to a sequestered stack after thread startup or other special contexts.
+//
+// Macro parameters:
+//   trampolineName: Name of the trampoline function (e.g., callThreadEntryPointFinishSetupWithNewStack)
+//   argType: Type of the context argument (e.g., void*, Heap*)
+//   argName: Parameter name for the context argument (e.g., context, heap)
+//   callExpression: Expression to invoke the target function (e.g., Thread::entryPointFinishSetup(context), heap->method())
+//
+// Trampoline signature: void trampolineName(argType argName, void* newStack)
+//   - argName: Context argument passed to the target function (or 'this' pointer for member functions)
+//   - newStack: Pointer to the top of the new stack (stacks grow down)
+//
+// When the function returns, the trampoline restores the original stack and returns to the caller.
+#define WTF_FOR_EACH_STACK_SWITCH_TRAMPOLINE(macro) \
+    macro(callThreadEntryPointFinishSetupWithNewStack, void*, context, Thread::entryPointFinishSetup(context))
+
 extern "C" {
 
-// Switches from the current stack to a new stack and calls Thread::entryPointFinishSetup.
-// This is used to "teleport" to a sequestered stack after thread startup.
-//
-// Parameters:
-//   newStack: Pointer to the top of the new stack (stacks grow down)
-//   context: Pointer passed as the first argument to Thread::entryPointFinishSetup
-//
-// When the function returns, this function restores the original stack
-// and returns to the caller.
-WTF_EXPORT_PRIVATE void callThreadEntryPointFinishSetupWithNewStack(void* context, void* newStack);
+#define DECLARE_STACK_SWITCH_TRAMPOLINE(trampolineName, argType, argName, callExpression) \
+    WTF_EXPORT_PRIVATE void trampolineName(argType argName, void* newStack);
+
+WTF_FOR_EACH_STACK_SWITCH_TRAMPOLINE(DECLARE_STACK_SWITCH_TRAMPOLINE)
+#undef DECLARE_STACK_SWITCH_TRAMPOLINE
 
 }


### PR DESCRIPTION
#### 49ccbc26efdbaab9fb05e5a4c1172842548e5b50
<pre>
[WTF] Refactor StackSwitch to accomodate multiple trampolines
<a href="https://bugs.webkit.org/show_bug.cgi?id=307997">https://bugs.webkit.org/show_bug.cgi?id=307997</a>
<a href="https://rdar.apple.com/170492474">rdar://170492474</a>

Reviewed by NOBODY (OOPS!).

In order to prevent these trampolines from being used as general gadgets
for attackers, we want each to be wired to a specific callee.
However, we don&apos;t want to be copying these around every time we need
to stack-switch inside a given function, esp. given all the assembly.
These macros allow us to more easily abstract over the interface and
make creating new wired trampolines easier.

The reason I have this &quot;callExpression&quot; in there is to allow for e.g.
calling member functions using the parameter, which is something we will
likely need soon.
If we come to need multi-argument trampolines, then we can add support for
that when we get there.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/49ccbc26efdbaab9fb05e5a4c1172842548e5b50

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17810 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9585 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153801 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98765 "Failed to checkout and rebase branch from PR 58822") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e59db1a5-392a-4a63-982e-50d9004f149b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18293 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111587 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/98765 "Failed to checkout and rebase branch from PR 58822") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3ab91975-6e4f-4af9-a438-e25c07e33068) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148092 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13961 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130353 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92485 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a00e2a48-9128-4d99-afeb-593ab1492f81) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13324 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11075 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1245 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122846 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7110 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156113 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5938 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17661 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119595 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17707 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119926 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15703 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73325 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17282 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6627 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176418 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17018 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81061 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45380 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17227 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17082 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->