### PR TITLE
[JSC] Sanitize -0 in DFG arith mod constant folding

### DIFF
--- a/JSTests/stress/int52-arith-mod.js
+++ b/JSTests/stress/int52-arith-mod.js
@@ -516,3 +516,15 @@ for (let i = 0; i < testLoopCount; i++) {
     if (result !== expected)
         throw "FAIL: modAlmostDivisor, got " + result + " expected " + expected;
 }
+
+function negZeroWithInt32Overflow(x) {
+    let sum = x + x;
+    let neg = -sum;
+    return (neg % sum) | 0;
+}
+for (let i = 0; i < testLoopCount; i++) {
+    let result = negZeroWithInt32Overflow(0x7FFFFFFF);
+    let expected = 0;
+    if (result !== expected)
+        throw "FAIL: negZeroWith32Overflow, got " + result + " expected " + expected;
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -391,10 +391,9 @@ bool AbstractInterpreter<AbstractStateType>::handleConstantDivOp(Node* node)
 
                 if (node->child1().useKind() == Int52RepUse) {
                     if (node->hasArithMode()) {
-                        if (!shouldCheckOverflow(node->arithMode())) {
-                            if (std::isnan(doubleResult))
-                                doubleResult = 0;
-                        } else if (!shouldCheckNegativeZero(node->arithMode()))
+                        if (!shouldCheckOverflow(node->arithMode()) && std::isnan(doubleResult))
+                            doubleResult = 0;
+                        else if (!shouldCheckNegativeZero(node->arithMode()))
                             doubleResult += 0; // Sanitizes zero.
                     }
                     if (tryConvertToInt52(doubleResult) != JSValue::notInt52) {


### PR DESCRIPTION
#### 0f41131e73da067be424a306693bc68c309c5a84
<pre>
[JSC] Sanitize -0 in DFG arith mod constant folding
<a href="https://bugs.webkit.org/show_bug.cgi?id=308016">https://bugs.webkit.org/show_bug.cgi?id=308016</a>
<a href="https://rdar.apple.com/170174915">rdar://170174915</a>

Reviewed by Yusuke Suzuki.

Fix a case where we miss sanitizing -0 to +0 when the Arith::Mode of the node
is !shouldCheckNegativeZero().

Test: JSTests/stress/int52-arith-mod.js

* JSTests/stress/int52-arith-mod.js:
(negZeroWithInt32Overflow):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::handleConstantDivOp):

Canonical link: <a href="https://commits.webkit.org/307681@main">https://commits.webkit.org/307681@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4a51c87ff03b548248cf4400c31544aeac5b3a98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145130 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17811 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153802 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40a144d5-4a2f-48fc-aa18-aa9414b46a6d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17703 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111588 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e71e1a0-983d-4998-9f19-e3cb22721382) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148093 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130357 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92486 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40080f2f-d201-421b-b7f2-c1aeb9641c93) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13312 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11077 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1246 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137121 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122833 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156114 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5939 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119597 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17708 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14736 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119928 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30765 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15705 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128372 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17283 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6631 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176419 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17019 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81062 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45381 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17083 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->