### PR TITLE
[AutoFill Debugging] Scroll interaction type should support `text` as an argument

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt
@@ -7,9 +7,14 @@ PASS select.value is "Three"
 PASS selectTextError is ""
 PASS getSelection().toString() is "Subject"
 PASS scrollChildContainerError is ""
-PASS childScroller.scrollTop is 100
+PASS childScrollerScrollTopAfterScrollBy is 100
 PASS scrollPageError is ""
-PASS document.scrollingElement.scrollTop is 100
+PASS pageScrollTopAfterScrollBy is 100
+PASS scrollToRevealInScrollerError is ""
+PASS childScrollerScrollTopAfterScrollToReveal is > 0
+PASS scrollToRevealInPageError is ""
+PASS pageScrollTopAfterScrollToReveal is > 100
+PASS scrollToRevealNotFoundError is "'Nonexistent text' not found inside the target node"
 PASS invalidActionError is "Failed to resolve nodeIdentifier 4294967293"
 PASS clickDisabledError is "Click target is disabled"
 PASS textInputReadonlyError is "Target is readonly"
@@ -27,4 +32,6 @@ Hello world.
 1
 
 Foo bar
+Hidden in scroller
 
+Hidden in page

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html
@@ -41,8 +41,10 @@
     <h1 class="click-count">0</h1>
     <div class="scroller" aria-label="Child scroller">
         <div class="tall">Foo bar</div>
+        <p>Hidden in scroller</p>
     </div>
     <div class="tall"></div>
+    <p>Hidden in page</p>
     <script>
     jsTestIsAsync = true;
 
@@ -86,7 +88,7 @@
             text: "Subject"
         });
 
-        scrollChildContainerError = await UIHelper.performTextExtractionInteraction("scrollby", {
+        scrollChildContainerError = await UIHelper.performTextExtractionInteraction("scroll", {
             nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Child scroller"),
             scrollDelta: {
                 x: 0,
@@ -94,11 +96,43 @@
             }
         });
 
-        scrollPageError = await UIHelper.performTextExtractionInteraction("scrollby", {
+        scrollPageError = await UIHelper.performTextExtractionInteraction("scroll", {
             scrollDelta: {
                 x: 0,
                 y: 100
             }
+        });
+
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        childScrollerScrollTopAfterScrollBy = childScroller.scrollTop;
+        pageScrollTopAfterScrollBy = document.scrollingElement.scrollTop;
+
+        childScroller.scrollTop = 0;
+        document.scrollingElement.scrollTop = 0;
+
+        scrollToRevealInScrollerError = await UIHelper.performTextExtractionInteraction("scroll", {
+            nodeIdentifier: UIHelper.nodeIdentifierFromDebugText(debugText, "Child scroller"),
+            text: "Hidden in scroller"
+        });
+
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        childScrollerScrollTopAfterScrollToReveal = childScroller.scrollTop;
+
+        scrollToRevealInPageError = await UIHelper.performTextExtractionInteraction("scroll", {
+            text: "Hidden in page"
+        });
+
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        pageScrollTopAfterScrollToReveal = document.scrollingElement.scrollTop;
+
+        scrollToRevealNotFoundError = await UIHelper.performTextExtractionInteraction("scroll", {
+            text: "Nonexistent text"
         });
 
         invalidActionError = await UIHelper.performTextExtractionInteraction("click", {
@@ -129,9 +163,14 @@
         shouldBeEqualToString("selectTextError", "");
         shouldBeEqualToString("getSelection().toString()", "Subject");
         shouldBeEqualToString("scrollChildContainerError", "");
-        shouldBe("childScroller.scrollTop", "100");
+        shouldBe("childScrollerScrollTopAfterScrollBy", "100");
         shouldBeEqualToString("scrollPageError", "");
-        shouldBe("document.scrollingElement.scrollTop", "100");
+        shouldBe("pageScrollTopAfterScrollBy", "100");
+        shouldBeEqualToString("scrollToRevealInScrollerError", "");
+        shouldBeGreaterThan("childScrollerScrollTopAfterScrollToReveal", "0");
+        shouldBeEqualToString("scrollToRevealInPageError", "");
+        shouldBeGreaterThan("pageScrollTopAfterScrollToReveal", "100");
+        shouldBeEqualToString("scrollToRevealNotFoundError", "'Nonexistent text' not found inside the target node");
         shouldBeEqualToString("invalidActionError", "Failed to resolve nodeIdentifier 4294967293");
         shouldBeEqualToString("clickDisabledError", "Click target is disabled");
         shouldBeEqualToString("textInputReadonlyError", "Target is readonly");

--- a/Source/WebCore/page/text-extraction/TextExtractionTypes.h
+++ b/Source/WebCore/page/text-extraction/TextExtractionTypes.h
@@ -55,7 +55,7 @@ enum class Action : uint8_t {
     TextInput,
     KeyPress,
     HighlightText,
-    ScrollBy,
+    Scroll,
 };
 
 struct Interaction {

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -6865,7 +6865,7 @@ header: <WebCore/TextExtractionTypes.h>
     TextInput,
     KeyPress,
     HighlightText,
-    ScrollBy
+    Scroll
 };
 
 header: <WebCore/TextExtractionTypes.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -7096,8 +7096,8 @@ static RetainPtr<_WKTextExtractionResult> createEmptyTextExtractionResult()
             return WebCore::TextExtraction::Action::KeyPress;
         case _WKTextExtractionActionHighlightText:
             return WebCore::TextExtraction::Action::HighlightText;
-        case _WKTextExtractionActionScrollBy:
-            return WebCore::TextExtraction::Action::ScrollBy;
+        case _WKTextExtractionActionScroll:
+            return WebCore::TextExtraction::Action::Scroll;
         default:
             ASSERT_NOT_REACHED();
             return WebCore::TextExtraction::Action::Click;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h
@@ -258,7 +258,8 @@ typedef NS_ENUM(NSInteger, _WKTextExtractionAction) {
     _WKTextExtractionActionTextInput,
     _WKTextExtractionActionKeyPress,
     _WKTextExtractionActionHighlightText,
-    _WKTextExtractionActionScrollBy
+    _WKTextExtractionActionScroll,
+    _WKTextExtractionActionScrollBy = _WKTextExtractionActionScroll,
 } WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA));
 
 WK_CLASS_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA), visionos(WK_XROS_TBA))

--- a/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
+++ b/Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm
@@ -518,8 +518,8 @@ void UIScriptControllerCocoa::performTextExtractionInteraction(JSStringRef jsAct
         action = _WKTextExtractionActionKeyPress;
     if (equalLettersIgnoringASCIICase(actionName, "highlighttext"))
         action = _WKTextExtractionActionHighlightText;
-    if (equalLettersIgnoringASCIICase(actionName, "scrollby"))
-        action = _WKTextExtractionActionScrollBy;
+    if (equalLettersIgnoringASCIICase(actionName, "scroll"))
+        action = _WKTextExtractionActionScroll;
 
     if (!action) {
         ASSERT_NOT_REACHED();


### PR DESCRIPTION
#### 0cd43e05ec09889a999e6e859c73e331d949faec
<pre>
[AutoFill Debugging] Scroll interaction type should support `text` as an argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=308014">https://bugs.webkit.org/show_bug.cgi?id=308014</a>
<a href="https://rdar.apple.com/170513168">rdar://170513168</a>

Reviewed by Abrar Rahman Protyasha and Megan Gardner.

Add `text` as a valid argument for scrolling interaction type; see below for more details.

* LayoutTests/fast/text-extraction/debug-text-extraction-interactions-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-interactions.html:

Extend an existing layout test to cover this case.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::searchForText):
(WebCore::TextExtraction::scrollToReveal):
(WebCore::TextExtraction::handleInteraction):
(WebCore::TextExtraction::interactionDescription):

Handle the `text` argument with `scroll` interaction type by searching for the text in the DOM, and
scrolling to reveal the element containing the start of the matching range.

* Source/WebCore/page/text-extraction/TextExtractionTypes.h:

Also rename `ScrollBy` to just `Scroll`, now that it takes either a scroll delta or search string.

* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _convertToWebCoreInteraction:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTextExtraction.h:
* Tools/WebKitTestRunner/cocoa/UIScriptControllerCocoa.mm:
(WTR::UIScriptControllerCocoa::performTextExtractionInteraction):

Canonical link: <a href="https://commits.webkit.org/307689@main">https://commits.webkit.org/307689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e8dff427d1374891909385a23c905a6a586499

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145157 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9613 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153829 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a4eaa6d6-b03c-4bf5-b76f-d5e337bb7661) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18321 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17730 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111612 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98793 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/026b710f-d3f3-4b07-a56b-2f6f4f355d80) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148120 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92510 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f86ffba1-59ab-44ed-9cca-a7b9fd91214e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11096 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1274 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122855 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7134 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156141 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17689 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119619 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17735 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14758 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119953 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30769 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15723 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128392 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73353 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17310 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6650 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17047 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81089 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17255 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17110 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->