### PR TITLE
GitHub.com: Profile icons can shift on commits page of a repo when increasing layout zoom.

### DIFF
--- a/LayoutTests/fast/media/media-query-with-rem-expected.html
+++ b/LayoutTests/fast/media/media-query-with-rem-expected.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<body style="margin: 0;">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+<script>
+</script>
+</html>

--- a/LayoutTests/fast/media/media-query-with-rem.html
+++ b/LayoutTests/fast/media/media-query-with-rem.html
@@ -1,0 +1,24 @@
+<html>
+<head>
+  <style>
+    body {
+      margin: 0;
+    }
+    @media (min-width:20rem) {
+      div {
+        background-color: green;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <p style="zoom: 0.5;">Test passes if there is a filled green square.</p>
+  <div style="width: 50px; height: 50px;"></div>
+</body>
+<script>
+  if (window.internals)
+    internals.setPageZoomFactor(2);
+  document.body.offsetHeight;
+</script>
+</html>

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -60,13 +60,14 @@ CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, S
 {
 }
 
-CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, const RenderStyle* rootStyle, const RenderStyle* parentStyle, const RenderView* renderView, const Element* elementForContainerUnitResolution)
+CSSToLengthConversionData::CSSToLengthConversionData(const RenderStyle& style, const RenderStyle* rootStyle, const RenderStyle* parentStyle, const RenderView* renderView, const Element* elementForContainerUnitResolution, CSS::RangeZoomOptions rangeZoomOptions)
     : m_style(&style)
     , m_rootStyle(rootStyle)
     , m_parentStyle(parentStyle)
     , m_renderView(renderView)
     , m_elementForContainerUnitResolution(elementForContainerUnitResolution)
     , m_zoom(1.f)
+    , m_rangeZoomOption(rangeZoomOptions)
 {
 }
 

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -57,7 +57,7 @@ public:
     // This is used during style building. The 'zoom' property is taken into account.
     CSSToLengthConversionData(const RenderStyle&, Style::BuilderState&);
     // This constructor ignores the `zoom` property.
-    CSSToLengthConversionData(const RenderStyle&, const RenderStyle* rootStyle, const RenderStyle* parentStyle, const RenderView*, const Element* elementForContainerUnitResolution = nullptr);
+    CSSToLengthConversionData(const RenderStyle&, const RenderStyle* rootStyle, const RenderStyle* parentStyle, const RenderView*, const Element* elementForContainerUnitResolution = nullptr, CSS::RangeZoomOptions = CSS::RangeZoomOptions::Default);
 
     WEBCORE_EXPORT ~CSSToLengthConversionData();
 

--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -86,7 +86,7 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         if (!document->view() || !document->documentElement())
             return EvaluationResult::Unknown;
 
-        FeatureEvaluationContext context { *document, { *rootElementStyle, rootElementStyle.get(), nullptr, document->renderView() }, nullptr };
+        FeatureEvaluationContext context { *document, { *rootElementStyle, rootElementStyle.get(), nullptr, document->renderView(), nullptr, CSS::RangeZoomOptions::Unzoomed }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();
 


### PR DESCRIPTION
#### 9a3dec2946c44efcf600159d35097df89f553f3c
<pre>
GitHub.com: Profile icons can shift on commits page of a repo when increasing layout zoom.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308172">https://bugs.webkit.org/show_bug.cgi?id=308172</a>
<a href="https://rdar.apple.com/168700141">rdar://168700141</a>

Reviewed by Brent Fulgham.

If you go to the commits page that is associated with a repository, such
as <a href="https://github.com/WebKit/WebKit/commits/main/">https://github.com/WebKit/WebKit/commits/main/</a>, it is possible that
the profile icons associated with a commit may shift around as you
increase the layout zoom of a page (e.g. using cmd + plus). This
behavior seems to occur when the author and committer associated with a
commit are different, as the two different profile icons may end up
getting separated from each other depending on the viewport width and
zoom level.

This seems to be due to some styles associated with the following types
of media queries:
@media screen and (max-width:calc(48rem - .02px)) {
  ....
  --avatar-stack-size: var(--stackSize-narrow)
}
@media screen and (min-width:48rem) {
  ...
  --avatar-stack-size: var(--stackSize-regular)
}

It turns out that stackSize-narrow and stackSize-regular are the exact
same value, but when we increase the scale by a certain amount, we fail to
start applying the second media query. How this is exactly happening is
described alongside the reduced test case below, but basically, it is due
to the fact that when we resolve the 48rem for the second media query, we
end up applying zoom to it when we should not (for the first media query,
we do not apply zoom).

In MediaQueryEvaluator, we create a FeatureEvaluationContext that gets
passed around during media query evaluation. This object has a
CSSToLengthConversionData that gets used when we need to evaluate length
values for the media query, such as the ones above. It seems like the
intention is to not be taking zoom into consideration at all, since
the constructor associated with the CSSToLengthConversionData has a
comment saying that it is used to ignore zoom. This is because before we
evaluate the media query, we divide the size of the RenderView by its
usedZoom value. So if you apply a page scale factor of 2, as an example,
then the width of the RenderView will get halved for the purposes of
evaluating the media query.

In order to make sure this is done properly with respect to the rem unit, we
need to make sure that the conversion data is marked as CSS::RangeZoomOptions::Unzoomed
to make sure it does not use the computed font size, which is what causes
the bug. Since 48rem is a font relative unit and the default value for
the CSS::RangeZoomOption is Default, we will end up using the computed
font size with zoom factored in.

* LayoutTests/fast/media/media-query-with-rem-expected.html
* LayoutTests/fast/media/media-query-with-rem.html
Assuming a viewport of 800px and a root font size of 16px. When the
content is unzoomed, we get a min-width value of 320 and end up correctly
applying the media query. When we set a page scale factor of 2, the width
of the RenderView ends up becoming 400, and the value associated with the
media query ends up becoming 720, which is incorrect since we end up
using the computed font size with zoom.

Canonical link: <a href="https://commits.webkit.org/307845@main">https://commits.webkit.org/307845@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf1a8e7f8c1be136e6b4db8e9ee3c8366848fa17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145721 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18410 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10345 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154400 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c60d36a-52d6-4dbc-8fe8-09d436f9217e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147596 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18301 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112072 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148684 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92975 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f9e8776-b55c-458e-8ea0-5d798ebaab73) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13764 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11524 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1845 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7742 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156712 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8893 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120079 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15248 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120423 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30864 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18309 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74005 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16156 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7156 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17880 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81667 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17617 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17679 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->