### PR TITLE
AX: On macOS with site isolation enabled, VoiceOver cannot traverse into iframes because UIElementsForSearchPredicate only searches within the same process

### DIFF
--- a/LayoutTests/accessibility/ax-object-destroyed-on-reload-expected.txt
+++ b/LayoutTests/accessibility/ax-object-destroyed-on-reload-expected.txt
@@ -1,10 +1,8 @@
 This test ensures that when a page is reloaded, we properly clean up the AX objects from the previous iteration of the page.
 
 Role of #button element retained from first page load: AXRole:
-#button element retained from first page load is valid: false
 
 Role of #button element from second page load: AXRole: AXButton
-#button element from second page load is valid: true
 
 PASS successfullyParsed is true
 

--- a/LayoutTests/accessibility/ax-object-destroyed-on-reload.html
+++ b/LayoutTests/accessibility/ax-object-destroyed-on-reload.html
@@ -9,35 +9,32 @@
 <button id="button">Click me</button>
 
 <script>
-    var testOutput = "This test ensures that when a page is reloaded, we properly clean up the AX objects from the previous iteration of the page.\n\n";
+var testOutput = "This test ensures that when a page is reloaded, we properly clean up the AX objects from the previous iteration of the page.\n\n";
 
-    if (window.accessibilityController) {
-        window.jsTestIsAsync = true;
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
 
-        const axButton = accessibilityController.accessibleElementById("button");
-        const storageKey = "webkit-test-did-reload";
-        if (window.localStorage.getItem(storageKey) === null) {
-            window.localStorage.setItem(storageKey, "true")
-            // Before forcing a reload, retain this AccessibilityUIElement (which wraps a WebAccessibilityObjectWrapper
-            // on Cocoa platforms) so we can use it post-reload. This is similar behavior to some AX clients who preserve
-            // references to elements across page loads for certain features.
-            accessibilityController.setRetainedElement(axButton);
-            // Note that this reloads the test, too.
-            internals.forceReload(true);
-        } else {
-            window.localStorage.removeItem(storageKey);
-            // The wrapper backing this AccessibilityUIElement should've been deleted by the reload, so no role should
-            // be returned here, and the AccessibilityUIElement should be considered invalid.
-            testOutput += `Role of #button element retained from first page load: ${accessibilityController.retainedElement().role}\n`;
-            testOutput += `#button element retained from first page load is valid: ${accessibilityController.retainedElement().isValid}\n`;
+    const axButton = accessibilityController.accessibleElementById("button");
+    const storageKey = "webkit-test-did-reload";
+    if (window.localStorage.getItem(storageKey) === null) {
+        window.localStorage.setItem(storageKey, "true")
+        // Before forcing a reload, retain this AccessibilityUIElement (which wraps a WebAccessibilityObjectWrapper
+        // on Cocoa platforms) so we can use it post-reload. This is similar behavior to some AX clients who preserve
+        // references to elements across page loads for certain features.
+        accessibilityController.setRetainedElement(axButton);
+        // Note that this reloads the test, too.
+        internals.forceReload(true);
+    } else {
+        window.localStorage.removeItem(storageKey);
+        // The backing object of the wrapper backing this AccessibilityUIElement should've been deleted by the reload,
+        // so no role should be returned here, and the AccessibilityUIElement should be considered invalid.
+        testOutput += `Role of #button element retained from first page load: ${accessibilityController.retainedElement().role}\n`;
+        testOutput += `\nRole of #button element from second page load: ${axButton.role}\n`;
 
-            testOutput += `\nRole of #button element from second page load: ${axButton.role}\n`;
-            testOutput += `#button element from second page load is valid: ${axButton.isValid}\n`;
-
-            debug(testOutput);
-            finishJSTest();
-        }
+        debug(testOutput);
+        finishJSTest();
     }
+}
 </script>
 </body>
 </html>

--- a/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-headings-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-headings-expected.txt
@@ -1,0 +1,24 @@
+Tests that uiElementsForSearchPredicate returns headings across process boundaries.
+  1: domIdentifier=main-h1, role=AXRole: AXHeading
+  2: domIdentifier=main-h2, role=AXRole: AXHeading
+  3: (remote platform element)
+  4: (remote platform element)
+  5: (remote platform element)
+PASS: results.length === 5
+PASS: results[0].domIdentifier === 'main-h1'
+PASS: results[0].isRemotePlatformElement === false
+PASS: results[1].domIdentifier === 'main-h2'
+PASS: results[1].isRemotePlatformElement === false
+PASS: results[2].isRemotePlatformElement === true
+PASS: results[3].isRemotePlatformElement === true
+PASS: results[4].isRemotePlatformElement === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Main Heading 1
+
+Main Heading 2
+
+
+Main Heading 3 (after iframe)

--- a/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-headings.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-headings.html
@@ -1,0 +1,77 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<h1 id="main-h1">Main Heading 1</h1>
+<h2 id="main-h2">Main Heading 2</h2>
+
+<iframe id="iframe" src="http://localhost:8000/site-isolation/accessibility/resources/iframe-with-headings.html"></iframe>
+
+<h3 id="main-h3">Main Heading 3 (after iframe)</h3>
+
+<script>
+var output = "Tests that uiElementsForSearchPredicate returns headings across process boundaries.\n";
+
+window.jsTestIsAsync = true;
+
+var results;
+async function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    var root = accessibilityController.rootElement;
+    touchAccessibilityTree(root);
+
+    var webArea = root.childAtIndex(0);
+
+    // Wait for cross-process search to return 5 headings (2 from main + 3 from iframe)
+    await waitFor(() => {
+        results = webArea.uiElementsForSearchPredicate(
+            null,           // startElement (null = from beginning)
+            true,           // isDirectionNext (forward)
+            "AXHeadingSearchKey",
+            "",             // searchText
+            false,          // visibleOnly
+            false,          // immediateDescendantsOnly
+            5               // resultsLimit
+        );
+        return results && results.length === 5;
+    });
+
+    if (!results) {
+        output += "FAIL: uiElementsForSearchPredicate returned null\n";
+        debug(output);
+        finishJSTest();
+        return;
+    }
+
+    for (var i = 0; i < results.length; i++) {
+        if (results[i].isRemotePlatformElement)
+            output += `  ${i + 1}: (remote platform element)\n`;
+        else
+            output += `  ${i + 1}: domIdentifier=${results[i].domIdentifier}, role=${results[i].role}\n`;
+    }
+
+    output += expect("results.length", "5");
+    // First 2 headings are local (from main frame before iframe)
+    output += expect("results[0].domIdentifier", "'main-h1'");
+    output += expect("results[0].isRemotePlatformElement", "false");
+    output += expect("results[1].domIdentifier", "'main-h2'");
+    output += expect("results[1].isRemotePlatformElement", "false");
+
+    // Next 3 headings are remote (from iframe in different process)
+    output += expect("results[2].isRemotePlatformElement", "true");
+    output += expect("results[3].isRemotePlatformElement", "true");
+    output += expect("results[4].isRemotePlatformElement", "true");
+
+    debug(output);
+    finishJSTest();
+}
+
+document.getElementById("iframe").onload = runTest;
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-nested-iframes-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-nested-iframes-expected.txt
@@ -1,0 +1,35 @@
+Tests cross-process search through three-level nested iframes (A -> B -> C).
+
+=== Forward Heading Search (3 levels) ===
+Forward heading search found 4 headings:
+  1: domIdentifier=main-h1, role=AXRole: AXHeading
+  2: (remote platform element)
+  3: (remote platform element)
+  4: domIdentifier=main-h2, role=AXRole: AXHeading
+PASS: forwardResults.length >= 4 === true
+PASS: forwardResults[0].domIdentifier === 'main-h1'
+PASS: forwardResults[0].isRemotePlatformElement === false
+PASS: forwardResults[1].isRemotePlatformElement === true
+PASS: forwardResults[forwardResults.length - 1].domIdentifier === 'main-h2'
+PASS: forwardResults[forwardResults.length - 1].isRemotePlatformElement === false
+
+=== Backward Heading Search ===
+Backward heading search found 4 headings:
+  1: domIdentifier=main-h2, role=AXRole: AXHeading
+  2: (remote platform element)
+  3: (remote platform element)
+  4: domIdentifier=main-h1, role=AXRole: AXHeading
+PASS: backwardResults.length >= 4 === true
+PASS: backwardResults[0].domIdentifier === 'main-h2'
+PASS: backwardResults[0].isRemotePlatformElement === false
+PASS: backwardResults[1].isRemotePlatformElement === true
+PASS: backwardResults[backwardResults.length - 1].domIdentifier === 'main-h1'
+PASS: backwardResults[backwardResults.length - 1].isRemotePlatformElement === false
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Main Frame Heading
+
+
+Main Frame Heading After Iframe

--- a/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-nested-iframes.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-nested-iframes.html
@@ -1,0 +1,145 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<h1 id="main-h1">Main Frame Heading</h1>
+<iframe id="outer-iframe" src="http://localhost:8000/site-isolation/accessibility/resources/nested-iframe-middle.html"></iframe>
+<h2 id="main-h2">Main Frame Heading After Iframe</h2>
+
+<script>
+var output = "Tests cross-process search through three-level nested iframes (A -> B -> C).\n";
+
+window.jsTestIsAsync = true;
+
+var iframeLoadCount = 0;
+var expectedLoads = 2; // outer iframe + inner iframe inside it
+
+function checkReady() {
+    iframeLoadCount++;
+    if (iframeLoadCount >= expectedLoads) {
+        // Wait a small delay for the nested iframes to fully load and be accessible.
+        setTimeout(runTest, 100);
+    }
+}
+
+async function performSearch(webArea, isForward, resultsLimit) {
+    var results;
+    await waitFor(() => {
+        results = webArea.uiElementsForSearchPredicate(
+            null,           // startElement
+            isForward,      // isDirectionNext
+            "AXHeadingSearchKey",
+            "",             // searchText
+            false,          // visibleOnly
+            false,          // immediateDescendantsOnly
+            resultsLimit
+        );
+        // Check that we have at least 4 results (headings from all 3 levels plus after)
+        // and at least one is a remote platform element.
+        if (!results || results.length < 4)
+            return false;
+        for (var i = 0; i < results.length; i++) {
+            if (results[i].isRemotePlatformElement)
+                return true;
+        }
+        return false;
+    });
+    return results;
+}
+
+function formatResults(results, direction) {
+    var formatted = `${direction} heading search found ${results.length} headings:\n`;
+    for (var i = 0; i < results.length; i++) {
+        var element = results[i];
+        if (element.isRemotePlatformElement)
+            formatted += `  ${i + 1}: (remote platform element)\n`;
+        else
+            formatted += `  ${i + 1}: domIdentifier=${element.domIdentifier || "(no id)"}, role=${element.role}\n`;
+    }
+    return formatted;
+}
+
+async function performSearchAndFormatResults(webArea, isForward) {
+    var searchResults = await performSearch(webArea, isForward, 10);
+
+    const directionString = isForward ? "Forward" : "Backward";
+    output += `\n=== ${directionString} Heading Search${isForward ? " (3 levels)" : ""} ===\n`;
+    if (!searchResults) {
+        output += `FAIL: ${directionString} heading search returned null\n`;
+        debug(output);
+        finishJSTest();
+        return null;
+    }
+    output += formatResults(searchResults, directionString);
+    return searchResults;
+}
+
+var forwardResults, backwardResults;
+async function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    var root = accessibilityController.rootElement;
+    touchAccessibilityTree(root);
+    var webArea = root.childAtIndex(0);
+
+    forwardResults = await performSearchAndFormatResults(webArea, /* isForward */ true);
+    if (!forwardResults)
+        return;
+
+    // Verify we found headings from all three levels
+    // Expected: main-h1 (local), remote elements from nested iframes, main-h2 (local)
+    output += expect("forwardResults.length >= 4", "true");
+    output += expect("forwardResults[0].domIdentifier", "'main-h1'");
+    output += expect("forwardResults[0].isRemotePlatformElement", "false");
+    // Middle elements should be remote (from nested iframes)
+    output += expect("forwardResults[1].isRemotePlatformElement", "true");
+    // Last element should be main-h2 (local, after the iframe)
+    output += expect("forwardResults[forwardResults.length - 1].domIdentifier", "'main-h2'");
+    output += expect("forwardResults[forwardResults.length - 1].isRemotePlatformElement", "false");
+
+    backwardResults = await performSearchAndFormatResults(webArea, /* isForward */ false);
+    if (!backwardResults)
+        return;
+
+    // Backward should have main-h2 first, then remote elements, then main-h1
+    output += expect("backwardResults.length >= 4", "true");
+    output += expect("backwardResults[0].domIdentifier", "'main-h2'");
+    output += expect("backwardResults[0].isRemotePlatformElement", "false");
+    // Middle elements should be remote (from nested iframes)
+    output += expect("backwardResults[1].isRemotePlatformElement", "true");
+    // Last element should be main-h1 (local, before the iframe)
+    output += expect("backwardResults[backwardResults.length - 1].domIdentifier", "'main-h1'");
+    output += expect("backwardResults[backwardResults.length - 1].isRemotePlatformElement", "false");
+
+    debug(output);
+    finishJSTest();
+}
+
+// The outer iframe will trigger this when loaded, and we also need to wait for nested iframe
+document.getElementById("outer-iframe").onload = function() {
+    checkReady();
+    // Also listen for the nested iframe load via message
+    var outerIframe = document.getElementById("outer-iframe");
+    try {
+        var innerIframe = outerIframe.contentDocument.getElementById("inner-iframe");
+        if (innerIframe) {
+            if (innerIframe.contentDocument && innerIframe.contentDocument.readyState === "complete")
+                checkReady();
+            else
+                innerIframe.onload = checkReady;
+        } else {
+            // Inner iframe might not be accessible due to cross-origin, use a timeout fallback.
+            setTimeout(checkReady, 200);
+        }
+    } catch (exception) {
+        // Cross-origin access denied, use hardcoded timeout.
+        setTimeout(checkReady, 200);
+    }
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-traversal-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-traversal-expected.txt
@@ -1,0 +1,59 @@
+Tests forward and backward AnyType search traversal across process boundaries.
+
+=== Forward Traversal ===
+Forward search found 18 elements:
+  1: domIdentifier=btn-before, role=AXRole: AXButton
+  2: domIdentifier=text-before, role=AXRole: AXGroup
+  3: domIdentifier=(no id), role=AXRole: AXStaticText
+  4: (remote platform element)
+  5: (remote platform element)
+  6: (remote platform element)
+  7: (remote platform element)
+  8: (remote platform element)
+  9: (remote platform element)
+  10: (remote platform element)
+  11: (remote platform element)
+  12: (remote platform element)
+  13: (remote platform element)
+  14: (remote platform element)
+  15: (remote platform element)
+  16: domIdentifier=text-after, role=AXRole: AXGroup
+  17: domIdentifier=(no id), role=AXRole: AXStaticText
+  18: domIdentifier=btn-after, role=AXRole: AXButton
+
+=== Backward Traversal ===
+Backward search found 18 elements:
+  1: domIdentifier=btn-after, role=AXRole: AXButton
+  2: domIdentifier=text-after, role=AXRole: AXGroup
+  3: domIdentifier=(no id), role=AXRole: AXStaticText
+  4: (remote platform element)
+  5: (remote platform element)
+  6: (remote platform element)
+  7: (remote platform element)
+  8: (remote platform element)
+  9: (remote platform element)
+  10: (remote platform element)
+  11: (remote platform element)
+  12: (remote platform element)
+  13: (remote platform element)
+  14: (remote platform element)
+  15: (remote platform element)
+  16: domIdentifier=text-before, role=AXRole: AXGroup
+  17: domIdentifier=(no id), role=AXRole: AXStaticText
+  18: domIdentifier=btn-before, role=AXRole: AXButton
+
+=== Verification ===
+PASS: forwardResults.length === backwardResults.length
+First forward element: btn-before
+Last backward element: btn-before
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Button Before
+Text before iframe
+
+
+Text after iframe
+
+Button After

--- a/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-traversal.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-traversal.html
@@ -1,0 +1,114 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+</head>
+<body>
+
+<button id="btn-before">Button Before</button>
+<p id="text-before">Text before iframe</p>
+
+<iframe id="iframe" src="http://localhost:8000/site-isolation/accessibility/resources/iframe-with-headings.html"></iframe>
+
+<p id="text-after">Text after iframe</p>
+<button id="btn-after">Button After</button>
+
+<script>
+var output = "Tests forward and backward AnyType search traversal across process boundaries.\n";
+
+window.jsTestIsAsync = true;
+
+async function performSearch(webArea, isForward, resultsLimit) {
+    var results;
+    await waitFor(() => {
+        results = webArea.uiElementsForSearchPredicate(
+            null,           // startElement
+            isForward,      // isDirectionNext
+            "AXAnyTypeSearchKey",
+            "",             // searchText
+            false,          // visibleOnly
+            false,          // immediateDescendantsOnly
+            resultsLimit
+        );
+        // Check that we have results and at least one is a remote platform element,
+        // indicating the iframe has loaded its accessibility tree.
+        if (!results || results.length === 0)
+            return false;
+        for (var i = 0; i < results.length; i++) {
+            if (results[i].isRemotePlatformElement)
+                return true;
+        }
+        return false;
+    });
+    return results;
+}
+
+function filterSearchResults(results) {
+    // Filter out AXScrollArea elements - these are implementation details
+    // that differ between ENABLE_ACCESSIBILITY_LOCAL_FRAME configurations.
+    return results.filter(function(element) {
+        if (element.isRemotePlatformElement)
+            return true;
+        return !element.role || !element.role.includes("AXScrollArea");
+    });
+}
+
+function formatResults(results, direction) {
+    var formatted = `${direction} search found ${results.length} elements:\n`;
+    for (var i = 0; i < results.length; i++) {
+        var element = results[i];
+        if (element.isRemotePlatformElement)
+            formatted += `  ${i + 1}: (remote platform element)\n`;
+        else
+            formatted += `  ${i + 1}: domIdentifier=${element.domIdentifier || "(no id)"}, role=${element.role}\n`;
+    }
+    return formatted;
+}
+
+var forwardResults, backwardResults;
+async function performSearchAndFormatResults(isForward) {
+    searchResults = await performSearch(webArea, isForward, 20);
+
+    const directionString = isForward ? "Forward" : "Backward";
+    output += `\n=== ${directionString} Traversal ===\n`;
+    if (!searchResults) {
+        output += `FAIL: ${directionString} search returned null\n`;
+        debug(output);
+        finishJSTest();
+        return 0;
+    }
+    searchResults = filterSearchResults(searchResults);
+    output += formatResults(searchResults, directionString);
+    return searchResults;
+}
+
+var root, webArea;
+async function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    root = accessibilityController.rootElement;
+    touchAccessibilityTree(root);
+    webArea = root.childAtIndex(0);
+
+    forwardResults = await performSearchAndFormatResults(/* isForward */ true);
+    backwardResults = await performSearchAndFormatResults(/* isForward */ false);
+
+    // Verify that forward and backward traversals are inverses
+    output += "\n=== Verification ===\n";
+    output += expect("forwardResults.length", "backwardResults.length");
+
+    // First element of forward should be last element of backward (approximately, accounting for search behavior)
+    if (forwardResults.length > 0 && backwardResults.length > 0) {
+        output += `First forward element: ${forwardResults[0].domIdentifier}\n`;
+        output += `Last backward element: ${backwardResults[backwardResults.length - 1].domIdentifier}\n`;
+    }
+
+    debug(output);
+    finishJSTest();
+}
+
+document.getElementById("iframe").onload = runTest;
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/accessibility/resources/iframe-with-headings.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/resources/iframe-with-headings.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Iframe with Headings</title>
+</head>
+<body>
+    <h1 id="iframe-h1">Iframe Heading 1</h1>
+    <p>Some content between headings.</p>
+    <h2 id="iframe-h2">Iframe Heading 2</h2>
+    <p>More content.</p>
+    <h3 id="iframe-h3">Iframe Heading 3</h3>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/accessibility/resources/nested-iframe-inner.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/resources/nested-iframe-inner.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Nested Iframe Inner</title>
+</head>
+<body>
+    <h1 id="inner-h1">Inner Frame Heading</h1>
+    <p>Content in the innermost frame.</p>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/accessibility/resources/nested-iframe-middle.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/resources/nested-iframe-middle.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Nested Iframe Middle</title>
+</head>
+<body>
+    <h1 id="middle-h1">Middle Frame Heading</h1>
+    <p>Content in the middle frame.</p>
+    <iframe id="inner-iframe" src="http://127.0.0.1:8000/site-isolation/accessibility/resources/nested-iframe-inner.html"></iframe>
+</body>
+</html>

--- a/LayoutTests/platform/ios/accessibility/ax-object-destroyed-on-reload-expected.txt
+++ b/LayoutTests/platform/ios/accessibility/ax-object-destroyed-on-reload-expected.txt
@@ -1,10 +1,8 @@
 This test ensures that when a page is reloaded, we properly clean up the AX objects from the previous iteration of the page.
 
 Role of #button element retained from first page load: null
-#button element retained from first page load is valid: false
 
 Role of #button element from second page load: Button
-#button element from second page load is valid: true
 
 PASS successfullyParsed is true
 

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -814,9 +814,11 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     Scripts/generate-log-declarations.py
 
+    accessibility/AXAnnouncementTypes.h
     accessibility/AXAttributeCacheScope.h
     accessibility/AXComputedObjectAttributeCache.h
     accessibility/AXCoreObject.h
+    accessibility/AXCrossProcessSearch.h
     accessibility/AXGeometryManager.h
     accessibility/AXID.h
     accessibility/AXListHelpers.h
@@ -826,6 +828,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/AXObjectCache.h
     accessibility/AXObjectCacheInlines.h
     accessibility/AXObjectRareData.h
+    accessibility/AXRemoteFrame.h
     accessibility/AXSearchManager.h
     accessibility/AXStitchGroup.h
     accessibility/AXTextMarker.h
@@ -838,9 +841,12 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     accessibility/AccessibilityMockObject.h
     accessibility/AccessibilityNodeObject.h
     accessibility/AccessibilityObject.h
+    accessibility/AccessibilityObjectInlines.h
+    accessibility/AccessibilityRemoteToken.h
     accessibility/AccessibilityRenderObject.h
     accessibility/AccessibilityRole.h
     accessibility/AccessibilityScrollView.h
+    accessibility/AccessibilitySearchCriteriaIPC.h
     accessibility/ForcedAccessibilityValue.h
     accessibility/isolatedtree/AXIsolatedObject.h
     accessibility/isolatedtree/AXIsolatedTree.h

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -584,6 +584,7 @@ Modules/webxr/XRWebGLSubImage.cpp
 accessibility/AXAttributeCacheScope.cpp
 accessibility/AXComputedObjectAttributeCache.cpp
 accessibility/AXCoreObject.cpp
+accessibility/AXCrossProcessSearch.cpp
 accessibility/AXGeometryManager.cpp
 accessibility/AXLiveRegionManager.cpp
 accessibility/AXLocalFrame.cpp

--- a/Source/WebCore/accessibility/AXAnnouncementTypes.h
+++ b/Source/WebCore/accessibility/AXAnnouncementTypes.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/AXID.h>
+#include <wtf/HashSet.h>
+#include <wtf/OptionSet.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+enum class NotifyPriority : uint8_t { Normal, High };
+
+enum class InterruptBehavior : uint8_t { None, All, Pending };
+
+enum class LiveRegionStatus : uint8_t { Off, Polite, Assertive };
+
+enum class LiveRegionRelevant : uint8_t {
+    Additions = 1 << 0,
+    Removals  = 1 << 1,
+    Text      = 1 << 2,
+    All       = 1 << 3
+};
+
+enum class AnnouncementContents : bool { All, Changes };
+
+struct LiveRegionObject {
+    AXID objectID;
+    String text;
+    String language;
+    HashSet<AXID> descendants; // For atomic regions only, to track additions/removals of descendants.
+};
+
+struct LiveRegionSnapshot {
+    Vector<LiveRegionObject> objects;
+    LiveRegionStatus liveRegionStatus { LiveRegionStatus::Off };
+    OptionSet<LiveRegionRelevant> liveRegionRelevant { { LiveRegionRelevant::Additions, LiveRegionRelevant::Text } };
+};
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -32,6 +32,7 @@
 #include <WebCore/CharacterRange.h>
 #include <WebCore/Color.h>
 #include <WebCore/ColorConversion.h>
+#include <WebCore/FrameIdentifier.h>
 #include <WebCore/HTMLTextFormControlElement.h>
 #include <WebCore/InputType.h>
 #include <WebCore/LayoutRect.h>
@@ -144,7 +145,7 @@ enum class AccessibilityDetachmentType { CacheDestroyed, ElementDestroyed, Eleme
 enum class AccessibilityConversionSpace { Screen, Page };
 
 // FIXME: This should be replaced by AXDirection (or vice versa).
-enum class AccessibilitySearchDirection {
+enum class AccessibilitySearchDirection : uint8_t {
     Next = 1,
     Previous,
 };
@@ -634,7 +635,8 @@ public:
     bool isFrame() const;
 #if PLATFORM(COCOA)
     virtual RetainPtr<id> remoteFramePlatformElement() const = 0;
-    virtual pid_t remoteFrameProcessIdentifier() const = 0;
+    virtual pid_t remoteFramePID() const = 0;
+    virtual std::optional<FrameIdentifier> remoteFrameID() const = 0;
 #endif
     virtual bool hasRemoteFrameChild() const = 0;
 
@@ -856,7 +858,8 @@ public:
     AXCoreObject* parentObjectIncludingCrossFrame() const;
     AXCoreObject* parentObjectUnignoredIncludingCrossFrame() const;
 
-    virtual AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&) = 0;
+    // Finds objects within |this| object matching the given search criteria.
+    virtual AccessibilityChildrenVector findMatchingObjectsWithin(AccessibilitySearchCriteria&&);
     virtual bool isDescendantOfRole(AccessibilityRole) const = 0;
     AXCoreObject* selfOrFirstTextDescendant();
 

--- a/Source/WebCore/accessibility/AXCrossProcessSearch.cpp
+++ b/Source/WebCore/accessibility/AXCrossProcessSearch.cpp
@@ -1,0 +1,452 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "AXCrossProcessSearch.h"
+
+#include <WebCore/AXCoreObject.h>
+#include <WebCore/AXObjectCache.h>
+#include <WebCore/AXTreeStoreInlines.h>
+#include <WebCore/Chrome.h>
+#include <WebCore/ChromeClient.h>
+#include <WebCore/LocalFrame.h>
+#include <WebCore/Page.h>
+#include <wtf/MainThread.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/RefCounted.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/threads/BinarySemaphore.h>
+
+#if PLATFORM(COCOA)
+#include <CoreFoundation/CFRunLoop.h>
+#endif
+
+#if PLATFORM(MAC)
+#define PLATFORM_SUPPORTS_REMOTE_SEARCH 1
+#else
+#define PLATFORM_SUPPORTS_REMOTE_SEARCH 0
+#endif
+
+namespace WebCore {
+
+static bool canDoRemoteSearch(const std::optional<AXTreeID>& treeID)
+{
+#if PLATFORM_SUPPORTS_REMOTE_SEARCH
+    return treeID.has_value();
+#else
+    UNUSED_PARAM(treeID);
+    return false;
+#endif // PLATFORM_SUPPORTS_REMOTE_SEARCH
+}
+
+// Spins the run loop on the main thread while waiting for a condition to become true.
+// In the future, we could consider changing callers to implement a solution that doesn't
+// require polling as done in this function, since polling can be inefficient.
+template<typename Predicate>
+static DidTimeout spinRunLoopUntil(Predicate&& isComplete, Seconds timeout)
+{
+    AX_ASSERT(isMainThread());
+
+    auto deadline = MonotonicTime::now() + timeout;
+    while (MonotonicTime::now() < deadline) {
+        if (isComplete())
+            return DidTimeout::No;
+#if PLATFORM(COCOA)
+        CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.02, true);
+#else
+        Thread::yield();
+#endif
+    }
+    return isComplete() ? DidTimeout::No : DidTimeout::Yes;
+}
+
+DidTimeout AXCrossProcessSearchCoordinator::waitWithTimeout(Seconds timeout)
+{
+    auto isComplete = [this] {
+        return m_searchComplete.load(std::memory_order_acquire) && !m_pendingCount.load(std::memory_order_acquire);
+    };
+
+    // If search is already complete with no pending requests, return immediately.
+    if (isComplete())
+        return DidTimeout::No;
+
+    if (isMainThread()) {
+        // On the main thread, we can't block on a semaphore because IPC callbacks
+        // need to run on the main thread. Instead, spin the run loop.
+        return spinRunLoopUntil(isComplete, timeout);
+    }
+
+    // On background threads (e.g., the accessibility thread), we can safely
+    // block on the semaphore.
+    return m_semaphore.waitFor(timeout) ? DidTimeout::No : DidTimeout::Yes;
+}
+
+// Helper to merge stream entries into AccessibilitySearchResults.
+// If coordinator is provided, also pulls in remote results for RemoteFrame entries.
+static AccessibilitySearchResults mergeStreamResults(const Vector<SearchResultEntry>& entries, unsigned limit, AXCrossProcessSearchCoordinator* coordinator)
+{
+    AccessibilitySearchResults results;
+    for (const auto& entry : entries) {
+        if (results.size() >= limit)
+            break;
+
+        if (RefPtr object = entry.objectIfLocalResult())
+            results.append(AccessibilitySearchResult::local(object.releaseNonNull()));
+        else if (coordinator) {
+            // The search result was from an AXRemoteFrame we contain. Pull
+            // AccessibilityRemoteTokens from the search coordinator and
+            // convert them into results.
+            auto tokens = coordinator->takeRemoteResults(entry.streamIndex());
+            for (auto& token : tokens) {
+                if (results.size() >= limit)
+                    break;
+                results.append(AccessibilitySearchResult::remote(WTF::move(token)));
+            }
+        }
+    }
+    return results;
+}
+
+#if PLATFORM_SUPPORTS_REMOTE_SEARCH
+// Computes remaining timeout from an absolute deadline, accounting for IPC overhead.
+// Returns std::nullopt if the deadline has already passed (so callers can skip the search).
+// Returns at least crossProcessSearchMinimumTimeout to ensure deeply nested frames
+// always get some time to search.
+static std::optional<Seconds> computeRemainingTimeout(std::optional<MonotonicTime> deadline)
+{
+    if (!deadline)
+        return crossProcessSearchTimeout;
+
+    auto remaining = *deadline - MonotonicTime::now() - crossProcessSearchIPCOverhead;
+    if (remaining <= 1_ms)
+        return std::nullopt;
+    return std::max(crossProcessSearchMinimumTimeout, remaining);
+}
+
+// Dispatches an IPC request to search a remote frame.
+// The coordinator's responseReceived() will be called when the response arrives (or on failure).
+static void dispatchRemoteFrameSearch(Ref<AXCrossProcessSearchCoordinator> coordinator, FrameIdentifier frameID, AccessibilitySearchCriteriaIPC criteria, size_t streamIndex, AXTreeID treeID)
+{
+    ensureOnMainThread([coordinator = WTF::move(coordinator), frameID, criteria = WTF::move(criteria), streamIndex, treeID]() mutable {
+        AX_ASSERT(isMainThread());
+
+        WeakPtr cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(treeID);
+        RefPtr page = cache ? cache->page() : nullptr;
+        if (!page) {
+            coordinator->responseReceived();
+            return;
+        }
+
+        page->chrome().client().performAccessibilitySearchInRemoteFrame(frameID, criteria,
+            [coordinator = WTF::move(coordinator), streamIndex](Vector<AccessibilityRemoteToken>&& tokens) mutable {
+                coordinator->storeRemoteResults(streamIndex, WTF::move(tokens));
+                coordinator->responseReceived();
+            });
+    });
+}
+#endif // PLATFORM_SUPPORTS_REMOTE_SEARCH
+
+AccessibilitySearchResults performCrossProcessSearch(AccessibilitySearchResultStream&& stream, const AccessibilitySearchCriteriaIPC& criteriaForIPC, std::optional<AXTreeID> treeID, unsigned originalLimit, std::optional<FrameIdentifier> requestingFrameID)
+{
+    if (!canDoRemoteSearch(treeID)) {
+        UNUSED_PARAM(criteriaForIPC);
+        UNUSED_PARAM(requestingFrameID);
+        return mergeStreamResults(stream.entries(), originalLimit, nullptr);
+    }
+
+#if PLATFORM_SUPPORTS_REMOTE_SEARCH
+    // Calculate how many results to request from each remote frame.
+    // We need to account for local results that precede each remote frame in tree order.
+    Vector<std::pair<const SearchResultEntry*, unsigned>> remoteFrameRequests;
+    unsigned localCountSoFar = 0;
+    for (const auto& entry : stream.entries()) {
+        if (entry.isLocalResult())
+            ++localCountSoFar;
+        else {
+            // For this remote frame, request enough to potentially fill remaining quota.
+            unsigned remaining = originalLimit > localCountSoFar ? originalLimit - localCountSoFar : 0;
+            // If we've already filled our quota with local results before this remote frame,
+            // we don't need to query it.
+            if (remaining > 0)
+                remoteFrameRequests.append({ &entry, remaining });
+        }
+    }
+
+    if (remoteFrameRequests.isEmpty()) {
+        // All remote frames were skipped because local results filled the quota.
+        return mergeStreamResults(stream.entries(), originalLimit, nullptr);
+    }
+
+    // We have remote frames to query. Create a coordinator for synchronization.
+    Ref coordinator = AXCrossProcessSearchCoordinator::create();
+
+    if (requestingFrameID) {
+        // Pre-populate with requesting frame to prevent re-searching it.
+        coordinator->markFrameAsSearched(*requestingFrameID);
+    }
+
+    // Dispatch IPC for each remote frame.
+    for (const auto& [entry, maxResults] : remoteFrameRequests) {
+        if (!entry->frameID()) {
+            // No frame ID, nothing to dispatch.
+            continue;
+        }
+
+        // Skip frames we've already searched.
+        if (!coordinator->markFrameAsSearched(*entry->frameID()))
+            continue;
+
+        coordinator->addPendingRequest();
+
+        auto slotCriteria = criteriaForIPC;
+        slotCriteria.resultsLimit = maxResults;
+
+        dispatchRemoteFrameSearch(coordinator.copyRef(), *entry->frameID(), WTF::move(slotCriteria), entry->streamIndex(), *treeID);
+    }
+
+    // Mark search complete (all remote frames have been dispatched).
+    coordinator->markSearchComplete();
+
+    // Wait for all responses using the cascading timeout (remaining time from deadline).
+    if (std::optional remainingTimeout = computeRemainingTimeout(criteriaForIPC.deadline))
+        coordinator->waitWithTimeout(*remainingTimeout);
+
+    // Merge results in tree order.
+    return mergeStreamResults(stream.entries(), originalLimit, coordinator.ptr());
+#else
+    RELEASE_ASSERT_NOT_REACHED();
+#endif // PLATFORM_SUPPORTS_REMOTE_SEARCH
+}
+
+AccessibilitySearchResults performSearchWithCrossProcessCoordination(AXCoreObject& anchorObject, AccessibilitySearchCriteria&& criteria)
+{
+    unsigned originalLimit = criteria.resultsLimit;
+    std::optional treeID = anchorObject.treeID();
+    if (!canDoRemoteSearch(treeID)) {
+        criteria.anchorObject = &anchorObject;
+        auto stream = AXSearchManager().findMatchingObjectsAsStream(WTF::move(criteria));
+        return mergeStreamResults(stream.entries(), originalLimit, nullptr);
+    }
+
+#if PLATFORM_SUPPORTS_REMOTE_SEARCH
+    auto criteriaForIPC = AccessibilitySearchCriteriaIPC(criteria);
+
+    // If no deadline has been set, set one now. This establishes the timeout budget
+    // for the entire search tree, ensuring nested frames share the same deadline.
+    if (!criteriaForIPC.deadline)
+        criteriaForIPC.deadline = MonotonicTime::now() + crossProcessSearchTimeout;
+
+    // Create coordinator upfront for eager IPC dispatch.
+    Ref coordinator = AXCrossProcessSearchCoordinator::create();
+
+    // Callback invoked when a remote frame is encountered during search.
+    // Dispatches IPC immediately so remote search runs in parallel with local search.
+    auto remoteFrameCallback = [&coordinator, &criteriaForIPC, originalLimit, treeID](FrameIdentifier frameID, size_t streamIndex, unsigned localResultCount) {
+        // Skip frames we've already searched.
+        if (!coordinator->markFrameAsSearched(frameID))
+            return;
+
+        // Calculate how many results we need from this remote frame.
+        unsigned remaining = originalLimit > localResultCount ? originalLimit - localResultCount : 0;
+        if (!remaining) {
+            // Local results already filled quota, skip this remote frame.
+            return;
+        }
+
+        coordinator->addPendingRequest();
+
+        auto slotCriteria = criteriaForIPC;
+        slotCriteria.resultsLimit = remaining;
+
+        dispatchRemoteFrameSearch(coordinator.copyRef(), frameID, WTF::move(slotCriteria), streamIndex, *treeID);
+    };
+
+    criteria.anchorObject = &anchorObject;
+    auto stream = AXSearchManager().findMatchingObjectsAsStream(WTF::move(criteria), WTF::move(remoteFrameCallback));
+
+    // Mark search complete so coordinator knows all remote frames have been encountered.
+    coordinator->markSearchComplete();
+
+    // Wait for all responses using the cascading timeout (remaining time from deadline).
+    if (std::optional remainingTimeout = computeRemainingTimeout(criteriaForIPC.deadline))
+        coordinator->waitWithTimeout(*remainingTimeout);
+
+    // Merge results in tree order.
+    return mergeStreamResults(stream.entries(), originalLimit, coordinator.ptr());
+#else
+    RELEASE_ASSERT_NOT_REACHED();
+#endif // PLATFORM_SUPPORTS_REMOTE_SEARCH
+}
+
+AccessibilitySearchResults mergeParentSearchResults(AccessibilitySearchResults&& localResults, Vector<AccessibilityRemoteToken>&& parentTokens, bool isForwardSearch, unsigned limit)
+{
+    if (parentTokens.isEmpty())
+        return WTF::move(localResults);
+
+    if (isForwardSearch) {
+        // Forward search: local results first, then parent results (elements after the frame).
+        for (auto& token : parentTokens) {
+            if (localResults.size() >= limit)
+                break;
+            localResults.append(AccessibilitySearchResult::remote(WTF::move(token)));
+        }
+        return WTF::move(localResults);
+    }
+
+    // Backward search: parent results first (elements before the frame), then local results.
+    AccessibilitySearchResults mergedResults;
+    unsigned localCount = localResults.size();
+    for (auto& token : parentTokens) {
+        if (mergedResults.size() + localCount >= limit)
+            break;
+        mergedResults.append(AccessibilitySearchResult::remote(WTF::move(token)));
+    }
+    mergedResults.appendVector(WTF::move(localResults));
+    return mergedResults;
+}
+
+#if PLATFORM_SUPPORTS_REMOTE_SEARCH
+// Ref-counted context for coordinating search continuation into a parent frame.
+// When a child frame's search needs results from its parent frame (e.g. elements
+// before or after the iframe in tree order), this context manages the IPC roundtrip
+// and prevents use-after-free if the calling thread times out before the callback.
+class ParentFrameSearchContext : public RefCounted<ParentFrameSearchContext> {
+    WTF_MAKE_NONCOPYABLE(ParentFrameSearchContext);
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(ParentFrameSearchContext);
+public:
+    ParentFrameSearchContext() = default;
+
+    void signal()
+    {
+        if (m_shouldSignal.exchange(false, std::memory_order_acq_rel))
+            m_semaphore.signal();
+    }
+
+    DidTimeout waitWithTimeout(Seconds timeout)
+    {
+        DidTimeout didTimeout;
+        if (isMainThread()) {
+            // On the main thread, we can't block on a semaphore because IPC callbacks
+            // need to run on the main thread. Instead, spin the run loop.
+            auto isComplete = [this] {
+                return !m_shouldSignal.load(std::memory_order_acquire);
+            };
+            didTimeout = spinRunLoopUntil(isComplete, timeout);
+        } else
+            didTimeout = m_semaphore.waitFor(timeout) ? DidTimeout::No : DidTimeout::Yes;
+
+        if (didTimeout == DidTimeout::Yes)
+            m_shouldSignal.exchange(false, std::memory_order_acq_rel);
+        return didTimeout;
+    }
+
+    void markParentDispatched() { m_dispatchedParent.store(true, std::memory_order_release); }
+    bool didDispatchParent() const { return m_dispatchedParent.load(std::memory_order_acquire); }
+
+    void setParentTokens(Vector<AccessibilityRemoteToken>&& tokens)
+    {
+        Locker locker { m_lock };
+        m_parentTokens = WTF::move(tokens);
+    }
+
+    Vector<AccessibilityRemoteToken> takeParentTokens()
+    {
+        Locker locker { m_lock };
+        return std::exchange(m_parentTokens, { });
+    }
+
+private:
+    BinarySemaphore m_semaphore;
+    std::atomic<bool> m_shouldSignal { true };
+    std::atomic<bool> m_dispatchedParent { false };
+    Lock m_lock;
+    Vector<AccessibilityRemoteToken> m_parentTokens WTF_GUARDED_BY_LOCK(m_lock);
+};
+#endif // PLATFORM_SUPPORTS_REMOTE_SEARCH
+
+AccessibilitySearchResults performSearchWithParentCoordination(AXCoreObject& anchorObject, AccessibilitySearchCriteria&& criteria, std::optional<FrameIdentifier> currentFrameID)
+{
+    std::optional treeID = anchorObject.treeID();
+    if (!canDoRemoteSearch(treeID)) {
+        UNUSED_PARAM(currentFrameID);
+        return performSearchWithCrossProcessCoordination(anchorObject, WTF::move(criteria));
+    }
+
+#if PLATFORM_SUPPORTS_REMOTE_SEARCH
+    // Save original parameters for parent coordination.
+    unsigned originalLimit = criteria.resultsLimit;
+    bool isForward = criteria.searchDirection == AccessibilitySearchDirection::Next;
+    auto criteriaForParent = AccessibilitySearchCriteriaIPC(criteria);
+
+    // If no deadline has been set, set one now. This establishes the timeout budget
+    // for the entire search tree, ensuring nested frames share the same deadline.
+    if (!criteriaForParent.deadline)
+        criteriaForParent.deadline = MonotonicTime::now() + crossProcessSearchTimeout;
+
+    // Use ref-counted context to safely coordinate between threads.
+    Ref context = adoptRef(*new ParentFrameSearchContext);
+
+    ensureOnMainThread([context, criteriaForParent, treeID, currentFrameID]() mutable {
+        WeakPtr cache = AXTreeStore<AXObjectCache>::axObjectCacheForID(*treeID);
+        RefPtr document = cache ? cache->document() : nullptr;
+        RefPtr frame = document ? document->frame() : nullptr;
+        RefPtr page = frame ? frame->page() : nullptr;
+
+        if (!frame || !page || frame->isMainFrame() || !page->settings().siteIsolationEnabled()) {
+            // Not in a child frame, or site isolation is disabled (so no cross-process coordination needed).
+            context->signal();
+            return;
+        }
+
+        context->markParentDispatched();
+
+        // Use the provided frameID if available, otherwise use the frame's own ID.
+        FrameIdentifier frameIDToUse = currentFrameID.value_or(frame->frameID());
+
+        // Request full limit from parent - we'll truncate during merge.
+        page->chrome().client().continueAccessibilitySearchFromChildFrame(frameIDToUse, criteriaForParent,
+            [context](Vector<AccessibilityRemoteToken>&& tokens) mutable {
+                context->setParentTokens(WTF::move(tokens));
+                context->signal();
+            });
+    });
+
+    // Perform local + nested remote frame search (runs in parallel with parent search).
+    auto searchResults = performSearchWithCrossProcessCoordination(anchorObject, WTF::move(criteria));
+
+    // Wait for parent search to complete using the cascading timeout.
+    if (auto remainingTimeout = computeRemainingTimeout(criteriaForParent.deadline))
+        context->waitWithTimeout(*remainingTimeout);
+
+    // Merge parent results with local results based on search direction.
+    if (context->didDispatchParent())
+        searchResults = mergeParentSearchResults(WTF::move(searchResults), context->takeParentTokens(), isForward, originalLimit);
+
+    return searchResults;
+#else
+    RELEASE_ASSERT_NOT_REACHED();
+#endif // PLATFORM_SUPPORTS_REMOTE_SEARCH
+}
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXCrossProcessSearch.h
+++ b/Source/WebCore/accessibility/AXCrossProcessSearch.h
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/AXID.h>
+#include <WebCore/AXSearchManager.h>
+#include <WebCore/AccessibilityRemoteToken.h>
+#include <wtf/HashMap.h>
+#include <wtf/HashSet.h>
+#include <wtf/Lock.h>
+#include <wtf/Seconds.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/Vector.h>
+#include <wtf/threads/BinarySemaphore.h>
+
+namespace WebCore {
+
+enum class DidTimeout : bool;
+
+// Timeout for cross-process accessibility search operations.
+constexpr Seconds crossProcessSearchTimeout = 200_ms;
+// Buffer to account for IPC overhead when cascading timeouts to nested frames.
+constexpr Seconds crossProcessSearchIPCOverhead = 10_ms;
+// Minimum timeout to ensure deeply nested frames always get some search time.
+constexpr Seconds crossProcessSearchMinimumTimeout = 20_ms;
+
+// Coordinates cross-process accessibility search, handling synchronization
+// and storage of remote results as tokens. Platform-specific conversion
+// of tokens to accessibility elements is handled by the caller.
+class AXCrossProcessSearchCoordinator : public ThreadSafeRefCounted<AXCrossProcessSearchCoordinator> {
+    WTF_MAKE_NONCOPYABLE(AXCrossProcessSearchCoordinator);
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(AXCrossProcessSearchCoordinator);
+public:
+    static Ref<AXCrossProcessSearchCoordinator> create()
+    {
+        return adoptRef(*new AXCrossProcessSearchCoordinator());
+    }
+
+    // Wait for all pending responses or timeout.
+    // Returns DidTimeout::No if all responses were received, DidTimeout::Yes if timed out.
+    // On the main thread, spins the run loop to allow IPC callbacks to be processed.
+    WEBCORE_EXPORT DidTimeout waitWithTimeout(Seconds timeout);
+
+    // Increment the pending request count. Called when dispatching an IPC request.
+    void addPendingRequest() { ++m_pendingCount; }
+
+    // Mark that the local search has completed. If there are no pending requests,
+    // signals the semaphore immediately.
+    void markSearchComplete()
+    {
+        m_searchComplete.store(true, std::memory_order_release);
+        checkCompletion();
+    }
+
+    // Signal that a response was received. If the search is complete and this
+    // was the last pending response, signals the semaphore.
+    void responseReceived()
+    {
+        --m_pendingCount;
+        checkCompletion();
+    }
+
+    // Store remote tokens for a given stream index.
+    void storeRemoteResults(size_t streamIndex, Vector<AccessibilityRemoteToken>&& tokens)
+    {
+        Locker locker { m_lock };
+        m_remoteResults.set(streamIndex, WTF::move(tokens));
+    }
+
+    // Take stored remote results for a stream index.
+    Vector<AccessibilityRemoteToken> takeRemoteResults(size_t streamIndex)
+    {
+        Locker locker { m_lock };
+        return m_remoteResults.take(streamIndex);
+    }
+
+    // Returns true if this is a new frame (not already searched), false if duplicate.
+    bool markFrameAsSearched(FrameIdentifier frameID)
+    {
+        Locker locker { m_lock };
+        return m_searchedFrames.add(frameID).isNewEntry;
+    }
+
+private:
+    AXCrossProcessSearchCoordinator() = default;
+
+    void checkCompletion()
+    {
+        // Only signal completion when:
+        // 1. The local search has finished (so we know all remote frames have been encountered)
+        // 2. All pending IPC requests have received responses
+        if (m_searchComplete.load(std::memory_order_acquire) && !m_pendingCount.load(std::memory_order_acquire))
+            m_semaphore.signal();
+    }
+
+    BinarySemaphore m_semaphore;
+    std::atomic<size_t> m_pendingCount { 0 };
+    std::atomic<bool> m_searchComplete { false };
+    Lock m_lock;
+    HashMap<size_t, Vector<AccessibilityRemoteToken>> m_remoteResults WTF_GUARDED_BY_LOCK(m_lock);
+    HashSet<FrameIdentifier> m_searchedFrames WTF_GUARDED_BY_LOCK(m_lock);
+};
+
+// Performs cross-process search coordination:
+// 1. Takes a stream with local results + remote frame placeholders
+// 2. Sends IPC to each remote frame via ChromeClient (on main thread)
+// 3. Waits for responses (with timeout)
+// 4. Returns merged AccessibilitySearchResults in tree order
+//
+// If treeID is nullopt or no remote frames exist, returns only local results.
+// requestingFrameID is pre-populated in the coordinator to prevent re-searching
+// the child frame that requested search continuation in its parent.
+WEBCORE_EXPORT AccessibilitySearchResults performCrossProcessSearch(AccessibilitySearchResultStream&&, const AccessibilitySearchCriteriaIPC&, std::optional<AXTreeID>, unsigned originalLimit, std::optional<FrameIdentifier> requestingFrameID = std::nullopt);
+
+// High-level search function that handles cross-process coordination automatically.
+// Sets anchorObject, performs the search, and coordinates with remote frames.
+WEBCORE_EXPORT AccessibilitySearchResults performSearchWithCrossProcessCoordination(AXCoreObject& anchorObject, AccessibilitySearchCriteria&&);
+
+// Merges parent frame search results with local results based on search direction.
+// For forward search: local results first, then parent results (elements after the frame).
+// For backward search: parent results first (elements before the frame), then local results.
+// Results are truncated to limit.
+WEBCORE_EXPORT AccessibilitySearchResults mergeParentSearchResults(AccessibilitySearchResults&& localResults, Vector<AccessibilityRemoteToken>&& parentTokens, bool isForwardSearch, unsigned limit);
+
+// Performs accessibility search with automatic parent frame coordination.
+// If the search originates from a child frame, dispatches to the parent in parallel
+// and merges results. Uses performSearchWithCrossProcessCoordination internally for
+// nested remote frames.
+//
+// currentFrameID: If provided, this frame's ID is passed to the parent to prevent
+// re-searching this frame during parent continuation.
+WEBCORE_EXPORT AccessibilitySearchResults performSearchWithParentCoordination(AXCoreObject& anchorObject, AccessibilitySearchCriteria&&, std::optional<FrameIdentifier> currentFrameID = std::nullopt);
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AXLiveRegionManager.h
+++ b/Source/WebCore/accessibility/AXLiveRegionManager.h
@@ -31,8 +31,9 @@
 #include <wtf/Platform.h>
 #if PLATFORM(COCOA)
 
-#include "AXCoreObject.h"
-#include "AttributedString.h"
+#include <WebCore/AXAnnouncementTypes.h>
+#include <WebCore/AXCoreObject.h>
+#include <WebCore/AttributedString.h>
 #include <wtf/HashMap.h>
 #include <wtf/text/WTFString.h>
 
@@ -40,29 +41,6 @@ namespace WebCore {
 
 class AccessibilityObject;
 class AXObjectCache;
-enum class LiveRegionStatus : uint8_t;
-
-enum class LiveRegionRelevant : uint8_t {
-    Additions = 1 << 0,
-    Removals  = 1 << 1,
-    Text      = 1 << 2,
-    All       = 1 << 3
-};
-
-struct LiveRegionObject {
-    AXID objectID;
-    String text;
-    String language;
-    HashSet<AXID> descendants; // For atomic regions only, to track additions/removals of descendants.
-};
-
-struct LiveRegionSnapshot {
-    Vector<LiveRegionObject> objects;
-    LiveRegionStatus liveRegionStatus { LiveRegionStatus::Off };
-    OptionSet<LiveRegionRelevant> liveRegionRelevant { { LiveRegionRelevant::Additions, LiveRegionRelevant::Text } };
-};
-
-enum class AnnouncementContents : bool { All, Changes };
 
 class AXLiveRegionManager {
     WTF_MAKE_NONCOPYABLE(AXLiveRegionManager);

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -1275,6 +1275,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::WebAreaTitle:
         stream << "WebAreaTitle";
         break;
+    case AXProperty::RemoteFrameID:
+        stream << "RemoteFrameID";
+        break;
     }
     return stream;
 }
@@ -1356,7 +1359,7 @@ void streamAXCoreObject(TextStream& stream, const AXCoreObject& object, const Op
 
 #if PLATFORM(COCOA)
     if (object.role() == AccessibilityRole::RemoteFrame) {
-        pid_t pid = object.remoteFrameProcessIdentifier();
+        pid_t pid = object.remoteFramePID();
         stream.dumpProperty("remotePID"_s, pid);
     }
 #endif

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -811,7 +811,8 @@ AccessibilityObject* AXObjectCache::getOrCreateSlow(Node& node, IsPartOfRelation
     AX_ASSERT(!get(node));
 
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME
-    AX_ASSERT(&node.document() == document());
+    // Easily reproducible on most pages with ITM off.
+    AX_BROKEN_ASSERT(&node.document() == document());
 #endif
 
     bool isYouTubeReplacement = false;

--- a/Source/WebCore/accessibility/AXObjectCache.h
+++ b/Source/WebCore/accessibility/AXObjectCache.h
@@ -25,8 +25,10 @@
 
 #pragma once
 
+#include <WebCore/AXAnnouncementTypes.h>
 #include <WebCore/AXTextMarker.h>
 #include <WebCore/AXTreeStore.h>
+#include <WebCore/AccessibilityRemoteToken.h>
 #include <WebCore/Document.h>
 #include <WebCore/RenderView.h>
 #include <WebCore/SimpleRange.h>
@@ -96,7 +98,6 @@ struct TextMarkerData;
 enum class AXNotification : uint8_t;
 enum class AXStreamOptions : uint16_t;
 enum class AXProperty : uint16_t;
-enum class LiveRegionStatus: uint8_t;
 enum class TextMarkerOrigin : uint16_t;
 
 struct CharacterOffset {
@@ -156,12 +157,6 @@ struct AXDebugInfo {
     uint64_t webProcessLocalTokenHash;
 };
 
-enum class NotifyPriority : uint8_t { Normal, High };
-
-enum class InterruptBehavior : uint8_t { None, All, Pending };
-
-enum class LiveRegionStatus : uint8_t { Off, Polite, Assertive };
-
 // When this is updated, WebCoreArgumentCoders.serialization.in must be updated as well.
 struct AriaNotifyData {
     String message;
@@ -193,32 +188,6 @@ struct AriaNotifyData {
         };
         return makeString("AriaNotifyData { message: \""_s, message, "\", priority: "_s, priorityString(), ", interrupt: "_s, interruptString(), ", language: \""_s, language, "\" }"_s);
     }
-};
-
-struct AccessibilityRemoteToken {
-    AccessibilityRemoteToken()
-#if !PLATFORM(MAC)
-        : uuid(WTF::UUID::createVersion4())
-        , pid(0)
-#endif
-    { }
-
-#if PLATFORM(MAC)
-    AccessibilityRemoteToken(Vector<uint8_t> bytes)
-        : bytes(bytes)
-#else
-    AccessibilityRemoteToken(WTF::UUID uuid, ProcessID pid)
-        : uuid(uuid)
-        , pid(pid)
-#endif
-    { }
-
-#if PLATFORM(MAC)
-    Vector<uint8_t> bytes;
-#else
-    WTF::UUID uuid;
-    ProcessID pid;
-#endif
 };
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/accessibility/AXRemoteFrame.h
+++ b/Source/WebCore/accessibility/AXRemoteFrame.h
@@ -25,8 +25,8 @@
 
 #pragma once
 
-#include "AXObjectCache.h"
-#include "AccessibilityMockObject.h"
+#include <WebCore/AXObjectCache.h>
+#include <WebCore/AccessibilityMockObject.h>
 
 namespace WebCore {
 
@@ -40,9 +40,8 @@ public:
     void initializePlatformElementWithRemoteToken(AccessibilityRemoteToken, int);
     AccessibilityRemoteToken generateRemoteToken() const;
     RetainPtr<id> remoteFramePlatformElement() const final { return m_remoteFramePlatformElement; }
-    pid_t remoteFrameProcessIdentifier() const final { return m_processIdentifier; }
-    pid_t processIdentifier() const { return m_processIdentifier; }
-    std::optional<FrameIdentifier> frameID() const { return m_frameID; }
+    pid_t remoteFramePID() const final { return m_processIdentifier; }
+    std::optional<FrameIdentifier> remoteFrameID() const final { return m_frameID; }
     void setFrameID(FrameIdentifier frameID) { m_frameID = frameID; }
 #endif
 

--- a/Source/WebCore/accessibility/AXStitchUtilities.h
+++ b/Source/WebCore/accessibility/AXStitchUtilities.h
@@ -25,6 +25,9 @@
 
 #pragma once
 
+#include <wtf/Ref.h>
+#include <wtf/WeakPtr.h>
+
 namespace WebCore {
 
 class AccessibilityObject;

--- a/Source/WebCore/accessibility/AccessibilityMockObject.h
+++ b/Source/WebCore/accessibility/AccessibilityMockObject.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include "AccessibilityObject.h"
+#include <WebCore/AccessibilityObject.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityNodeObject.cpp
@@ -90,6 +90,7 @@
 #include "HTMLTextFormControlElement.h"
 #include "HTMLVideoElement.h"
 #include "HitTestSource.h"
+#include "InlineIteratorBoxInlines.h"
 #include "InlineIteratorLineBoxInlines.h"
 #include "KeyboardEvent.h"
 #include "LayoutIntegrationLineLayout.h"

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -38,7 +38,6 @@
 #include "AXObjectCacheInlines.h"
 #include "AXObjectRareData.h"
 #include "AXRemoteFrame.h"
-#include "AXSearchManager.h"
 #include "AXTextMarker.h"
 #include "AXUtilities.h"
 #include "AccessibilityMockObject.h"
@@ -744,13 +743,12 @@ void AccessibilityObject::resetChildrenIndexInParent() const
     }
 }
 
-AXCoreObject::AccessibilityChildrenVector AccessibilityObject::findMatchingObjects(AccessibilitySearchCriteria&& criteria)
+AXCoreObject::AccessibilityChildrenVector AccessibilityObject::findMatchingObjectsWithin(AccessibilitySearchCriteria&& criteria)
 {
     if (CheckedPtr cache = axObjectCache())
         cache->startCachingComputedObjectAttributesUntilTreeMutates();
 
-    criteria.anchorObject = this;
-    return AXSearchManager().findMatchingObjects(WTF::move(criteria));
+    return AXCoreObject::findMatchingObjectsWithin(WTF::move(criteria));
 }
 
 // Returns the range that is fewer positions away from the reference range.

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -359,7 +359,7 @@ public:
     AccessibilityObject* displayContentsParent() const;
     AccessibilityObject* parentObjectUnignored() const final { return downcast<AccessibilityObject>(AXCoreObject::parentObjectUnignored()); }
     static AccessibilityObject* firstAccessibleObjectFromNode(const Node*);
-    AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&) final;
+    AccessibilityChildrenVector findMatchingObjectsWithin(AccessibilitySearchCriteria&&) final;
     virtual bool isDescendantOfBarrenParent() const { return false; }
 
 #if ENABLE_ACCESSIBILITY_LOCAL_FRAME
@@ -514,7 +514,8 @@ public:
     RetainPtr<RemoteAXObjectRef> remoteParent() const final;
     FloatRect convertRectToPlatformSpace(const FloatRect&, AccessibilityConversionSpace) const final;
     RetainPtr<id> remoteFramePlatformElement() const override { return nil; }
-    pid_t remoteFrameProcessIdentifier() const override { return 0; }
+    pid_t remoteFramePID() const override { return 0; }
+    std::optional<FrameIdentifier> remoteFrameID() const override { return std::nullopt; }
 #endif
     bool hasRemoteFrameChild() const override { return false; }
 

--- a/Source/WebCore/accessibility/AccessibilityRemoteToken.h
+++ b/Source/WebCore/accessibility/AccessibilityRemoteToken.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <wtf/UUID.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+// Token used to identify accessibility objects across process boundaries.
+// On Mac, this is an opaque byte array from NSAccessibilityRemoteUIElement.
+// On other platforms, it's a UUID and process ID pair.
+struct AccessibilityRemoteToken {
+    AccessibilityRemoteToken()
+#if !PLATFORM(MAC)
+        : uuid(WTF::UUID::createVersion4())
+        , pid(0)
+#endif
+    { }
+
+#if PLATFORM(MAC)
+    AccessibilityRemoteToken(Vector<uint8_t> bytes)
+        : bytes(bytes)
+    { }
+
+    Vector<uint8_t> bytes;
+#else
+    AccessibilityRemoteToken(WTF::UUID uuid, ProcessID pid)
+        : uuid(uuid)
+        , pid(pid)
+    { }
+
+    WTF::UUID uuid;
+    ProcessID pid;
+#endif
+};
+
+} // namespace WebCore

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -88,6 +88,7 @@
 #include "LineSelection.h"
 #include "LocalFrame.h"
 #include "LocalizedStrings.h"
+#include "Logging.h"
 #include "NodeList.h"
 #include "Page.h"
 #include "PathUtilities.h"

--- a/Source/WebCore/accessibility/AccessibilityScrollView.cpp
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.cpp
@@ -109,7 +109,7 @@ void AccessibilityScrollView::detachRemoteParts(AccessibilityDetachmentType deta
     if (remoteFrameView && m_remoteFrame && (detachmentType == AccessibilityDetachmentType::ElementDestroyed || detachmentType == AccessibilityDetachmentType::CacheDestroyed)) {
 #if PLATFORM(MAC)
         Ref remoteFrame = remoteFrameView->frame();
-        remoteFrame->unbindRemoteAccessibilityFrames(m_remoteFrame->processIdentifier());
+        remoteFrame->unbindRemoteAccessibilityFrames(protect(m_remoteFrame)->remoteFramePID());
 #endif
         m_remoteFrame = nullptr;
     }

--- a/Source/WebCore/accessibility/AccessibilityScrollView.h
+++ b/Source/WebCore/accessibility/AccessibilityScrollView.h
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "AXRemoteFrame.h"
-#include "AccessibilityObject.h"
-#include "ScrollView.h"
+#include <WebCore/AXRemoteFrame.h>
+#include <WebCore/AccessibilityObject.h>
+#include <WebCore/ScrollView.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/accessibility/AccessibilitySearchCriteriaIPC.h
+++ b/Source/WebCore/accessibility/AccessibilitySearchCriteriaIPC.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1.  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ * 2.  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/AXSearchManager.h>
+
+// This header is included for WebKit IPC message generation.
+// The actual AccessibilitySearchCriteriaIPC struct is defined in AXSearchManager.h
+// and this header simply re-exports it for the message generator.

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -2287,7 +2287,7 @@ static RenderObject* rendererForView(WAKView* view)
         return nil;
 
     auto criteria = accessibilitySearchCriteriaForSearchPredicate(*backingObject, parameters);
-    return makeNSArray(backingObject->findMatchingObjects(WTF::move(criteria)));
+    return makeNSArray(backingObject->findMatchingObjectsWithin(WTF::move(criteria)));
 }
 
 - (void)accessibilityModifySelection:(TextGranularity)granularity increase:(BOOL)increase

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -33,7 +33,6 @@
 #include "AXLogger.h"
 #include "AXLoggerBase.h"
 #include "AXObjectCacheInlines.h"
-#include "AXSearchManager.h"
 #include "AXTextMarker.h"
 #include "AXTextRun.h"
 #include "AXUtilities.h"
@@ -1138,12 +1137,6 @@ Vector<String> AXIsolatedObject::performTextOperation(const AccessibilityTextOpe
             return object->performTextOperation(textOperation);
         return Vector<String>();
     }, Accessibility::InteractiveTimeout, Vector<String> { });
-}
-
-AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::findMatchingObjects(AccessibilitySearchCriteria&& criteria)
-{
-    criteria.anchorObject = this;
-    return AXSearchManager().findMatchingObjects(WTF::move(criteria));
 }
 
 String AXIsolatedObject::textUnderElement(TextUnderElementMode) const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -418,7 +418,6 @@ private:
     // Parameterized attribute retrieval.
     Vector<SimpleRange> findTextRanges(const AccessibilitySearchTextCriteria&) const final;
     Vector<String> performTextOperation(const AccessibilityTextOperation&) final;
-    AccessibilityChildrenVector findMatchingObjects(AccessibilitySearchCriteria&&) final;
 
 #if PLATFORM(COCOA)
     bool preventKeyboardDOMEventDispatch() const final { return boolAttributeValue(AXProperty::PreventKeyboardDOMEventDispatch); }
@@ -587,7 +586,8 @@ private:
 #if PLATFORM(COCOA)
     bool hasApplePDFAnnotationAttribute() const final { return boolAttributeValue(AXProperty::HasApplePDFAnnotationAttribute); }
     RetainPtr<id> remoteFramePlatformElement() const final;
-    pid_t remoteFrameProcessIdentifier() const final { return propertyValue<pid_t>(AXProperty::RemoteFrameProcessIdentifier); }
+    pid_t remoteFramePID() const final { return propertyValue<pid_t>(AXProperty::RemoteFrameProcessIdentifier); }
+    std::optional<FrameIdentifier> remoteFrameID() const final { return optionalAttributeValue<FrameIdentifier>(AXProperty::RemoteFrameID); }
 #endif
     bool hasRemoteFrameChild() const final { return boolAttributeValue(AXProperty::HasRemoteFrameChild); }
 

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1456,7 +1456,8 @@ void AXIsolatedTree::applyPendingChangesLocked()
             object->attachPlatformWrapper(wrapper.get());
 
         // The object must have a wrapper by this point.
-        AX_ASSERT(object->wrapper());
+        // Can hit this on many tests with ITM + ENABLE_ACCESSIBILITY_LOCAL_FRAME (e.g. accessibility/deleting-iframe-destroys-axcache.html).
+        AX_BROKEN_ASSERT(object->wrapper());
         // The reference count of the just added IsolatedObject must be 2
         // because it is referenced by m_readerThreadNodeMap and m_pendingAppends.
         // When m_pendingAppends is cleared, the object will be held only by m_readerThreadNodeMap. The exception is the root node whose reference count is 3.

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -273,6 +273,7 @@ enum class AXProperty : uint16_t {
     RemoteFrameOffset,
     RemoteFramePlatformElement,
 #if PLATFORM(COCOA)
+    RemoteFrameID,
     RemoteFrameProcessIdentifier,
     RemoteParent,
 #endif

--- a/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
+++ b/Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm
@@ -79,7 +79,9 @@ void appendPlatformProperties(AXPropertyVector& properties, OptionSet<AXProperty
         setProperty(AXProperty::StringValue, object->stringValue().isolatedCopy());
 
     setProperty(AXProperty::RemoteFramePlatformElement, object->remoteFramePlatformElement());
-    setProperty(AXProperty::RemoteFrameProcessIdentifier, object->remoteFrameProcessIdentifier());
+    setProperty(AXProperty::RemoteFrameProcessIdentifier, object->remoteFramePID());
+    if (std::optional frameID = object->remoteFrameID())
+        setProperty(AXProperty::RemoteFrameID, *frameID);
 
     if (object->isWebArea()) {
         setProperty(AXProperty::PreventKeyboardDOMEventDispatch, object->preventKeyboardDOMEventDispatch());

--- a/Source/WebCore/page/ChromeClient.cpp
+++ b/Source/WebCore/page/ChromeClient.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "ChromeClient.h"
 
+#include "AXObjectCache.h"
+#include "AXSearchManager.h"
 #include "BarcodeDetectorInterface.h"
 #include "BarcodeDetectorOptionsInterface.h"
 #include "BarcodeFormatInterface.h"
@@ -133,5 +135,17 @@ void ChromeClient::showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedC
     completionHandler(Exception { ExceptionCode::NotSupportedError, "Caption Display Settings are not supported."_s });
 }
 #endif
+
+#if PLATFORM(MAC)
+void ChromeClient::performAccessibilitySearchInRemoteFrame(FrameIdentifier, const AccessibilitySearchCriteriaIPC&, CompletionHandler<void(Vector<AccessibilityRemoteToken>&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+
+void ChromeClient::continueAccessibilitySearchFromChildFrame(FrameIdentifier, const AccessibilitySearchCriteriaIPC&, CompletionHandler<void(Vector<AccessibilityRemoteToken>&&)>&& completionHandler)
+{
+    completionHandler({ });
+}
+#endif // PLATFORM(MAC)
 
 } // namespace WebCore

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -151,6 +151,8 @@ struct GraphicsContextGLAttributes;
 #endif
 
 struct AppHighlight;
+struct AccessibilityRemoteToken;
+struct AccessibilitySearchCriteriaIPC;
 struct ApplePayAMSUIRequest;
 struct AriaNotifyData;
 struct CharacterRange;
@@ -630,6 +632,12 @@ public:
     virtual void isAnyAnimationAllowedToPlayDidChange(bool /* anyAnimationCanPlay */) { };
 #endif
     virtual void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const IntPoint&, CompletionHandler<void(String)>&& callback) { callback(""_s); };
+#if PLATFORM(MAC)
+    WEBCORE_EXPORT virtual void performAccessibilitySearchInRemoteFrame(FrameIdentifier, const AccessibilitySearchCriteriaIPC&, CompletionHandler<void(Vector<AccessibilityRemoteToken>&&)>&&);
+    // Called by a child frame to continue a search in its parent frame.
+    // The parent searches from the child frame's position in its tree.
+    WEBCORE_EXPORT virtual void continueAccessibilitySearchFromChildFrame(FrameIdentifier childFrameID, const AccessibilitySearchCriteriaIPC&, CompletionHandler<void(Vector<AccessibilityRemoteToken>&&)>&&);
+#endif
 
     virtual void isPlayingMediaDidChange(MediaProducerMediaStateFlags) { }
     virtual void handleAutoplayEvent(AutoplayEvent, OptionSet<AutoplayEventFlags>) { }

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -77,7 +77,7 @@ public:
 
     Frame* NODELETE child(unsigned index) const;
     Frame* NODELETE childBySpecifiedName(const AtomString& name) const;
-    Frame* NODELETE descendantByFrameID(FrameIdentifier) const;
+    WEBCORE_EXPORT Frame* NODELETE descendantByFrameID(FrameIdentifier) const;
     WEBCORE_EXPORT RefPtr<Frame> findByUniqueName(const AtomString&, Frame& activeFrame) const;
     WEBCORE_EXPORT RefPtr<Frame> findBySpecifiedName(const AtomString&, Frame& activeFrame) const;
     WEBCORE_EXPORT unsigned NODELETE childCount() const;

--- a/Source/WebKit/Scripts/webkit/messages.py
+++ b/Source/WebKit/Scripts/webkit/messages.py
@@ -1135,6 +1135,7 @@ def headers_for_type(type, for_implementation_file=False):
         'WallTime': ['<wtf/WallTime.h>'],
         'WebCore::AXDebugInfo': ['<WebCore/AXObjectCache.h>'],
         'WebCore::AccessibilityRemoteToken': ['<WebCore/AXObjectCache.h>'],
+        'WebCore::AccessibilitySearchCriteriaIPC': ['<WebCore/AXSearchManager.h>'],
         'WebCore::AriaNotifyData': ['<WebCore/AXObjectCache.h>'],
         'WebCore::LiveRegionAnnouncementData': ['<WebCore/AXObjectCache.h>'],
         'WebCore::AlternativeTextType': ['<WebCore/AlternativeTextClient.h>'],

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9345,6 +9345,68 @@ header: <WebCore/AXObjectCache.h>
 #endif
 }
 
+header: <WebCore/AXCoreObject.h>
+enum class WebCore::AccessibilitySearchDirection : uint8_t {
+    Next,
+    Previous,
+};
+
+header: <WebCore/AXSearchManager.h>
+enum class WebCore::AccessibilitySearchKey : uint8_t {
+    AnyType,
+    Article,
+    BlockquoteSameLevel,
+    Blockquote,
+    BoldFont,
+    Button,
+    Checkbox,
+    Control,
+    DifferentType,
+    FontChange,
+    FontColorChange,
+    Frame,
+    Graphic,
+    HeadingLevel1,
+    HeadingLevel2,
+    HeadingLevel3,
+    HeadingLevel4,
+    HeadingLevel5,
+    HeadingLevel6,
+    HeadingSameLevel,
+    Heading,
+    Highlighted,
+    ItalicFont,
+    KeyboardFocusable,
+    Landmark,
+    Link,
+    List,
+    LiveRegion,
+    MisspelledWord,
+    Outline,
+    PlainText,
+    RadioGroup,
+    SameType,
+    StaticText,
+    StyleChange,
+    TableSameLevel,
+    Table,
+    TextField,
+    Underline,
+    UnvisitedLink,
+    VisitedLink,
+};
+
+header: <WebCore/AXSearchManager.h>
+[CustomHeader] struct WebCore::AccessibilitySearchCriteriaIPC {
+    WebCore::AccessibilitySearchDirection searchDirection;
+    Vector<WebCore::AccessibilitySearchKey> searchKeys;
+    String searchText;
+    unsigned resultsLimit;
+    bool visibleOnly;
+    bool immediateDescendantsOnly;
+    std::optional<MonotonicTime> deadline;
+};
+
 header: <WebCore/ScriptTrackingPrivacyCategory.h>
 [OptionSet] enum class WebCore::ScriptTrackingPrivacyFlag : uint16_t {
     Audio,

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -260,6 +260,7 @@ enum class AttachmentAssociatedElementType : uint8_t;
 
 struct AXDebugInfo;
 struct AccessibilityRemoteToken;
+struct AccessibilitySearchCriteriaIPC;
 struct AppHighlight;
 struct ApplePayAMSUIRequest;
 struct ApplicationManifest;
@@ -3054,6 +3055,10 @@ private:
 #endif
 
     void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, WebCore::IntPoint, CompletionHandler<void(String)>&&);
+#if PLATFORM(MAC)
+    void performAccessibilitySearchInRemoteFrame(WebCore::FrameIdentifier, WebCore::AccessibilitySearchCriteriaIPC, CompletionHandler<void(Vector<WebCore::AccessibilityRemoteToken>&&)>&&);
+    void continueAccessibilitySearchFromChildFrame(WebCore::FrameIdentifier childFrameID, WebCore::AccessibilitySearchCriteriaIPC, CompletionHandler<void(Vector<WebCore::AccessibilityRemoteToken>&&)>&&);
+#endif
     void updateSandboxFlags(IPC::Connection&, WebCore::FrameIdentifier, WebCore::SandboxFlags);
     void updateReferrerPolicy(IPC::Connection&, WebCore::FrameIdentifier, WebCore::ReferrerPolicy);
     void updateOpener(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::FrameIdentifier>);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -171,6 +171,10 @@ messages -> WebPageProxy {
     [EnabledBy=SiteIsolationEnabled] UpdateScrollingMode(WebCore::FrameIdentifier frameID, enum:uint8_t WebCore::ScrollbarMode scrollingMode)
     [EnabledBy=SiteIsolationEnabled] SetFramePrinting(WebCore::FrameIdentifier frameID, bool printing, WebCore::FloatSize pageSize, WebCore::FloatSize originalPageSize, float maximumShrinkRatio, enum:bool WebCore::AdjustViewSize shouldAdjustViewSize);
     ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)
+#if PLATFORM(MAC)
+    [EnabledBy=SiteIsolationEnabled] PerformAccessibilitySearchInRemoteFrame(WebCore::FrameIdentifier frameID, struct WebCore::AccessibilitySearchCriteriaIPC criteria) -> (Vector<WebCore::AccessibilityRemoteToken> results)
+    [EnabledBy=SiteIsolationEnabled] ContinueAccessibilitySearchFromChildFrame(WebCore::FrameIdentifier childFrameID, struct WebCore::AccessibilitySearchCriteriaIPC criteria) -> (Vector<WebCore::AccessibilityRemoteToken> results)
+#endif
 
     MainFramePluginHandlesPageScaleGestureDidChange(bool mainFramePluginHandlesPageScaleGesture, double minScale, double maxScale)
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -76,6 +76,7 @@
 #include "WebSearchPopupMenu.h"
 #include "WebWorkerClient.h"
 #include <WebCore/AXObjectCache.h>
+#include <WebCore/AXSearchManager.h>
 #include <WebCore/AppHighlight.h>
 #include <WebCore/BarcodeDetectorInterface.h>
 #include <WebCore/ColorChooser.h>
@@ -1809,6 +1810,24 @@ void WebChromeClient::resolveAccessibilityHitTestForTesting(FrameIdentifier fram
     else
         callback({ });
 }
+
+#if PLATFORM(MAC)
+void WebChromeClient::performAccessibilitySearchInRemoteFrame(FrameIdentifier frameID, const AccessibilitySearchCriteriaIPC& criteria, CompletionHandler<void(Vector<AccessibilityRemoteToken>&&)>&& callback)
+{
+    if (RefPtr page = m_page.get())
+        page->sendWithAsyncReply(Messages::WebPageProxy::PerformAccessibilitySearchInRemoteFrame(frameID, criteria), WTF::move(callback));
+    else
+        callback({ });
+}
+
+void WebChromeClient::continueAccessibilitySearchFromChildFrame(FrameIdentifier childFrameID, const AccessibilitySearchCriteriaIPC& criteria, CompletionHandler<void(Vector<AccessibilityRemoteToken>&&)>&& callback)
+{
+    if (RefPtr page = m_page.get())
+        page->sendWithAsyncReply(Messages::WebPageProxy::ContinueAccessibilitySearchFromChildFrame(childFrameID, criteria), WTF::move(callback));
+    else
+        callback({ });
+}
+#endif
 
 void WebChromeClient::isPlayingMediaDidChange(MediaProducerMediaStateFlags state)
 {

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h
@@ -406,6 +406,10 @@ private:
     void isAnyAnimationAllowedToPlayDidChange(bool /* anyAnimationCanPlay */) final;
 #endif
     void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const WebCore::IntPoint&, CompletionHandler<void(String)>&&) final;
+#if PLATFORM(MAC)
+    void performAccessibilitySearchInRemoteFrame(WebCore::FrameIdentifier, const WebCore::AccessibilitySearchCriteriaIPC&, CompletionHandler<void(Vector<WebCore::AccessibilityRemoteToken>&&)>&&) final;
+    void continueAccessibilitySearchFromChildFrame(WebCore::FrameIdentifier childFrameID, const WebCore::AccessibilitySearchCriteriaIPC&, CompletionHandler<void(Vector<WebCore::AccessibilityRemoteToken>&&)>&&) final;
+#endif
     void isPlayingMediaDidChange(WebCore::MediaProducerMediaStateFlags) final;
     void handleAutoplayEvent(WebCore::AutoplayEvent, OptionSet<WebCore::AutoplayEventFlags>) final;
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -292,6 +292,7 @@ enum class PaintBehavior : uint32_t;
 
 struct AXDebugInfo;
 struct AccessibilityRemoteToken;
+struct AccessibilitySearchCriteriaIPC;
 struct AppHighlight;
 struct AriaNotifyData;
 struct AttributedString;
@@ -2705,6 +2706,10 @@ private:
     void updateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifier, const WebCore::InheritedFrameState&);
 #endif
     void resolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier, const WebCore::IntPoint&, CompletionHandler<void(String)>&&);
+#if PLATFORM(MAC)
+    void performAccessibilitySearchInRemoteFrame(WebCore::FrameIdentifier, WebCore::AccessibilitySearchCriteriaIPC, CompletionHandler<void(Vector<WebCore::AccessibilityRemoteToken>&&)>&&);
+    void continueAccessibilitySearchInParentFrame(WebCore::FrameIdentifier childFrameID, WebCore::AccessibilitySearchCriteriaIPC, CompletionHandler<void(Vector<WebCore::AccessibilityRemoteToken>&&)>&&);
+#endif
 
     void requestAllTextAndRects(CompletionHandler<void(Vector<std::pair<String, WebCore::FloatRect>>&&)>&&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -544,6 +544,10 @@ messages -> WebPage WantsAsyncDispatchMessage {
     UpdateRemotePageAccessibilityInheritedState(WebCore::FrameIdentifier frameID, struct WebCore::InheritedFrameState state);
 #endif
     ResolveAccessibilityHitTestForTesting(WebCore::FrameIdentifier frameID, WebCore::IntPoint point) -> (String result)
+#if PLATFORM(MAC)
+    PerformAccessibilitySearchInRemoteFrame(WebCore::FrameIdentifier frameID, struct WebCore::AccessibilitySearchCriteriaIPC criteria) -> (Vector<WebCore::AccessibilityRemoteToken> results)
+    ContinueAccessibilitySearchInParentFrame(WebCore::FrameIdentifier childFrameID, struct WebCore::AccessibilitySearchCriteriaIPC criteria) -> (Vector<WebCore::AccessibilityRemoteToken> results)
+#endif
     EnableAccessibility()
 
 #if PLATFORM(MAC)

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp
@@ -1474,6 +1474,11 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElement::uiElementForSearchPredica
     return nullptr;
 }
 
+JSValueRef AccessibilityUIElement::uiElementsForSearchPredicate(OpaqueJSContext const*, WTR::AccessibilityUIElement*, bool, OpaqueJSValue const*, OpaqueJSString*, bool, bool, unsigned)
+{
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElement::url()
 {
     return nullptr;

--- a/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h
@@ -283,6 +283,7 @@ public:
     virtual bool attributedStringRangeIsMisspelled(unsigned location, unsigned length);
     virtual unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
     virtual RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly);
+    virtual JSValueRef uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit);
     virtual JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity);
     virtual JSValueRef searchTextWithCriteria(JSContextRef, JSValueRef searchStrings, JSStringRef startFrom, JSStringRef direction);
     virtual JSValueRef performTextOperation(JSContextRef, JSStringRef operationType, JSValueRef markerRanges, JSValueRef replacementStrings, bool shouldSmartReplace);

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl
@@ -227,6 +227,7 @@ interface AccessibilityUIElement {
     boolean attributedStringRangeIsMisspelled(unsigned long location, unsigned long length);
     unsigned long uiElementCountForSearchPredicate(AccessibilityUIElement startElement, boolean isDirectionNext, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
     AccessibilityUIElement uiElementForSearchPredicate(AccessibilityUIElement startElement, boolean isDirectionNext, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly);
+    object uiElementsForSearchPredicate(AccessibilityUIElement startElement, boolean isDirectionNext, object searchKey, DOMString searchText, boolean visibleOnly, boolean immediateDescendantsOnly, unsigned long resultsLimit);
     DOMString selectTextWithCriteria(DOMString ambiguityResolution, object searchStrings, DOMString replacementString, DOMString activity);
     object searchTextWithCriteria(object searchStrings, DOMString startFrom, DOMString direction);
     object performTextOperation(DOMString operationType, object markerRanges, object replacementStrings, boolean shouldSmartReplace);

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp
@@ -1318,6 +1318,11 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElementAtspi::uiElementForSearchPr
     return nullptr;
 }
 
+JSValueRef AccessibilityUIElementAtspi::uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool, unsigned)
+{
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElementAtspi::selectTextWithCriteria(JSContextRef context, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity)
 {
     return nullptr;

--- a/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h
@@ -207,6 +207,7 @@ public:
     bool attributedStringRangeIsMisspelled(unsigned location, unsigned length) override;
     unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
     RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSValueRef uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit) override;
     JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
 
     RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row) override;

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h
@@ -236,6 +236,7 @@ public:
     // Search methods
     unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
     RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSValueRef uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit) override;
     JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
 
     // Table attribute methods

--- a/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm
@@ -893,6 +893,21 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElementIOS::uiElementForSearchPred
     return nullptr;
 }
 
+JSValueRef AccessibilityUIElementIOS::uiElementsForSearchPredicate(JSContextRef context, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit)
+{
+    NSDictionary *parameter = searchPredicateForSearchCriteria(context, startElement, nullptr, isDirectionNext, resultsLimit, searchKey, searchText, visibleOnly, immediateDescendantsOnly);
+    id searchResults = [m_element accessibilityFindMatchingObjects:parameter];
+    if (![searchResults isKindOfClass:[NSArray class]])
+        return nullptr;
+
+    Vector<RefPtr<AccessibilityUIElement>> elements;
+    for (id result in searchResults) {
+        if ([result isAccessibilityElement])
+            elements.append(AccessibilityUIElement::create(result));
+    }
+    return makeJSArray(context, elements);
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElementIOS::selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity)
 {
     return nullptr;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
@@ -49,7 +49,7 @@ public:
 
     virtual ~AccessibilityUIElementMac();
 
-    PlatformUIElement platformUIElement() override { return m_element.getAutoreleased(); }
+    PlatformUIElement platformUIElement() override { return m_element.get(); }
 
     bool isEqual(AccessibilityUIElement* otherElement) override;
     JSRetainPtr<JSStringRef> domIdentifier() const override;
@@ -245,6 +245,7 @@ public:
     bool attributedStringRangeIsMisspelled(unsigned location, unsigned length) override;
     unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
     RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSValueRef uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit) override;
     JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
     JSValueRef searchTextWithCriteria(JSContextRef, JSValueRef searchStrings, JSStringRef startFrom, JSStringRef direction) override;
     JSValueRef performTextOperation(JSContextRef, JSStringRef operationType, JSValueRef markerRanges, JSValueRef replacementStrings, bool shouldSmartReplace) override;
@@ -350,7 +351,7 @@ private:
     double numberAttributeValueNS(NSString *attribute) const;
     bool isAttributeSettableNS(NSString *) const;
 
-    WeakObjCPtr<id> m_element;
+    RetainPtr<id> m_element;
     RetainPtr<id> m_notificationHandler;
 
     void getLinkedUIElements(Vector<RefPtr<AccessibilityUIElement> >&);

--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp
@@ -594,6 +594,12 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElementPlayStation::uiElementForSe
     return nullptr;
 }
 
+JSValueRef AccessibilityUIElementPlayStation::uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool, unsigned)
+{
+    notImplemented();
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElementPlayStation::selectTextWithCriteria(JSContextRef, JSStringRef, JSValueRef, JSStringRef, JSStringRef)
 {
     notImplemented();

--- a/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.h
@@ -185,6 +185,7 @@ public:
     bool attributedStringRangeIsMisspelled(unsigned location, unsigned length) override;
     unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
     RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSValueRef uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit) override;
     JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
 
     RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row) override;

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp
@@ -599,6 +599,12 @@ RefPtr<AccessibilityUIElement> AccessibilityUIElementWin::uiElementForSearchPred
     return nullptr;
 }
 
+JSValueRef AccessibilityUIElementWin::uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement*, bool, JSValueRef, JSStringRef, bool, bool, unsigned)
+{
+    notImplemented();
+    return nullptr;
+}
+
 JSRetainPtr<JSStringRef> AccessibilityUIElementWin::selectTextWithCriteria(JSContextRef, JSStringRef, JSValueRef, JSStringRef, JSStringRef)
 {
     notImplemented();

--- a/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.h
@@ -185,6 +185,7 @@ public:
     bool attributedStringRangeIsMisspelled(unsigned location, unsigned length) override;
     unsigned uiElementCountForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
     RefPtr<AccessibilityUIElement> uiElementForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly) override;
+    JSValueRef uiElementsForSearchPredicate(JSContextRef, AccessibilityUIElement* startElement, bool isDirectionNext, JSValueRef searchKey, JSStringRef searchText, bool visibleOnly, bool immediateDescendantsOnly, unsigned resultsLimit) override;
     JSRetainPtr<JSStringRef> selectTextWithCriteria(JSContextRef, JSStringRef ambiguityResolution, JSValueRef searchStrings, JSStringRef replacementString, JSStringRef activity) override;
 
     RefPtr<AccessibilityUIElement> cellForColumnAndRow(unsigned column, unsigned row) override;


### PR DESCRIPTION
#### c1e16773122e8d52ef7b55c00404eb530575f4a4
<pre>
AX: On macOS with site isolation enabled, VoiceOver cannot traverse into iframes because UIElementsForSearchPredicate only searches within the same process
<a href="https://bugs.webkit.org/show_bug.cgi?id=307994">https://bugs.webkit.org/show_bug.cgi?id=307994</a>
<a href="https://rdar.apple.com/170487304">rdar://170487304</a>

Reviewed by Joshua Hoffman.

This change implements cross-process accessibility search to support VoiceOver
navigation across site-isolated iframes. When a search encounters a remote frame,
it sends async IPC to the child process to continue the search, then continues its
search in its own process. The parent process is also queried via async IPC,
since the search may require moving beyond this frame (e.g. asking for the next
element at the last element in an iframe). When children + parent processes return
results, we merge them back in tree order, resolving AccessibilityRemoteToken results into
NSAccessibilityRemoteUIElements as necessary.

The search uses a single absolute deadline established when the top-level search begins,
rather than giving each nested frame its own independent timeout. When dispatching to child
frames, the remaining time until the deadline (minus IPC overhead buffer) is passed along,
ensuring deeply nested frame hierarchies share the original timeout budget. This prevents
timeout multiplication where N levels of nesting would otherwise allow N × timeout total
wait time, while still guaranteeing each frame gets at least a minimum search duration.

Other key changes:
  - Add AXCrossProcessSearch.{h,cpp} with coordination infrastructure for parallel
    IPC dispatch and cascading timeouts (described above) across nested frames

  - Refactor AXSearchManager to return AccessibilitySearchResultStream that records
    both local results and remote frame placeholders in tree order

  - Add ChromeClient methods for performAccessibilitySearchInRemoteFrame() and
    continueAccessibilitySearchFromChildFrame() to enable bidirectional search.

  - Add uiElementsForSearchPredicate() test helper for verifying multi-result searches.

  - Track accessibility enabled state in WebPageCreationParameters so newly-created
    web processes for site-isolated frames start with accessibility being enabled.
    This was required to make my three new tests pass because accessibility must be
    enabled by the time they got a cross-process accessibility search request.

  - Searched frames are tracked by ID and will not be searched multiple times.

New tests were added to exercise various interesting scenarios:
  - http/tests/site-isolation/accessibility/cross-process-search-headings.html
   * Ensures proper merging of local and remote results.
  - http/tests/site-isolation/accessibility/cross-process-search-nested-iframes.html
   * Verifies search progresses through multiple layers of iframes.
  - http/tests/site-isolation/accessibility/cross-process-search-traversal.html
   * Ensures that we can traverse all the way forwards and back through
     the all content on the page.

* LayoutTests/accessibility/ax-object-destroyed-on-reload-expected.txt:
* LayoutTests/accessibility/ax-object-destroyed-on-reload.html:
* LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-headings-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-headings.html: Added.
* LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-nested-iframes-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-nested-iframes.html: Added.
* LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-traversal-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/cross-process-search-traversal.html: Added.
* LayoutTests/http/tests/site-isolation/accessibility/resources/iframe-with-headings.html: Added.
* LayoutTests/http/tests/site-isolation/accessibility/resources/nested-iframe-inner.html: Added.
* LayoutTests/http/tests/site-isolation/accessibility/resources/nested-iframe-middle.html: Added.
* LayoutTests/platform/ios/accessibility/ax-object-destroyed-on-reload-expected.txt:
* Source/WebCore/Headers.cmake:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/accessibility/AXAnnouncementTypes.h: Added.
* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::partialOrder):
(WebCore::AXCoreObject::findMatchingObjectsWithin):
* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/AXCrossProcessSearch.cpp: Added.
(WebCore::canDoRemoteSearch):
(WebCore::spinRunLoopUntil):
(WebCore::AXCrossProcessSearchCoordinator::waitWithTimeout):
(WebCore::mergeStreamResults):
(WebCore::computeRemainingTimeout):
(WebCore::dispatchRemoteFrameSearch):
(WebCore::performCrossProcessSearch):
(WebCore::performSearchWithCrossProcessCoordination):
(WebCore::mergeParentSearchResults):
(WebCore::ParentFrameSearchContext::signal):
(WebCore::ParentFrameSearchContext::waitWithTimeout):
(WebCore::ParentFrameSearchContext::markParentDispatched):
(WebCore::ParentFrameSearchContext::didDispatchParent const):
(WebCore::ParentFrameSearchContext::setParentTokens):
(WebCore::ParentFrameSearchContext::takeParentTokens):
(WebCore::performSearchWithParentCoordination):
* Source/WebCore/accessibility/AXCrossProcessSearch.h: Added.
(WebCore::AXCrossProcessSearchCoordinator::create):
(WebCore::AXCrossProcessSearchCoordinator::addPendingRequest):
(WebCore::AXCrossProcessSearchCoordinator::markSearchComplete):
(WebCore::AXCrossProcessSearchCoordinator::responseReceived):
(WebCore::AXCrossProcessSearchCoordinator::storeRemoteResults):
(WebCore::AXCrossProcessSearchCoordinator::takeRemoteResults):
(WebCore::AXCrossProcessSearchCoordinator::markFrameAsSearched):
(WebCore::AXCrossProcessSearchCoordinator::checkCompletion):
* Source/WebCore/accessibility/AXLiveRegionManager.h:
(): Deleted.
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
(WebCore::streamAXCoreObject):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::getOrCreateSlow):
* Source/WebCore/accessibility/AXObjectCache.h:
(WebCore::AccessibilityRemoteToken::AccessibilityRemoteToken): Deleted.
* Source/WebCore/accessibility/AXRemoteFrame.h:
* Source/WebCore/accessibility/AXSearchManager.cpp:
(WebCore::AXSearchManager::findMatchingObjectsAsStream):
(WebCore::AXSearchManager::findMatchingObjectsInternalAsStream):
(WebCore::AXSearchManager::findMatchingRange):
(WebCore::AXSearchManager::matchWithResultsLimit): Deleted.
(WebCore::AXSearchManager::findMatchingObjectsInternal): Deleted.
* Source/WebCore/accessibility/AXSearchManager.h:
(WebCore::AccessibilitySearchCriteriaIPC::AccessibilitySearchCriteriaIPC):
(WebCore::AccessibilitySearchCriteriaIPC::toSearchCriteria const):
(WebCore::SearchResultEntry::localResult):
(WebCore::SearchResultEntry::remoteFrame):
(WebCore::SearchResultEntry::isLocalResult const):
(WebCore::SearchResultEntry::isRemoteFrame const):
(WebCore::SearchResultEntry::objectIfLocalResult const):
(WebCore::SearchResultEntry::frameID const):
(WebCore::SearchResultEntry::streamIndex const):
(WebCore::SearchResultEntry::SearchResultEntry):
(WebCore::AccessibilitySearchResultStream::appendLocalResult):
(WebCore::AccessibilitySearchResultStream::appendRemoteFrame):
(WebCore::AccessibilitySearchResultStream::entries const):
(WebCore::AccessibilitySearchResultStream::entryCount const):
(WebCore::AccessibilitySearchResultStream::setResultsLimit):
(WebCore::AccessibilitySearchResultStream::resultsLimit const):
(WebCore::AccessibilitySearchResultStream::nextIndex const):
(WebCore::AccessibilitySearchResult::local):
(WebCore::AccessibilitySearchResult::remote):
(WebCore::AccessibilitySearchResult::isLocal const):
(WebCore::AccessibilitySearchResult::isRemote const):
(WebCore::AccessibilitySearchResult::objectIfLocalResult const):
(WebCore::AccessibilitySearchResult::remoteToken const):
(WebCore::AccessibilitySearchResult::AccessibilitySearchResult):
(WebCore::AXSearchManager::findMatchingObjects): Deleted.
* Source/WebCore/accessibility/AXStitchUtilities.h:
* Source/WebCore/accessibility/AccessibilityMockObject.h:
* Source/WebCore/accessibility/AccessibilityNodeObject.cpp:
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::findMatchingObjectsWithin):
(WebCore::AccessibilityObject::findMatchingObjects): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/AccessibilityRemoteToken.h: Added.
(WebCore::AccessibilityRemoteToken::AccessibilityRemoteToken):
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
* Source/WebCore/accessibility/AccessibilityScrollView.cpp:
(WebCore::AccessibilityScrollView::detachRemoteParts):
* Source/WebCore/accessibility/AccessibilityScrollView.h:
* Source/WebCore/accessibility/AccessibilitySearchCriteriaIPC.h: Added.
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityFindMatchingObjects:]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::findMatchingObjects): Deleted.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::applyPendingChangesLocked):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/isolatedtree/mac/AXIsolatedObjectMac.mm:
(WebCore::appendPlatformProperties):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(remoteElementFromToken):
(searchResultsToNSArray):
(performSearchWithRemoteFrames):
(-[WebAccessibilityObjectWrapper _accessibilityHitTestResolvingRemoteFrame:callback:]):
(-[WebAccessibilityObjectWrapper accessibilityAttributeValue:forParameter:]):
* Source/WebCore/page/ChromeClient.cpp:
(WebCore::ChromeClient::performAccessibilitySearchInRemoteFrame):
(WebCore::ChromeClient::continueAccessibilitySearchFromChildFrame):
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/FrameTree.h:
* Source/WebKit/Scripts/webkit/messages.py:
(headers_for_type):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::performAccessibilitySearchInRemoteFrame):
(WebKit::WebPageProxy::continueAccessibilitySearchFromChildFrame):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::performAccessibilitySearchInRemoteFrame):
(WebKit::WebChromeClient::continueAccessibilitySearchFromChildFrame):
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::tokenFromWrapper):
(WebKit::convertSearchResultsToRemoteTokens):
(WebKit::WebPage::performAccessibilitySearchInRemoteFrame):
(WebKit::WebPage::continueAccessibilitySearchInParentFrame):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.cpp:
(WTR::AccessibilityUIElement::uiElementsForSearchPredicate):
* Tools/WebKitTestRunner/InjectedBundle/AccessibilityUIElement.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/AccessibilityUIElement.idl:
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.cpp:
(WTR::AccessibilityUIElementAtspi::uiElementsForSearchPredicate):
* Tools/WebKitTestRunner/InjectedBundle/atspi/AccessibilityUIElementAtspi.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.h:
* Tools/WebKitTestRunner/InjectedBundle/ios/AccessibilityUIElementIOS.mm:
(WTR::AccessibilityUIElementIOS::uiElementsForSearchPredicate):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::AccessibilityUIElementMac::attributeValue const):
(WTR::AccessibilityUIElementMac::allAttributes):
(WTR::AccessibilityUIElementMac::setBoolAttributeValue):
(WTR::AccessibilityUIElementMac::setValue):
(WTR::AccessibilityUIElementMac::isAttributeSupported):
(WTR::AccessibilityUIElementMac::isValid const):
(WTR::AccessibilityUIElementMac::uiElementsForSearchPredicate):
(WTR::AccessibilityUIElementMac::setSelectedTextRange):
(WTR::AccessibilityUIElementMac::invokeCustomActionAtIndex):
(WTR::AccessibilityUIElementMac::setSelectedTextMarkerRange):
(WTR::AccessibilityUIElementMac::setSelectedChild const):
(WTR::AccessibilityUIElementMac::setSelectedChildAtIndex const):
(WTR::AccessibilityUIElementMac::removeSelectionAtIndex const):
(WTR::AccessibilityUIElementMac::takeFocus):
(WTR::AccessibilityUIElementMac::resetSelectedTextMarkerRange):
* Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.cpp:
(WTR::AccessibilityUIElementPlayStation::uiElementsForSearchPredicate):
* Tools/WebKitTestRunner/InjectedBundle/playstation/AccessibilityUIElementPlayStation.h:
* Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.cpp:
(WTR::AccessibilityUIElementWin::uiElementsForSearchPredicate):
* Tools/WebKitTestRunner/InjectedBundle/win/AccessibilityUIElementWin.h:

Canonical link: <a href="https://commits.webkit.org/308321@main">https://commits.webkit.org/308321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2562f373e83cde3ef157b3f5f237d00cae2035af

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147070 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13341 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155752 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100484 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148944 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19651 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113336 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80862 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150032 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132128 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94092 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/146394 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14787 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12554 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3194 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124374 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10049 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158083 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1214 "Found 1 new failure in accessibility/AccessibilityRenderObject.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121360 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121561 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31151 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19561 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131806 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75520 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17122 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8624 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19167 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82922 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18897 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19048 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18956 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->