### PR TITLE
[JSC] Air Greedy Register Allocator should handle FP constants

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirArg.h
+++ b/Source/JavaScriptCore/b3/air/AirArg.h
@@ -862,6 +862,19 @@ public:
         return kind() == FPImm128;
     }
 
+    bool isFPImmZero() const
+    {
+        switch (kind()) {
+        case FPImm32:
+        case FPImm64:
+            return value() == 0;
+        case FPImm128:
+            return bitEquals(asV128(), v128_t { });
+        default:
+            return false;
+        }
+    }
+
     bool isZeroReg() const
     {
         return kind() == ZeroReg;

--- a/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
+++ b/Source/JavaScriptCore/b3/air/AirOpcode.opcodes
@@ -821,6 +821,7 @@ MoveFloat U:F:32, D:F:32
     Index, Tmp as loadFloat
     Tmp, Addr as storeFloat
     Tmp, Index as storeFloat
+    64: FPImm32, Tmp as move32ToFloat
 
 MoveFloat U:F:32, D:F:32, S:F:32
     Addr, Addr, Tmp
@@ -831,6 +832,7 @@ MoveDouble U:F:64, D:F:64
     Index, Tmp as loadDouble
     Tmp, Addr as storeDouble
     Tmp, Index as storeDouble
+    64: FPImm64, Tmp as move64ToDouble
 
 MoveDouble U:F:64, D:F:64, S:F:64
     Addr, Addr, Tmp
@@ -853,27 +855,18 @@ arm64: StorePairDouble U:F:64, U:F:64, D:F:128
     Index, Tmp as loadVector
     Tmp, Addr as storeVector
     Tmp, Index as storeVector
+    FPImm128, Tmp as move128ToVector
 
 64: MoveVector U:F:128, D:F:128, S:F:128
     Addr, Addr, Tmp
 
-MoveZeroToDouble D:F:64
-    Tmp
-
-MoveZeroToFloat D:F:32
-    Tmp
-
 64: Move64ToDouble U:G:64, D:F:64
     Tmp, Tmp
     x86: Addr, Tmp as loadDouble
-    FPImm64, Tmp
     Index, Tmp as loadDouble
 
 32: Move64ToDouble U:G:32, U:G:32, D:F:64
     Tmp, Tmp, Tmp
-
-64: Move128ToVector U:G:128, D:F:128
-    FPImm128, Tmp
 
 32: Move32ToDoubleHi U:G:32, UD:F:64
     Tmp, Tmp
@@ -881,7 +874,6 @@ MoveZeroToFloat D:F:32
 Move32ToFloat U:G:32, D:F:32
     Tmp, Tmp
     x86: Addr, Tmp as loadFloat
-    64: FPImm32, Tmp
     Index, Tmp as loadFloat
 
 64: MoveDoubleTo64 U:F:64, D:G:64
@@ -1984,9 +1976,6 @@ arm64: VectorNot U:G:Ptr, U:F:128, D:F:128
 
 64: VectorXor U:G:Ptr, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp
-
-64: MoveZeroToVector D:F:128
-    Tmp
 
 64: VectorUshl U:G:Ptr, U:F:128, U:F:128, D:F:128
     SIMDInfo, Tmp, Tmp, Tmp

--- a/Source/JavaScriptCore/b3/air/opcode_generator.rb
+++ b/Source/JavaScriptCore/b3/air/opcode_generator.rb
@@ -471,12 +471,20 @@ class Parser
                         parseError("Form has wrong number of arguments for overload") unless kinds.length == signature.length
                         kinds.each_with_index {
                             | kind, index |
-                            if kind.name == "Imm" or kind.name == "BigImm" or kind.name == "BitImm" or kind.name == "BitImm64" or kind.name == "FPImm32" or kind.name == "FPImm64" or kind.name == "FPImm128"
+                            if kind.name == "Imm" or kind.name == "BigImm" or kind.name == "BitImm" or kind.name == "BitImm64"
                                 if signature[index].role != "U"
                                     parseError("Form has an immediate for a non-use argument")
                                 end
                                 if signature[index].bank != "G"
                                     parseError("Form has an immediate for a non-general-purpose argument")
+                                end
+                            end
+                            if kind.name == "FPImm32" or kind.name == "FPImm64" or kind.name == "FPImm128"
+                                if signature[index].role != "U"
+                                    parseError("Form has an immediate for a non-use argument")
+                                end
+                                if signature[index].bank != "F"
+                                    parseError("Form has an immediate for a non-floating-point-purpose argument")
                                 end
                             end
                             if kind.name == "ZeroReg"

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1403,6 +1403,19 @@ void testVectorMulLow();
 void testConstDoubleMove();
 void testConstFloatMove();
 
+void testConstDoubleZero();
+void testConstDoubleNegativeZero();
+void testConstFloatZero();
+void testConstFloatNegativeZero();
+void testConstDoubleAddZero();
+void testConstFloatAddZero();
+void testConstDoubleCompareZero();
+void testConstFloatCompareZero();
+void testConstDoubleSelectZero();
+void testConstFloatSelectZero();
+void testConstDoubleMultipleZeroUses();
+void testConstFloatMultipleZeroUses();
+
 void testSShrCompare32(int32_t);
 void testSShrCompare64(int64_t);
 

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -878,6 +878,19 @@ void run(const TestConfig* config)
     RUN(testConstDoubleMove());
     RUN(testConstFloatMove());
 
+    RUN(testConstDoubleZero());
+    RUN(testConstDoubleNegativeZero());
+    RUN(testConstFloatZero());
+    RUN(testConstFloatNegativeZero());
+    RUN(testConstDoubleAddZero());
+    RUN(testConstFloatAddZero());
+    RUN(testConstDoubleCompareZero());
+    RUN(testConstFloatCompareZero());
+    RUN(testConstDoubleSelectZero());
+    RUN(testConstFloatSelectZero());
+    RUN(testConstDoubleMultipleZeroUses());
+    RUN(testConstFloatMultipleZeroUses());
+
     RUN(testLoadImmutable());
 
     // ARM64 conditional compare (ccmp) tests


### PR DESCRIPTION
#### 40a9116442c908d0497fe3d5bb9d5393ee42a18a
<pre>
[JSC] Air Greedy Register Allocator should handle FP constants
<a href="https://bugs.webkit.org/show_bug.cgi?id=308019">https://bugs.webkit.org/show_bug.cgi?id=308019</a>
<a href="https://rdar.apple.com/170516740">rdar://170516740</a>

Reviewed by Dan Hecht.

Let&apos;s support full fledged FP constants handling in Air Greedy Register
Allocator.

1. Remove Move32ToFloat / Move64ToDouble / Move128ToVector with FPImm to
   MoveFloat / MoveDouble / MoveVector, which is now well aligned to
   what Move / Move32 are doing.
2. Remove MoveZeroToFloat / MoveZeroToDouble / MoveZeroToVector and use
   MoveFloat / MoveDouble / MoveVector with 0 FPImm instead. This makes
   0 constant handling easy and simple.
3. AirUseCounts tracks FP constants too.
4. Air Greedy Register Allocator handles FP constants rematerialization
   in the same way to GP constants rematerialization. Now since we use
   MoveFloat / MoveDouble / MoveVector for constant materialization, it
   is easy to convert arg to FPImm (since loading from spills is also
   using the same instructions).

Tests: Source/JavaScriptCore/b3/air/testair.cpp
       Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_8.cpp

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGraphColoring.cpp:
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::initSpillCosts):
(JSC::B3::Air::Greedy::GreedyAllocator::trySplitIntraBlock):
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
* Source/JavaScriptCore/b3/air/AirArg.h:
(JSC::B3::Air::Arg::isFPImmZero const):
* Source/JavaScriptCore/b3/air/AirFixPartialRegisterStalls.cpp:
(JSC::B3::Air::fixPartialRegisterStalls):
* Source/JavaScriptCore/b3/air/AirOpcode.opcodes:
* Source/JavaScriptCore/b3/air/AirUseCounts.h:
(JSC::B3::Air::UseCounts::UseCounts):
(JSC::B3::Air::UseCounts::constant const):
(JSC::B3::Air::UseCounts::constantWidth const):
* Source/JavaScriptCore/b3/air/opcode_generator.rb:
* Source/JavaScriptCore/b3/air/testair.cpp:
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_8.cpp:
(testConstDoubleZero):
(testConstDoubleNegativeZero):
(testConstFloatZero):
(testConstFloatNegativeZero):
(testConstDoubleAddZero):
(testConstFloatAddZero):
(testConstDoubleCompareZero):
(testConstFloatCompareZero):
(testConstDoubleSelectZero):
(testConstFloatSelectZero):
(testConstDoubleMultipleZeroUses):
(testConstFloatMultipleZeroUses):

Canonical link: <a href="https://commits.webkit.org/307724@main">https://commits.webkit.org/307724@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/55da28f7344ed974e88a2c61dfe967a9eb649502

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145192 "10 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153864 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98828 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89f49f66-c60e-4d13-870a-32c08e4bc4d9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18356 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17765 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111639 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80022 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148155 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14003 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130406 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92538 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42d63878-0840-430d-9803-be5416b3a654) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13360 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11121 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1309 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137183 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156176 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6001 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17724 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8252 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119647 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17770 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119981 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15752 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128422 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73388 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22406 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17345 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6680 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176481 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17082 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81124 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45392 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17290 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17145 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->