### PR TITLE
REGRESSION (307520@main): Webpage crashes trying to inspect a <select> element

### DIFF
--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-crash-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-crash-expected.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div>Test passes if it doesn't crash</div>

--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-crash.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-crash.html
@@ -1,0 +1,7 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
+<!DOCTYPE html>
+<div id="div">Test passes if it doesn't crash</div>
+<script>
+    div.style.borderRadius = "-internal-auto-base(initial, 0.5em)";
+    div.style.getPropertyValue("border-radius");
+</script>

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -26,6 +26,7 @@
 #include "ShorthandSerializer.h"
 
 #include "CSSBorderImageWidthValue.h"
+#include "CSSFunctionValue.h"
 #include "CSSGridLineNamesValue.h"
 #include "CSSGridTemplateAreasValue.h"
 #include "CSSParserIdioms.h"
@@ -264,6 +265,10 @@ bool ShorthandSerializer::commonSerializationChecks(const StyleProperties& prope
 
         // Don't serialize if any longhand was set to a variable.
         if (is<CSSVariableReferenceValue>(value))
+            return true;
+
+        // Don't serialize if any longhand was set to -internal-auto-base().
+        if (RefPtr functionValue = dynamicDowncast<CSSFunctionValue>(value); functionValue && functionValue->name() == CSSValueInternalAutoBase)
             return true;
 
         // Don't serialize if any longhand was set by a different shorthand.


### PR DESCRIPTION
#### ebc04e9b23b06e06bf32d0087f0991bc0b84d4c4
<pre>
REGRESSION (307520@main): Webpage crashes trying to inspect a &lt;select&gt; element
<a href="https://bugs.webkit.org/show_bug.cgi?id=308021">https://bugs.webkit.org/show_bug.cgi?id=308021</a>
<a href="https://rdar.apple.com/170517420">rdar://170517420</a>

Reviewed by Simon Fraser.

Treat -internal-auto-base() like var() and don&apos;t try to eagerly serialize.

* LayoutTests/fast/forms/appearance-base/internal-auto-base-function-crash-expected.html: Added.
* LayoutTests/fast/forms/appearance-base/internal-auto-base-function-crash.html: Added.
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::commonSerializationChecks):

Canonical link: <a href="https://commits.webkit.org/307684@main">https://commits.webkit.org/307684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7f8da827bcdfb1ad8ae52ee30fcf4043c422c89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9610 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153826 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/178e8e1c-1392-4e69-8814-414872ce0497) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147029 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18318 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111608 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdf54896-18fe-4e2b-a04d-bfd3cebd0a5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13968 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130369 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92506 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d16b3d99-f7b7-4185-b440-f4cb704dbcb5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13329 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11092 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1271 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122851 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7127 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156138 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17686 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8215 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119615 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17732 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119949 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30767 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15717 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128385 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17307 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6643 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17043 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81086 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17252 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17107 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->