### PR TITLE
AX: Controls with aria-labelledby should use native label geometry when both they and their ARIA label has no visible bounding box

### DIFF
--- a/LayoutTests/accessibility/native-label-geometry-with-aria-labelledby-expected.txt
+++ b/LayoutTests/accessibility/native-label-geometry-with-aria-labelledby-expected.txt
@@ -1,0 +1,12 @@
+This test ensures an input that has both aria-labelledby pointing to a visually-hidden element, and a native label with visible geometry, gets geometry from the native label.
+
+PASS: radioInput.width >= 195 === true
+PASS: radioInput.height >= 45 === true
+PASS: Math.abs(radioInput.pageX - 8) <= 2 === true
+PASS: Math.abs(radioInput.pageY - 8) <= 2 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+Sky Blue

--- a/LayoutTests/accessibility/native-label-geometry-with-aria-labelledby.html
+++ b/LayoutTests/accessibility/native-label-geometry-with-aria-labelledby.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+<style>
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+.visible-label {
+    display: block;
+    width: 200px;
+    height: 50px;
+    background: lightblue;
+}
+</style>
+</head>
+<body>
+
+<input class="visually-hidden" type="radio" id="radio-input" aria-labelledby="hidden-label-text" name="test" value="test">
+<label for="radio-input" class="visible-label">
+    <span id="hidden-label-text" class="visually-hidden">Sky Blue</span>
+</label>
+
+<script>
+var output = "This test ensures an input that has both aria-labelledby pointing to a visually-hidden element, and a native label with visible geometry, gets geometry from the native label.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var pageX, pageY;
+    var radioInput = accessibilityController.accessibleElementById("radio-input");
+    setTimeout(async function() {
+        // The width should be approximately 200 (the label width), but leave a little buffer since the exact value doesn't
+        // matter much.
+        output += await expectAsync("radioInput.width >= 195", "true");
+        // The height should be approximately 50 (the label height).
+        output += await expectAsync("radioInput.height >= 45", "true");
+        output += await expectAsync("Math.abs(radioInput.pageX - 8) <= 2", "true");
+        output += await expectAsync("Math.abs(radioInput.pageY - 8) <= 2", "true");
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+
+}
+</script>
+</body>
+</html>
+

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -907,6 +907,9 @@ accessibility/select-whitespace-collapsed-text.html [ Failure ]
 # Need to implement AccessibilityUIElement::insertText.
 accessibility/insert-text-into-password-field.html [ Skip ]
 
+# Need to implement AccessibilityUIElement::{pageX, pageY}.
+accessibility/native-label-geometry-with-aria-labelledby.html [ Skip ]
+
 # These test a Cocoa-only API.
 accessibility/mixed-contenteditable-visible-character-range-hang.html [ Skip ]
 accessibility/mixed-contenteditable-double-br-visible-character-range-hang.html [ Skip ]

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -381,6 +381,8 @@ enum class AXRelation : uint8_t {
     HeaderFor,
     LabeledBy,
     LabelFor,
+    NativeLabeledBy,
+    NativeLabelFor,
     OwnedBy,
     OwnerFor,
 };
@@ -762,6 +764,11 @@ public:
     AccessibilityChildrenVector flowFromObjects() const { return relatedObjects(AXRelation::FlowsFrom); }
     AccessibilityChildrenVector labeledByObjects() const { return relatedObjects(AXRelation::LabeledBy); }
     AccessibilityChildrenVector labelForObjects() const { return relatedObjects(AXRelation::LabelFor); }
+    // This function exists because in the accname calculation, aria-labelledby takes precedence over "native"
+    // labels (like <label for="z"><input id="z">), and thus we do not create a LabelFor relationship for the native
+    // label. However, sometimes outside of accname, we do also want to know the native label relationship,
+    // which is what this function is for.
+    AccessibilityChildrenVector nativeLabeledByObjects() const { return relatedObjects(AXRelation::NativeLabeledBy); }
     AccessibilityChildrenVector ownedObjects() const { return relatedObjects(AXRelation::OwnerFor); }
     AccessibilityChildrenVector owners() const { return relatedObjects(AXRelation::OwnedBy); }
     virtual AccessibilityChildrenVector relatedObjects(AXRelation) const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -573,6 +573,12 @@ TextStream& operator<<(TextStream& stream, AXRelation relation)
     case AXRelation::LabelFor:
         stream << "LabelFor";
         break;
+    case AXRelation::NativeLabeledBy:
+        stream << "NativeLabeledBy";
+        break;
+    case AXRelation::NativeLabelFor:
+        stream << "NativeLabelFor";
+        break;
     case AXRelation::OwnedBy:
         stream << "OwnedBy";
         break;

--- a/Source/WebCore/accessibility/AXObjectCache.cpp
+++ b/Source/WebCore/accessibility/AXObjectCache.cpp
@@ -5675,6 +5675,10 @@ AXRelation AXObjectCache::symmetricRelation(AXRelation relation)
         return AXRelation::LabelFor;
     case AXRelation::LabelFor:
         return AXRelation::LabeledBy;
+    case AXRelation::NativeLabeledBy:
+        return AXRelation::NativeLabelFor;
+    case AXRelation::NativeLabelFor:
+        return AXRelation::NativeLabeledBy;
     case AXRelation::OwnedBy:
         return AXRelation::OwnerFor;
     case AXRelation::OwnerFor:
@@ -6009,8 +6013,13 @@ void AXObjectCache::addLabelForRelation(Element& origin)
 
     // LabelFor relations are established for <label for=...>.
     if (RefPtr label = dynamicDowncast<HTMLLabelElement>(origin)) {
-        if (RefPtr control = Accessibility::controlForLabelElement(*label))
-            addedRelation = addRelation(origin, *control, AXRelation::LabelFor);
+        if (RefPtr control = Accessibility::controlForLabelElement(*label)) {
+            // Always add NativeLabelFor for geometry purposes.
+            addedRelation = addRelation(origin, *control, AXRelation::NativeLabelFor);
+            // Only add LabelFor (for accname) if no ARIA labelling exists.
+            if (!hasAnyARIALabelling(*control))
+                addRelation(origin, *control, AXRelation::LabelFor);
+        }
     }
 
     if (addedRelation)


### PR DESCRIPTION
#### 24ef9396933d6067dbf9bb6f9f4744b42d699757
<pre>
AX: Controls with aria-labelledby should use native label geometry when both they and their ARIA label has no visible bounding box
<a href="https://bugs.webkit.org/show_bug.cgi?id=308022">https://bugs.webkit.org/show_bug.cgi?id=308022</a>
<a href="https://rdar.apple.com/problem/170518900">rdar://problem/170518900</a>

Reviewed by Joshua Hoffman.

When a visually-hidden control has both aria-labelledby pointing to a visually-hidden element and a
native &lt;label for&gt; element with visible geometry, we were unable to compute a bounding box
for the control because we rejected the native label relationship entirely when ARIA
labelling existed. This was done because ARIA labels beat out native labels in the accname
calculation.

This patch introduces NativeLabelFor/NativeLabeledBy relations that are always created
for label-for=&quot;id&quot; associations, independent of the presence of ARIA labelling. The existing
LabelFor/LabeledBy relations continue to respect ARIA precedence for accessible name calculation.
In relativeFrame(), we now fall back to native label geometry when ARIA labels don&apos;t
provide a usable frame.

* LayoutTests/accessibility/native-label-geometry-with-aria-labelledby-expected.txt: Added.
* LayoutTests/accessibility/native-label-geometry-with-aria-labelledby.html: Added.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::nativeLabeledByObjects const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AXObjectCache.cpp:
(WebCore::AXObjectCache::symmetricRelation):
(WebCore::AXObjectCache::addLabelForRelation):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::relativeFrame const):

Canonical link: <a href="https://commits.webkit.org/307727@main">https://commits.webkit.org/307727@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3d9e5d4c6c0b7ced0b83dd6808127b617e369b5f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145221 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17902 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9687 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153893 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98857 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/de751b1b-dfe6-491a-a50e-14bc15289104) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147096 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18385 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17794 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111663 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80037 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db37cca4-15dc-4e6c-84c1-b69050447b81) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148184 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14027 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92563 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/148b31e7-2044-4bbd-aa16-b0fcc91aaf33) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13384 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11146 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1338 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122909 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156205 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17753 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8288 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119673 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17799 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120007 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30791 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15777 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73434 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17374 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6716 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17111 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81153 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17319 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17174 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->