### PR TITLE
[macOS Release] http/tests/webgpu/webgpu/shader/validation/functions/restrictions.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt
@@ -586,6 +586,8 @@ PASS :binding_point_on_function_var:group="";binding="%40binding(0)"
 PASS :binding_point_on_function_var:group="%40group(0)";binding=""
 PASS :binding_point_on_function_var:group="%40group(0)";binding="%40binding(0)"
 FAIL :binding_collisions:a_group=0;b_group=0;a_binding=0;b_binding=0;b_use="same" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -600,10 +602,11 @@ FAIL :binding_collisions:a_group=0;b_group=0;a_binding=0;b_binding=0;b_use="same
 
           _ = b;
         }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/decl/var.spec.js:519:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :binding_collisions:a_group=0;b_group=0;a_binding=0;b_binding=0;b_use="different"
 PASS :binding_collisions:a_group=0;b_group=0;a_binding=0;b_binding=1;b_use="same"
@@ -611,6 +614,8 @@ PASS :binding_collisions:a_group=0;b_group=0;a_binding=0;b_binding=1;b_use="diff
 PASS :binding_collisions:a_group=0;b_group=0;a_binding=1;b_binding=0;b_use="same"
 PASS :binding_collisions:a_group=0;b_group=0;a_binding=1;b_binding=0;b_use="different"
 FAIL :binding_collisions:a_group=0;b_group=0;a_binding=1;b_binding=1;b_use="same" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -625,10 +630,11 @@ FAIL :binding_collisions:a_group=0;b_group=0;a_binding=1;b_binding=1;b_use="same
 
           _ = b;
         }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/decl/var.spec.js:519:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :binding_collisions:a_group=0;b_group=0;a_binding=1;b_binding=1;b_use="different"
 PASS :binding_collisions:a_group=0;b_group=1;a_binding=0;b_binding=0;b_use="same"
@@ -648,6 +654,8 @@ PASS :binding_collisions:a_group=1;b_group=0;a_binding=1;b_binding=0;b_use="diff
 PASS :binding_collisions:a_group=1;b_group=0;a_binding=1;b_binding=1;b_use="same"
 PASS :binding_collisions:a_group=1;b_group=0;a_binding=1;b_binding=1;b_use="different"
 FAIL :binding_collisions:a_group=1;b_group=1;a_binding=0;b_binding=0;b_use="same" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -662,10 +670,11 @@ FAIL :binding_collisions:a_group=1;b_group=1;a_binding=0;b_binding=0;b_use="same
 
           _ = b;
         }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/decl/var.spec.js:519:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :binding_collisions:a_group=1;b_group=1;a_binding=0;b_binding=0;b_use="different"
 PASS :binding_collisions:a_group=1;b_group=1;a_binding=0;b_binding=1;b_use="same"
@@ -673,6 +682,8 @@ PASS :binding_collisions:a_group=1;b_group=1;a_binding=0;b_binding=1;b_use="diff
 PASS :binding_collisions:a_group=1;b_group=1;a_binding=1;b_binding=0;b_use="same"
 PASS :binding_collisions:a_group=1;b_group=1;a_binding=1;b_binding=0;b_use="different"
 FAIL :binding_collisions:a_group=1;b_group=1;a_binding=1;b_binding=1;b_use="same" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -687,10 +698,11 @@ FAIL :binding_collisions:a_group=1;b_group=1;a_binding=1;b_binding=1;b_use="same
 
           _ = b;
         }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/decl/var.spec.js:519:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :binding_collisions:a_group=1;b_group=1;a_binding=1;b_binding=1;b_use="different"
 PASS :binding_collision_unused_helper:
@@ -965,6 +977,8 @@ PASS :shader_stage:stage="compute";kind="uniform"
 PASS :shader_stage:stage="compute";kind="workgroup"
 PASS :shader_stage:stage="vertex";kind="handle_ro"
 FAIL :shader_stage:stage="vertex";kind="handle_wo" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -977,12 +991,15 @@ FAIL :shader_stage:stage="vertex";kind="handle_wo" assert_unreached:
               _ = v;
               return vec4f();
             }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/decl/var.spec.js:857:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :shader_stage:stage="vertex";kind="handle_rw" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -995,15 +1012,18 @@ FAIL :shader_stage:stage="vertex";kind="handle_rw" assert_unreached:
               _ = v;
               return vec4f();
             }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/decl/var.spec.js:857:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :shader_stage:stage="vertex";kind="function"
 PASS :shader_stage:stage="vertex";kind="private"
 PASS :shader_stage:stage="vertex";kind="storage_ro"
 FAIL :shader_stage:stage="vertex";kind="storage_rw" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1016,13 +1036,16 @@ FAIL :shader_stage:stage="vertex";kind="storage_rw" assert_unreached:
               _ = v;
               return vec4f();
             }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/decl/var.spec.js:857:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :shader_stage:stage="vertex";kind="uniform"
 FAIL :shader_stage:stage="vertex";kind="workgroup" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1035,10 +1058,11 @@ FAIL :shader_stage:stage="vertex";kind="workgroup" assert_unreached:
               _ = v;
               return vec4f();
             }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/decl/var.spec.js:857:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :shader_stage:stage="fragment";kind="handle_ro"
 PASS :shader_stage:stage="fragment";kind="handle_wo"
@@ -1049,6 +1073,8 @@ PASS :shader_stage:stage="fragment";kind="storage_ro"
 PASS :shader_stage:stage="fragment";kind="storage_rw"
 PASS :shader_stage:stage="fragment";kind="uniform"
 FAIL :shader_stage:stage="fragment";kind="workgroup" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1060,9 +1086,10 @@ FAIL :shader_stage:stage="fragment";kind="workgroup" assert_unreached:
 
               _ = v;
             }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/decl/var.spec.js:857:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/atomics-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/atomics-expected.txt
@@ -21,6 +21,8 @@ PASS :stage:stage="vertex";atomicOp="load"
 PASS :stage:stage="vertex";atomicOp="store"
 PASS :stage:stage="vertex";atomicOp="exchange"
 FAIL :stage:stage="vertex";atomicOp="compareexchangeweak" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -32,10 +34,11 @@ FAIL :stage:stage="vertex";atomicOp="compareexchangeweak" assert_unreached:
       atomicCompareExchangeWeak(&a,1,1);
       return vec4<f32>();
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/atomics.spec.js:95:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :stage:stage="compute";atomicOp="add"
 PASS :stage:stage="compute";atomicOp="sub"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/cross-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/cross-expected.txt
@@ -3,29 +3,29 @@ PASS :values:stage="constant";type="vec3%3Cabstract-int%3E"
 PASS :values:stage="constant";type="vec3%3Cabstract-float%3E"
 PASS :values:stage="constant";type="vec3%3Cf32%3E"
 FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
+  - (in subcase: a=-65504;b=-65504) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=-65504;b=-65504) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     enable f16;
     const v  = cross(vec3(-65504.0h, -65504.0h, -65504.0h), vec3(-65504.0h, -65504.0h, -65504.0h));
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    validateConstOrOverrideBuiltinEval@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/const_override_validation.js:171:30
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/cross.spec.js:71:37
-  - (in subcase: a=-65504;b=-65504) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: a=-65504;b=-65504) INFO: subcase ran
+  - (in subcase: a=-65504;b=-63.96875) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=-65504;b=-63.96875) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     enable f16;
     const v  = cross(vec3(-65504.0h, -65504.0h, -65504.0h), vec3(-63.96875h, -63.96875h, -63.96875h));
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    validateConstOrOverrideBuiltinEval@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/const_override_validation.js:171:30
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/cross.spec.js:71:37
-  - (in subcase: a=-65504;b=-63.96875) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: a=-65504;b=-63.96875) INFO: subcase ran
   - (in subcase: a=-65504;b=-0.062469482421875) INFO: subcase ran
   - (in subcase: a=-65504;b=-0.00006103515625) INFO: subcase ran
@@ -35,6 +35,8 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
   - (in subcase: a=-65504;b=5.960464477539063e-8) INFO: subcase ran
   - (in subcase: a=-65504;b=0.00006103515625) INFO: subcase ran
   - (in subcase: a=-65504;b=0.062469482421875) INFO: subcase ran
+  - (in subcase: a=-65504;b=63.96875) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=-65504;b=63.96875) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -42,9 +44,9 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(-65504.0h, -65504.0h, -65504.0h), vec3(63.96875h, 63.96875h, 63.96875h));
       at (elided: only 2 shown)
-  - (in subcase: a=-65504;b=63.96875) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=-65504;b=63.96875) INFO: subcase ran
+  - (in subcase: a=-65504;b=65504) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=-65504;b=65504) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -52,9 +54,9 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(-65504.0h, -65504.0h, -65504.0h), vec3(65504.0h, 65504.0h, 65504.0h));
       at (elided: only 2 shown)
-  - (in subcase: a=-65504;b=65504) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=-65504;b=65504) INFO: subcase ran
+  - (in subcase: a=-63.96875;b=-65504) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=-63.96875;b=-65504) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -62,8 +64,6 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(-63.96875h, -63.96875h, -63.96875h), vec3(-65504.0h, -65504.0h, -65504.0h));
       at (elided: only 2 shown)
-  - (in subcase: a=-63.96875;b=-65504) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=-63.96875;b=-65504) INFO: subcase ran
   - (in subcase: a=-63.96875;b=-63.96875) INFO: subcase ran
   - (in subcase: a=-63.96875;b=-0.062469482421875) INFO: subcase ran
@@ -75,6 +75,8 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
   - (in subcase: a=-63.96875;b=0.00006103515625) INFO: subcase ran
   - (in subcase: a=-63.96875;b=0.062469482421875) INFO: subcase ran
   - (in subcase: a=-63.96875;b=63.96875) INFO: subcase ran
+  - (in subcase: a=-63.96875;b=65504) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=-63.96875;b=65504) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -82,8 +84,6 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(-63.96875h, -63.96875h, -63.96875h), vec3(65504.0h, 65504.0h, 65504.0h));
       at (elided: only 2 shown)
-  - (in subcase: a=-63.96875;b=65504) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=-63.96875;b=65504) INFO: subcase ran
   - (in subcase: a=-0.062469482421875;b=-65504) INFO: subcase ran
   - (in subcase: a=-0.062469482421875;b=-63.96875) INFO: subcase ran
@@ -181,6 +181,8 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
   - (in subcase: a=0.062469482421875;b=0.062469482421875) INFO: subcase ran
   - (in subcase: a=0.062469482421875;b=63.96875) INFO: subcase ran
   - (in subcase: a=0.062469482421875;b=65504) INFO: subcase ran
+  - (in subcase: a=63.96875;b=-65504) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=63.96875;b=-65504) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -188,8 +190,6 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(63.96875h, 63.96875h, 63.96875h), vec3(-65504.0h, -65504.0h, -65504.0h));
       at (elided: only 2 shown)
-  - (in subcase: a=63.96875;b=-65504) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=63.96875;b=-65504) INFO: subcase ran
   - (in subcase: a=63.96875;b=-63.96875) INFO: subcase ran
   - (in subcase: a=63.96875;b=-0.062469482421875) INFO: subcase ran
@@ -201,6 +201,8 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
   - (in subcase: a=63.96875;b=0.00006103515625) INFO: subcase ran
   - (in subcase: a=63.96875;b=0.062469482421875) INFO: subcase ran
   - (in subcase: a=63.96875;b=63.96875) INFO: subcase ran
+  - (in subcase: a=63.96875;b=65504) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=63.96875;b=65504) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -208,9 +210,9 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(63.96875h, 63.96875h, 63.96875h), vec3(65504.0h, 65504.0h, 65504.0h));
       at (elided: only 2 shown)
-  - (in subcase: a=63.96875;b=65504) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=63.96875;b=65504) INFO: subcase ran
+  - (in subcase: a=65504;b=-65504) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=65504;b=-65504) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -218,9 +220,9 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(65504.0h, 65504.0h, 65504.0h), vec3(-65504.0h, -65504.0h, -65504.0h));
       at (elided: only 2 shown)
-  - (in subcase: a=65504;b=-65504) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=65504;b=-65504) INFO: subcase ran
+  - (in subcase: a=65504;b=-63.96875) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=65504;b=-63.96875) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -228,8 +230,6 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(65504.0h, 65504.0h, 65504.0h), vec3(-63.96875h, -63.96875h, -63.96875h));
       at (elided: only 2 shown)
-  - (in subcase: a=65504;b=-63.96875) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=65504;b=-63.96875) INFO: subcase ran
   - (in subcase: a=65504;b=-0.062469482421875) INFO: subcase ran
   - (in subcase: a=65504;b=-0.00006103515625) INFO: subcase ran
@@ -239,6 +239,8 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
   - (in subcase: a=65504;b=5.960464477539063e-8) INFO: subcase ran
   - (in subcase: a=65504;b=0.00006103515625) INFO: subcase ran
   - (in subcase: a=65504;b=0.062469482421875) INFO: subcase ran
+  - (in subcase: a=65504;b=63.96875) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=65504;b=63.96875) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -246,9 +248,9 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(65504.0h, 65504.0h, 65504.0h), vec3(63.96875h, 63.96875h, 63.96875h));
       at (elided: only 2 shown)
-  - (in subcase: a=65504;b=63.96875) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=65504;b=63.96875) INFO: subcase ran
+  - (in subcase: a=65504;b=65504) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: a=65504;b=65504) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -256,8 +258,6 @@ FAIL :values:stage="constant";type="vec3%3Cf16%3E" assert_unreached:
     enable f16;
     const v  = cross(vec3(65504.0h, 65504.0h, 65504.0h), vec3(65504.0h, 65504.0h, 65504.0h));
       at (elided: only 2 shown)
-  - (in subcase: a=65504;b=65504) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
   - (in subcase: a=65504;b=65504) INFO: subcase ran
  Reached unreachable code
 PASS :values:stage="override";type="vec3%3Cf32%3E"
@@ -265,14 +265,14 @@ FAIL :values:stage="override";type="vec3%3Cf16%3E" assert_unreached:
   - (in subcase: a=-65504;b=-65504) EXPECTATION FAILED: Expected validation error
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
+    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:216:24
     validateConstOrOverrideBuiltinEval@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/const_override_validation.js:194:31
     @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/cross.spec.js:71:37
   - (in subcase: a=-65504;b=-65504) INFO: subcase ran
   - (in subcase: a=-65504;b=-63.96875) EXPECTATION FAILED: Expected validation error
     eventualAsyncExpectation@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:258:33
     expectGPUError@http://127.0.0.1:8000/webgpu/webgpu/gpu_test.js:1143:34
-    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:209:24
+    expectPipelineResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:216:24
     validateConstOrOverrideBuiltinEval@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/const_override_validation.js:194:31
     @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/cross.spec.js:71:37
   - (in subcase: a=-65504;b=-63.96875) INFO: subcase ran

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias-expected.txt
@@ -485,6 +485,8 @@ PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="f32"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="f16"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Cabstract-int%3E"
 FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Cabstract-int%3E" assert_unreached:
+  - (in subcase: value=-9) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: value=-9) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -497,14 +499,15 @@ FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Cabstr
       return vec4f(0);
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias.spec.js:278:24
-  - (in subcase: value=-9) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: value=-9) INFO: subcase ran
   - (in subcase: value=-8) INFO: subcase ran
   - (in subcase: value=0) INFO: subcase ran
   - (in subcase: value=7) INFO: subcase ran
+  - (in subcase: value=8) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: value=8) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -517,10 +520,9 @@ FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Cabstr
       return vec4f(0);
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias.spec.js:278:24
-  - (in subcase: value=8) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: value=8) INFO: subcase ran
  Reached unreachable code
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Cabstract-int%3E"
@@ -536,6 +538,8 @@ PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Cf16%3
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="i32"
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec2%3Ci32%3E"
 FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Ci32%3E" assert_unreached:
+  - (in subcase: value=-9) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: value=-9) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -548,14 +552,15 @@ FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Ci32%3
       return vec4f(0);
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias.spec.js:278:24
-  - (in subcase: value=-9) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: value=-9) INFO: subcase ran
   - (in subcase: value=-8) INFO: subcase ran
   - (in subcase: value=0) INFO: subcase ran
   - (in subcase: value=7) INFO: subcase ran
+  - (in subcase: value=8) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: value=8) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -568,10 +573,9 @@ FAIL :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec3%3Ci32%3
       return vec4f(0);
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias.spec.js:278:24
-  - (in subcase: value=8) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: value=8) INFO: subcase ran
  Reached unreachable code
 PASS :offset_argument:textureType="texture_3d%3Cf32%3E";offsetType="vec4%3Ci32%3E"
@@ -587,6 +591,8 @@ PASS :offset_argument,non_const:textureType="texture_2d_array%3Cf32%3E";varType=
 PASS :offset_argument,non_const:textureType="texture_2d_array%3Cf32%3E";varType="l"
 PASS :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="c"
 FAIL :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="u" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -602,12 +608,15 @@ FAIL :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="u" as
       return vec4f(0);
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias.spec.js:316:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="l" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -623,10 +632,11 @@ FAIL :offset_argument,non_const:textureType="texture_3d%3Cf32%3E";varType="l" as
       return vec4f(0);
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias.spec.js:316:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :only_in_fragment:textureType="texture_2d%3Cf32%3E";entryPoint="none";offset=false
 PASS :only_in_fragment:textureType="texture_2d%3Cf32%3E";entryPoint="none";offset=true

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad-expected.txt
@@ -15,6 +15,8 @@ PASS :no_atomics:type="bool";call="bar()"
 PASS :no_atomics:type="bool";call="workgroupUniformLoad(%26wgvar)"
 PASS :no_atomics:type="array%3Catomic%3Ci32%3E,%204%3E";call="bar()"
 FAIL :no_atomics:type="array%3Catomic%3Ci32%3E,%204%3E";call="workgroupUniformLoad(%26wgvar)" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -33,13 +35,16 @@ FAIL :no_atomics:type="array%3Catomic%3Ci32%3E,%204%3E";call="workgroupUniformLo
     fn foo() {
       _ = workgroupUniformLoad(&wgvar);
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad.spec.js:119:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :no_atomics:type="AtomicStruct";call="bar()"
 FAIL :no_atomics:type="AtomicStruct";call="workgroupUniformLoad(%26wgvar)" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -58,13 +63,16 @@ FAIL :no_atomics:type="AtomicStruct";call="workgroupUniformLoad(%26wgvar)" asser
     fn foo() {
       _ = workgroupUniformLoad(&wgvar);
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad.spec.js:119:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :param_constructible_only:stage="const"
 FAIL :param_constructible_only:stage="override" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -76,10 +84,11 @@ FAIL :param_constructible_only:stage="override" assert_unreached:
     fn foo() {
       _ = workgroupUniformLoad(&wgvar)[0];
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad.spec.js:137:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :must_use:use=true
 PASS :must_use:use=false

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/functions/restrictions-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/functions/restrictions-expected.txt
@@ -4,6 +4,8 @@ PASS :vertex_returns_position:case="nested_position"
 PASS :vertex_returns_position:case="no_bare_position"
 PASS :vertex_returns_position:case="no_nested_position"
 FAIL :entry_point_call_target:stage="%40fragment";entry_point="with" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -18,13 +20,16 @@ FAIL :entry_point_call_target:stage="%40fragment";entry_point="with" assert_unre
       bar();
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/functions/restrictions.spec.js:97:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :entry_point_call_target:stage="%40fragment";entry_point="without"
 FAIL :entry_point_call_target:stage="%40vertex";entry_point="with" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -39,13 +44,16 @@ FAIL :entry_point_call_target:stage="%40vertex";entry_point="with" assert_unreac
       let tmp = bar();
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/functions/restrictions.spec.js:97:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :entry_point_call_target:stage="%40vertex";entry_point="without"
 FAIL :entry_point_call_target:stage="%40compute%20%40workgroup_size(1,1,1)";entry_point="with" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -60,10 +68,11 @@ FAIL :entry_point_call_target:stage="%40compute%20%40workgroup_size(1,1,1)";entr
       bar();
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/functions/restrictions.spec.js:97:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :entry_point_call_target:stage="%40compute%20%40workgroup_size(1,1,1)";entry_point="without"
 PASS :function_return_types:case="u32"
@@ -159,6 +168,8 @@ PASS :function_parameter_types:case="invalid_ptr5"
 PASS :function_parameter_types:case="invalid_ptr6"
 PASS :function_parameter_types:case="invalid_ptr7"
 FAIL :function_parameter_types:case="invalid_ptr8" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -192,10 +203,11 @@ FAIL :function_parameter_types:case="invalid_ptr8" assert_unreached:
 
     fn foo(param : ptr<function, texture_external>) {
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/functions/restrictions.spec.js:313:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :function_parameter_matching:decl="u32"
 PASS :function_parameter_matching:decl="i32"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/comments-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/comments-expected.txt
@@ -5,76 +5,82 @@ PASS :line_comment_terminators:blankspace=["%20","space"]
 PASS :line_comment_terminators:blankspace=["%5Ct","tab"]
 PASS :line_comment_terminators:blankspace=["%5Cn","line_feed"]
 FAIL :line_comment_terminators:blankspace=["%5Cu000b","vertical_tab"] assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     // Line commentconst invalid_outside_comment = should_fail
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/comments.spec.js:61:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :line_comment_terminators:blankspace=["%5Cf","form_feed"] assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     // Line commentconst invalid_outside_comment = should_fail
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/comments.spec.js:61:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :line_comment_terminators:blankspace=["%5Cr","carriage_return"] assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     // Line comment\rconst invalid_outside_comment = should_fail
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/comments.spec.js:61:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :line_comment_terminators:blankspace=["%5Cr%5Cn","carriage_return_line_feed"]
 FAIL :line_comment_terminators:blankspace=["%C2%85","next_line"] assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     // Line commentconst invalid_outside_comment = should_fail
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/comments.spec.js:61:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :line_comment_terminators:blankspace=["%E2%80%A8","line_separator"] assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     // Line comment const invalid_outside_comment = should_fail
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/comments.spec.js:61:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :line_comment_terminators:blankspace=["%E2%80%A9","paragraph_separator"] assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     // Line comment const invalid_outside_comment = should_fail
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/comments.spec.js:61:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :unterminated_block_comment:terminated=true

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/identifiers-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/identifiers-expected.txt
@@ -198,27 +198,29 @@ PASS :module_var_name:ident="noexcept"
 PASS :module_var_name:ident="noinline"
 PASS :module_var_name:ident="nointerpolation"
 FAIL :module_var_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     var<private> non_coherent : i32;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:282:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :module_var_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     var<private> noncoherent : i32;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:282:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :module_var_name:ident="noperspective"
@@ -485,27 +487,29 @@ PASS :module_const_name:ident="noexcept"
 PASS :module_const_name:ident="noinline"
 PASS :module_const_name:ident="nointerpolation"
 FAIL :module_const_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     const non_coherent : i32 = 0;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:295:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :module_const_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     const noncoherent : i32 = 0;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:295:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :module_const_name:ident="noperspective"
@@ -772,27 +776,29 @@ PASS :override_name:ident="noexcept"
 PASS :override_name:ident="noinline"
 PASS :override_name:ident="nointerpolation"
 FAIL :override_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     override non_coherent : i32 = 0;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:308:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :override_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     override noncoherent : i32 = 0;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:308:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :override_name:ident="noperspective"
@@ -1059,27 +1065,29 @@ PASS :function_name:ident="noexcept"
 PASS :function_name:ident="noinline"
 PASS :function_name:ident="nointerpolation"
 FAIL :function_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     fn non_coherent() {}
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:320:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :function_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     fn noncoherent() {}
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:320:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :function_name:ident="noperspective"
@@ -1346,27 +1354,29 @@ PASS :struct_name:ident="noexcept"
 PASS :struct_name:ident="noinline"
 PASS :struct_name:ident="nointerpolation"
 FAIL :struct_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     struct non_coherent { i : i32 }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:333:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :struct_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     struct noncoherent { i : i32 }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:333:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :struct_name:ident="noperspective"
@@ -1633,27 +1643,29 @@ PASS :alias_name:ident="noexcept"
 PASS :alias_name:ident="noinline"
 PASS :alias_name:ident="nointerpolation"
 FAIL :alias_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     alias non_coherent = i32;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:346:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :alias_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     alias noncoherent = i32;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:346:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :alias_name:ident="noperspective"
@@ -1920,27 +1932,29 @@ PASS :function_param_name:ident="noexcept"
 PASS :function_param_name:ident="noinline"
 PASS :function_param_name:ident="nointerpolation"
 FAIL :function_param_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     fn F(non_coherent : i32) {}
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:359:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :function_param_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     fn F(noncoherent : i32) {}
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:359:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :function_param_name:ident="noperspective"
@@ -2209,6 +2223,8 @@ PASS :function_const_name:ident="noexcept"
 PASS :function_const_name:ident="noinline"
 PASS :function_const_name:ident="nointerpolation"
 FAIL :function_const_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2216,13 +2232,14 @@ FAIL :function_const_name:ident="non_coherent" assert_unreached:
     fn F() {
       const non_coherent = 1;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:373:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :function_const_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2230,10 +2247,9 @@ FAIL :function_const_name:ident="noncoherent" assert_unreached:
     fn F() {
       const noncoherent = 1;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:373:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :function_const_name:ident="noperspective"
@@ -2502,6 +2518,8 @@ PASS :function_let_name:ident="noexcept"
 PASS :function_let_name:ident="noinline"
 PASS :function_let_name:ident="nointerpolation"
 FAIL :function_let_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2509,13 +2527,14 @@ FAIL :function_let_name:ident="non_coherent" assert_unreached:
     fn F() {
       let non_coherent = 1;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:387:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :function_let_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2523,10 +2542,9 @@ FAIL :function_let_name:ident="noncoherent" assert_unreached:
     fn F() {
       let noncoherent = 1;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:387:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :function_let_name:ident="noperspective"
@@ -2795,6 +2813,8 @@ PASS :function_var_name:ident="noexcept"
 PASS :function_var_name:ident="noinline"
 PASS :function_var_name:ident="nointerpolation"
 FAIL :function_var_name:ident="non_coherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2802,13 +2822,14 @@ FAIL :function_var_name:ident="non_coherent" assert_unreached:
     fn F() {
       var non_coherent = 1;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:401:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :function_var_name:ident="noncoherent" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2816,10 +2837,9 @@ FAIL :function_var_name:ident="noncoherent" assert_unreached:
     fn F() {
       var noncoherent = 1;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/parse/identifiers.spec.js:401:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :function_var_name:ident="noperspective"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt
@@ -10,6 +10,8 @@ PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="";sampling=
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="";sampling="linear"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling=""
 FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="center" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -23,13 +25,14 @@ FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampl
           return vec4<f32>();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="centroid" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -43,13 +46,14 @@ FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampl
           return vec4<f32>();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="sample" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -63,10 +67,9 @@ FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampl
           return vec4<f32>();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="flat";sampling="first"
@@ -79,6 +82,8 @@ PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="sample"
 FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -92,13 +97,14 @@ FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective
           return vec4<f32>();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -112,10 +118,9 @@ FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective
           return vec4<f32>();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="perspective";sampling="flat"
@@ -126,6 +131,8 @@ PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sam
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="sample"
 FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -139,13 +146,14 @@ FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sam
           return vec4<f32>();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -159,10 +167,9 @@ FAIL :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sam
           return vec4<f32>();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="vertex";io="in";use_struct=true;type="linear";sampling="flat"
@@ -224,6 +231,8 @@ PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="";sampling
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="";sampling="linear"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling=""
 FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="center" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -238,13 +247,14 @@ FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";samp
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="centroid" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -259,13 +269,14 @@ FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";samp
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="sample" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -280,10 +291,9 @@ FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";samp
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="flat";sampling="first"
@@ -296,6 +306,8 @@ PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspectiv
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="sample"
 FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -310,13 +322,14 @@ FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspectiv
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -331,10 +344,9 @@ FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspectiv
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="perspective";sampling="flat"
@@ -345,6 +357,8 @@ PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sa
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="sample"
 FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -359,13 +373,14 @@ FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sa
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -380,10 +395,9 @@ FAIL :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sa
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="vertex";io="out";use_struct=true;type="linear";sampling="flat"
@@ -445,6 +459,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="";samplin
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="";sampling="linear"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling=""
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="center" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -458,13 +474,14 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sam
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="centroid" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -478,13 +495,14 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sam
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="sample" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -498,10 +516,9 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sam
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="flat";sampling="first"
@@ -514,6 +531,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspecti
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="sample"
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -527,13 +546,14 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspecti
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -547,10 +567,9 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspecti
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="perspective";sampling="flat"
@@ -561,6 +580,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";s
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="sample"
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -574,13 +595,14 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";s
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -594,10 +616,9 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";s
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=true;type="linear";sampling="flat"
@@ -659,6 +680,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="";sampli
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="";sampling="linear"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling=""
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="center" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -668,13 +691,14 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sa
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="centroid" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -684,13 +708,14 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sa
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="sample" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -700,10 +725,9 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sa
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="flat";sampling="first"
@@ -716,6 +740,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspect
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="sample"
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -725,13 +751,14 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspect
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -741,10 +768,9 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspect
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="perspective";sampling="flat"
@@ -755,6 +781,8 @@ PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="sample"
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -764,13 +792,14 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -780,10 +809,9 @@ FAIL :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="in";use_struct=false;type="linear";sampling="flat"
@@ -845,6 +873,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="";sampli
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="";sampling="linear"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling=""
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="center" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -858,13 +888,14 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sa
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="centroid" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -878,13 +909,14 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sa
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="sample" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -898,10 +930,9 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sa
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="flat";sampling="first"
@@ -914,6 +945,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspect
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="sample"
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -927,13 +960,14 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspect
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -947,10 +981,9 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspect
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="perspective";sampling="flat"
@@ -961,6 +994,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="sample"
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -974,13 +1009,14 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -994,10 +1030,9 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=true;type="linear";sampling="flat"
@@ -1059,6 +1094,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="";sampl
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="";sampling="linear"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling=""
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="center" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1068,13 +1105,14 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";s
           return f32();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="centroid" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1084,13 +1122,14 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";s
           return f32();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="sample" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1100,10 +1139,9 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";s
           return f32();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="flat";sampling="first"
@@ -1116,6 +1154,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspec
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="sample"
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1125,13 +1165,14 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspec
           return f32();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1141,10 +1182,9 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspec
           return f32();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="perspective";sampling="flat"
@@ -1155,6 +1195,8 @@ PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="centroid"
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="sample"
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="first" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1164,13 +1206,14 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear"
           return f32();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="either" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1180,10 +1223,9 @@ FAIL :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear"
           return f32();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:82:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :type_and_sampling:stage="fragment";io="out";use_struct=false;type="linear";sampling="flat"
@@ -1243,6 +1285,8 @@ PASS :require_location:stage="fragment";attribute="%40location(0)";use_struct=fa
 PASS :require_location:stage="fragment";attribute="%40builtin(position)";use_struct=true
 PASS :require_location:stage="fragment";attribute="%40builtin(position)";use_struct=false
 FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1257,13 +1301,14 @@ FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="" asse
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1278,13 +1323,14 @@ FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1299,13 +1345,14 @@ FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1320,16 +1367,17 @@ FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1344,13 +1392,14 @@ FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1365,13 +1414,14 @@ FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1386,13 +1436,14 @@ FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1407,13 +1458,14 @@ FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1428,10 +1480,9 @@ FAIL :integral_types:stage="vertex";type="i32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute=""
@@ -1447,6 +1498,8 @@ PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute="%40in
 PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
 PASS :integral_types:stage="vertex";type="i32";use_struct=false;attribute="%40interpolate(linear,%20sample)"
 FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1461,13 +1514,14 @@ FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="" asse
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1482,13 +1536,14 @@ FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1503,13 +1558,14 @@ FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1524,16 +1580,17 @@ FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1548,13 +1605,14 @@ FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1569,13 +1627,14 @@ FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1590,13 +1649,14 @@ FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1611,13 +1671,14 @@ FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1632,10 +1693,9 @@ FAIL :integral_types:stage="vertex";type="u32";use_struct=true;attribute="%40int
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute=""
@@ -1651,6 +1711,8 @@ PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute="%40in
 PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
 PASS :integral_types:stage="vertex";type="u32";use_struct=false;attribute="%40interpolate(linear,%20sample)"
 FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1665,13 +1727,14 @@ FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1686,13 +1749,14 @@ FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1707,13 +1771,14 @@ FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1728,16 +1793,17 @@ FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1752,13 +1818,14 @@ FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1773,13 +1840,14 @@ FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1794,13 +1862,14 @@ FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1815,13 +1884,14 @@ FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1836,10 +1906,9 @@ FAIL :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute=""
@@ -1855,6 +1924,8 @@ PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attrib
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
 PASS :integral_types:stage="vertex";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"
 FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1869,13 +1940,14 @@ FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1890,13 +1962,14 @@ FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1911,13 +1984,14 @@ FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1932,16 +2006,17 @@ FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1956,13 +2031,14 @@ FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1977,13 +2053,14 @@ FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -1998,13 +2075,14 @@ FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2019,13 +2097,14 @@ FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2040,10 +2119,9 @@ FAIL :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=true;attribu
           return S();
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute=""
@@ -2059,6 +2137,8 @@ PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attrib
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)"
 PASS :integral_types:stage="vertex";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)"
 FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2072,13 +2152,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="" as
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2092,13 +2173,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2112,13 +2194,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2132,16 +2215,17 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2155,13 +2239,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2175,13 +2260,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2195,13 +2281,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2215,13 +2302,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2235,13 +2323,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2251,13 +2340,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="" a
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2267,13 +2357,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2283,13 +2374,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2299,16 +2391,17 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2318,13 +2411,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2334,13 +2428,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2350,13 +2445,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2366,13 +2462,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2382,13 +2479,14 @@ FAIL :integral_types:stage="fragment";type="i32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2402,13 +2500,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="" as
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2422,13 +2521,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2442,13 +2542,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2462,16 +2563,17 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2485,13 +2587,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2505,13 +2608,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2525,13 +2629,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2545,13 +2650,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2565,13 +2671,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=true;attribute="%40i
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2581,13 +2688,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="" a
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2597,13 +2705,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2613,13 +2722,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2629,16 +2739,17 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2648,13 +2759,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2664,13 +2776,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2680,13 +2793,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2696,13 +2810,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2712,13 +2827,14 @@ FAIL :integral_types:stage="fragment";type="u32";use_struct=false;attribute="%40
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2732,13 +2848,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2752,13 +2869,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2772,13 +2890,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2792,16 +2911,17 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2815,13 +2935,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2835,13 +2956,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2855,13 +2977,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2875,13 +2998,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2895,13 +3019,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2911,13 +3036,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2927,13 +3053,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2943,13 +3070,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2959,16 +3087,17 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2978,13 +3107,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -2994,13 +3124,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3010,13 +3141,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3026,13 +3158,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3042,13 +3175,14 @@ FAIL :integral_types:stage="fragment";type="vec2%3Ci32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3062,13 +3196,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3082,13 +3217,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3102,13 +3238,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3122,16 +3259,17 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3145,13 +3283,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3165,13 +3304,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3185,13 +3325,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3205,13 +3346,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3225,13 +3367,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=true;attri
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3241,13 +3384,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3257,13 +3401,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3273,13 +3418,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3289,16 +3435,17 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(flat)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(flat,%20first)"
 PASS :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(flat,%20either)"
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(perspective,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3308,13 +3455,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3324,13 +3472,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20center)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3340,13 +3489,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20centroid)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3356,13 +3506,14 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attribute="%40interpolate(linear,%20sample)" assert_unreached:
+  - (in subcase: ) EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - (in subcase: ) VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -3372,10 +3523,9 @@ FAIL :integral_types:stage="fragment";type="vec4%3Cu32%3E";use_struct=false;attr
 
         }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/interpolate.spec.js:137:24
-  - (in subcase: ) EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
   - (in subcase: ) INFO: subcase ran
  Reached unreachable code
 PASS :duplicate:attr=""

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/size-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/size-expected.txt
@@ -28,6 +28,8 @@ PASS :size_fp16:ext=""
 PASS :size_fp16:ext="h"
 PASS :size_non_struct:attr="control"
 FAIL :size_non_struct:attr="struct" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -36,10 +38,11 @@ FAIL :size_non_struct:attr="struct" assert_unreached:
     @workgroup_size(1)
     @compute fn main() {
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_io/size.spec.js:216:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :size_non_struct:attr="constant"
 PASS :size_non_struct:attr="vec"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/continue-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/continue-expected.txt
@@ -13,6 +13,8 @@ PASS :placement:stmt="nested_switch_case_continue"
 PASS :placement:stmt="return_continue"
 PASS :placement:stmt="loop_continue_after_decl_used_in_continuing"
 FAIL :placement:stmt="loop_continue_before_decl_used_in_continuing" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -24,13 +26,16 @@ FAIL :placement:stmt="loop_continue_before_decl_used_in_continuing" assert_unrea
       return vec4f(1);
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/continue.spec.js:103:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :placement:stmt="loop_continue_before_decl_not_used_in_continuing"
 FAIL :placement:stmt="loop_nested_continue_before_decl_used_in_continuing" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -42,10 +47,11 @@ FAIL :placement:stmt="loop_nested_continue_before_decl_used_in_continuing" asser
       return vec4f(1);
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/continue.spec.js:103:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :placement:stmt="loop_continue_expression"
 PASS :placement:stmt="for_init_continue"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/discard-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/discard-expected.txt
@@ -1,5 +1,7 @@
 
 FAIL :placement:place="compute" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -40,12 +42,15 @@ FAIL :placement:place="compute" assert_unreached:
       subcomp();
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/discard.spec.js:64:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :placement:place="vertex" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -86,15 +91,18 @@ FAIL :placement:place="vertex" assert_unreached:
       subcomp();
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/discard.spec.js:64:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :placement:place="fragment"
 PASS :placement:place="module"
 PASS :placement:place="subfrag"
 FAIL :placement:place="subvert" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -135,12 +143,15 @@ FAIL :placement:place="subvert" assert_unreached:
       subcomp();
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/discard.spec.js:64:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :placement:place="subcomp" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -181,9 +192,10 @@ FAIL :placement:place="subcomp" assert_unreached:
       subcomp();
     }
 
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/discard.spec.js:64:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/loop-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/loop-expected.txt
@@ -33,6 +33,8 @@ PASS :parse:test="continuing_break_if"
 PASS :parse:test="expr_break"
 PASS :parse:test="loop"
 FAIL :parse:test="continuing_break" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -42,10 +44,11 @@ FAIL :parse:test="continuing_break" assert_unreached:
       let expr = true;
       loop { continuing {} break; }
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/loop.spec.js:89:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :parse:test="break_continuing_continue"
 PASS :parse:test="break_continuing_return"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/phony-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/phony-expected.txt
@@ -15,6 +15,8 @@ PASS :rhs_constructible:type="abstractFloat"
 PASS :rhs_constructible:type="array"
 PASS :rhs_constructible:type="struct"
 FAIL :rhs_constructible:type="atomic_u32" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -25,12 +27,15 @@ FAIL :rhs_constructible:type="atomic_u32" assert_unreached:
     fn f() {
       _ = xu;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/phony.spec.js:63:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :rhs_constructible:type="atomic_i32" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -41,13 +46,16 @@ FAIL :rhs_constructible:type="atomic_i32" assert_unreached:
     fn f() {
       _ = xi;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/phony.spec.js:63:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :rhs_with_decl:test="storage"
 FAIL :rhs_with_decl:test="storage_unsized" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -59,12 +67,15 @@ FAIL :rhs_with_decl:test="storage_unsized" assert_unreached:
 
       _ = x;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/phony.spec.js:124:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :rhs_with_decl:test="storage_atomic" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -76,10 +87,11 @@ FAIL :rhs_with_decl:test="storage_atomic" assert_unreached:
 
       _ = x;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/phony.spec.js:124:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :rhs_with_decl:test="uniform"
 PASS :rhs_with_decl:test="texture"
@@ -88,6 +100,8 @@ PASS :rhs_with_decl:test="sampler_comparison"
 PASS :rhs_with_decl:test="private"
 PASS :rhs_with_decl:test="workgroup"
 FAIL :rhs_with_decl:test="workgroup_atomic" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -99,10 +113,11 @@ FAIL :rhs_with_decl:test="workgroup_atomic" assert_unreached:
 
       _ = x;
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/phony.spec.js:124:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :rhs_with_decl:test="override"
 PASS :rhs_with_decl:test="function_var"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/switch-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/switch-expected.txt
@@ -77,6 +77,8 @@ PASS :parse:test="L_no_default"
 PASS :parse:test="L_default_default"
 PASS :parse:test="L_default_block_default_block"
 FAIL :parse:test="L_case_1_case_1_default" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -88,12 +90,15 @@ FAIL :parse:test="L_case_1_case_1_default" assert_unreached:
       const C2 = 2;
       switch L { case 1 {} case 1 {} default {} }
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/switch.spec.js:166:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :parse:test="L_case_C1_case_C1_default" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -105,12 +110,15 @@ FAIL :parse:test="L_case_C1_case_C1_default" assert_unreached:
       const C2 = 2;
       switch L { case C1 {} case C1 {} default {} }
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/switch.spec.js:166:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :parse:test="L_case_C2_case_expr_default" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -122,10 +130,11 @@ FAIL :parse:test="L_case_C2_case_expr_default" assert_unreached:
       const C2 = 2;
       switch L { case C2 {} case 1+1 {} default {} }
     }
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/statement/switch.spec.js:166:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :parse:test="L_default_1"
 PASS :parse:test="L_default_2_case_1"

--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/types/pointer-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/types/pointer-expected.txt
@@ -38,26 +38,32 @@ PASS :access_mode:aspace="private";access="read_write";comma=","
 PASS :access_mode:aspace="storage";access="read";comma=""
 PASS :access_mode:aspace="storage";access="read";comma=","
 FAIL :access_mode:aspace="storage";access="write";comma="" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     alias T = ptr<storage, u32, write>;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/types/pointer.spec.js:63:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 FAIL :access_mode:aspace="storage";access="write";comma="," assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
     ---- shader ----
     alias T = ptr<storage, u32, write,>;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/types/pointer.spec.js:63:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :access_mode:aspace="storage";access="read_write";comma=""
 PASS :access_mode:aspace="storage";access="read_write";comma=","
@@ -99,6 +105,8 @@ PASS :type:case="struct_T"
 PASS :type:case="ptr_function_u32"
 PASS :type:case="ptr_workgroup_bool"
 FAIL :type:case="sampler" assert_unreached:
+  - EXPECTATION FAILED: Expected validation error
+      at (elided: below max severity)
   - VALIDATION FAILED: Missing expected compilationInfo 'error' message.
 
 
@@ -109,10 +117,11 @@ FAIL :type:case="sampler" assert_unreached:
         struct T { s : array<S> }
         alias u32_alias = u32;
         alias Type = ptr<storage, sampler>;
-    expectCompileResult@http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:73:28
-    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/types/pointer.spec.js:139:24
-  - EXPECTATION FAILED: Expected validation error
-      at (elided: below max severity)
+    @http://127.0.0.1:8000/webgpu/webgpu/shader/validation/shader_validation_test.js:91:30
+    async finalize@http://127.0.0.1:8000/webgpu/common/framework/fixture.js:128:16
+    async runTest@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:534:28
+    async run@http://127.0.0.1:8000/webgpu/common/internal/test_group.js:682:31
+    @http://127.0.0.1:8000/webgpu/common/runtime/wpt.js:75:27
  Reached unreachable code
 PASS :type:case="texture_2d"
 PASS :type:case="alias"

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2488,8 +2488,6 @@ webkit.org/b/307886 [ Release arm64 ] js/dom/promise-stack-overflow.html [ Pass 
 
 webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failure ]
 
- webkit.org/b/308026 [ Release arm64 ] http/tests/webgpu/webgpu/shader/validation/functions/restrictions.html [ Pass Failure ]
-
 webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/console/message-from-iframe.html [ Failure ]
 webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/console/message-from-worker.html [ Failure ]
 


### PR DESCRIPTION
#### 8e292742055ce876a551a200599f8030c3223db5
<pre>
[macOS Release] http/tests/webgpu/webgpu/shader/validation/functions/restrictions.html is a flaky text failure
<a href="https://rdar.apple.com/170521658">rdar://170521658</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308026">https://bugs.webkit.org/show_bug.cgi?id=308026</a>

Reviewed by Mike Wyrzykowski.

Moddified shader_validation_test.js:56-116 to combine both async checks into a single sequential operation.
The following changes were made:
 - Replaced parallel async checks with sequential execution - The GPU error check now completes before the compilation info check starts, ensuring deterministic error message ordering.
 - 16 test expected output files rebased - The baseline now reflects the new consistent ordering (with corrected stack traces showing the updated line numbers).

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/decl/var-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/atomics-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/cross-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/textureSampleBias-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/functions/restrictions-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/comments-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/parse/identifiers-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/interpolate-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_io/size-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/shader_validation_test.js:
(export.ShaderValidationTest.prototype.expectCompileResult):
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/continue-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/discard-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/loop-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/phony-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/statement/switch-expected.txt:
* LayoutTests/http/tests/webgpu/webgpu/shader/validation/types/pointer-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/307878@main">https://commits.webkit.org/307878@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6830bb54493f92eaf70cf5ee91ccef283f500e9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18423 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10369 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154412 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99363 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18909 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18313 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112080 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80297 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14460 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130910 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92983 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13771 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11533 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1859 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7754 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156725 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120086 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18271 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15258 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120430 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30886 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129073 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74017 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16162 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7167 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17892 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17629 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17838 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17691 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->