### PR TITLE
Better Move->Move32 spill and ZDef handling

### DIFF
--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -2253,15 +2253,19 @@ private:
                 // only claim to read 32 bits from the source if only 32 bits of the destination are
                 // read. Note that we only apply this logic if this turns into a load or store, since
                 // Move is the canonical way to move data between GPRs.
-                bool canUseMove32IfDidSpill = false;
+                bool useMove32IfDidSpill = false;
                 bool didSpill = false;
                 bool needScratch = false;
                 Tmp scratchForTmp;
-                if (bank == GP && inst.kind.opcode == Move) {
-                    if ((inst.args[0].isTmp() && m_tmpWidth.width(inst.args[0].tmp()) <= Width32)
-                        || (inst.args[1].isTmp() && m_tmpWidth.width(inst.args[1].tmp()) <= Width32))
-                        canUseMove32IfDidSpill = true;
-                }
+                auto notSpilledOrHasRequiredWidth32 = [this](const Arg& arg) {
+                    if (!arg.isTmp() || !spillSlot<bank>(arg.tmp()))
+                        return true;
+                    return m_tmpWidth.requiredWidth(arg.tmp()) <= Width32;
+                };
+                if (bank == GP && inst.kind.opcode == Move
+                    && notSpilledOrHasRequiredWidth32(inst.args[0])
+                    && notSpilledOrHasRequiredWidth32(inst.args[1]))
+                    useMove32IfDidSpill = true;
 
                 bool maybeCoalescable = this->mayBeCoalescable(inst);
                 // Try to replace the register use by memory use when possible.
@@ -2323,7 +2327,7 @@ private:
                             // we need to avoid placing the Tmp's stack address into the instruction.
                             return;
                         }
-                        Width spillWidth = m_tmpWidth.requiredWidth(groupForSpill<bank>(arg.tmp()));
+                        Width spillWidth = m_tmpWidth.requiredWidth(arg.tmp());
                         if (Arg::isAnyDef(role) && width < spillWidth) {
                             // Either there are users of this tmp who will use more than width,
                             // or there are producers who will produce more than width non-zero
@@ -2336,14 +2340,13 @@ private:
                             // stretch the spill slot on demand. One possibility is that it's ZDefs of
                             // smaller width than 32-bit.
                             // https://bugs.webkit.org/show_bug.cgi?id=169823
+                            //dataLogLn("XXX inst=", inst);
+                            //ASSERT_NOT_REACHED();
                             m_stats[bank].numInPlaceSpillGiveUpSpillWidth++;
                             return;
                         }
                         ASSERT(inst.kind.opcode == Move || !(Arg::isAnyUse(role) && width > spillWidth));
-                        if (spillWidth != Width32)
-                            canUseMove32IfDidSpill = false;
-
-                        spilled->ensureSize(canUseMove32IfDidSpill ? 4 : bytesForWidth(width));
+                        spilled->ensureSize(useMove32IfDidSpill ? 4 : bytesForWidth(width));
                         didSpill = true;
                         if (needScratchIfSpilledInPlace) {
                             needScratch = true;
@@ -2353,7 +2356,7 @@ private:
                         m_stats[bank].numInPlaceSpill++;
                     });
 
-                if (didSpill && canUseMove32IfDidSpill)
+                if (didSpill && useMove32IfDidSpill)
                     inst.kind.opcode = Move32;
 
                 if (needScratch) {

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -2140,6 +2140,11 @@ private:
         return 16;
     }
 
+    unsigned stackSlotMinimumWidth(Tmp tmp)
+    {
+        return stackSlotMinimumWidth(m_tmpWidth.requiredWidth(tmp));
+    }
+
     void spill(Tmp tmp, TmpData& tmpData)
     {
         RELEASE_ASSERT(tmpData.spillCost() != unspillableCost);
@@ -2182,26 +2187,20 @@ private:
         return true;
     }
 
-    Opcode moveOpcode(Tmp tmp)
+    Opcode moveOpcode(Bank bank, unsigned byteWidth)
     {
-        Opcode move = Oops;
-        Width width = m_tmpWidth.requiredWidth(tmp);
-        switch (stackSlotMinimumWidth(width)) {
+        ASSERT(bank == GP || bank == FP);
+        switch (byteWidth) {
         case 4:
-            move = tmp.bank() == GP ? Move32 : MoveFloat;
-            break;
+            return bank == GP ? Move32 : MoveFloat;
         case 8:
-            move = tmp.bank() == GP ? Move : MoveDouble;
-            break;
+            return bank == GP ? Move : MoveDouble;
         case 16:
-            ASSERT(tmp.bank() == FP);
-            move = MoveVector;
-            break;
+            ASSERT(bank == FP);
+            return MoveVector;
         default:
             RELEASE_ASSERT_NOT_REACHED();
-            break;
         }
-        return move;
     }
 
     template<Bank bank>
@@ -2374,7 +2373,6 @@ private:
                     if (!spilled)
                         return;
 
-                    Opcode move = moveOpcode(tmp);
                     auto originalTmp = tmp;
                     auto tmpIndex = AbsoluteTmpMapper<bank>::absoluteIndex(tmp);
 
@@ -2405,7 +2403,8 @@ private:
                                 dataLogLnIf(verbose(), "Rematerialized (bigImm) BB", *block, " ", originalTmp, ": ", tmp, " <- ", WTF::RawHex(value));
                             }
                         } else {
-                            m_insertionSets[block].insert(instIndex, spillLoad, move, inst.origin, arg, tmp);
+                            Opcode loadOp = moveOpcode(bank, stackSlotMinimumWidth(tmp));
+                            m_insertionSets[block].insert(instIndex, spillLoad, loadOp, inst.origin, arg, tmp);
                             m_stats[bank].numLoadSpill++;
                         }
                     }
@@ -2417,7 +2416,8 @@ private:
                             dataLogLnIf(verbose(), "Rematerialized BB", *block, " removing def inst: ", inst);
                         } else {
                             ASSERT(!doKillInst);
-                            m_insertionSets[block].insert(instIndex + 1, spillStore, move, inst.origin, tmp, arg);
+                            Opcode storeOp = moveOpcode(bank, arg.stackSlot()->byteSize());
+                            m_insertionSets[block].insert(instIndex + 1, spillStore, storeOp, inst.origin, tmp, arg);
                             m_stats[bank].numStoreSpill++;
                         }
                     }
@@ -2467,13 +2467,19 @@ private:
                 unsigned instIndex = this->instIndex(positionOfHead(block), lastPoint);
                 Inst& inst = block->at(instIndex);
 
-                Arg arg = gapTmp;
+                Arg arg;
+                unsigned byteWidth;
                 StackSlot* spilled = spillSlot(gapTmp);
-                if (spilled)
+                if (spilled) {
                     arg = Arg::stack(spilled);
-                Opcode move = moveOpcode(gapTmp);
-                m_insertionSets[block].insert(instIndex, splitMoveFrom, move, inst.origin, metadata.originalTmp, arg);
-                m_insertionSets[block].insert(instIndex + 1, splitMoveTo, move, inst.origin, arg, metadata.originalTmp);
+                    byteWidth = spilled->byteSize();
+                } else {
+                    arg = gapTmp;
+                    byteWidth = stackSlotMinimumWidth(gapTmp);
+                }
+                Opcode moveOp = moveOpcode(gapTmp.bank(), byteWidth);
+                m_insertionSets[block].insert(instIndex, splitMoveFrom, moveOp, inst.origin, metadata.originalTmp, arg);
+                m_insertionSets[block].insert(instIndex + 1, splitMoveTo, moveOp, inst.origin, arg, metadata.originalTmp);
                 dataLogLnIf(verbose(), "Inserted Moves around clobber tmp=", metadata.originalTmp, " gapTmp=", gapTmp, " gapReg = ", assignedReg(gapTmp), " block=", *block, " index=", instIndex, " inst = ", inst);
             }
         }
@@ -2485,9 +2491,11 @@ private:
 
         Tmp originalTmp = metadata.originalTmp;
         Bank bank = originalTmp.bank();
-        Opcode move = moveOpcode(originalTmp);
         StackSlot* spilled = spillSlot(originalTmp);
         ASSERT(spilled);
+
+        Opcode loadOp = moveOpcode(originalTmp.bank(), stackSlotMinimumWidth(originalTmp));
+        Opcode storeOp = moveOpcode(originalTmp.bank(), spilled->byteSize());
 
         for (auto& split : metadata.splits) {
             Tmp clusterTmp = split.tmp;
@@ -2507,7 +2515,7 @@ private:
             // trySplitIntraBlock includes the Pre point in the cluster interval iff the original Tmp is live into the cluster.
             if (pointAtOffset(clusterInterval.begin(), PointOffsets::Pre) == clusterInterval.begin()) {
                 unsigned instIndex = this->instIndex(positionOfHead, clusterInterval.begin());
-                m_insertionSets[block].insert(instIndex, splitMoveFrom, move, block->at(instIndex).origin, Arg::stack(spilled), clusterTmp);
+                m_insertionSets[block].insert(instIndex, splitMoveFrom, loadOp, block->at(instIndex).origin, Arg::stack(spilled), clusterTmp);
                 m_stats[bank].numSplitIntraBlockLoad++;
             } else
                 ASSERT(split.lastDefPoint);
@@ -2515,7 +2523,7 @@ private:
             // Need to store back into the original Tmp's spill slot only if the cluster def'ed the Tmp
             if (split.lastDefPoint) {
                 unsigned instIndex = this->instIndex(positionOfHead, split.lastDefPoint);
-                m_insertionSets[block].insert(instIndex + 1, splitMoveTo, move, block->at(instIndex).origin, clusterTmp, Arg::stack(spilled));
+                m_insertionSets[block].insert(instIndex + 1, splitMoveTo, storeOp, block->at(instIndex).origin, clusterTmp, Arg::stack(spilled));
                 m_stats[bank].numSplitIntraBlockStore++;
             }
         }

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -2327,25 +2327,6 @@ private:
                             // we need to avoid placing the Tmp's stack address into the instruction.
                             return;
                         }
-                        Width spillWidth = m_tmpWidth.requiredWidth(arg.tmp());
-                        if (Arg::isAnyDef(role) && width < spillWidth) {
-                            // Either there are users of this tmp who will use more than width,
-                            // or there are producers who will produce more than width non-zero
-                            // bits.
-                            // FIXME: It's not clear why we should have to return here. We have
-                            // a ZDef fixup in allocateStack. And if this isn't a ZDef, then it
-                            // doesn't seem like it matters what happens to the high bits. Note
-                            // that this isn't the case where we're storing more than what the
-                            // spill slot can hold - we already got that covered because we
-                            // stretch the spill slot on demand. One possibility is that it's ZDefs of
-                            // smaller width than 32-bit.
-                            // https://bugs.webkit.org/show_bug.cgi?id=169823
-                            //dataLogLn("XXX inst=", inst);
-                            //ASSERT_NOT_REACHED();
-                            m_stats[bank].numInPlaceSpillGiveUpSpillWidth++;
-                            return;
-                        }
-                        ASSERT(inst.kind.opcode == Move || !(Arg::isAnyUse(role) && width > spillWidth));
                         spilled->ensureSize(useMove32IfDidSpill ? 4 : bytesForWidth(width));
                         didSpill = true;
                         if (needScratchIfSpilledInPlace) {

--- a/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
+++ b/Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp
@@ -2256,15 +2256,19 @@ private:
                 bool didSpill = false;
                 bool needScratch = false;
                 Tmp scratchForTmp;
-                auto notSpilledOrHasRequiredWidth32 = [this](const Arg& arg) {
-                    if (!arg.isTmp() || !spillSlot<bank>(arg.tmp()))
-                        return true;
-                    return m_tmpWidth.requiredWidth(arg.tmp()) <= Width32;
-                };
-                if (bank == GP && inst.kind.opcode == Move
-                    && notSpilledOrHasRequiredWidth32(inst.args[0])
-                    && notSpilledOrHasRequiredWidth32(inst.args[1]))
-                    useMove32IfDidSpill = true;
+
+                if (bank == GP && inst.kind.opcode == Move) {
+                    Arg& srcArg = inst.args[0];
+                    Arg& dstArg = inst.args[1];
+                    if (dstArg.isTmp() && spillSlot(dstArg.tmp())) {
+                        // Storing to spill. If storing to a 4-byte slot, use store32, otherwise storePtr.
+                        useMove32IfDidSpill = spillSlot(dstArg.tmp())->byteSize() == 4;
+                    } else if (srcArg.isTmp() && spillSlot(srcArg.tmp())) {
+                        // Loading from a spill slot (but not storing to a spill slot). If loading from a
+                        // 4-byte slot, then use load32, otherwise loadPtr.
+                        useMove32IfDidSpill = spillSlot(srcArg.tmp())->byteSize() == 4;
+                    }
+                }
 
                 bool maybeCoalescable = this->mayBeCoalescable(inst);
                 // Try to replace the register use by memory use when possible.
@@ -2326,13 +2330,25 @@ private:
                             // we need to avoid placing the Tmp's stack address into the instruction.
                             return;
                         }
+
+                        Arg spilledArg = Arg::stack(spilled);
+                        if (role == Arg::Role::ZDef && bytesForWidth(width) < spilled->byteSize()) {
+                            // ZDef32 to 64 slot would require two store32 (second one for zero extend), so
+                            // usually it will be better to ZDef into a register and then storePtr the register.
+                            // Unless, this move can be coalesced.
+                            ASSERT_IMPLIES(maybeCoalescable, &arg == &inst.args[1]);
+                            if (!maybeCoalescable || spilledArg != inst.args[0]) {
+                                m_stats[bank].numInPlaceSpillGiveUpSpillWidth++;
+                                return;
+                            }
+                        }
                         spilled->ensureSize(useMove32IfDidSpill ? 4 : bytesForWidth(width));
                         didSpill = true;
                         if (needScratchIfSpilledInPlace) {
                             needScratch = true;
                             scratchForTmp = arg.tmp();
                         }
-                        arg = Arg::stack(spilled);
+                        arg = spilledArg;
                         m_stats[bank].numInPlaceSpill++;
                     });
 


### PR DESCRIPTION
#### 74f65278d5f46736704feb8c8a46e3755a9214ee
<pre>
Better Move-&gt;Move32 spill and ZDef handling
</pre>
----------------------------------------------------------------------
#### d28e9957bdbf731c573733cd55c1bfd27a6db980
<pre>
Better spill / fill instruction selection
</pre>
----------------------------------------------------------------------
#### 25a5500d8daf7e82d50304ccbb1f92a521d192d8
<pre>
Remove unnecessary def width check
</pre>
----------------------------------------------------------------------
#### d7f1d9b4b4a887f23a7f0ed59bcec991225c2ed0
<pre>
[WIP] simplify useMove32IfDidSpill and def width check
Need the bug URL (OOPS!).
Include a Radar link (OOPS!).

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).
* Source/JavaScriptCore/b3/air/AirAllocateRegistersByGreedy.cpp:
(JSC::B3::Air::Greedy::GreedyAllocator::emitSpillCodeAndEnqueueNewTmps):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74f65278d5f46736704feb8c8a46e3755a9214ee

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17854 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153845 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98809 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c9b117f-a679-42d5-be25-25101ee98cdc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18337 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111623 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80012 "4 flakes 5 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e2671dd-e950-4c13-bb7b-58ae1e47cd26) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/13985 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130387 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92521 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2e4ca228-40b0-493f-9596-2b75eb6b11cd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13345 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11108 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1290 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137164 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122868 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7145 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156157 "Built successfully") | | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/5982 "Found 1 new JSC stress test failure: stress/re-enter-resolve-rope-string.js.no-ftl (failure)") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17705 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8233 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119632 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17751 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14771 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119966 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15740 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128403 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17326 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6661 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176462 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17063 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81105 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45385 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17126 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->