### PR TITLE
[CSS Tables] scrollWidth incorrectly inflated by collapsed border overflow

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-scroll-overflow-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-scroll-overflow-expected.txt
@@ -1,4 +1,4 @@
 header	body body body body body body body body body body body
 
-FAIL collapsed-scroll-overflow assert_equals: The collapsed border does not exceed the scroll container. expected 500 but got 540
+PASS collapsed-scroll-overflow
 

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -4,7 +4,7 @@
  *           (C) 1998 Waldo Bastian (bastian@kde.org)
  *           (C) 1999 Lars Knoll (knoll@kde.org)
  *           (C) 1999 Antti Koivisto (koivisto@kde.org)
- * Copyright (C) 2003-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2003-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2014-2019 Google Inc. All rights reserved.
  * Copyright (C) 2006 Alexey Proskuryakov (ap@nypop.com)
  *
@@ -810,7 +810,10 @@ void RenderTable::addOverflowFromInFlowChildren(OptionSet<ComputeOverflowOptions
         LayoutUnit topBorderOverflow = borderTop() - outerBorderTop();
         LayoutRect borderOverflowRect(leftBorderOverflow, topBorderOverflow, rightBorderOverflow - leftBorderOverflow, bottomBorderOverflow - topBorderOverflow);
         if (borderOverflowRect != borderBoxRect()) {
-            addLayoutOverflow(borderOverflowRect);
+            // Do NOT add layout overflow for collapsed borders — they are a
+            // painting artifact and must not inflate the scroll container's
+            // scrollWidth/scrollHeight.
+            // See https://github.com/w3c/csswg-drafts/issues/6230
             addVisualOverflow(borderOverflowRect);
         }
     }


### PR DESCRIPTION
#### 8f695151e326f093b36e528823f18412f3ff2633
<pre>
[CSS Tables] scrollWidth incorrectly inflated by collapsed border overflow
<a href="https://bugs.webkit.org/show_bug.cgi?id=291514">https://bugs.webkit.org/show_bug.cgi?id=291514</a>
<a href="https://rdar.apple.com/149675907">rdar://149675907</a>

Reviewed by Alan Baradlay.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Collapsed borders that extend outside a table&apos;s border box are a painting
artifact and should not contribute to scrollable overflow. Previously,
addOverflowFromInFlowChildren() passed the collapsed border overflow rect
to both addLayoutOverflow() and addVisualOverflow(), causing the scroll
container&apos;s scrollWidth/scrollHeight to include the outer half of any
collapsed section/cell border. Remove the addLayoutOverflow() call so only
visual overflow is recorded for collapsed border geometry.

* LayoutTests/imported/w3c/web-platform-tests/css/css-tables/collapsed-scroll-overflow-expected.txt:
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::addOverflowFromInFlowChildren):

Canonical link: <a href="https://commits.webkit.org/308311@main">https://commits.webkit.org/308311@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f457a550786a7ced3597daf1d971cda950eab158

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145193 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9649 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153865 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98829 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6fb9a193-aad8-4c40-ae4c-59ba4c112794) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147068 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18357 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17766 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111640 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80021 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b817d565-5e18-4564-83af-805fcc3b2ef4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148156 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14001 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92539 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a9701eb7-78f6-44b1-b44b-62725355dc1e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13358 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11123 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1310 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7167 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156177 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8255 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119649 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17725 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14790 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119983 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31141 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17771 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128425 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73389 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15754 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6683 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81125 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17083 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17291 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17146 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->