### PR TITLE
[YARR] Fix operand reversal in non-greedy backreference max count check in JIT

### DIFF
--- a/JSTests/stress/regexp-nongreedy-backref-max-count.js
+++ b/JSTests/stress/regexp-nongreedy-backref-max-count.js
@@ -1,0 +1,59 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value: expected: " + String(expected) + " actual: " + String(actual));
+}
+
+function shouldBeArray(actual, expected) {
+    shouldBe(actual.length, expected.length);
+    for (var i = 0; i < expected.length; ++i)
+        shouldBe(actual[i], expected[i]);
+}
+
+// Non-greedy backreference with finite max count.
+// The JIT had a bug where the operands in the max count check were reversed,
+// causing the backreference to never match on backtrack.
+
+// \1?? with max=1: should try zero first, then one on backtrack
+{
+    let result = /^(a)\1??$/.exec("aa");
+    shouldBeArray(result, ["aa", "a"]);
+}
+
+// \1?? in context: non-greedy should initially skip, then backtrack to match
+{
+    let result = /(a)\1??b/.exec("aab");
+    shouldBe(result.index, 0);
+    shouldBeArray(result, ["aab", "a"]);
+}
+
+// \1{0,2}? non-greedy with max=2
+{
+    let result = /^(a)\1{0,2}?$/.exec("aaa");
+    shouldBeArray(result, ["aaa", "a"]);
+}
+
+// \1{0,3}? non-greedy with max=3, matching exactly 3 repetitions
+{
+    let result = /^(a)\1{0,3}?$/.exec("aaaa");
+    shouldBeArray(result, ["aaaa", "a"]);
+}
+
+// Ensure non-greedy prefers fewer matches when possible
+{
+    let result = /(a)\1{0,2}?b/.exec("aaab");
+    shouldBe(result.index, 0);
+    shouldBeArray(result, ["aaab", "a"]);
+}
+
+// Run in a loop to exercise JIT compilation
+for (let i = 0; i < 200; ++i) {
+    let result = /^(a)\1??$/.exec("aa");
+    shouldBeArray(result, ["aa", "a"]);
+
+    result = /(a)\1??b/.exec("aab");
+    shouldBe(result.index, 0);
+    shouldBeArray(result, ["aab", "a"]);
+
+    result = /^(a)\1{0,2}?$/.exec("aaa");
+    shouldBeArray(result, ["aaa", "a"]);
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2318,7 +2318,7 @@ class YarrGenerator final : public YarrJITInfo {
             failures.append(atEndOfInput());
             loadFromFrame(parenthesesFrameLocation + BackTrackInfoBackReference::matchAmountIndex(), matchAmount);
             if (term->quantityMaxCount != quantifyInfinite)
-                failures.append(m_jit.branch32(MacroAssembler::AboveOrEqual, MacroAssembler::Imm32(term->quantityMaxCount), matchAmount));
+                failures.append(m_jit.branch32(MacroAssembler::AboveOrEqual, matchAmount, MacroAssembler::Imm32(term->quantityMaxCount)));
 
             // If the index hasn't advanced past beginIndex and matchAmount > 0,
             // the backreference matched zero-width (undefined or empty capture).


### PR DESCRIPTION
#### 09dc962c7d5510a835fdabf5f86512f07da6768d
<pre>
[YARR] Fix operand reversal in non-greedy backreference max count check in JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=308045">https://bugs.webkit.org/show_bug.cgi?id=308045</a>

Reviewed by Yusuke Suzuki.

In YarrJIT&apos;s backtracking code for non-greedy backreferences, the operands
of the max count comparison were reversed. branch32(AboveOrEqual, Imm32(max),
matchAmount) gets commuted by MacroAssembler, effectively testing
matchAmount &lt;= max, which is always true when matchAmount starts at 0.
This caused the backreference to immediately fail on every backtrack attempt,
making patterns like /^(a)\1??$/ unable to match &quot;aa&quot; under JIT.

Fix by swapping the operands so that matchAmount is on the left and
Imm32(max) is on the right, correctly testing matchAmount &gt;= max.

Test: JSTests/stress/regexp-nongreedy-backref-max-count.js

* JSTests/stress/regexp-nongreedy-backref-max-count.js: Added.
(shouldBe):
(shouldBeArray):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307899@main">https://commits.webkit.org/307899@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76b5ef4f7609fd80ba305bf01f8ab7d314d87f02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9666 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153877 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98841 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17778 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111652 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80029 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148168 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14014 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130424 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92551 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13371 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11133 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1322 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137196 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122896 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7182 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156189 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6014 "Built successfully and passed tests") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8270 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119661 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17737 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119995 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30898 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17783 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73403 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15763 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6698 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176494 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81137 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45396 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17095 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17303 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17158 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->