### PR TITLE
[YARR] Fix incorrect offset when reading pattern character for Unicode backreference in JIT

### DIFF
--- a/JSTests/stress/regexp-backreference-unicode-offset.js
+++ b/JSTests/stress/regexp-backreference-unicode-offset.js
@@ -1,0 +1,38 @@
+// Regression test for https://bugs.webkit.org/show_bug.cgi?id=XXXXX
+// Unicode backreference pattern character read offset was wrong when
+// checkedOffset != inputPosition (i.e., when there are terms after the backreference).
+
+function shouldBe(actual, expected, message) {
+    if (actual !== expected)
+        throw new Error("FAIL: " + message + ". Expected: " + JSON.stringify(expected) + ", Actual: " + JSON.stringify(actual));
+}
+
+// Warm up the JIT by running the tests many times.
+for (var i = 0; i < 500; i++) {
+    // Basic case: backreference followed by a literal character.
+    // This triggers checkedOffset != inputPosition for the backreference term.
+    var result = /(.)\1c/u.exec("\u{10000}\u{10000}c");
+    shouldBe(result !== null, true, "/(.)\u005C1c/u should match surrogate pair followed by same pair and 'c'");
+    shouldBe(result[0], "\u{10000}\u{10000}c", "/(.)\u005C1c/u matched string");
+    shouldBe(result[1], "\u{10000}", "/(.)\u005C1c/u capture group");
+
+    // Without trailing term (checkedOffset == inputPosition), this already worked.
+    var result2 = /(.)\1/u.exec("\u{10000}\u{10000}");
+    shouldBe(result2 !== null, true, "/(.)\u005C1/u should match");
+    shouldBe(result2[0], "\u{10000}\u{10000}", "/(.)\u005C1/u matched string");
+
+    // Multiple trailing terms.
+    var result3 = /(.)\1cd/u.exec("\u{10000}\u{10000}cd");
+    shouldBe(result3 !== null, true, "/(.)\u005C1cd/u should match");
+    shouldBe(result3[0], "\u{10000}\u{10000}cd", "/(.)\u005C1cd/u matched string");
+
+    // Case insensitive unicode backreference with trailing term.
+    var result4 = /(.)\1c/iu.exec("aac");
+    shouldBe(result4 !== null, true, "/(.)\u005C1c/iu should match 'aac'");
+    shouldBe(result4[0], "aac", "/(.)\u005C1c/iu matched string");
+
+    // Surrogate pair with case insensitive and trailing term.
+    var result5 = /(.)\1c/iu.exec("\u{10000}\u{10000}c");
+    shouldBe(result5 !== null, true, "/(.)\u005C1c/iu should match surrogate pair");
+    shouldBe(result5[0], "\u{10000}\u{10000}c", "/(.)\u005C1c/iu matched string");
+}

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -2011,7 +2011,7 @@ class YarrGenerator final : public YarrJITInfo {
         else {
             // For reading Unicode characters, use the standard resultReg so we can call the standard tryReadUnicodeChar()
             // helper instead of emitting an inlined version.
-            readCharacter(op.m_checkedOffset - term->inputPosition, character, patternIndex);
+            readCharacter(0, character, patternIndex);
             m_jit.move(character, patternCharacter);
         }
 #else


### PR DESCRIPTION
#### 2693828e8d7300d8f20c194af1a260163044b13a
<pre>
[YARR] Fix incorrect offset when reading pattern character for Unicode backreference in JIT
<a href="https://bugs.webkit.org/show_bug.cgi?id=308046">https://bugs.webkit.org/show_bug.cgi?id=308046</a>

Reviewed by Yusuke Suzuki.

In matchBackreference(), the Unicode (surrogate pair) path used
`op.m_checkedOffset - term-&gt;inputPosition` as the offset for reading
the captured pattern character via patternIndex. However, patternIndex
holds an absolute position into the captured text, so the offset should
be 0, as it already is in the non-Unicode path.

When there are terms following the backreference (e.g., /(.)\1c/u),
checkedOffset differs from inputPosition, causing the JIT to read from
the wrong position in the captured text and incorrectly failing to match.

Test: JSTests/stress/regexp-backreference-unicode-offset.js

* JSTests/stress/regexp-backreference-unicode-offset.js: Added.
(shouldBe):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307791@main">https://commits.webkit.org/307791@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfd81f1462dd58a928ccfa27b0e9ca9ca430e22c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145206 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17887 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153878 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98842 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17779 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111653 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80030 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14013 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92552 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13370 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11135 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1323 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137197 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122895 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7184 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156190 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6015 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17738 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8272 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119662 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17784 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14802 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119996 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30829 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15764 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128442 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73406 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17359 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6700 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176495 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17096 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81138 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45397 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17304 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17159 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->