### PR TITLE
[YARR] Fix tryConsumeBackReference pos corruption with surrogate pairs in interpreter

### DIFF
--- a/JSTests/stress/regexp-backreference-surrogate-pos-corruption.js
+++ b/JSTests/stress/regexp-backreference-surrogate-pos-corruption.js
@@ -1,0 +1,46 @@
+//@ runDefault("--useRegExpJIT=false")
+
+// Regression test for tryConsumeBackReference pos corruption when a BMP
+// captured character is compared against a surrogate pair in the input.
+// readChecked() has a side effect of advancing pos by 1 when it decodes a
+// surrogate pair.  When the comparison fails, uncheckInput only restores the
+// checkInput amount, leaving pos off by 1.  This causes subsequent terms to
+// read from the wrong position.
+
+(function() {
+    // /(a)\1*(.)/u  -- backreference \1 captures 'a' (BMP).
+    // Input "a\u{10000}" -- after matching 'a', the greedy \1* attempts to
+    // match another 'a' but finds U+10000 (surrogate pair).  The failed
+    // tryConsumeBackReference should not corrupt pos, so (.) can still match
+    // U+10000.
+    var re1 = /(a)\1*(.)/u;
+    var result1 = re1.exec("a\u{10000}");
+    if (!result1)
+        throw new Error("Test 1 failed: expected a match but got null");
+    if (result1[0] !== "a\u{10000}")
+        throw new Error("Test 1 failed: expected 'a\\u{10000}' but got '" + result1[0] + "'");
+    if (result1[1] !== "a")
+        throw new Error("Test 1 failed: capture 1 expected 'a' but got '" + result1[1] + "'");
+    if (result1[2] !== "\u{10000}")
+        throw new Error("Test 1 failed: capture 2 expected '\\u{10000}' but got '" + result1[2] + "'");
+
+    // Same pattern with a different BMP character.
+    var re2 = /(b)\1*(.)/u;
+    var result2 = re2.exec("b\u{10000}");
+    if (!result2)
+        throw new Error("Test 2 failed: expected a match but got null");
+    if (result2[0] !== "b\u{10000}")
+        throw new Error("Test 2 failed: expected 'b\\u{10000}' but got '" + result2[0] + "'");
+    if (result2[1] !== "b")
+        throw new Error("Test 2 failed: capture 1 expected 'b' but got '" + result2[1] + "'");
+    if (result2[2] !== "\u{10000}")
+        throw new Error("Test 2 failed: capture 2 expected '\\u{10000}' but got '" + result2[2] + "'");
+
+    // Verify that a backreference that *should* match still works.
+    var re3 = /(a)\1/u;
+    var result3 = re3.exec("aa");
+    if (!result3)
+        throw new Error("Test 3 failed: expected a match but got null");
+    if (result3[0] !== "aa")
+        throw new Error("Test 3 failed: expected 'aa' but got '" + result3[0] + "'");
+})();

--- a/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
+++ b/Source/JavaScriptCore/yarr/YarrInterpreter.cpp
@@ -322,11 +322,10 @@ public:
             unsigned p = pos - negativePositionOffest;
             ASSERT(p < length);
             auto result = input[p];
-            if (U16_IS_LEAD(result) && decodeSurrogatePairs && p + 1 < length && U16_IS_TRAIL(input[p + 1])) {
-                if (atEnd())
-                    return errorCodePoint;
+            if (U16_IS_LEAD(result) && decodeSurrogatePairs && p + 1 < length && U16_IS_TRAIL(input[p + 1]))
                 return U16_GET_SUPPLEMENTARY(result, input[p + 1]);
-            }
+            if (U16_IS_TRAIL(result) && decodeSurrogatePairs && p > 0 && U16_IS_LEAD(input[p - 1]))
+                return errorCodePoint;
             return result;
         }
 
@@ -659,7 +658,7 @@ public:
                 ch = input.readSurrogatePairChecked(negativeInputOffset);
                 ++i;
             } else
-                ch = term.matchDirection() == Forward ? input.readChecked(negativeInputOffset) : input.tryReadBackward(negativeInputOffset);
+                ch = term.matchDirection() == Forward ? input.readCheckedDontAdvance(negativeInputOffset) : input.tryReadBackward(negativeInputOffset);
 
             if (oldCh == errorCodePoint || ch == errorCodePoint)
                 return false;


### PR DESCRIPTION
#### f458b13465b19c8260b7336037bc776f0b25ae1b
<pre>
[YARR] Fix tryConsumeBackReference pos corruption with surrogate pairs in interpreter
<a href="https://bugs.webkit.org/show_bug.cgi?id=308047">https://bugs.webkit.org/show_bug.cgi?id=308047</a>

Reviewed by Yusuke Suzuki.

When a backreference captures a BMP character (e.g. &apos;a&apos;) and the input at
the comparison position is a surrogate pair (e.g. U+10000), two bugs in the
Yarr bytecode interpreter cause pos corruption:

1. readChecked() in tryConsumeBackReference has a side effect of advancing
   pos via next() when it decodes a surrogate pair. When the comparison
   fails, uncheckInput(matchSize) only restores the checkInput amount,
   leaving the extra +1 from next(). Fix: use readCheckedDontAdvance().

2. readCheckedDontAdvance() itself has a spurious atEnd() check copied from
   readChecked(). Since readCheckedDontAdvance() never calls next(), the
   atEnd() check is unnecessary. When pos happens to be at the end of input,
   this causes errorCodePoint to be returned for a valid surrogate pair,
   which triggers an early return in tryConsumeBackReference without calling
   uncheckInput, corrupting pos. Fix: remove the atEnd() check and add
   the missing lone trail surrogate check for consistency with readChecked().

Test: JSTests/stress/regexp-backreference-surrogate-pos-corruption.js

* JSTests/stress/regexp-backreference-surrogate-pos-corruption.js: Added.
* Source/JavaScriptCore/yarr/YarrInterpreter.cpp:
(JSC::Yarr::Interpreter::InputStream::readCheckedDontAdvance):
(JSC::Yarr::Interpreter::tryConsumeBackReference):

Canonical link: <a href="https://commits.webkit.org/307792@main">https://commits.webkit.org/307792@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5f4b12e9024e8a0cccf4fae061cec7eee7d3754

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145208 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9670 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98844 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111654 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80031 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148171 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92553 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13372 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11136 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1325 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137199 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7186 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156192 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6017 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17740 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8274 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119663 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14803 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/119997 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30828 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15765 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128444 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73409 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17361 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6702 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176497 "Built successfully") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81140 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45398 "Passed tests") | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17306 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17161 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->