### PR TITLE
Move from HashSet<RefPtr> to Ref in Worklet and StyleUpdate

### DIFF
--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.cpp
@@ -131,7 +131,7 @@ void RenderTreeUpdater::commit(std::unique_ptr<Style::Update> styleUpdate)
     for (auto& root : m_styleUpdate->roots()) {
         if (&root->document() != m_document.ptr())
             continue;
-        RefPtr renderingRoot = findRenderingRoot(*root);
+        RefPtr renderingRoot = findRenderingRoot(root.get());
         if (!renderingRoot)
             continue;
         updateRenderTree(*renderingRoot);
@@ -219,7 +219,7 @@ void RenderTreeUpdater::updateRebuildRoots()
         if (rebuildRoots.isEmpty())
             break;
         for (auto& rebuildRoot : rebuildRoots) {
-            if (RefPtr newRebuildRoot = findNewRebuildRoot(*rebuildRoot))
+            if (RefPtr newRebuildRoot = findNewRebuildRoot(rebuildRoot.get()))
                 addSubtreeForRebuild(*newRebuildRoot);
         }
     }

--- a/Source/WebCore/style/StyleUpdate.cpp
+++ b/Source/WebCore/style/StyleUpdate.cpp
@@ -97,7 +97,7 @@ void Update::addElement(Element& element, Element* parent, ElementUpdate&& eleme
     ASSERT(composedTreeAncestors(element).first() == parent);
     ASSERT(!m_elements.contains(&element));
 
-    m_roots.remove(&element);
+    m_roots.remove(element);
     addPossibleRoot(parent);
 
     if (elementUpdate.mayNeedRebuildRoot)
@@ -135,7 +135,7 @@ void Update::addText(Text& text, TextUpdate&& textUpdate)
 void Update::addSVGRendererUpdate(SVGElement& element)
 {
     RefPtr parent = composedTreeAncestors(element).first();
-    m_roots.remove(&element);
+    m_roots.remove(element);
     addPossibleRoot(parent.get());
     element.setNeedsSVGRendererUpdate(true);
 }
@@ -148,20 +148,20 @@ void Update::addInitialContainingBlockUpdate(std::unique_ptr<RenderStyle> style)
 void Update::addPossibleRoot(Element* element)
 {
     if (!element) {
-        m_roots.add(m_document.ptr());
+        m_roots.add(m_document);
         return;
     }
     if (element->needsSVGRendererUpdate() || m_elements.contains(element))
         return;
-    m_roots.add(element);
+    m_roots.add(*element);
 }
 
 void Update::addPossibleRebuildRoot(Element& element, Element* parent)
 {
-    if (parent && m_rebuildRoots.contains(parent))
+    if (parent && m_rebuildRoots.contains(*parent))
         return;
 
-    m_rebuildRoots.add(&element);
+    m_rebuildRoots.add(element);
 }
 
 }

--- a/Source/WebCore/style/StyleUpdate.h
+++ b/Source/WebCore/style/StyleUpdate.h
@@ -63,8 +63,8 @@ public:
     Update(Document&);
     ~Update();
 
-    const ListHashSet<RefPtr<ContainerNode>>& roots() const { return m_roots; }
-    ListHashSet<RefPtr<Element>> takeRebuildRoots() { return WTF::move(m_rebuildRoots); }
+    const ListHashSet<Ref<ContainerNode>>& roots() const { return m_roots; }
+    ListHashSet<Ref<Element>> takeRebuildRoots() { return WTF::move(m_rebuildRoots); }
 
     const ElementUpdate* elementUpdate(const Element&) const;
     ElementUpdate* elementUpdate(const Element&);
@@ -92,8 +92,8 @@ private:
     void addPossibleRebuildRoot(Element&, Element* parent);
 
     const Ref<Document> m_document;
-    ListHashSet<RefPtr<ContainerNode>> m_roots;
-    ListHashSet<RefPtr<Element>> m_rebuildRoots;
+    ListHashSet<Ref<ContainerNode>> m_roots;
+    ListHashSet<Ref<Element>> m_rebuildRoots;
     HashMap<Ref<const Element>, ElementUpdate> m_elements;
     HashMap<Ref<const Text>, TextUpdate> m_texts;
     std::unique_ptr<RenderStyle> m_initialContainingBlockUpdate;

--- a/Source/WebCore/workers/Worker.h
+++ b/Source/WebCore/workers/Worker.h
@@ -118,7 +118,6 @@ private:
     bool m_shouldBypassMainWorldContentSecurityPolicy { false };
     bool m_isSuspendedForBackForwardCache { false };
     JSC::RuntimeFlags m_runtimeFlags;
-    Deque<RefPtr<Event>> m_pendingEvents;
     bool m_wasTerminated { false };
     bool m_didStartWorkerGlobalScope { false };
     const ScriptExecutionContextIdentifier m_clientIdentifier;

--- a/Source/WebCore/worklets/Worklet.cpp
+++ b/Source/WebCore/worklets/Worklet.cpp
@@ -82,8 +82,8 @@ void Worklet::addModule(const String& moduleURLString, WorkletOptions&& options,
     if (m_proxies.isEmpty())
         m_proxies.appendVector(createGlobalScopes());
 
-    auto pendingTasks = WorkletPendingTasks::create(*this, WTF::move(promise), m_proxies.size());
-    m_pendingTasksSet.add(pendingTasks.copyRef());
+    Ref pendingTasks = WorkletPendingTasks::create(*this, WTF::move(promise), m_proxies.size());
+    m_pendingTasksSet.add(pendingTasks);
 
     for (auto& proxy : m_proxies) {
         proxy->postTaskForModeToWorkletGlobalScope([pendingTasks = pendingTasks.copyRef(), moduleURL = moduleURL.isolatedCopy(), credentials = options.credentials, pendingActivity = makePendingActivity(*this)](ScriptExecutionContext& context) mutable {
@@ -102,9 +102,9 @@ void Worklet::addModule(const String& moduleURLString, WorkletOptions&& options,
 void Worklet::finishPendingTasks(WorkletPendingTasks& tasks)
 {
     ASSERT(isMainThread());
-    ASSERT(m_pendingTasksSet.contains(&tasks));
+    ASSERT(m_pendingTasksSet.contains(tasks));
 
-    m_pendingTasksSet.remove(&tasks);
+    m_pendingTasksSet.remove(tasks);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/worklets/Worklet.h
+++ b/Source/WebCore/worklets/Worklet.h
@@ -67,7 +67,7 @@ private:
 
     String m_identifier;
     Vector<Ref<WorkletGlobalScopeProxy>> m_proxies;
-    HashSet<RefPtr<WorkletPendingTasks>> m_pendingTasksSet;
+    HashSet<Ref<WorkletPendingTasks>> m_pendingTasksSet;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 83be0c8295bf0b37b7a043c5a1953c0c325b8e10
<pre>
Move from HashSet&lt;RefPtr&gt; to Ref in Worklet and StyleUpdate
<a href="https://bugs.webkit.org/show_bug.cgi?id=308050">https://bugs.webkit.org/show_bug.cgi?id=308050</a>

Reviewed by Sam Weinig.

Also remove an unused member variable in Worker.

Canonical link: <a href="https://commits.webkit.org/307712@main">https://commits.webkit.org/307712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/35b44dec7049127f2ab03eb263edcb2d4ef40ae7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17896 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9678 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98851 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1873c87-ae03-448d-b15e-b8330613d369) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17788 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111659 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dddf6c92-a49f-44cf-a4af-17ffa14bc473) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148178 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130436 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92559 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae0339f0-30fd-4296-b34a-b2d1f0ce7fad) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13380 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11141 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1332 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137206 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156199 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-debug-arm64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-O3-Debug-arm64-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17747 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8282 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119670 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17793 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14808 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120004 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15773 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128452 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73419 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22402 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17368 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6710 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176504 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17105 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81147 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/176504 "Build is in progress. Recent messages:") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17313 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->