### PR TITLE
Use tri-state mayBlockNetworkRequest for controlling blocking latch mode in Network Process

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -347,23 +347,27 @@ bool NetworkLoadChecker::shouldBlockForTrackingPolicy(const ResourceRequest& req
     if (!m_webPageProxyID)
         return false;
 
-    bool needsAdvancedPrivacyProtections = false;
-    bool mayBlock = false;
-    if (RefPtr networkResourceLoader = m_networkResourceLoader.get()) {
-        mayBlock = networkResourceLoader->parameters().mayBlockNetworkRequest;
-        if (mayBlock && networkResourceLoader->parameters().options.destination != FetchOptionsDestination::Script) {
-            LOAD_CHECKER_RELEASE_LOG("shouldBlockForTrackingPolicy - Blocked non-script load by tracking protections");
-            return true;
-        }
+    RefPtr networkResourceLoader = m_networkResourceLoader.get();
+    if (!networkResourceLoader)
+        return false;
 
-        needsAdvancedPrivacyProtections = networkResourceLoader->parameters().advancedPrivacyProtections.contains(WebCore::AdvancedPrivacyProtections::BaselineProtections);
+    auto mayBlock = networkResourceLoader->parameters().mayBlockNetworkRequest;
+    bool needsAdvancedPrivacyProtections = networkResourceLoader->parameters().advancedPrivacyProtections.contains(WebCore::AdvancedPrivacyProtections::BaselineProtections);
+    if (!mayBlock)
+        return false;
+
+    if (*mayBlock && networkResourceLoader->parameters().options.destination != FetchOptionsDestination::Script) {
+        LOAD_CHECKER_RELEASE_LOG("shouldBlockForTrackingPolicy - Blocked non-script load by tracking protections");
+        return true;
     }
+
     if (CheckedPtr networkSession = m_networkProcess->networkSession(m_sessionID)) {
-        if (networkSession->shouldBlockRequestForTrackingPolicyAndUpdatePolicy(request, *m_webPageProxyID, mayBlock, needsAdvancedPrivacyProtections)) {
+        if (networkSession->shouldBlockRequestForTrackingPolicyAndUpdatePolicy(request, *m_webPageProxyID, *mayBlock, needsAdvancedPrivacyProtections)) {
             LOAD_CHECKER_RELEASE_LOG("shouldBlockForTrackingPolicy - Blocked by tracking protections");
             return true;
         }
     }
+
     return false;
 }
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h
@@ -75,7 +75,7 @@ struct NetworkResourceLoadParameters {
     bool hadMainFrameMainResourcePrivateRelayed { false };
     bool allowPrivacyProxy { true };
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections { };
-    bool mayBlockNetworkRequest { false };
+    std::optional<bool> mayBlockNetworkRequest { false };
 
     uint64_t requiredCookiesVersion { 0 };
 

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in
@@ -49,7 +49,7 @@ enum class WebKit::NavigatingToAppBoundDomain : bool;
     bool hadMainFrameMainResourcePrivateRelayed;
     bool allowPrivacyProxy;
     OptionSet<WebCore::AdvancedPrivacyProtections> advancedPrivacyProtections;
-    bool mayBlockNetworkRequest;
+    std::optional<bool> mayBlockNetworkRequest;
     uint64_t requiredCookiesVersion;
 
     Markable<WebCore::ResourceLoaderIdentifier> identifier;

--- a/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
+++ b/Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp
@@ -400,8 +400,8 @@ static void addParametersShared(const LocalFrame* frame, NetworkResourceLoadPara
         parameters.crossOriginEmbedderPolicy = document->crossOriginEmbedderPolicy();
         parameters.isClearSiteDataHeaderEnabled = document->settings().clearSiteDataHTTPHeaderEnabled();
         parameters.isClearSiteDataExecutionContextEnabled = document->settings().clearSiteDataExecutionContextsSupportEnabled();
-        parameters.mayBlockNetworkRequest = document->settings().scriptTrackingPrivacyNetworkRequestBlockingLatchEnabled()
-            && WebProcess::singleton().shouldBlockRequest(parameters.request.url(), protect(document->topOrigin()));
+        parameters.mayBlockNetworkRequest = document->settings().scriptTrackingPrivacyNetworkRequestBlockingLatchEnabled() ?
+            std::optional { WebProcess::singleton().shouldBlockRequest(parameters.request.url(), protect(document->topOrigin())) } : std::nullopt;
     }
 
     if (RefPtr page = frame->page()) {


### PR DESCRIPTION
#### ff0faf2c4d52aae405395b052b7c1472333ce48d
<pre>
Use tri-state mayBlockNetworkRequest for controlling blocking latch mode in Network Process
<a href="https://bugs.webkit.org/show_bug.cgi?id=308052">https://bugs.webkit.org/show_bug.cgi?id=308052</a>
<a href="https://rdar.apple.com/170551008">rdar://170551008</a>

Reviewed by Charlie Wolfe.

In 307413@main, the blocking behavior that happens in the Network Process may
still happen when the associated feature flag is disabled. This patch changes
the NetworkResourceLoadParameter to be a std::optional and let&apos;s us
differentiate between when the feature is disabled and when the domain is not
present on the fingerprinting script list (but the feature is still enabled).

Covered by existing tests.

* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::shouldBlockForTrackingPolicy):
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.h:
* Source/WebKit/NetworkProcess/NetworkResourceLoadParameters.serialization.in:
* Source/WebKit/WebProcess/Network/WebLoaderStrategy.cpp:
(WebKit::addParametersShared):

Canonical link: <a href="https://commits.webkit.org/307760@main">https://commits.webkit.org/307760@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/156c6fb1b5cd73a4f3c44883e88ef249934fec95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18101 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99056 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18585 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17994 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111830 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f32a03a-c03e-4ba6-a5f9-c5c8427f108d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148382 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92731 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/38380de9-e14b-45cf-b719-1b17cf634304) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13537 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11299 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1537 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123071 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156403 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17951 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8504 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119837 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14986 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120177 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30809 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15935 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128672 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73662 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17572 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6899 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17309 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81351 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17372 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->