### PR TITLE
[GStreamer] Raw video rendering broken when Qualcomm quirk is enabled

### DIFF
--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp
@@ -62,6 +62,11 @@ bool GStreamerQuirkQualcomm::isPlatformSupported() const
     return true;
 }
 
+bool GStreamerQuirkQualcomm::isVideoCapsGLCompatible(const GRefPtr<GstCaps>& caps) const
+{
+    return !gst_caps_features_contains(gst_caps_get_features(caps.get(), 0), "memory:GBM");
+}
+
 #undef GST_CAT_DEFAULT
 
 } // namespace WebCore

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h
@@ -32,6 +32,7 @@ public:
     bool isPlatformSupported() const final;
     const ASCIILiteral identifier() const final { return "Qualcomm"_s; }
     [[nodiscard]] GRefPtr<GstCaps> videoSinkGLCapsFormat() const final { return m_glCaps; }
+    bool isVideoCapsGLCompatible(const GRefPtr<GstCaps>&) const final;
 
 private:
     mutable GRefPtr<GstCaps> m_glCaps;

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp
@@ -325,6 +325,15 @@ GRefPtr<GstCaps> GStreamerQuirksManager::videoSinkGLCapsFormat() const
     return nullptr;
 }
 
+bool GStreamerQuirksManager::isVideoCapsGLCompatible(const GRefPtr<GstCaps>& caps) const
+{
+    for (auto& quirk : m_quirks) {
+        if (!quirk->isVideoCapsGLCompatible(caps))
+            return false;
+    }
+    return true;
+}
+
 bool GStreamerQuirksManager::needsBufferingPercentageCorrection() const
 {
     for (auto& quirk : m_quirks) {

--- a/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
+++ b/Source/WebCore/platform/gstreamer/GStreamerQuirks.h
@@ -106,7 +106,8 @@ public:
         return false;
     }
 
-    [[nodiscard]] virtual GRefPtr<GstCaps> videoSinkGLCapsFormat() const { return nullptr;  }
+    [[nodiscard]] virtual GRefPtr<GstCaps> videoSinkGLCapsFormat() const { return nullptr; }
+    virtual bool isVideoCapsGLCompatible(const GRefPtr<GstCaps>&) const { return true; }
 };
 
 class GStreamerHolePunchQuirk : public GStreamerQuirkBase {
@@ -142,6 +143,7 @@ public:
     Vector<String> disallowedWebAudioDecoders() const;
 
     [[nodiscard]] GRefPtr<GstCaps> videoSinkGLCapsFormat() const;
+    bool isVideoCapsGLCompatible(const GRefPtr<GstCaps>&) const;
 
     bool supportsVideoHolePunchRendering() const;
     GstElement* createHolePunchVideoSink(bool isLegacyPlaybin, const MediaPlayer*);


### PR DESCRIPTION
#### 1e972faccb32bdd2430384bfd7b8e70053532bfa
<pre>
[GStreamer] Raw video rendering broken when Qualcomm quirk is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=308053">https://bugs.webkit.org/show_bug.cgi?id=308053</a>

Reviewed by Xabier Rodriguez-Calvar.

With the Qualcomm quirk enabled the video sink no longer had GL converters, which broke caps
negotiation in case the media player source element provides raw video, such as the MediaStream mock
video source. In order to fix this we now dynamically insert the GL converters using a pad probe and
checking the accept-caps query.

* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(probeCallback):
(webKitGLVideoSinkConstructed):
* Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.cpp:
(WebCore::GStreamerQuirkQualcomm::isVideoCapsGLCompatible const):
* Source/WebCore/platform/gstreamer/GStreamerQuirkQualcomm.h:
* Source/WebCore/platform/gstreamer/GStreamerQuirks.cpp:
(WebCore::GStreamerQuirksManager::isVideoCapsGLCompatible const):
* Source/WebCore/platform/gstreamer/GStreamerQuirks.h:
(WebCore::GStreamerQuirk::videoSinkGLCapsFormat const):
(WebCore::GStreamerQuirk::isVideoCapsGLCompatible const):

Canonical link: <a href="https://commits.webkit.org/307814@main">https://commits.webkit.org/307814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1cc79154c082117a5b8908cd5dd618209f0096f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17913 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9700 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153904 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98868 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147107 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18396 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17805 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111673 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80047 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148195 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13391 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11157 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1349 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122916 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7216 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156216 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119683 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14825 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120017 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30847 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15786 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128474 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73449 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17385 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6733 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17122 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81164 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17330 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17185 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->