### PR TITLE
[AutoFill Debugging] Add id and class names to human-readable element descriptions

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm
@@ -258,7 +258,7 @@ TEST(TextExtractionTests, InteractionDebugDescription)
 
         [interaction setNodeIdentifier:testButtonID.get()];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Click on button labeled “Click Me”, with rendered text “Test”", description);
+        EXPECT_WK_STREQ("Click on button labeled “Click Me” with id “test-button”, with rendered text “Test”", description);
         EXPECT_NULL(error);
 
         [interaction setNodeIdentifier:emailID.get()];
@@ -268,7 +268,7 @@ TEST(TextExtractionTests, InteractionDebugDescription)
 
         [interaction setNodeIdentifier:composeID.get()];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Click on editable div labeled “Compose a new message”, with rendered text “Subject  'The quick brown fox jumped over the lazy dog'”, containing child labeled “Heading”", description);
+        EXPECT_WK_STREQ("Click on editable div labeled “Compose a new message” with class “message-body”, with rendered text “Subject 'The quick brown fox jumped over the lazy dog'”, containing child labeled “Heading”", description);
         EXPECT_NULL(error);
     }
     {
@@ -285,7 +285,7 @@ TEST(TextExtractionTests, InteractionDebugDescription)
         [interaction setText:@"«Testing»"];
         [interaction setReplaceAll:NO];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        EXPECT_WK_STREQ("Enter text “'Testing'” into editable div labeled “Compose a new message”, with rendered text “Subject  'The quick brown fox jumped over the lazy dog'”, containing child labeled “Heading”", description);
+        EXPECT_WK_STREQ("Enter text “'Testing'” into editable div labeled “Compose a new message” with class “message-body”, with rendered text “Subject 'The quick brown fox jumped over the lazy dog'”, containing child labeled “Heading”", description);
         EXPECT_NULL(error);
     }
     {
@@ -301,7 +301,7 @@ TEST(TextExtractionTests, InteractionDebugDescription)
         auto clickLocation = [webView elementMidpointFromSelector:@"#test-button"];
         [interaction setLocation:clickLocation];
         description = [interaction debugDescriptionInWebView:webView.get() error:&error];
-        RetainPtr expectedString = [NSString stringWithFormat:@"Click at coordinates (%.0f, %.0f) on child node of button labeled “Click Me”, with rendered text “Test”", clickLocation.x, clickLocation.y];
+        RetainPtr expectedString = [NSString stringWithFormat:@"Click at coordinates (%.0f, %.0f) on child node of button labeled “Click Me” with id “test-button”, with rendered text “Test”", clickLocation.x, clickLocation.y];
         EXPECT_WK_STREQ(expectedString.get(), description);
         EXPECT_NULL(error);
     }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html
@@ -11,14 +11,14 @@
     </style>
 </head>
 <body>
-    <button id="test-button" aria-label="Click Me">Test</button>
+    <button id="test-button" class="0ebc6266-1019-4b3d-86fe-d6907ce2b3cd" aria-label="Click Me">Test</button>
     <input type="email" placeholder="Recipient address" value="foo" />
     <select role="menu">
         <option>One</option>
         <option selected>Two</option>
         <option>Three</option>
     </select>
-    <div aria-label="Compose a new message" contenteditable="plaintext-only">
+    <div id="MWUxYTU4NTljN2Mz" class="message-body cE_1e1a5859c7c3" aria-label="Compose a new message" contenteditable="plaintext-only">
         <h3 aria-label="Heading">Subject</h3>
         <p>“The quick brown fox jumped over the lazy dog”</p>
     </div>


### PR DESCRIPTION
#### 474182fa172de470ab7e1b59b5e10a1f3c15ec47
<pre>
[AutoFill Debugging] Add id and class names to human-readable element descriptions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308062">https://bugs.webkit.org/show_bug.cgi?id=308062</a>
<a href="https://rdar.apple.com/170562403">rdar://170562403</a>

Reviewed by Aditya Keerthi and Abrar Rahman Protyasha.

Add support for surfacing element ID and class names in interaction description strings, but with
some limitations:

-   Each class name or ID must be &quot;probably human readable&quot; (based on the same heuristics used for
    URL shortening)
-   Each class name or ID must be between some minimum / maximum lengths (for now, we arbitrarily
    choose 6 and 20).
-   Limit to 3 class names

Tests: TextExtractionTests.InteractionDebugDescription

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::normalizeText):
(WebCore::TextExtraction::textDescription):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDebugDescription)):

Rebaseline an existing API test.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/debug-text-extraction.html:

Canonical link: <a href="https://commits.webkit.org/307722@main">https://commits.webkit.org/307722@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/78279cf5d3722dee682ab5f3e9645a32128f3f5b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145248 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17929 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9717 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98884 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6930fb6-2cf3-4ac2-875e-6282dc1dc387) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147123 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18412 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111687 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/677a0cee-de84-4981-8491-29cb0e9d813a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148211 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14050 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130467 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92587 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f440e18f-0284-49a1-bf67-2e966f38142b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13405 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11168 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1365 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122930 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156232 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17780 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8316 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119695 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17826 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120030 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30787 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15797 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128486 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73465 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17401 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6743 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17138 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81180 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17346 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17201 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->