### PR TITLE
ScrollingEffectsController should know maximum banner view height

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -246,6 +246,7 @@ public:
 
 #if ENABLE(BANNER_VIEW_OVERLAYS)
     virtual float bannerViewHeight() const { return 0; }
+    virtual float bannerViewMaximumHeight() const { return 0; }
     virtual bool hasBannerViewOverlay() const { return false; }
 #endif
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h
@@ -92,6 +92,7 @@ private:
     FloatSize rubberBandTargetOffset() const final;
 #if ENABLE(BANNER_VIEW_OVERLAYS)
     bool hasBannerViewOverlay() const final;
+    float bannerViewMaximumHeight() const final;
 #endif
     bool scrollPositionIsNotRubberbandingEdge(const FloatPoint&) const;
 

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm
@@ -368,6 +368,14 @@ FloatSize ScrollingTreeScrollingNodeDelegateMac::rubberBandTargetOffset() const
 
 #if ENABLE(BANNER_VIEW_OVERLAYS)
 
+float ScrollingTreeScrollingNodeDelegateMac::bannerViewMaximumHeight() const
+{
+    if (scrollingNode()->nodeType() != ScrollingNodeType::MainFrame)
+        return 0;
+
+    return scrollingTree()->bannerViewMaximumHeight();
+}
+
 bool ScrollingTreeScrollingNodeDelegateMac::hasBannerViewOverlay() const
 {
     return scrollingNode()->nodeType() == ScrollingNodeType::MainFrame && scrollingTree()->hasBannerViewOverlay();

--- a/Source/WebCore/platform/ScrollingEffectsController.h
+++ b/Source/WebCore/platform/ScrollingEffectsController.h
@@ -112,6 +112,7 @@ public:
 
     virtual FloatSize rubberBandTargetOffset() const { return { }; }
     virtual bool hasBannerViewOverlay() const { return false; }
+    virtual float bannerViewMaximumHeight() const { return 0; }
 #endif
 
     virtual void deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason) const { /* Do nothing */ }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp
@@ -300,6 +300,11 @@ void RemoteScrollingCoordinatorProxy::setBannerViewHeight(float offset)
         m_scrollingTree->triggerMainFrameRubberBandSnapBack();
 }
 
+void RemoteScrollingCoordinatorProxy::setBannerViewMaximumHeight(float offset)
+{
+    m_scrollingTree->setBannerViewMaximumHeight(offset);
+}
+
 void RemoteScrollingCoordinatorProxy::setHasBannerViewOverlay(bool hasBannerView)
 {
     m_scrollingTree->setHasBannerViewOverlay(hasBannerView);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h
@@ -182,6 +182,7 @@ public:
     WebCore::FloatBoxExtent obscuredContentInsets() const;
 #if ENABLE(BANNER_VIEW_OVERLAYS)
     void setBannerViewHeight(float);
+    void setBannerViewMaximumHeight(float);
     void setHasBannerViewOverlay(bool);
 #endif
     WebCore::FloatPoint currentMainFrameScrollPosition() const;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -99,6 +99,8 @@ public:
 #if ENABLE(BANNER_VIEW_OVERLAYS)
     float bannerViewHeight() const override { return m_bannerViewHeight; }
     void setBannerViewHeight(float height) { m_bannerViewHeight = height; }
+    float bannerViewMaximumHeight() const override { return m_bannerViewMaximumHeight; }
+    void setBannerViewMaximumHeight(float height) { m_bannerViewMaximumHeight = height; }
     void triggerMainFrameRubberBandSnapBack() override { }
 
     bool hasBannerViewOverlay() const override { return m_hasBannerViewOverlay; }
@@ -126,6 +128,7 @@ protected:
     bool m_hasNodesWithSynchronousScrollingReasons WTF_GUARDED_BY_LOCK(m_treeLock) { false };
 #if ENABLE(BANNER_VIEW_OVERLAYS)
     float m_bannerViewHeight { 0 };
+    float m_bannerViewMaximumHeight { 0 };
     bool m_hasBannerViewOverlay { false };
 #endif
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -849,6 +849,7 @@ public:
 
     void applyBannerViewOverlayHeight(CGFloat, bool);
     CGFloat bannerViewHeight() const;
+    CGFloat bannerViewMaximumHeight() const;
     void updateBannerViewForWheelEvent(NSEvent *);
     void updateBannerViewForPanGesture(NSGestureRecognizerState);
     void updateBannerViewFrame();

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -1498,9 +1498,10 @@ void WebViewImpl::didRelaunchProcess()
 void WebViewImpl::scrollingCoordinatorWasCreated()
 {
 #if ENABLE(BANNER_VIEW_OVERLAYS)
-    // Sync banner view state that may have been set before the scrolling coordinator existed.
-    if (CheckedPtr scrollingCoordinator = m_page->scrollingCoordinatorProxy())
+    if (CheckedPtr scrollingCoordinator = m_page->scrollingCoordinatorProxy()) {
         scrollingCoordinator->setHasBannerViewOverlay(!!m_bannerView);
+        scrollingCoordinator->setBannerViewMaximumHeight(bannerViewMaximumHeight());
+    }
 #endif
 }
 


### PR DESCRIPTION
#### 6ad274be0bc6ed5a339c1a5af04eb2e0bbe40aac
<pre>
ScrollingEffectsController should know maximum banner view height
<a href="https://bugs.webkit.org/show_bug.cgi?id=308067">https://bugs.webkit.org/show_bug.cgi?id=308067</a>
<a href="https://rdar.apple.com/170531539">rdar://170531539</a>

Reviewed by Abrar Rahman Protyasha.

Allow ScrollingEffectsController to access the maximum banner
view height. The maximum banner view height is set on the
ScrollingTree, and the ScrollingTreeScrollingNodeDelegate
reports this value to the controller.

* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::bannerViewMaximumHeight const):
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeScrollingNodeDelegateMac.mm:
(WebCore::ScrollingTreeScrollingNodeDelegateMac::bannerViewMaximumHeight const):
* Source/WebCore/platform/ScrollingEffectsController.h:
(WebCore::ScrollingEffectsControllerClient::bannerViewMaximumHeight const):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.cpp:
(WebKit::RemoteScrollingCoordinatorProxy::setBannerViewMaximumHeight):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingCoordinatorProxy.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteScrollingTree::setBannerViewMaximumHeight):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::scrollingCoordinatorWasCreated):

Canonical link: <a href="https://commits.webkit.org/307726@main">https://commits.webkit.org/307726@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/de48a7e02b388e8d8fc691d496271af46568dfa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145262 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153934 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/574ef77e-c08a-4413-a37f-df950668a0b3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147137 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111697 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/098ef734-9c67-4033-8149-1e3afba4e801) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148225 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14061 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130482 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92597 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/967c0036-efd1-45b8-a68d-d85340fc9778) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13415 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11175 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1380 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/122941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7243 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156246 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17794 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8331 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119706 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17840 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14850 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120041 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15807 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128501 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73482 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22408 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17415 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17152 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81194 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17360 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17215 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->