### PR TITLE
[Site Isolation] Web Inspector: Console message from cross-origin iframe appended by JS don't show up

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/console/message-from-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/message-from-iframe-expected.txt
@@ -1,24 +1,38 @@
 CONSOLE MESSAGE: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Warning from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Error from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
-CONSOLE MESSAGE: iframe 0 is loaded in http://127.0.0.1:8000/site-isolation/inspector/console/message-from-iframe.html
+CONSOLE MESSAGE: Hello from http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Warning from http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Error from http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/embedded-same-origin.html
 CONSOLE MESSAGE: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Warning from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 CONSOLE MESSAGE: Error from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
-CONSOLE MESSAGE: iframe is loaded in iframe http://127.0.0.1:8000/site-isolation/inspector/console/resources/embedded-same-origin.html
-CONSOLE MESSAGE: iframe 2 is loaded in http://127.0.0.1:8000/site-isolation/inspector/console/message-from-iframe.html
+CONSOLE MESSAGE: Hello from http://localhost:8000/site-isolation/inspector/console/resources/embedded-cross-origin.html
+CONSOLE MESSAGE: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Warning from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
+CONSOLE MESSAGE: Error from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 
 == Running test suite: MessageFromIFrame
 -- Running test case: MessageFromIFrame.SameOriginIFrame
 Got message from frame target: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 Got message from frame target: Warning from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 Got message from frame target: Error from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
-Got message from frame target: iframe 0 is loaded in http://127.0.0.1:8000/site-isolation/inspector/console/message-from-iframe.html
+
+-- Running test case: MessageFromIFrame.CrossOriginIFrame
+Got message from frame target: Hello from http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html
+Got message from frame target: Warning from http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html
+Got message from frame target: Error from http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html
 
 -- Running test case: MessageFromIFrame.GrandChildSameOriginIFrameInSameOrigin
+Got message from frame target: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/embedded-same-origin.html
 Got message from frame target: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 Got message from frame target: Warning from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 Got message from frame target: Error from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
-Got message from frame target: iframe is loaded in iframe http://127.0.0.1:8000/site-isolation/inspector/console/resources/embedded-same-origin.html
-Got message from frame target: iframe 2 is loaded in http://127.0.0.1:8000/site-isolation/inspector/console/message-from-iframe.html
+
+-- Running test case: MessageFromIFrame.GrandChildSameOriginIFrameInCrossOrigin
+Got message from frame target: Hello from http://localhost:8000/site-isolation/inspector/console/resources/embedded-cross-origin.html
+Got message from frame target: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
+Got message from frame target: Warning from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
+Got message from frame target: Error from http://127.0.0.1:8000/site-isolation/inspector/console/resources/console-messages.html
 

--- a/LayoutTests/http/tests/site-isolation/inspector/console/message-from-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/message-from-iframe.html
@@ -1,10 +1,9 @@
 <script src="/inspector/resources/inspector-test.js"></script>
 <script>
     // Utilities for page code.
-    function addIFrame(url, id) {
+    function addIFrame(url) {
         const iframe = document.createElement("iframe");
         iframe.src = url;
-        iframe.onload = () => console.log(`iframe ${id} is loaded in ${location.href}`);
         document.body.appendChild(iframe);
     }
 
@@ -35,28 +34,26 @@
         suite.addTestCase({
             name: "MessageFromIFrame.SameOriginIFrame",
             description: "console message coming from same origin iframe",
-            test: (resolve) => runMessageTest(resolve, 4, `addIFrame("resources/console-messages.html", 0)`),
+            test: (resolve) => runMessageTest(resolve, 3, `addIFrame("resources/console-messages.html")`),
         });
 
-        // FIXME <https://webkit.org/b/307733>: Additional work needed to make this test work.
-        /* suite.addTestCase({
+        suite.addTestCase({
             name: "MessageFromIFrame.CrossOriginIFrame",
             description: "console message coming from cross origin iframe",
-            test: (resolve) => runMessageTest(resolve, 4, `addIFrame("http://localhost:8000/inspector/console/resources/console-messages.html", 1)`),
-        }); */
+            test: (resolve) => runMessageTest(resolve, 3, `addIFrame("http://localhost:8000/site-isolation/inspector/console/resources/console-messages.html")`),
+        });
 
         suite.addTestCase({
             name: "MessageFromIFrame.GrandChildSameOriginIFrameInSameOrigin",
             description: "console message coming from same origin grand-child iframe in same origin iframe",
-            test: (resolve) => runMessageTest(resolve, 5, `addIFrame("resources/embedded-same-origin.html", 2)`),
+            test: (resolve) => runMessageTest(resolve, 4, `addIFrame("resources/embedded-same-origin.html")`),
         });
 
-        // FIXME <https://webkit.org/b/307733>: Additional work needed to make this test work.
-        /* suite.addTestCase({
+        suite.addTestCase({
             name: "MessageFromIFrame.GrandChildSameOriginIFrameInCrossOrigin",
             description: "console message coming from same origin grand-child iframe in cross origin iframe",
-            test: (resolve) => runMessageTest(resolve, 5, `addIFrame("http://localhost:8000/inspector/console/resources/embedded-cross-origin.html", 3)`),
-        }); */
+            test: (resolve) => runMessageTest(resolve, 4, `addIFrame("http://localhost:8000/site-isolation/inspector/console/resources/embedded-cross-origin.html")`),
+        });
 
         suite.runTestCasesAndFinish();
     }

--- a/LayoutTests/http/tests/site-isolation/inspector/console/message-from-worker-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/message-from-worker-expected.txt
@@ -1,4 +1,4 @@
-CONSOLE MESSAGE: iframe is loaded in http://127.0.0.1:8000/site-isolation/inspector/console/message-from-worker.html [same-origin]
+CONSOLE MESSAGE: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/worker-in-iframe.html
 
 == Running test suite: MessageFromWorker
 -- Running test case: MessageFromWorker.WorkerInSamePage
@@ -6,7 +6,7 @@ Got message: Worker started
 Got message: Message received in the worker: Hello
 
 -- Running test case: MessageFromWorker.WorkerInSameOriginIFrame
-Got message: iframe is loaded in http://127.0.0.1:8000/site-isolation/inspector/console/message-from-worker.html [same-origin]
+Got message: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/worker-in-iframe.html
 Got message: Worker started
 Got message: Message received in the worker: Hello from http://127.0.0.1:8000/site-isolation/inspector/console/resources/worker-in-iframe.html
 

--- a/LayoutTests/http/tests/site-isolation/inspector/console/message-from-worker.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/message-from-worker.html
@@ -4,7 +4,6 @@
     function addIFrame(url, testId) {
         const iframe = document.createElement("iframe");
         iframe.src = url;
-        iframe.onload = () => console.log("iframe is loaded in " + location.href + " [" + testId + "]");
         document.body.appendChild(iframe);
     }
 
@@ -47,7 +46,7 @@
             test: (resolve) => runMessageTest(resolve, 3, `addIFrame('resources/worker-in-iframe.html', 'same-origin')`),
         });
 
-        // FIXME <https://webkit.org/b/307733>: Additional work needed to make this test work.
+        // FIXME <rdar://143596746>: Additional work needed around presenting cross-origin workers.
         /* suite.addTestCase({
             name: "MessageFromWorker.WorkerInCrossOriginIFrame",
             description: "console message coming from worker in cross origin iframe",

--- a/LayoutTests/http/tests/site-isolation/inspector/console/resources/console-messages.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/resources/console-messages.html
@@ -1,7 +1,9 @@
 <p>iframe</p>
 
-<script type="module">
-    console.log(`Hello from ${location.href}`);
-    console.warn(`Warning from ${location.href}`);
-    throw `Error from ${location.href}`;
+<script>
+    document.body.onload = function () {
+        console.log(`Hello from ${location.href}`);
+        console.warn(`Warning from ${location.href}`);
+        throw `Error from ${location.href}`;
+    };
 </script>

--- a/LayoutTests/http/tests/site-isolation/inspector/console/resources/embedded-cross-origin.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/resources/embedded-cross-origin.html
@@ -1,11 +1,12 @@
 <p>iframe embedding other cross origin iframe</p>
 
 <script>
+    document.body.onload = function () {
+        console.log(`Hello from ${location.href}`);
 
-const iframe = document.createElement("iframe");
-const crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
-iframe.src = `http://${crossOriginHost}:8000/inspector/console/resources/console-messages.html`;
-iframe.onload = () => console.log("iframe is loaded in " + location.href);
-document.body.appendChild(iframe);
-
+        let iframe = document.createElement("iframe");
+        let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+        iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/console/resources/console-messages.html`;
+        document.body.appendChild(iframe);
+    };
 </script>

--- a/LayoutTests/http/tests/site-isolation/inspector/console/resources/embedded-same-origin.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/resources/embedded-same-origin.html
@@ -1,3 +1,11 @@
 <p>iframe embedding other same origin iframe</p>
 
-<iframe src="console-messages.html" onload="console.log('iframe is loaded in iframe ' + location.href)"></iframe>
+<script>
+    document.body.onload = function () {
+        console.log(`Hello from ${location.href}`);
+
+        let iframe = document.createElement("iframe");
+        iframe.src = "console-messages.html";
+        document.body.append(iframe);
+    };
+</script>

--- a/LayoutTests/http/tests/site-isolation/inspector/console/resources/worker-in-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/console/resources/worker-in-iframe.html
@@ -1,10 +1,9 @@
 <h1>Iframe invoking Worker</h1>
 <script>
-    window.addEventListener('load', () => {
-        // Make sure worker is created after load event is handled in the parent.
-        setTimeout(() => {
-            const worker1 = new Worker('worker.js');
-            worker1.postMessage(`Hello from ${location.href}`);
-        }, 0);
-    });
+    document.body.onload = function () {
+        console.log(`Hello from ${location.href}`);
+
+        let worker1 = new Worker("worker.js");
+        worker1.postMessage(`Hello from ${location.href}`);
+    };
 </script>

--- a/LayoutTests/http/tests/site-isolation/inspector/target/resources/leaf-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/resources/leaf-iframe.html
@@ -1,1 +1,7 @@
 <p>Leaf iframe</p>
+
+<script>
+    document.body.onload = function () {
+        console.log(`Hello from leaf-iframe ${location.href}`);
+    };
+</script>

--- a/LayoutTests/http/tests/site-isolation/inspector/target/resources/middle-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/resources/middle-iframe.html
@@ -1,2 +1,10 @@
-<p>Middle iframe</p>
-<iframe src="http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe"></iframe>
+<p>Middle iframe that embeds a cross origin leaf iframe</p>
+
+<script>
+    document.body.onload = function () {
+        let iframe = document.createElement("iframe");
+        let crossOriginHost = location.hostname === "localhost" ? "127.0.0.1" : "localhost";
+        iframe.src = `http://${crossOriginHost}:8000/site-isolation/inspector/target/resources/leaf-iframe.html`;
+        document.body.append(iframe);
+    };
+</script>

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target-expected.txt
@@ -1,8 +1,36 @@
+CONSOLE MESSAGE: Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html
+CONSOLE MESSAGE: Hello from leaf-iframe http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html
+CONSOLE MESSAGE: Hello from leaf-iframe http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html
+CONSOLE MESSAGE: Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html
 
 == Running test suite: SiteIsolation.Target
--- Running test case: SiteIsolation.Target.FrameTargetLifecycleEvents
-{"eventType":"target-manager-target-added","targetType":"frame"}
-{"eventType":"target-manager-target-added","targetType":"frame"}
-{"eventType":"target-manager-target-removed","targetType":"frame"}
-{"eventType":"target-manager-target-removed","targetType":"frame"}
+-- Running test case: SiteIsolation.Target.SameOriginIframe
+{"event":"target-manager-target-added","target":0,"type":"frame","isProvisional":false}
+{"event":"console-manager-message-added","target":0,"message":"Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html"}
+
+-- Running test case: SiteIsolation.Target.CrossOriginIframe
+{"event":"target-manager-target-added","target":1,"type":"frame","isProvisional":false}
+{"event":"target-manager-target-added","target":2,"type":"frame","isProvisional":true}
+{"event":"target-manager-target-removed","target":1,"type":"frame","isProvisional":false}
+{"event":"target-manager-provisional-target-committed","target":2,"type":"frame","isProvisional":false}
+{"event":"console-manager-message-added","target":2,"message":"Hello from leaf-iframe http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html"}
+
+-- Running test case: SiteIsolation.Target.GrandChildCrossOriginIframeInSameOrigin
+{"event":"target-manager-target-added","target":3,"type":"frame","isProvisional":false}
+{"event":"target-manager-target-added","target":4,"type":"frame","isProvisional":false}
+{"event":"target-manager-target-added","target":5,"type":"frame","isProvisional":true}
+{"event":"target-manager-target-removed","target":4,"type":"frame","isProvisional":false}
+{"event":"target-manager-provisional-target-committed","target":5,"type":"frame","isProvisional":false}
+{"event":"console-manager-message-added","target":5,"message":"Hello from leaf-iframe http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html"}
+
+-- Running test case: SiteIsolation.Target.GrandChildSameOriginIframeInCrossOrigin
+{"event":"target-manager-target-added","target":6,"type":"frame","isProvisional":false}
+{"event":"target-manager-target-added","target":7,"type":"frame","isProvisional":true}
+{"event":"target-manager-target-removed","target":6,"type":"frame","isProvisional":false}
+{"event":"target-manager-provisional-target-committed","target":7,"type":"frame","isProvisional":false}
+{"event":"target-manager-target-added","target":8,"type":"frame","isProvisional":false}
+{"event":"target-manager-target-added","target":9,"type":"frame","isProvisional":true}
+{"event":"target-manager-target-removed","target":8,"type":"frame","isProvisional":false}
+{"event":"target-manager-provisional-target-committed","target":9,"type":"frame","isProvisional":false}
+{"event":"console-manager-message-added","target":9,"message":"Hello from leaf-iframe http://127.0.0.1:8000/site-isolation/inspector/target/resources/leaf-iframe.html"}
 

--- a/LayoutTests/http/tests/site-isolation/inspector/target/target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/target/target.html
@@ -1,42 +1,137 @@
-<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
 <script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../../../inspector/resources/stable-id-map.js"></script>
+
 <script>
-function appendAndRemoveIframe() {
-    let iframe = document.createElement("iframe");
-    iframe.src = "http://localhost:8000/site-isolation/inspector/target/resources/middle-iframe.html";
-    iframe.addEventListener("load", () => {
-        setTimeout(() => {
+    function addIframe(url) {
+        let iframe = document.createElement("iframe");
+        iframe.src = url;
+        document.body.append(iframe);
+    }
+
+    function addAndRemoveIframe() {
+        let iframe = document.createElement("iframe");
+        iframe.src = "http://localhost:8000/resources/network-simulator.py?test=inspector-target-remove&path=/site-isolation/inspector/target/resources/leaf-iframe.html&initialdelay=2000";
+        document.body.append(iframe);
+        requestAnimationFrame(function () {
+            // Remove before it has a chance to load.
             iframe.remove();
-        }, 0);
-    });
-    document.body.append(iframe);
-}
+        });
+    }
 
-function test() {
-    let suite = InspectorTest.createAsyncSuite("SiteIsolation.Target");
+    function addAndNavigateAwayIframe() {
+        let iframe = document.createElement("iframe");
+        iframe.src = "http://localhost:8000/resources/network-simulator.py?test=inspector-target-navigate&path=/site-isolation/inspector/target/resources/leaf-iframe.html&initialdelay=2000";
+        document.body.append(iframe);
+        requestAnimationFrame(function () {
+            // Navigate same-origin, cancelling the provisional cross-origin load.
+            iframe.src = "resources/leaf-iframe.html";
+        });
+    }
 
-    suite.addTestCase({
-        name: "SiteIsolation.Target.FrameTargetLifecycleEvents",
-        description: "Target lifecycle events for frame creation and deletion.",
-        test(resolve) {
-            let eventsSeen = 0;
-            const eventsExpected = 4;
+    function test() {
+        let stableTargetIds = new StableIdMap;
 
-            let handleTargetManagerEvent = (event) => {
-                InspectorTest.log({ eventType: event.type, targetType: event.data.target.type });
-                ++eventsSeen;
-                if (eventsSeen == eventsExpected)
-                    resolve();
+        // Run JS in testScript, wait for a number of callbacksExpected, and then resolve.
+        function runCallbackCountingTest(resolve, callbacksExpected, testScript) {
+            function handleTargetEvent(event) {
+                let { identifier, type, isProvisional } = event.data.target;
+                InspectorTest.log({
+                    event: event.type,
+                    target: stableTargetIds.get(identifier),
+                    type,
+                    isProvisional,
+                });
+                callback();
             }
-            WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, handleTargetManagerEvent);
-            WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, handleTargetManagerEvent);
+            WI.targetManager.addEventListener(WI.TargetManager.Event.TargetAdded, handleTargetEvent);
+            WI.targetManager.addEventListener(WI.TargetManager.Event.TargetRemoved, handleTargetEvent);
+            WI.targetManager.addEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, handleTargetEvent);
 
-            InspectorTest.evaluateInPage(`appendAndRemoveIframe();`);
+            // Also wait for a console message confirming leaf-iframe's loading to ensure the test case completes
+            // before moving on.
+            function handleMessageAdded(event) {
+                InspectorTest.log({
+                    event: event.type,
+                    target: stableTargetIds.get(event.data.message.target.identifier),
+                    message: event.data.message.messageText,
+                });
+                callback();
+            }
+            WI.consoleManager.addEventListener(WI.ConsoleManager.Event.MessageAdded, handleMessageAdded);
+
+            let callbacksSeen = 0;
+            function callback() {
+                ++callbacksSeen;
+                if (callbacksSeen === callbacksExpected) {
+                    WI.targetManager.removeEventListener(WI.TargetManager.Event.TargetAdded, handleTargetEvent);
+                    WI.targetManager.removeEventListener(WI.TargetManager.Event.TargetRemoved, handleTargetEvent);
+                    WI.targetManager.removeEventListener(WI.TargetManager.Event.DidCommitProvisionalTarget, handleTargetEvent);
+                    WI.consoleManager.removeEventListener(WI.ConsoleManager.Event.MessageAdded, handleMessageAdded);
+
+                    resolve();
+                }
+            }
+
+            InspectorTest.evaluateInPage(testScript);
         }
-    });
 
-    suite.runTestCasesAndFinish();
-}
+        let suite = InspectorTest.createAsyncSuite("SiteIsolation.Target");
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.SameOriginIframe",
+            description: "Same-origin iframe creates non-provisional frame target.",
+            test(resolve) {
+                runCallbackCountingTest(resolve, 2, `addIframe("resources/leaf-iframe.html");`);
+            },
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.CrossOriginIframe",
+            description: "Cross-origin iframe creates provisional frame target that commits.",
+            test(resolve) {
+                runCallbackCountingTest(resolve, 5, `
+                    addIframe("http://localhost:8000/site-isolation/inspector/target/resources/leaf-iframe.html");
+                `);
+            },
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.GrandChildCrossOriginIframeInSameOrigin",
+            description: "Same-origin parent with cross-origin grandchild creates provisional grandchild target.",
+            test(resolve) {
+                runCallbackCountingTest(resolve, 6, `addIframe("resources/middle-iframe.html");`);
+            },
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.GrandChildSameOriginIframeInCrossOrigin",
+            description: "Cross-origin parent with same-origin grandchild creates provisional child target and grandchild target.",
+            test(resolve) {
+                runCallbackCountingTest(resolve, 9, `
+                    addIframe("http://localhost:8000/site-isolation/inspector/target/resources/middle-iframe.html");
+                `);
+            },
+        });
+
+        // FIXME <https://webkit.org/b/309172>: Fix timing around cancelling provisional loading and LoadRequest.
+        /* suite.addTestCase({
+            name: "SiteIsolation.Target.ProvisionalFrameCancelledByRemoval",
+            description: "Removing cross-origin iframe before loading completes destroys both targets.",
+            test(resolve) {
+                runCallbackCountingTest(resolve, 4, `addAndRemoveIframe();`);
+            },
+        });
+
+        suite.addTestCase({
+            name: "SiteIsolation.Target.ProvisionalFrameCancelledByNavigation",
+            description: "Cancelling cross-origin load destroys provisional target but keeps committed target.",
+            test(resolve) {
+                runCallbackCountingTest(resolve, 4, `addAndNavigateAwayIframe();`);
+            },
+        }); */
+
+        suite.runTestCasesAndFinish();
+    }
 </script>
 
 <body onload="runTest()"></body>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2469,8 +2469,6 @@ webkit.org/b/307886 [ Release arm64 ] js/dom/promise-stack-overflow.html [ Pass 
 
 webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failure ]
 
-webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/console/message-from-iframe.html [ Failure ]
-webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/console/message-from-worker.html [ Failure ]
 webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html [ Failure ]
 webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/execution-context-from-frame-target.html [ Failure ]
 webkit.org/b/308240 http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html [ Failure ]

--- a/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
+++ b/Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp
@@ -92,8 +92,6 @@ Protocol::ErrorStringOr<void> InspectorTargetAgent::sendMessageToTarget(const St
 
 void InspectorTargetAgent::sendMessageFromTargetToFrontend(const String& targetId, const String& message)
 {
-    ASSERT_WITH_MESSAGE(m_targets.get(targetId), "Sending a message from an untracked target to the frontend.");
-
     m_frontendDispatcher->dispatchMessageFromTarget(targetId, message);
 }
 

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -27,21 +27,24 @@
 #include "WebPageInspectorController.h"
 
 #include "APIUIClient.h"
+#include "FrameInspectorTarget.h"
 #include "FrameInspectorTargetProxy.h"
 #include "InspectorBrowserAgent.h"
 #include "PageInspectorTarget.h"
 #include "PageInspectorTargetProxy.h"
+#include "ProvisionalFrameProxy.h"
 #include "ProvisionalPageProxy.h"
 #include "WebFrameProxy.h"
 #include "WebPageInspectorAgentBase.h"
 #include "WebPageProxy.h"
-#include "WebProcess/Inspector/FrameInspectorTarget.h"
+#include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
 #include <JavaScriptCore/InspectorAgentBase.h>
 #include <JavaScriptCore/InspectorBackendDispatcher.h>
 #include <JavaScriptCore/InspectorBackendDispatchers.h>
 #include <JavaScriptCore/InspectorFrontendRouter.h>
 #include <JavaScriptCore/InspectorTargetAgent.h>
+#include <wtf/Assertions.h>
 #include <wtf/HashMap.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -52,6 +55,16 @@ using namespace Inspector;
 static String getTargetID(const ProvisionalPageProxy& provisionalPage)
 {
     return PageInspectorTarget::toTargetID(provisionalPage.webPageID());
+}
+
+static String getTargetID(const WebFrameProxy& frame)
+{
+    return FrameInspectorTarget::toTargetID(frame.frameID(), frame.process().coreProcessIdentifier());
+}
+
+static String getTargetID(const ProvisionalFrameProxy& provisionalFrame)
+{
+    return FrameInspectorTarget::toTargetID(protect(provisionalFrame.frame())->frameID(), provisionalFrame.process().coreProcessIdentifier());
 }
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebPageInspectorController);
@@ -166,6 +179,15 @@ void WebPageInspectorController::setIndicating(bool indicating)
 
 void WebPageInspectorController::sendMessageToInspectorFrontend(const String& targetId, const String& message)
 {
+    if (!m_targets.contains(targetId)) {
+        // FIXME <https://webkit.org/b/308182>: This assertion is currently relaxed under site isolation.
+        // More fine-tuning is needed around reporting provisional frame targets' destruction.
+        if (shouldManageFrameTargets())
+            return;
+
+        ASSERT_NOT_REACHED_WITH_MESSAGE("Sending a message from an untracked target to the frontend.");
+    }
+
     protect(m_targetAgent)->sendMessageFromTargetToFrontend(targetId, message);
 }
 
@@ -217,14 +239,53 @@ void WebPageInspectorController::didCommitProvisionalPage(WebCore::PageIdentifie
 
 void WebPageInspectorController::didCreateFrame(WebFrameProxy& frame)
 {
-    if (protect(protect(m_inspectedPage)->preferences())->siteIsolationEnabled())
-        addTarget(FrameInspectorTargetProxy::create(frame, FrameInspectorTarget::toTargetID(frame.frameID())));
+    if (!shouldManageFrameTargets())
+        return;
+
+    addTarget(FrameInspectorTargetProxy::create(frame, getTargetID(frame)));
 }
 
 void WebPageInspectorController::willDestroyFrame(const WebFrameProxy& frame)
 {
-    if (protect(protect(m_inspectedPage)->preferences())->siteIsolationEnabled())
-        removeTarget(FrameInspectorTarget::toTargetID(frame.frameID()));
+    if (!shouldManageFrameTargets())
+        return;
+
+    removeTarget(getTargetID(frame));
+}
+
+void WebPageInspectorController::didCreateProvisionalFrame(ProvisionalFrameProxy& provisionalFrame)
+{
+    if (!shouldManageFrameTargets())
+        return;
+
+    addTarget(FrameInspectorTargetProxy::create(provisionalFrame, getTargetID(provisionalFrame)));
+}
+
+void WebPageInspectorController::willDestroyProvisionalFrame(const ProvisionalFrameProxy& provisionalFrame)
+{
+    if (!shouldManageFrameTargets())
+        return;
+
+    removeTarget(getTargetID(provisionalFrame));
+}
+
+void WebPageInspectorController::didCommitProvisionalFrame(WebFrameProxy& frame, WebCore::ProcessIdentifier oldProcessID, WebCore::ProcessIdentifier newProcessID)
+{
+    if (!shouldManageFrameTargets())
+        return;
+
+    WebCore::FrameIdentifier frameID = frame.frameID();
+    String oldTargetID = FrameInspectorTarget::toTargetID(frameID, oldProcessID);
+    String newTargetID = FrameInspectorTarget::toTargetID(frameID, newProcessID);
+
+    CheckedPtr targetAgent = m_targetAgent;
+    CheckedPtr newTarget = m_targets.get(newTargetID);
+    ASSERT(newTarget);
+    newTarget->didCommitProvisionalTarget();
+    targetAgent->didCommitProvisionalTarget(oldTargetID, newTargetID);
+
+    if (auto oldTarget = m_targets.take(oldTargetID))
+        targetAgent->targetDestroyed(protect(*oldTarget));
 }
 
 InspectorBrowserAgent* WebPageInspectorController::enabledBrowserAgent() const
@@ -266,6 +327,11 @@ void WebPageInspectorController::removeTarget(const String& targetId)
         return;
     protect(m_targetAgent)->targetDestroyed(CheckedRef { *it->value });
     m_targets.remove(it);
+}
+
+bool WebPageInspectorController::shouldManageFrameTargets() const
+{
+    return protect(protect(m_inspectedPage)->preferences())->siteIsolationEnabled();
 }
 
 void WebPageInspectorController::setEnabledBrowserAgent(InspectorBrowserAgent* agent)

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -82,6 +82,9 @@ public:
     void didCommitProvisionalPage(WebCore::PageIdentifier oldWebPageID, WebCore::PageIdentifier newWebPageID);
     void didCreateFrame(WebFrameProxy&);
     void willDestroyFrame(const WebFrameProxy&);
+    void didCreateProvisionalFrame(ProvisionalFrameProxy&);
+    void willDestroyProvisionalFrame(const ProvisionalFrameProxy&);
+    void didCommitProvisionalFrame(WebFrameProxy&, WebCore::ProcessIdentifier oldProcessID, WebCore::ProcessIdentifier newProcessID);
 
     InspectorBrowserAgent* NODELETE enabledBrowserAgent() const;
     void setEnabledBrowserAgent(InspectorBrowserAgent*);
@@ -95,6 +98,8 @@ private:
 
     void addTarget(std::unique_ptr<InspectorTargetProxy>&&);
     void removeTarget(const String& targetId);
+
+    bool shouldManageFrameTargets() const;
 
     const Ref<Inspector::FrontendRouter> m_frontendRouter;
     const Ref<Inspector::BackendDispatcher> m_backendDispatcher;

--- a/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp
@@ -31,6 +31,7 @@
 #include "VisitedLinkStore.h"
 #include "WebFrameMessages.h"
 #include "WebFrameProxy.h"
+#include "WebPageInspectorController.h"
 #include "WebPageProxy.h"
 #include "WebProcessProxy.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -54,6 +55,9 @@ ProvisionalFrameProxy::~ProvisionalFrameProxy()
 {
     if (!m_frameProcess)
         return;
+
+    if (RefPtr page = protect(m_frame)->page())
+        page->inspectorController().willDestroyProvisionalFrame(*this);
 
     Ref frame = m_frame.get();
     Ref process = this->process();

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -72,6 +72,7 @@
 #include <wtf/CallbackAggregator.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/RunLoop.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/WeakRef.h>
 #include <wtf/text/WTFString.h>
 
@@ -551,6 +552,10 @@ void WebFrameProxy::prepareForProvisionalLoadInProcess(WebProcessProxy& process,
 
     m_provisionalFrame = nullptr;
     m_provisionalFrame = adoptRef(*new ProvisionalFrameProxy(*this, group.ensureProcessForSite(site, mainFrameSite, process, protect(page->preferences())), commitTiming));
+
+    if (RefPtr provisionalFrame = m_provisionalFrame)
+        page->inspectorController().didCreateProvisionalFrame(*provisionalFrame);
+
     protect(protect(page->websiteDataStore())->networkProcess())->addAllowedFirstPartyForCookies(process, mainFrameDomain, LoadedWebArchive::No, [pageID = page->webPageIDInProcess(process), completionHandler = WTF::move(completionHandler)] mutable {
         completionHandler(pageID);
     });
@@ -562,8 +567,14 @@ void WebFrameProxy::commitProvisionalFrame(IPC::Connection& connection, FrameIde
     if (m_provisionalFrame) {
         protect(process())->send(Messages::WebPage::LoadDidCommitInAnotherProcess(frameID, m_layerHostingContextIdentifier), *webPageIDInCurrentProcess());
 
+        WebCore::ProcessIdentifier oldProcessID = process().coreProcessIdentifier();
+        WebCore::ProcessIdentifier newProcessID = protect(m_provisionalFrame)->process().coreProcessIdentifier();
+
         if (RefPtr process = std::exchange(m_provisionalFrame, nullptr)->takeFrameProcess())
             setProcess(process.releaseNonNull());
+
+        if (RefPtr page = m_page.get())
+            page->inspectorController().didCommitProvisionalFrame(*this, oldProcessID, newProcessID);
     }
 
     protect(page())->didCommitLoadForFrame(connection, frameID, WTF::move(frameInfo), WTF::move(request), navigationID, WTF::move(mimeType), frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, WTF::move(proxyName), source, containsPluginDocument, hasInsecureContent, mouseEventPolicy, WTF::move(documentSecurityPolicy), userData);

--- a/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.cpp
@@ -49,7 +49,7 @@ FrameInspectorTarget::~FrameInspectorTarget() = default;
 
 String FrameInspectorTarget::identifier() const
 {
-    return toTargetID(m_frame->frameID());
+    return toTargetID(protect(m_frame)->frameID(), WebCore::Process::identifier());
 }
 
 void FrameInspectorTarget::connect(Inspector::FrontendChannel::ConnectionType connectionType)
@@ -62,7 +62,8 @@ void FrameInspectorTarget::connect(Inspector::FrontendChannel::ConnectionType co
     ASSERT(page);
     m_channel = makeUnique<UIProcessForwardingFrontendChannel>(*page, identifier(), connectionType);
 
-    if (RefPtr coreFrame = frame->coreLocalFrame())
+    RefPtr coreFrame = frame->provisionalFrame() ?: frame->coreLocalFrame();
+    if (coreFrame)
         protect(coreFrame->inspectorController())->connectFrontend(*m_channel);
 }
 
@@ -71,7 +72,9 @@ void FrameInspectorTarget::disconnect()
     if (!m_channel)
         return;
 
-    if (RefPtr coreFrame = protect(m_frame)->coreLocalFrame())
+    Ref frame = m_frame.get();
+    RefPtr coreFrame = frame->provisionalFrame() ?: frame->coreLocalFrame();
+    if (coreFrame)
         protect(coreFrame->inspectorController())->disconnectFrontend(*m_channel);
 
     m_channel.reset();
@@ -79,13 +82,15 @@ void FrameInspectorTarget::disconnect()
 
 void FrameInspectorTarget::sendMessageToTargetBackend(const String& message)
 {
-    if (RefPtr coreFrame = protect(m_frame)->coreLocalFrame())
+    Ref frame = m_frame.get();
+    RefPtr coreFrame = frame->provisionalFrame() ?: frame->coreLocalFrame();
+    if (coreFrame)
         protect(coreFrame->inspectorController())->dispatchMessageFromFrontend(message);
 }
 
-String FrameInspectorTarget::toTargetID(WebCore::FrameIdentifier frameID)
+String FrameInspectorTarget::toTargetID(WebCore::FrameIdentifier frameID, WebCore::ProcessIdentifier processID)
 {
-    return makeString("frame-"_s, frameID.toUInt64());
+    return makeString("frame-"_s, frameID.toUInt64(), '-', processID.toUInt64());
 }
 
 } // namespace WebKit

--- a/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.h
@@ -27,6 +27,7 @@
 
 #include <JavaScriptCore/InspectorTarget.h>
 #include <WebCore/FrameIdentifier.h>
+#include <WebCore/ProcessIdentifier.h>
 #include <memory>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
@@ -53,7 +54,7 @@ public:
     void disconnect() override;
     void sendMessageToTargetBackend(const String&) override;
 
-    static String toTargetID(WebCore::FrameIdentifier);
+    static String toTargetID(WebCore::FrameIdentifier, WebCore::ProcessIdentifier);
 
 private:
     WeakRef<WebFrame> m_frame;


### PR DESCRIPTION
#### 34201b414d6591dc899d5dfba704c6217ab1fabb
<pre>
[Site Isolation] Web Inspector: Console message from cross-origin iframe appended by JS don&apos;t show up
<a href="https://bugs.webkit.org/show_bug.cgi?id=307733">https://bugs.webkit.org/show_bug.cgi?id=307733</a>

Reviewed by BJ Burg.

When a cross-origin iframe is added dynamically, there is a delay
between creating a new WebFrameProxy and eventually loading the frame
in a new web process. A LocalFrame is first created in the original
web process, and only at a certain point -- when the new provisional
frame &quot;commits&quot; -- will a second LocalFrame be made in the destination
process. This gives the frontend an opportunity to perform initializing
work (e.g. Console.enable) while the WebFrameProxy was still tied to
the old web process&apos;s frame target. Thus, the new frame target was never
set up to push any console messages to the frontend.

Fix this issue by implementing support for provisional frame targets
in a similar fashion to provisional page targets. In summary, this is
what the frontend sees:
- Normally, there&apos;s only one frame target per frame element.
- When a frame navigates, didCreateProvisionalFrame occurs, surfacing a
  new provisional frame target to the frontend. There are now two
  frame targets referring to the same frame element.
- If loading fails (e.g. was blocked), willDestroyProvisionalFrame
  occurs, destroying the provisional frame target.
- When the provisional frame commits, didCommitProvisionalFrame occurs,
  destroying the old committed frame target and transitioning the
  provisional target to committed state. Destroying either target brings
  us back to one regular frame target per frame.
This procedure compares closely to how provisional page loading works.

(There is still additional work needed to refine the timing of
destroying provisional frame targets when loading in cancelled. The
underlying issue should occur infrequently. See <a href="https://webkit.org/b/308182.)">https://webkit.org/b/308182.)</a>

For WebFrame on the web process side, before a provisional frame
commits, the coreFrame is a remote frame, and there&apos;s a separate
provisional LocalFrame member. So unlike in the page&apos;s case,
FrameInspectorTarget must check for the provisional frame and route
commands accordingly.

As the frame id stays the same across even a cross-origin navigation,
we update the id that we present to the frontend to also include the
web process id in order to keep target ids still unique.

Tests: http/tests/site-isolation/inspector/target/target.html,
   http/tests/site-isolation/inspector/console/message-from-iframe.html

Update the target.html test to include more scenarios involving cross-
origin loading and also adding grandchild iframes using JavaScript.
The message-from-iframe.html test now also progressed. Loading
grandchild iframes only when document.body.onload is added to ensure
consistent loading and logging order. Avoid logging from both
childIframe.onload and document.body.onload inside the child iframe for
similar reasons.

The two cases in target.html that cancel provisional loading revealed
a bug that loading could be canceled while handling
addAllowedFirstPartyForCookies, invalidating the eventual resource
loading when that network process operation completes. Skip these two
cases for now and filed <a href="https://webkit.org/b/309172">https://webkit.org/b/309172</a> as a follow-up.
(I could only repro this bug with this inspector test on a debug+asan
build. It should be very hard to repro or run into otherwise.)

A test case in message-from-worker.html involving cross-origin-iframe-
owned worker still fails due to not having SI support in Worker domain.
Revise that test case similarly to fix flakiness in test output.

* LayoutTests/http/tests/site-isolation/inspector/console/message-from-iframe-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/console/message-from-iframe.html:
* LayoutTests/http/tests/site-isolation/inspector/console/message-from-worker-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/console/message-from-worker.html:
* LayoutTests/http/tests/site-isolation/inspector/console/resources/console-messages.html:
* LayoutTests/http/tests/site-isolation/inspector/console/resources/embedded-cross-origin.html:
* LayoutTests/http/tests/site-isolation/inspector/console/resources/embedded-same-origin.html:
* LayoutTests/http/tests/site-isolation/inspector/console/resources/worker-in-iframe.html:
* LayoutTests/http/tests/site-isolation/inspector/target/resources/leaf-iframe.html:
* LayoutTests/http/tests/site-isolation/inspector/target/resources/middle-iframe.html:
* LayoutTests/http/tests/site-isolation/inspector/target/target-expected.txt:
* LayoutTests/http/tests/site-isolation/inspector/target/target.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/JavaScriptCore/inspector/agents/InspectorTargetAgent.cpp:
(Inspector::InspectorTargetAgent::sendMessageFromTargetToFrontend):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::getTargetID):
(WebKit::WebPageInspectorController::sendMessageToInspectorFrontend):
(WebKit::WebPageInspectorController::didCreateFrame):
(WebKit::WebPageInspectorController::willDestroyFrame):
(WebKit::WebPageInspectorController::didCreateProvisionalFrame):
(WebKit::WebPageInspectorController::willDestroyProvisionalFrame):
(WebKit::WebPageInspectorController::didCommitProvisionalFrame):
(WebKit::WebPageInspectorController::shouldManageFrameTargets const):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/ProvisionalFrameProxy.cpp:
(WebKit::ProvisionalFrameProxy::~ProvisionalFrameProxy):
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::prepareForProvisionalLoadInProcess):
(WebKit::WebFrameProxy::commitProvisionalFrame):
* Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.cpp:
(WebKit::FrameInspectorTarget::identifier const):
(WebKit::FrameInspectorTarget::connect):
(WebKit::FrameInspectorTarget::disconnect):
(WebKit::FrameInspectorTarget::sendMessageToTargetBackend):
(WebKit::FrameInspectorTarget::toTargetID):
* Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.h:

Canonical link: <a href="https://commits.webkit.org/308662@main">https://commits.webkit.org/308662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/111bbb730b04aac2befd170bf1f680d127eccbe8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148108 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20793 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14389 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156791 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19a0a512-8a3b-4b60-9a8d-6fa13efda149) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21251 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20698 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114182 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16418 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133010 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94949 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29ca5638-6b09-4b19-b0c3-206834a4d2f2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15555 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13354 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4228 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/140075 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10898 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159124 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/8895 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2258 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12415 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122212 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20592 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17301 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122427 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132721 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76748 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22825 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17864 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9472 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179528 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20209 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83968 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45969 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19939 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20086 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19995 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->