### PR TITLE
[Gardening]: [Tahoe Debug] TestWebKitAPI.WebKit.WKNavigationResponseDownloadAttribute is flaky failure

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationResponse.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationResponse.mm
@@ -208,7 +208,12 @@ TEST(WebKit, WKNavigationResponsePDFType)
 
 @end
 
+// FIXME when rdar://170575820 is resolved.
+#if PLATFORM(MAC) && __MAC_OS_X_VERSION_MIN_REQUIRED >= 260000
+TEST(WebKit, DISABLED_WKNavigationResponseDownloadAttribute)
+#else
 TEST(WebKit, WKNavigationResponseDownloadAttribute)
+#endif
 {
     auto getDownloadResponse = [] (RetainPtr<NSString> body) -> RetainPtr<WKNavigationResponse> {
         using namespace TestWebKitAPI;


### PR DESCRIPTION
#### 2dbfe9faa00927da40e903fc8a82868fc4909866
<pre>
[Gardening]: [Tahoe Debug] TestWebKitAPI.WebKit.WKNavigationResponseDownloadAttribute is flaky failure
<a href="https://rdar.apple.com/170575820">rdar://170575820</a>

Unreviewed test gardening

Skipping API test in Tahoe Debug and above till it&apos;s fixed.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/WKNavigationResponse.mm:
(TEST(WebKit, WKNavigationResponseDownloadAttribute)):

Canonical link: <a href="https://commits.webkit.org/307837@main">https://commits.webkit.org/307837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40002c5286945384dc22931389a08f9592747f6e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145280 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17961 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9752 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153952 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98917 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d0aba6a-a9de-4f19-9d51-ff0551db90be) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18444 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17853 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111710 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80069 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/451182d6-f789-4ea0-a612-bf4b72b9178f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148243 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14078 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130502 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92610 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/787198f5-099a-408b-80e3-1c7da9917a80) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13429 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11188 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1398 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122957 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156264 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17812 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8353 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119718 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17858 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14866 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120053 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15820 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128523 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73500 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22462 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17433 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6774 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17170 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17378 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17233 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->