### PR TITLE
[Render Replaced][youtube.com] Resolve percentage height for aspect ratio adjusted widths.

### DIFF
--- a/LayoutTests/fast/replaced/image-percent-sizing-in-inline-block-expected.html
+++ b/LayoutTests/fast/replaced/image-percent-sizing-in-inline-block-expected.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html> 
+<html>
+    <style>
+        img { width:90px; height:90px; }
+    </style>
+    <img src="../images/resources/green-24x24.jpg">
+</html>

--- a/LayoutTests/fast/replaced/image-percent-sizing-in-inline-block.html
+++ b/LayoutTests/fast/replaced/image-percent-sizing-in-inline-block.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<style>
+    .inline-block { display: inline-block; }
+    .background { height: 90px; background-color: red; }
+    img { width: 100%; height: 100%; object-fit: contain; }
+</style>
+<div class="inline-block background">
+    <img src="../images/resources/green-24x24.jpg">
+</div>


### PR DESCRIPTION
#### 6b3a23bbdc75ad36883f89e45be2321971498a45
<pre>
[Render Replaced][youtube.com] Resolve percentage height for aspect ratio adjusted widths.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308080">https://bugs.webkit.org/show_bug.cgi?id=308080</a>
&lt;<a href="https://rdar.apple.com/170270187">rdar://170270187</a>&gt;

Reviewed by Alan Baradlay.

This PR resolves percentage/calc heights for RenderImage when the used (min, max, intrinsic)
height can be computed.

This fixes a bug where youtube.com shop ads were being rendered with stretched images
because of incorrect logical widths.

* LayoutTests/fast/replaced/image-percent-sizing-in-inline-block-expected.html: Added.
* LayoutTests/fast/replaced/image-percent-sizing-in-inline-block.html: Added.
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):

Canonical link: <a href="https://commits.webkit.org/307751@main">https://commits.webkit.org/307751@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d4154fb5dad99fee06fb9ae4aca62d64a3dcec9b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145363 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9848 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99000 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147238 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18529 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17938 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111781 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2b26fef-b86e-4c31-a5ef-4a9f24693b32) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148326 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14142 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130579 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92682 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4759353d-736a-4935-8394-65ca6164af4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13485 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11247 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1481 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123016 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7346 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156347 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17895 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8440 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119785 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17941 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120125 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30803 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15885 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128609 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73593 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17516 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6842 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81295 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17461 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17316 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->