### PR TITLE
[iOS] AudioSession category incorrectly reset after pausing a media element that started playing while muted

### DIFF
--- a/LayoutTests/http/wpt/mediasession/setCaptureState-audio-category.html
+++ b/LayoutTests/http/wpt/mediasession/setCaptureState-audio-category.html
@@ -63,7 +63,7 @@ promise_test(async (test) => {
     await navigator.mediaSession.setMicrophoneActive(false);
     await new Promise(resolve => track.onmute = resolve);
 
-    validateInternalAudioCategory("None");
+    validateInternalAudioCategory("MediaPlayback");
 
     await video.play();
     await waitForInternalAudioCategory("MediaPlayback");

--- a/LayoutTests/media/audio-session-category-play-unmute-pause-expected.txt
+++ b/LayoutTests/media/audio-session-category-play-unmute-pause-expected.txt
@@ -1,0 +1,38 @@
+
+Test that the audio session retains the MediaPlayback category when a video is paused after being played then unmuted.
+
+** Check category before anything has loaded.
+EXPECTED (internals.audioSessionCategory() == 'None') OK
+
+** Check category when a muted, paused, element has loaded.
+EVENT(canplaythrough)
+EXPECTED (internals.audioSessionCategory() == 'None') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
+
+** Check category when a muted element is playing.
+RUN(video.play())
+EVENT(playing)
+EXPECTED (internals.audioSessionCategory() == 'None') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
+EXPECTED (internals.routeSharingPolicy() == 'Default') OK
+
+** Check category when an unmuted element is playing.
+RUN(video.muted = false)
+EVENT(volumechange)
+
+EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
+EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
+
+** Pause the element, check again after 500ms.
+RUN(video.pause())
+EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
+EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
+
+** And check again after 3 seconds.
+EXPECTED (internals.audioSessionCategory() == 'MediaPlayback') OK
+EXPECTED (internals.audioSessionMode() == 'Default') OK
+EXPECTED (internals.routeSharingPolicy() == 'LongFormAudio') OK
+END OF TEST
+

--- a/LayoutTests/media/audio-session-category-play-unmute-pause.html
+++ b/LayoutTests/media/audio-session-category-play-unmute-pause.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>audio-session-category-play-unmute-pause</title>
+    <script src='video-test.js'></script>
+    <script src='media-file.js'></script>
+    <script>
+
+        async function waitForCategory(category, duration, message)
+        {
+            consoleWrite(message);
+
+            const maxTries = duration * 1000 / 10;
+            let counter = 0;
+            while (++counter < maxTries) {
+                if (internals.audioSessionCategory() == category)
+                    break;
+                await new Promise(resolve => setTimeout(resolve, 10));
+            }
+
+            testExpected('internals.audioSessionCategory()', category);
+        }
+
+        async function testAudioElement()
+        {
+            await waitForCategory('None', 10, '<br>** Check category before anything has loaded.');
+
+            consoleWrite('<br>** Check category when a muted, paused, element has loaded.');
+            video.src = findMediaFile('video', 'content/test');
+
+            await waitFor(video, 'canplaythrough');
+            testExpected('internals.audioSessionCategory()', 'None');
+            testExpected('internals.audioSessionMode()', 'Default');
+
+            consoleWrite('<br>** Check category when a muted element is playing.');
+            runWithKeyDown(() => { run('video.play()') });
+            await waitFor(video, 'playing');
+            testExpected('internals.audioSessionCategory()', 'None');
+            testExpected('internals.audioSessionMode()', 'Default');
+            testExpected('internals.routeSharingPolicy()', 'Default');
+
+            consoleWrite('<br>** Check category when an unmuted element is playing.');
+            runWithKeyDown(() => { run('video.muted = false') });
+            await waitFor(video, 'volumechange');
+            await waitForCategory('MediaPlayback', 1, '');
+            testExpected('internals.audioSessionMode()', 'Default');
+            testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
+
+            consoleWrite('<br>** Pause the element, check again after 500ms.');
+            run('video.pause()');
+            await sleepFor(500);
+            testExpected('internals.audioSessionCategory()', 'MediaPlayback');
+            testExpected('internals.audioSessionMode()', 'Default');
+            testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
+
+            await waitForCategory('MediaPlayback', 3, '<br>** And check again after 3 seconds.');
+            testExpected('internals.audioSessionMode()', 'Default');
+            testExpected('internals.routeSharingPolicy()', 'LongFormAudio');
+
+            video.src = '';
+            video.load();
+        }
+
+        window.addEventListener('load', async event => {
+            if (!window.internals) {
+                failTest(`<br>This test requires internals!`);
+                return;
+            }
+
+            consoleWrite('Test that the audio session retains the MediaPlayback category when a video is paused after being played then unmuted.')
+
+            internals.settings.setShouldManageAudioSessionCategory(true);
+
+            video = document.getElementsByTagName('video')[0];
+
+            failTestIn(20000);
+            await testAudioElement();
+            endTest();
+        });
+    </script>
+</head>
+<body>
+    <video muted controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3490,6 +3490,7 @@ http/tests/contentextensions/cross-origin-content-rules.html [ Skip ]
 # Tests behavior specific to MediaSessionManagerCocoa
 media/audio-session-category.html [ Skip ]
 media/audio-session-category-at-most-recent-playback.html [ Skip ]
+media/audio-session-category-play-unmute-pause.html [ Skip ]
 
 # This test assumes we cannot play RTSP, but we can.
 media/unsupported-rtsp.html [ WontFix Skip ]

--- a/Source/WebCore/platform/audio/AudioSession.cpp
+++ b/Source/WebCore/platform/audio/AudioSession.cpp
@@ -135,7 +135,7 @@ bool AudioSession::tryToSetActive(bool active)
     if (!tryToSetActiveInternal(active))
         return false;
 
-    ALWAYS_LOG(LOGIDENTIFIER, "is active = ", m_active, ", previousIsActive = ", previousIsActive);
+    ALWAYS_LOG(LOGIDENTIFIER, "is active = ", active, ", previousIsActive = ", previousIsActive);
 
     bool hasActiveChanged = previousIsActive != isActive();
     m_active = active;

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -171,9 +171,11 @@ void PlatformMediaSession::setState(State state)
     if (state == m_state)
         return;
 
-    ALWAYS_LOG(LOGIDENTIFIER, state);
+    bool canProduceAudio = this->canProduceAudio();
+    ALWAYS_LOG(LOGIDENTIFIER, state, ", canProduceAudio=", canProduceAudio);
+
     m_state = state;
-    if (m_state == State::Playing && canProduceAudio())
+    if (m_state == State::Playing && canProduceAudio)
         setHasPlayedAudiblySinceLastInterruption(true);
 
     if (RefPtr manager = sessionManager())
@@ -382,6 +384,9 @@ bool PlatformMediaSession::activeAudioSessionRequired() const
 
 void PlatformMediaSession::canProduceAudioChanged()
 {
+    if (m_state == State::Playing && canProduceAudio())
+        setHasPlayedAudiblySinceLastInterruption(true);
+
     if (RefPtr manager = sessionManager())
         manager->sessionCanProduceAudioChanged();
 }


### PR DESCRIPTION
#### 0b6f4e7703f54fb929fd7a17b7d5eb56c8325e7d
<pre>
[iOS] AudioSession category incorrectly reset after pausing a media element that started playing while muted
<a href="https://bugs.webkit.org/show_bug.cgi?id=308083">https://bugs.webkit.org/show_bug.cgi?id=308083</a>
<a href="https://rdar.apple.com/170586419">rdar://170586419</a>

Reviewed by Youenn Fablet and Jer Noble.

PlatformMediaSession tracks whether its associated media element has played audibly since the last
interruption. When it has, MediaSessionManager considers the session to be potentially audible and
retains the MediaPlayback category on the shared audio session even if playback is paused.

PlatformMediaSession set hasPlayedAudiblySinceLastInterruption to true when an audible media
session starts playing, but did *not* set hasPlayedAudiblySinceLastInterruption to true if a media
session becomes audible after it starts playing. If the user plays a muted video, unmutes it, then
pauses it, MediaSessionManager would incorrectly change the shared audio session&apos;s category to
Ambient.

Resolved this by calling PlatformMediaSession::setHasPlayedAudiblySinceLastInterruption(true) in
PlatformMediaSession::canProduceAudioChanged() when m_state is Playing.

Test: media/audio-session-category-play-unmute-pause.html

* LayoutTests/http/wpt/mediasession/setCaptureState-audio-category.html:
* LayoutTests/media/audio-session-category-play-unmute-pause-expected.txt: Added.
* LayoutTests/media/audio-session-category-play-unmute-pause.html: Added.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::tryToSetActive):
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::setState):
(WebCore::PlatformMediaSession::canProduceAudioChanged):

Canonical link: <a href="https://commits.webkit.org/307778@main">https://commits.webkit.org/307778@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01627b4fdb880cb86df5bad105b16788823129cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145352 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18034 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9835 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154024 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98989 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd8b0a92-b9be-40e5-9943-c183d2ee8453) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147227 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18518 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111775 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80106 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8023d188-7a38-4f78-8e3d-dc15856aab25) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14136 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130567 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92676 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b2a469e-cfa8-4237-8faa-755102c2e005) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11241 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1470 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123010 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7334 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156336 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17884 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8428 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119780 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14925 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120119 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30821 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15873 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73578 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17505 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6830 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17242 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81284 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17450 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17305 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->