### PR TITLE
Add check to wasm function parser for illegal memory instructions

### DIFF
--- a/JSTests/wasm/regress/unreachable-illegal-load-parse-error.js
+++ b/JSTests/wasm/regress/unreachable-illegal-load-parse-error.js
@@ -1,0 +1,20 @@
+// see rdar://170534591
+
+import * as assert from "../assert.js";
+
+var wasm_code = new Uint8Array([0x00,0x61,0x73,0x6D,0x01,0x00,0x00,0x00,0x01,0x85,0x00,0x01,0x60,0x00,0x01,0x7C,0x03,0x82,0x00,0x01,0x00,0x0A,0x8A,0x00,0x01,0x08,0x00,0x00,0x2C,0x05,0x83,0xFD,0x6D,0x0B,]);
+
+let exception = undefined;
+
+try {
+    var wasm_module = new WebAssembly.Module(wasm_code);
+    var wasm_instance = new WebAssembly.Instance(wasm_module);
+    var f = wasm_instance.exports.main;
+    f();
+} catch(e) {
+    exception = "" + e;
+}
+
+assert.eq(exception, "CompileError: WebAssembly.Module doesn't parse at byte 3: load/store instruction without memory, in function at index 0 (evaluating 'new WebAssembly.Module(wasm_code)')");
+
+// this should throw a parse error instead of triggering a runtime assertion

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -3997,6 +3997,7 @@ auto FunctionParser<Context>::parseUnreachableExpression() -> PartialResult
     // two immediate cases
     FOR_EACH_WASM_MEMORY_LOAD_OP(CREATE_CASE)
     FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE) {
+        WASM_PARSER_FAIL_IF(!m_info.memoryCount(), "load/store instruction without memory"_s);
         uint32_t unused;
         WASM_PARSER_FAIL_IF(!parseVarUInt32(unused), "can't get first immediate for "_s, m_currentOpcode, " in unreachable context"_s);
         if (m_info.theOnlyMemory().isMemory64()) {


### PR DESCRIPTION
#### cfde220e1cb351256dc97382c36c278c729f5ede
<pre>
Add check to wasm function parser for illegal memory instructions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308081">https://bugs.webkit.org/show_bug.cgi?id=308081</a>
<a href="https://rdar.apple.com/170534591">rdar://170534591</a>

Reviewed by Keith Miller.

This is in response to a fuzzer bug that triggers a release assertion
failure instead of throwing a parse error. If the parser is given a wasm
module with no memories that contains a load or store instruction in an
unreachable expression, it should check whether there are any memories
in the module instead of triggering the assert.

Test: JSTests/wasm/regress/unreachable-illegal-load-parse-error.js

* JSTests/wasm/regress/unreachable-illegal-load-parse-error.js: Added.
(catch):
* Source/JavaScriptCore/wasm/WasmFunctionParser.h:
(JSC::Wasm::FunctionParser&lt;Context&gt;::parseUnreachableExpression):

Canonical link: <a href="https://commits.webkit.org/307788@main">https://commits.webkit.org/307788@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a56d06e48356c12c72951129371ef8a53035956

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18144 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9969 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154134 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99099 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdf47f4e-538c-4f77-9588-e59b0c4b3ac3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18628 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18037 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111868 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5757da8c-7ec0-44dd-ab4c-3cb6d5ba8c68) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14238 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92769 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d06f8c8c-5400-4f7c-b39d-44f2126af7bb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13570 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11330 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1580 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137453 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7448 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156446 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6271 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8554 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119874 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18040 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120215 "Passed tests") | | 
| [❌ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30827 "") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15969 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128724 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73723 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22441 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17615 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6937 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176752 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17352 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81394 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45429 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17560 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17415 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->