### PR TITLE
[Gardening][Tahoe arm64] compositing/visible-rect/animated-from-none.html is a flaky text failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2495,3 +2495,5 @@ webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failu
 
 webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/console/message-from-iframe.html [ Failure ]
 webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/console/message-from-worker.html [ Failure ]
+
+webkit.org/b/308086 [ Tahoe Release arm64 ] compositing/visible-rect/animated-from-none.html [ Pass Failure ]


### PR DESCRIPTION
#### afd479689c784a5b5fd43937da7b90ce605b3992
<pre>
[Tahoe arm64] compositing/visible-rect/animated-from-none.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=308086">https://bugs.webkit.org/show_bug.cgi?id=308086</a>
<a href="https://rdar.apple.com/170589380">rdar://170589380</a>

Reviewed by NOBODY (OOPS!).

This test merely used an animation&apos;s `ready` promise to determine that its effect would be
accounted for in the layer tree. It needs to account for the accelerated representation of
that animation to be uploaded to the remote layer tree using the `animationAcceleration()`
helper and then for one rendering frame to ensure the remote animation has been applied.
This yields stable results.

* LayoutTests/compositing/visible-rect/animated-from-none.html:
* LayoutTests/platform/mac-wk2/TestExpectations:
</pre>