### PR TITLE
Optimize CSS d property

### DIFF
--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4634,8 +4634,11 @@
                 "computed-style-storage-path": ["m_svgData", "layoutData"],
                 "computed-style-storage-kind": "reference",
                 "computed-style-type": "Style::SVGPathData",
+                "computed-style-has-explicitly-set-policy": "all-author-origin",
+                "computed-style-has-explicitly-set-storage-path": ["m_svgData", "layoutData"],
                 "parser-grammar": "none | <path()>",
-                "settings-flag": "cssDPropertyEnabled"
+                "settings-flag": "cssDPropertyEnabled",
+                "style-extractor-custom": true
             },
             "specification": {
                 "category": "svg",

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -299,7 +299,15 @@ bool RenderSVGPath::isRenderingDisabled() const
 void RenderSVGPath::styleDidChange(Style::Difference diff, const RenderStyle* oldStyle)
 {
     if (RefPtr pathElement = dynamicDowncast<SVGPathElement>(graphicsElement())) {
-        if (!oldStyle || style().d() != oldStyle->d())
+        bool dChanged = false;
+        if (!oldStyle) {
+            dChanged = true;
+        } else if (style().hasExplicitlySetD() != oldStyle->hasExplicitlySetD()) {
+            dChanged = true;
+        } else if (style().hasExplicitlySetD() && style().d() != oldStyle->d())
+            dChanged = true;
+
+        if (dChanged)
             pathElement->pathDidChange();
     }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -310,7 +310,15 @@ bool LegacyRenderSVGPath::isRenderingDisabled() const
 void LegacyRenderSVGPath::styleDidChange(Style::Difference diff, const RenderStyle* oldStyle)
 {
     if (RefPtr pathElement = dynamicDowncast<SVGPathElement>(graphicsElement())) {
-        if (!oldStyle || style().d() != oldStyle->d())
+        bool dChanged = false;
+        if (!oldStyle) {
+            dChanged = true;
+        } else if (style().hasExplicitlySetD() != oldStyle->hasExplicitlySetD()) {
+            dChanged = true;
+        } else if (style().hasExplicitlySetD() && style().d() != oldStyle->d())
+            dChanged = true;
+
+        if (dChanged)
             pathElement->pathDidChange();
     }
 

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -44,6 +44,8 @@
 #include "HTMLElement.h"
 #include "HTMLSlotElement.h"
 #include "SVGElement.h"
+#include "SVGElementTypeHelpers.h"
+#include "SVGPathElement.h"
 #include "SelectorCheckerTestFunctions.h"
 #include "SelectorCompiler.h"
 #include "SelectorMatchingState.h"
@@ -855,6 +857,15 @@ static inline bool compareRules(MatchedRule r1, MatchedRule r2)
     return r1.ruleData->position() < r2.ruleData->position();
 }
 
+bool ElementRuleCollector::matchedRulesContainProperty(CSSPropertyID propertyID) const
+{
+    for (const auto& matchedRule : m_matchedRules) {
+        if (matchedRule.ruleData->styleRule().properties().findPropertyIndex(propertyID) >= 0)
+            return true;
+    }
+    return false;
+}
+
 void ElementRuleCollector::sortMatchedRules()
 {
     std::ranges::sort(m_matchedRules, compareRules);
@@ -897,8 +908,19 @@ void ElementRuleCollector::matchAllRules(bool matchAuthorAndUserStyles, bool inc
         clearMatchedRules();
 
         collectMatchingRules(DeclarationOrigin::Author);
-        sortMatchedRules();
 
+        // If CSS uses the d property, add the d attribute presentational hint for proper cascade.
+        // This must be done BEFORE transferring author rules so that author rules can override
+        // the presentational hint. This avoids creating CSSPathValue when CSS doesn't touch
+        // the d property (which is the common case).
+        if (RefPtr pathElement = dynamicDowncast<SVGPathElement>(element())) {
+            if (matchedRulesContainProperty(CSSPropertyD)) {
+                if (RefPtr dHintStyle = pathElement->presentationalHintStyleForDAttribute())
+                    addElementStyleProperties(dHintStyle.get(), RuleSet::cascadeLayerPriorityForPresentationalHints);
+            }
+        }
+
+        sortMatchedRules();
         transferMatchedRules(DeclarationOrigin::Author, ScopeOrdinal::Element);
 
         // Inline style behaves as if it has higher specificity than any rule.

--- a/Source/WebCore/style/ElementRuleCollector.h
+++ b/Source/WebCore/style/ElementRuleCollector.h
@@ -108,6 +108,7 @@ private:
     std::pair<bool, std::optional<Vector<ScopingRootWithDistance>>> scopeRulesMatch(const RuleData&, const MatchRequest&);
 
     void sortMatchedRules();
+    bool matchedRulesContainProperty(CSSPropertyID) const;
 
     Vector<MatchedProperties>& declarationsForOrigin(DeclarationOrigin);
     void sortAndTransferMatchedRules(DeclarationOrigin);

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -60,6 +60,7 @@
 #include "RenderGrid.h"
 #include "RenderInline.h"
 #include "RenderStyle+GettersInlines.h"
+#include "SVGPathElement.h"
 #include "StyleComputedStyle+InitialInlines.h"
 #include "StyleExtractorState.h"
 #include "StyleInterpolation.h"
@@ -130,6 +131,7 @@ public:
     static Ref<CSSValue> extractWebkitMaskSourceType(ExtractorState&);
     static Ref<CSSValue> extractColor(ExtractorState&);
     static Ref<CSSValue> extractCaretColor(ExtractorState&);
+    static Ref<CSSValue> extractD(ExtractorState&);
 
     // MARK: Shorthands
 
@@ -228,6 +230,7 @@ public:
     static void extractWebkitMaskSourceTypeSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractColorSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractCaretColorSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
+    static void extractDSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
 
     static void extractAnimationShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
     static void extractAnimationRangeShorthandSerialization(ExtractorState&, StringBuilder&, const CSS::SerializationContext&);
@@ -1275,6 +1278,23 @@ template<> struct PropertyExtractorAdaptor<CSSPropertyCaretColor> {
     template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
     {
         return functor(state.style.caretColor().colorOrCurrentColor());
+    }
+};
+
+template<> struct PropertyExtractorAdaptor<CSSPropertyD> {
+    template<typename F> decltype(auto) computedValue(ExtractorState& state, F&& functor) const
+    {
+        if (!state.style.hasExplicitlySetD()) {
+            if (RefPtr pathElement = dynamicDowncast<SVGPathElement>(state.element.get())) {
+                auto& byteStream = pathElement->pathByteStream();
+                if (!byteStream.isEmpty()) {
+                    PathFunction pathFunction { Path { std::nullopt, Path::Data { byteStream }, 1.0f } };
+                    return functor(SVGPathData { WTF::move(pathFunction) });
+                }
+            }
+        }
+
+        return functor(state.style.d());
     }
 };
 
@@ -2393,6 +2413,16 @@ inline void ExtractorCustom::extractCaretColorSerialization(ExtractorState& stat
         return;
     }
     extractSerialization<CSSPropertyCaretColor>(state, builder, context);
+}
+
+inline Ref<CSSValue> ExtractorCustom::extractD(ExtractorState& state)
+{
+    return extractCSSValue<CSSPropertyD>(state);
+}
+
+inline void ExtractorCustom::extractDSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context)
+{
+    extractSerialization<CSSPropertyD>(state, builder, context);
 }
 
 // MARK: - Shorthands

--- a/Source/WebCore/style/computed/data/StyleSVGLayoutData.cpp
+++ b/Source/WebCore/style/computed/data/StyleSVGLayoutData.cpp
@@ -62,6 +62,7 @@ inline SVGLayoutData::SVGLayoutData(const SVGLayoutData& other)
     , x(other.x)
     , y(other.y)
     , d(other.d)
+    , hasExplicitlySetD(other.hasExplicitlySetD)
 {
 }
 
@@ -79,7 +80,8 @@ bool SVGLayoutData::operator==(const SVGLayoutData& other) const
         && ry == other.ry
         && x == other.x
         && y == other.y
-        && d == other.d;
+        && d == other.d
+        && hasExplicitlySetD == other.hasExplicitlySetD;
 }
 
 #if !LOG_DISABLED
@@ -93,6 +95,7 @@ void SVGLayoutData::dumpDifferences(TextStream& ts, const SVGLayoutData& other) 
     LOG_IF_DIFFERENT(x);
     LOG_IF_DIFFERENT(y);
     LOG_IF_DIFFERENT(d);
+    LOG_IF_DIFFERENT(hasExplicitlySetD);
 }
 #endif
 
@@ -106,6 +109,7 @@ TextStream& operator<<(TextStream& ts, const SVGLayoutData& data)
     ts.dumpProperty("x"_s, data.x);
     ts.dumpProperty("y"_s, data.y);
     ts.dumpProperty("d"_s, data.d);
+    ts.dumpProperty("hasExplicitlySetD"_s, data.hasExplicitlySetD);
     return ts;
 }
 

--- a/Source/WebCore/style/computed/data/StyleSVGLayoutData.h
+++ b/Source/WebCore/style/computed/data/StyleSVGLayoutData.h
@@ -62,6 +62,7 @@ public:
     SVGCoordinateComponent x;
     SVGCoordinateComponent y;
     SVGPathData d;
+    bool hasExplicitlySetD { false };
 
 private:
     SVGLayoutData();

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -866,7 +866,7 @@ bool SVGElement::rendererIsNeeded(const RenderStyle& style)
     return false;
 }
 
-CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& attrName, const Settings& settings)
+CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& attrName, const Settings&)
 {
     if (!attrName.namespaceURI().isNull())
         return CSSPropertyInvalid;
@@ -896,10 +896,6 @@ CSSPropertyID SVGElement::cssPropertyIdForSVGAttributeName(const QualifiedName& 
         return CSSPropertyCx;
     case AttributeNames::cyAttr:
         return CSSPropertyCy;
-    case AttributeNames::dAttr:
-        if (settings.cssDPropertyEnabled())
-            return CSSPropertyD;
-        break;
     case AttributeNames::directionAttr:
         return CSSPropertyDirection;
     case AttributeNames::displayAttr:

--- a/Source/WebCore/svg/SVGPathElement.cpp
+++ b/Source/WebCore/svg/SVGPathElement.cpp
@@ -149,8 +149,13 @@ void SVGPathElement::svgAttributeChanged(const QualifiedName& attrName)
             path->setNeedsShapeUpdate();
 
         updateSVGRendererForElementChange();
-        if (document().settings().cssDPropertyEnabled())
-            setPresentationalHintStyleIsDirty();
+
+        if (document().settings().cssDPropertyEnabled()) {
+            invalidateDPresentationalHintCache();
+            if (renderer() && renderer()->style().hasExplicitlySetD())
+                invalidateStyle();
+        }
+
         invalidateResourceImageBuffersIfNeeded();
         return;
     }
@@ -239,9 +244,11 @@ const SVGPathByteStream& SVGPathElement::pathByteStream() const
 {
     if (document().settings().cssDPropertyEnabled()) {
         if (CheckedPtr renderer = this->renderer()) {
-            if (auto& pathFunction = renderer->style().d().tryPath())
-                return pathFunction->parameters.data.byteStream;
-            return SVGPathByteStream::empty();
+            if (renderer->style().hasExplicitlySetD()) {
+                if (auto& pathFunction = renderer->style().d().tryPath())
+                    return pathFunction->parameters.data.byteStream;
+                return SVGPathByteStream::empty();
+            }
         }
     }
 
@@ -252,40 +259,40 @@ Path SVGPathElement::path() const
 {
     if (document().settings().cssDPropertyEnabled()) {
         if (CheckedPtr renderer = this->renderer()) {
-            if (auto& pathFunction = renderer->style().d().tryPath())
-                return Style::path(pathFunction->parameters, FloatRect { });
-            return { };
+            if (renderer->style().hasExplicitlySetD()) {
+                if (auto& pathFunction = renderer->style().d().tryPath())
+                    return Style::path(pathFunction->parameters, FloatRect { });
+                return { };
+            }
         }
     }
 
     return Ref { m_pathSegList }->currentPath();
 }
 
-void SVGPathElement::collectPresentationalHintsForAttribute(const QualifiedName& name, const AtomString& value, MutableStyleProperties& style)
-{
-    if (name == SVGNames::dAttr && document().settings().cssDPropertyEnabled())
-        collectDPresentationalHint(style);
-    else
-        SVGGeometryElement::collectPresentationalHintsForAttribute(name, value, style);
-}
-
-void SVGPathElement::collectExtraStyleForPresentationalHints(MutableStyleProperties& style)
+RefPtr<MutableStyleProperties> SVGPathElement::presentationalHintStyleForDAttribute() const
 {
     if (!document().settings().cssDPropertyEnabled())
-        return;
-    if (style.findPropertyIndex(CSSPropertyD) == -1)
-        collectDPresentationalHint(style);
+        return nullptr;
+
+    if (!m_cachedDPresentationalHintStyle)
+        m_cachedDPresentationalHintStyle = buildDPresentationalHintStyle();
+
+    return m_cachedDPresentationalHintStyle;
 }
 
-void SVGPathElement::collectDPresentationalHint(MutableStyleProperties& style)
+Ref<MutableStyleProperties> SVGPathElement::buildDPresentationalHintStyle() const
 {
-    ASSERT(document().settings().cssDPropertyEnabled());
-    // In the case of the `d` property, we want to avoid providing a string value since it will require
-    // the path data to be parsed again and path data can be unwieldy.
-    auto property = cssPropertyIdForSVGAttributeName(SVGNames::dAttr, document().settings());
+    auto style = MutableStyleProperties::create(SVGAttributeMode);
     // The fill rule value passed here is not relevant for the `d` property.
     auto cssPathValue = CSSPathValue::create(CSS::PathFunction { CSS::Keyword::Nonzero { }, CSS::Path::Data { Ref { m_pathSegList }->currentPathByteStream() } });
-    addPropertyToPresentationalHintStyle(style, property, WTF::move(cssPathValue));
+    style->setProperty(CSSPropertyD, WTF::move(cssPathValue));
+    return style;
+}
+
+void SVGPathElement::invalidateDPresentationalHintCache()
+{
+    m_cachedDPresentationalHintStyle = nullptr;
 }
 
 void SVGPathElement::pathDidChange()

--- a/Source/WebCore/svg/SVGPathElement.h
+++ b/Source/WebCore/svg/SVGPathElement.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "MutableStyleProperties.h"
 #include "Path.h"
 #include "SVGGeometryElement.h"
 #include "SVGNames.h"
@@ -104,6 +105,8 @@ public:
 
     void pathDidChange();
 
+    RefPtr<MutableStyleProperties> presentationalHintStyleForDAttribute() const;
+
     static void clearCache();
 
     using PropertyRegistry = SVGPropertyOwnerRegistry<SVGPathElement, SVGGeometryElement>;
@@ -124,11 +127,11 @@ private:
 
     void invalidateMPathDependencies();
 
-    void collectPresentationalHintsForAttribute(const QualifiedName&, const AtomString&, MutableStyleProperties&) final;
-    void collectExtraStyleForPresentationalHints(MutableStyleProperties&) override;
-    void collectDPresentationalHint(MutableStyleProperties&);
+    void invalidateDPresentationalHintCache();
+    Ref<MutableStyleProperties> buildDPresentationalHintStyle() const;
 
     Ref<SVGAnimatedPathSegList> m_pathSegList { SVGAnimatedPathSegList::create(this) };
+    mutable RefPtr<MutableStyleProperties> m_cachedDPresentationalHintStyle;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### bd56a695fa5f
<pre>
Optimize CSS d property
<a href="https://bugs.webkit.org/show_bug.cgi?id=304761">https://bugs.webkit.org/show_bug.cgi?id=304761</a>
<a href="https://rdar.apple.com/167300890">rdar://167300890</a>

Reviewed by NOBODY (OOPS!).

The CSS d property for SVG path elements caused a performance regression
because CSSPathValue creation is expensive. This cost was incurred for
every path element during style resolution, even when CSS doesn&apos;t use the d property.

This change defers creation of the d presentational hint until we know CSS
actually references the d property. In the common case where CSS doesn&apos;t
touch d, no CSSPathValue is created and the path uses its attribute value
directly.

The d attribute is intentionally not mapped in cssPropertyIdForSVGAttributeName
to keep it out of the generic presentational hint machinery. Instead,
SVGPathElement provides a separately cached presentational hint that
ElementRuleCollector adds only when author rules contain the d property.

This fully recovers the performance regression.

                          Baseline    After
  React-Stockcharts-SVG   3.32%       0.23%
  PanTheChart             1.70%       0.07%
  ZoomTheChart            6.54%       0.36%

* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::RenderSVGPath::styleDidChange):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::LegacyRenderSVGPath::styleDidChange):
* Source/WebCore/style/ElementRuleCollector.cpp:
(WebCore::Style::ElementRuleCollector::matchedRulesContainProperty const):
(WebCore::Style::ElementRuleCollector::matchAllRules):
* Source/WebCore/style/ElementRuleCollector.h:
* Source/WebCore/style/StyleExtractorCustom.h:
(WebCore::Style::PropertyExtractorAdaptor&lt;CSSPropertyD&gt;::computedValue const):
(WebCore::Style::ExtractorCustom::extractD):
(WebCore::Style::ExtractorCustom::extractDSerialization):
* Source/WebCore/style/computed/data/StyleSVGLayoutData.cpp:
(WebCore::Style::SVGLayoutData::SVGLayoutData):
(WebCore::Style::SVGLayoutData::operator== const):
(WebCore::Style::SVGLayoutData::dumpDifferences const):
(WebCore::Style::operator&lt;&lt;):
* Source/WebCore/style/computed/data/StyleSVGLayoutData.h:
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::cssPropertyIdForSVGAttributeName):
* Source/WebCore/svg/SVGPathElement.cpp:
(WebCore::SVGPathElement::svgAttributeChanged):
(WebCore::SVGPathElement::pathByteStream const):
(WebCore::SVGPathElement::path const):
(WebCore::SVGPathElement::presentationalHintStyleForDAttribute const):
(WebCore::SVGPathElement::buildDPresentationalHintStyle const):
(WebCore::SVGPathElement::invalidateDPresentationalHintCache):
(WebCore::SVGPathElement::collectPresentationalHintsForAttribute): Deleted.
(WebCore::SVGPathElement::collectExtraStyleForPresentationalHints): Deleted.
(WebCore::SVGPathElement::collectDPresentationalHint): Deleted.
* Source/WebCore/svg/SVGPathElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd56a695fa5f64c24f44ac528cda080f73bdfb37

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145980 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18669 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10816 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154659 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99516 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/563ba822-6495-4d59-b767-8704107f37bb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147855 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19149 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112291 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80386 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b50dbd67-b045-4448-a671-165cac38fd7c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148943 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14671 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131135 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93191 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e79c31c-b27a-4208-af87-9f7d609254a8) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13953 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-layer-noop.html?include=6 imported/w3c/web-platform-tests/css/css-cascade/all-prop-revert-noop.html?include=6 (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11710 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2104 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123509 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8069 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156970 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120304 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18503 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15470 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120639 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18536 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129484 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74214 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16343 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7426 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18122 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81890 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17858 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18038 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17918 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->