### PR TITLE
Fix serializations of scroll-timeline/view-timeline shorthand computed values

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-shorthand-expected.txt
@@ -44,9 +44,11 @@ PASS e.style['scroll-timeline'] = "--abc y, --def" should not set unrelated long
 PASS e.style['scroll-timeline'] = "--abc, --def" should set scroll-timeline-axis
 PASS e.style['scroll-timeline'] = "--abc, --def" should set scroll-timeline-name
 PASS e.style['scroll-timeline'] = "--abc, --def" should not set unrelated longhands
-PASS Shorthand contraction of scroll-timeline-name:--abc:undefined;scroll-timeline-axis:inline:undefined
-PASS Shorthand contraction of scroll-timeline-name:--a, --b:undefined;scroll-timeline-axis:inline, block:undefined
-PASS Shorthand contraction of scroll-timeline-name:none, none:undefined;scroll-timeline-axis:block, block:undefined
-PASS Shorthand contraction of scroll-timeline-name:--a, --b, --c:undefined;scroll-timeline-axis:inline, inline:undefined
-PASS Shorthand contraction of scroll-timeline-name:--a, --b:undefined;scroll-timeline-axis:inline, inline, inline:undefined
+PASS Shorthand contraction of scroll-timeline-name:--abc;scroll-timeline-axis:inline
+PASS Shorthand contraction of scroll-timeline-name:--a, --b;scroll-timeline-axis:inline, block
+PASS Shorthand contraction of scroll-timeline-name:none, none;scroll-timeline-axis:block, block
+PASS Shorthand contraction of scroll-timeline-name:--a, --b, --c;scroll-timeline-axis:inline, inline
+PASS Shorthand contraction of scroll-timeline-name:--a, --b;scroll-timeline-axis:inline, inline, inline
+PASS Shorthand contraction of scroll-timeline-name:--a, --b
+PASS Shorthand contraction of scroll-timeline-axis:inline, inline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-shorthand.html
@@ -67,7 +67,7 @@ test_shorthand_value('scroll-timeline', '--abc, --def',
 });
 
 function test_shorthand_contraction(shorthand, longhands, expected) {
-  let longhands_fmt = Object.entries(longhands).map((e) => `${e[0]}:${e[1]}:${e[2]}`).join(';');
+  let longhands_fmt = Object.entries(longhands).map((e) => `${e[0]}:${e[1]}`).join(';');
   test((t) => {
     t.add_cleanup(() => {
       for (let shorthand of Object.keys(longhands))
@@ -95,15 +95,23 @@ test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-axis': 'block, block',
 }, 'none, none');
 
-// Longhands with different lengths:
+// Longhands with different lengths will cause the shorthand to serialize as the empty string due to no longer being able to round trip.
 
 test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-name': '--a, --b, --c',
   'scroll-timeline-axis': 'inline, inline',
-}, '--a inline, --b inline, --c inline');
+}, '');
 
 test_shorthand_contraction('scroll-timeline', {
   'scroll-timeline-name': '--a, --b',
   'scroll-timeline-axis': 'inline, inline, inline',
-}, '--a inline, --b inline');
+}, '');
+
+test_shorthand_contraction('scroll-timeline', {
+  'scroll-timeline-name': '--a, --b',
+}, '');
+
+test_shorthand_contraction('scroll-timeline', {
+  'scroll-timeline-axis': 'inline, inline',
+}, '');
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-shorthand-expected.txt
@@ -75,11 +75,14 @@ PASS e.style['view-timeline'] = "--abc 1px inline" should set view-timeline-axis
 PASS e.style['view-timeline'] = "--abc 1px inline" should set view-timeline-inset
 PASS e.style['view-timeline'] = "--abc 1px inline" should set view-timeline-name
 PASS e.style['view-timeline'] = "--abc 1px inline" should not set unrelated longhands
-PASS Shorthand contraction of view-timeline-name:--abc:undefined;view-timeline-axis:inline:undefined;view-timeline-inset:auto:undefined
-PASS Shorthand contraction of view-timeline-name:--a, --b:undefined;view-timeline-axis:inline, block:undefined;view-timeline-inset:auto, auto:undefined
-PASS Shorthand contraction of view-timeline-name:--a, --b:undefined;view-timeline-axis:inline, block:undefined;view-timeline-inset:1px 2px, 3px 3px:undefined
-PASS Shorthand contraction of view-timeline-name:none, none:undefined;view-timeline-axis:block, block:undefined;view-timeline-inset:auto auto, auto:undefined
-PASS Shorthand contraction of view-timeline-name:--a, --b, --c:undefined;view-timeline-axis:inline, inline:undefined;view-timeline-inset:auto, auto:undefined
-PASS Shorthand contraction of view-timeline-name:--a, --b:undefined;view-timeline-axis:inline, inline, inline:undefined;view-timeline-inset:auto, auto, auto:undefined
-PASS Shorthand contraction of view-timeline-name:--a, --b:undefined;view-timeline-axis:inline, inline:undefined;view-timeline-inset:auto, auto, auto:undefined
+PASS Shorthand contraction of view-timeline-name:--abc;view-timeline-axis:inline;view-timeline-inset:auto
+PASS Shorthand contraction of view-timeline-name:--a, --b;view-timeline-axis:inline, block;view-timeline-inset:auto, auto
+PASS Shorthand contraction of view-timeline-name:--a, --b;view-timeline-axis:inline, block;view-timeline-inset:1px 2px, 3px 3px
+PASS Shorthand contraction of view-timeline-name:none, none;view-timeline-axis:block, block;view-timeline-inset:auto auto, auto
+PASS Shorthand contraction of view-timeline-name:--a, --b, --c;view-timeline-axis:inline, inline;view-timeline-inset:auto, auto
+PASS Shorthand contraction of view-timeline-name:--a, --b;view-timeline-axis:inline, inline, inline;view-timeline-inset:auto, auto, auto
+PASS Shorthand contraction of view-timeline-name:--a, --b;view-timeline-axis:inline, inline;view-timeline-inset:auto, auto, auto
+PASS Shorthand contraction of view-timeline-name:--a, --b
+PASS Shorthand contraction of view-timeline-axis:inline, inline
+PASS Shorthand contraction of view-timeline-name:--a, --b;view-timeline-axis:inline, inline
 

--- a/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-shorthand.html
@@ -105,7 +105,7 @@ test_shorthand_value('view-timeline', '--abc 1px inline',
 });
 
 function test_shorthand_contraction(shorthand, longhands, expected) {
-  let longhands_fmt = Object.entries(longhands).map((e) => `${e[0]}:${e[1]}:${e[2]}`).join(';');
+  let longhands_fmt = Object.entries(longhands).map((e) => `${e[0]}:${e[1]}`).join(';');
   test((t) => {
     t.add_cleanup(() => {
       for (let shorthand of Object.keys(longhands))
@@ -142,23 +142,36 @@ test_shorthand_contraction('view-timeline', {
   'view-timeline-inset': 'auto auto, auto',
 }, 'none, none');
 
-// Longhands with different lengths:
+// Longhands with different lengths will cause the shorthand to serialize as the empty string due to no longer being able to round trip.
 
 test_shorthand_contraction('view-timeline', {
   'view-timeline-name': '--a, --b, --c',
   'view-timeline-axis': 'inline, inline',
   'view-timeline-inset': 'auto, auto',
-}, '--a inline, --b inline, --c inline');
+}, '');
 
 test_shorthand_contraction('view-timeline', {
   'view-timeline-name': '--a, --b',
   'view-timeline-axis': 'inline, inline, inline',
   'view-timeline-inset': 'auto, auto, auto',
-}, '--a inline, --b inline');
+}, '');
 
 test_shorthand_contraction('view-timeline', {
   'view-timeline-name': '--a, --b',
   'view-timeline-axis': 'inline, inline',
   'view-timeline-inset': 'auto, auto, auto',
-}, '--a inline, --b inline');
+}, '');
+
+test_shorthand_contraction('view-timeline', {
+  'view-timeline-name': '--a, --b',
+}, '');
+
+test_shorthand_contraction('view-timeline', {
+  'view-timeline-axis': 'inline, inline',
+}, '');
+
+test_shorthand_contraction('view-timeline', {
+  'view-timeline-name': '--a, --b',
+  'view-timeline-axis': 'inline, inline',
+}, '');
 </script>

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -3037,11 +3037,18 @@ inline RefPtr<CSSValue> ExtractorCustom::extractScrollTimelineShorthand(Extracto
     if (scrollTimelines.isInitial())
         return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
-    // FIXME: This should probably be using `scrollTimelines.computedValues()`, but a WPT test, scroll-animations/css/scroll-timeline-shorthand.html, currently relies on the shorthand serializing the used value list.
-    // See https://github.com/w3c/csswg-drafts/issues/13500
+    // If there is more than one scroll timeline and any scroll timeline has any
+    // property not set, there is no serialization that will round-trip, so the
+    // extraction fails.
+    if (scrollTimelines.computedLength() > 1) {
+        for (auto& scrollTimeline : scrollTimelines.computedValues()) {
+            if (!allPropertiesAreSet(scrollTimeline))
+                return nullptr;
+        }
+    }
 
     CSSValueListBuilder list;
-    for (auto& scrollTimeline : scrollTimelines.usedValues()) {
+    for (auto& scrollTimeline : scrollTimelines.computedValues()) {
         auto& name = scrollTimeline.name();
         auto axis = scrollTimeline.axis();
 
@@ -3067,10 +3074,17 @@ inline void ExtractorCustom::extractScrollTimelineShorthandSerialization(Extract
         return;
     }
 
-    // FIXME: This should probably be using `scrollTimelines.computedValues()`, but a WPT test, scroll-animations/css/scroll-timeline-shorthand.html, currently relies on the shorthand serializing the used value list.
-    // See https://github.com/w3c/csswg-drafts/issues/13500
+    // If there is more than one scroll timeline and any scroll timeline has any
+    // property not set, there is no serialization that will round-trip, so the
+    // extraction fails.
+    if (scrollTimelines.computedLength() > 1) {
+        for (auto& scrollTimeline : scrollTimelines.computedValues()) {
+            if (!allPropertiesAreSet(scrollTimeline))
+                return;
+        }
+    }
 
-    builder.append(interleave(scrollTimelines.usedValues(), [&](auto& builder, auto& scrollTimeline) {
+    builder.append(interleave(scrollTimelines.computedValues(), [&](auto& builder, auto& scrollTimeline) {
         auto& name = scrollTimeline.name();
         auto axis = scrollTimeline.axis();
 
@@ -3213,11 +3227,18 @@ inline RefPtr<CSSValue> ExtractorCustom::extractViewTimelineShorthand(ExtractorS
     if (viewTimelines.isInitial())
         return createCSSValue(state.pool, state.style, CSS::Keyword::None { });
 
-    // FIXME: This should probably be using `viewTimelines.computedValues()`, but a WPT test, scroll-animations/css/view-timeline-shorthand.html, currently relies on the shorthand serializing the used value list.
-    // See https://github.com/w3c/csswg-drafts/issues/13500
+    // If there is more than one view timeline and any view timeline has any
+    // property not set, there is no serialization that will round-trip, so the
+    // extraction fails.
+    if (viewTimelines.computedLength() > 1) {
+        for (auto& viewTimeline : viewTimelines.computedValues()) {
+            if (!allPropertiesAreSet(viewTimeline))
+                return nullptr;
+        }
+    }
 
     CSSValueListBuilder list;
-    for (auto& viewTimeline : viewTimelines.usedValues()) {
+    for (auto& viewTimeline : viewTimelines.computedValues()) {
         auto& name = viewTimeline.name();
         auto axis = viewTimeline.axis();
         auto& inset = viewTimeline.inset();
@@ -3256,10 +3277,17 @@ inline void ExtractorCustom::extractViewTimelineShorthandSerialization(Extractor
         return;
     }
 
-    // FIXME: This should probably be using `viewTimelines.computedValues()`, but a WPT test, scroll-animations/css/view-timeline-shorthand.html, currently relies on the shorthand serializing the used value list.
-    // See https://github.com/w3c/csswg-drafts/issues/13500
+    // If there is more than one view timeline and any view timeline has any
+    // property not set, there is no serialization that will round-trip, so the
+    // extraction fails.
+    if (viewTimelines.computedLength() > 1) {
+        for (auto& viewTimeline : viewTimelines.computedValues()) {
+            if (!allPropertiesAreSet(viewTimeline))
+                return;
+        }
+    }
 
-    builder.append(interleave(viewTimelines.usedValues(), [&](auto& builder, auto& viewTimeline) {
+    builder.append(interleave(viewTimelines.computedValues(), [&](auto& builder, auto& viewTimeline) {
         auto& name = viewTimeline.name();
         auto axis = viewTimeline.axis();
         auto& inset = viewTimeline.inset();

--- a/Source/WebCore/style/values/primitives/StyleCoordinatedValueListValue.h
+++ b/Source/WebCore/style/values/primitives/StyleCoordinatedValueListValue.h
@@ -292,5 +292,14 @@ bool allPropertiesAreUnsetOrFilled(const T& value)
     });
 }
 
+template<CoordinatedValueListValue T>
+bool allPropertiesAreSet(const T& value)
+{
+    return allOfCoordinatedValueListProperties<T>([&value]<CSSPropertyID propertyID>() {
+        using PropertyAccessor = CoordinatedValueListPropertyConstAccessor<propertyID>;
+        return PropertyAccessor { value }.isSet();
+    });
+}
+
 } // namespace Style
 } // namespace WebCore


### PR DESCRIPTION
#### 205c87dbf7f2977fd05411a3a5a02ff292988706
<pre>
Fix serializations of scroll-timeline/view-timeline shorthand computed values
<a href="https://bugs.webkit.org/show_bug.cgi?id=308068">https://bugs.webkit.org/show_bug.cgi?id=308068</a>

Reviewed by Darin Adler.

Per discussion in <a href="https://github.com/w3c/csswg-drafts/issues/13500">https://github.com/w3c/csswg-drafts/issues/13500</a>, the empty
string is the correct serialization for coordinated list property shorthands that:

  - have more than one item
  - have at least one longhand that doesn&apos;t set a value for every item

This implements that rule for scroll-timeline/view-timeline, which makes us
match Firefox and Chrome. The remaining coordinated list properties will be
worked on separately.

* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/scroll-timeline-shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/scroll-animations/css/view-timeline-shorthand.html:
* Source/WebCore/css/ShorthandSerializer.cpp:
* Source/WebCore/style/StyleExtractorCustom.h:
* Source/WebCore/style/values/primitives/StyleCoordinatedValueListValue.h:

Canonical link: <a href="https://commits.webkit.org/307783@main">https://commits.webkit.org/307783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcc74e2afc4c4fd154098a3cecd167b06767c1bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/17989 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153979 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98944 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147182 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18473 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111739 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80080 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148270 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14103 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130531 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92640 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11212 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122977 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156291 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17839 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119748 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17885 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120085 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30824 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15848 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128555 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73529 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17460 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6800 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17197 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81239 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17405 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17260 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->