### PR TITLE
Adopt NODELETE annotation on more non-inline trivial functions in WebCore/rendering

### DIFF
--- a/Source/WebCore/rendering/RenderAttachment.h
+++ b/Source/WebCore/rendering/RenderAttachment.h
@@ -39,7 +39,7 @@ public:
     RenderAttachment(HTMLAttachmentElement&, RenderStyle&&);
     virtual ~RenderAttachment();
 
-    HTMLAttachmentElement& attachmentElement() const;
+    HTMLAttachmentElement& NODELETE attachmentElement() const;
 
     void setShouldDrawBorder(bool drawBorder) { m_shouldDrawBorder = drawBorder; }
     bool shouldDrawBorder() const;

--- a/Source/WebCore/rendering/RenderButton.h
+++ b/Source/WebCore/rendering/RenderButton.h
@@ -40,7 +40,7 @@ public:
     RenderButton(HTMLFormControlElement&, RenderStyle&&);
     virtual ~RenderButton();
 
-    HTMLFormControlElement& formControlElement() const;
+    HTMLFormControlElement& NODELETE formControlElement() const;
 
     bool canBeSelectionLeaf() const override;
 

--- a/Source/WebCore/rendering/RenderFileUploadControl.h
+++ b/Source/WebCore/rendering/RenderFileUploadControl.h
@@ -40,7 +40,7 @@ public:
     String buttonValue();
     String fileTextValue() const;
 
-    HTMLInputElement& inputElement() const;
+    HTMLInputElement& NODELETE inputElement() const;
     
 private:
     void element() const = delete;

--- a/Source/WebCore/rendering/RenderFrame.h
+++ b/Source/WebCore/rendering/RenderFrame.h
@@ -37,7 +37,7 @@ public:
     RenderFrame(HTMLFrameElement&, RenderStyle&&);
     virtual ~RenderFrame();
 
-    HTMLFrameElement& frameElement() const;
+    HTMLFrameElement& NODELETE frameElement() const;
     FrameEdgeInfo edgeInfo() const;
 
     void updateFromElement() final;

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -60,7 +60,7 @@ public:
     RenderFrameSet(HTMLFrameSetElement&, RenderStyle&&);
     virtual ~RenderFrameSet();
 
-    HTMLFrameSetElement& frameSetElement() const;
+    HTMLFrameSetElement& NODELETE frameSetElement() const;
 
     FrameEdgeInfo edgeInfo() const;
 

--- a/Source/WebCore/rendering/RenderHTMLCanvas.h
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.h
@@ -38,7 +38,7 @@ public:
     RenderHTMLCanvas(HTMLCanvasElement&, RenderStyle&&);
     virtual ~RenderHTMLCanvas();
 
-    HTMLCanvasElement& canvasElement() const;
+    HTMLCanvasElement& NODELETE canvasElement() const;
 
     void canvasSizeChanged();
 

--- a/Source/WebCore/rendering/RenderIFrame.h
+++ b/Source/WebCore/rendering/RenderIFrame.h
@@ -38,7 +38,7 @@ public:
     RenderIFrame(HTMLIFrameElement&, RenderStyle&&);
     virtual ~RenderIFrame();
 
-    HTMLIFrameElement& iframeElement() const;
+    HTMLIFrameElement& NODELETE iframeElement() const;
 
 private:
     void frameOwnerElement() const = delete;

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -54,7 +54,7 @@ public:
     void decrementCheckedPtrCount() const final { CanMakeCheckedPtr::decrementCheckedPtrCount(); }
     void setDidBeginCheckedPtrDeletion() final { CanMakeCheckedPtr::setDidBeginCheckedPtrDeletion(); }
 
-    HTMLSelectElement& selectElement() const;
+    HTMLSelectElement& NODELETE selectElement() const;
 
     void selectionChanged();
 

--- a/Source/WebCore/rendering/RenderMenuList.h
+++ b/Source/WebCore/rendering/RenderMenuList.h
@@ -37,7 +37,7 @@ public:
     RenderMenuList(HTMLSelectElement&, RenderStyle&&);
     virtual ~RenderMenuList();
 
-    HTMLSelectElement& selectElement() const;
+    HTMLSelectElement& NODELETE selectElement() const;
 
     // CheckedPtr interface.
     uint32_t checkedPtrCount() const { return RenderFlexibleBox::checkedPtrCount(); }

--- a/Source/WebCore/rendering/RenderModel.h
+++ b/Source/WebCore/rendering/RenderModel.h
@@ -40,7 +40,7 @@ public:
     RenderModel(HTMLModelElement&, RenderStyle&&);
     virtual ~RenderModel();
 
-    HTMLModelElement& modelElement() const;
+    HTMLModelElement& NODELETE modelElement() const;
 
 private:
     void element() const = delete;

--- a/Source/WebCore/rendering/RenderProgress.h
+++ b/Source/WebCore/rendering/RenderProgress.h
@@ -40,7 +40,7 @@ public:
     bool isDeterminate() const;
     void updateFromElement() override;
 
-    HTMLProgressElement* progressElement() const;
+    HTMLProgressElement* NODELETE progressElement() const;
 
 private:
     ASCIILiteral renderName() const override { return "RenderProgress"_s; }

--- a/Source/WebCore/rendering/RenderSlider.h
+++ b/Source/WebCore/rendering/RenderSlider.h
@@ -36,7 +36,7 @@ public:
     RenderSlider(HTMLInputElement&, RenderStyle&&);
     virtual ~RenderSlider();
 
-    HTMLInputElement& element() const;
+    HTMLInputElement& NODELETE element() const;
 
     bool canHaveGeneratedChildren() const override { return false; }
 

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -109,7 +109,7 @@ public:
     RenderTableSection* NODELETE firstBody() const;
 
     // This function returns 0 if the table has no section.
-    RenderTableSection* topSection() const;
+    RenderTableSection* NODELETE topSection() const;
     RenderTableSection* bottomSection() const;
 
     // This function returns 0 if the table has no non-empty sections.

--- a/Source/WebCore/rendering/RenderTextControl.h
+++ b/Source/WebCore/rendering/RenderTextControl.h
@@ -36,7 +36,7 @@ class RenderTextControl : public RenderBlockFlow {
 public:
     virtual ~RenderTextControl();
 
-    WEBCORE_EXPORT HTMLTextFormControlElement& textFormControlElement() const;
+    WEBCORE_EXPORT HTMLTextFormControlElement& NODELETE textFormControlElement() const;
 
 #if PLATFORM(IOS_FAMILY)
     bool canScroll() const;

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -40,7 +40,7 @@ public:
     RenderVideo(HTMLVideoElement&, RenderStyle&&);
     virtual ~RenderVideo();
 
-    WEBCORE_EXPORT HTMLVideoElement& videoElement() const;
+    WEBCORE_EXPORT HTMLVideoElement& NODELETE videoElement() const;
 
     IntRect videoBox() const;
     WEBCORE_EXPORT IntRect videoBoxInRootView() const;


### PR DESCRIPTION
#### d27fac28ecdf2cef736fb7160eb222e3f3ab2ac4
<pre>
Adopt NODELETE annotation on more non-inline trivial functions in WebCore/rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=308091">https://bugs.webkit.org/show_bug.cgi?id=308091</a>
<a href="https://rdar.apple.com/170594913">rdar://170594913</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/rendering/RenderAttachment.h:
* Source/WebCore/rendering/RenderButton.h:
* Source/WebCore/rendering/RenderFileUploadControl.h:
* Source/WebCore/rendering/RenderFrame.h:
* Source/WebCore/rendering/RenderFrameSet.h:
* Source/WebCore/rendering/RenderHTMLCanvas.h:
* Source/WebCore/rendering/RenderIFrame.h:
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderMenuList.h:
* Source/WebCore/rendering/RenderModel.h:
* Source/WebCore/rendering/RenderProgress.h:
* Source/WebCore/rendering/RenderSlider.h:
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTextControl.h:
* Source/WebCore/rendering/RenderVideo.h:

Canonical link: <a href="https://commits.webkit.org/307762@main">https://commits.webkit.org/307762@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0bd55313979defa68736d950ab4f698adbd109ec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145320 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18002 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/153992 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98957 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18486 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111747 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80130 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148283 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14112 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130539 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92648 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13458 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11218 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1438 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122986 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7302 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156304 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17852 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8412 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119753 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17898 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14900 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120091 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30812 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15854 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128564 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73542 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17473 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6806 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81252 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17418 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17273 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->