### PR TITLE
ParentalControlsURLFilter should try to request permission for URL's if possible (for MacOS)

### DIFF
--- a/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
+++ b/Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm
@@ -169,7 +169,7 @@ void ContentFilterUnblockHandler::requestUnblockAsync(DecisionHandlerFunction&& 
         Ref filter = WebCore::ParentalControlsURLFilter::singleton();
 #endif
 #if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
-        if (requestURL && filter->canRequestPermissionForURL()) {
+        if (requestURL) {
             filter->requestPermissionForURL(*m_evaluatedURL, *requestURL, [decisionHandler = WTF::move(decisionHandler)](bool didAllow) mutable {
                 callOnMainThread([decisionHandler = WTF::move(decisionHandler), didAllow]() {
                     decisionHandler(didAllow);

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h
@@ -27,6 +27,7 @@
 
 #if HAVE(WEBCONTENTRESTRICTIONS)
 
+#include "ParentalControlsURLFilterParameters.h"
 #include <wtf/ThreadSafeRefCounted.h>
 
 OBJC_CLASS WCRBrowserEngineClient;
@@ -37,7 +38,7 @@ class WorkQueue;
 
 namespace WebCore {
 
-struct ParentalControlsURLFilterParameters;
+// struct ParentalControlsURLFilterParameters;
 class ParentalControlsContentFilter;
 
 class ParentalControlsURLFilter : public ThreadSafeRefCounted<ParentalControlsURLFilter, WTF::DestructionThread::Main> {
@@ -58,8 +59,9 @@ public:
     void isURLAllowed(const URL& mainDocumentURL, const URL&, ParentalControlsContentFilter&);
     WEBCORE_EXPORT void isURLAllowed(const URL& mainDocumentURL, const URL&, CompletionHandler<void(bool, NSData *)>&&);
     virtual void allowURL(const URL&, CompletionHandler<void(bool)>&&);
-    virtual void requestPermissionForURL(const URL&, const URL&, CompletionHandler<void(bool)>&&);
-    virtual bool canRequestPermissionForURL() { return false; }
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    virtual void requestPermissionForURL(const URL&, const URL& referrerURL, CompletionHandler<void(bool)>&&);
+#endif
 
 protected:
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)

--- a/Source/WebCore/platform/cocoa/ParentalControlsURLFilterParameters.h
+++ b/Source/WebCore/platform/cocoa/ParentalControlsURLFilterParameters.h
@@ -34,6 +34,9 @@ struct ParentalControlsURLFilterParameters {
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     String configurationPath;
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    std::optional<URL> referrerURL;
+#endif
 };
 
 }

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -3383,7 +3383,20 @@ void NetworkProcess::setDefaultRequestTimeoutInterval(double timeoutInterval)
 #if HAVE(WEBCONTENTRESTRICTIONS)
 void NetworkProcess::allowEvaluatedURL(const WebCore::ParentalControlsURLFilterParameters& parameters, CompletionHandler<void(bool)>&& completionHandler)
 {
-    WebCore::ParentalControlsURLFilter::allowURL(parameters, WTF::move(completionHandler));
+#if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
+    Ref filter = WebCore::ParentalControlsURLFilter::filterWithConfigurationPath(parameters.configurationPath);
+#else
+    Ref filter = WebCore::ParentalControlsURLFilter::singleton();
+#endif
+
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    if (parameters.referrerURL) {
+        filter->requestPermissionForURL(parameters.urlToAllow, *parameters.referrerURL, WTF::move(completionHandler));
+        return;
+    }
+#else
+    filter->allowURL(parameters.urlToAllow, WTF::move(completionHandler));
+#endif
 }
 #endif
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -9295,6 +9295,9 @@ struct WebCore::ParentalControlsURLFilterParameters {
 #if HAVE(WEBCONTENTRESTRICTIONS_PATH_SPI)
     String configurationPath;
 #endif
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
+    std::optional<URL> referrerURL;
+#endif
 };
 #endif
 

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h
@@ -46,8 +46,9 @@ private:
     bool isEnabledImpl() const final;
     void isURLAllowedImpl(const URL& mainDocumentURL, const URL&, CompletionHandler<void(bool, NSData *)>&&) final;
     void allowURL(const URL&, CompletionHandler<void(bool)>&&) final;
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
     void requestPermissionForURL(const URL&, const URL& referrerURL, CompletionHandler<void(bool)>&&) final;
-    bool canRequestPermissionForURL() final { return true; }
+#endif
 
     BEWebContentFilter* ensureWebContentFilter();
 

--- a/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
+++ b/Source/WebKit/Shared/ios/WebParentalControlsURLFilter.mm
@@ -122,9 +122,9 @@ void WebParentalControlsURLFilter::setSharedParentalControlsURLFilterIfNecessary
 #endif
 }
 
+#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
 void WebParentalControlsURLFilter::requestPermissionForURL(const URL& url, const URL& referrerURL, CompletionHandler<void(bool)>&& completionHandler)
 {
-#if HAVE(WEBCONTENTRESTRICTIONS_ASK_TO)
     workQueueSingleton().dispatchSync([this, protectedThis = Ref { *this }, currentIsEnabled = isEnabled(), url = crossThreadCopy(url), referrerURL = crossThreadCopy(referrerURL), completionHandler = WTF::move(completionHandler)]() mutable {
         if (!currentIsEnabled) {
             callOnMainRunLoop([completionHandler = WTF::move(completionHandler)] mutable {
@@ -138,8 +138,8 @@ void WebParentalControlsURLFilter::requestPermissionForURL(const URL& url, const
         MAYBE_REQUEST_PERMISSION_ASK_TO
 #endif
     });
-#endif
 }
+#endif
 
 } // namespace WebKit
 


### PR DESCRIPTION
#### 33e2d076381544a83dfd649f17b21dfb7703f751
<pre>
ParentalControlsURLFilter should try to request permission for URL&apos;s if possible (for MacOS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=308093">https://bugs.webkit.org/show_bug.cgi?id=308093</a>
<a href="https://rdar.apple.com/168696619">rdar://168696619</a>

Reviewed by Sihui Liu.

ParentalControlsURLFilter can either request permission for the URL or allow the URL. We should try to request
permission for the URL if possible.

No new tests are needed.
* Source/WebCore/platform/cocoa/ContentFilterUnblockHandlerCocoa.mm:
(WebCore::ContentFilterUnblockHandler::requestUnblockAsync):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.h:
(WebCore::ParentalControlsURLFilter::canRequestPermissionForURL): Deleted.
* Source/WebCore/platform/cocoa/ParentalControlsURLFilter.mm:
(WebCore::ParentalControlsURLFilter::approveAccessToURL):
(WebCore::ParentalControlsURLFilter::requestPermissionForURL):
* Source/WebCore/platform/cocoa/ParentalControlsURLFilterParameters.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::allowEvaluatedURL):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/ios/WebParentalControlsURLFilter.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::didHandleContentFilterUnblockNavigation):

Canonical link: <a href="https://commits.webkit.org/307795@main">https://commits.webkit.org/307795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb5e7b6bee37e05b43582f5ffbfdd2e875ab860b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145552 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10076 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154224 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147427 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18127 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111933 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148515 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14300 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/130744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92838 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13619 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1671 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7529 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156537 "Built successfully") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18084 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Failed to checkout and rebase branch from PR 58886") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8638 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/119937 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18130 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120284 "Passed tests") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/16021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128811 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73813 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22445 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17705 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/7001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/17442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17650 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17505 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->