### PR TITLE
Expose WKNavigation on WKDownload

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.h
@@ -27,6 +27,7 @@
 #import <WebKit/WKFoundation.h>
 
 @class WKFrameInfo;
+@class WKNavigation;
 @class WKWebView;
 @protocol NSProgressReporting;
 @protocol WKDownloadDelegate;
@@ -54,6 +55,9 @@ WK_SWIFT_UI_ACTOR
 
 /* @abstract The frame that originated this download. */
 @property (nonatomic, readonly) WKFrameInfo *originatingFrame WK_API_AVAILABLE(macos(15.2), ios(18.2));
+
+/* @abstract The navigation that initiated this download. */
+@property (nonatomic, readonly, weak) WKNavigation *navigation WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
 
 /* @abstract Cancel the download.
  @param completionHandler A block to invoke when cancellation is finished.

--- a/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm
@@ -27,6 +27,7 @@
 #import "WKDownloadInternal.h"
 
 #import "APIDownloadClient.h"
+#import "APINavigation.h"
 #import "CompletionHandlerCallChecker.h"
 #import "DownloadProxy.h"
 #import "WKDownloadDelegate.h"
@@ -34,6 +35,7 @@
 #import "WKFrameInfoInternal.h"
 #import "WKNSData.h"
 #import "WKNSURLAuthenticationChallenge.h"
+#import "WKNavigationInternal.h"
 #import "WKWebViewInternal.h"
 #import "WebPageProxy.h"
 #import <Foundation/Foundation.h>
@@ -318,6 +320,11 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 - (WKFrameInfo *)originatingFrame
 {
     return WebKit::wrapper(_download->frameInfo());
+}
+
+- (WKNavigation *)navigation
+{
+    return WebKit::wrapper(_download->navigation());
 }
 
 - (id <WKDownloadDelegate>)delegate

--- a/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp
@@ -652,7 +652,7 @@ WebKitDownload* webkit_network_session_download_uri(WebKitNetworkSession* sessio
 
     WebCore::ResourceRequest request(String::fromUTF8(uri));
     Ref websiteDataStore = webkitWebsiteDataManagerGetDataStore(session->priv->websiteDataManager.get());
-    auto downloadProxy = websiteDataStore->createDownloadProxy(adoptRef(*new API::DownloadClient), request, nullptr, { });
+    auto downloadProxy = websiteDataStore->createDownloadProxy(adoptRef(*new API::DownloadClient), request, nullptr, nullptr, { });
     auto download = webkitDownloadCreate(downloadProxy);
     downloadProxy->setDidStartCallback([session = GRefPtr<WebKitNetworkSession> { session }, download = download.get()](auto* downloadProxy) {
         if (!downloadProxy)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp
@@ -55,12 +55,13 @@
 namespace WebKit {
 using namespace WebCore;
 
-DownloadProxy::DownloadProxy(DownloadProxyMap& downloadProxyMap, WebsiteDataStore& dataStore, API::DownloadClient& client, const ResourceRequest& resourceRequest, const std::optional<FrameInfoData>& frameInfoData, WebPageProxy* originatingPage)
+DownloadProxy::DownloadProxy(DownloadProxyMap& downloadProxyMap, WebsiteDataStore& dataStore, API::DownloadClient& client, const ResourceRequest& resourceRequest, const std::optional<FrameInfoData>& frameInfoData, API::Navigation* navigation, WebPageProxy* originatingPage)
     : m_downloadProxyMap(downloadProxyMap)
     , m_dataStore(&dataStore)
     , m_client(client)
     , m_downloadID(DownloadID::generate())
     , m_request(resourceRequest)
+    , m_navigation(navigation)
     , m_originatingPage(originatingPage)
     , m_frameInfo(frameInfoData ? API::FrameInfo::create(FrameInfoData { *frameInfoData }) : API::FrameInfo::create(legacyEmptyFrameInfo(ResourceRequest { URL { aboutBlankURL() } })))
 #if HAVE(MODERN_DOWNLOADPROGRESS)

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxy.h
@@ -107,6 +107,9 @@ public:
 #if PLATFORM(MAC)
     void updateQuarantinePropertiesIfPossible();
 #endif
+
+    API::Navigation* navigation() { return m_navigation.get(); }
+
     API::FrameInfo& frameInfo() { return m_frameInfo.get(); }
 
     API::DownloadClient& client() { return m_client.get(); }
@@ -136,7 +139,7 @@ public:
 #endif
 
 private:
-    explicit DownloadProxy(DownloadProxyMap&, WebsiteDataStore&, API::DownloadClient&, const WebCore::ResourceRequest&, const std::optional<FrameInfoData>&, WebPageProxy*);
+    explicit DownloadProxy(DownloadProxyMap&, WebsiteDataStore&, API::DownloadClient&, const WebCore::ResourceRequest&, const std::optional<FrameInfoData>&, API::Navigation*, WebPageProxy*);
 
 
     // IPC::MessageReceiver
@@ -155,6 +158,8 @@ private:
     WebCore::ResourceRequest m_request;
     String m_suggestedFilename;
     String m_destinationFilename;
+
+    RefPtr<API::Navigation> m_navigation;
 
     WeakPtr<WebPageProxy> m_originatingPage;
     Vector<URL> m_redirectChain;

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp
@@ -27,6 +27,7 @@
 #include "DownloadProxyMap.h"
 
 #include "APIDownloadClient.h"
+#include "APINavigation.h"
 #include "AuxiliaryProcessProxy.h"
 #include "DownloadProxy.h"
 #include "DownloadProxyMessages.h"
@@ -82,9 +83,9 @@ void DownloadProxyMap::platformDestroy()
 }
 #endif
 
-Ref<DownloadProxy> DownloadProxyMap::createDownloadProxy(WebsiteDataStore& dataStore, Ref<API::DownloadClient>&& client, const WebCore::ResourceRequest& resourceRequest, const std::optional<FrameInfoData>& frameInfo, WebPageProxy* originatingPage)
+Ref<DownloadProxy> DownloadProxyMap::createDownloadProxy(WebsiteDataStore& dataStore, Ref<API::DownloadClient>&& client, const WebCore::ResourceRequest& resourceRequest, const std::optional<FrameInfoData>& frameInfo, API::Navigation* navigation, WebPageProxy* originatingPage)
 {
-    Ref downloadProxy = DownloadProxy::create(*this, dataStore, WTF::move(client), resourceRequest, frameInfo, originatingPage);
+    Ref downloadProxy = DownloadProxy::create(*this, dataStore, WTF::move(client), resourceRequest, frameInfo, navigation, originatingPage);
     m_downloads.set(downloadProxy->downloadID(), downloadProxy);
 
     RELEASE_LOG(Loading, "Adding download %" PRIu64 " to UIProcess DownloadProxyMap", downloadProxy->downloadID().toUInt64());

--- a/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
+++ b/Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h
@@ -38,6 +38,7 @@
 
 namespace API {
 class DownloadClient;
+class Navigation;
 }
 
 namespace WebCore {
@@ -60,7 +61,7 @@ public:
     explicit DownloadProxyMap(NetworkProcessProxy&);
     ~DownloadProxyMap();
 
-    Ref<DownloadProxy> createDownloadProxy(WebsiteDataStore&, Ref<API::DownloadClient>&&, const WebCore::ResourceRequest&, const std::optional<FrameInfoData>&, WebPageProxy* originatingPage);
+    Ref<DownloadProxy> createDownloadProxy(WebsiteDataStore&, Ref<API::DownloadClient>&&, const WebCore::ResourceRequest&, const std::optional<FrameInfoData>&, API::Navigation*, WebPageProxy* originatingPage);
     void downloadFinished(DownloadProxy&);
 
     bool isEmpty() const { return m_downloads.isEmpty(); }

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp
@@ -370,12 +370,12 @@ void NetworkProcessProxy::synthesizeAppIsBackground(bool background)
         applicationWillEnterForeground();
 }
 
-Ref<DownloadProxy> NetworkProcessProxy::createDownloadProxy(WebsiteDataStore& dataStore, Ref<API::DownloadClient>&& client, const ResourceRequest& resourceRequest, const std::optional<FrameInfoData>& frameInfo, WebPageProxy* originatingPage)
+Ref<DownloadProxy> NetworkProcessProxy::createDownloadProxy(WebsiteDataStore& dataStore, Ref<API::DownloadClient>&& client, const ResourceRequest& resourceRequest, const std::optional<FrameInfoData>& frameInfo, API::Navigation* navigation, WebPageProxy* originatingPage)
 {
     if (!m_downloadProxyMap)
         lazyInitialize(m_downloadProxyMap, makeUniqueWithoutRefCountedCheck<DownloadProxyMap>(*this));
 
-    return protect(*m_downloadProxyMap)->createDownloadProxy(dataStore, WTF::move(client), resourceRequest, frameInfo, originatingPage);
+    return protect(*m_downloadProxyMap)->createDownloadProxy(dataStore, WTF::move(client), resourceRequest, frameInfo, navigation, originatingPage);
 }
 
 void NetworkProcessProxy::dataTaskWithRequest(WebPageProxy& page, PAL::SessionID sessionID, WebCore::ResourceRequest&& request, const std::optional<SecurityOriginData>& topOrigin, bool shouldRunAtForegroundPriority, CompletionHandler<void(API::DataTask&)>&& completionHandler)

--- a/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
+++ b/Source/WebKit/UIProcess/Network/NetworkProcessProxy.h
@@ -62,6 +62,7 @@ class FormDataReference;
 
 namespace API {
 class DataTask;
+class Navigation;
 }
 
 namespace PAL {
@@ -142,7 +143,7 @@ public:
 
     void sharedPreferencesForWebProcessDidChange(WebProcessProxy&, SharedPreferencesForWebProcess&&, CompletionHandler<void()>&&);
 
-    Ref<DownloadProxy> createDownloadProxy(WebsiteDataStore&, Ref<API::DownloadClient>&&, const WebCore::ResourceRequest&, const std::optional<FrameInfoData>&, WebPageProxy* originatingPage);
+    Ref<DownloadProxy> createDownloadProxy(WebsiteDataStore&, Ref<API::DownloadClient>&&, const WebCore::ResourceRequest&, const std::optional<FrameInfoData>&, API::Navigation*, WebPageProxy* originatingPage);
     void dataTaskWithRequest(WebPageProxy&, PAL::SessionID, WebCore::ResourceRequest&&, const std::optional<WebCore::SecurityOriginData>& topOrigin, bool shouldRunAtForegroundPriority, CompletionHandler<void(API::DataTask&)>&&);
 
     void addAllowedFirstPartyForCookies(WebProcessProxy&, const WebCore::RegistrableDomain& firstPartyForCookies, LoadedWebArchive, CompletionHandler<void()>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -5420,9 +5420,9 @@ void WebPageProxy::receivedPolicyDecision(PolicyAction action, API::Navigation* 
         RefPtr<DownloadProxy> download;
 
         if (navigation && (navigation->targetItem() || navigation->isRequestFromClientOrUserInput()))
-            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, navigationAction->request(), downloadOriginatingPage(navigation).ptr(), std::nullopt);
+            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, navigationAction->request(), navigation, downloadOriginatingPage(navigation).ptr(), std::nullopt);
         else
-            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, navigationAction->request(), downloadOriginatingPage(navigation).ptr(), navigation ? navigation->originatingFrameInfo() : std::optional(navigationAction->data().originatingFrameInfoData));
+            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, navigationAction->request(), navigation, downloadOriginatingPage(navigation).ptr(), navigation ? navigation->originatingFrameInfo() : std::optional(navigationAction->data().originatingFrameInfoData));
 
         download->setDidStartCallback([weakThis = WeakPtr { *this }, navigationAction = WTF::move(navigationAction)] (auto* downloadProxy) {
             RefPtr protectedThis = weakThis.get();
@@ -5466,9 +5466,9 @@ void WebPageProxy::receivedNavigationResponsePolicyDecision(WebCore::PolicyActio
         RefPtr<DownloadProxy> download;
 
         if (navigation && (navigation->targetItem() || navigation->isRequestFromClientOrUserInput()))
-            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, request, downloadOriginatingPage(navigation).ptr(), std::nullopt);
+            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, request, navigation, downloadOriginatingPage(navigation).ptr(), std::nullopt);
         else
-            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, request, downloadOriginatingPage(navigation).ptr(), navigation ? navigation->originatingFrameInfo() : std::nullopt);
+            download = protect(m_configuration->processPool())->createDownloadProxy(m_websiteDataStore, request, navigation, downloadOriginatingPage(navigation).ptr(), navigation ? navigation->originatingFrameInfo() : std::nullopt);
 
         download->setDidStartCallback([weakThis = WeakPtr { *this }, navigationResponse = WTF::move(navigationResponse)] (auto* downloadProxy) {
             RefPtr protectedThis = weakThis.get();

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1467,14 +1467,14 @@ bool WebProcessPool::hasPagesUsingWebsiteDataStore(WebsiteDataStore& dataStore) 
 
 Ref<DownloadProxy> WebProcessPool::download(WebsiteDataStore& dataStore, WebPageProxy* initiatingPage, const ResourceRequest& request, const std::optional<FrameInfoData>& frameInfo, const String& suggestedFilename)
 {
-    Ref downloadProxy = createDownloadProxy(dataStore, request, initiatingPage, frameInfo);
+    Ref downloadProxy = createDownloadProxy(dataStore, request, nullptr, initiatingPage, frameInfo);
     dataStore.download(downloadProxy, suggestedFilename);
     return downloadProxy;
 }
 
 Ref<DownloadProxy> WebProcessPool::resumeDownload(WebsiteDataStore& dataStore, WebPageProxy* initiatingPage, const API::Data& resumeData, const String& path, CallDownloadDidStart callDownloadDidStart)
 {
-    Ref downloadProxy = createDownloadProxy(dataStore, ResourceRequest(), initiatingPage, { });
+    Ref downloadProxy = createDownloadProxy(dataStore, ResourceRequest(), nullptr, initiatingPage, { });
     dataStore.resumeDownload(downloadProxy, resumeData, path, callDownloadDidStart);
     return downloadProxy;
 }
@@ -1727,10 +1727,10 @@ void WebProcessPool::setDefaultRequestTimeoutInterval(double timeoutInterval)
     sendToAllProcesses(Messages::WebProcess::SetDefaultRequestTimeoutInterval(timeoutInterval));
 }
 
-Ref<DownloadProxy> WebProcessPool::createDownloadProxy(WebsiteDataStore& dataStore, const ResourceRequest& request, WebPageProxy* originatingPage, const std::optional<FrameInfoData>& frameInfo)
+Ref<DownloadProxy> WebProcessPool::createDownloadProxy(WebsiteDataStore& dataStore, const ResourceRequest& request,  API::Navigation* navigation, WebPageProxy* originatingPage, const std::optional<FrameInfoData>& frameInfo)
 {
     Ref client = m_legacyDownloadClient ? Ref<API::DownloadClient>(*m_legacyDownloadClient) : adoptRef(*new API::DownloadClient);
-    return dataStore.createDownloadProxy(WTF::move(client), request, originatingPage, frameInfo);
+    return dataStore.createDownloadProxy(WTF::move(client), request, navigation, originatingPage, frameInfo);
 }
 
 void WebProcessPool::addMessageReceiver(IPC::ReceiverName messageReceiverName, IPC::MessageReceiver& messageReceiver)

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -315,7 +315,7 @@ public:
     void setEnhancedAccessibility(bool);
     
     // Downloads.
-    Ref<DownloadProxy> createDownloadProxy(WebsiteDataStore&, const WebCore::ResourceRequest&, WebPageProxy* originatingPage, const std::optional<FrameInfoData>&);
+    Ref<DownloadProxy> createDownloadProxy(WebsiteDataStore&, const WebCore::ResourceRequest&, API::Navigation*, WebPageProxy* originatingPage, const std::optional<FrameInfoData>&);
 
     API::LegacyContextHistoryClient& historyClient() { return *m_historyClient; }
     WebContextClient& client() { return m_client; }

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2711,9 +2711,9 @@ void WebsiteDataStore::setEmulatedConditions(std::optional<int64_t>&& bytesPerSe
 
 #endif // ENABLE(INSPECTOR_NETWORK_THROTTLING)
 
-Ref<DownloadProxy> WebsiteDataStore::createDownloadProxy(Ref<API::DownloadClient>&& client, const WebCore::ResourceRequest& request, WebPageProxy* originatingPage, const std::optional<FrameInfoData>& frameInfo)
+Ref<DownloadProxy> WebsiteDataStore::createDownloadProxy(Ref<API::DownloadClient>&& client, const WebCore::ResourceRequest& request, API::Navigation* navigation, WebPageProxy* originatingPage, const std::optional<FrameInfoData>& frameInfo)
 {
-    return protect(networkProcess())->createDownloadProxy(*this, WTF::move(client), request, frameInfo, originatingPage);
+    return protect(networkProcess())->createDownloadProxy(*this, WTF::move(client), request, frameInfo, navigation, originatingPage);
 }
 
 void WebsiteDataStore::download(const DownloadProxy& downloadProxy, const String& suggestedFilename)

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h
@@ -78,6 +78,7 @@ namespace API {
 class Data;
 class DownloadClient;
 class HTTPCookieStore;
+class Navigation;
 }
 
 namespace WebCore {
@@ -480,7 +481,7 @@ public:
     void setServiceWorkerOverridePreferences(WebPreferences* preferences) { m_serviceWorkerOverridePreferences = preferences; }
     WebPreferences* serviceWorkerOverridePreferences() const { return m_serviceWorkerOverridePreferences.get(); }
 
-    Ref<DownloadProxy> createDownloadProxy(Ref<API::DownloadClient>&&, const WebCore::ResourceRequest&, WebPageProxy* originatingPage, const std::optional<FrameInfoData>&);
+    Ref<DownloadProxy> createDownloadProxy(Ref<API::DownloadClient>&&, const WebCore::ResourceRequest&, API::Navigation*, WebPageProxy* originatingPage, const std::optional<FrameInfoData>&);
     void download(const DownloadProxy&, const String& suggestedFilename);
     void resumeDownload(const DownloadProxy&, const API::Data&, const String& path, CallDownloadDidStart);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm
@@ -1504,14 +1504,20 @@ TEST(WKDownload, FinishSuccessfully)
     auto webView = adoptNS([WKWebView new]);
     [webView setNavigationDelegate:delegate.get()];
 
+    __block RetainPtr<WKNavigation> retainedNavigation;
     delegate.get().navigationResponseDidBecomeDownload = ^(WKWebView *, WKNavigationResponse *, WKDownload *download) {
         download.delegate = delegate.get();
+        EXPECT_NOT_NULL(download.navigation);
+        EXPECT_EQ(download.navigation, retainedNavigation.get());
         delegate.get().decideDestinationUsingResponse = ^(WKDownload *download, NSURLResponse *, NSString *, void (^completionHandler)(NSURL *)) {
             EXPECT_NULL(download.progress.fileURL);
             completionHandler(expectedDownloadFile.get());
             EXPECT_NOT_NULL(download.progress.fileURL);
             EXPECT_WK_STREQ(download.progress.fileURL.absoluteString, expectedDownloadFile.get().absoluteString);
         };
+    };
+    delegate.get().didStartProvisionalNavigation = ^(WKWebView *, WKNavigation *navigation) {
+        retainedNavigation = navigation;
     };
     [webView loadRequest:server.request()];
     [delegate waitForDownloadDidFinish];
@@ -1521,6 +1527,7 @@ TEST(WKDownload, FinishSuccessfully)
 
     checkCallbackRecord(delegate.get(), {
         DownloadCallback::NavigationAction,
+        DownloadCallback::DidStartProvisionalNavigation,
         DownloadCallback::NavigationResponse,
         DownloadCallback::NavigationResponseBecameDownload,
         DownloadCallback::DecideDestination,

--- a/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h
+++ b/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h
@@ -37,6 +37,7 @@ enum class DownloadCallback : uint8_t {
 #endif
     DidFinish,
     DidFailWithError,
+    DidStartProvisionalNavigation,
     NavigationActionBecameDownload,
     NavigationResponseBecameDownload,
     NavigationAction,
@@ -51,6 +52,7 @@ enum class DownloadCallback : uint8_t {
 @property (nonatomic, copy) void (^downloadDidFinish)(WKDownload *);
 @property (nonatomic, copy) void (^didFailWithError)(WKDownload *, NSError *, NSData *);
 
+@property (nonatomic, copy) void (^didStartProvisionalNavigation)(WKWebView *, WKNavigation *);
 @property (nonatomic, copy) void (^navigationActionDidBecomeDownload)(WKWebView *, WKNavigationAction *, WKDownload *);
 @property (nonatomic, copy) void (^navigationResponseDidBecomeDownload)(WKWebView *, WKNavigationResponse *, WKDownload *);
 @property (nonatomic, copy) void (^decidePolicyForNavigationAction)(WKNavigationAction *, void (^)(WKNavigationActionPolicy));

--- a/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
+++ b/Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm
@@ -94,6 +94,14 @@
         _didFailWithError(download, error, resumeData);
 }
 
+- (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation
+{
+    _callbackRecord.append(DownloadCallback::DidStartProvisionalNavigation);
+
+    if (_didStartProvisionalNavigation)
+        _didStartProvisionalNavigation(webView, navigation);
+}
+
 - (void)webView:(WKWebView *)webView navigationAction:(WKNavigationAction *)navigationAction didBecomeDownload:(WKDownload *)download
 {
     _callbackRecord.append(DownloadCallback::NavigationActionBecameDownload);


### PR DESCRIPTION
#### 4d45adbbab82317973764a750faf734d38aa5e59
<pre>
Expose WKNavigation on WKDownload
<a href="https://bugs.webkit.org/show_bug.cgi?id=308095">https://bugs.webkit.org/show_bug.cgi?id=308095</a>

Reviewed by NOBODY (OOPS!).

Added &quot;navigation&quot; property which returns WKNavigation on WKDownload.

Tests: TestWebKitAPI.WKDownload.FinishSuccessfully

* Source/WebKit/UIProcess/API/Cocoa/WKDownload.h:
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
(-[WKDownload navigation]):
* Source/WebKit/UIProcess/API/glib/WebKitNetworkSession.cpp:
(webkit_network_session_download_uri):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.cpp:
(WebKit::DownloadProxy::DownloadProxy):
* Source/WebKit/UIProcess/Downloads/DownloadProxy.h:
(WebKit::DownloadProxy::navigation):
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.cpp:
(WebKit::DownloadProxyMap::createDownloadProxy):
* Source/WebKit/UIProcess/Downloads/DownloadProxyMap.h:
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.cpp:
(WebKit::NetworkProcessProxy::createDownloadProxy):
* Source/WebKit/UIProcess/Network/NetworkProcessProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::receivedPolicyDecision):
(WebKit::WebPageProxy::receivedNavigationResponsePolicyDecision):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::download):
(WebKit::WebProcessPool::resumeDownload):
(WebKit::WebProcessPool::createDownloadProxy):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::createDownloadProxy):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/Download.mm:
(TestWebKitAPI::FinishSuccessfully)):
* Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.h:
* Tools/TestWebKitAPI/cocoa/TestDownloadDelegate.mm:
(-[TestDownloadDelegate webView:didStartProvisionalNavigation:]):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d45adbbab82317973764a750faf734d38aa5e59

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18014 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154004 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98969 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aa284b3f-b74c-4120-a60c-49c1a15207aa) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111756 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80094 "Exiting early after 60 failures. 15380 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14116 "Passed tests") | [⏳ 🧪 api-mac](https://ews-build.webkit.org/#/builders/API-Tests-macOS-EWS "Waiting to run tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92657 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd49423a-34ce-4635-9fc2-a4e0db4ade5c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13462 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11226 "Found 17 new API test failures: TestWebKitAPI.WKDownload.SuggestedFilenameFromHost, TestWebKitAPI.WKDownload.ResumeWithExtraInitialDataOnDisk, TestWebKitAPI.WKDownload.SubframeOriginator, TestWebKitAPI.WKDownload.BlobResponseNoFilename, TestWebKitAPI.WKDownload.LockdownModePDF, TestWebKitAPI.WKDownload.CancelNoResumeData, TestWebKitAPI.WKDownload.NetworkProcessCrash, TestWebKitAPI.WKDownload.ResumeWithoutInitialDataOnDisk, TestWebKitAPI.WKDownload.LockdownModeUSDZ, TestWebKitAPI.WKDownload.DestinationNullString ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1450 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122990 "Found 17 new API test failures: TestWebKitAPI.WKDownload.SuggestedFilenameFromHost, TestWebKitAPI.WKDownload.ResumeCantReconnect, TestWebKitAPI.WKDownload.UnknownContentLength, TestWebKitAPI.WKDownload.ResumeWithExtraInitialDataOnDisk, TestWebKitAPI.WKDownload.SubframeOriginator, TestWebKitAPI.WKDownload.FailNoResumeData, TestWebKitAPI.WKDownload.BlobResponseNoFilename, TestWebKitAPI.WKDownload.ResumeWithoutInitialDataOnDisk, TestWebKitAPI.WKDownload.LockdownModePDF, TestWebKitAPI.WKDownload.CancelNoResumeData ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156316 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17864 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8395 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119762 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14908 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120101 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15861 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128565 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73554 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17485 "Built successfully") | [⏳ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK2-Intel-Tests-EWS "Waiting to run tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17222 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81264 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17430 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17285 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->