### PR TITLE
Add NODELETE to NodeTraversal functions

### DIFF
--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -1200,7 +1200,7 @@ bool Node::isComposedTreeDescendantOf(const Node& node) const
 Node* Node::pseudoAwarePreviousSibling() const
 {
     auto* pseudoElement = dynamicDowncast<PseudoElement>(*this);
-    RefPtr parentOrHost = pseudoElement ? pseudoElement->hostElement() : parentElement();
+    auto* parentOrHost = pseudoElement ? pseudoElement->hostElement() : parentElement();
     if (parentOrHost && !previousSibling()) {
         if (isAfterPseudoElement() && parentOrHost->lastChild())
             return parentOrHost->lastChild();
@@ -1213,7 +1213,7 @@ Node* Node::pseudoAwarePreviousSibling() const
 Node* Node::pseudoAwareNextSibling() const
 {
     auto* pseudoElement = dynamicDowncast<PseudoElement>(*this);
-    RefPtr parentOrHost = pseudoElement ? pseudoElement->hostElement() : parentElement();
+    auto* parentOrHost = pseudoElement ? pseudoElement->hostElement() : parentElement();
     if (parentOrHost && !nextSibling()) {
         if (isBeforePseudoElement() && parentOrHost->firstChild())
             return parentOrHost->firstChild();
@@ -1226,7 +1226,7 @@ Node* Node::pseudoAwareNextSibling() const
 Node* Node::pseudoAwareFirstChild() const
 {
     if (auto* currentElement = dynamicDowncast<Element>(*this)) {
-        SUPPRESS_UNCHECKED_LOCAL Node* first = currentElement->beforePseudoElement();
+        Node* first = currentElement->beforePseudoElement();
         if (first)
             return first;
         first = currentElement->firstChild();
@@ -1240,7 +1240,7 @@ Node* Node::pseudoAwareFirstChild() const
 Node* Node::pseudoAwareLastChild() const
 {
     if (auto* currentElement = dynamicDowncast<Element>(*this)) {
-        SUPPRESS_UNCHECKED_LOCAL Node* last = currentElement->afterPseudoElement();
+        Node* last = currentElement->afterPseudoElement();
         if (last)
             return last;
         last = currentElement->lastChild();

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -179,10 +179,10 @@ public:
     inline Node* lastChild() const;
     inline bool hasAttributes() const;
     inline NamedNodeMap* attributesMap() const;
-    Node* pseudoAwareNextSibling() const;
-    Node* pseudoAwarePreviousSibling() const;
-    Node* pseudoAwareFirstChild() const;
-    Node* pseudoAwareLastChild() const;
+    Node* NODELETE pseudoAwareNextSibling() const;
+    Node* NODELETE pseudoAwarePreviousSibling() const;
+    Node* NODELETE pseudoAwareFirstChild() const;
+    Node* NODELETE pseudoAwareLastChild() const;
 
     WEBCORE_EXPORT const URL& baseURI() const;
     

--- a/Source/WebCore/dom/NodeTraversal.cpp
+++ b/Source/WebCore/dom/NodeTraversal.cpp
@@ -33,13 +33,13 @@ namespace NodeTraversal {
 
 Node* previousIncludingPseudo(const Node& current, const Node* stayWithin)
 {
-    CheckedPtr<Node> previous;
+    Node* previous = nullptr;
     if (&current == stayWithin)
         return nullptr;
     if ((previous = current.pseudoAwarePreviousSibling())) {
         while (previous->pseudoAwareLastChild())
             previous = previous->pseudoAwareLastChild();
-        return previous.unsafeGet();
+        return previous;
     }
     auto* pseudoElement = dynamicDowncast<PseudoElement>(current);
     return pseudoElement ? pseudoElement->hostElement() : current.parentNode();
@@ -47,38 +47,38 @@ Node* previousIncludingPseudo(const Node& current, const Node* stayWithin)
 
 Node* nextIncludingPseudo(const Node& current, const Node* stayWithin)
 {
-    CheckedPtr<Node> next;
+    Node* next = nullptr;
     if ((next = current.pseudoAwareFirstChild()))
-        return next.unsafeGet();
+        return next;
     if (&current == stayWithin)
         return nullptr;
     if ((next = current.pseudoAwareNextSibling()))
-        return next.unsafeGet();
+        return next;
     auto* pseudoElement = dynamicDowncast<PseudoElement>(current);
-    CheckedPtr<const Node> ancestor = pseudoElement ? pseudoElement->hostElement() : current.parentNode();
+    const Node* ancestor = pseudoElement ? pseudoElement->hostElement() : current.parentNode();
     for (; ancestor; ancestor = ancestor->parentNode()) {
         if (ancestor == stayWithin)
             return nullptr;
         if ((next = ancestor->pseudoAwareNextSibling()))
-            return next.unsafeGet();
+            return next;
     }
     return nullptr;
 }
 
 Node* nextIncludingPseudoSkippingChildren(const Node& current, const Node* stayWithin)
 {
-    CheckedPtr<Node> next;
+    Node* next = nullptr;
     if (&current == stayWithin)
         return nullptr;
     if ((next = current.pseudoAwareNextSibling()))
-        return next.unsafeGet();
+        return next;
     auto* pseudoElement = dynamicDowncast<PseudoElement>(current);
-    CheckedPtr<const Node> ancestor = pseudoElement ? pseudoElement->hostElement() : current.parentNode();
+    const Node* ancestor = pseudoElement ? pseudoElement->hostElement() : current.parentNode();
     for (; ancestor; ancestor = ancestor->parentNode()) {
         if (ancestor == stayWithin)
             return nullptr;
         if ((next = ancestor->pseudoAwareNextSibling()))
-            return next.unsafeGet();
+            return next;
     }
     return nullptr;
 }

--- a/Source/WebCore/dom/NodeTraversal.h
+++ b/Source/WebCore/dom/NodeTraversal.h
@@ -35,43 +35,43 @@ namespace NodeTraversal {
 // This uses the same order that tags appear in the source file. If the stayWithin
 // argument is non-null, the traversal will stop once the specified node is reached.
 // This can be used to restrict traversal to a particular sub-tree.
-Node* next(const Node&);
-Node* next(const Node&, const Node* stayWithin);
-Node* next(const ContainerNode&);
-Node* next(const ContainerNode&, const Node* stayWithin);
-Node* next(const Text&);
-Node* next(const Text&, const Node* stayWithin);
+inline Node* next(const Node&);
+inline Node* next(const Node&, const Node* stayWithin);
+inline Node* next(const ContainerNode&);
+inline Node* next(const ContainerNode&, const Node* stayWithin);
+inline Node* next(const Text&);
+inline Node* next(const Text&, const Node* stayWithin);
 
 // Like next, but skips children and starts with the next sibling.
-Node* nextSkippingChildren(const Node&);
-Node* nextSkippingChildren(const Node&, const Node* stayWithin);
+inline Node* nextSkippingChildren(const Node&);
+inline Node* nextSkippingChildren(const Node&, const Node* stayWithin);
 
 // Does a reverse pre-order traversal to find the node that comes before the current one in document order
-WEBCORE_EXPORT Node* last(const ContainerNode&);
-Node* previous(const Node&, const Node* stayWithin = nullptr);
+WEBCORE_EXPORT Node* NODELETE last(const ContainerNode&);
+inline Node* previous(const Node&, const Node* stayWithin = nullptr);
 
 // Like previous, but skips children and starts with the next sibling.
-Node* previousSkippingChildren(const Node&, const Node* stayWithin = nullptr);
+Node* NODELETE previousSkippingChildren(const Node&, const Node* stayWithin = nullptr);
 
 // Like next, but visits parents after their children.
-Node* nextPostOrder(const Node&, const Node* stayWithin = nullptr);
+Node* NODELETE nextPostOrder(const Node&, const Node* stayWithin = nullptr);
 
 // Like previous/previousSkippingChildren, but visits parents before their children.
-Node* previousPostOrder(const Node&, const Node* stayWithin = nullptr);
-Node* previousSkippingChildrenPostOrder(const Node&, const Node* stayWithin = nullptr);
+Node* NODELETE previousPostOrder(const Node&, const Node* stayWithin = nullptr);
+Node* NODELETE previousSkippingChildrenPostOrder(const Node&, const Node* stayWithin = nullptr);
 
 // Pre-order traversal including the pseudo-elements.
-Node* previousIncludingPseudo(const Node&, const Node* = nullptr);
-Node* nextIncludingPseudo(const Node&, const Node* = nullptr);
-Node* nextIncludingPseudoSkippingChildren(const Node&, const Node* = nullptr);
+Node* NODELETE previousIncludingPseudo(const Node&, const Node* = nullptr);
+Node* NODELETE nextIncludingPseudo(const Node&, const Node* = nullptr);
+Node* NODELETE nextIncludingPseudoSkippingChildren(const Node&, const Node* = nullptr);
 
 }
 
 namespace NodeTraversal {
 
-WEBCORE_EXPORT Node* nextAncestorSibling(const Node&);
-WEBCORE_EXPORT Node* nextAncestorSibling(const Node&, const Node* stayWithin);
-WEBCORE_EXPORT Node* deepLastChild(Node&);
+WEBCORE_EXPORT Node* NODELETE nextAncestorSibling(const Node&);
+WEBCORE_EXPORT Node* NODELETE nextAncestorSibling(const Node&, const Node* stayWithin);
+WEBCORE_EXPORT Node* NODELETE deepLastChild(Node&);
 
 template <class NodeType>
 inline Node* traverseNextTemplate(NodeType& current)


### PR DESCRIPTION
#### e2cc67fc6cce5e4c44e1d00eb3c4451fcc33f09a
<pre>
Add NODELETE to NodeTraversal functions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308099">https://bugs.webkit.org/show_bug.cgi?id=308099</a>

Reviewed by Geoffrey Garen.

Deployed NODELETE annotations to out-of-line functions in NodeTraversal.
Also added &quot;inline&quot; keyword on inline functions.

No new tests since there should be no behavioral changes.

* Source/WebCore/dom/Node.cpp:
(WebCore::Node::pseudoAwarePreviousSibling const):
(WebCore::Node::pseudoAwareNextSibling const):
(WebCore::Node::pseudoAwareFirstChild const):
(WebCore::Node::pseudoAwareLastChild const):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeTraversal.cpp:
(WebCore::NodeTraversal::previousIncludingPseudo):
(WebCore::NodeTraversal::nextIncludingPseudo):
(WebCore::NodeTraversal::nextIncludingPseudoSkippingChildren):
* Source/WebCore/dom/NodeTraversal.h:

Canonical link: <a href="https://commits.webkit.org/307745@main">https://commits.webkit.org/307745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/abb6b7565659c68fc5b06d80b428377c8631b434

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18018 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9814 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154008 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/98973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1e50808-8992-487e-95fd-ac59a2fce032) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147211 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17911 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111761 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/98973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/141f88fa-be41-4da3-a24c-b6cd74fd0623) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148299 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14124 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130551 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92662 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d7f5ecfa-c378-4463-ac40-7549877fa71e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13469 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11229 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1454 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/122998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7318 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156320 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8411 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119765 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17914 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14912 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120104 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15862 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128581 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73558 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22420 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17489 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6817 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17226 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81268 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17434 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17289 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->