### PR TITLE
CNN livestream stuck loading

### DIFF
--- a/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only-expected.txt
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only-expected.txt
@@ -24,6 +24,9 @@ EVENT(updateend)
 Playing
 RUN(audio.play())
 Promise resolved OK
-EXPECTED (audio.currentTime > '0.1') OK
+EXPECTED (audio.currentTime > '0.2') OK
+-
+Verifying audio is producing audible sound
+EXPECTED (isPlayingAudio == 'true') OK
 END OF TEST
 

--- a/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html
+++ b/LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html
@@ -6,6 +6,8 @@
     <script src=support.js></script>
     <script src="eme2016.js"></script>
     <script>
+    var isPlayingAudio = false;
+
     window.addEventListener('load', async event => {
         startTest().then(endTest).catch(failTest);
     });
@@ -41,7 +43,15 @@
         consoleWrite('Playing');
         await shouldResolve(run('audio.play()'));
 
-        await testExpectedEventually('audio.currentTime', '0.1', '>', 1000);
+        await testExpectedEventually('audio.currentTime', '0.2', '>', 2000);
+
+        consoleWrite('-');
+        consoleWrite('Verifying audio is producing audible sound');
+        
+        if (window.internals) {
+            isPlayingAudio = internals.pageMediaState().includes('IsPlayingAudio') && audio.currentTime > 0;
+            testExpected('isPlayingAudio', true, '==');
+        }
     }
     </script>
 </head>


### PR DESCRIPTION
#### b2e3a90d9c8dc63cb7e1a055ebc05f14b3169e8b
<pre>
CNN livestream stuck loading
<a href="https://bugs.webkit.org/show_bug.cgi?id=308089">https://bugs.webkit.org/show_bug.cgi?id=308089</a>
<a href="https://rdar.apple.com/170517249">rdar://170517249</a>

Reviewed by Youenn Fablet.

The encryption keys attached to an audio CMSampleBuffer were lost during the CP-&gt;GPUP serialisation.
This preventing the audio stream from being successfully decoded.
While the `sinf` box was correctly attached to the CMSampleBuffer&apos;s extensions
the `CommonEncryptionTrackEncryptionBox` was only attached for video samples.

We amend createFormatDescriptionFromTrackInfo so that it handles both audio and video
content in the same way.

Amend existing test which was incorrectly succeeding.

* LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only-expected.txt:
* LayoutTests/http/tests/media/fairplay/fps-mse-unmuxed-audio-only.html:
* Source/WebCore/platform/graphics/cocoa/CMUtilities.mm:
(WebCore::createExtensionsDictionary):
(WebCore::createAudioFormatDescription):
(WebCore::createFormatDescriptionFromTrackInfo):

Canonical link: <a href="https://commits.webkit.org/307752@main">https://commits.webkit.org/307752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb3b73925fe412e19d419e647d6b3eac2acdd06b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18032 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9833 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154022 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98987 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/71eededa-cc51-43af-90cf-cd2c335afbf8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147225 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18516 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17925 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111772 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32e08d6f-4e90-47bd-a2ab-6a92e3eb602a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148313 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14132 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92673 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13476 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11237 "Found 1 new API test failure: TestWebKitAPI.WKWebsiteDataStore.FetchPersistentCredentials (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1468 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7335 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156334 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17882 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119777 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17928 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14921 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30804 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15874 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73574 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17503 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6831 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17240 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81282 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17448 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17303 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->