### PR TITLE
AX: Expose support for NSAccessibilityIntersectionWithSelectionRangeAttribute and NSAccessibilityIntersectTextMarkerRangesAttribute for text controls and static text objects.

### DIFF
--- a/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-expected.txt
@@ -71,6 +71,7 @@ AXLineTextMarkerRangeForTextMarker
 AXSelectTextWithCriteria
 AXSearchTextWithCriteria
 AXTextOperation
+AXIntersectTextMarkerRanges
 
 ----------------------
 PASS: textChild.boundsForRange(6, 10) was equal or approximately equal to (x: -1, y: -1, w: 60, h: 18).

--- a/LayoutTests/accessibility/mac/supported-attributes-expected.txt
+++ b/LayoutTests/accessibility/mac/supported-attributes-expected.txt
@@ -1,0 +1,23 @@
+This test checks that various element types support the expected attributes.
+
+Static text:
+PASS: staticText.role === 'AXRole: AXStaticText'
+PASS: staticText.isAttributeSupported('AXIntersectionWithSelectionRange') === true
+PASS: staticText.isAttributeSupported('AXIntersectTextMarkerRanges') === true
+
+Text field:
+PASS: textField.role === 'AXRole: AXTextField'
+PASS: textField.isAttributeSupported('AXIntersectionWithSelectionRange') === true
+PASS: textField.isAttributeSupported('AXIntersectTextMarkerRanges') === true
+
+Text area:
+PASS: textArea.role === 'AXRole: AXTextArea'
+PASS: textArea.isAttributeSupported('AXIntersectionWithSelectionRange') === true
+PASS: textArea.isAttributeSupported('AXIntersectTextMarkerRanges') === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+This is static text.
+
+

--- a/LayoutTests/accessibility/mac/supported-attributes.html
+++ b/LayoutTests/accessibility/mac/supported-attributes.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<p id="static-text">This is static text.</p>
+
+<input type="text" id="text-field" value="Text field content">
+
+<textarea id="text-area">Text area content</textarea>
+
+<script>
+var output = "This test checks that various element types support the expected attributes.\n\n";
+
+if (window.accessibilityController) {
+    output += "Static text:\n";
+    var staticText = accessibilityController.accessibleElementById("static-text").childAtIndex(0);
+    output += expect("staticText.role", "'AXRole: AXStaticText'");
+    output += expect("staticText.isAttributeSupported('AXIntersectionWithSelectionRange')", "true");
+    output += expect("staticText.isAttributeSupported('AXIntersectTextMarkerRanges')", "true");
+    output += "\n";
+
+    output += "Text field:\n";
+    var textField = accessibilityController.accessibleElementById("text-field");
+    output += expect("textField.role", "'AXRole: AXTextField'");
+    output += expect("textField.isAttributeSupported('AXIntersectionWithSelectionRange')", "true");
+    output += expect("textField.isAttributeSupported('AXIntersectTextMarkerRanges')", "true");
+    output += "\n";
+
+    output += "Text area:\n";
+    var textArea = accessibilityController.accessibleElementById("text-area");
+    output += expect("textArea.role", "'AXRole: AXTextArea'");
+    output += expect("textArea.isAttributeSupported('AXIntersectionWithSelectionRange')", "true");
+    output += expect("textArea.isAttributeSupported('AXIntersectTextMarkerRanges')", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -685,6 +685,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         [tempArray addObject:NSAccessibilityInvalidAttribute];
         [tempArray addObject:NSAccessibilityPlaceholderValueAttribute];
         [tempArray addObject:NSAccessibilityValueAutofillAvailableAttribute];
+        [tempArray addObject:NSAccessibilityIntersectionWithSelectionRangeAttribute];
         return tempArray;
     }();
     static NeverDestroyed listAttrs = [] {
@@ -2307,6 +2308,12 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
         [tempArray addObject:(NSString*)kAXRTFForRangeParameterizedAttribute];
         [tempArray addObject:(NSString*)kAXAttributedStringForRangeParameterizedAttribute];
         [tempArray addObject:(NSString*)kAXStyleRangeForIndexParameterizedAttribute];
+        [tempArray addObject:NSAccessibilityIntersectTextMarkerRangesAttribute];
+        return tempArray;
+    }();
+    static NeverDestroyed staticTextParamAttrs = [] {
+        auto tempArray = adoptNS([[NSMutableArray alloc] initWithArray:paramAttrs.get().get()]);
+        [tempArray addObject:NSAccessibilityIntersectTextMarkerRangesAttribute];
         return tempArray;
     }();
     static NeverDestroyed tableParamAttrs = [] {
@@ -2338,6 +2345,9 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
     if (backingObject->isWebArea())
         return webAreaParamAttrs.get().get();
+
+    if (backingObject->isStaticText())
+        return staticTextParamAttrs.get().get();
 
     // The object that serves up the remote frame also is the one that does the frame conversion.
     if (backingObject->hasRemoteFrameChild())

--- a/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
+++ b/Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm
@@ -655,7 +655,8 @@ bool AccessibilityUIElement::isAttributeSettable(JSStringRef attribute)
 bool AccessibilityUIElement::isAttributeSupported(JSStringRef attribute)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    return [[m_element accessibilityAttributeNames] containsObject:[NSString stringWithJSStringRef:attribute]];
+    NSString *attributeName = [NSString stringWithJSStringRef:attribute];
+    return [[m_element accessibilityAttributeNames] containsObject:attributeName] || [[m_element accessibilityParameterizedAttributeNames] containsObject:attributeName];
     END_AX_OBJC_EXCEPTIONS
 
     return false;

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h
@@ -40,6 +40,7 @@ namespace WTR {
 class AccessibilityUIElementMac final : public AccessibilityUIElement {
     // Helper functions that dispatch to AX secondary thread
     friend RetainPtr<NSArray> supportedAttributes(id);
+    friend RetainPtr<NSArray> supportedParameterizedAttributes(id);
     friend void setAttributeValue(id, NSString *, id, bool synchronous);
 
 public:

--- a/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
+++ b/Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm
@@ -162,6 +162,19 @@ RetainPtr<NSArray> supportedAttributes(id element)
     return attributes;
 }
 
+RetainPtr<NSArray> supportedParameterizedAttributes(id element)
+{
+    RetainPtr<NSArray> attributes;
+
+    BEGIN_AX_OBJC_EXCEPTIONS
+    AccessibilityUIElementMac::s_controller->executeOnAXThreadAndWait([&attributes, &element] {
+        attributes = [element accessibilityParameterizedAttributeNames];
+    });
+    END_AX_OBJC_EXCEPTIONS
+
+    return attributes;
+}
+
 static id attributeValue(id element, NSString *attribute)
 {
     // The given `element` may not respond to `accessibilityAttributeValue`, so first check to see if it responds to the attribute-specific selector.
@@ -966,7 +979,9 @@ bool AccessibilityUIElementMac::isAttributeSettableNS(NSString *attribute) const
 bool AccessibilityUIElementMac::isAttributeSupported(JSStringRef attribute)
 {
     BEGIN_AX_OBJC_EXCEPTIONS
-    return [supportedAttributes(m_element.getAutoreleased()) containsObject:[NSString stringWithJSStringRef:attribute]];
+    NSString *attributeName = [NSString stringWithJSStringRef:attribute];
+    id element = m_element.getAutoreleased();
+    return [supportedAttributes(element) containsObject:attributeName] || [supportedParameterizedAttributes(element) containsObject:attributeName];
     END_AX_OBJC_EXCEPTIONS
 
     return false;


### PR DESCRIPTION
#### e449c32774ffb360afb53383ca4faa9c8a907ef9
<pre>
AX: Expose support for NSAccessibilityIntersectionWithSelectionRangeAttribute and NSAccessibilityIntersectTextMarkerRangesAttribute for text controls and static text objects.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308090">https://bugs.webkit.org/show_bug.cgi?id=308090</a>
&lt;<a href="https://rdar.apple.com/problem/170594004">rdar://problem/170594004</a>&gt;

Reviewed by Joshua Hoffman.

This change exposes accessibility attribute support for text controls and static text:

- NSAccessibilityIntersectionWithSelectionRangeAttribute is added to accessibilityAttributeNames
  for text controls (textAttrs). Static text already had this attribute.

- NSAccessibilityIntersectTextMarkerRangesAttribute is added to accessibilityParameterizedAttributeNames
  for both text controls (textParamAttrs) and static text (new staticTextParamAttrs).

Additionally, AccessibilityUIElement::isAttributeSupported in both WebKitTestRunner and
DumpRenderTree is updated to check both regular attributes (accessibilityAttributeNames) and
parameterized attributes (accessibilityParameterizedAttributeNames), allowing layout tests
to verify support for parameterized attributes.

Test: accessibility/mac/supported-attributes.html
* LayoutTests/accessibility/mac/bounds-for-range-expected.txt:
* LayoutTests/accessibility/mac/supported-attributes-expected.txt: Added.
* LayoutTests/accessibility/mac/supported-attributes.html: Added.
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(-[WebAccessibilityObjectWrapper accessibilityAttributeNames]):
(-[WebAccessibilityObjectWrapper accessibilityParameterizedAttributeNames]):
* Tools/DumpRenderTree/mac/AccessibilityUIElementMac.mm:
(AccessibilityUIElement::isAttributeSupported):
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.h:
* Tools/WebKitTestRunner/InjectedBundle/mac/AccessibilityUIElementMac.mm:
(WTR::supportedParameterizedAttributes):
(WTR::AccessibilityUIElementMac::isAttributeSupported):

Canonical link: <a href="https://commits.webkit.org/307757@main">https://commits.webkit.org/307757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6895831ee9bf0c77258e23d328b9aa063d19fbc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145343 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18025 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9823 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154015 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98980 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ded52ed-e741-4444-9fc5-06e0b5715f93) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18509 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17918 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111766 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80097 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/175fcdf3-c2cf-496e-830c-ae9ecc1e1f54) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148306 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130558 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92667 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/feea7bcd-2ae6-499e-ba2e-41933234c203) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13475 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11232 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1461 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156327 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17875 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8419 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119771 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17921 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120110 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30808 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15865 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128588 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73565 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17496 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6823 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17233 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81275 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17441 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17296 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->