### PR TITLE
[JSC] A bit defensively adding DeferGC for Butterfly baking

### DIFF
--- a/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayConstructor.cpp
@@ -189,6 +189,8 @@ ALWAYS_INLINE JSArray* fastArrayOf(JSGlobalObject* globalObject, CallFrame* call
         nullptr, AllocationFailureMode::ReturnNull);
     if (!memory) [[unlikely]]
         return nullptr;
+
+    DeferGC deferGC(vm);
     auto* resultButterfly = Butterfly::fromBase(memory, 0, 0);
     resultButterfly->setVectorLength(vectorLength);
     resultButterfly->setPublicLength(length);
@@ -317,6 +319,8 @@ static ALWAYS_INLINE JSArray* tryCreateArrayFromArguments(JSGlobalObject* global
         nullptr, AllocationFailureMode::ReturnNull);
     if (!memory) [[unlikely]]
         return nullptr;
+
+    DeferGC deferGC(vm);
     auto* resultButterfly = Butterfly::fromBase(memory, 0, 0);
     resultButterfly->setVectorLength(vectorLength);
     resultButterfly->setPublicLength(length);
@@ -402,6 +406,8 @@ static JSArray* tryCreateArrayFromSet(JSGlobalObject* globalObject, JSSet* set)
         nullptr, AllocationFailureMode::ReturnNull);
     if (!memory) [[unlikely]]
         return nullptr;
+
+    DeferGC deferGC(vm);
     auto* resultButterfly = Butterfly::fromBase(memory, 0, 0);
     resultButterfly->setVectorLength(vectorLength);
     resultButterfly->setPublicLength(length);
@@ -509,6 +515,8 @@ static JSArray* tryCreateArrayFromMapIterator(JSGlobalObject* globalObject, JSMa
         nullptr, AllocationFailureMode::ReturnNull);
     if (!memory) [[unlikely]]
         return nullptr;
+
+    DeferGC deferGC(vm);
     auto* resultButterfly = Butterfly::fromBase(memory, 0, 0);
     resultButterfly->setVectorLength(vectorLength);
     resultButterfly->setPublicLength(length);

--- a/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/ArrayPrototype.cpp
@@ -1552,6 +1552,8 @@ static JSArray* concatAppendArray(JSGlobalObject* globalObject, VM& vm, JSArray*
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }
+
+    DeferGC deferGC(vm);
     auto* butterfly = Butterfly::fromBase(memory, 0, 0);
     butterfly->setVectorLength(vectorLength);
     butterfly->setPublicLength(resultSize);

--- a/Source/JavaScriptCore/runtime/JSArray.cpp
+++ b/Source/JavaScriptCore/runtime/JSArray.cpp
@@ -570,6 +570,8 @@ JSArray* JSArray::fastToReversed(JSGlobalObject* globalObject, uint64_t length)
             nullptr, AllocationFailureMode::ReturnNull);
         if (!memory) [[unlikely]]
             return nullptr;
+
+        DeferGC deferGC(vm);
         auto* butterfly = Butterfly::fromBase(memory, 0, 0);
         butterfly->setVectorLength(vectorLength);
         butterfly->setPublicLength(length);
@@ -672,6 +674,8 @@ JSArray* JSArray::fastWith(JSGlobalObject* globalObject, uint32_t index, JSValue
             nullptr, AllocationFailureMode::ReturnNull);
         if (!memory) [[unlikely]]
             return nullptr;
+
+        DeferGC deferGC(vm);
         auto* butterfly = Butterfly::fromBase(memory, 0, 0);
         butterfly->setVectorLength(vectorLength);
         butterfly->setPublicLength(length);
@@ -937,6 +941,8 @@ JSArray* JSArray::fastToSpliced(JSGlobalObject* globalObject, CallFrame* callFra
             nullptr, AllocationFailureMode::ReturnNull);
         if (!memory) [[unlikely]]
             return nullptr;
+
+        DeferGC deferGC(vm);
         auto* resultButterfly = Butterfly::fromBase(memory, 0, 0);
         resultButterfly->setVectorLength(vectorLength);
         resultButterfly->setPublicLength(newLength);
@@ -1412,6 +1418,7 @@ JSArray* JSArray::fastSlice(JSGlobalObject* globalObject, JSObject* source, uint
         if (!memory) [[unlikely]]
             return nullptr;
 
+        DeferGC deferGC(vm);
         auto* butterfly = Butterfly::fromBase(memory, 0, 0);
         butterfly->setVectorLength(vectorLength);
         butterfly->setPublicLength(initialLength);
@@ -2175,6 +2182,8 @@ JSArray* tryCloneArrayFromFast(JSGlobalObject* globalObject, JSValue arrayValue)
         throwOutOfMemoryError(globalObject, scope);
         return { };
     }
+
+    DeferGC deferGC(vm);
     auto* resultButterfly = Butterfly::fromBase(memory, 0, 0);
     resultButterfly->setVectorLength(vectorLength);
     resultButterfly->setPublicLength(resultSize);
@@ -2421,6 +2430,7 @@ JSArray* JSArray::fastFlat(JSGlobalObject* globalObject, uint64_t depth, uint64_
         if (!memory) [[unlikely]]
             return nullptr;
 
+        DeferGC deferGC(vm);
         auto* butterfly = Butterfly::fromBase(memory, 0, 0);
         butterfly->setVectorLength(vectorLength);
         butterfly->setPublicLength(flattenedLength);

--- a/Source/JavaScriptCore/runtime/ScopedArguments.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArguments.cpp
@@ -226,6 +226,7 @@ JSArray* ScopedArguments::fastSlice(JSGlobalObject* globalObject, ScopedArgument
     if (!memory) [[unlikely]]
         return nullptr;
 
+    DeferGC deferGC(vm);
     auto* resultButterfly = Butterfly::fromBase(memory, 0, 0);
     resultButterfly->setVectorLength(vectorLength);
     resultButterfly->setPublicLength(resultLength);


### PR DESCRIPTION
#### 1f4abb51322ee99723e525de8fff76e4d55361a4
<pre>
[JSC] A bit defensively adding DeferGC for Butterfly baking
<a href="https://bugs.webkit.org/show_bug.cgi?id=308105">https://bugs.webkit.org/show_bug.cgi?id=308105</a>
<a href="https://rdar.apple.com/170604854">rdar://170604854</a>

Reviewed by Keith Miller.

Baking Butterfly is really complex. Butterfly itself is kept via GC.
But Butterfly elements are not scanned until it gets connected to owner
JSObject. This means that createWithButterfly function requires extra
care since we do GC for owner cell allocation, thus, we need to ensure
that content of Butterfly is also kept alive by someone. Currently, all
of JSArray::createWithButterfly&apos;s butterfly contents are copied from
some other objects, thus this object should keep them alive. But in some
cases like clang optimization for tail call to
JSArray::createWithButterfly, there is theoretical possibility that this
owner object is no longer kept when creating JSArray because it was the
last use. And in this case, we may destroy the content of these
butterflies. We are not 100% sure whether this can happen. But let&apos;s a
bit defensive against the current use by adding DeferGC to ensure that
we will not invoke GC for JSArray::createWithButterfly&apos;s owner cell
creation.

* Source/JavaScriptCore/runtime/ArrayConstructor.cpp:
(JSC::fastArrayOf):
(JSC::tryCreateArrayFromArguments):
(JSC::tryCreateArrayFromSet):
(JSC::tryCreateArrayFromMapIterator):
* Source/JavaScriptCore/runtime/ArrayPrototype.cpp:
(JSC::concatAppendArray):
* Source/JavaScriptCore/runtime/JSArray.cpp:
(JSC::JSArray::fastToReversed):
(JSC::JSArray::fastWith):
(JSC::JSArray::fastToSpliced):
(JSC::JSArray::fastSlice):
(JSC::tryCloneArrayFromFast):
(JSC::JSArray::fastFlat):
* Source/JavaScriptCore/runtime/ScopedArguments.cpp:
(JSC::ScopedArguments::fastSlice):

Canonical link: <a href="https://commits.webkit.org/307787@main">https://commits.webkit.org/307787@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/13a0a81d81347209d5e330e578898b3a74007d4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18031 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/98986 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18515 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17924 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111770 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80101 "Exiting early after 60 failures. 15384 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4e6d7a1f-f3ba-45fb-bcb9-eb8f9b557fd8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148312 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14135 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130562 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92671 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11249469-0bef-452c-a936-ecd3d552845b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13479 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11235 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1467 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137340 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123009 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7329 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156333 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6158 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17881 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8423 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119775 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17927 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14919 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120114 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15870 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128592 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73572 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22440 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17502 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6827 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176638 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17239 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81281 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45414 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17447 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17302 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->