### PR TITLE
Enhanced <select>: optgroup elements should be rendered

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -644,8 +644,6 @@ imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customiz
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-left.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right-scroller.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-fallback-top-right.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend-and-label.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-legend.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-appearance-optgroup-rendering.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-only-picker-opt-in.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/uses-label-dynamic.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt
@@ -52,7 +52,7 @@ PASS UA stylesheet rule for unicode-bidi, for <img>
 PASS UA stylesheet rule for unicode-bidi, for <ins>
 PASS UA stylesheet rule for unicode-bidi, for <kbd>
 PASS UA stylesheet rule for unicode-bidi, for <label>
-FAIL UA stylesheet rule for unicode-bidi, for <legend> assert_equals: expected "isolate" but got "normal"
+PASS UA stylesheet rule for unicode-bidi, for <legend>
 FAIL UA stylesheet rule for unicode-bidi, for <li> assert_equals: expected "isolate" but got "normal"
 PASS UA stylesheet rule for unicode-bidi, for <link>
 FAIL UA stylesheet rule for unicode-bidi, for <main> assert_equals: expected "isolate" but got "normal"

--- a/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-expected.txt
@@ -2,7 +2,7 @@
 
 
 PASS in-body: display
-FAIL in-body: unicodeBidi assert_equals: expected "isolate" but got "normal"
+PASS in-body: unicodeBidi
 PASS in-body: marginTop
 PASS in-body: marginRight
 PASS in-body: marginBottom
@@ -16,7 +16,7 @@ PASS in-body: height
 PASS in-body: box-sizing
 FAIL in-body: width assert_not_equals: got disallowed value "0px"
 PASS rendered-legend: display
-FAIL rendered-legend: unicodeBidi assert_equals: expected "isolate" but got "normal"
+PASS rendered-legend: unicodeBidi
 PASS rendered-legend: marginTop
 PASS rendered-legend: marginRight
 PASS rendered-legend: marginBottom
@@ -30,7 +30,7 @@ PASS rendered-legend: height
 PASS rendered-legend: box-sizing
 PASS rendered-legend: width
 PASS in-fieldset-second-child: display
-FAIL in-fieldset-second-child: unicodeBidi assert_equals: expected "isolate" but got "normal"
+PASS in-fieldset-second-child: unicodeBidi
 PASS in-fieldset-second-child: marginTop
 PASS in-fieldset-second-child: marginRight
 PASS in-fieldset-second-child: marginBottom
@@ -44,7 +44,7 @@ PASS in-fieldset-second-child: height
 PASS in-fieldset-second-child: box-sizing
 FAIL in-fieldset-second-child: width assert_not_equals: got disallowed value "0px"
 PASS in-fieldset-descendant: display
-FAIL in-fieldset-descendant: unicodeBidi assert_equals: expected "isolate" but got "normal"
+PASS in-fieldset-descendant: unicodeBidi
 PASS in-fieldset-descendant: marginTop
 PASS in-fieldset-descendant: marginRight
 PASS in-fieldset-descendant: marginBottom

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt
@@ -7,7 +7,7 @@ FAIL UA styles of base appearance ::picker(select) assert_equals: box-sizing exp
 PASS UA styles of base appearance <option>.
 PASS UA styles of base appearance option::checkmark.
 FAIL UA styles of base appearance <optgroup>. assert_equals: display expected "block" but got "inline"
-FAIL UA styles of base appearance <legend>. assert_equals: min-block-size expected "13px" but got "0px"
+PASS UA styles of base appearance <legend>.
 FAIL UA styles of base appearance select <button>. assert_equals: display expected "contents" but got "block"
 PASS UA styles of base appearance <option> in <optgroup>.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt
@@ -10,7 +10,10 @@ Hippopotamus
 Rhinoceros
 Flamingo
 Crocodile
-Chimpanzee
+Polar Bear
+ Chimpanzee
+ Ostrich
+ Wolf
 
 FAIL In dialog mode the first focusable element should get focus. assert_equals: The anchor should be focused. expected Element node <a id="interactive1" href="https://www.example.com/">Elep... but got Element node <select id="target">
   <div></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-arrow-keys.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-arrow-keys.optional-expected.txt
@@ -1,4 +1,10 @@
 
+one
+two
+three
+four
+five
+six
 
 FAIL Keyboard navigation forwards and backwards should visit each option with optgroups. assert_equals: First option should be initially focused. expected Element node <option class="one">one</option> but got Element node <select>
   <optgroup label="group1">

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1206,6 +1206,14 @@ select option:disabled {
     color: color-mix(in lab, currentColor 50%, transparent);
 }
 
+select option::checkmark {
+    content: "\2713" / "";
+}
+
+select option:not(:checked)::checkmark {
+    visibility: hidden;
+}
+
 select optgroup {
     font-weight: bolder;
 }
@@ -1214,12 +1222,9 @@ select optgroup option {
     font-weight: normal;
 }
 
-select option::checkmark {
-    content: "\2713" / "";
-}
-
-select option:not(:checked)::checkmark {
-    visibility: hidden;
+select optgroup legend {
+    padding-inline: 0.5em;
+    min-block-size: 1lh;
 }
 
 output {
@@ -1485,7 +1490,7 @@ iframe {
     border: 2px inset;
 }
 
-hr, bdi, output {
+hr, bdi, legend, output {
     unicode-bidi: isolate;
 }
 

--- a/Source/WebCore/html/HTMLOptGroupElement.cpp
+++ b/Source/WebCore/html/HTMLOptGroupElement.cpp
@@ -55,6 +55,15 @@ Ref<HTMLOptGroupElement> HTMLOptGroupElement::create(const QualifiedName& tagNam
     return adoptRef(*new HTMLOptGroupElement(tagName, document));
 }
 
+bool HTMLOptGroupElement::rendererIsNeeded(const RenderStyle&)
+{
+    RefPtr select = ownerSelectElement();
+    if (!select)
+        return false;
+
+    return document().settings().htmlEnhancedSelectEnabled() && select->usesBaseAppearancePicker();
+}
+
 auto HTMLOptGroupElement::insertedIntoAncestor(InsertionType insertionType, ContainerNode& parentOfInsertedTree) -> InsertedIntoAncestorResult
 {
     auto result = HTMLElement::insertedIntoAncestor(insertionType, parentOfInsertedTree);

--- a/Source/WebCore/html/HTMLOptGroupElement.h
+++ b/Source/WebCore/html/HTMLOptGroupElement.h
@@ -49,7 +49,7 @@ private:
     const AtomString& formControlType() const;
     bool isFocusable() const final;
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) final;
-    bool rendererIsNeeded(const RenderStyle&) final { return false; }
+    bool rendererIsNeeded(const RenderStyle&) final;
 
     void childrenChanged(const ChildChange&) final;
 

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -160,7 +160,7 @@ bool HTMLOptionElement::rendererIsNeeded(const RenderStyle&)
     if (!select)
         return false;
 
-    return select->document().settings().htmlEnhancedSelectEnabled() && select->usesBaseAppearancePicker();
+    return document().settings().htmlEnhancedSelectEnabled() && select->usesBaseAppearancePicker();
 }
 
 String HTMLOptionElement::text() const


### PR DESCRIPTION
#### d6798cd5910375aeb96bd175678b63718b04ef29
<pre>
Enhanced &lt;select&gt;: optgroup elements should be rendered
<a href="https://bugs.webkit.org/show_bug.cgi?id=308109">https://bugs.webkit.org/show_bug.cgi?id=308109</a>
<a href="https://rdar.apple.com/170610702">rdar://170610702</a>

Reviewed by Ryosuke Niwa.

Start creating renderers for optgroup elements when the base appearance picker is used.

This commit doesn&apos;t include support for label attribute, which will be covered separately.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/bidi-rendering/unicode-bidi-ua-rules-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/rendering/non-replaced-elements/the-fieldset-and-legend-elements/legend-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-base-appearance-computed-style-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-dialog-mode-focus.optional-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-optgroup-arrow-keys.optional-expected.txt:
* Source/WebCore/css/html.css:
(select option::checkmark):
(select option:not(:checked)::checkmark):
(select optgroup legend):
(hr, bdi, legend, output):
(hr, bdi, output): Deleted.
* Source/WebCore/html/HTMLOptGroupElement.cpp:
(WebCore::HTMLOptGroupElement::rendererIsNeeded):
* Source/WebCore/html/HTMLOptGroupElement.h:
* Source/WebCore/html/HTMLOptionElement.cpp:
(WebCore::HTMLOptionElement::rendererIsNeeded):

Canonical link: <a href="https://commits.webkit.org/307848@main">https://commits.webkit.org/307848@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dc29f592fabba9b2f7143febdf6e75b0c8d74a31

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18365 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99323 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ecc08bce-0d96-4d80-8b7b-da2d68aae947) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147558 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18850 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18258 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112038 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e6699a4f-da0f-45ce-99bc-6dd0b28f9a0f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148646 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14413 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130855 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92943 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/983f2512-9a12-4e1f-b279-c6468e564ddf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13718 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11479 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1802 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123265 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7692 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156668 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120041 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18215 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15196 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120393 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128982 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73955 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22468 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16124 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7108 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17836 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81616 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17573 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17781 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17636 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->