### PR TITLE
Remove the support for webkitshadowrootattached event

### DIFF
--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3312,24 +3312,6 @@ void Element::addShadowRoot(Ref<ShadowRoot>&& newShadowRoot)
 
     if (shadowRoot->mode() == ShadowRootMode::UserAgent)
         didAddUserAgentShadowRoot(shadowRoot);
-    else
-        enqueueShadowRootAttachedEvent();
-}
-
-void Element::enqueueShadowRootAttachedEvent()
-{
-    if (hasStateFlag(StateFlag::IsShadowRootAttachedEventPending))
-        return;
-    setStateFlag(StateFlag::IsShadowRootAttachedEventPending);
-    MutationObserver::enqueueShadowRootAttachedEvent(*this);
-}
-
-void Element::dispatchShadowRootAttachedEvent()
-{
-    Ref<Event> event = Event::create(eventNames().webkitshadowrootattachedEvent, Event::CanBubble::Yes, Event::IsCancelable::No, Event::IsComposed::Yes);
-    event->setIsShadowRootAttachedEvent();
-    event->setTarget(Ref { *this });
-    dispatchEvent(event);
 }
 
 void Element::removeShadowRootSlow(ShadowRoot& oldRoot)

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -459,9 +459,6 @@ public:
     bool isInLargestContentfulPaintTextContentSet() const { return hasStateFlag(StateFlag::InLargestContentfulPaintTextContentSet); }
     void setInLargestContentfulPaintTextContentSet() { setStateFlag(StateFlag::InLargestContentfulPaintTextContentSet); }
 
-    void didDispatchShadowRootAttachedEvent() { clearStateFlag(StateFlag::IsShadowRootAttachedEventPending); }
-    void dispatchShadowRootAttachedEvent();
-
     enum class CustomElementRegistryKind : bool { Window, Null };
 
     WEBCORE_EXPORT ExceptionOr<ShadowRoot&> attachShadow(const ShadowRootInit&, std::optional<CustomElementRegistryKind> = std::nullopt);
@@ -1014,8 +1011,6 @@ private:
     SerializedNode serializeNode(CloningOperation) const override;
     void cloneShadowTreeIfPossible(Element& newHost) const;
     virtual Ref<Element> cloneElementWithoutAttributesAndChildren(Document&, CustomElementRegistry*) const;
-
-    void enqueueShadowRootAttachedEvent();
 
     inline void removeShadowRoot(); // Defined in ElementRareData.h.
     void removeShadowRootSlow(ShadowRoot&);

--- a/Source/WebCore/dom/Event.cpp
+++ b/Source/WebCore/dom/Event.cpp
@@ -60,7 +60,6 @@ ALWAYS_INLINE Event::Event(MonotonicTime createTime, enum EventInterfaceType eve
     , m_isExecutingPassiveEventListener { false }
     , m_currentTargetIsInShadowTree { false }
     , m_isAutofillEvent { false }
-    , m_isShadowRootAttachedEvent { false }
     , m_eventPhase { NONE }
     , m_eventInterface(std::to_underlying(eventInterface))
     , m_type { type }

--- a/Source/WebCore/dom/Event.h
+++ b/Source/WebCore/dom/Event.h
@@ -147,9 +147,6 @@ public:
     bool isAutofillEvent() { return m_isAutofillEvent; }
     void setIsAutofillEvent() { m_isAutofillEvent = true; }
 
-    bool isShadowRootAttachedEvent() { return m_isShadowRootAttachedEvent; }
-    void setIsShadowRootAttachedEvent() { m_isShadowRootAttachedEvent = true; }
-
 protected:
     explicit Event(enum EventInterfaceType, IsTrusted = IsTrusted::No);
     Event(enum EventInterfaceType, const AtomString& type, CanBubble, IsCancelable, IsComposed = IsComposed::No);
@@ -179,7 +176,6 @@ private:
     unsigned m_isExecutingPassiveEventListener : 1;
     unsigned m_currentTargetIsInShadowTree : 1;
     unsigned m_isAutofillEvent : 1;
-    unsigned m_isShadowRootAttachedEvent : 1;
 
     unsigned m_eventPhase : 2;
 

--- a/Source/WebCore/dom/EventNames.json
+++ b/Source/WebCore/dom/EventNames.json
@@ -323,7 +323,6 @@
     "webkitplaybacktargetavailabilitychanged": { },
     "webkitpresentationmodechanged": { },
     "webkitremovesourcebuffer": { },
-    "webkitshadowrootattached": { },
     "webkitsourceclose": { },
     "webkitsourceended": { },
     "webkitsourceopen": { },

--- a/Source/WebCore/dom/EventTarget.cpp
+++ b/Source/WebCore/dom/EventTarget.cpp
@@ -377,11 +377,6 @@ void EventTarget::innerInvokeEventListeners(Event& event, EventListenerVector li
                 continue; // webkitrequestautofill only fires in a world with autofill capability.
         }
 
-        if (event.isShadowRootAttachedEvent()) [[unlikely]] {
-            if (!worldForDOMObject(*callback->jsFunction()).canAccessAnyShadowRoot())
-                continue; // webkitshadowrootattached only fires in a world with access to all shadow roots.
-        }
-
         // Do this before invocation to avoid reentrancy issues.
         if (registeredListener->isOnce())
             removeEventListener(event.type(), callback, { .capture = registeredListener->useCapture() });

--- a/Source/WebCore/dom/MutationObserver.cpp
+++ b/Source/WebCore/dom/MutationObserver.cpp
@@ -164,17 +164,6 @@ void MutationObserver::enqueueSlotChangeEvent(HTMLSlotElement& slot)
     eventLoop->queueMutationObserverCompoundMicrotask();
 }
 
-void MutationObserver::enqueueShadowRootAttachedEvent(Element& element)
-{
-    ASSERT(isMainThread());
-    Ref eventLoop = element.document().windowEventLoop();
-    auto& list = eventLoop->shadowRootAttachedElements();
-    ASSERT(list.findIf([&element](auto& entry) { return entry.ptr() == &element; }) == notFound);
-    list.append(element);
-
-    eventLoop->queueMutationObserverCompoundMicrotask();
-}
-
 void MutationObserver::setHasTransientRegistration(Document& document)
 {
     Ref eventLoop = document.windowEventLoop();
@@ -247,7 +236,7 @@ void MutationObserver::notifyMutationObservers(WindowEventLoop& eventLoop)
         }
     }
 
-    while (!eventLoop.activeMutationObservers().isEmpty() || !eventLoop.signalSlotList().isEmpty() || !eventLoop.shadowRootAttachedElements().isEmpty()) {
+    while (!eventLoop.activeMutationObservers().isEmpty() || !eventLoop.signalSlotList().isEmpty()) {
         // 2. Let notify list be a copy of unit of related similar-origin browsing contexts' list of MutationObserver objects.
         auto notifyList = copyToVector(eventLoop.activeMutationObservers());
         eventLoop.activeMutationObservers().clear();
@@ -264,10 +253,6 @@ void MutationObserver::notifyMutationObservers(WindowEventLoop& eventLoop)
                 slot->didRemoveFromSignalSlotList();
         }
 
-        Vector<GCReachableRef<Element>> shadowRootAttachedElements = std::exchange(eventLoop.shadowRootAttachedElements(), { });
-        for (auto& element : shadowRootAttachedElements)
-            element->didDispatchShadowRootAttachedEvent();
-
         // 5. For each MutationObserver object mo in notify list, execute a compound microtask subtask
         for (auto& observer : notifyList) {
             if (observer->canDeliver())
@@ -279,9 +264,6 @@ void MutationObserver::notifyMutationObservers(WindowEventLoop& eventLoop)
         // 6. For each slot slot in signalList, in order, fire an event named slotchange, with its bubbles attribute set to true, at slot.
         for (auto& slot : slotList)
             slot->dispatchSlotChangeEvent();
-
-        for (auto& element : shadowRootAttachedElements)
-            element->dispatchShadowRootAttachedEvent();
     }
 }
 

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -91,7 +91,6 @@ public:
     MutationCallback& callback() const { return m_callback.get(); }
 
     static void enqueueSlotChangeEvent(HTMLSlotElement&);
-    static void enqueueShadowRootAttachedEvent(Element&);
 
     static void notifyMutationObservers(WindowEventLoop&);
 

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -677,12 +677,11 @@ protected:
 #if ENABLE(FULLSCREEN_API)
         IsFullscreen = 1 << 19,
 #endif
-        IsShadowRootAttachedEventPending = 1 << 20,
-        InLargestContentfulPaintTextContentSet = 1 << 21,
-        DidMutateSubtreeAfterSetInnerHTML = 1 << 22,
-        WasParsedWithFastPath = 1 << 23,
-        HasShadowRoot = 1 << 24
-        // 7 bits free.
+        InLargestContentfulPaintTextContentSet = 1 << 20,
+        DidMutateSubtreeAfterSetInnerHTML = 1 << 21,
+        WasParsedWithFastPath = 1 << 22,
+        HasShadowRoot = 1 << 23,
+        // 8 bits free.
     };
 
     enum class TabIndexState : uint8_t {

--- a/Source/WebCore/dom/WindowEventLoop.h
+++ b/Source/WebCore/dom/WindowEventLoop.h
@@ -54,7 +54,6 @@ public:
 
     void queueMutationObserverCompoundMicrotask();
     Vector<GCReachableRef<HTMLSlotElement>>& signalSlotList() { return m_signalSlotList; }
-    Vector<GCReachableRef<Element>>& shadowRootAttachedElements() { return m_shadowRootAttachedElementList; }
     HashSet<Ref<MutationObserver>>& activeMutationObservers() { return m_activeObservers; }
     HashSet<Ref<MutationObserver>>& suspendedMutationObservers() { return m_suspendedObservers; }
 
@@ -96,7 +95,6 @@ private:
     bool m_mutationObserverCompoundMicrotaskQueuedFlag { false };
     bool m_deliveringMutationRecords { false }; // FIXME: This flag doesn't exist in the spec.
     Vector<GCReachableRef<HTMLSlotElement>> m_signalSlotList; // https://dom.spec.whatwg.org/#signal-slot-list
-    Vector<GCReachableRef<Element>> m_shadowRootAttachedElementList;
     HashSet<Ref<MutationObserver>> m_activeObservers;
     HashSet<Ref<MutationObserver>> m_suspendedObservers;
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm
@@ -1401,23 +1401,6 @@ TEST(WKUserContentController, BeforeBlurEvent)
     EXPECT_WK_STREQ([webView _test_waitForAlert], "blur-pass");
 }
 
-TEST(WKUserContentController, ShadowRootAttachedEvent)
-{
-    RetainPtr webView = adoptNS([TestWKWebView new]);
-    RetainPtr configuration = adoptNS([WKContentWorldConfiguration new]);
-    configuration.get().openClosedShadowRootsEnabled = YES;
-    RetainPtr shadowRootWorld = [WKContentWorld worldWithConfiguration:configuration.get()];
-    NSString *pageWorldJS = @"window.addEventListener('webkitshadowrootattached', () => alert('fail') ); onload = () => { setTimeout(() => alert('fail'), 100); }";
-    NSString *shadowRootWorldJS = @"window.addEventListener('webkitshadowrootattached', (e) => { setTimeout(() => alert('pass ' + e.target.localName), 50)})";
-    RetainPtr pageWorldScript = adoptNS([[WKUserScript alloc] initWithSource:pageWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES]);
-    RetainPtr shadowRootScript = adoptNS([[WKUserScript alloc] initWithSource:shadowRootWorldJS injectionTime:WKUserScriptInjectionTimeAtDocumentStart forMainFrameOnly:YES inContentWorld:shadowRootWorld.get()]);
-    RetainPtr<WKUserContentController> userContentController = [webView configuration].userContentController;
-    [userContentController addUserScript:pageWorldScript.get()];
-    [userContentController addUserScript:shadowRootScript.get()];
-    [webView loadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"closed-shadow-tree-test" withExtension:@"html"]]];
-    EXPECT_WK_STREQ([webView _test_waitForAlert], "pass shadow-host");
-}
-
 #if WK_HAVE_C_SPI
 
 TEST(WKUserContentController, DisableAutofillSpellcheck)


### PR DESCRIPTION
#### 20485662bb03f2f299223e7bde2dcc7aa1f01923
<pre>
Remove the support for webkitshadowrootattached event
<a href="https://bugs.webkit.org/show_bug.cgi?id=308111">https://bugs.webkit.org/show_bug.cgi?id=308111</a>

Reviewed by Anne van Kesteren.

Removed the code for this failed experiment.

No new tests but removed the existing WKUserContentController.ShadowRootAttachedEvent.

* Source/WebCore/dom/Element.cpp:
(WebCore::Element::addShadowRoot):
(WebCore::Element::enqueueShadowRootAttachedEvent): Deleted.
(WebCore::Element::dispatchShadowRootAttachedEvent): Deleted.
* Source/WebCore/dom/Element.h:
(WebCore::Element::didDispatchShadowRootAttachedEvent): Deleted.
* Source/WebCore/dom/Event.cpp:
* Source/WebCore/dom/Event.h:
(WebCore::Event::isShadowRootAttachedEvent): Deleted.
(WebCore::Event::setIsShadowRootAttachedEvent): Deleted.
* Source/WebCore/dom/EventNames.json:
* Source/WebCore/dom/EventTarget.cpp:
(WebCore::EventTarget::innerInvokeEventListeners):
* Source/WebCore/dom/MutationObserver.cpp:
(WebCore::MutationObserver::notifyMutationObservers):
(WebCore::MutationObserver::enqueueShadowRootAttachedEvent): Deleted.
* Source/WebCore/dom/MutationObserver.h:
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/WindowEventLoop.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/UserContentController.mm:
(TEST(WKUserContentController, ShadowRootAttachedEvent)): Deleted.

Canonical link: <a href="https://commits.webkit.org/307750@main">https://commits.webkit.org/307750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4608e9bc57b5b9868b7aa0cfa31fb55e93d327fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9857 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154042 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8832ad2b-8e5f-42aa-92cb-41eb5b43a307) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147245 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18536 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17945 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111787 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/36a67ac8-7243-49c1-bc80-3041419c2032) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148333 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14151 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92688 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13492 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11254 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1488 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123025 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156354 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17902 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8448 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119791 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17948 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14940 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120131 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15888 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128617 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73601 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22422 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17523 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6850 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17468 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->