### PR TITLE
REGRESSION(302480@main): GRID Legends: Failed to switch the language to Simplified Chinese and Traditional Chinese)

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3468,6 +3468,21 @@ HTMLEnhancedSelectParsingEnabled:
      WebCore:
        default: true
 
+HTMLEnhancedSelectParsingQuirkEnabled:
+  type: bool
+  status: internal
+  category: dom
+  humanReadableName: "Enhanced HTML select element parsing quirk"
+  humanReadableDescription: "Enable enhanced HTML select element parsing quirk for specific applications"
+  defaultValue:
+    WebKitLegacy:
+      PLATFORM(MAC): WebKit::defaultHTMLEnhancedSelectParsingQuirkEnabled()
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 HTTPEquivEnabled:
   type: bool
   status: mature

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -134,6 +134,7 @@ enum class SDKAlignedBehavior {
     GetBoundingClientRectZoomed,
     CrashWhenMutatingProcessAssertionsFromBackgroundThread,
     NoFontFaceSetConstructor,
+    NoHTMLEnhancedSelectParsingQuirk,
 
     NumberOfBehaviors
 };
@@ -186,6 +187,7 @@ WTF_EXPORT_PRIVATE bool isHRBlock();
 WTF_EXPORT_PRIVATE bool isTurboTax();
 WTF_EXPORT_PRIVATE bool isEpsonSoftwareUpdater();
 WTF_EXPORT_PRIVATE bool isMimeoPhotoProject();
+WTF_EXPORT_PRIVATE bool isGridLegends();
 
 } // MacApplication
 

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -506,6 +506,12 @@ bool MacApplication::isMimeoPhotoProject()
     return isMimeoPhotoProject;
 }
 
+bool MacApplication::isGridLegends()
+{
+    static bool isGridLegends = applicationBundleIsEqualTo("com.feralinteractive.gridlegends"_s);
+    return isGridLegends;
+}
+
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/html/parser/HTMLParserOptions.cpp
+++ b/Source/WebCore/html/parser/HTMLParserOptions.cpp
@@ -37,6 +37,7 @@ HTMLParserOptions::HTMLParserOptions()
     : scriptingFlag(false)
     , usePreHTML5ParserQuirks(false)
     , enhancedSelect(false)
+    , enhancedSelectQuirk(false)
     , maximumDOMTreeDepth(Settings::defaultMaximumHTMLParserDOMTreeDepth)
 {
 }
@@ -51,6 +52,7 @@ HTMLParserOptions::HTMLParserOptions(Document& document)
 
     usePreHTML5ParserQuirks = document.settings().usePreHTML5ParserQuirks();
     enhancedSelect = document.settings().htmlEnhancedSelectParsingEnabled();
+    enhancedSelectQuirk = document.settings().htmlEnhancedSelectParsingQuirkEnabled();
     maximumDOMTreeDepth = document.settings().maximumHTMLParserDOMTreeDepth();
 }
 

--- a/Source/WebCore/html/parser/HTMLParserOptions.h
+++ b/Source/WebCore/html/parser/HTMLParserOptions.h
@@ -38,6 +38,7 @@ public:
     bool scriptingFlag;
     bool usePreHTML5ParserQuirks;
     bool enhancedSelect;
+    bool enhancedSelectQuirk;
     unsigned maximumDOMTreeDepth;
 };
 

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -641,6 +641,11 @@ void HTMLTreeBuilder::processStartTagForInBody(AtomHTMLToken&& token)
     case TagName::noframes:
     case TagName::script:
     case TagName::style:
+        if (m_options.enhancedSelectQuirk && m_tree.openElements().inScope(HTML::select)) {
+            parseError(token);
+            return;
+        }
+        [[fallthrough]];
     case TagName::title: {
         bool didProcess = processStartTagForInHead(WTF::move(token));
         ASSERT_UNUSED(didProcess, didProcess);

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.h
@@ -55,6 +55,7 @@ bool defaultScrollAnimatorEnabled();
 bool defaultTreatsAnyTextCSSLinkAsStylesheet();
 bool defaultNeedsFrameNameFallbackToIdQuirk();
 bool defaultNeedsKeyboardEventDisambiguationQuirks();
+bool defaultHTMLEnhancedSelectParsingQuirkEnabled();
 #endif
 
 bool defaultMutationEventsEnabled();

--- a/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebPreferencesDefaultValues.mm
@@ -154,6 +154,11 @@ bool defaultNeedsKeyboardEventDisambiguationQuirks()
     return needsQuirks;
 }
 
+bool defaultHTMLEnhancedSelectParsingQuirkEnabled()
+{
+    return WTF::MacApplication::isGridLegends() && !linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::NoHTMLEnhancedSelectParsingQuirk);
+}
+
 #endif // PLATFORM(MAC)
 
 bool defaultFontFaceSetConstructorEnabled()


### PR DESCRIPTION
#### 0ffaa9a71e2d4e0180930b78cbd593dc1358dc1c
<pre>
REGRESSION(302480@main): GRID Legends: Failed to switch the language to Simplified Chinese and Traditional Chinese)
<a href="https://bugs.webkit.org/show_bug.cgi?id=307647">https://bugs.webkit.org/show_bug.cgi?id=307647</a>
<a href="https://rdar.apple.com/170187680">rdar://170187680</a>

Reviewed by Ryosuke Niwa.

Through local inspection it appears that the app depends on &lt;style&gt;
start tags getting dropped as was the case before we introduced
enhanced &lt;select&gt; parsing. So we selectively restore that behavior for
this app and do it in such a way that we can remove the quirk in the
future once the app is updated.

Manually verified.

Canonical link: <a href="https://commits.webkit.org/307768@main">https://commits.webkit.org/307768@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/078b80ac0ed96c3ec48ac81330041c0ea085aaf8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145397 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9887 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154069 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99034 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ada5886-5c54-4ed2-8690-5b6648434273) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147272 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18563 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17972 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111810 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80128 "1 flakes 1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dea1ac47-1222-4266-b277-f9f66e99cf44) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148360 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92711 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66e59f5d-6f98-4d51-a8f4-0117df44718f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13518 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11278 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1515 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137388 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123051 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7384 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156381 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6206 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17929 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8478 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119817 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14965 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120157 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15913 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128647 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73628 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22430 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17550 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6879 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176687 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17287 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81329 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45422 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17495 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17350 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->