### PR TITLE
REGRESSION (Safari 26): MediaRecorder emits empty Blobs for small timeslice values

### DIFF
--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html
@@ -53,7 +53,7 @@
     }
 
     function maybeStartPlayback() {
-        if (canPlayReceived && player.duration > 1 && !playbackStarted) {
+        if (canPlayReceived && player.duration > 0.6 && !playbackStarted) {
             playbackStarted = true;
             player.play();
         }
@@ -83,14 +83,19 @@
             assert_true(blobEvent.data.size > 0, 'the blob should contain some buffers');
             blobData = new Blob([blobData, blobEvent.data]);
 
-            if (blobEvent.timecode == 0)
+            if (blobEvent.timecode < 0.5)
                 return;
-            if (blobEvent.timecode >= 0.2 && paintingState == 0) {
+
+            if (blobEvent.timecode >= 0.5 && paintingState == 0) {
                 paintingState = 1;
                 doGreenImageDraw();
                 return;
             }
-            assert_greater_than(blobEvent.timecode, .4, "more than .4s recorded");
+
+            if (blobEvent.timecode < 1)
+                return;
+
+            assert_greater_than(blobEvent.timecode, 1, "more than 1s recorded");
             if (++paintingState == 2) {
                 recorder.stop();
                 ac.close();
@@ -110,7 +115,7 @@
             });
             player.onplay = () => {
                 player.pause();
-                assert_greater_than(player.duration, .4, 'the duration should be greater than .4s')
+                assert_greater_than(player.duration, 1, 'the duration should be greater than .6s')
                 player.currentTime = player.duration - 0.05;
             };
             player.onseeked = t.step_func(() => {

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-start-timeSlice-small-expected.txt
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-start-timeSlice-small-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Make sure that all ondataavailable callbacks contain non-empty blobs
+PASS Make sure that all ondataavailable callbacks with audio MP4 contain non-empty blobs
+

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-start-timeSlice-small.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-start-timeSlice-small.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<html>
+<head>
+    <title>MediaRecorder start timeSlice option</title>
+    <link rel="help" href="https://w3c.github.io/mediacapture-record/MediaRecorder.html#mediarecorder">
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+<canvas id="canvas" width="200" height="200">
+</canvas>
+<script>
+    promise_test(async t => {
+        const audio = await navigator.mediaDevices.getUserMedia({ audio : true });
+        t.add_cleanup(() => audio.getTracks().forEach(track => track.stop()));
+        const recorder = new MediaRecorder(audio, { mimeType: 'audio/webm; codecs=opus' });
+
+        const dataAvailableEvents = [];
+        const expectedCallbackCount = 3;
+        
+        let dataAvailablePromise = new Promise(resolve => {
+            recorder.ondataavailable = event => {
+                dataAvailableEvents.push(event);
+                if (dataAvailableEvents.length >= expectedCallbackCount) {
+                    resolve();
+                }
+            };
+        });
+
+        recorder.start(50);
+        await dataAvailablePromise;
+        recorder.stop();
+
+        // Verify all ondataavailable callbacks received non-empty blobs
+        assert_equals(dataAvailableEvents.length, expectedCallbackCount, 'Should receive expected number of ondataavailable events');
+        for (let i = 0; i < dataAvailableEvents.length; i++) {
+            assert_true(dataAvailableEvents[i].data instanceof Blob, `Event ${i} data should be a Blob`);
+            assert_greater_than(dataAvailableEvents[i].data.size, 0, `Event ${i} blob should not be empty`);
+        }
+    }, 'Make sure that all ondataavailable callbacks contain non-empty blobs');
+
+    promise_test(async t => {
+        const audio = await navigator.mediaDevices.getUserMedia({ audio : true });
+        t.add_cleanup(() => audio.getTracks().forEach(track => track.stop()));
+        const recorder = new MediaRecorder(audio, { mimeType: 'audio/mp4' });
+
+        const dataAvailableEvents = [];
+        const expectedCallbackCount = 3;
+        
+        let dataAvailablePromise = new Promise(resolve => {
+            recorder.ondataavailable = event => {
+                dataAvailableEvents.push(event);
+                if (dataAvailableEvents.length >= expectedCallbackCount) {
+                    resolve();
+                }
+            };
+        });
+
+        recorder.start(50);
+        await dataAvailablePromise;
+        recorder.stop();
+
+        // Verify all ondataavailable callbacks received non-empty blobs
+        assert_equals(dataAvailableEvents.length, expectedCallbackCount, 'Should receive expected number of ondataavailable events');
+        for (let i = 0; i < dataAvailableEvents.length; i++) {
+            assert_true(dataAvailableEvents[i].data instanceof Blob, `Event ${i} data should be a Blob`);
+            assert_greater_than(dataAvailableEvents[i].data.size, 0, `Event ${i} blob should not be empty`);
+        }
+    }, 'Make sure that all ondataavailable callbacks with audio MP4 contain non-empty blobs');
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html
+++ b/LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html
@@ -53,7 +53,7 @@
     }
 
     function maybeStartPlayback() {
-        if (canPlayReceived && player.duration > 1 && !playbackStarted) {
+        if (canPlayReceived && player.duration > 0.6 && !playbackStarted) {
             playbackStarted = true;
             player.play();
         }
@@ -83,14 +83,18 @@
             assert_true(blobEvent.data.size > 0, 'the blob should contain some buffers');
             blobData = new Blob([blobData, blobEvent.data]);
 
-            if (blobEvent.timecode == 0)
+            if (blobEvent.timecode < 0.2)
                 return;
+
             if (blobEvent.timecode >= 0.2 && paintingState == 0) {
                 paintingState = 1;
                 doGreenImageDraw();
                 return;
             }
-            assert_greater_than(blobEvent.timecode, .4, "more than .4s recorded");
+            if (blobEvent.timecode < 0.6)
+                return;
+
+            assert_greater_than(blobEvent.timecode, .6, "more than .6s recorded");
             if (++paintingState == 2) {
                 recorder.stop();
                 ac.close();
@@ -110,7 +114,7 @@
             });
             player.onplay = () => {
                 player.pause();
-                assert_greater_than(player.duration, .4, 'the duration should be greater than .4s')
+                assert_greater_than(player.duration, .6, 'the duration should be greater than .6s')
                 player.currentTime = player.duration - 0.05;
             };
             player.onseeked = t.step_func(() => {

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1755,6 +1755,9 @@ webkit.org/b/227910 imported/w3c/web-platform-tests/webrtc/RTCDtlsTransport-stat
 # rdar://80345578 ([ Mac iOS Debug ] imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sub-sample-buffer-stitching.html is flaky crashing)
 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audiobuffersourcenode-interface/sub-sample-buffer-stitching.html [ Pass Failure Crash ]
 
+# On machines with no integrated graphic, the h264 encoder is too slow for this test.
+webkit.org/b/308588 [ x86_64 ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html [ Skip ]
+
 webkit.org/b/225804 imported/w3c/web-platform-tests/webxr/xrBoundedReferenceSpace_updates.https.html [ Pass Failure ]
 
 webkit.org/b/225882 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-audioworklet-interface/audioworkletprocessor-process-frozen-array.https.html [ Pass Failure ]

--- a/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
+++ b/Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h
@@ -63,6 +63,7 @@ public:
     WEBCORE_EXPORT MediaRecorderPrivateWriter();
     WEBCORE_EXPORT virtual ~MediaRecorderPrivateWriter();
 
+    virtual bool segmentsMustStartWithKeyframe() const = 0;
     virtual std::optional<uint8_t> addAudioTrack(const AudioInfo&) = 0;
     virtual std::optional<uint8_t> addVideoTrack(const VideoInfo&, const std::optional<CGAffineTransform>&) = 0;
     virtual bool allTracksAdded() = 0;
@@ -78,6 +79,7 @@ private:
     virtual Ref<GenericPromise> close(Deque<UniqueRef<MediaSamplesBlock>>&&, const MediaTime&) = 0;
     Deque<UniqueRef<MediaSamplesBlock>> m_pendingFrames;
     MediaTime m_lastEndTime { MediaTime::invalidTime() };
+    MediaTime m_lastSegmentEndTime { MediaTime::zeroTime() };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h
@@ -46,6 +46,7 @@ public:
 private:
     MediaRecorderPrivateWriterAVFObjC(RetainPtr<AVAssetWriter>&&, MediaRecorderPrivateWriterListener&);
 
+    bool segmentsMustStartWithKeyframe() const final { return true; }
     std::optional<uint8_t> addAudioTrack(const AudioInfo&) final;
     std::optional<uint8_t> addVideoTrack(const VideoInfo&, const std::optional<CGAffineTransform>&) final;
     bool allTracksAdded() final;

--- a/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
+++ b/Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h
@@ -43,6 +43,7 @@ public:
 private:
     MediaRecorderPrivateWriterWebM(MediaRecorderPrivateWriterListener&);
 
+    bool segmentsMustStartWithKeyframe() const final { return false; }
     std::optional<uint8_t> addAudioTrack(const AudioInfo&) final;
     std::optional<uint8_t> addVideoTrack(const VideoInfo&, const std::optional<CGAffineTransform>&) final;
     bool allTracksAdded() final { return true; }


### PR DESCRIPTION
#### a18b470687811b29dc54c960dd2d1ef0b0680555
<pre>
REGRESSION (Safari 26): MediaRecorder emits empty Blobs for small timeslice values
<a href="https://bugs.webkit.org/show_bug.cgi?id=301507">https://bugs.webkit.org/show_bug.cgi?id=301507</a>
<a href="https://rdar.apple.com/163489898">rdar://163489898</a>

Reviewed by Jer Noble.

The MediaRecorderPrivateWriter would ensure that a generated segment is always
at least one second long.
This decision was made due to two requirements:
1- a call to MediaRecorder&apos;s requestData always generate a valid segment and the complete
   media generated is playable.
2- AVAssetWriter requires all segments to start with a keyframe and can&apos;t generate partial progressive segments.

It wasn&apos;t reasonable to allow very small segments that would ultimately only
be made of video keyframes, so a minimum output of 1s was chosen.

The webm recorder due to the nature of webm (no sample table) allows to output
content progressively, with each frames gathered so far.
As MP4 requires a samples table to be produced at the start of the segment,
that segment must be finalized first before being output.

We now separate the behaviour between the WebM recorder and the mp4 one.
The WebM writer will now generate 10s long media segments, and will return
partial content whenever requestData() is called (including when the slicing interval has been reached).

The MP4 writer, when recording only audio, will generate a new media segment
with all the samples collected since the last request.
When recording contains video, the old behaviour of only ever generating
segment with a minimum length of 1s is retained.

Test: http/wpt/mediarecorder/MediaRecorder-start-timeSlice-small.html

* LayoutTests/http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html: Test would have only worked earlier as dataavailable would have been called after 1s of data only. Amend
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-start-timeSlice-small-expected.txt: Added.
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-start-timeSlice-small.html: Added.
* LayoutTests/http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html: Test would have only worked earlier as dataavailable would have been called after 1s of data only. Amend
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.cpp:
(WebCore::MediaRecorderPrivateEncoder::audioSamplesAvailable):
(WebCore::MediaRecorderPrivateEncoder::appendVideoFrame):
(WebCore::MediaRecorderPrivateEncoder::segmentsMustStartWithVideoKeyframe const):
(WebCore::MediaRecorderPrivateEncoder::enqueueCompressedAudioSampleBuffers):
(WebCore::MediaRecorderPrivateEncoder::encodePendingVideoFrames):
(WebCore::MediaRecorderPrivateEncoder::processVideoEncoderActiveConfiguration):
(WebCore::MediaRecorderPrivateEncoder::flushToEndSegment):
(WebCore::MediaRecorderPrivateEncoder::interleaveAndEnqueueNextFrame):
(WebCore::MediaRecorderPrivateEncoder::flushPendingData):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateEncoder.h:
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.cpp:
(WebCore::MediaRecorderPrivateWriter::writeFrames):
* Source/WebCore/platform/mediarecorder/MediaRecorderPrivateWriter.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterAVFObjC.h:
* Source/WebCore/platform/mediarecorder/cocoa/MediaRecorderPrivateWriterWebM.h:

Canonical link: <a href="https://commits.webkit.org/308266@main">https://commits.webkit.org/308266@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24c7ce8b988fb4662eb66fdcef500ddf45389339

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19534 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155536 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100242 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d39cfb2c-fee9-44c3-80ef-eb776d9f0116) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148728 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19435 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113160 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80771 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149816 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93914 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10958744-c51b-4822-a19b-ebc99745c44e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14633 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12414 "Found 2 new API test failures: TestWebKitAPI.CSSViewportUnits.MaximumViewportInsetWithZoom, TestWebKitAPI.WebKit.PreferenceChanges (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2978 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9877 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157867 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/998 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11317 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121179 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16243 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121381 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31117 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19345 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131633 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75196 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16973 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8486 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18951 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82706 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18681 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18832 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->