### PR TITLE
ANGLE: Fix static_assert messages in GetPrimitiveRestartIndexFromType

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/utilities.h
+++ b/Source/ThirdParty/ANGLE/src/common/utilities.h
@@ -101,9 +101,9 @@ constexpr T GetPrimitiveRestartIndexFromType()
 static_assert(GetPrimitiveRestartIndexFromType<uint8_t>() == 0xFF,
               "verify restart index for uint8_t values");
 static_assert(GetPrimitiveRestartIndexFromType<uint16_t>() == 0xFFFF,
-              "verify restart index for uint8_t values");
+              "verify restart index for uint16_t values");
 static_assert(GetPrimitiveRestartIndexFromType<uint32_t>() == 0xFFFFFFFF,
-              "verify restart index for uint8_t values");
+              "verify restart index for uint32_t values");
 
 bool IsTriangleMode(PrimitiveMode drawMode);
 bool IsPolygonMode(PrimitiveMode mode);


### PR DESCRIPTION
#### be31fb4e83c7abdc3c950af29c8ee02f5ac25071
<pre>
ANGLE: Fix static_assert messages in GetPrimitiveRestartIndexFromType
<a href="https://bugs.webkit.org/show_bug.cgi?id=308117">https://bugs.webkit.org/show_bug.cgi?id=308117</a>
<a href="https://rdar.apple.com/170618813">rdar://170618813</a>

Reviewed by Mike Wyrzykowski.

The static_assert messages for uint16_t and uint32_t incorrectly say
&quot;verify restart index for uint8_t values&quot;.  Fix the messages to
reference the correct types.

No new tests since no change in behavior.

* Source/ThirdParty/ANGLE/src/common/utilities.h:

Canonical link: <a href="https://commits.webkit.org/307772@main">https://commits.webkit.org/307772@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7567acfeda9fe510a80be3e140564538207963f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18063 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154053 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99018 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe43d3c0-3315-43c8-a2a5-b3e7dcb50633) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18547 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17956 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111794 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80117 "Exiting early after 60 failures. 15361 tests run. 60 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148344 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92695 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/785a8f41-b253-4fdc-b1eb-f9b4dc4138a3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13500 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11262 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1499 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156365 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17913 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119801 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14949 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120141 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30819 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15893 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128629 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73612 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17534 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6861 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17271 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17479 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17334 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->