### PR TITLE
[GTK][WPE] LayerTreeHost should use WeakRef for WebPage member instead of a reference

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -128,7 +128,7 @@ AcceleratedSurface::AcceleratedSurface(WebPage& webPage, Function<void()>&& fram
 
 #if (PLATFORM(GTK) || ENABLE(WPE_PLATFORM)) && (USE(GBM) || OS(ANDROID))
     if (m_swapChain.type() == SwapChain::Type::EGLImage)
-        m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), isColorOpaque(m_backgroundColor));
+        m_swapChain.setupBufferFormat(webPage.preferredBufferFormats(), isColorOpaque(m_backgroundColor));
 #endif
 #if USE(WPE_RENDERER)
     if (m_swapChain.type() == SwapChain::Type::WPEBackend)
@@ -973,7 +973,7 @@ void AcceleratedSurface::preferredBufferFormatsDidChange()
     if (m_swapChain.type() != SwapChain::Type::EGLImage)
         return;
 
-    m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), isColorOpaque(m_backgroundColor));
+    m_swapChain.setupBufferFormat(protect(m_webPage)->preferredBufferFormats(), isColorOpaque(m_backgroundColor));
 }
 #endif
 
@@ -997,7 +997,8 @@ void AcceleratedSurface::visibilityDidChange(bool isVisible)
 void AcceleratedSurface::backgroundColorDidChange()
 {
     ASSERT(RunLoop::isMain());
-    const auto& color = m_webPage->backgroundColor();
+    Ref webPage = m_webPage;
+    const auto& color = webPage->backgroundColor();
 
     bool wasOpaque = isColorOpaque(m_backgroundColor);
     m_backgroundColor = color ? color->toResolvedColorComponentsInColorSpace(WebCore::ColorSpace::SRGB) : white;
@@ -1008,7 +1009,7 @@ void AcceleratedSurface::backgroundColorDidChange()
 
 #if (PLATFORM(GTK) || ENABLE(WPE_PLATFORM)) && (USE(GBM) || OS(ANDROID))
     if (m_swapChain.type() == SwapChain::Type::EGLImage)
-        m_swapChain.setupBufferFormat(m_webPage->preferredBufferFormats(), isOpaque);
+        m_swapChain.setupBufferFormat(webPage->preferredBufferFormats(), isOpaque);
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -413,7 +413,7 @@ private:
 
     static constexpr ColorComponents white { 1.f, 1.f, 1.f, WebCore::AlphaTraits<float>::opaque };
 
-    WeakRef<WebPage> m_webPage;
+    const WeakRef<WebPage> m_webPage;
     Function<void()> m_frameCompleteHandler;
     uint64_t m_id { 0 };
     WebCore::IntSize m_size;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp
@@ -49,8 +49,6 @@
 
 #if PLATFORM(PLAYSTATION)
 #include "LayerTreeHostPlayStation.h"
-#else
-#include "LayerTreeHost.h"
 #endif
 
 #if USE(GLIB_EVENT_LOOP)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
@@ -102,8 +102,7 @@ void NonCompositedFrameRenderer::addDirtyRect(const IntRect& rect)
 
 void NonCompositedFrameRenderer::setNeedsDisplay()
 {
-    Ref webPage = m_webPage.get();
-    auto dirtyRect = webPage->bounds();
+    auto dirtyRect = m_webPage->bounds();
     if (dirtyRect.isEmpty())
         return;
 
@@ -113,9 +112,8 @@ void NonCompositedFrameRenderer::setNeedsDisplay()
 
 void NonCompositedFrameRenderer::setNeedsDisplayInRect(const IntRect& rect)
 {
-    Ref webPage = m_webPage.get();
     auto dirtyRect = rect;
-    dirtyRect.intersect(webPage->bounds());
+    dirtyRect.intersect(m_webPage->bounds());
     if (dirtyRect.isEmpty())
         return;
 
@@ -126,21 +124,20 @@ void NonCompositedFrameRenderer::setNeedsDisplayInRect(const IntRect& rect)
 #if ENABLE(DAMAGE_TRACKING)
 void NonCompositedFrameRenderer::resetFrameDamage()
 {
-    Ref webPage = m_webPage.get();
-    auto scaledRect = webPage->bounds();
-    scaledRect.scale(webPage->deviceScaleFactor());
+    auto scaledRect = m_webPage->bounds();
+    scaledRect.scale(m_webPage->deviceScaleFactor());
     if (!m_context) {
         // For CPU rendering use the damage unconditionally to reduce the amount of pixels to upload to the GPU for the UI process.
         m_frameDamage = std::make_optional<Damage>(scaledRect, Damage::Mode::Rectangles, 4);
         return;
     }
 
-    if (!webPage->corePage()->settings().propagateDamagingInformation()) {
+    if (!m_webPage->corePage()->settings().propagateDamagingInformation()) {
         m_frameDamage = std::nullopt;
         return;
     }
 
-    m_frameDamage = std::make_optional<Damage>(scaledRect, webPage->corePage()->settings().unifyDamagedRegions() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, 4);
+    m_frameDamage = std::make_optional<Damage>(scaledRect, m_webPage->corePage()->settings().unifyDamagedRegions() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, 4);
 }
 #endif
 
@@ -187,7 +184,7 @@ void NonCompositedFrameRenderer::updateRendering()
 
     WTFBeginSignpost(this, NonCompositedRenderingUpdate);
 
-    Ref webPage = m_webPage.get();
+    Ref webPage = m_webPage;
     webPage->updateRendering();
     webPage->finalizeRenderingUpdate({ });
     webPage->flushPendingEditorStateUpdate();
@@ -323,13 +320,13 @@ void NonCompositedFrameRenderer::foreachRegionInDamageHistoryForTesting(Function
 #if PLATFORM(GTK)
 void NonCompositedFrameRenderer::adjustTransientZoom(double scale, FloatPoint, FloatPoint unscrolledOrigin)
 {
-    Ref webPage = m_webPage.get();
+    Ref webPage = m_webPage;
     webPage->scalePage(scale / webPage->viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
 }
 
 void NonCompositedFrameRenderer::commitTransientZoom(double scale, FloatPoint, FloatPoint unscrolledOrigin)
 {
-    Ref webPage = m_webPage.get();
+    Ref webPage = m_webPage;
     webPage->scalePage(scale / webPage->viewScaleFactor(), roundedIntPoint(-unscrolledOrigin));
 }
 #endif

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h
@@ -41,7 +41,7 @@ class NonCompositedFrameRenderer final : public FrameRenderer {
 public:
     static std::unique_ptr<NonCompositedFrameRenderer> create(WebPage&);
 
-    NonCompositedFrameRenderer(WebPage&);
+    explicit NonCompositedFrameRenderer(WebPage&);
     ~NonCompositedFrameRenderer();
 
 private:
@@ -77,7 +77,7 @@ private:
     void commitTransientZoom(double, WebCore::FloatPoint, WebCore::FloatPoint) override;
 #endif
 
-    WeakRef<WebPage> m_webPage;
+    const WeakRef<WebPage> m_webPage;
     Ref<AcceleratedSurface> m_surface;
     std::unique_ptr<WebCore::GLContext> m_context;
     bool m_canRenderNextFrame { true };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -52,6 +52,7 @@ namespace WebKit {
 class AcceleratedSurface;
 class CoordinatedSceneState;
 class LayerTreeHost;
+class WebPage;
 struct RenderProcessInfo;
 
 class ThreadedCompositor : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr<ThreadedCompositor>, public CanMakeThreadSafeCheckedPtr<ThreadedCompositor> {
@@ -59,7 +60,7 @@ class ThreadedCompositor : public ThreadSafeRefCountedAndCanMakeThreadSafeWeakPt
     WTF_MAKE_NONCOPYABLE(ThreadedCompositor);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ThreadedCompositor);
 public:
-    static Ref<ThreadedCompositor> create(LayerTreeHost&);
+    static Ref<ThreadedCompositor> create(WebPage&, LayerTreeHost&, CoordinatedSceneState&);
     virtual ~ThreadedCompositor();
 
     uint64_t surfaceID() const;
@@ -96,7 +97,7 @@ public:
     void fillGLInformation(RenderProcessInfo&&, CompletionHandler<void(RenderProcessInfo&&)>&&);
 
 private:
-    explicit ThreadedCompositor(LayerTreeHost&);
+    ThreadedCompositor(WebPage&, LayerTreeHost&, CoordinatedSceneState&);
 
     void startRenderTimer();
     void stopRenderTimer();


### PR DESCRIPTION
#### 3f7a23f7a999f9b48d30ffedfb6ec708122dd01d
<pre>
[GTK][WPE] LayerTreeHost should use WeakRef for WebPage member instead of a reference
<a href="https://bugs.webkit.org/show_bug.cgi?id=308118">https://bugs.webkit.org/show_bug.cgi?id=308118</a>

Reviewed by Fujii Hironori.

Also protect web page reference in LayerTreeHost and related classes
that also use WeakRef. This patch also changes the ThreadedCompositor
constructor to receive a WebPage and CoordinatedSceneState instead of
taking them from LayerTreeHost.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::AcceleratedSurface):
(WebKit::AcceleratedSurface::preferredBufferFormatsDidChange):
(WebKit::AcceleratedSurface::backgroundColorDidChange):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphics.cpp:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::updatePreferences):
(WebKit::DrawingAreaCoordinatedGraphics::enterAcceleratedCompositingModeIfNeeded):
(WebKit::DrawingAreaCoordinatedGraphics::setDeviceScaleFactor):
(WebKit::DrawingAreaCoordinatedGraphics::updateGeometry):
(WebKit::DrawingAreaCoordinatedGraphics::adjustTransientZoom):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::create):
(WebKit::LayerTreeHost::LayerTreeHost):
(WebKit::LayerTreeHost::scheduleRenderingUpdate):
(WebKit::LayerTreeHost::updateRendering):
(WebKit::LayerTreeHost::updateRenderingWithForcedRepaint):
(WebKit::LayerTreeHost::ensureDrawing):
(WebKit::LayerTreeHost::visibleContentsRect const):
(WebKit::LayerTreeHost::attachLayer):
(WebKit::LayerTreeHost::willRenderFrame):
(WebKit::LayerTreeHost::didRenderFrame):
(WebKit::LayerTreeHost::constrainTransientZoomOrigin const):
(WebKit::LayerTreeHost::layerForTransientZoom const):
(WebKit::LayerTreeHost::commitTransientZoom):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp:
(WebKit::NonCompositedFrameRenderer::setNeedsDisplay):
(WebKit::NonCompositedFrameRenderer::setNeedsDisplayInRect):
(WebKit::NonCompositedFrameRenderer::resetFrameDamage):
(WebKit::NonCompositedFrameRenderer::updateRendering):
(WebKit::NonCompositedFrameRenderer::adjustTransientZoom):
(WebKit::NonCompositedFrameRenderer::commitTransientZoom):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::create):
(WebKit::ThreadedCompositor::ThreadedCompositor):
(WebKit::m_renderTimer):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:

Canonical link: <a href="https://commits.webkit.org/307825@main">https://commits.webkit.org/307825@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/495927cec84a595e94cd9c0081c63c2a85575fe3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145653 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18335 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10215 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154325 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18820 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18228 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112012 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148616 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14382 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130827 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92917 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13692 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11457 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1772 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123237 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156638 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18185 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8761 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120013 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15170 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120365 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16095 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128938 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73923 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22458 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17806 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7078 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17543 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81586 "Built successfully") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17751 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17606 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->