### PR TITLE
Adjust Quirks for hotels.com to remove the flickering

### DIFF
--- a/LayoutTests/fast/css/hotels-animation-quirk-expected.txt
+++ b/LayoutTests/fast/css/hotels-animation-quirk-expected.txt
@@ -1,0 +1,4 @@
+
+PASS hotels.com animation quirk overrides animation:none for the menu container element
+PASS hotels.com animation quirk sets correct animation-delay and animation-duration
+

--- a/LayoutTests/fast/css/hotels-animation-quirk.html
+++ b/LayoutTests/fast/css/hotels-animation-quirk.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<!-- Test for hotels.com animation quirk (https://webkit.org/b/308116)
+     The quirk restores menu-grow-left and menu-fade-in animations for elements
+     matching .uitk-menu-mounted .uitk-menu-container.uitk-menu-container-autoposition.uitk-menu-container-has-intersection-root-el
+     which otherwise receive animation:none from a @supports (-webkit-hyphens:none) block on the real site. -->
+<head>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<style>
+/* Mirrors the relevant hotels.com CSS that this quirk is meant to fix.
+   The real site uses @supports (-webkit-hyphens:none) and (stroke-color:transparent)
+   to set animation:none on Safari, overriding the intended open-menu animations. */
+.uitk-menu-mounted .uitk-menu-container.uitk-menu-container-autoposition.uitk-menu-container-has-intersection-root-el {
+    animation: none;
+}
+</style>
+<body>
+<!-- Minimal DOM structure matching the hotels.com menu, per the quirk's CSS selector -->
+<div class="uitk-menu-mounted">
+    <div id="target" class="uitk-menu-container uitk-menu-container-autoposition uitk-menu-container-has-intersection-root-el"></div>
+</div>
+<script>
+"use strict";
+
+if (window.internals)
+    window.internals.setTopDocumentURLForQuirks("https://www.hotels.com");
+
+test(function() {
+    assert_true(!!window.internals, "This test requires window.internals");
+
+    const target = document.getElementById("target");
+    const animations = getComputedStyle(target).animationName;
+    // Without the quirk, the element would have animationName "none" due to the CSS above.
+    // With the quirk, WebCore overrides the computed style to apply the two named animations.
+    assert_not_equals(animations, "none", "animation:none should be overridden by the quirk");
+    assert_true(animations.includes("menu-grow-left"), "quirk should apply menu-grow-left animation");
+    assert_true(animations.includes("menu-fade-in"), "quirk should apply menu-fade-in animation");
+}, "hotels.com animation quirk overrides animation:none for the menu container element");
+
+test(function() {
+    assert_true(!!window.internals, "This test requires window.internals");
+
+    const target = document.getElementById("target");
+    const style = getComputedStyle(target);
+    // animation-delay: 0s for menu-grow-left, 0.06s for menu-fade-in
+    const delays = style.animationDelay;
+    assert_true(delays.includes("0s") || delays.includes("0.06s"),
+        "quirk should set correct animation delays (0s, 0.06s); got: " + delays);
+    // animation-duration: 0.18s for menu-grow-left, 0.06s for menu-fade-in
+    const durations = style.animationDuration;
+    assert_true(durations.includes("0.18s") || durations.includes("0.06s"),
+        "quirk should set correct animation durations (0.18s, 0.06s); got: " + durations);
+}, "hotels.com animation quirk sets correct animation-delay and animation-duration");
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -1064,7 +1064,9 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
         //     animation-fill-mode: none, forwards;
         //     animation-name: menu-grow-left, menu-fade-in;
         auto menuGrowLeftAnimation = Style::Animation { { ScopedName { "menu-grow-left"_s } } };
+        menuGrowLeftAnimation.setDelay(0_css_s);
         menuGrowLeftAnimation.setDuration(.18_css_s);
+        menuGrowLeftAnimation.setFillMode(AnimationFillMode::None);
 
         auto menuFadeInAnimation = Style::Animation { { ScopedName { "menu-fade-in"_s } } };
         menuFadeInAnimation.setDelay(.06_css_s);
@@ -1072,8 +1074,8 @@ void Adjuster::adjustForSiteSpecificQuirks(RenderStyle& style) const
         menuFadeInAnimation.setFillMode(AnimationFillMode::Forwards);
 
         auto& animations = style.ensureAnimations();
-        animations.append(WTF::move(menuGrowLeftAnimation));
-        animations.append(WTF::move(menuFadeInAnimation));
+        animations = Style::Animations { WTF::move(menuGrowLeftAnimation), WTF::move(menuFadeInAnimation) };
+        animations.prepareForUse();
     }
 
 #if PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 381ad0cbb2cd9e68af23fe758823126c1e765cf7
<pre>
Adjust Quirks for hotels.com to remove the flickering
<a href="https://bugs.webkit.org/show_bug.cgi?id=308116">https://bugs.webkit.org/show_bug.cgi?id=308116</a>
<a href="https://rdar.apple.com/170331800">rdar://170331800</a>

Reviewed by Brandon Stewart, Antoine Quint, and Sam Weinig.

The previous quirk stopped working, but the markup and CSS do not seem
to have changed at all. This is another strategy to make it work. The
flickering doesn&apos;t happen.

* LayoutTests/fast/css/hotels-animation-quirk.html: Added
  Test for making sure any future changes will not break this quirk.

* LayoutTests/fast/css/hotels-animation-quirk-expected.txt: Added.
* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::needsHotelsAnimationQuirk const):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustForSiteSpecificQuirks const):

Canonical link: <a href="https://commits.webkit.org/308678@main">https://commits.webkit.org/308678@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7bca4276478e7501bcb1a20db19c59d1fe56bbc1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148217 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156900 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150090 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20808 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114263 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8559683e-b977-4809-a56b-1149a9df5cc1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16499 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/133087 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95034 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f884757b-473b-4f88-8b4a-872191ddc0f3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4337 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10985 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159233 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2367 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12503 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122296 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20701 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/17391 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122515 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/31658 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132809 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22835 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9551 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20318 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/84103 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/20049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20195 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/20104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->