### PR TITLE
REGRESSION(307236@main): [Tahoe] webanimations/no-scheduling-while-filling-non-accelerated.html is a flaky text failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2483,8 +2483,6 @@ webkit.org/b/306444 [ Release ] imported/w3c/web-platform-tests/editing/other/ty
 webkit.org/b/306444 [ Release ] imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-non-collapsed-selection.tentative.html?target=DesignMode&parent=b [ Pass Failure ]
 webkit.org/b/306444 [ Release ] imported/w3c/web-platform-tests/editing/other/typing-around-link-element-at-non-collapsed-selection.tentative.html?target=DesignMode&child=b [ Pass Failure ]
 
-webkit.org/b/307822 [ Tahoe ] webanimations/no-scheduling-while-filling-non-accelerated.html [ Pass Failure ]
-
 webkit.org/b/307850 media/modern-media-controls/tracks-support/audio-single-track.html [ Pass Timeout ]
 
 webkit.org/b/307886 [ Release arm64 ] js/dom/promise-stack-overflow.html [ Pass Failure ]

--- a/Source/WebCore/animation/AnimationTimeline.cpp
+++ b/Source/WebCore/animation/AnimationTimeline.cpp
@@ -43,6 +43,9 @@ AnimationTimeline::AnimationTimeline(std::optional<WebAnimationTime> duration)
 #endif
 {
     m_duration = duration;
+#if ENABLE(THREADED_ANIMATIONS)
+    m_canBeAccelerated = computeCanBeAccelerated();
+#endif
 }
 
 AnimationTimeline::~AnimationTimeline() = default;

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1947,6 +1947,11 @@ const TimingFunction* KeyframeEffect::timingFunctionForKeyframeAtIndex(size_t in
 
 bool KeyframeEffect::canBeAccelerated() const
 {
+    return canBeAccelerated(AccountForTimelineAccelerationAbility::Yes);
+}
+
+bool KeyframeEffect::canBeAccelerated(AccountForTimelineAccelerationAbility accountForTimelineAccelerationAbility) const
+{
     if (!animation() || !animation()->timeline() || animation()->isSkippedContentAnimation())
         return false;
 
@@ -1975,7 +1980,9 @@ bool KeyframeEffect::canBeAccelerated() const
 
 #if ENABLE(THREADED_ANIMATIONS)
     if (canHaveAcceleratedRepresentation())
-        return !animation()->pending() && animation()->timeline()->canBeAccelerated();
+        return !animation()->pending() && (accountForTimelineAccelerationAbility == AccountForTimelineAccelerationAbility::No || animation()->timeline()->canBeAccelerated());
+#else
+    UNUSED_PARAM(accountForTimelineAccelerationAbility);
 #endif
 
     if (m_isAssociatedWithProgressBasedTimeline)
@@ -3186,7 +3193,8 @@ void KeyframeEffect::scheduleAssociatedAcceleratedEffectStackUpdate(const std::o
 
 void KeyframeEffect::timelineAccelerationAbilityDidChange()
 {
-    scheduleAssociatedAcceleratedEffectStackUpdate();
+    if (canBeAccelerated(AccountForTimelineAccelerationAbility::No))
+        scheduleAssociatedAcceleratedEffectStackUpdate();
 }
 
 Ref<AcceleratedEffect> KeyframeEffect::acceleratedRepresentation(const IntRect& borderBoxRect, const AcceleratedEffectValues& baseValues, OptionSet<AcceleratedEffectProperty>& disallowedProperties)

--- a/Source/WebCore/animation/KeyframeEffect.h
+++ b/Source/WebCore/animation/KeyframeEffect.h
@@ -249,6 +249,9 @@ private:
     void updateIsAssociatedWithProgressBasedTimeline();
     bool isRunningAccountingForSuspension() const;
 
+    enum AccountForTimelineAccelerationAbility : bool { No, Yes };
+    bool canBeAccelerated(AccountForTimelineAccelerationAbility) const;
+
     void abilityToBeAcceleratedDidChange();
     void updateAcceleratedAnimationIfNecessary();
 


### PR DESCRIPTION
#### 7bcd19f3fd56a4d71e90a298fc384d3a72635cde
<pre>
REGRESSION(307236@main): [Tahoe] webanimations/no-scheduling-while-filling-non-accelerated.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=307822">https://bugs.webkit.org/show_bug.cgi?id=307822</a>
<a href="https://rdar.apple.com/170329998">rdar://170329998</a>

Reviewed by Anne van Kesteren.

When a timeline&apos;s ability to be accelerated changes, we unconditionally mark that timeline&apos;s animations&apos; effects
as pending an acceleration update via `KeyframeEffect::timelineAccelerationAbilityDidChange()`. We introduced this
in 303589@main but were too naive. Only effects that can be accelerated should be added. Since timeline acceleration
is a factor when deciding whether an effect can be accelerated, we now add the ability to remove this condition and
use this new ability in `KeyframeEffect::timelineAccelerationAbilityDidChange()`. Now a test that does not involve
accelerated animations such as `webanimations/no-scheduling-while-filling-non-accelerated.html` will no longer have
unexpected animation updates scheduled due to threaded animations.

But this could have also been addressed by making sure that document timelines, which can always be accelerated,
have `m_canBeAccelerated` set to `true` right as they are constructed. So we also make a change to set that flag
to the value returned by `computeCanBeAccelerated()` in the `AnimationTimeline` constructor.

* LayoutTests/platform/mac-wk2/TestExpectations:
* Source/WebCore/animation/AnimationTimeline.cpp:
(WebCore::AnimationTimeline::AnimationTimeline):
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::canBeAccelerated const):
(WebCore::KeyframeEffect::timelineAccelerationAbilityDidChange):
* Source/WebCore/animation/KeyframeEffect.h:

Canonical link: <a href="https://commits.webkit.org/307758@main">https://commits.webkit.org/307758@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3934a380ef71f13a030e074539f9d7a18cbc537e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18088 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9898 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99043 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/33f1bdeb-05e0-4f54-8de0-e8d3945c44d6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147281 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18572 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17981 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111817 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130625 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92718 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13526 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11287 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1524 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7391 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156390 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17938 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8486 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119825 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14974 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120165 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15921 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128655 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73645 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22426 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17559 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6885 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81338 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17504 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->