### PR TITLE
REGRESSION(306393@main): Web Inspector Sources tab select no longer shows popup

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mousedown-slot-mutation.optional-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mousedown-slot-mutation.optional-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS Select opens when options are mutated during mousedown
+PASS Select options work correctly after mousedown mutation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mousedown-slot-mutation.optional.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mousedown-slot-mutation.optional.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+
+<!-- This test verifies that mutating a select's options during mousedown
+  does not prevent the picker from opening. This is a regression test for
+  a bug where DOM mutations during mousedown would tear down the select's
+  renderer, preventing the picker popup from showing. -->
+
+<select id="test-select">
+  <option value="a">Option A</option>
+  <option value="b">Option B</option>
+  <option value="c">Option C</option>
+</select>
+
+<style>
+  select, ::picker(select) {
+    appearance: base-select;
+  }
+</style>
+
+<script>
+  const select = document.getElementById('test-select');
+
+  // Mutate the select's options on mousedown, similar to what
+  // Web Inspector's HierarchicalPathComponent does.
+  // Only mutate when the select is closed (opening click), not when
+  // clicking options inside the open picker.
+  select.addEventListener('mousedown', function(event) {
+    // Don't mutate if already open (clicking inside the picker)
+    if (this.matches(':open')) {
+      return;
+    }
+
+    // Save current options
+    const options = Array.from(this.options).map(opt => ({
+      value: opt.value,
+      text: opt.textContent
+    }));
+
+    // Remove all children
+    while (this.firstChild) {
+      this.removeChild(this.firstChild);
+    }
+
+    // Re-add options
+    options.forEach(opt => {
+      const option = document.createElement('option');
+      option.value = opt.value;
+      option.textContent = opt.text;
+      this.appendChild(option);
+    });
+  });
+
+  promise_test(async (t) => {
+    assert_false(select.matches(':open'), 'select should be closed initially');
+
+    // Click the select - it should open despite the mousedown mutation
+    await test_driver.click(select);
+
+    assert_true(select.matches(':open'), 'select should be open after click despite mousedown mutation');
+
+    // Clean up - close the select
+    await test_driver.send_keys(select, '\uE00C'); // Escape
+  }, 'Select opens when options are mutated during mousedown');
+
+  promise_test(async (t) => {
+    assert_false(select.matches(':open'), 'select should be closed initially');
+
+    // Verify options are still accessible after mutation
+    assert_equals(select.options.length, 3, 'should have 3 options');
+    assert_equals(select.options[0].value, 'a', 'first option should be "a"');
+    assert_equals(select.options[1].value, 'b', 'second option should be "b"');
+    assert_equals(select.options[2].value, 'c', 'third option should be "c"');
+
+    // Click to open
+    await test_driver.click(select);
+    assert_true(select.matches(':open'), 'select should be open');
+
+    // Verify options still work after mutation - click second option
+    const option2 = select.options[1];
+    await test_driver.click(option2);
+
+    assert_false(select.matches(':open'), 'select should be closed after selection');
+    assert_equals(select.value, 'b', 'selected value should be "b"');
+  }, 'Select options work correctly after mousedown mutation');
+</script>

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mousedown-slot-mutation.optional-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/html/semantics/forms/the-select-element/customizable-select/select-mousedown-slot-mutation.optional-expected.txt
@@ -1,0 +1,8 @@
+
+Option A
+Option B
+Option C
+
+PASS Select opens when options are mutated during mousedown
+FAIL Select options work correctly after mousedown mutation assert_false: select should be closed initially expected false got true
+

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -97,9 +97,12 @@ private:
     void popParentsToDepth(unsigned depth);
 
     // FIXME: Use OptionSet.
-    enum class TeardownType { Full, FullAfterSlotOrShadowRootChange, RendererUpdate, RendererUpdateCancelingAnimations };
+    enum class TeardownType { Full, FullAfterShadowRootInsertion, RendererUpdate, RendererUpdateCancelingAnimations };
     static void tearDownRenderers(Element&, TeardownType);
     static void tearDownRenderers(Element&, TeardownType, RenderTreeBuilder&);
+    static void tearDownDescendantRenderers(Element&, TeardownType, RenderTreeBuilder&);
+    enum class TeardownScope { IncludingRoot, DescendantsOnly };
+    template<TeardownScope> static void tearDownRenderersInternal(Element&, TeardownType, RenderTreeBuilder&);
     enum class NeedsRepaintAndLayout : bool { No, Yes };
     static void tearDownTextRenderer(Text&, const ContainerNode* root, RenderTreeBuilder&, NeedsRepaintAndLayout = NeedsRepaintAndLayout::Yes);
     static void tearDownLeftoverChildrenOfComposedTree(Element&, RenderTreeBuilder&);


### PR DESCRIPTION
#### 9cda04f15377d6ef85f679d08e9047bebeb31205
<pre>
REGRESSION(306393@main): Web Inspector Sources tab select no longer shows popup
<a href="https://bugs.webkit.org/show_bug.cgi?id=308123">https://bugs.webkit.org/show_bug.cgi?id=308123</a>
<a href="https://rdar.apple.com/170365601">rdar://170365601</a>

Reviewed by Antti Koivisto.

Whenever a shadow root&apos;s slot&apos;s assigned nodes would change, we would
destroy the shadow root&apos;s host renderer. This created a problem for Web
Inspector as it manipulated select&apos;s children during mousedown, which
would then cause select&apos;s renderer to be destroyed, which resulted in
the internal mousedown handler returning early.

As it seems like shadow root&apos;s host does not need to be destroyed, only
destroy its descendants. This passes existing tests and makes us pass a
new test.

Canonical link: <a href="https://commits.webkit.org/307843@main">https://commits.webkit.org/307843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70609e6634f3a41816196e84c7066d3d5a31d0b1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18391 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10307 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154381 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c3e106d-2320-447f-a047-640c4cbb35d8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18876 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112060 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99346 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd3ec330-2c62-45cb-86ab-03bfc9377d70) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148672 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130891 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92966 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5f582fc-2ca6-4a32-a65d-b9019e488033) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13755 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11514 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1828 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7724 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156694 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120062 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18241 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15222 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120413 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129029 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73982 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22466 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16138 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7133 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17863 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81642 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17599 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17807 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17662 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->