### PR TITLE
[JSC] Support fccmp in B3

### DIFF
--- a/Source/JavaScriptCore/b3/B3Type.h
+++ b/Source/JavaScriptCore/b3/B3Type.h
@@ -78,6 +78,7 @@ public:
     inline bool isFloat() const;
     inline bool isNumeric() const;
     inline bool isTuple() const;
+    inline bool isScalar() const;
     inline bool isVector() const;
 
     friend bool operator==(const Type&, const Type&) = default;
@@ -130,6 +131,11 @@ inline bool Type::isNumeric() const
 inline bool Type::isTuple() const
 {
     return kind() == Tuple;
+}
+
+inline bool Type::isScalar() const
+{
+    return isInt() || isFloat();
 }
 
 inline bool Type::isVector() const

--- a/Source/JavaScriptCore/b3/testb3.h
+++ b/Source/JavaScriptCore/b3/testb3.h
@@ -1463,4 +1463,17 @@ void testCCmpNegatedOr32(int32_t, int32_t);
 void testCCmpMixedWidth32And64(int32_t, int64_t, int32_t);
 void testCCmpMixedWidth64And32(int64_t, int32_t);
 
+// ARM64 fccmp tests (floating-point conditional compare)
+void testFCCmpAndDouble(double, double, double, double);
+void testFCCmpOrDouble(double, double, double, double);
+void testFCCmpAndFloat(float, float, float, float);
+void testFCCmpOrFloat(float, float, float, float);
+void testFCCmpAndAndDouble(double, double, double, double, double, double);
+void testFCCmpMixedIntDouble(int32_t, int32_t, double, double);
+void testFCCmpMixedDoubleInt(double, double, int32_t, int32_t);
+void testFCCmpLessThanAndDouble(double, double, double, double);
+void testFCCmpGreaterEqualOrDouble(double, double, double, double);
+void testFCCmpNaN(double, double, double, double);
+void testFCCmpNegatedAndDouble(double, double, double, double);
+
 #endif // ENABLE(B3_JIT)

--- a/Source/JavaScriptCore/b3/testb3_1.cpp
+++ b/Source/JavaScriptCore/b3/testb3_1.cpp
@@ -1021,6 +1021,64 @@ void run(const TestConfig* config)
     RUN(testCCmpMixedWidth64And32(5000, 9));        // second doesn't match
     RUN(testCCmpMixedWidth64And32(4999, 10));       // first doesn't match
 
+    // ARM64 fccmp tests (floating-point conditional compare)
+    RUN(testFCCmpAndDouble(1.0, 1.0, 2.0, 2.0));    // both true
+    RUN(testFCCmpAndDouble(1.0, 2.0, 2.0, 2.0));    // first false
+    RUN(testFCCmpAndDouble(1.0, 1.0, 2.0, 3.0));    // second false
+    RUN(testFCCmpAndDouble(1.0, 2.0, 2.0, 3.0));    // both false
+
+    RUN(testFCCmpOrDouble(1.0, 1.0, 2.0, 2.0));     // both true
+    RUN(testFCCmpOrDouble(1.0, 1.0, 2.0, 3.0));     // first true
+    RUN(testFCCmpOrDouble(1.0, 2.0, 2.0, 2.0));     // second true
+    RUN(testFCCmpOrDouble(1.0, 2.0, 2.0, 3.0));     // both false
+
+    RUN(testFCCmpAndFloat(1.0f, 1.0f, 2.0f, 2.0f)); // both true
+    RUN(testFCCmpAndFloat(1.0f, 2.0f, 2.0f, 2.0f)); // first false
+    RUN(testFCCmpAndFloat(1.0f, 1.0f, 2.0f, 3.0f)); // second false
+    RUN(testFCCmpAndFloat(1.0f, 2.0f, 2.0f, 3.0f)); // both false
+
+    RUN(testFCCmpOrFloat(1.0f, 1.0f, 2.0f, 2.0f));  // both true
+    RUN(testFCCmpOrFloat(1.0f, 1.0f, 2.0f, 3.0f));  // first true
+    RUN(testFCCmpOrFloat(1.0f, 2.0f, 2.0f, 2.0f));  // second true
+    RUN(testFCCmpOrFloat(1.0f, 2.0f, 2.0f, 3.0f));  // both false
+
+    RUN(testFCCmpAndAndDouble(1.0, 1.0, 2.0, 2.0, 3.0, 3.0));  // all true
+    RUN(testFCCmpAndAndDouble(1.0, 1.0, 2.0, 2.0, 3.0, 4.0));  // first two true, last false
+    RUN(testFCCmpAndAndDouble(1.0, 1.0, 2.0, 3.0, 3.0, 3.0));  // first true, second false
+    RUN(testFCCmpAndAndDouble(1.0, 2.0, 2.0, 2.0, 3.0, 3.0));  // first false
+    RUN(testFCCmpAndAndDouble(1.0, 2.0, 2.0, 3.0, 3.0, 4.0));  // all false
+
+    RUN(testFCCmpMixedIntDouble(5, 5, 1.0, 2.0));   // int true, double true
+    RUN(testFCCmpMixedIntDouble(5, 6, 1.0, 2.0));   // int false, double true
+    RUN(testFCCmpMixedIntDouble(5, 5, 2.0, 1.0));   // int true, double false
+    RUN(testFCCmpMixedIntDouble(5, 6, 2.0, 1.0));   // int false, double false
+
+    RUN(testFCCmpMixedDoubleInt(1.0, 2.0, 5, 5));   // double true, int true
+    RUN(testFCCmpMixedDoubleInt(2.0, 1.0, 5, 5));   // double false, int true
+    RUN(testFCCmpMixedDoubleInt(1.0, 2.0, 5, 6));   // double true, int false
+    RUN(testFCCmpMixedDoubleInt(2.0, 1.0, 5, 6));   // double false, int false
+
+    RUN(testFCCmpLessThanAndDouble(1.0, 2.0, 3.0, 4.0));  // both true
+    RUN(testFCCmpLessThanAndDouble(2.0, 1.0, 3.0, 4.0));  // first false
+    RUN(testFCCmpLessThanAndDouble(1.0, 2.0, 4.0, 3.0));  // second false
+    RUN(testFCCmpLessThanAndDouble(2.0, 1.0, 4.0, 3.0));  // both false
+
+    RUN(testFCCmpGreaterEqualOrDouble(2.0, 1.0, 4.0, 3.0));  // both true
+    RUN(testFCCmpGreaterEqualOrDouble(2.0, 1.0, 3.0, 4.0));  // first true
+    RUN(testFCCmpGreaterEqualOrDouble(1.0, 2.0, 4.0, 3.0));  // second true
+    RUN(testFCCmpGreaterEqualOrDouble(1.0, 2.0, 3.0, 4.0));  // both false
+
+    // NaN tests
+    RUN(testFCCmpNaN(1.0, 1.0, std::numeric_limits<double>::quiet_NaN(), 1.0));  // second has NaN
+    RUN(testFCCmpNaN(std::numeric_limits<double>::quiet_NaN(), 1.0, 1.0, 1.0));  // first has NaN
+    RUN(testFCCmpNaN(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN(), 1.0, 1.0));  // NaN == NaN is false
+
+    // Negated fccmp
+    RUN(testFCCmpNegatedAndDouble(1.0, 2.0, 3.0, 4.0));  // !(true && true) = false
+    RUN(testFCCmpNegatedAndDouble(2.0, 1.0, 3.0, 4.0));  // !(false && true) = true
+    RUN(testFCCmpNegatedAndDouble(1.0, 2.0, 4.0, 3.0));  // !(true && false) = true
+    RUN(testFCCmpNegatedAndDouble(2.0, 1.0, 4.0, 3.0));  // !(false && false) = true
+
     RUN_UNARY(testSShrCompare32, int32OperandsMore());
     RUN_UNARY(testSShrCompare64, int64OperandsMore());
 

--- a/Source/JavaScriptCore/b3/testb3_8.cpp
+++ b/Source/JavaScriptCore/b3/testb3_8.cpp
@@ -2836,6 +2836,334 @@ void testConstFloatMultipleZeroUses()
     CHECK_EQ(compileAndRun<float>(proc, 2.5f, 3.5f), 6.0f);
 }
 
+void testFCCmpAndDouble(double a, double b, double c, double d)
+{
+    // Test: (a == b) && (c == d)
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<double, double, double, double>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, Equal, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, Equal, Origin(), arguments[2], arguments[3]);
+    Value* condition = root->appendNew<Value>(proc, BitAnd, Origin(), cmp1, cmp2);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a == b && c == d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
+void testFCCmpOrDouble(double a, double b, double c, double d)
+{
+    // Test: (a == b) || (c == d)
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<double, double, double, double>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, Equal, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, Equal, Origin(), arguments[2], arguments[3]);
+    Value* condition = root->appendNew<Value>(proc, BitOr, Origin(), cmp1, cmp2);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a == b || c == d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
+void testFCCmpAndFloat(float a, float b, float c, float d)
+{
+    // Test: (a == b) && (c == d)
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<float, float, float, float>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, Equal, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, Equal, Origin(), arguments[2], arguments[3]);
+    Value* condition = root->appendNew<Value>(proc, BitAnd, Origin(), cmp1, cmp2);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a == b && c == d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
+void testFCCmpOrFloat(float a, float b, float c, float d)
+{
+    // Test: (a == b) || (c == d)
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<float, float, float, float>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, Equal, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, Equal, Origin(), arguments[2], arguments[3]);
+    Value* condition = root->appendNew<Value>(proc, BitOr, Origin(), cmp1, cmp2);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a == b || c == d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
+void testFCCmpAndAndDouble(double a, double b, double c, double d, double e, double f)
+{
+    // Test: ((a == b) && (c == d)) && (e == f)
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<double, double, double, double, double, double>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, Equal, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, Equal, Origin(), arguments[2], arguments[3]);
+    Value* and1 = root->appendNew<Value>(proc, BitAnd, Origin(), cmp1, cmp2);
+    Value* cmp3 = root->appendNew<Value>(proc, Equal, Origin(), arguments[4], arguments[5]);
+    Value* condition = root->appendNew<Value>(proc, BitAnd, Origin(), and1, cmp3);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a == b && c == d && e == f) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d, e, f), expected);
+}
+
+void testFCCmpMixedIntDouble(int32_t a, int32_t b, double c, double d)
+{
+    // Test: (a == b) && (c < d) — int compare AND float compare
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<int32_t, int32_t, double, double>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, Equal, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, LessThan, Origin(), arguments[2], arguments[3]);
+    Value* condition = root->appendNew<Value>(proc, BitAnd, Origin(), cmp1, cmp2);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a == b && c < d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
+void testFCCmpMixedDoubleInt(double a, double b, int32_t c, int32_t d)
+{
+    // Test: (a < b) && (c == d) — float compare AND int compare
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<double, double, int32_t, int32_t>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, LessThan, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, Equal, Origin(), arguments[2], arguments[3]);
+    Value* condition = root->appendNew<Value>(proc, BitAnd, Origin(), cmp1, cmp2);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a < b && c == d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
+void testFCCmpLessThanAndDouble(double a, double b, double c, double d)
+{
+    // Test: (a < b) && (c < d)
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<double, double, double, double>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, LessThan, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, LessThan, Origin(), arguments[2], arguments[3]);
+    Value* condition = root->appendNew<Value>(proc, BitAnd, Origin(), cmp1, cmp2);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a < b && c < d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
+void testFCCmpGreaterEqualOrDouble(double a, double b, double c, double d)
+{
+    // Test: (a >= b) || (c >= d)
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<double, double, double, double>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, GreaterEqual, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, GreaterEqual, Origin(), arguments[2], arguments[3]);
+    Value* condition = root->appendNew<Value>(proc, BitOr, Origin(), cmp1, cmp2);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a >= b || c >= d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
+void testFCCmpNaN(double a, double b, double c, double d)
+{
+    // Test: (a == b) && (c == d) with NaN inputs
+    // NaN comparisons should always be false
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<double, double, double, double>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, Equal, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, Equal, Origin(), arguments[2], arguments[3]);
+    Value* condition = root->appendNew<Value>(proc, BitAnd, Origin(), cmp1, cmp2);
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), condition,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = (a == b && c == d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
+void testFCCmpNegatedAndDouble(double a, double b, double c, double d)
+{
+    // Test: !(a < b && c < d)
+    // This becomes: (a < b && c < d) == 0
+    Procedure proc;
+    BasicBlock* root = proc.addBlock();
+    BasicBlock* thenCase = proc.addBlock();
+    BasicBlock* elseCase = proc.addBlock();
+    auto arguments = cCallArgumentValues<double, double, double, double>(proc, root);
+
+    Value* cmp1 = root->appendNew<Value>(proc, LessThan, Origin(), arguments[0], arguments[1]);
+    Value* cmp2 = root->appendNew<Value>(proc, LessThan, Origin(), arguments[2], arguments[3]);
+    Value* andResult = root->appendNew<Value>(proc, BitAnd, Origin(), cmp1, cmp2);
+
+    Value* negated = root->appendNew<Value>(
+        proc, Equal, Origin(),
+        andResult,
+        root->appendNew<Const32Value>(proc, Origin(), 0));
+
+    root->appendNewControlValue(
+        proc, Branch, Origin(), negated,
+        FrequentedBlock(thenCase), FrequentedBlock(elseCase));
+
+    thenCase->appendNewControlValue(
+        proc, Return, Origin(),
+        thenCase->appendNew<Const32Value>(proc, Origin(), 1));
+
+    elseCase->appendNewControlValue(
+        proc, Return, Origin(),
+        elseCase->appendNew<Const32Value>(proc, Origin(), 0));
+
+    int32_t expected = !(a < b && c < d) ? 1 : 0;
+    CHECK_EQ(compileAndRun<int32_t>(proc, a, b, c, d), expected);
+}
+
 #endif // ENABLE(B3_JIT)
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END


### PR DESCRIPTION
#### 75d2a27f5eca91605ff97cf6b0d81af0b01748ad
<pre>
[JSC] Support fccmp in B3
<a href="https://bugs.webkit.org/show_bug.cgi?id=308124">https://bugs.webkit.org/show_bug.cgi?id=308124</a>
<a href="https://rdar.apple.com/170627645">rdar://170627645</a>

Reviewed by Keith Miller.

This patch extends the existing ccmp optimization to support fccmp,
which includes float / double comparisons.

Tests: Source/JavaScriptCore/b3/testb3_1.cpp
       Source/JavaScriptCore/b3/testb3_8.cpp

* Source/JavaScriptCore/b3/B3LowerToAir.cpp:
* Source/JavaScriptCore/b3/B3Type.h:
(JSC::B3::Type::isScalar const):
* Source/JavaScriptCore/b3/testb3.h:
* Source/JavaScriptCore/b3/testb3_1.cpp:
(run):
* Source/JavaScriptCore/b3/testb3_8.cpp:
(testFCCmpAndDouble):
(testFCCmpOrDouble):
(testFCCmpAndFloat):
(testFCCmpOrFloat):
(testFCCmpAndAndDouble):
(testFCCmpMixedIntDouble):
(testFCCmpMixedDoubleInt):
(testFCCmpLessThanAndDouble):
(testFCCmpGreaterEqualOrDouble):
(testFCCmpNaN):
(testFCCmpNegatedAndDouble):

Canonical link: <a href="https://commits.webkit.org/307782@main">https://commits.webkit.org/307782@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d1dc8d6c70d556a566aa12987be1b02edfe0f02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145494 "40 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18176 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/10011 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154166 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd692e02-be23-4fc9-98e7-acfbd1e6328a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18661 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18069 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/111895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51b5914c-eaad-46a2-8f5c-b1965c8276af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148457 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/14267 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/130711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/92796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/611a1df2-bbc9-484a-992e-2961e875722b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1613 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137485 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/7485 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156478 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6303 "Built successfully and passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18026 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/8596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/119902 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18072 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/120243 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/15992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/128766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/73755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22438 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17647 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176784 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17384 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81427 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45432 "Passed tests") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17447 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->