### PR TITLE
check-webkit-style: add checker on smart pointer access alongside .release() in a single call

### DIFF
--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3688,6 +3688,70 @@ def check_objc_protocol(clean_lines, line_number, file_extension, error):
     error(line_number, 'spacing/objc-protocol', 2, "Protocol names shouldn't have a space before them.")
 
 
+def check_release_with_access(clean_lines, line_number, error):
+    """Checks for UB from accessing a smart pointer in the same expression as .release().
+
+    In C++, function arguments have indeterminate evaluation order. If
+    ptr.release() and ptr->member (or ptr.get()) are arguments to the same
+    function call, the compiler may evaluate .release() first, making the
+    other accesses dereference a null pointer (undefined behavior).
+    """
+    line = clean_lines.elided[line_number]
+
+    release_match = search(r'\b(\w+)\.release\(\)', line)
+    if not release_match:
+        return
+
+    varname = release_match.group(1)
+
+    # Collect lines belonging to the same expression by scanning backwards.
+    # Track brace depth to skip over lambda/block bodies: going backwards,
+    # '}' increases depth (entering a block) and '{' decreases it (exiting).
+    # Only collect lines at depth 0 (the outer expression level).
+    # Store (line_number, text) so we can report errors on the right lines.
+    expression_lines = [(line_number, line)]
+    brace_depth = line.count('}') - line.count('{')
+    i = line_number - 1
+    max_lookback = 80
+    while i >= 0 and (line_number - i) <= max_lookback:
+        prev_line = clean_lines.elided[i].strip()
+        if not prev_line:
+            i -= 1
+            continue
+        brace_depth += prev_line.count('}') - prev_line.count('{')
+        if brace_depth < 0:
+            # Gone past the opening of our enclosing block.
+            break
+        if brace_depth == 0:
+            # At the outer expression level: check for statement boundary.
+            if prev_line.endswith(';'):
+                break
+            expression_lines.insert(0, (i, prev_line))
+        # brace_depth > 0: inside a nested block (lambda body), skip.
+        i -= 1
+
+    expression = ' '.join(text for _, text in expression_lines)
+
+    # Check for varname-> or varname.member (excluding .release() itself)
+    access_pattern = r'\b' + re.escape(varname) + r'(?:->|\.(?!release\b)\w+)'
+    if not search(access_pattern, expression):
+        return
+
+    message = ("Accessing '%s' in the same expression as %s.release() is undefined behavior"
+               " due to indeterminate argument evaluation order."
+               " Extract the value into a local variable before the call."
+               % (varname, varname))
+
+    # Report on every participating line so the error surfaces regardless of
+    # which line is in the diff (check-webkit-style filters by line number).
+    reported = set()
+    for expr_line_number, expr_text in expression_lines:
+        if search(access_pattern, expr_text) or search(r'\b' + re.escape(varname) + r'\.release\(\)', expr_text):
+            if expr_line_number not in reported:
+                error(expr_line_number, 'safercpp/release_with_access', 4, message)
+                reported.add(expr_line_number)
+
+
 def check_safer_cpp(clean_lines, line_number, error):
     """Looks for safer C++ errors.
 
@@ -3912,6 +3976,7 @@ def check_style(clean_lines, line_number, file_extension, class_state, file_stat
     check_arguments_for_wk_api_available(clean_lines, line_number, error)
     check_objc_protocol(clean_lines, line_number, file_extension, error)
     check_safer_cpp(clean_lines, line_number, error)
+    check_release_with_access(clean_lines, line_number, error)
 
 
 _RE_PATTERN_INCLUDE_NEW_STYLE = re.compile(r'#(?:include|import) +"[^/]+\.h"')
@@ -5190,6 +5255,7 @@ class CppChecker(object):
         'safercpp/memmove',
         'safercpp/memset',
         'safercpp/memset_s',
+        'safercpp/release_with_access',
         'safercpp/weak_ref_exception',
         'safercpp/strcmp',
         'safercpp/strncmp',

--- a/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py
@@ -6856,6 +6856,76 @@ class WebKitStyleTest(CppStyleTestBase):
         self.assert_lint('if (RefPtr document = viewportDocumentForFrame(protectedMainFrame()))', '', 'foo.cpp')
         self.assert_lint('if (RefPtr foo = someFunction(checkedBar()))', '', 'foo.cpp')
 
+        # Tests for release_with_access: release and access in same expression is UB.
+        self.assert_lint(
+            'g_foo_call(foo, request->cancellable.get(), callback, request.release());',
+            "Accessing 'request' in the same expression as request.release() is undefined behavior"
+            " due to indeterminate argument evaluation order."
+            " Extract the value into a local variable before the call."
+            "  [safercpp/release_with_access] [4]",
+            'foo.cpp')
+
+        # Standalone release (no access of the same variable): no error
+        self.assert_lint(
+            'auto* raw = request.release();',
+            '',
+            'foo.cpp')
+
+        # Different variables: no error (only 'other' is accessed, not 'request')
+        self.assert_lint(
+            'func(other->member, request.release());',
+            '',
+            'foo.cpp')
+
+        # Using .get() on the same variable as .release(): should error
+        self.assert_lint(
+            'func(request.get(), request.release());',
+            "Accessing 'request' in the same expression as request.release() is undefined behavior"
+            " due to indeterminate argument evaluation order."
+            " Extract the value into a local variable before the call."
+            "  [safercpp/release_with_access] [4]",
+            'foo.cpp')
+
+        # Multi-line: access and release in same call: error reported on both
+        # the access line and the .release() line so check-webkit-style catches
+        # the bug regardless of which line appears in the diff.
+        release_with_access_error = (
+            "Accessing 'request' in the same expression as request.release() is undefined behavior"
+            " due to indeterminate argument evaluation order."
+            " Extract the value into a local variable before the call."
+            "  [safercpp/release_with_access] [4]")
+        self.assert_multi_line_lint(
+            'g_foo_call(foo,\n'
+            '    request->cancellable.get(),\n'
+            '    callback, request.release());',
+            [release_with_access_error, release_with_access_error],
+            'foo.cpp')
+
+        # Multi-line with lambda body between access and release (the real-world crash pattern).
+        # The brace-aware scan should skip over the lambda body and still detect the UB.
+        self.assert_multi_line_lint(
+            'g_foo_call(foo,\n'
+            '    G_SOME_FLAGS, -1,\n'
+            '    request->cancellable.get(),\n'
+            '    [](GObject* object, GAsyncResult* result, gpointer userData) {\n'
+            '    auto* req = static_cast<Request*>(userData);\n'
+            '    req->complete();\n'
+            '}, request.release());',
+            [release_with_access_error, release_with_access_error],
+            'foo.cpp')
+
+        # Lambda body with nested braces: should still detect the UB
+        self.assert_multi_line_lint(
+            'func(request->value,\n'
+            '    [](int x) {\n'
+            '    if (x) {\n'
+            '        doFirst();\n'
+            '        doSecond();\n'
+            '    }\n'
+            '}, request.release());',
+            [release_with_access_error, release_with_access_error],
+            'foo.cpp')
+
     def test_ctype_fucntion(self):
         self.assert_lint(
             'int i = isascii(8);',


### PR DESCRIPTION
#### 50e0d4cef4a1e650b666f259e762c0f7654d1423
<pre>
check-webkit-style: add checker on smart pointer access alongside .release() in a single call
<a href="https://bugs.webkit.org/show_bug.cgi?id=308056">https://bugs.webkit.org/show_bug.cgi?id=308056</a>

Reviewed by NOBODY (OOPS!).

The check-webkit-style tool should warn about accessing a smart pointer
as a function argument when it has been released in another, as
arguments have indeterminate evaluation order in C++.

Bad patterns that should trigger warnings:
```cpp
g_baz_async(foo-&gt;bar.get(), callback, foo.release();
```

Good patterns that should not trigger warnings:
```cpp
auto* bar = foo-&gt;bar.get();
g_baz_async(bar, callback, foo.release();
```

* Tools/Scripts/webkitpy/style/checkers/cpp.py:
(check_release_with_access):
(check_style):
(CppChecker):
* Tools/Scripts/webkitpy/style/checkers/cpp_unittest.py:
(WebKitStyleTest.test_safer_cpp):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50e0d4cef4a1e650b666f259e762c0f7654d1423

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145402 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18084 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9893 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154074 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99039 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147277 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18568 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111815 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80133 "Exiting early after 60 failures. 15368 tests run. 60 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14181 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92716 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/144728 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13521 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11282 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1520 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156386 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17934 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119821 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17980 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14969 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120161 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15915 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128650 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73638 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17555 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6881 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17292 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17500 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17355 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->