### PR TITLE
Replace keyIdentifier() usage with keyCode()

### DIFF
--- a/Source/WebCore/html/BaseCheckableInputType.cpp
+++ b/Source/WebCore/html/BaseCheckableInputType.cpp
@@ -38,6 +38,7 @@
 #include "HTMLInputElement.h"
 #include "HTMLNames.h"
 #include "KeyboardEvent.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 
@@ -71,8 +72,7 @@ bool BaseCheckableInputType::appendFormData(DOMFormData& formData) const
 
 auto BaseCheckableInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseEventHandler
 {
-    const String& key = event.keyIdentifier();
-    if (key == "U+0020"_s) {
+    if (event.keyCode() == VK_SPACE) {
         ASSERT(element());
         protect(element())->setActive(true);
         // No setDefaultHandled(), because IE dispatches a keypress in this case

--- a/Source/WebCore/html/BaseClickableWithKeyInputType.cpp
+++ b/Source/WebCore/html/BaseClickableWithKeyInputType.cpp
@@ -34,6 +34,7 @@
 
 #include "HTMLInputElement.h"
 #include "KeyboardEvent.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -44,8 +45,7 @@ using namespace HTMLNames;
 
 auto BaseClickableWithKeyInputType::handleKeydownEvent(HTMLInputElement& element, KeyboardEvent& event) -> ShouldCallBaseEventHandler
 {
-    const String& key = event.keyIdentifier();
-    if (key == "U+0020"_s) {
+    if (event.keyCode() == VK_SPACE) {
         element.setActive(true);
         // No setDefaultHandled(), because IE dispatches a keypress in this case
         // and the caller will only dispatch a keypress if we don't call setDefaultHandled().
@@ -70,8 +70,7 @@ void BaseClickableWithKeyInputType::handleKeypressEvent(HTMLInputElement& elemen
 
 void BaseClickableWithKeyInputType::handleKeyupEvent(InputType& inputType, KeyboardEvent& event)
 {
-    const String& key = event.keyIdentifier();
-    if (key != "U+0020"_s)
+    if (event.keyCode() != VK_SPACE)
         return;
     // Simulate mouse click for spacebar for button types.
     inputType.dispatchSimulatedClickIfActive(event);

--- a/Source/WebCore/html/CheckboxInputType.cpp
+++ b/Source/WebCore/html/CheckboxInputType.cpp
@@ -58,6 +58,7 @@
 #include "ShadowRoot.h"
 #include "UserAgentParts.h"
 #include "UserGestureIndicator.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/TZoneMallocInlines.h>
 
 #if ENABLE(IOS_TOUCH_EVENTS)
@@ -112,8 +113,7 @@ void CheckboxInputType::createShadowSubtree()
 
 void CheckboxInputType::handleKeyupEvent(KeyboardEvent& event)
 {
-    const String& key = event.keyIdentifier();
-    if (key != "U+0020"_s)
+    if (event.keyCode() != VK_SPACE)
         return;
     dispatchSimulatedClickIfActive(event);
 }

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -62,6 +62,7 @@
 #include "SystemPreviewInfo.h"
 #include "URLKeepingBlobAlive.h"
 #include "UserGestureIndicator.h"
+#include "WindowsKeyboardCodes.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/RuntimeApplicationChecks.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -659,7 +660,7 @@ bool isEnterKeyKeydownEvent(Event& event)
     if (event.type() != eventNames().keydownEvent)
         return false;
     auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event);
-    return keyboardEvent && keyboardEvent->keyIdentifier() == "Enter"_s;
+    return keyboardEvent && keyboardEvent->keyCode() == VK_RETURN;
 }
 
 bool shouldProhibitLinks(Element* element)

--- a/Source/WebCore/html/HTMLButtonElement.cpp
+++ b/Source/WebCore/html/HTMLButtonElement.cpp
@@ -37,6 +37,7 @@
 #include "RenderButton.h"
 #include "RenderStyle+GettersInlines.h"
 #include "Settings.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/SetForScope.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -298,7 +299,7 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
     }
 
     if (RefPtr keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
-        if (keyboardEvent->type() == eventNames.keydownEvent && keyboardEvent->keyIdentifier() == "U+0020"_s) {
+        if (keyboardEvent->type() == eventNames.keydownEvent && keyboardEvent->keyCode() == VK_SPACE) {
             setActive(true);
             // No setDefaultHandled() - IE dispatches a keypress in this case.
             return;
@@ -315,7 +316,7 @@ void HTMLButtonElement::defaultEventHandler(Event& event)
                     return;
             }
         }
-        if (keyboardEvent->type() == eventNames.keyupEvent && keyboardEvent->keyIdentifier() == "U+0020"_s) {
+        if (keyboardEvent->type() == eventNames.keyupEvent && keyboardEvent->keyCode() == VK_SPACE) {
             if (active())
                 dispatchSimulatedClick(keyboardEvent.get());
             keyboardEvent->setDefaultHandled();

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -73,6 +73,7 @@
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "SlotAssignment.h"
+#include "WindowsKeyboardCodes.h"
 #include <JavaScriptCore/ConsoleTypes.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
@@ -1345,7 +1346,7 @@ bool HTMLSelectElement::platformHandleKeydownEvent(KeyboardEvent* event)
         return false;
 
     if (!document().settings().spatialNavigationEnabled()) {
-        if (event->keyIdentifier() == "Down"_s || event->keyIdentifier() == "Up"_s) {
+        if (event->keyCode() == VK_DOWN || event->keyCode() == VK_UP) {
             focus();
             protect(document())->updateStyleIfNeeded();
             // Calling focus() may cause us to lose our renderer. Return true so
@@ -1392,7 +1393,7 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
                 return;
         }
 
-        const String& keyIdentifier = keyboardEvent->keyIdentifier();
+        int keyCode = keyboardEvent->keyCode();
         bool handled = true;
         auto& listItems = this->listItems();
         int listIndex = optionToListIndex(selectedIndex());
@@ -1400,24 +1401,35 @@ void HTMLSelectElement::menuListDefaultEventHandler(Event& event)
         // When using caret browsing, we want to be able to move the focus
         // out of the select element when user hits a left or right arrow key.
         if (document().settings().caretBrowsingEnabled()) {
-            if (keyIdentifier == "Left"_s || keyIdentifier == "Right"_s)
+            if (keyCode == VK_LEFT || keyCode == VK_RIGHT)
                 return;
         }
 
-        if (keyIdentifier == "Down"_s || keyIdentifier == "Right"_s)
+        switch (keyCode) {
+        case VK_DOWN:
+        case VK_RIGHT:
             listIndex = nextValidIndex(listIndex, SkipDirection::Forwards, 1);
-        else if (keyIdentifier == "Up"_s || keyIdentifier == "Left"_s)
+            break;
+        case VK_UP:
+        case VK_LEFT:
             listIndex = nextValidIndex(listIndex, SkipDirection::Backwards, 1);
-        else if (keyIdentifier == "PageDown"_s)
+            break;
+        case VK_NEXT:
             listIndex = nextValidIndex(listIndex, SkipDirection::Forwards, 3);
-        else if (keyIdentifier == "PageUp"_s)
+            break;
+        case VK_PRIOR:
             listIndex = nextValidIndex(listIndex, SkipDirection::Backwards, 3);
-        else if (keyIdentifier == "Home"_s)
+            break;
+        case VK_HOME:
             listIndex = nextValidIndex(-1, SkipDirection::Forwards, 1);
-        else if (keyIdentifier == "End"_s)
+            break;
+        case VK_END:
             listIndex = nextValidIndex(listItems.size(), SkipDirection::Backwards, 1);
-        else
+            break;
+        default:
             handled = false;
+            break;
+        }
 
         if (handled && static_cast<size_t>(listIndex) < listItems.size())
             selectOption(listToOptionIndex(listIndex), { SelectOptionFlag::DeselectOtherOptions, SelectOptionFlag::DispatchChangeEvent, SelectOptionFlag::UserDriven });
@@ -1648,59 +1660,64 @@ void HTMLSelectElement::listBoxDefaultEventHandler(Event& event)
         bool isHorizontalWritingMode = renderer ? renderer->writingMode().isHorizontal() : true;
         bool isBlockFlipped = renderer ? renderer->writingMode().isBlockFlipped() : false;
 
-        auto nextKeyIdentifier = isHorizontalWritingMode ? "Down"_s : "Right"_s;
-        auto previousKeyIdentifier = isHorizontalWritingMode ? "Up"_s : "Left"_s;
+        int nextKeyCode = isHorizontalWritingMode ? VK_DOWN : VK_RIGHT;
+        int previousKeyCode = isHorizontalWritingMode ? VK_UP : VK_LEFT;
         if (isBlockFlipped)
-            std::swap(nextKeyIdentifier, previousKeyIdentifier);
+            std::swap(nextKeyCode, previousKeyCode);
 
-        const String& keyIdentifier = keyboardEvent->keyIdentifier();
+        int keyCode = keyboardEvent->keyCode();
 
         bool handled = false;
         int endIndex = 0;
         if (m_activeSelectionEndIndex < 0) {
             // Initialize the end index
-            if (keyIdentifier == nextKeyIdentifier || keyIdentifier == "PageDown"_s) {
+            if (keyCode == nextKeyCode || keyCode == VK_NEXT) {
                 int startIndex = lastSelectedListIndex();
                 handled = true;
-                if (keyIdentifier == nextKeyIdentifier)
+                if (keyCode == nextKeyCode)
                     endIndex = nextSelectableListIndex(startIndex);
                 else
                     endIndex = nextSelectableListIndexPageAway(startIndex, SkipDirection::Forwards);
-            } else if (keyIdentifier == previousKeyIdentifier || keyIdentifier == "PageUp"_s) {
+            } else if (keyCode == previousKeyCode || keyCode == VK_PRIOR) {
                 int startIndex = optionToListIndex(selectedIndex());
                 handled = true;
-                if (keyIdentifier == previousKeyIdentifier)
+                if (keyCode == previousKeyCode)
                     endIndex = previousSelectableListIndex(startIndex);
                 else
                     endIndex = nextSelectableListIndexPageAway(startIndex, SkipDirection::Backwards);
             }
         } else {
             // Set the end index based on the current end index.
-            if (keyIdentifier == nextKeyIdentifier) {
+            if (keyCode == nextKeyCode) {
                 endIndex = nextSelectableListIndex(m_activeSelectionEndIndex);
                 handled = true;
-            } else if (keyIdentifier == previousKeyIdentifier) {
+            } else if (keyCode == previousKeyCode) {
                 endIndex = previousSelectableListIndex(m_activeSelectionEndIndex);
                 handled = true;
-            } else if (keyIdentifier == "PageDown"_s) {
+            } else if (keyCode == VK_NEXT) {
                 endIndex = nextSelectableListIndexPageAway(m_activeSelectionEndIndex, SkipDirection::Forwards);
                 handled = true;
-            } else if (keyIdentifier == "PageUp"_s) {
+            } else if (keyCode == VK_PRIOR) {
                 endIndex = nextSelectableListIndexPageAway(m_activeSelectionEndIndex, SkipDirection::Backwards);
                 handled = true;
             }
         }
-        if (keyIdentifier == "Home"_s) {
+        switch (keyCode) {
+        case VK_HOME:
             endIndex = firstSelectableListIndex();
             handled = true;
-        } else if (keyIdentifier == "End"_s) {
+            break;
+        case VK_END:
             endIndex = lastSelectableListIndex();
             handled = true;
+            break;
+        default:
+            break;
         }
 
         if (document().settings().spatialNavigationEnabled()) {
             // Check if the selection moves to the boundary.
-            if (keyIdentifier == "Left"_s || keyIdentifier == "Right"_s || ((keyIdentifier == "Down"_s || keyIdentifier == "Up"_s) && endIndex == m_activeSelectionEndIndex))
+            if (keyCode == VK_LEFT || keyCode == VK_RIGHT || ((keyCode == VK_DOWN || keyCode == VK_UP) && endIndex == m_activeSelectionEndIndex))
                 return;
         }
 

--- a/Source/WebCore/html/HTMLSelectElementWin.cpp
+++ b/Source/WebCore/html/HTMLSelectElementWin.cpp
@@ -30,16 +30,26 @@
 
 #include "Element.h"
 #include "KeyboardEvent.h"
+#include "WindowsKeyboardCodes.h"
 
 namespace WebCore {
 
 bool HTMLSelectElement::platformHandleKeydownEvent(KeyboardEvent* event)
 {
     // Allow (Shift) F4 and (Ctrl/Shift) Alt/AltGr + Up/Down arrow to pop the menu, matching Firefox.
-    bool eventShowsMenu = ((!event->altKey() && !event->ctrlKey() && event->keyIdentifier() == "F4"_s)
-        || event->altKey()) && (event->keyIdentifier() == "Down"_s || event->keyIdentifier() == "Up"_s);
-    if (!eventShowsMenu)
+    switch (event->keyCode()) {
+    case VK_F4:
+        if (event->altKey() || event->ctrlKey())
+            return false;
+        break;
+    case VK_DOWN:
+    case VK_UP:
+        if (!event->altKey())
+            return false;
+        break;
+    default:
         return false;
+    }
 
     // Save the selection so it can be compared to the new selection when dispatching change events during setSelectedIndex,
     // which gets called from RenderMenuList::valueChanged, which gets called after the user makes a selection from the menu.

--- a/Source/WebCore/html/HTMLSummaryElement.cpp
+++ b/Source/WebCore/html/HTMLSummaryElement.cpp
@@ -34,6 +34,7 @@
 #include "SVGAElement.h"
 #include "SVGElementTypeHelpers.h"
 #include "ShadowRoot.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -103,7 +104,7 @@ void HTMLSummaryElement::defaultEventHandler(Event& event)
         }
 
         if (auto* keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
-            if (keyboardEvent->type() == eventNames.keydownEvent && keyboardEvent->keyIdentifier() == "U+0020"_s) {
+            if (keyboardEvent->type() == eventNames.keydownEvent && keyboardEvent->keyCode() == VK_SPACE) {
                 setActive(true);
                 // No setDefaultHandled() - IE dispatches a keypress in this case.
                 return;
@@ -120,7 +121,7 @@ void HTMLSummaryElement::defaultEventHandler(Event& event)
                     return;
                 }
             }
-            if (keyboardEvent->type() == eventNames.keyupEvent && keyboardEvent->keyIdentifier() == "U+0020"_s) {
+            if (keyboardEvent->type() == eventNames.keyupEvent && keyboardEvent->keyCode() == VK_SPACE) {
                 if (active())
                     dispatchSimulatedClick(&event);
                 keyboardEvent->setDefaultHandled();

--- a/Source/WebCore/html/RadioInputType.cpp
+++ b/Source/WebCore/html/RadioInputType.cpp
@@ -35,6 +35,7 @@
 #include "NodeTraversal.h"
 #include "Settings.h"
 #include "TypedElementDescendantIteratorInlines.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -129,8 +130,8 @@ auto RadioInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
         return ShouldCallBaseEventHandler::No;
     if (event.defaultHandled())
         return ShouldCallBaseEventHandler::Yes;
-    const String& key = event.keyIdentifier();
-    if (key != "Up"_s && key != "Down"_s && key != "Left"_s && key != "Right"_s)
+    int keyCode = event.keyCode();
+    if (keyCode != VK_UP && keyCode != VK_DOWN && keyCode != VK_LEFT && keyCode != VK_RIGHT)
         return ShouldCallBaseEventHandler::Yes;
 
     RefPtr element = this->element();
@@ -142,7 +143,7 @@ auto RadioInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
     // However, when using Spatial Navigation, we need to be able to navigate without changing the selection.
     if (element->document().settings().spatialNavigationEnabled())
         return ShouldCallBaseEventHandler::Yes;
-    bool forward = (key == "Down"_s || key == "Right"_s);
+    bool forward = (keyCode == VK_DOWN || keyCode == VK_RIGHT);
 
     // We can only stay within the form's children if the form hasn't been demoted to a leaf because
     // of malformed HTML.
@@ -171,8 +172,7 @@ auto RadioInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
 
 void RadioInputType::handleKeyupEvent(KeyboardEvent& event)
 {
-    const String& key = event.keyIdentifier();
-    if (key != "U+0020"_s)
+    if (event.keyCode() != VK_SPACE)
         return;
 
     RefPtr element = this->element();

--- a/Source/WebCore/html/RangeInputType.cpp
+++ b/Source/WebCore/html/RangeInputType.cpp
@@ -56,6 +56,7 @@
 #include "SliderThumbElement.h"
 #include "StepRange.h"
 #include "UserAgentParts.h"
+#include "WindowsKeyboardCodes.h"
 #include <limits>
 #include <numeric>
 #include <ranges>
@@ -202,8 +203,6 @@ auto RangeInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
     if (element->isDisabledFormControl())
         return ShouldCallBaseEventHandler::Yes;
 
-    const String& key = event.keyIdentifier();
-
     const Decimal current = parseToNumberOrNaN(element->value());
     ASSERT(current.isFinite());
 
@@ -219,24 +218,34 @@ auto RangeInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBaseE
         isVertical = renderer->style().usedAppearance() == StyleAppearance::SliderVertical;
 
     Decimal newValue;
-    if (key == "Up"_s)
+    switch (event.keyCode()) {
+    case VK_UP:
         newValue = current + step;
-    else if (key == "Down"_s)
+        break;
+    case VK_DOWN:
         newValue = current - step;
-    else if (key == "Left"_s)
+        break;
+    case VK_LEFT:
         newValue = isVertical ? current + step : current - step;
-    else if (key == "Right"_s)
+        break;
+    case VK_RIGHT:
         newValue = isVertical ? current - step : current + step;
-    else if (key == "PageUp"_s)
+        break;
+    case VK_PRIOR:
         newValue = current + bigStep;
-    else if (key == "PageDown"_s)
+        break;
+    case VK_NEXT:
         newValue = current - bigStep;
-    else if (key == "Home"_s)
+        break;
+    case VK_HOME:
         newValue = isVertical ? stepRange.maximum() : stepRange.minimum();
-    else if (key == "End"_s)
+        break;
+    case VK_END:
         newValue = isVertical ? stepRange.minimum() : stepRange.maximum();
-    else
+        break;
+    default:
         return ShouldCallBaseEventHandler::Yes; // Did not match any key binding.
+    }
 
     newValue = stepRange.clampValue(newValue);
 

--- a/Source/WebCore/html/SearchInputType.cpp
+++ b/Source/WebCore/html/SearchInputType.cpp
@@ -49,6 +49,7 @@
 #include "StylePreferredSize.h"
 #include "TextControlInnerElements.h"
 #include "UserAgentParts.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -323,8 +324,7 @@ auto SearchInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallBase
     if (!element->isMutable())
         return TextFieldInputType::handleKeydownEvent(event);
 
-    const String& key = event.keyIdentifier();
-    if (key == "U+001B"_s) {
+    if (event.keyCode() == VK_ESCAPE) {
         element->setValue(emptyString(), DispatchChangeEvent);
         event.setDefaultHandled();
         return ShouldCallBaseEventHandler::Yes;

--- a/Source/WebCore/html/TextFieldInputType.cpp
+++ b/Source/WebCore/html/TextFieldInputType.cpp
@@ -72,6 +72,7 @@
 #include "UserAgentParts.h"
 #include "UserGestureIndicator.h"
 #include "UserTypingGestureIndicator.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -208,9 +209,9 @@ auto TextFieldInputType::handleKeydownEvent(KeyboardEvent& event) -> ShouldCallB
     Ref element = *this->element();
     if (!element->focused())
         return ShouldCallBaseEventHandler::Yes;
-    const String& key = event.keyIdentifier();
-    if (RefPtr suggestionPicker = m_suggestionPicker; suggestionPicker && (key == "Enter"_s || key == "Up"_s || key == "Down"_s || key == "U+001B"_s)) {
-        suggestionPicker->handleKeydownWithIdentifier(key);
+    int keyCode = event.keyCode();
+    if (RefPtr suggestionPicker = m_suggestionPicker; suggestionPicker && (keyCode == VK_RETURN || keyCode == VK_UP || keyCode == VK_DOWN || keyCode == VK_ESCAPE)) {
+        suggestionPicker->handleKeydownWithKeyCode(keyCode);
         event.setDefaultHandled();
     }
     RefPtr frame = element->document().frame();
@@ -226,10 +227,10 @@ void TextFieldInputType::handleKeydownEventForSpinButton(KeyboardEvent& event)
         return;
     if (m_suggestionPicker)
         return;
-    const String& key = event.keyIdentifier();
-    if (key == "Up"_s)
+    int keyCode = event.keyCode();
+    if (keyCode == VK_UP)
         spinButtonStepUp();
-    else if (key == "Down"_s)
+    else if (keyCode == VK_DOWN)
         spinButtonStepDown();
     else
         return;

--- a/Source/WebCore/html/shadow/DateTimeEditElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.cpp
@@ -46,6 +46,7 @@
 #include "ScriptDisallowedScope.h"
 #include "Text.h"
 #include "UserAgentParts.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/StringBuilder.h>
 
@@ -236,7 +237,7 @@ size_t DateTimeEditElement::fieldIndexOf(const DateTimeFieldElement& fieldToFind
 void DateTimeEditElement::defaultEventHandler(Event& event)
 {
     if (RefPtr keyboardEvent = dynamicDowncast<KeyboardEvent>(event)) {
-        if (keyboardEvent->keyIdentifier() == "U+0020"_s && m_editControlOwner) {
+        if (keyboardEvent->keyCode() == VK_SPACE && m_editControlOwner) {
             // Forward space keypresses to the owner to activate the date picker.
             m_editControlOwner->didReceiveSpaceKeyFromControl();
             // We want to mark the event as handled to avoid scrolling the page.

--- a/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
+++ b/Source/WebCore/html/shadow/DateTimeFieldElement.cpp
@@ -40,6 +40,7 @@
 #include "ResolvedStyle.h"
 #include "StyleResolver.h"
 #include "Text.h"
+#include "WindowsKeyboardCodes.h"
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/WTFString.h>
 
@@ -101,21 +102,21 @@ void DateTimeFieldElement::defaultKeyboardEventHandler(KeyboardEvent& keyboardEv
     if (keyboardEvent.type() != eventNames().keydownEvent)
         return;
 
-    auto key = keyboardEvent.keyIdentifier();
+    int keyCode = keyboardEvent.keyCode();
     auto code = keyboardEvent.code();
 
     bool isHorizontal = isFieldOwnerHorizontal();
-    auto nextKeyIdentifier = isHorizontal ? "Right"_s : "Down"_s;
-    auto previousKeyIdentifier = isHorizontal ? "Left"_s : "Up"_s;
-    auto stepUpKeyIdentifier = isHorizontal ? "Up"_s : "Right"_s;
-    auto stepDownKeyIdentifier = isHorizontal ? "Down"_s : "Left"_s;
+    int nextKeyCode = isHorizontal ? VK_RIGHT : VK_DOWN;
+    int previousKeyCode = isHorizontal ? VK_LEFT : VK_UP;
+    int stepUpKeyCode = isHorizontal ? VK_UP : VK_RIGHT;
+    int stepDownKeyCode = isHorizontal ? VK_DOWN : VK_LEFT;
 
-    if (key == previousKeyIdentifier && m_fieldOwner && m_fieldOwner->focusOnPreviousField(*this)) {
+    if (keyCode == previousKeyCode && m_fieldOwner && m_fieldOwner->focusOnPreviousField(*this)) {
         keyboardEvent.setDefaultHandled();
         return;
     }
 
-    if ((key == nextKeyIdentifier || code == "Comma"_s || code == "Minus"_s || code == "Period"_s || code == "Slash"_s || code == "Semicolon"_s)
+    if ((keyCode == nextKeyCode || code == "Comma"_s || code == "Minus"_s || code == "Period"_s || code == "Slash"_s || code == "Semicolon"_s)
         && m_fieldOwner && m_fieldOwner->focusOnNextField(*this)) {
         keyboardEvent.setDefaultHandled();
         return;
@@ -124,20 +125,20 @@ void DateTimeFieldElement::defaultKeyboardEventHandler(KeyboardEvent& keyboardEv
     if (isFieldOwnerReadOnly())
         return;
 
-    if (key == stepUpKeyIdentifier) {
+    if (keyCode == stepUpKeyCode) {
         stepUp();
         keyboardEvent.setDefaultHandled();
         return;
     }
 
-    if (key == stepDownKeyIdentifier) {
+    if (keyCode == stepDownKeyCode) {
         stepDown();
         keyboardEvent.setDefaultHandled();
         return;
     }
 
     // Clear value when pressing backspace or delete.
-    if (key == "U+0008"_s || key == "U+007F"_s) {
+    if (keyCode == VK_BACK || keyCode == VK_DELETE) {
         setEmptyValue(DispatchInputAndChangeEvents);
         keyboardEvent.setDefaultHandled();
         return;

--- a/Source/WebCore/platform/DataListSuggestionPicker.h
+++ b/Source/WebCore/platform/DataListSuggestionPicker.h
@@ -39,7 +39,7 @@ public:
 
     virtual void detach() { }
     virtual void close() { }
-    virtual void handleKeydownWithIdentifier(const String&) { }
+    virtual void handleKeydownWithKeyCode(int) { }
     virtual void displayWithActivationType(DataListSuggestionActivationType) { }
 };
 

--- a/Source/WebCore/platform/WindowsKeyboardCodes.h
+++ b/Source/WebCore/platform/WindowsKeyboardCodes.h
@@ -23,9 +23,11 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef VK_UNKNOWN
+#pragma once
 
+#ifndef VK_UNKNOWN
 #define VK_UNKNOWN 0
+#endif
 
 // Left mouse button
 // Right mouse button
@@ -316,5 +318,3 @@
 #define VK_PA1 0xFD // VK_PA1 (FD) PA1 key
 
 #define VK_OEM_CLEAR 0xFE // Clear key
-
-#endif // VK_UNKNOWN

--- a/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.h
+++ b/Source/WebKit/UIProcess/WebDataListSuggestionsDropdown.h
@@ -39,7 +39,7 @@ public:
     virtual ~WebDataListSuggestionsDropdown();
 
     virtual void show(WebCore::DataListSuggestionInformation&&) = 0;
-    virtual void handleKeydownWithIdentifier(const String&) = 0;
+    virtual void handleKeydownWithKeyCode(int) = 0;
     virtual void close();
 
 protected:

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -10326,13 +10326,13 @@ void WebPageProxy::showDataListSuggestions(WebCore::DataListSuggestionInformatio
     protect(*internals().dataListSuggestionsDropdown)->show(WTF::move(info));
 }
 
-void WebPageProxy::handleKeydownInDataList(const String& key)
+void WebPageProxy::handleKeydownInDataList(int keyCode)
 {
     RefPtr dataListSuggestionsDropdown = internals().dataListSuggestionsDropdown;
     if (!dataListSuggestionsDropdown)
         return;
 
-    dataListSuggestionsDropdown->handleKeydownWithIdentifier(key);
+    dataListSuggestionsDropdown->handleKeydownWithKeyCode(keyCode);
 }
 
 void WebPageProxy::endDataListSuggestions()

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3182,7 +3182,7 @@ private:
     void showColorPicker(IPC::Connection&, const WebCore::Color& initialColor, const WebCore::IntRect&, ColorControlSupportsAlpha, Vector<WebCore::Color>&&, std::optional<WebCore::FrameIdentifier>&&);
 
     void showDataListSuggestions(WebCore::DataListSuggestionInformation&&);
-    void handleKeydownInDataList(const String&);
+    void handleKeydownInDataList(int);
     void endDataListSuggestions();
 
     void showDateTimePicker(WebCore::DateTimeChooserParameters&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -119,7 +119,7 @@ messages -> WebPageProxy {
     [EnabledBy=InputTypeColorEnabled] EndColorPicker();
 
     [EnabledBy=DataListElementEnabled] ShowDataListSuggestions(struct WebCore::DataListSuggestionInformation suggestionInformation);
-    [EnabledBy=DataListElementEnabled] HandleKeydownInDataList(String key);
+    [EnabledBy=DataListElementEnabled] HandleKeydownInDataList(int keyCode);
     [EnabledBy=DataListElementEnabled] EndDataListSuggestions();
 
     [EnabledBy=InputTypeDateEnabled || InputTypeDateTimeLocalEnabled || InputTypeMonthEnabled || InputTypeTimeEnabled || InputTypeWeekEnabled] ShowDateTimePicker(struct WebCore::DateTimeChooserParameters params);

--- a/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.cpp
@@ -32,6 +32,7 @@
 #include "WebPageProxy.h"
 #include <WebCore/DataListSuggestionInformation.h>
 #include <WebCore/IntPoint.h>
+#include <WebCore/WindowsKeyboardCodes.h>
 #include <wtf/glib/GRefPtr.h>
 #include <wtf/glib/GUniquePtr.h>
 
@@ -213,13 +214,13 @@ void WebDataListSuggestionsDropdownGtk::show(WebCore::DataListSuggestionInformat
     gtk_widget_show(m_popup);
 }
 
-void WebDataListSuggestionsDropdownGtk::handleKeydownWithIdentifier(const String& key)
+void WebDataListSuggestionsDropdownGtk::handleKeydownWithKeyCode(int keyCode)
 {
     auto* selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(m_treeView));
     GtkTreeModel* model;
     GtkTreeIter iter;
     bool hasSelection = gtk_tree_selection_get_selected(selection, &model, &iter);
-    if (key == "Enter"_s) {
+    if (keyCode == VK_RETURN) {
         if (hasSelection) {
             GUniqueOutPtr<char> item;
             gtk_tree_model_get(model, &iter, 0, &item.outPtr(), -1);
@@ -229,12 +230,12 @@ void WebDataListSuggestionsDropdownGtk::handleKeydownWithIdentifier(const String
         return;
     }
 
-    if (key == "Up"_s) {
+    if (keyCode == VK_UP) {
         if ((hasSelection && gtk_tree_model_iter_previous(model, &iter)) || gtk_tree_model_iter_nth_child(model, &iter, nullptr, gtk_tree_model_iter_n_children(model, nullptr) - 1))
             gtk_tree_selection_select_iter(selection, &iter);
         else
             return;
-    } else if (key == "Down"_s) {
+    } else if (keyCode == VK_DOWN) {
         if ((hasSelection && gtk_tree_model_iter_next(model, &iter)) || gtk_tree_model_get_iter_first(model, &iter))
             gtk_tree_selection_select_iter(selection, &iter);
         else

--- a/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.h
+++ b/Source/WebKit/UIProcess/gtk/WebDataListSuggestionsDropdownGtk.h
@@ -48,7 +48,7 @@ private:
     WebDataListSuggestionsDropdownGtk(GtkWidget*, WebPageProxy&);
 
     void show(WebCore::DataListSuggestionInformation&&) final;
-    void handleKeydownWithIdentifier(const String&) final;
+    void handleKeydownWithKeyCode(int) final;
     void close() final;
 
     static void treeViewRowActivatedCallback(GtkTreeView*, GtkTreePath*, GtkTreeViewColumn*, WebDataListSuggestionsDropdownGtk*);

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.h
@@ -62,7 +62,7 @@ private:
     WebDataListSuggestionsDropdownIOS(WebPageProxy&, WKContentView *);
 
     void show(WebCore::DataListSuggestionInformation&&) final;
-    void handleKeydownWithIdentifier(const String&) final;
+    void handleKeydownWithKeyCode(int) final;
     void close() final;
 
     WeakObjCPtr<WKContentView> m_contentView;

--- a/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebDataListSuggestionsDropdownIOS.mm
@@ -132,7 +132,7 @@ void WebDataListSuggestionsDropdownIOS::show(WebCore::DataListSuggestionInformat
     [m_suggestionsControl showSuggestionsDropdown:*this activationType:type];
 }
 
-void WebDataListSuggestionsDropdownIOS::handleKeydownWithIdentifier(const String&)
+void WebDataListSuggestionsDropdownIOS::handleKeydownWithKeyCode(int)
 {
 }
 

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.h
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.h
@@ -46,7 +46,7 @@ private:
     WebDataListSuggestionsDropdownMac(WebPageProxy&, NSView *);
 
     void show(WebCore::DataListSuggestionInformation&&) final;
-    void handleKeydownWithIdentifier(const String&) final;
+    void handleKeydownWithKeyCode(int) final;
     void close() final;
 
     void selectOption();

--- a/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebDataListSuggestionsDropdownMac.mm
@@ -33,6 +33,7 @@
 #import "WebPreferencesDefaultValues.h"
 #import <WebCore/IntRect.h>
 #import <WebCore/LocalizedStrings.h>
+#import <WebCore/WindowsKeyboardCodes.h>
 #import <pal/spi/mac/NSColorSPI.h>
 
 constexpr CGFloat dropdownTopMargin = 3;
@@ -60,7 +61,7 @@ static NSString * const suggestionCellReuseIdentifier = @"WKDataListSuggestionVi
 - (id)initWithInformation:(WebCore::DataListSuggestionInformation&&)information inView:(NSView *)view;
 - (void)showSuggestionsDropdown:(WebKit::WebDataListSuggestionsDropdownMac&)dropdown;
 - (void)updateWithInformation:(WebCore::DataListSuggestionInformation&&)information;
-- (void)moveSelectionByDirection:(const String&)direction;
+- (void)moveSelectionByDirection:(int)direction;
 - (void)invalidate;
 
 - (String)currentSelectedString;
@@ -116,12 +117,19 @@ void WebDataListSuggestionsDropdownMac::selectOption()
     close();
 }
 
-void WebDataListSuggestionsDropdownMac::handleKeydownWithIdentifier(const String& key)
+void WebDataListSuggestionsDropdownMac::handleKeydownWithKeyCode(int keyCode)
 {
-    if (key == "Enter"_s)
+    switch (keyCode) {
+    case VK_RETURN:
         selectOption();
-    else if (key == "Up"_s || key == "Down"_s)
-        [m_dropdownUI moveSelectionByDirection:key];
+        break;
+    case VK_UP:
+    case VK_DOWN:
+        [m_dropdownUI moveSelectionByDirection:keyCode];
+        break;
+    default:
+        break;
+    }
 }
 
 void WebDataListSuggestionsDropdownMac::close()
@@ -405,16 +413,16 @@ static BOOL shouldShowDividersBetweenCells(const Vector<WebCore::DataListSuggest
     });
 }
 
-- (void)moveSelectionByDirection:(const String&)direction
+- (void)moveSelectionByDirection:(int)direction
 {
     size_t size = _suggestions.size();
     NSInteger oldSelection = [_table selectedRow];
     NSInteger newSelection = -1;
 
     if (oldSelection == -1)
-        newSelection = (direction == "Up"_s) ? (size - 1) : 0;
+        newSelection = (direction == VK_UP) ? (size - 1) : 0;
     else {
-        NSInteger adjustment = (direction == "Up"_s) ? -1 : 1;
+        NSInteger adjustment = (direction == VK_UP) ? -1 : 1;
         newSelection = std::clamp<NSInteger>(oldSelection + adjustment, 0, size);
     }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.cpp
@@ -31,6 +31,7 @@
 #include "WebProcess.h"
 #include <WebCore/DataListSuggestionsClient.h>
 #include <WebCore/LocalFrameView.h>
+#include <WebCore/WindowsKeyboardCodes.h>
 
 namespace WebKit {
 
@@ -42,9 +43,9 @@ WebDataListSuggestionPicker::WebDataListSuggestionPicker(WebPage& page, WebCore:
 
 WebDataListSuggestionPicker::~WebDataListSuggestionPicker() = default;
 
-void WebDataListSuggestionPicker::handleKeydownWithIdentifier(const String& key)
+void WebDataListSuggestionPicker::handleKeydownWithKeyCode(int keyCode)
 {
-    if (key == "U+001B"_s) {
+    if (keyCode == VK_ESCAPE) {
         close();
         return;
     }
@@ -53,7 +54,7 @@ void WebDataListSuggestionPicker::handleKeydownWithIdentifier(const String& key)
     if (!page)
         return;
 
-    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::HandleKeydownInDataList(key), page->identifier());
+    protect(WebProcess::singleton().parentProcessConnection())->send(Messages::WebPageProxy::HandleKeydownInDataList(keyCode), page->identifier());
 }
 
 void WebDataListSuggestionPicker::didSelectOption(const String& selectedOption)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebDataListSuggestionPicker.h
@@ -57,7 +57,7 @@ public:
 private:
     WebDataListSuggestionPicker(WebPage&, WebCore::DataListSuggestionsClient&);
 
-    void handleKeydownWithIdentifier(const String&) final;
+    void handleKeydownWithKeyCode(int) final;
     void displayWithActivationType(WebCore::DataListSuggestionActivationType) final;
     void close() final;
     void detach() final;


### PR DESCRIPTION
#### 8d027a7896bfbe45994b4922e8732d6c82c7badf
<pre>
Replace keyIdentifier() usage with keyCode()
<a href="https://bugs.webkit.org/show_bug.cgi?id=308127">https://bugs.webkit.org/show_bug.cgi?id=308127</a>

Reviewed by NOBODY (OOPS!).

This was requested for new usage of keyIdentifier() so best update the
old usage first.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d027a7896bfbe45994b4922e8732d6c82c7badf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145408 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9900 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154080 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99045 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55c407d4-c982-445b-b175-fb7208625fb6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18574 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/17983 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111820 "Found 11 new test failures: accessibility/multiselect-list-reports-active-option.html fast/events/simulated-key-state.html fast/forms/number/number-outofrange.html fast/forms/number/number-stepup-stepdown-from-renderer.html fast/forms/number/number-type-update-by-change-event.html fast/forms/range/range-keyoperation.html fast/forms/range/range-stepup-stepdown-from-renderer.html imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/checkable-active-space-key-untrusted-event.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-untrusted-key-event.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80138 "Exiting early after 60 failures. 14896 tests run. 60 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5de967b-dbc8-453f-8a0f-55ce375c3934) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148371 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14189 "Found 6 new test failures: fast/events/simulated-key-state.html fast/forms/number/number-outofrange.html fast/forms/number/number-stepup-stepdown-from-renderer.html fast/forms/number/number-type-update-by-change-event.html fast/forms/range/range-keyoperation.html fast/forms/range/range-stepup-stepdown-from-renderer.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130627 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92721 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/256a7528-0a8b-4d6d-8fbf-78b2b32eef9c) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13529 "Found 4 new test failures: imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/checkable-active-space-key-untrusted-event.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-untrusted-key-event.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/summary-untrusted-key-event.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11289 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1526 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7393 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156392 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17940 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8488 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119827 "Found 11 new test failures: accessibility/multiselect-list-reports-active-option.html fast/events/simulated-key-state.html fast/forms/number/number-outofrange.html fast/forms/number/number-stepup-stepdown-from-renderer.html fast/forms/number/number-type-update-by-change-event.html fast/forms/range/range-keyoperation.html fast/forms/range/range-stepup-stepdown-from-renderer.html imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/checkable-active-space-key-untrusted-event.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-untrusted-key-event.html ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/17986 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/14976 "Found 10 new test failures: fast/events/simulated-key-state.html fast/forms/number/number-outofrange.html fast/forms/number/number-stepup-stepdown-from-renderer.html fast/forms/number/number-type-update-by-change-event.html fast/forms/range/range-keyoperation.html fast/forms/range/range-stepup-stepdown-from-renderer.html imported/w3c/web-platform-tests/html/semantics/forms/the-button-element/button-untrusted-key-event.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/checkable-active-space-key-untrusted-event.html imported/w3c/web-platform-tests/html/semantics/forms/the-input-element/input-untrusted-key-event.html imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-summary-element/summary-untrusted-key-event.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120167 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15924 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128657 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73649 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17561 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6887 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81340 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17506 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17361 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->