### PR TITLE
workspaces.xyz: (Regression: 305212@main) Hovering on menu makes it to be jumpy

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2400,6 +2400,13 @@ bool Quirks::shouldDisableDOMAudioSessionQuirk() const
     return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldDisableDOMAudioSession);
 }
 
+bool Quirks::shouldComparareUsedValuesForBorderWidthForTriggeringTransitions() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions);
+}
+
 #if ENABLE(PICTURE_IN_PICTURE_API)
 bool Quirks::shouldReportVisibleDueToActivePictureInPictureContent() const
 {
@@ -3278,6 +3285,15 @@ static void handleWeeblyQuirks(QuirksData& quirksData, const URL& /* quirksURL *
     quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldDispatchSyntheticMouseEventsWhenModifyingSelectionQuirk);
 }
 
+static void handleWorkspacesQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
+{
+    QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("workspaces.xyz"_s);
+
+    // workspaces.xyz rdar://170412045
+    // https://bugs.webkit.org/show_bug.cgi?id=307933
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions);
+}
+
 static void handleWikipediaQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
 {
     QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("wikipedia.org"_s);
@@ -3580,6 +3596,7 @@ void Quirks::determineRelevantQuirks()
         { "webex"_s, &handleScriptToEvaluateBeforeRunningScriptFromURLQuirk },
 #endif
         { "weebly"_s, &handleWeeblyQuirks },
+        { "workspaces"_s, &handleWorkspacesQuirks },
 #if PLATFORM(MAC)
         { "wpdevelopment"_s, &handleWPDevelopmentQuirks },
 #endif

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -322,6 +322,8 @@ public:
     bool shouldReportVisibleDueToActivePictureInPictureContent() const;
 #endif
 
+    bool shouldComparareUsedValuesForBorderWidthForTriggeringTransitions() const;
+
     void determineRelevantQuirks();
 
 private:

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -140,6 +140,7 @@ struct QuirksData {
         ShouldAvoidScrollingWhenFocusedContentIsVisibleQuirk,
         ShouldBlockFetchWithNewlineAndLessThan,
         ShouldBypassAsyncScriptDeferring,
+        ShouldComparareUsedValuesForBorderWidthForTriggeringTransitions,
         ShouldDelayReloadWhenRegisteringServiceWorker,
 #if HAVE(PIP_SKIP_PREROLL)
         ShouldDisableAdSkippingInPip,

--- a/Source/WebCore/style/StyleChangedAnimatableProperties.cpp
+++ b/Source/WebCore/style/StyleChangedAnimatableProperties.cpp
@@ -33,7 +33,7 @@
 namespace WebCore {
 namespace Style {
 
-void conservativelyCollectChangedAnimatableProperties(const RenderStyle& a, const RenderStyle& b, CSSPropertiesBitSet& changingProperties)
+void conservativelyCollectChangedAnimatableProperties(const RenderStyle& a, const RenderStyle& b, CSSPropertiesBitSet& changingProperties, EnumSet<AnimatablePropertiesCollectionQuirks> quirks)
 {
     // Check property values on RenderStyle for changes.
 
@@ -51,6 +51,18 @@ void conservativelyCollectChangedAnimatableProperties(const RenderStyle& a, cons
     // `insideLink` changes visited / non-visited colors, thus, we need to add all color properties.
     if (a.insideLink() != b.insideLink())
         changingProperties.m_properties.merge(CSSProperty::colorProperties);
+
+    if (quirks.contains(AnimatablePropertiesCollectionQuirks::ComparareUsedValuesForBorderWidth)) {
+        // Don't transition if the used value does not change. This is also affected by `border-*-style`.
+        if (a.usedBorderTopWidth() == b.usedBorderTopWidth())
+            changingProperties.m_properties.clear(CSSPropertyBorderTopWidth);
+        if (a.usedBorderRightWidth() == b.usedBorderRightWidth())
+            changingProperties.m_properties.clear(CSSPropertyBorderRightWidth);
+        if (a.usedBorderBottomWidth() == b.usedBorderBottomWidth())
+            changingProperties.m_properties.clear(CSSPropertyBorderBottomWidth);
+        if (a.usedBorderLeftWidth() == b.usedBorderLeftWidth())
+            changingProperties.m_properties.clear(CSSPropertyBorderLeftWidth);
+    }
 }
 
 } // namespace Style

--- a/Source/WebCore/style/StyleChangedAnimatableProperties.h
+++ b/Source/WebCore/style/StyleChangedAnimatableProperties.h
@@ -36,7 +36,10 @@ namespace Style {
 // to precisely check equivalence before saying "this property needs to be visited". This is tuned
 // based on Speedometer3.0 data.
 
-void conservativelyCollectChangedAnimatableProperties(const RenderStyle&, const RenderStyle&, CSSPropertiesBitSet&);
+enum class AnimatablePropertiesCollectionQuirks : uint8_t {
+    ComparareUsedValuesForBorderWidth
+};
+void conservativelyCollectChangedAnimatableProperties(const RenderStyle&, const RenderStyle&, CSSPropertiesBitSet&, EnumSet<AnimatablePropertiesCollectionQuirks>);
 
 } // namespace Style
 } // namespace WebCore

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -816,7 +816,14 @@ void Styleable::updateCSSTransitions(const RenderStyle& currentStyle, const Rend
         if (auto* lastStyleChangeEventStyle = this->lastStyleChangeEventStyle())
             targetStyle = lastStyleChangeEventStyle;
 
-        Style::conservativelyCollectChangedAnimatableProperties(*targetStyle, newStyle, transitionProperties);
+        auto collectionQuirks = [&] {
+            EnumSet<Style::AnimatablePropertiesCollectionQuirks> quirks;
+            if (protect(element.document())->quirks().shouldComparareUsedValuesForBorderWidthForTriggeringTransitions())
+                quirks.add(Style::AnimatablePropertiesCollectionQuirks::ComparareUsedValuesForBorderWidth);
+            return quirks;
+        }();
+
+        Style::conservativelyCollectChangedAnimatableProperties(*targetStyle, newStyle, transitionProperties, collectionQuirks);
 
         // When we have keyframeEffectStack, it can affect on properties. So we just add them.
         if (keyframeEffectStack()) {


### PR DESCRIPTION
#### aeac793ec439908c853c409d3d12c9e1fa579980
<pre>
workspaces.xyz: (Regression: 305212@main) Hovering on menu makes it to be jumpy
<a href="https://bugs.webkit.org/show_bug.cgi?id=307933">https://bugs.webkit.org/show_bug.cgi?id=307933</a>
<a href="https://rdar.apple.com/170412045">rdar://170412045</a>

Reviewed by Simon Fraser and Sam Weinig.

Border width change is triggering spurious transitions on this site. The site expects that if used value does not
change there is no transition.

Our new behavior matches the spec and Firefox (but not Chrome) so add a site-specific quirk that maintains the old behavior.

This is a quirk version of the fix made by Sam Weinig.

* Source/WebCore/page/Quirks.cpp:
(WebCore::Quirks::shouldComparareUsedValuesForBorderWidthForTriggeringTransitions const):
(WebCore::handleWorkspacesQuirks):
(WebCore::Quirks::determineRelevantQuirks):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebCore/style/StyleChangedAnimatableProperties.cpp:
(WebCore::Style::conservativelyCollectChangedAnimatableProperties):

With quirk enabled don&apos;t transition border width properties if the used value does not change.

* Source/WebCore/style/StyleChangedAnimatableProperties.h:
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::updateCSSTransitions const):

Canonical link: <a href="https://commits.webkit.org/307770@main">https://commits.webkit.org/307770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7569f29ec45db6909e7573a5c4d5583168b7995e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145446 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9949 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154118 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99083 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b58b6904-ec09-4d18-a628-d519242b4583) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147321 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111852 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/584ca401-6546-447b-a12a-67cc2006d75c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92753 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c2cd9ba-1879-40b8-b581-feba8e6cec83) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13558 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11318 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1564 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123094 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7431 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156430 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/17978 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/8533 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119859 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18024 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15011 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120200 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30813 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15956 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128701 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73697 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17599 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17336 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81378 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17544 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17399 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->