### PR TITLE
Remove advanced privacy protection condition for blockable requests

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -352,7 +352,6 @@ bool NetworkLoadChecker::shouldBlockForTrackingPolicy(const ResourceRequest& req
         return false;
 
     auto mayBlock = networkResourceLoader->parameters().mayBlockNetworkRequest;
-    bool needsAdvancedPrivacyProtections = networkResourceLoader->parameters().advancedPrivacyProtections.contains(WebCore::AdvancedPrivacyProtections::BaselineProtections);
     if (!mayBlock)
         return false;
 
@@ -362,7 +361,7 @@ bool NetworkLoadChecker::shouldBlockForTrackingPolicy(const ResourceRequest& req
     }
 
     if (CheckedPtr networkSession = m_networkProcess->networkSession(m_sessionID)) {
-        if (networkSession->shouldBlockRequestForTrackingPolicyAndUpdatePolicy(request, *m_webPageProxyID, *mayBlock, needsAdvancedPrivacyProtections)) {
+        if (networkSession->shouldBlockRequestForTrackingPolicyAndUpdatePolicy(request, *m_webPageProxyID, *mayBlock)) {
             LOAD_CHECKER_RELEASE_LOG("shouldBlockForTrackingPolicy - Blocked by tracking protections");
             return true;
         }

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -317,10 +317,10 @@ bool NetworkSession::isTrackingPreventionEnabled() const
     return !!m_resourceLoadStatistics;
 }
 
-bool NetworkSession::isRequestBlockable(const WebCore::ResourceRequest& request, bool needsAdvancedPrivacyProtections)
+bool NetworkSession::isRequestBlockable(const WebCore::ResourceRequest& request)
 {
 #if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
-    return WebKit::isRequestBlockable(request, needsAdvancedPrivacyProtections);
+    return WebKit::isRequestBlockable(request);
 #else
     return false;
 #endif
@@ -342,9 +342,9 @@ IsKnownCrossSiteTracker NetworkSession::isResourceFromKnownCrossSiteTracker(cons
     return isRequestToKnownCrossSiteTracker(request);
 }
 
-bool NetworkSession::shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const WebCore::ResourceRequest& request, WebPageProxyIdentifier webPageID, bool mayBlockScriptLoad, bool needsAdvancedPrivacyProtections)
+bool NetworkSession::shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const WebCore::ResourceRequest& request, WebPageProxyIdentifier webPageID, bool mayBlockScriptLoad)
 {
-    if (!mayBlockScriptLoad && !isRequestBlockable(request, needsAdvancedPrivacyProtections))
+    if (!mayBlockScriptLoad && !isRequestBlockable(request))
         return false;
     auto it = m_trackerBlockingPolicyByPageIdentifier.find(webPageID);
     if (it == m_trackerBlockingPolicyByPageIdentifier.end())

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -144,8 +144,8 @@ public:
     bool isTrackingPreventionEnabled() const;
     static WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore::ResourceRequest&);
     static WebCore::IsKnownCrossSiteTracker isResourceFromKnownCrossSiteTracker(const URL& firstParty, const URL& resource);
-    static bool isRequestBlockable(const WebCore::ResourceRequest&, bool needsAdvancedPrivacyProtections);
-    bool shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const WebCore::ResourceRequest&, WebPageProxyIdentifier, bool mayBlockScriptLoad, bool needsAdvancedPrivacyProtections);
+    static bool isRequestBlockable(const WebCore::ResourceRequest&);
+    bool shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const WebCore::ResourceRequest&, WebPageProxyIdentifier, bool mayBlockScriptLoad);
     void deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
     void registrableDomainsWithWebsiteData(OptionSet<WebsiteDataType>, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
     bool enableResourceLoadStatisticsLogTestingEvent() const { return m_enableResourceLoadStatisticsLogTestingEvent; }

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -65,7 +65,7 @@ enum class RestrictedOpenerType : uint8_t;
 void configureForAdvancedPrivacyProtections(NSURLSession *);
 bool isKnownTrackerAddressOrDomain(StringView host);
 WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore::ResourceRequest&);
-bool isRequestBlockable(const WebCore::ResourceRequest&, bool);
+bool isRequestBlockable(const WebCore::ResourceRequest&);
 void requestLinkDecorationFilteringData(CompletionHandler<void(Vector<WebCore::LinkDecorationFilteringData>&&)>&&);
 
 class ListDataObserver : public RefCountedAndCanMakeWeakPtr<ListDataObserver> {

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -764,7 +764,7 @@ WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore:
     return request.isThirdParty() && isKnownTrackerAddressOrDomain(request.url().host()) ? WebCore::IsKnownCrossSiteTracker::Yes : WebCore::IsKnownCrossSiteTracker::No;
 }
 
-bool isRequestBlockable(const WebCore::ResourceRequest& request, bool needsAdvancedPrivacyProtections)
+bool isRequestBlockable(const WebCore::ResourceRequest& request)
 {
     TrackerAddressLookupInfo::populateIfNeeded();
     TrackerDomainLookupInfo::populateIfNeeded();
@@ -774,9 +774,7 @@ bool isRequestBlockable(const WebCore::ResourceRequest& request, bool needsAdvan
         return true;
 
     if (auto info = TrackerDomainLookupInfo::find(domain.string()); info.owner().length()) {
-        if (info.canBlock() == TrackerDomainLookupInfo::CanBlock::No)
-            return false;
-        return needsAdvancedPrivacyProtections || info.canBlock() == TrackerDomainLookupInfo::CanBlock::WithDefaultProtections;
+        return info.canBlock() == TrackerDomainLookupInfo::CanBlock::WithDefaultProtections;
     }
     return false;
 }
@@ -791,7 +789,7 @@ bool isTaintedScriptURLBlockable(const URL& url)
 void configureForAdvancedPrivacyProtections(NSURLSession *) { }
 bool isKnownTrackerAddressOrDomain(StringView) { return false; }
 WebCore::IsKnownCrossSiteTracker isRequestToKnownCrossSiteTracker(const WebCore::ResourceRequest&) { return WebCore::IsKnownCrossSiteTracker::No; }
-bool isRequestBlockable(const WebCore::ResourceRequest&, bool) { return false; }
+bool isRequestBlockable(const WebCore::ResourceRequest&) { return false; }
 bool isTaintedScriptURLBlockable(const URL&) { return false; }
 
 #endif

--- a/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp
+++ b/Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp
@@ -119,6 +119,9 @@ bool ScriptTrackingPrivacyFilter::shouldBlockRequest(const URL& url, const WebCo
 #endif
 
     auto categoryFlag = WebCore::scriptCategoryAsFlag(ScriptTrackingPrivacyCategory::NetworkRequests);
+    if (!m_categoriesWithAllowedHosts.contains(categoryFlag))
+        return true;
+
     auto result = lookup(url, topOrigin);
     return result.foundMatch && !result.allowedCategories.contains(categoryFlag);
 }


### PR DESCRIPTION
#### 768e23e01c07542e5a341e87b8e272c6db6426a7
<pre>
Remove advanced privacy protection condition for blockable requests
<a href="https://bugs.webkit.org/show_bug.cgi?id=308008">https://bugs.webkit.org/show_bug.cgi?id=308008</a>
<a href="https://rdar.apple.com/170489913">rdar://170489913</a>

Reviewed by Charlie Wolfe.

Currently, requests are blockable if we have advanced privacy protections
enabled, or if a particular domain is annotated as being blockable with default
privacy protections. This change relaxes the first condition, so we only block
requests if that is web compatible.

This patch also adds an early return when none of the NetworkRequest category
is never allowed.

Covered by existing tests.

* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::shouldBlockForTrackingPolicy):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::isRequestBlockable):
(WebKit::NetworkSession::shouldBlockRequestForTrackingPolicyAndUpdatePolicy):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::isRequestBlockable):
* Source/WebKit/Shared/ScriptTrackingPrivacyFilter.cpp:
(WebKit::ScriptTrackingPrivacyFilter::shouldBlockRequest):

Canonical link: <a href="https://commits.webkit.org/307774@main">https://commits.webkit.org/307774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd53abeb0d88d56d07823e646b3783bb1c9771b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145468 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18150 "Failed to checkout and rebase branch from PR 58929") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/9978 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154140 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e349d0f-a69d-4816-8d3e-22fcfdb4581b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18635 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18043 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/111871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/554c2d9d-1766-4608-be2e-2fea0b3508f5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14241 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/130681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92772 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/966211f8-0c86-4984-8ce3-46cee973781f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13573 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1586 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156452 "Built successfully") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/18000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/8557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/119876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18046 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120217 "Passed tests") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/128727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73729 "Build is in progress. Recent messages:") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22432 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17621 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/6940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/17358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17566 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/17421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->