### PR TITLE
[Site Isolation] Make dispatching pagehide event work

### DIFF
--- a/LayoutTests/http/tests/site-isolation/pagehide-event-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/pagehide-event-expected.txt
@@ -1,0 +1,10 @@
+Tests that pagehide is fired when site isolation is enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is "pagehide"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/pagehide-event-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/pagehide-event-iframe-expected.txt
@@ -1,0 +1,10 @@
+Tests that pagehide is fired in iframes when site isolation is enabled.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.data is "pagehide"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/pagehide-event-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/pagehide-event-iframe.html
@@ -1,0 +1,21 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!-- Similar to pagehide-event.html, but tests that event is fired in iframes. -->
+
+<!DOCTYPE html>
+<title>Tests that pagehide is fired in iframes when site isolation is enabled.</title>
+
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that pagehide is fired in iframes when site isolation is enabled.");
+jsTestIsAsync = true;
+
+const chan = new BroadcastChannel("pagehide-chan");
+chan.addEventListener("message", (event) => {
+  shouldBeEqualToString("event.data", "pagehide");
+  finishJSTest();
+})
+
+</script>
+
+<!-- This iframe is same-origin with this page. -->
+<iframe src="/site-isolation/resources/pagehide-event-subpage.html"></iframe>

--- a/LayoutTests/http/tests/site-isolation/pagehide-event.html
+++ b/LayoutTests/http/tests/site-isolation/pagehide-event.html
@@ -1,0 +1,22 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<!-- This test is adapted from LayoutTests/imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub.html -->
+
+<!DOCTYPE html>
+<title>Tests that pagehide is fired when site isolation is enabled.</title>
+
+<script src="/js-test-resources/js-test.js"></script>
+<script>
+description("Tests that pagehide is fired when site isolation is enabled.");
+jsTestIsAsync = true;
+
+var popup;
+
+const chan = new BroadcastChannel("pagehide-chan");
+chan.addEventListener("message", (event) => {
+  shouldBeEqualToString("event.data", "pagehide");
+  popup.close();
+  finishJSTest();
+});
+
+popup = window.open("/site-isolation/resources/pagehide-event-subpage.html");
+</script>

--- a/LayoutTests/http/tests/site-isolation/resources/pagehide-event-subpage.html
+++ b/LayoutTests/http/tests/site-isolation/resources/pagehide-event-subpage.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Subpage that navigates away to a cross-origin page and sends a message when pagehide is fired</title>
+
+<script>
+
+const params = new URLSearchParams(location.search);
+const is_new_page = params.has('new');
+const chan = new BroadcastChannel("pagehide-chan");
+
+if (!is_new_page) {
+  onload = () => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      location.href = "http://localhost:8000/site-isolation/resources/pagehide-event-subpage.html?new";
+    }));
+  };
+
+  onpagehide = (event) => {
+    chan.postMessage("pagehide");
+  };
+}
+</script>

--- a/Source/WebCore/page/RemoteFrame.cpp
+++ b/Source/WebCore/page/RemoteFrame.cpp
@@ -49,14 +49,9 @@ Ref<RemoteFrame> RemoteFrame::createMainFrame(Page& page, ClientCreator&& client
     return adoptRef(*new RemoteFrame(page, WTF::move(clientCreator), identifier, nullptr, nullptr, std::nullopt, opener, WTF::move(frameTreeSyncData)));
 }
 
-Ref<RemoteFrame> RemoteFrame::createSubframe(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, Frame& parent, Frame* opener, Ref<FrameTreeSyncData>&& frameTreeSyncData, AddToFrameTree addToFrameTree)
+Ref<RemoteFrame> RemoteFrame::createSubframe(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, Frame& parent, Frame* opener, std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier, Ref<FrameTreeSyncData>&& frameTreeSyncData, AddToFrameTree addToFrameTree)
 {
-    return adoptRef(*new RemoteFrame(page, WTF::move(clientCreator), identifier, nullptr, &parent, std::nullopt, opener, WTF::move(frameTreeSyncData), addToFrameTree));
-}
-
-Ref<RemoteFrame> RemoteFrame::createSubframeWithContentsInAnotherProcess(Page& page, ClientCreator&& clientCreator, FrameIdentifier identifier, HTMLFrameOwnerElement& ownerElement, std::optional<LayerHostingContextIdentifier> layerHostingContextIdentifier, Ref<FrameTreeSyncData>&& frameTreeSyncData)
-{
-    return adoptRef(*new RemoteFrame(page, WTF::move(clientCreator), identifier, &ownerElement, ownerElement.document().frame(), layerHostingContextIdentifier, nullptr, WTF::move(frameTreeSyncData), AddToFrameTree::No));
+    return adoptRef(*new RemoteFrame(page, WTF::move(clientCreator), identifier, nullptr, &parent, layerHostingContextIdentifier, opener, WTF::move(frameTreeSyncData), addToFrameTree));
 }
 
 RemoteFrame::RemoteFrame(Page& page, ClientCreator&& clientCreator, FrameIdentifier frameID, HTMLFrameOwnerElement* ownerElement, Frame* parent, Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier, Frame* opener, Ref<FrameTreeSyncData>&& frameTreeSyncData, AddToFrameTree addToFrameTree)

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -53,8 +53,7 @@ class RemoteFrame final : public Frame {
 public:
     using ClientCreator = CompletionHandler<UniqueRef<RemoteFrameClient>(RemoteFrame&)>;
     WEBCORE_EXPORT static Ref<RemoteFrame> createMainFrame(Page&, ClientCreator&&, FrameIdentifier, Frame* opener, Ref<FrameTreeSyncData>&&);
-    WEBCORE_EXPORT static Ref<RemoteFrame> createSubframe(Page&, ClientCreator&&, FrameIdentifier, Frame& parent, Frame* opener, Ref<FrameTreeSyncData>&&, AddToFrameTree);
-    WEBCORE_EXPORT static Ref<RemoteFrame> createSubframeWithContentsInAnotherProcess(Page&, ClientCreator&&, FrameIdentifier, HTMLFrameOwnerElement&, std::optional<LayerHostingContextIdentifier>, Ref<FrameTreeSyncData>&&);
+    WEBCORE_EXPORT static Ref<RemoteFrame> createSubframe(Page&, ClientCreator&&, FrameIdentifier, Frame& parent, Frame* opener, std::optional<LayerHostingContextIdentifier>, Ref<FrameTreeSyncData>&&, AddToFrameTree);
     ~RemoteFrame();
 
     RemoteDOMWindow& NODELETE window() const;


### PR DESCRIPTION
#### 1e83941265e7ca16a9739688fda0f7482cf51c53
<pre>
[Site Isolation] Make dispatching pagehide event work
<a href="https://rdar.apple.com/169910652">rdar://169910652</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307268">https://bugs.webkit.org/show_bug.cgi?id=307268</a>

Reviewed by Ryosuke Niwa.

WebFrame::loadDidCommitInAnotherProcess is called when the frame is loaded in another
process. It replaces the Frame object in the current process from LocalFrame to
RemoteFrame, because the newly loaded frame now lives in the other process. The
process looks like this:

(1) disconnect the old LocalFrame from its owner element
(2) create a new RemoteFrame that connects to the owner element, using
    RemoteFrame::createSubframeWithContentsInAnotherProcess
(3) replace the old LocalFrame in the frame tree with the new RemoteFrame using
    FrameTree::replaceChild. replaceChild() detaches the old LocalFrame
    from its parent using FrameLoader::detachFromParent.

(1) needs to happen before (2), because (2) attaches the new RemoteFrame to the
owner element, so it must not be attached to anything beforehand.
But (1) also detaches the document in the LocalFrame from the frame itself
(Frame::disconnectOwnerElement -&gt; LocalFrame::frameWasDisconnectedFromOwner -&gt;
Document::detachFromFrame). Then in (3), when FrameLoader::detachFromParent() is
called, it tries to dispatch pagehide event (FrameLoader::detachFromParent -&gt;
FrameLoader::closeURL -&gt; FrameLoader::stopLoading -&gt; FrameLoader::dispatchUnloadEvents -&gt;
Document::dispatchPagehideEvent), but the dispatch fails because the document is
already detached from the frame.

To fix this, this patch breaks (2) into two steps:

* create a new RemoteFrame without connecting to an owner element
* connect the newly created RemoteFrame to an owner element

Then, we rearrange the process so that when (3) dispatches pagehide event,
the document is still attached to the frame:

* create a new RemoteFrame without connecting to the owner element (yet)
* replace the old LocalFrame with the new RemoteFrame in the frame tree using
  FrameTree::replaceChild. Since we haven&apos;t disconnect the old LocalFrame from its
  owner element, the document inside is still attached to the frame, so pagehide
  can be dispatched.
* now we disconnect the owner element from the old LocalFrame and connect it to
  the new RemoteFrame

Tests: http/tests/site-isolation/pagehide-event-iframe.html
       http/tests/site-isolation/pagehide-event.html
       imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-cross-origin.sub.html

* LayoutTests/http/tests/site-isolation/pagehide-event-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/pagehide-event-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/pagehide-event-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/pagehide-event.html: Added.
* LayoutTests/http/tests/site-isolation/resources/pagehide-event-subpage.html: Added.
* Source/WebCore/page/RemoteFrame.cpp:
(WebCore::RemoteFrame::createSubframe):
(WebCore::RemoteFrame::createSubframeWithContentsInAnotherProcess):
    - Remote constructor that&apos;s no longer needed.

* Source/WebCore/page/RemoteFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::createRemoteSubframe):
(WebKit::WebFrame::loadDidCommitInAnotherProcess):

Canonical link: <a href="https://commits.webkit.org/308194@main">https://commits.webkit.org/308194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12884a2ee36a1e7b93642dc130ffda501a924030

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146601 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19277 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/12798 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155265 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99988 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112954 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80665 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149564 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131727 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93701 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14440 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12218 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2709 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124020 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/9589 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157592 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/736 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11023 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120963 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19080 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16025 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121173 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31060 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19087 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131341 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74889 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16806 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8251 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18696 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82443 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18426 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18576 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18485 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->