### PR TITLE
[ macOS wk2 Release arm64 ] http/wpt/webcodecs/webcodecs-message-gc.html is a flaky text failure

### DIFF
--- a/LayoutTests/http/wpt/webcodecs/webcodecs-message-gc.html
+++ b/LayoutTests/http/wpt/webcodecs/webcodecs-message-gc.html
@@ -82,6 +82,25 @@ async function doEncodeDecode(encoderConfig)
   clearInterval(timer);
 }
 
+function listenToConsoleMessages()
+{
+  window.gotVideoFrameConsoleMessage = false;
+  const messagePromise = new Promise((resolve, reject) => {
+    if (!window.internals) {
+      window.gotVideoFrameConsoleMessage = true;
+      return;
+    }
+    internals.setConsoleMessageListener(message => {
+      window.gotVideoFrameConsoleMessage |= message.includes("A VideoFrame was destroyed");
+    });
+  });
+}
+
+function didReceiveVideoFrameConsoleMessage()
+{
+  return window.gotVideoFrameConsoleMessage;
+}
+
 function doTest(codec, title)
 {
   const config = { codec };
@@ -91,7 +110,15 @@ function doTest(codec, title)
   config.framerate = 30;
 
   promise_test(async t => {
-    return doEncodeDecode(config);
+    listenToConsoleMessages();
+
+    let counter = 0;
+    while (++counter < 50) {
+      await doEncodeDecode(config);
+      if (didReceiveVideoFrameConsoleMessage())
+        break;
+    }
+    assert_less_than(counter, 50);
   }, title);
 }
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2303,8 +2303,6 @@ webkit.org/b/296202 imported/w3c/web-platform-tests/service-workers/service-work
 
 webkit.org/b/297613 [ Debug ] fast/scrolling/mac/stateless-user-scroll-scrollend.html [ Pass Failure ]
 
-webkit.org/b/297623 [ Release arm64 ] http/wpt/webcodecs/webcodecs-message-gc.html [ Pass Failure ]
-
 webkit.org/b/297674 [ Sonoma Release ] http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html [ Pass Failure ]
 
 # webkit.org/b/297737 [macOS Debug] ipc/send-gradient.html is crashing in EWS


### PR DESCRIPTION
#### 59e0d6c0c78e28316de68ace404880c29a1899c3
<pre>
[ macOS wk2 Release arm64 ] http/wpt/webcodecs/webcodecs-message-gc.html is a flaky text failure
<a href="https://rdar.apple.com/158720259">rdar://158720259</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=297623">https://bugs.webkit.org/show_bug.cgi?id=297623</a>

Reviewed by Jean-Yves Avenard.

We cannot be sure that GC will always kick in to destroy a VideoFrame and trigger a message in the JS console.
To make sure we hit GC, we keep creating VideoFrames until we hit a VideoFrame gc warning in the JS console.
We do this by registering a console message listener using the internals API.

* LayoutTests/http/wpt/webcodecs/webcodecs-message-gc.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/307829@main">https://commits.webkit.org/307829@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e42b07b2f968535d3f029ccb81653569fd4b38f5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145650 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18332 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10208 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154322 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112009 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e43264b7-940d-4a12-8377-3d030e1dccf3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130820 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92914 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d452419c-fc14-4618-a348-27cc610d296c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13687 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11454 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1769 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123232 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7641 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156635 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18182 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8751 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120010 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18228 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15167 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120362 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30855 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16089 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128928 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73919 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17803 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7071 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17540 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17748 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17603 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->