### PR TITLE
GitHub.com: File names in files changed tab of pull request can get cut off when increasing layout zoom.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/contain-intrinsic-height-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/contain-intrinsic-height-expected.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/contain-intrinsic-height.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/contain-intrinsic-height.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+<style>
+html {
+  font-size: 1px;
+}
+p {
+  font-size: initial;
+}
+.containment {
+  zoom: 10;
+  width: 10px;
+  contain-intrinsic-height: 10rem;
+  contain: size;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="containment">
+    <div style="width: 10px; height: 10px;"></div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/contain-intrinsic-width-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/contain-intrinsic-width-expected.html
@@ -1,0 +1,7 @@
+<html>
+<head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div style="width: 100px; height: 100px; background-color: green;"></div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/contain-intrinsic-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/contain-intrinsic-width.html
@@ -1,0 +1,25 @@
+<html>
+<head>
+<style>
+html {
+  font-size: 1px;
+}
+p {
+  font-size: initial;
+}
+.containment {
+  zoom: 10;
+  width: min-content;
+  contain-intrinsic-width: 10rem;
+  contain: inline-size;
+  background-color: green;
+}
+</style>
+</head>
+<body>
+  <p>Test passes if there is a filled green square.</p>
+  <div class="containment">
+    <div style="width: 10px; height: 10px;"></div>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -5156,7 +5156,8 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerWidth() const
 {
     ASSERT(isHorizontalWritingMode() ? shouldApplySizeOrInlineSizeContainment() : shouldApplySizeContainment());
 
-    auto& containIntrinsicWidth = style().containIntrinsicWidth();
+    auto& style = this->style();
+    auto& containIntrinsicWidth = style.containIntrinsicWidth();
     if (containIntrinsicWidth.isNone())
         return { };
 
@@ -5169,7 +5170,7 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerWidth() const
     }
 
     if (auto length = containIntrinsicWidth.tryLength())
-        return LayoutUnit { length->resolveZoom(Style::ZoomNeeded { }) };
+        return LayoutUnit { length->resolveZoom(style.usedZoomForLength()) };
 
     ASSERT(containIntrinsicWidth.isAutoAndNone());
     return { };
@@ -5179,7 +5180,8 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerHeight() const
 {
     ASSERT(isHorizontalWritingMode() ? shouldApplySizeContainment() : shouldApplySizeOrInlineSizeContainment());
 
-    auto& containIntrinsicHeight = style().containIntrinsicHeight();
+    auto& style = this->style();
+    auto& containIntrinsicHeight = style.containIntrinsicHeight();
     if (containIntrinsicHeight.isNone())
         return { };
 
@@ -5192,7 +5194,7 @@ std::optional<LayoutUnit> RenderBox::explicitIntrinsicInnerHeight() const
     }
 
     if (auto length = containIntrinsicHeight.tryLength())
-        return LayoutUnit { length->resolveZoom(Style::ZoomNeeded { }) };
+        return LayoutUnit { length->resolveZoom(style.usedZoomForLength()) };
 
     ASSERT(containIntrinsicHeight.isAutoAndNone());
     return { };

--- a/Source/WebCore/style/values/sizing/StyleContainIntrinsicSize.h
+++ b/Source/WebCore/style/values/sizing/StyleContainIntrinsicSize.h
@@ -35,7 +35,7 @@ using namespace CSS::Literals;
 // <'contain-intrinsic-*'> = auto? [ none | <length [0,inf]> ]
 // https://drafts.csswg.org/css-sizing-4/#intrinsic-size-override
 struct ContainIntrinsicSize {
-    using Length = Style::Length<CSS::Nonnegative, float>;
+    using Length = Style::Length<CSS::NonnegativeUnzoomed, float>;
 
     ContainIntrinsicSize(CSS::Keyword::None)
         : type { ContainIntrinsicSizeType::None }


### PR DESCRIPTION
#### 5a93c2cd1fdd0aba3ee209352bc76191400b1214
<pre>
GitHub.com: File names in files changed tab of pull request can get cut off when increasing layout zoom.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308137">https://bugs.webkit.org/show_bug.cgi?id=308137</a>
<a href="https://rdar.apple.com/170652492">rdar://170652492</a>

Reviewed by Brent Fulgham.

The sidebar which contains the file names on the left hand side of the
&quot;Files changed,&quot; section of a PR contains content with
contain-intrinsic-height with a rem value. The reason the file names can
eventually get cut off if you increase layout zoom (e.g. via cmd + plus)
is because we fail to scale these values properly.

We can fix this by marking StyleContrainIntrinsicSize as an &quot;Unzoomed,&quot;
property and then properly pasing in the used zoom whenever we evaluate
these values.

Canonical link: <a href="https://commits.webkit.org/307851@main">https://commits.webkit.org/307851@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5ff0e4995f358318afe8981a5c752e9720bb537c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/9991 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154151 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99116 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e034a9a-a479-41d9-a66b-262ca3ea6977) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147354 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18054 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111878 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80171 "1 flakes 1 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a1b24070-7c4a-40a1-b7b0-0b69f5f104a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14249 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92779 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d89b2fb8-89dd-43c8-b5a7-f95b9b332067) 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11342 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1598 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7463 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156463 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8574 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119885 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18011 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15039 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120226 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30870 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128744 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73740 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15987 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6950 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17632 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81412 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17369 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17432 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->