### PR TITLE
Fix WebKit Bugzilla 307398: export-w3c-test-changes crashes and fails…

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -602,6 +602,10 @@ nothing to commit, working tree clean
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.commit(message=args[3], env=kwargs.get('env', dict())),
             ), mocks.Subprocess.Route(
+                self.executable, 'apply', '--index', '--binary', '-3', re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.apply(),
+            ), mocks.Subprocess.Route(
                 self.executable, 'apply', '--index', re.compile(r'.+'), '-3',
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.apply(),

--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -110,9 +110,13 @@ class WebPlatformTestExporter(object):
     @property
     @memoized
     def _wpt_fork_remote(self):
+        # Always return a string to avoid None comparison crashes.
+        # Prefer explicit remote name, then username, then default to "origin".
         wpt_fork_remote = self._options.repository_remote
         if not wpt_fork_remote:
             wpt_fork_remote = self.username
+        if not wpt_fork_remote:
+            wpt_fork_remote = "origin"
 
         return wpt_fork_remote
 
@@ -231,30 +235,57 @@ class WebPlatformTestExporter(object):
         self._run_wpt_git(['checkout', self._wpt_repo.default_branch])
         self._run_wpt_git(['reset', '--hard', 'origin/master'])
 
+    def wpt_already_has_bug_export(self):
+        if not self._bug_id:
+            return False
+
+        grep_patterns = [str(self._bug_id), f'bugs.webkit.org/show_bug.cgi?id={self._bug_id}']
+        for pattern in grep_patterns:
+            result = self._run_wpt_git(['log', '--oneline', '-n', '1', f'--grep={pattern}'], capture_output=True)
+            if result.returncode == 0 and result.stdout and result.stdout.strip():
+                _log.error(f'Bug {self._bug_id} appears already exported to WPT: {result.stdout.decode("utf-8", "replace").strip()}')
+                return True
+        return False
+
     def create_branch_with_patch(self, patch):
         _log.info('Applying patch to web-platform-tests branch ' + self._branch_name)
-        try:
-            self._run_wpt_git(['checkout', '-b', self._branch_name])
-        except Exception as e:
-            _log.warning(e)
-            _log.info('Retrying to create the branch')
-            if self._run_wpt_git(['show-ref', '--quiet', '--verify', f'refs/heads/{self._branch_name}']):
+        # Use -B to create or reset the branch from current HEAD. Idempotent: re-running does not
+        # fail with "branch already exists". If -B fails (e.g. branch never existed), create with -b.
+        result = self._run_wpt_git(['checkout', '-B', self._branch_name])
+        if result.returncode:
+            if not self._run_wpt_git(['show-ref', '--quiet', '--verify', f'refs/heads/{self._branch_name}']).returncode:
                 self._run_wpt_git(['branch', '-D', self._branch_name])
             self._run_wpt_git(['checkout', '-b', self._branch_name])
 
         try:
-            output = self._run_wpt_git(['apply', '--index', patch, '-3'], stderr=subprocess.STDOUT)
+            output = self._run_wpt_git(['apply', '--index', '--binary', '-3', patch], capture_output=True)
             if output.returncode:
-                _log.error(f'Failed to apply patch!')
-                _log.error(f"{output.stdout.decode('utf-8', 'replace')}")
-                return False
+                # Fallback: --index can partially apply (text hunks into index) then fail on new
+                # files (e.g. binary PNGs) that don't exist in the index. The index is then dirty,
+                # so a retry without --index would see wrong context. Reset and clean before retry.
+                _log.info('Patch application with --index failed (likely contains new files), resetting and retrying without --index...')
+                self._run_wpt_git(['reset', '--hard', 'HEAD'])
+                self._run_wpt_git(['clean', '-fd'])
+                output = self._run_wpt_git(['apply', '--binary', '-3', patch], capture_output=True)
+                if output.returncode:
+                    _log.info('Retrying patch application without 3-way merge...')
+                    self._run_wpt_git(['reset', '--hard', 'HEAD'])
+                    self._run_wpt_git(['clean', '-fd'])
+                    output = self._run_wpt_git(['apply', '--binary', patch], capture_output=True)
+                    if output.returncode:
+                        _log.error('Failed to apply patch!')
+                        if output.stdout:
+                            _log.error(output.stdout.decode('utf-8', 'replace'))
+                        if getattr(output, 'stderr', None):
+                            _log.error(output.stderr.decode('utf-8', 'replace'))
+                        return False
         except Exception as e:
             _log.warning(e)
             return False
 
-        # Check if there are no changes to commit
+        # Add all changes to index (including new files created by the patch)
         if self._run_wpt_git(['add', '--all']).returncode:
-            _log.error('Failed to add changes')
+            _log.error('Failed to add changes to index')
             return False
 
         if not self._run_wpt_git(['diff', '--cached', '--quiet']).returncode:
@@ -268,18 +299,47 @@ class WebPlatformTestExporter(object):
         return True
 
     def set_up_wpt_fork(self):
-        if self._wpt_fork_remote not in self._run_wpt_git(['remote'], capture_output=True).stdout.decode('utf-8') and self._run_wpt_git(
-            ['remote', 'add', self._wpt_fork_remote, self._wpt_fork_push_url]
-        ).returncode not in [0, 3]:
-            _log.error("Failed to add '{}' remote\n".format(self._wpt_fork_remote))
+        # Ensure fork remote name is always a string (should be guaranteed by _wpt_fork_remote property)
+        fork_remote = self._wpt_fork_remote
+        if not fork_remote:
+            _log.error("Fork remote name is not set. Please provide --remote or ensure username is configured.")
             return
 
-        if self._run_wpt_git(['remote', 'show', self._wpt_fork_remote], capture_output=True).returncode:
+        # Check if remote already exists
+        remote_list_result = self._run_wpt_git(['remote'], capture_output=True)
+        remote_list = ''
+        if remote_list_result.stdout:
+            remote_list = remote_list_result.stdout.decode('utf-8', 'replace')
+
+        if fork_remote not in remote_list:
+            # Remote doesn't exist, try to add it
+            push_url = self._wpt_fork_push_url
+            if not push_url:
+                _log.error(
+                    f"Fork remote URL is not set. Expected remote name: '{fork_remote}'. "
+                    f"Please provide --remote-url or ensure username is configured.")
+                return
+
+            add_result = self._run_wpt_git(['remote', 'add', fork_remote, push_url])
+            if add_result.returncode not in [0, 3]:  # 0 = success, 3 = remote already exists
+                _log.error(
+                    f"Failed to add remote '{fork_remote}' with URL '{push_url}'. "
+                    f"Git error code: {add_result.returncode}")
+                return
+
+        # Verify the remote is accessible
+        show_result = self._run_wpt_git(['remote', 'show', fork_remote], capture_output=True)
+        if show_result.returncode:
+            push_url = self._wpt_fork_push_url or '(not set)'
+            username = self.username or '(not set)'
             # FIXME: If a fork doesn't exist, we should create one for the user - https://bugs.webkit.org/show_bug.cgi?id=293519
-            _log.error(f'Could not find a fork for {self._wpt_fork_remote}. Please fork WPT before continuing: https://github.com/web-platform-tests/wpt/fork')
+            _log.error(
+                f"Could not access fork remote '{fork_remote}' (URL: {push_url}, username: {username}). "
+                f"Please ensure the fork exists and is accessible. "
+                f"Fork WPT at: https://github.com/web-platform-tests/wpt/fork")
             return
 
-        self._run_wpt_git(['fetch', self._wpt_fork_remote, '--prune'])
+        self._run_wpt_git(['fetch', fork_remote, '--prune'])
         return True
 
     def push_to_wpt_fork(self):
@@ -353,6 +413,10 @@ class WebPlatformTestExporter(object):
         self._run_wpt_git(['fetch', 'origin', '--prune'])
         self.clean()
 
+        if self.wpt_already_has_bug_export():
+            _log.info(f'Bug {self._bug_id} has already been exported to WPT. Nothing to do.')
+            return 0
+
         if not self.set_up_wpt_fork():
             self.delete_local_branch(is_success=False)
             return 1
@@ -362,7 +426,7 @@ class WebPlatformTestExporter(object):
             self.delete_local_branch(is_success=False)
             return 1
 
-        if git_patch_file and self.clean:
+        if git_patch_file and self._options.clean:
             self._filesystem.remove(git_patch_file)
 
         if self._options.use_linter:


### PR DESCRIPTION
Problem:
export-w3c-test-changes can fail when exporting patches that add new files (including binary files), due to git apply --index requiring paths to exist in the index.

Fix:
Retry patch application without --index after resetting the working tree, and improve error handling to avoid None-related crashes.

Testing:
• Tools/Scripts/test-webkitpy webkitpy.w3c.test_exporter_unittest<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e469604aa002ccb539213b9535332a3e9b415486

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145891 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154570 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99458 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147766 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19064 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112210 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80349 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14591 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131051 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93115 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/145217 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13887 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11645 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2016 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7955 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156882 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120218 "Passed tests") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/145296 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18422 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15391 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120562 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18458 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129333 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74148 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16271 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7328 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18039 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17776 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17972 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17835 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->