### PR TITLE
Reset tracker blocking latch for page after loading new main frame main resource

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1140,6 +1140,9 @@ void NetworkResourceLoader::didFinishLoading(const NetworkLoadMetrics& networkLo
     if (shouldCaptureExtraNetworkLoadMetrics())
         connection->addNetworkLoadInformationMetrics(coreIdentifier(), networkLoadMetrics);
 
+    if (CheckedPtr session = isMainResource() && isMainFrameLoad() ? connection->networkSession() : nullptr)
+        session->resetTrackingPolicyForPageLoad(webPageProxyID());
+
     if (m_cacheEntryForValidation) {
         ASSERT(m_response.httpStatusCode() == httpStatus304NotModified);
         LOG(NetworkCache, "(NetworkProcess) revalidated");

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -349,8 +349,15 @@ bool NetworkSession::shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const We
     auto it = m_trackerBlockingPolicyByPageIdentifier.find(webPageID);
     if (it == m_trackerBlockingPolicyByPageIdentifier.end())
         it = m_trackerBlockingPolicyByPageIdentifier.set(webPageID, HashSet<RegistrableDomain> { }).iterator;
-    RegistrableDomain domain { request.url() };
-    return !it->value.add(domain).isNewEntry || !mayBlockScriptLoad;
+    return !it->value.add(RegistrableDomain { request.url() }).isNewEntry;
+}
+
+void NetworkSession::resetTrackingPolicyForPageLoad(WebPageProxyIdentifier webPageID)
+{
+    auto it = m_trackerBlockingPolicyByPageIdentifier.find(webPageID);
+    if (it == m_trackerBlockingPolicyByPageIdentifier.end())
+        return;
+    it->value.clear();
 }
 
 void NetworkSession::deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType> dataTypes, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&& domains, CompletionHandler<void(HashSet<RegistrableDomain>&&)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -146,6 +146,7 @@ public:
     static WebCore::IsKnownCrossSiteTracker isResourceFromKnownCrossSiteTracker(const URL& firstParty, const URL& resource);
     static bool isRequestBlockable(const WebCore::ResourceRequest&);
     bool shouldBlockRequestForTrackingPolicyAndUpdatePolicy(const WebCore::ResourceRequest&, WebPageProxyIdentifier, bool mayBlockScriptLoad);
+    void resetTrackingPolicyForPageLoad(WebPageProxyIdentifier);
     void deleteAndRestrictWebsiteDataForRegistrableDomains(OptionSet<WebsiteDataType>, RegistrableDomainsToDeleteOrRestrictWebsiteDataFor&&, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
     void registrableDomainsWithWebsiteData(OptionSet<WebsiteDataType>, CompletionHandler<void(HashSet<WebCore::RegistrableDomain>&&)>&&);
     bool enableResourceLoadStatisticsLogTestingEvent() const { return m_enableResourceLoadStatisticsLogTestingEvent; }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm
@@ -1231,6 +1231,27 @@ TEST(ScriptTrackingPrivacyTests, BlockSubsequent2Element)
 
     RetainPtr taintedLoadResult2 = [webView stringByEvaluatingJavaScript:@"window.taintedLoadResult2"];
     EXPECT_TRUE([taintedLoadResult2 hasPrefix:@"error"]);
+
+    // Do it again
+    [webView synchronouslyLoadRequest:[NSMutableURLRequest requestWithURL:[NSURL URLWithString:@"http://top-domain.org/dir/index.html"]]];
+    Util::waitForConditionWithLogging([&] -> bool {
+        return [[webView stringByEvaluatingJavaScript:@"window.pureLoadResult1 || ''"] length] > 0
+            && [[webView stringByEvaluatingJavaScript:@"window.taintedLoadResult1 || ''"] length] > 0
+            && [[webView stringByEvaluatingJavaScript:@"window.pureLoadResult2 || ''"] length] > 0
+            && [[webView stringByEvaluatingJavaScript:@"window.taintedLoadResult2 || ''"] length] > 0;
+    }, 11, @"Timed out waiting for element load.");
+
+    pureLoadResult1 = [webView stringByEvaluatingJavaScript:@"window.pureLoadResult1"];
+    EXPECT_TRUE([pureLoadResult1 hasPrefix:@"error"]);
+
+    taintedLoadResult1 = [webView stringByEvaluatingJavaScript:@"window.taintedLoadResult1"];
+    EXPECT_TRUE([taintedLoadResult1 hasPrefix:@"error"]);
+
+    pureLoadResult2 = [webView stringByEvaluatingJavaScript:@"window.pureLoadResult2"];
+    EXPECT_TRUE([pureLoadResult2 hasPrefix:@"success"]);
+
+    taintedLoadResult2 = [webView stringByEvaluatingJavaScript:@"window.taintedLoadResult2"];
+    EXPECT_TRUE([taintedLoadResult2 hasPrefix:@"error"]);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 53ea7e5e0f21c14e82a92cf68dbdd665ac72bb45
<pre>
Reset tracker blocking latch for page after loading new main frame main resource
<a href="https://bugs.webkit.org/show_bug.cgi?id=308150">https://bugs.webkit.org/show_bug.cgi?id=308150</a>
<a href="https://rdar.apple.com/170658295">rdar://170658295</a>

Reviewed by NOBODY (OOPS!).

Currently, the latch is scoped to a WebPageProxyID. This isn&apos;t entirely
correct, it should be scoped per navigation. This change resets the latch when
we receive a complete response for a new main frame main resource.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm

* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::didFinishLoading):
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
(WebKit::NetworkSession::shouldBlockRequestForTrackingPolicyAndUpdatePolicy):
(WebKit::NetworkSession::resetTrackingPolicyForPageLoad):
* Source/WebKit/NetworkProcess/NetworkSession.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ScriptTrackingPrivacyTests.mm:
(TestWebKitAPI::(ScriptTrackingPrivacyTests, BlockSubsequent2Element)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/53ea7e5e0f21c14e82a92cf68dbdd665ac72bb45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145489 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18171 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10004 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99126 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd89212a-643f-4047-9cae-c6b6a006d4ac) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147364 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18656 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18064 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111888 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80176 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14260 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130699 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92789 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f12df4c3-a97b-4eb4-8079-1dac4c22e463) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13587 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11350 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1608 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156473 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18021 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8581 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119894 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18067 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15047 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120235 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15984 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128751 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73750 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17642 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6956 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17379 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81422 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17587 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17442 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->