### PR TITLE
CRASH at WebKit::RemoteMediaSessionHelperProxy::ref const

### DIFF
--- a/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
+++ b/Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp
@@ -53,12 +53,20 @@ RemoteMediaSessionHelperProxy::~RemoteMediaSessionHelperProxy()
 
 void RemoteMediaSessionHelperProxy::ref() const
 {
-    m_gpuConnection.get()->ref();
+    if (RefPtr connection = m_gpuConnection.get()) {
+        connection->ref();
+        return;
+    }
+    ASSERT_NOT_REACHED("RemoteMediaSessionHelperProxy outlived its owning GPUConnectionToWebProcess");
 }
 
 void RemoteMediaSessionHelperProxy::deref() const
 {
-    m_gpuConnection.get()->deref();
+    if (RefPtr connection = m_gpuConnection.get()) {
+        connection->deref();
+        return;
+    }
+    ASSERT_NOT_REACHED("RemoteMediaSessionHelperProxy outlived its owning GPUConnectionToWebProcess");
 }
 
 void RemoteMediaSessionHelperProxy::startMonitoringWirelessRoutes()
@@ -81,55 +89,55 @@ void RemoteMediaSessionHelperProxy::stopMonitoringWirelessRoutes()
 
 void RemoteMediaSessionHelperProxy::uiApplicationWillEnterForeground(SuspendedUnderLock suspendedUnderLock)
 {
-    if (auto connection = m_gpuConnection.get())
+    if (RefPtr connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationWillEnterForeground(suspendedUnderLock), { });
 }
 
 void RemoteMediaSessionHelperProxy::uiApplicationDidEnterBackground(SuspendedUnderLock suspendedUnderLock)
 {
-    if (auto connection = m_gpuConnection.get())
+    if (RefPtr connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationDidEnterBackground(suspendedUnderLock), { });
 }
 
 void RemoteMediaSessionHelperProxy::uiApplicationWillBecomeInactive()
 {
-    if (auto connection = m_gpuConnection.get())
+    if (RefPtr connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationWillBecomeInactive(), { });
 }
 
 void RemoteMediaSessionHelperProxy::uiApplicationDidBecomeActive()
 {
-    if (auto connection = m_gpuConnection.get())
+    if (RefPtr connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ApplicationDidBecomeActive(), { });
 }
 
 void RemoteMediaSessionHelperProxy::externalOutputDeviceAvailableDidChange(HasAvailableTargets hasAvailableTargets)
 {
-    if (auto connection = m_gpuConnection.get())
+    if (RefPtr connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ExternalOutputDeviceAvailableDidChange(hasAvailableTargets), { });
 }
 
 void RemoteMediaSessionHelperProxy::isPlayingToAutomotiveHeadUnitDidChange(PlayingToAutomotiveHeadUnit playing)
 {
-    if (auto connection = m_gpuConnection.get())
+    if (RefPtr connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::IsPlayingToAutomotiveHeadUnitDidChange(playing), { });
 }
 
 void RemoteMediaSessionHelperProxy::activeAudioRouteDidChange(ShouldPause shouldPause)
 {
-    if (auto connection = m_gpuConnection.get())
+    if (RefPtr connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ActiveAudioRouteDidChange(shouldPause), { });
 }
 
 void RemoteMediaSessionHelperProxy::activeVideoRouteDidChange(SupportsAirPlayVideo supportsAirPlayVideo, Ref<WebCore::MediaPlaybackTarget>&& target)
 {
-    if (auto connection = m_gpuConnection.get())
+    if (RefPtr connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ActiveVideoRouteDidChange(supportsAirPlayVideo, MediaPlaybackTargetContextSerialized { target.get() }), { });
 }
 
 void RemoteMediaSessionHelperProxy::activeAudioRouteSupportsSpatialPlaybackDidChange(SupportsSpatialAudioPlayback supportsSpatialPlayback)
 {
-    if (auto connection = m_gpuConnection.get())
+    if (RefPtr connection = m_gpuConnection.get())
         connection->connection().send(Messages::RemoteMediaSessionHelper::ActiveAudioRouteSupportsSpatialPlaybackDidChange(supportsSpatialPlayback), { });
 }
 


### PR DESCRIPTION
#### 52ea8995f83eb440e6b48e695d6279308ad6d1f4
<pre>
CRASH at WebKit::RemoteMediaSessionHelperProxy::ref const
<a href="https://rdar.apple.com/169244528">rdar://169244528</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308151">https://bugs.webkit.org/show_bug.cgi?id=308151</a>

Reviewed by Eric Carlson.

It should not be possible for the lifetime of a RemoteMediaSessionHelperProxy
to outlast its owning GPUConnectionToWebProcess. However, that appears to
have happened, and is guarded against elsewhere within RemoteMediaSessionHelperProxy.

Null-check the output of m_gpuConnection.get() before using it, even in ::ref() and ::deref().

Drive-by fix: use RefPtr instead of `auto` for storing the results of m_gpuConnection.get().

* Source/WebKit/GPUProcess/media/ios/RemoteMediaSessionHelperProxy.cpp:
(WebKit::RemoteMediaSessionHelperProxy::ref const):
(WebKit::RemoteMediaSessionHelperProxy::deref const):
(WebKit::RemoteMediaSessionHelperProxy::uiApplicationWillEnterForeground):
(WebKit::RemoteMediaSessionHelperProxy::uiApplicationDidEnterBackground):
(WebKit::RemoteMediaSessionHelperProxy::uiApplicationWillBecomeInactive):
(WebKit::RemoteMediaSessionHelperProxy::uiApplicationDidBecomeActive):
(WebKit::RemoteMediaSessionHelperProxy::externalOutputDeviceAvailableDidChange):
(WebKit::RemoteMediaSessionHelperProxy::isPlayingToAutomotiveHeadUnitDidChange):
(WebKit::RemoteMediaSessionHelperProxy::activeAudioRouteDidChange):
(WebKit::RemoteMediaSessionHelperProxy::activeVideoRouteDidChange):
(WebKit::RemoteMediaSessionHelperProxy::activeAudioRouteSupportsSpatialPlaybackDidChange):

Canonical link: <a href="https://commits.webkit.org/307806@main">https://commits.webkit.org/307806@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20189302b63ce84f760eedf09f57626ddcfc2f3a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18195 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10033 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154185 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99150 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18680 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18088 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111906 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80190 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6749b5e2-c0cc-48ea-9123-5bdd7ecc67c2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148476 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130725 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92807 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5eb0bcce-0812-4b26-9727-8d5d595e66e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13602 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11367 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1632 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123145 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156498 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18045 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119912 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18091 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15068 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120253 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30840 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16000 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73774 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17666 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6982 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17403 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17611 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17466 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->