### PR TITLE
Include WebKit-Swift-Additions

### DIFF
--- a/Source/WebKit/Shared/WebKit-Swift.h
+++ b/Source/WebKit/Shared/WebKit-Swift.h
@@ -32,6 +32,8 @@
 // - select between the headers generated using built-in or custom build
 //   actions on different SDK versions
 
+#include <wtf/Platform.h>
+
 // If Swift function parameters or return types depend on C++ types, the
 // relevant headers must be included here. rdar://165068038
 #include "APIArray.h"
@@ -43,6 +45,10 @@
 
 #ifdef __OBJC__
 #include "WKUIDelegatePrivate.h"
+#endif
+
+#if USE(APPLE_INTERNAL_SDK)
+#include <WebKitAdditions/WebKit-Swift-Additions.h>
 #endif
 
 // rdar://165192318


### PR DESCRIPTION
#### fcca1710986d72b067b8ca409a078e0310721da1
<pre>
Include WebKit-Swift-Additions
<a href="https://bugs.webkit.org/show_bug.cgi?id=308152">https://bugs.webkit.org/show_bug.cgi?id=308152</a>
<a href="https://rdar.apple.com/170317937">rdar://170317937</a>

Reviewed by Elliott Williams.

This allows WebKit-Swift.h to include any extra APIs from WebKitAdditions when
building against internal SDKs. This is necessary because sometimes the
generated code within WebKit-Swift-Generated.h ends up referring to extra
types from those internal SDKs, and we need to be able to ensure any
pre-requisites are known.

Canonical link: <a href="https://commits.webkit.org/307818@main">https://commits.webkit.org/307818@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65c97c4d0fa2a2de5f3e3025cba6c0998bee0fc8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10008 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154164 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99129 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f8a5632-cdf2-491d-961a-8e1f5cfb9d48) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18659 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18067 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111891 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80179 "2 flakes 9 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148455 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14261 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92792 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a62c0bfb-923b-4c5c-9d43-5a340d55b16f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13588 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11353 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1611 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123129 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156476 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18024 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8588 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119897 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120238 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30848 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/15989 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128758 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73753 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17645 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6962 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17382 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81425 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17590 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17445 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->