### PR TITLE
[Site isolation] Make AudioSession activation asynchronous

### DIFF
--- a/LayoutTests/media/video-seek-after-end-play-expected.txt
+++ b/LayoutTests/media/video-seek-after-end-play-expected.txt
@@ -7,9 +7,9 @@ EVENT(ended)
 EVENT(seeking)
 EVENT(seeked)
 EVENT(play)
-EVENT(playing)
 EVENT(seeking)
 EVENT(seeked)
+EVENT(playing)
 EVENT(ended)
 END OF TEST
 

--- a/LayoutTests/media/video-src-blob-replay-expected.txt
+++ b/LayoutTests/media/video-src-blob-replay-expected.txt
@@ -2,7 +2,7 @@ OPEN FILE PANEL
 This tests the ability of the <video> element to load blob URLs, play to the end, and replay. In the browser, select a video file:
 
 EVENT(change)
-EVENT(playing)
 EVENT(seeked)
+EVENT(playing)
 END OF TEST
 

--- a/LayoutTests/media/video-src-blob-replay.html
+++ b/LayoutTests/media/video-src-blob-replay.html
@@ -14,8 +14,8 @@
              video.removeEventListener("ended", finish);
 
              video.currentTime = 0;
-             waitForEvent('playing');
-             waitForEventAndEnd('seeked');
+             waitForEvent('seeked');
+             waitForEventAndEnd('playing');
 
              video.play();
              video.currentTime = video.duration - 0.05;

--- a/Source/WebCore/Modules/webaudio/AudioContext.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioContext.cpp
@@ -335,8 +335,18 @@ void AudioContext::startRendering()
         if (!protectedThis || !willBegin)
             return;
 
+        if (protectedThis->isStopped() || protectedThis->m_wasSuspendedByScript)
+            return;
+
         protectedThis->lazyInitialize();
-        protect(protectedThis->destination())->startRendering([pendingActivity = protectedThis->makePendingActivity(*protectedThis), protectedThis = WTF::move(protectedThis)](std::optional<Exception>&& exception) {
+        if (!protectedThis->isInitialized())
+            return;
+
+        Ref destination = protectedThis->destination();
+        if (!destination->isInitialized())
+            return;
+
+        destination->startRendering([pendingActivity = protectedThis->makePendingActivity(*protectedThis), protectedThis = WTF::move(protectedThis)](std::optional<Exception>&& exception) {
             if (!exception)
                 protectedThis->setState(State::Running);
         });

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1330,8 +1330,20 @@ void HTMLMediaElement::resolvePendingPlayPromises(PlayPromiseVector&& pendingPla
 void HTMLMediaElement::scheduleNotifyAboutPlaying()
 {
     queueTaskKeepingObjectAlive(*this, TaskSource::MediaElement, [pendingPlayPromises = WTF::move(m_pendingPlayPromises)](auto& element) mutable {
-        if (!element.isContextStopped())
-            element.notifyAboutPlaying(WTF::move(pendingPlayPromises));
+        if (element.isContextStopped())
+            return;
+
+        // If a seek is in progress, defer the 'playing' notification until after 'seeked'
+        // fires. This ensures we always fire the event in seeking -> seeked -> playing regardless
+        // of whether audio session IPC or the media engine seek finishes first.
+        if (element.seeking()) {
+            ASSERT(element.m_pendingPlayPromises.isEmpty());
+            element.m_pendingPlayPromises = WTF::move(pendingPlayPromises);
+            element.m_hasDeferredPlayingNotification = true;
+            return;
+        }
+
+        element.notifyAboutPlaying(WTF::move(pendingPlayPromises));
     });
 }
 
@@ -1697,7 +1709,6 @@ void HTMLMediaElement::selectMediaResource()
         } else if (element.hasAttributeWithoutSynchronization(srcAttr)) {
             //    Otherwise, if the media element has no assigned media provider object but has a src attribute, then let mode be attribute.
             mode = Attribute;
-            ASSERT(element.m_player);
             if (!element.m_player) {
                 HTMLMEDIAELEMENT_RELEASE_LOG_WITH_THIS(&element, SELECTMEDIARESOURCE_HAS_SRCATTR_PLAYER_NOT_CREATED);
                 return;
@@ -4102,6 +4113,11 @@ void HTMLMediaElement::finishSeek()
     // 17 - Queue a task to fire a simple event named seeked at the element.
     scheduleEvent(eventNames().seekedEvent);
 
+    if (m_hasDeferredPlayingNotification) {
+        m_hasDeferredPlayingNotification = false;
+        scheduleNotifyAboutPlaying();
+    }
+
     if (protect(document())->quirks().needsCanPlayAfterSeekedQuirk() && m_readyState > HAVE_CURRENT_DATA)
         scheduleEvent(eventNames().canplayEvent);
 
@@ -4486,56 +4502,6 @@ void HTMLMediaElement::play()
     playInternal();
 }
 
-void HTMLMediaElement::completePlayInternal()
-{
-    // 4.8.10.9. Playing the media resource
-    if (!m_player || m_networkState == NETWORK_EMPTY)
-        selectMediaResource();
-
-    if (endedPlayback())
-        seekInternal(MediaTime::zeroTime());
-
-    if (RefPtr mediaController = m_mediaController)
-        mediaController->bringElementUpToSpeed(*this);
-
-    if (m_paused) {
-        setPaused(false);
-        setShowPosterFlag(false);
-        invalidateOfficialPlaybackPosition();
-
-        // This avoids the first timeUpdated event after playback starts, when currentTime is still
-        // the same as it was when the video was paused (and the time hasn't changed yet).
-        m_lastTimeUpdateEventMovieTime = currentMediaTime();
-        m_playbackStartedTime = m_lastTimeUpdateEventMovieTime.toDouble();
-
-        scheduleEvent(eventNames().playEvent);
-
-        // If the media element's readyState attribute has the value HAVE_NOTHING, HAVE_METADATA, or HAVE_CURRENT_DATA,
-        // queue a media element task given the media element to fire an event named waiting at the element.
-        // Otherwise, the media element's readyState attribute has the value HAVE_FUTURE_DATA or HAVE_ENOUGH_DATA:
-        // notify about playing for the element.
-        if (m_readyState <= HAVE_CURRENT_DATA)
-            scheduleEvent(eventNames().waitingEvent);
-        else
-            scheduleNotifyAboutPlaying();
-    } else if (m_readyState >= HAVE_FUTURE_DATA)
-        scheduleResolvePendingPlayPromises();
-
-    if (processingUserGestureForMedia()) {
-        if (m_autoplayEventPlaybackState == AutoplayEventPlaybackState::PreventedAutoplay) {
-            handleAutoplayEvent(AutoplayEvent::DidPlayMediaWithUserGesture);
-            setAutoplayEventPlaybackState(AutoplayEventPlaybackState::None);
-        } else
-            setAutoplayEventPlaybackState(AutoplayEventPlaybackState::StartedWithUserGesture);
-    } else
-        setAutoplayEventPlaybackState(AutoplayEventPlaybackState::StartedWithoutUserGesture);
-
-    m_autoplaying = false;
-    updatePlayState();
-
-    ImageOverlay::removeOverlaySoonIfNeeded(*this);
-}
-
 void HTMLMediaElement::playInternal()
 {
     HTMLMEDIAELEMENT_RELEASE_LOG(PLAYINTERNAL);
@@ -4554,20 +4520,92 @@ void HTMLMediaElement::playInternal()
     Ref mediaSession = this->mediaSession();
     mediaSession->setActive(true);
 
-    CompletionHandler<void (bool)> canBeginPlaybackCompletion = [weakThis = WeakPtr { *this }, logSiteIdentifier = WTF::move(logSiteIdentifier)](bool canBegin) {
+    // 4.8.10.9. Playing the media resource
+    // These steps are spec-observable and must happen synchronously when play() is called,
+    // before any asynchronous steps such as asyncronous audio session activation.
+    if (!m_player || m_networkState == NETWORK_EMPTY)
+        selectMediaResource();
+
+    if (endedPlayback())
+        seekInternal(MediaTime::zeroTime());
+
+    if (RefPtr mediaController = m_mediaController)
+        mediaController->bringElementUpToSpeed(*this);
+
+    // Track whether we need to dispatch notifyAboutPlaying in the async clientWillBeginPlayback
+    // completion. This is true when m_paused is true (the element transitions from paused to
+    // playing) and readyState is sufficient. Must be captured before setPaused(false) below.
+    bool shouldNotifyAboutPlaying = m_paused && m_readyState > HAVE_CURRENT_DATA;
+
+    if (m_paused) {
+        setPaused(false);
+        setPlaying(true);
+        setShowPosterFlag(false);
+        invalidateOfficialPlaybackPosition();
+
+        // This avoids the first timeUpdated event after playback starts, when currentTime is still
+        // the same as it was when the video was paused (and the time hasn't changed yet).
+        m_lastTimeUpdateEventMovieTime = currentMediaTime();
+        m_playbackStartedTime = m_lastTimeUpdateEventMovieTime.toDouble();
+
+        scheduleEvent(eventNames().playEvent);
+
+        // If the media element's readyState attribute has the value HAVE_NOTHING, HAVE_METADATA, or HAVE_CURRENT_DATA,
+        // queue a media element task given the media element to fire an event named waiting at the element.
+        // Otherwise (HAVE_FUTURE_DATA or HAVE_ENOUGH_DATA), scheduleNotifyAboutPlaying() is deferred to the
+        // clientWillBeginPlayback completion below. This ensures the 'playing' event and play promise
+        // resolution fire after:
+        //   (a) setState(Playing) runs (so beginInterruption() captures Playing, not Paused, in m_stateToRestore), and
+        //   (b) completeSessionWillBeginPlayback() enforces concurrent playback (so competing sessions are
+        //       paused before 'playing' fires and play promises are resolved).
+        if (m_readyState <= HAVE_CURRENT_DATA)
+            scheduleEvent(eventNames().waitingEvent);
+    } else if (m_readyState >= HAVE_FUTURE_DATA)
+        scheduleResolvePendingPlayPromises();
+
+    if (processingUserGestureForMedia()) {
+        if (m_autoplayEventPlaybackState == AutoplayEventPlaybackState::PreventedAutoplay) {
+            handleAutoplayEvent(AutoplayEvent::DidPlayMediaWithUserGesture);
+            setAutoplayEventPlaybackState(AutoplayEventPlaybackState::None);
+        } else
+            setAutoplayEventPlaybackState(AutoplayEventPlaybackState::StartedWithUserGesture);
+    } else
+        setAutoplayEventPlaybackState(AutoplayEventPlaybackState::StartedWithoutUserGesture);
+
+    m_autoplaying = false;
+
+    // If this element requires fullscreen for video playback, initiate the fullscreen transition
+    // synchronously before the async audio session activation, so that it is in-progress by the
+    // time the 'playing' event fires.
+    if (m_player && potentiallyPlaying() && mediaSession->requiresFullscreenForVideoPlayback() && !m_waitingToEnterFullscreen && !isFullscreen())
+        enterFullscreen();
+
+    RefPtr gestureToken = UserGestureIndicator::currentUserGesture();
+    mediaSession->clientWillBeginPlayback([weakThis = WeakPtr { *this }, logSiteIdentifier = WTF::move(logSiteIdentifier), gestureToken = WTF::move(gestureToken), shouldNotifyAboutPlaying](bool canBegin) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
 
         if (!canBegin) {
-            ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "returning because of interruption");
+            ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "clientWillBeginPlayback failed");
+
+            // Audio session activation failed after we already set paused = false synchronously.
+            // Roll back by pausing, which fires the pause event and rejects pending play promises.
+            protectedThis->pauseInternal();
             return;
         }
 
-        protectedThis->completePlayInternal();
-    };
+        UserGestureIndicator gestureIndicator(WTF::move(gestureToken));
 
-    mediaSession->clientWillBeginPlayback(WTF::move(canBeginPlaybackCompletion));
+        // Dispatch the 'playing' event and resolve play promises here, after setState(Playing) and
+        // concurrent playback enforcement have run. This preserves the ordering guarantee that
+        // competing sessions are paused before 'playing' fires, and ensures state() == Playing when
+        // beginInterruption() may run in response to the 'playing' event handler.
+        if (shouldNotifyAboutPlaying)
+            protectedThis->scheduleNotifyAboutPlaying();
+        protectedThis->updatePlayState();
+        ImageOverlay::removeOverlaySoonIfNeeded(*protectedThis);
+    });
 }
 
 void HTMLMediaElement::pause()
@@ -4620,6 +4658,8 @@ void HTMLMediaElement::pauseInternal()
     }
 
     m_autoplaying = false;
+
+    m_hasDeferredPlayingNotification = false;
 
     if (processingUserGestureForMedia())
         userDidInterfereWithAutoplay();

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -986,7 +986,6 @@ private:
     // These "internal" functions do not check user gesture restrictions.
     void playInternal();
     void pauseInternal();
-    void completePlayInternal();
 
     void prepareForLoad();
     void allowVideoRendering();
@@ -1310,6 +1309,7 @@ private:
     bool m_stalled : 1;
     bool m_seekRequested : 1;
     bool m_wasPlayingBeforeSeeking : 1;
+    bool m_hasDeferredPlayingNotification : 1 { false };
 
     // data has not been loaded since sending a "stalled" event
     bool m_sentStalledEvent : 1;

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -580,7 +580,7 @@ MediaPlayer::BufferingPolicy MediaElementSession::preferredBufferingPolicy() con
         return MediaPlayer::BufferingPolicy::Default;
 
     auto currentPolicy = element->bufferingPolicy();
-    auto isPlaying = state() == PlatformMediaSession::State::Playing;
+    auto isPlaying = state() == PlatformMediaSession::State::Playing || preparingToPlay();
     MediaPlayer::BufferingPolicy newPolicy = [&] {
 
         if (isSuspended())
@@ -1578,7 +1578,7 @@ void MediaElementSession::updateMediaUsageIfChanged()
     MediaUsageInfo usage = {
         element->currentSrc(),
         element->hasSource(),
-        state() == PlatformMediaSession::State::Playing,
+        state() == PlatformMediaSession::State::Playing || preparingToPlay(),
         canShowControlsManager(PlaybackControlsPurpose::ControlsManager),
         !page->isVisibleAndActive(),
         element->isSuspended(),

--- a/Source/WebCore/platform/audio/AudioSession.h
+++ b/Source/WebCore/platform/audio/AudioSession.h
@@ -126,7 +126,7 @@ public:
     virtual size_t numberOfOutputChannels() const;
     virtual size_t maximumNumberOfOutputChannels() const;
 
-    bool tryToSetActive(bool);
+    void tryToSetActive(bool, CompletionHandler<void(bool)>&& = [](bool) { });
 
     virtual size_t preferredBufferSize() const;
     virtual void setPreferredBufferSize(size_t);
@@ -176,7 +176,7 @@ protected:
     friend class NeverDestroyed<AudioSession>;
     AudioSession();
 
-    virtual bool tryToSetActiveInternal(bool);
+    virtual void tryToSetActiveInternal(bool, CompletionHandler<void(bool)>&&);
     void activeStateChanged();
 
     Logger& logger();

--- a/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
+++ b/Source/WebCore/platform/audio/MediaSessionManagerInterface.h
@@ -176,7 +176,7 @@ protected:
     WeakPtr<PlatformMediaSessionInterface> firstSessionMatching(NOESCAPE const Function<bool(const PlatformMediaSessionInterface&)>&) const;
 
     void maybeDeactivateAudioSession();
-    bool maybeActivateAudioSession();
+    void maybeActivateAudioSession(CompletionHandler<void(bool)>&&);
 
     void nowPlayingMetadataChanged(const NowPlayingMetadata&);
     void enqueueTaskOnMainThread(Function<void()>&&);
@@ -205,6 +205,7 @@ protected:
 
 private:
     bool has(PlatformMediaSessionMediaType) const;
+    void completeSessionWillBeginPlayback(PlatformMediaSessionInterface&, bool, CompletionHandler<void(bool)>&&);
 
     std::array<MediaSessionRestrictions, static_cast<unsigned>(PlatformMediaSessionMediaType::DOMMediaSession) + 1> m_restrictions;
 
@@ -231,6 +232,7 @@ private:
     mutable bool m_isApplicationInBackground { false };
 #if USE(AUDIO_SESSION)
     bool m_becameActive { false };
+    Vector<CompletionHandler<void(bool)>> m_pendingAudioSessionActivations;
 #endif
 };
 

--- a/Source/WebCore/platform/audio/PlatformMediaSession.cpp
+++ b/Source/WebCore/platform/audio/PlatformMediaSession.cpp
@@ -274,13 +274,14 @@ void PlatformMediaSession::clientWillBeginPlayback(CompletionHandler<void(bool)>
 
     ALWAYS_LOG(LOGIDENTIFIER, "state = ", m_state);
 
-    SetForScope preparingToPlay(m_preparingToPlay, true);
-
     RefPtr manager = sessionManager();
     if (!manager) {
         completionHandler(false);
         return;
     }
+
+    m_preparingToPlay = true;
+    m_stateToRestore = State::Playing;
 
     manager->sessionWillBeginPlayback(*this, [weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](bool canBegin) mutable {
         RefPtr protectedThis = weakThis.get();
@@ -289,15 +290,47 @@ void PlatformMediaSession::clientWillBeginPlayback(CompletionHandler<void(bool)>
             return;
         }
 
+        // `m_preparingToPlay == true` at this point means pause() was NOT called after play(),
+        // false means pause() WAS called after play() and cleared the flag, making this IPC stale.
+        bool intendingToPlay = protectedThis->m_preparingToPlay;
+        protectedThis->m_preparingToPlay = false;
+
         if (!canBegin) {
             if (protectedThis->state() == State::Interrupted)
                 protectedThis->m_stateToRestore = State::Playing;
+            else
+                protectedThis->setState(State::Paused);
             completionHandler(false);
             return;
         }
 
-        protectedThis->m_stateToRestore = State::Playing;
-        protectedThis->setState(State::Playing);
+        // Transition to Playing before notifying the caller, so that clients
+        // observing state() (e.g. mediaUsageState) see Playing by the time the
+        // 'playing' event fires. This is done here (after maybeActivateAudioSession
+        // completes) rather than synchronously before the manager call, to avoid
+        // triggering an AVAudioSession category-change interruption on iOS before
+        // the audio session is active. Skip if already Playing (re-entrant call
+        // from updatePlayState). If Interrupted, an interruption arrived during
+        // the async audio session activation window (or play() was called while
+        // already interrupted): ensure m_stateToRestore == Playing so that
+        // endInterruption(MayResumePlaying) will correctly resume. Also call
+        // setState(Playing) so that potentiallyPlaying() returns true and
+        // updatePlayState() can start the player (e.g. audio played while the
+        // page is hidden but not restricted from background playback).
+        if (protectedThis->state() == State::Interrupted)
+            protectedThis->m_stateToRestore = State::Playing;
+        if (protectedThis->state() != State::Playing
+            && (protectedThis->state() != State::Paused || intendingToPlay))
+            protectedThis->setState(State::Playing);
+        else if (protectedThis->state() == State::Paused && !intendingToPlay) {
+            // pause() was called after play() but before the audio session IPC completed.
+            // Don't override the pause. However, now that the audio session is confirmed
+            // active (canBegin=true), schedule a session status update so this session
+            // becomes the now-playing app.
+            if (RefPtr manager = protectedThis->sessionManager())
+                manager->scheduleSessionStatusUpdate();
+        }
+
         completionHandler(true);
     });
 }
@@ -314,6 +347,7 @@ bool PlatformMediaSession::processClientWillPausePlayback(DelayCallingUpdateNowP
         return false;
     }
 
+    m_preparingToPlay = false;
     setState(State::Paused);
     if (RefPtr manager = sessionManager())
         manager->sessionWillEndPlayback(*this, shouldDelayCallingUpdateNowPlaying);
@@ -377,7 +411,7 @@ bool PlatformMediaSession::activeAudioSessionRequired() const
 {
     if (mediaType() == PlatformMediaSession::MediaType::None)
         return false;
-    if (state() != PlatformMediaSession::State::Playing)
+    if (state() != PlatformMediaSession::State::Playing && !preparingToPlay())
         return false;
     return canProduceAudio();
 }

--- a/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.h
+++ b/Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.h
@@ -56,7 +56,7 @@ protected:
     static void setEligibleForSmartRoutingInternal(bool);
 
     // AudioSession
-    bool tryToSetActiveInternal(bool) final;
+    void tryToSetActiveInternal(bool, CompletionHandler<void(bool)>&&) final;
     void setCategory(CategoryType, Mode, RouteSharingPolicy) override;
 
     bool m_isEligibleForSmartRouting { false };

--- a/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp
@@ -1073,12 +1073,6 @@ bool GPUConnectionToWebProcess::dispatchSyncMessage(IPC::Connection& connection,
         return true;
     }
 #endif
-#if USE(AUDIO_SESSION)
-    if (decoder.messageReceiverName() == Messages::RemoteAudioSessionProxy::messageReceiverName()) {
-        protect(audioSessionProxy())->didReceiveSyncMessage(connection, decoder, replyEncoder);
-        return true;
-    }
-#endif
 #if ENABLE(VIDEO)
     if (decoder.messageReceiverName() == Messages::RemoteAudioVideoRendererProxyManager::messageReceiverName()) {
         protect(remoteAudioVideoRendererProxyManager())->didReceiveSyncMessage(connection, decoder, replyEncoder);

--- a/Source/WebKit/GPUProcess/GPUProcess.cpp
+++ b/Source/WebKit/GPUProcess/GPUProcess.cpp
@@ -534,8 +534,14 @@ void GPUProcess::cancelGetDisplayMediaPrompt()
 {
     WebCore::ScreenCaptureKitSharingSessionManager::singleton().cancelGetDisplayMediaPrompt();
 }
-
 #endif // HAVE(SCREEN_CAPTURE_KIT)
+
+#if USE(AUDIO_SESSION)
+void GPUProcess::tryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier identifier, bool active, CompletionHandler<void(bool)>&& completionHandler)
+{
+    protect(audioSessionManager())->tryToSetActiveForProcess(identifier, active, WTF::move(completionHandler));
+}
+#endif
 
 void GPUProcess::addSession(PAL::SessionID sessionID, GPUProcessSessionParameters&& parameters)
 {
@@ -592,7 +598,7 @@ WebCore::NowPlayingManager& GPUProcess::nowPlayingManager()
     return *m_nowPlayingManager;
 }
 
-#if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
+#if USE(AUDIO_SESSION)
 RemoteAudioSessionProxyManager& GPUProcess::audioSessionManager() const
 {
     if (!m_audioSessionManager)

--- a/Source/WebKit/GPUProcess/GPUProcess.h
+++ b/Source/WebKit/GPUProcess/GPUProcess.h
@@ -119,7 +119,7 @@ public:
     const String& NODELETE mediaKeysStorageDirectory(PAL::SessionID) const LIFETIME_BOUND;
 #endif
 
-#if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
+#if USE(AUDIO_SESSION)
     RemoteAudioSessionProxyManager& audioSessionManager() const;
 #endif
 
@@ -228,6 +228,9 @@ private:
     void promptForGetDisplayMedia(WebCore::DisplayCapturePromptType, CompletionHandler<void(std::optional<WebCore::CaptureDevice>)>&&);
     void cancelGetDisplayMediaPrompt();
 #endif
+#if USE(AUDIO_SESSION)
+    void tryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier, bool, CompletionHandler<void(bool)>&&);
+#endif
 #if PLATFORM(MAC)
     void setScreenProperties(const WebCore::ScreenProperties&);
     void updateProcessName();
@@ -302,7 +305,7 @@ private:
 #if PLATFORM(MAC)
     String m_uiProcessName;
 #endif
-#if ENABLE(GPU_PROCESS) && USE(AUDIO_SESSION)
+#if USE(AUDIO_SESSION)
     mutable RefPtr<RemoteAudioSessionProxyManager> m_audioSessionManager;
 #endif
 #if ENABLE(WEBXR)

--- a/Source/WebKit/GPUProcess/GPUProcess.messages.in
+++ b/Source/WebKit/GPUProcess/GPUProcess.messages.in
@@ -74,6 +74,10 @@ messages -> GPUProcess : AuxiliaryProcess {
     CancelGetDisplayMediaPrompt()
 #endif
 
+#if USE(AUDIO_SESSION)
+    TryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier processID, bool active) -> (bool successful)
+#endif
+
 #if PLATFORM(MAC)
     OpenDirectoryCacheInvalidated(WebKit::SandboxExtensionHandle handle)
 #endif

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h
@@ -82,7 +82,6 @@ public:
 
     // IPC::MessageReceiver
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
-    void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&) final;
 
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() const;
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const;
@@ -97,8 +96,7 @@ private:
     // Messages
     void setCategory(WebCore::AudioSession::CategoryType, WebCore::AudioSession::Mode, WebCore::RouteSharingPolicy);
     void setPreferredBufferSize(uint64_t);
-    using SetActiveCompletion = CompletionHandler<void(bool)>;
-    void tryToSetActive(bool, SetActiveCompletion&&);
+    void tryToSetActive(bool, CompletionHandler<void(bool)>&&);
     void setIsPlayingToBluetoothOverride(std::optional<bool>&& value);
     void triggerBeginInterruptionForTesting();
     void triggerEndInterruptionForTesting();

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in
@@ -33,7 +33,7 @@
 messages -> RemoteAudioSessionProxy {
     SetCategory(enum:uint8_t WebCore::AudioSessionCategory type, enum:uint8_t WebCore::AudioSessionMode mode, enum:uint8_t WebCore::RouteSharingPolicy policy)
     SetPreferredBufferSize(uint64_t preferredBufferSize)
-    TryToSetActive(bool active) -> (bool suceeded) Synchronous
+    TryToSetActive(bool active) -> (bool suceeded) Async
     SetIsPlayingToBluetoothOverride(std::optional<bool> value)
 
     [EnabledBy=AllowTestOnlyIPC] TriggerBeginInterruptionForTesting()

--- a/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h
@@ -62,7 +62,8 @@ public:
     void updatePreferredBufferSizeForProcess();
     void updateSpatialExperience();
 
-    bool tryToSetActiveForProcess(RemoteAudioSessionProxy&, bool);
+    void tryToSetActiveForProcess(RemoteAudioSessionProxy&, bool, CompletionHandler<void(bool)>&&);
+    void tryToSetActiveForProcess(WebCore::ProcessIdentifier, bool, CompletionHandler<void(bool)>&&);
 
     void beginInterruptionRemote();
     void endInterruptionRemote(WebCore::AudioSession::MayResume);

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp
@@ -505,6 +505,13 @@ void GPUProcessProxy::cancelGetDisplayMediaPrompt()
 }
 #endif
 
+#if USE(AUDIO_SESSION)
+void GPUProcessProxy::tryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier identifier, bool active, CompletionHandler<void(bool)>&& completionHandler)
+{
+    sendWithAsyncReply(Messages::GPUProcess::TryToSetAudioSessionActiveForProcess(identifier, active), WTF::move(completionHandler));
+}
+#endif
+
 void GPUProcessProxy::getLaunchOptions(ProcessLauncher::LaunchOptions& launchOptions)
 {
     launchOptions.processType = ProcessLauncher::ProcessType::GPU;

--- a/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
+++ b/Source/WebKit/UIProcess/GPU/GPUProcessProxy.h
@@ -123,6 +123,10 @@ public:
     void cancelGetDisplayMediaPrompt();
 #endif
 
+#if USE(AUDIO_SESSION)
+    void tryToSetAudioSessionActiveForProcess(WebCore::ProcessIdentifier, bool, CompletionHandler<void(bool)>&&);
+#endif
+
     void removeSession(PAL::SessionID);
 
 #if PLATFORM(MAC)

--- a/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
+++ b/Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h
@@ -130,7 +130,7 @@ private:
     size_t maximumNumberOfOutputChannels() const final { return m_audioConfiguration.maximumNumberOfOutputChannels; }
     size_t outputLatency() const final { return m_audioConfiguration.outputLatency; }
 
-    bool tryToSetActiveInternal(bool) final;
+    void tryToSetActiveInternal(bool, CompletionHandler<void(bool)>&&) final;
 
     size_t preferredBufferSize() const final { return m_audioConfiguration.preferredBufferSize; }
     void setPreferredBufferSize(size_t) final;

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h
@@ -83,7 +83,7 @@ private:
     size_t maximumNumberOfOutputChannels() const final { return configuration().maximumNumberOfOutputChannels; }
     size_t outputLatency() const final { return configuration().outputLatency; }
 
-    bool tryToSetActiveInternal(bool) final;
+    void tryToSetActiveInternal(bool, CompletionHandler<void(bool)>&&) final;
 
     size_t preferredBufferSize() const final { return configuration().preferredBufferSize; }
     void setPreferredBufferSize(size_t) final;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm
@@ -134,7 +134,12 @@ public:
 
         play();
         pause();
-        ASSERT_EQ(gpuProcessPID(), getNowPlayingClientPid());
+        // After async audio session activation, now playing registration may be delayed.
+        // Poll to allow the async IPC, scheduleSessionStatusUpdate, and MRMediaRemote to settle.
+        pid_t nowPlayingPid = 0;
+        for (int i = 0; i < 50 && !nowPlayingPid; ++i)
+            nowPlayingPid = getNowPlayingClientPid();
+        ASSERT_EQ(gpuProcessPID(), nowPlayingPid);
     }
 
     void runScriptWithUserGesture(NSString *script)


### PR DESCRIPTION
#### cbed12d2342e4a435771072db740f033f3d92ca8
<pre>
[Site isolation] Make AudioSession activation asynchronous
<a href="https://bugs.webkit.org/show_bug.cgi?id=308155">https://bugs.webkit.org/show_bug.cgi?id=308155</a>
<a href="https://rdar.apple.com/170662797">rdar://170662797</a>

Reviewed by NOBODY (OOPS!).

Replace synchronous audio session activation with a fully asynchronous completion handler-based
approach across the entire media playback stack. The previous implementation required using
synchronous IPC between the WebProcess, UIProcess, and GPUProcess when activating or
deactivating audio sessions. Fix this by updating AudioSession::tryToSetActive and all
platform-specific implementations to take CompletionHandlers instead of returning boolean
values directly. The RemoteAudioSessionProxy IPC message is converted from synchronous to
asynchronous, and the async pattern is piped through MediaSessionManagerInterface,
RemoteMediaSessionManagerProxy, and RemoteAudioSessionProxyManager. On Cocoa platforms, the
implementation properly handles threading by performing AVAudioSession operations on a
background dispatch queue while ensuring completion handlers are called back on the main
thread. All synchronous wrapper methods have been removed.

When site isolation is enabled, have RemoteMediaSessionManagerProxy do IPC to the
GPU Process directly rather than going back to the Web Process and then to the
GPU process.

* LayoutTests/media/video-seek-after-end-play-expected.txt: The old code queued `playing`
synchronously before seekInternal, leading to the following event order after a seek
to 0 because of a loop: `playing` -&gt; `seeking` -&gt; `seeked`. Update the test results now
that the events are fired in the correct order.

* LayoutTests/media/video-src-blob-replay-expected.txt: Update test and results now that
we postpone firing a `playing` event while a seek is pending. This new behavior is correct
as the spec says the `playing` event represents &quot;playback has started at the current position&quot;,
which cannot be true until a seek resolves.
* LayoutTests/media/video-src-blob-replay.html:

* Source/WebCore/Modules/webaudio/AudioContext.cpp:
(WebCore::AudioContext::startRendering):
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::scheduleNotifyAboutPlaying):
(WebCore::HTMLMediaElement::selectMediaResource): Remove ASSERT(element.m_player) in the
queued lambda. completePlayInternal() now fires asynchronously, and can call selectMediaResource()
after m_player has been cleared. The existing code already returns when m_player is null.
(WebCore::HTMLMediaElement::finishSeek):
(WebCore::HTMLMediaElement::playInternal): `clientWillBeginPlayback` is asynch, so forward
the current user gesture token across the async boundary because completePlayInternal()
checks processingUserGestureForMedia() to decide whether or not to fire
DidPlayMediaWithUserGesture.
(WebCore::HTMLMediaElement::pauseInternal):
(WebCore::HTMLMediaElement::completePlayInternal): Deleted.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/MediaElementSession.cpp:
(WebCore::MediaElementSession::preferredBufferingPolicy const):
(WebCore::MediaElementSession::updateMediaUsageIfChanged):
* Source/WebCore/platform/audio/AudioSession.cpp:
(WebCore::AudioSession::tryToSetActive):
(WebCore::AudioSession::tryToSetActiveInternal):
* Source/WebCore/platform/audio/AudioSession.h:
* Source/WebCore/platform/audio/MediaSessionManagerInterface.cpp:
(WebCore::MediaSessionManagerInterface::processDidResume):
(WebCore::MediaSessionManagerInterface::completeSessionWillBeginPlayback):
(WebCore::MediaSessionManagerInterface::sessionWillBeginPlayback):
(WebCore::MediaSessionManagerInterface::sessionCanProduceAudioChanged):
(WebCore::MediaSessionManagerInterface::maybeDeactivateAudioSession):
(WebCore::MediaSessionManagerInterface::maybeActivateAudioSession):
(WebCore::MediaSessionManagerInterface::scheduleUpdateSessionState):
* Source/WebCore/platform/audio/MediaSessionManagerInterface.h:
* Source/WebCore/platform/audio/PlatformMediaSession.cpp:
(WebCore::PlatformMediaSession::clientWillBeginPlayback):
(WebCore::PlatformMediaSession::processClientWillPausePlayback):
(WebCore::PlatformMediaSession::activeAudioSessionRequired const):
* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.h:
* Source/WebCore/platform/audio/cocoa/AudioSessionCocoa.mm:
(WebCore::AudioSessionCocoa::tryToSetActiveInternal):
* Source/WebKit/GPUProcess/GPUConnectionToWebProcess.cpp:
(WebKit::GPUConnectionToWebProcess::dispatchSyncMessage):
* Source/WebKit/GPUProcess/GPUProcess.cpp:
(WebKit::GPUProcess::cancelGetDisplayMediaPrompt):
(WebKit::GPUProcess::tryToSetAudioSessionActiveForProcess):
* Source/WebKit/GPUProcess/GPUProcess.h:
* Source/WebKit/GPUProcess/GPUProcess.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.cpp:
(WebKit::RemoteAudioSessionProxy::tryToSetActive):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.h:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxy.messages.in:
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.cpp:
(WebKit::RemoteAudioSessionProxyManager::tryToSetActiveForProcess):
* Source/WebKit/GPUProcess/media/RemoteAudioSessionProxyManager.h:
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.cpp:
(WebKit::GPUProcessProxy::tryToSetAudioSessionActiveForProcess):
* Source/WebKit/UIProcess/GPU/GPUProcessProxy.h:
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.cpp:
(WebKit::RemoteMediaSessionManagerProxy::tryToSetActiveInternal):
* Source/WebKit/UIProcess/Media/RemoteMediaSessionManagerProxy.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.cpp:
(WebKit::RemoteAudioSession::tryToSetActiveInternal): Converted from sendSync to sendWithAsyncReply.
(WebKit::RemoteAudioSession::configurationChanged):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSession.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/MediaSession.mm:
(TestWebKitAPI::MediaSessionTest::loadPageAndBecomeNowPlaying):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cbed12d2342e4a435771072db740f033f3d92ca8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20341 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13932 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156338 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101071 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b187244-edc4-456b-ab46-5571185d8450) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149529 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20241 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113823 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81183 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0675b615-9343-4634-8caa-ea13f8bfa73b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150618 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16064 "Found 2 new test failures: http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132622 "Found 1 new API test failure: TestWebKitAPI.MediaSessionTest.MinimalCommands (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94584 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/02140d61-a770-4c7d-adf5-31784c35be91) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15229 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13016 "Found 2 new API test failures: TestWebKitAPI.EditorStateTests.TypingAttributesTextAlignmentDirectionalText, TestWebKitAPI.MediaSessionTest.MinimalCommands (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3779 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10539 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158672 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1808 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12011 "Found 2 new test failures: http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121850 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20140 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16919 "Found 2 new test failures: http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html http/wpt/mediarecorder/MediaRecorder-webm-AV-audio-video-dataavailable.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122051 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20151 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132320 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76263 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17587 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9100 "Found 2 new test failures: http/wpt/mediarecorder/MediaRecorder-matroska-AV-audio-video-dataavailable.html media/video-seek-after-end-play.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19755 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83518 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19485 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19636 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19543 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->