### PR TITLE
[iOS] Fix deprecation warnings in WKAVContentSource

### DIFF
--- a/Source/WebKit/Platform/ios/PlaybackSessionInterfaceAVKit.mm
+++ b/Source/WebKit/Platform/ios/PlaybackSessionInterfaceAVKit.mm
@@ -165,8 +165,7 @@ void PlaybackSessionInterfaceAVKit::stopObservingNowPlayingMetadata()
 
 void PlaybackSessionInterfaceAVKit::nowPlayingMetadataChanged(const WebCore::NowPlayingMetadata& metadata)
 {
-    RetainPtr platformMetadata = adoptNS([allocAVInterfaceMetadataInstance() initWithAudioOnly:NO title:metadata.title.createNSString().get() subtitle:metadata.artist.createNSString().get() albumArtworks:nil]);
-    [m_contentSource setMetadata:platformMetadata.get()];
+    [m_contentSource setMetadata:createPlatformMetadata(metadata.title.createNSString().get(), metadata.artist.createNSString().get())];
 }
 
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/Platform/ios/WKAVContentSource.h
+++ b/Source/WebKit/Platform/ios/WKAVContentSource.h
@@ -28,6 +28,7 @@
 #import <AVKit/AVInterfaceControllable_Private.h>
 #import <CoreMedia/CoreMedia.h>
 #import <Foundation/Foundation.h>
+#import <wtf/Forward.h>
 
 namespace WebCore {
 class PlaybackSessionModel;
@@ -60,6 +61,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable) CALayer *videoLayer;
 @property (nonatomic) CGSize videoSize;
 @end
+
+RetainPtr<AVInterfaceMetadata> createPlatformMetadata(NSString * _Nullable title, NSString * _Nullable subtitle);
 
 NS_ASSUME_NONNULL_END
 


### PR DESCRIPTION
#### 8cb0e3fe44f0dd1e130e9a5361e1732aca569248
<pre>
[iOS] Fix deprecation warnings in WKAVContentSource
<a href="https://bugs.webkit.org/show_bug.cgi?id=308162">https://bugs.webkit.org/show_bug.cgi?id=308162</a>
<a href="https://rdar.apple.com/170668676">rdar://170668676</a>

Reviewed by Eric Carlson.

Fixed deprecation warnings in WKAVContentSource (and PlaybackSessionInterfaceAVKit).

* Source/WebKit/Platform/ios/PlaybackSessionInterfaceAVKit.mm:
(WebKit::PlaybackSessionInterfaceAVKit::nowPlayingMetadataChanged):
* Source/WebKit/Platform/ios/WKAVContentSource.h:
* Source/WebKit/Platform/ios/WKAVContentSource.mm:
(-[WKAVContentSource initWithModel:]):
(createPlatformMetadata):

Canonical link: <a href="https://commits.webkit.org/307798@main">https://commits.webkit.org/307798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2160e843febca6ca3fddec0ba016cafa5a458f7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145514 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10034 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154186 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/43d3c414-0072-4242-96a4-020c0368dd7c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111907 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c305799-b5a5-4e49-b24e-24ba3cc78416) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148477 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14275 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130728 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92808 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec487d1a-a1d9-47b6-bbaa-fe3b4b85a605) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13600 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11368 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1633 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123142 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156499 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18046 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8616 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119911 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15069 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120252 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30832 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16001 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128786 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73775 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17667 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6985 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81447 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17612 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17467 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->