### PR TITLE
SMIL animation: Filter empty values from trailing semicolons in values attribute

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-values-trailing-semicolon-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-values-trailing-semicolon-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Trailing semicolons in SMIL values attribute should produce valid path
+

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-values-trailing-semicolon.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-values-trailing-semicolon.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+
+<title>Trailing semicolons in SMIL values attribute should produce valid path</title>
+<meta charset="utf-8">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<link rel="help" href="https://svgwg.org/specs/animations/#ValuesAttribute">
+
+<svg viewbox="0 0 100 100">
+  <path fill="#1EB287">
+    <animate attributeName="d"
+             dur="1s"
+             repeatCount="indefinite"
+             values="M 0,0 L 50, 0 L 100,100 Z;
+                     M 100,0 L 0, 100 L 50, 0 Z; "/>
+  </path>
+</svg>
+
+<script>
+  async_test(function(t) {
+    window.onload = t.step_func(function() {
+      window.requestAnimationFrame(t.step_func_done(function() {
+        let path = document.querySelector("path");
+        let dValue = window.getComputedStyle(path).d;
+        assert_not_equals(dValue, "none", "d property should not be 'none'");
+        assert_regexp_match(dValue, /^path\(/, "d property should be a valid path value");
+      }));
+    });
+  });
+</script>

--- a/Source/WebCore/svg/SVGAnimationElement.cpp
+++ b/Source/WebCore/svg/SVGAnimationElement.cpp
@@ -173,7 +173,9 @@ void SVGAnimationElement::attributeChanged(const QualifiedName& name, const Atom
         // http://www.w3.org/TR/SVG11/animate.html#ValuesAttribute
         m_values.clear();
         newValue.string().split(';', [this](StringView innerValue) {
-            m_values.append(innerValue.trim(isASCIIWhitespace<char16_t>).toString());
+            auto trimmed = innerValue.trim(isASCIIWhitespace<char16_t>).toString();
+            if (!trimmed.isEmpty())
+                m_values.append(WTF::move(trimmed));
         });
         updateAnimationMode();
         break;
@@ -585,7 +587,7 @@ void SVGAnimationElement::startedActiveInterval()
 }
 
 void SVGAnimationElement::updateAnimation(float percent, unsigned repeatCount)
-{    
+{
     if (!m_animationValid)
         return;
 


### PR DESCRIPTION
#### 6bc3744f51476655f279015bed5d793b965d1e7c
<pre>
SMIL animation: Filter empty values from trailing semicolons in values attribute
<a href="https://bugs.webkit.org/show_bug.cgi?id=308160">https://bugs.webkit.org/show_bug.cgi?id=308160</a>
<a href="https://rdar.apple.com/170668176">rdar://170668176</a>

Reviewed by Brent Fulgham.

The SMIL values attribute parser was including empty strings when a trailing
semicolon was present. This caused setToAtEndOfDurationValue() to fail
validation since the last value was empty.

The WPT test spaces-at-end-of-path-data.html was passing only because
the test checks `assert_not_equals(getComputedStyle(path).d, &quot;none&quot;)` which
passed since undefined !== &quot;none&quot;.

The broken animation and test was exposed when when investigating CSS d
path here: <a href="https://github.com/WebKit/WebKit/pull/58880">https://github.com/WebKit/WebKit/pull/58880</a>

* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-values-trailing-semicolon-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/animations/smil-values-trailing-semicolon.html: Added.
* Source/WebCore/svg/SVGAnimationElement.cpp:
(WebCore::SVGAnimationElement::attributeChanged):
(WebCore::SVGAnimationElement::updateAnimation):

Canonical link: <a href="https://commits.webkit.org/307807@main">https://commits.webkit.org/307807@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/59b54863dfcabacbcd6560b0b99f009aba4dacd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145558 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10082 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154230 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99195 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6d302a9-120b-4817-a72d-3aef58ac719d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147433 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18725 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18133 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111938 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb837142-f0cf-49cc-a993-c5b38ca2dfab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14304 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130749 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92843 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb6408b3-af03-4693-b589-977b968866f3) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13623 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11390 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1677 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123169 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7537 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156543 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18090 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119940 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15095 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120288 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30841 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16023 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128819 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73819 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17711 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7006 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17448 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81491 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17656 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17511 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->