### PR TITLE
AX: Eagerly propagate accessibility enabled state to new WebProcesses

### DIFF
--- a/Source/WebKit/Shared/WebPageCreationParameters.h
+++ b/Source/WebKit/Shared/WebPageCreationParameters.h
@@ -381,6 +381,8 @@ struct WebPageCreationParameters {
     std::optional<TextManipulationParameters> textManipulationParameters { std::nullopt };
 
     bool isPopup { false };
+
+    bool accessibilityEnabled { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
+++ b/Source/WebKit/Shared/WebPageCreationParameters.serialization.in
@@ -297,6 +297,8 @@ enum class WebCore::UserInterfaceLayoutDirection : bool;
     std::optional<WebKit::TextManipulationParameters> textManipulationParameters;
 
     bool isPopup;
+
+    bool accessibilityEnabled;
 }
 
 [Nested] struct WebKit::RemotePageParameters {

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -6091,6 +6091,7 @@ void WebPageProxy::accessibilitySettingsDidChange()
 
 void WebPageProxy::enableAccessibilityForAllProcesses()
 {
+    m_accessibilityEnabled = true;
     forEachWebContentProcess([&](auto& webProcess, auto pageID) {
         webProcess.send(Messages::WebPage::EnableAccessibility(), pageID);
     });
@@ -12776,6 +12777,8 @@ WebPageCreationParameters WebPageProxy::creationParameters(WebProcessProxy& proc
 #endif
 
     parameters.textManipulationParameters = m_internals->textManipulationParameters;
+
+    parameters.accessibilityEnabled = m_accessibilityEnabled;
 
     return parameters;
 }

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3818,6 +3818,8 @@ private:
 
     bool m_isEditable { false };
 
+    bool m_accessibilityEnabled { false };
+
     double m_textZoomFactor { 1 };
     double m_pageZoomFactor { 1 };
     double m_pageScaleFactor { 1 };

--- a/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp
@@ -317,6 +317,13 @@ void* _WKAccessibilityRootObjectForTesting(WKBundleFrameRef frameRef)
         return document ? document->axObjectCache() : nullptr;
     };
 
+    // Notify the UI process that accessibility is enabled so that any new processes
+    // (e.g., for site-isolated iframes) will also have accessibility enabled.
+    if (!WebCore::AXObjectCache::accessibilityEnabled()) {
+        if (RefPtr page = WebKit::toProtectedImpl(frameRef)->page())
+            page->enableAccessibilityForAllProcesses();
+    }
+
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
     if (!isMainRunLoop()) {
         // AXIsolatedTree is threadsafe ref-counted, so it's OK to hold a reference here.

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1084,6 +1084,9 @@ WebPage::WebPage(PageIdentifier pageID, WebPageCreationParameters&& parameters)
     if (parameters.isEditable)
         setEditable(true);
 
+    if (parameters.accessibilityEnabled)
+        enableAccessibility();
+
 #if PLATFORM(MAC)
     setUseFormSemanticContext(parameters.useFormSemanticContext);
     setHeaderBannerHeight(parameters.headerBannerHeight);


### PR DESCRIPTION
#### 1a7ef8f120972a56f2b7dd04a72e986b2603ddda
<pre>
AX: Eagerly propagate accessibility enabled state to new WebProcesses
<a href="https://bugs.webkit.org/show_bug.cgi?id=308161">https://bugs.webkit.org/show_bug.cgi?id=308161</a>
<a href="https://rdar.apple.com/170668752">rdar://170668752</a>

Reviewed by Joshua Hoffman.

When accessibility is enabled via enableAccessibilityForAllProcesses,
set a flag that this has happened so that we can eagerly also enable
accessibility in any new processes that are created (e.g. via site
isolated iframes). This is important because otherwise the new web
content process may reject accessibility state synchronization from
other processes, or reject accessibility requests that stared in another
web content process and moved to this one (i.e. for <a href="https://github.com/WebKit/WebKit/pull/58826">https://github.com/WebKit/WebKit/pull/58826</a>
which propagates UIElementsForSearchPredicate requests between processes).

* Source/WebKit/Shared/WebPageCreationParameters.h:
* Source/WebKit/Shared/WebPageCreationParameters.serialization.in:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::enableAccessibilityForAllProcesses):
(WebKit::WebPageProxy::creationParameters):
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/WebProcess/InjectedBundle/API/c/WKBundleFrame.cpp:
(_WKAccessibilityRootObjectForTesting):

Canonical link: <a href="https://commits.webkit.org/307836@main">https://commits.webkit.org/307836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f803645ed42b01d5b8a5a5ae8978da0ec2dd954b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145517 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10037 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99154 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d79f9a79-5f88-49c4-bee3-64a45ba89fbe) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18092 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111911 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80192 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148480 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14282 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130734 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92812 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2f57aba-b1dc-4747-9694-d91c0b918357) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13605 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11371 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1636 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123149 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156502 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8624 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119918 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18095 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120260 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30859 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16009 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128794 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73778 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17670 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6991 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17407 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81450 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17470 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->