### PR TITLE
Wire two-phase click response handlers through PageClientImplCocoa

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebViewInternal.h
@@ -33,6 +33,7 @@
 
 #if !__has_feature(modules) || (defined(WK_SUPPORTS_SWIFT_OBJCXX_INTEROP) && WK_SUPPORTS_SWIFT_OBJCXX_INTEROP)
 
+#import "IdentifierTypes.h"
 #import "PDFPluginIdentifier.h"
 #import "VisibleContentRectUpdateInfo.h"
 #import <WebCore/CocoaView.h>
@@ -121,6 +122,10 @@ class Attachment;
 }
 
 namespace WebCore {
+class FloatQuad;
+class FloatRect;
+class IntPoint;
+class IntSize;
 struct AppHighlight;
 struct ExceptionData;
 struct ExceptionDetails;
@@ -746,6 +751,21 @@ RetainPtr<NSError> nsErrorFromExceptionDetails(const std::optional<WebCore::Exce
 #endif
 
 WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContainerEdges&, WebCore::BoxSide);
+
+#if ENABLE(TWO_PHASE_CLICKS)
+
+@interface WKWebView (TwoPhaseClicks)
+- (void)_didNotHandleTapAsClick:(const WebCore::IntPoint&)point;
+- (void)_didHandleTapAsHover;
+- (void)_didCompleteSyntheticClick;
+- (void)_commitPotentialTapFailed;
+- (void)_didGetTapHighlightGeometries:(WebKit::TapIdentifier)requestID color:(const WebCore::Color&)color quads:(const Vector<WebCore::FloatQuad>&)highlightedQuads topLeftRadius:(const WebCore::IntSize&)topLeftRadius topRightRadius:(const WebCore::IntSize&)topRightRadius bottomLeftRadius:(const WebCore::IntSize&)bottomLeftRadius bottomRightRadius:(const WebCore::IntSize&)bottomRightRadius nodeHasBuiltInClickHandling:(BOOL)nodeHasBuiltInClickHandling;
+- (BOOL)_isPotentialTapInProgress;
+- (void)_disableDoubleTapGesturesDuringTapIfNecessary:(WebKit::TapIdentifier)requestID;
+- (void)_handleSmartMagnificationInformationForPotentialTap:(WebKit::TapIdentifier)requestID renderRect:(const WebCore::FloatRect&)renderRect fitEntireRect:(BOOL)fitEntireRect viewportMinimumScale:(double)viewportMinimumScale viewportMaximumScale:(double)viewportMaximumScale nodeIsRootLevel:(BOOL)nodeIsRootLevel nodeIsPluginElement:(BOOL)nodeIsPluginElement;
+@end
+
+#endif
 
 #endif // !__has_feature(modules) || WK_SUPPORTS_SWIFT_OBJCXX_INTEROP
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -5108,6 +5108,54 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 @end
 
+#if ENABLE(TWO_PHASE_CLICKS)
+
+@implementation WKWebView (TwoPhaseClicks)
+
+- (void)_didNotHandleTapAsClick:(const WebCore::IntPoint&)point
+{
+    [_contentView _didNotHandleTapAsClick:point];
+}
+
+- (void)_didHandleTapAsHover
+{
+    [_contentView _didHandleTapAsHover];
+}
+
+- (void)_didCompleteSyntheticClick
+{
+    [_contentView _didCompleteSyntheticClick];
+}
+
+- (void)_commitPotentialTapFailed
+{
+    [_contentView _commitPotentialTapFailed];
+}
+
+- (void)_didGetTapHighlightGeometries:(WebKit::TapIdentifier)requestID color:(const WebCore::Color&)color quads:(const Vector<WebCore::FloatQuad>&)highlightedQuads topLeftRadius:(const WebCore::IntSize&)topLeftRadius topRightRadius:(const WebCore::IntSize&)topRightRadius bottomLeftRadius:(const WebCore::IntSize&)bottomLeftRadius bottomRightRadius:(const WebCore::IntSize&)bottomRightRadius nodeHasBuiltInClickHandling:(BOOL)nodeHasBuiltInClickHandling
+{
+    [_contentView _didGetTapHighlightForRequest:requestID color:color quads:highlightedQuads topLeftRadius:topLeftRadius topRightRadius:topRightRadius bottomLeftRadius:bottomLeftRadius bottomRightRadius:bottomRightRadius nodeHasBuiltInClickHandling:nodeHasBuiltInClickHandling];
+}
+
+- (BOOL)_isPotentialTapInProgress
+{
+    return [_contentView isPotentialTapInProgress];
+}
+
+- (void)_disableDoubleTapGesturesDuringTapIfNecessary:(WebKit::TapIdentifier)requestID
+{
+    [_contentView _disableDoubleTapGesturesDuringTapIfNecessary:requestID];
+}
+
+- (void)_handleSmartMagnificationInformationForPotentialTap:(WebKit::TapIdentifier)requestID renderRect:(const WebCore::FloatRect&)renderRect fitEntireRect:(BOOL)fitEntireRect viewportMinimumScale:(double)viewportMinimumScale viewportMaximumScale:(double)viewportMaximumScale nodeIsRootLevel:(BOOL)nodeIsRootLevel nodeIsPluginElement:(BOOL)nodeIsPluginElement
+{
+    [_contentView _handleSmartMagnificationInformationForPotentialTap:requestID renderRect:renderRect fitEntireRect:fitEntireRect viewportMinimumScale:viewportMinimumScale viewportMaximumScale:viewportMaximumScale nodeIsRootLevel:nodeIsRootLevel nodeIsPluginElement:nodeIsPluginElement];
+}
+
+@end
+
+#endif // ENABLE(TWO_PHASE_CLICKS)
+
 #undef WKWEBVIEW_RELEASE_LOG
 
 _WKTapHandlingResult wkTapHandlingResult(WebKit::TapHandlingResult result)

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.h
@@ -170,14 +170,14 @@ public:
     void videoControlsManagerDidChange() override;
 
 #if ENABLE(TWO_PHASE_CLICKS)
-    void didNotHandleTapAsClick(const WebCore::IntPoint&) override;
-    void didHandleTapAsHover() override;
-    void didCompleteSyntheticClick() override;
-    void commitPotentialTapFailed() override;
-    void didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color&, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling) override;
-    bool isPotentialTapInProgress() const override;
-    void disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier) override;
-    void handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier, const WebCore::FloatRect& renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel, bool nodeIsPluginElement) override;
+    void didNotHandleTapAsClick(const WebCore::IntPoint&) final;
+    void didHandleTapAsHover() final;
+    void didCompleteSyntheticClick() final;
+    void commitPotentialTapFailed() final;
+    void didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color&, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling) final;
+    bool isPotentialTapInProgress() const final;
+    void disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier) final;
+    void handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier, const WebCore::FloatRect& renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel, bool nodeIsPluginElement) final;
 #endif
 
     CocoaWindow *platformWindow() const final;

--- a/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/PageClientImplCocoa.mm
@@ -488,39 +488,44 @@ void PageClientImplCocoa::didCommitMainFrameData(const MainFrameData& mainFrameD
 
 #if ENABLE(TWO_PHASE_CLICKS)
 
-// FIXME: Coalesce platform-agnostic logic with PageClientImplIOS
-
-void PageClientImplCocoa::didNotHandleTapAsClick(const WebCore::IntPoint&)
+void PageClientImplCocoa::didNotHandleTapAsClick(const WebCore::IntPoint& point)
 {
+    [m_webView _didNotHandleTapAsClick:point];
 }
 
 void PageClientImplCocoa::didHandleTapAsHover()
 {
+    [m_webView _didHandleTapAsHover];
 }
 
 void PageClientImplCocoa::didCompleteSyntheticClick()
 {
+    [m_webView _didCompleteSyntheticClick];
 }
 
 void PageClientImplCocoa::commitPotentialTapFailed()
 {
+    [m_webView _commitPotentialTapFailed];
 }
 
-void PageClientImplCocoa::didGetTapHighlightGeometries(WebKit::TapIdentifier, const WebCore::Color&, const Vector<WebCore::FloatQuad>&, const WebCore::IntSize&, const WebCore::IntSize&, const WebCore::IntSize&, const WebCore::IntSize&, bool)
+void PageClientImplCocoa::didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color& color, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling)
 {
+    [m_webView _didGetTapHighlightGeometries:requestID color:color quads:highlightedQuads topLeftRadius:topLeftRadius topRightRadius:topRightRadius bottomLeftRadius:bottomLeftRadius bottomRightRadius:bottomRightRadius nodeHasBuiltInClickHandling:nodeHasBuiltInClickHandling];
 }
 
 bool PageClientImplCocoa::isPotentialTapInProgress() const
 {
-    return false;
+    return [m_webView _isPotentialTapInProgress];
 }
 
-void PageClientImplCocoa::disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier)
+void PageClientImplCocoa::disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier requestID)
 {
+    [m_webView _disableDoubleTapGesturesDuringTapIfNecessary:requestID];
 }
 
-void PageClientImplCocoa::handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier, const WebCore::FloatRect&, bool, double, double, bool, bool)
+void PageClientImplCocoa::handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier requestID, const WebCore::FloatRect& renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel, bool nodeIsPluginElement)
 {
+    [m_webView _handleSmartMagnificationInformationForPotentialTap:requestID renderRect:renderRect fitEntireRect:fitEntireRect viewportMinimumScale:viewportMinimumScale viewportMaximumScale:viewportMaximumScale nodeIsRootLevel:nodeIsRootLevel nodeIsPluginElement:nodeIsPluginElement];
 }
 
 #endif // ENABLE(TWO_PHASE_CLICKS)

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -186,9 +186,6 @@ private:
     RefPtr<ViewSnapshot> takeViewSnapshot(std::optional<WebCore::IntRect>&&) override;
     void wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent&) override;
 
-    void commitPotentialTapFailed() override;
-    void didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color&, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling) override;
-
     void didCommitLayerTree(const RemoteLayerTreeTransaction&, const std::optional<MainFrameData>&, const PageData&, const TransactionID&) final;
     void didCommitMainFrameData(const MainFrameData&) final;
     void layerTreeCommitComplete() override;
@@ -232,9 +229,6 @@ private:
 #endif
 
     void dismissAnyOpenPicker() override;
-
-    void disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier) override;
-    void handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier, const WebCore::FloatRect& renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel, bool nodeIsPluginElement) override;
 
     double minimumZoomScale() const override;
     WebCore::FloatRect documentRect() const override;
@@ -287,9 +281,6 @@ private:
     void didFinishNavigation(API::Navigation*) override;
     void didFailNavigation(API::Navigation*) override;
     void didSameDocumentNavigationForMainFrame(SameDocumentNavigationType) override;
-    void didNotHandleTapAsClick(const WebCore::IntPoint&) override;
-    void didHandleTapAsHover() override;
-    void didCompleteSyntheticClick() override;
 
     void runModalJavaScriptDialog(CompletionHandler<void()>&& callback) final;
 
@@ -368,8 +359,6 @@ private:
 #endif
 
     UIViewController *presentingViewController() const final;
-
-    bool isPotentialTapInProgress() const final;
 
     WebCore::FloatPoint webViewToRootView(const WebCore::FloatPoint&) const final;
     WebCore::FloatRect rootViewToWebView(const WebCore::FloatRect&) const final;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -353,21 +353,6 @@ void PageClientImpl::toolTipChanged(const String&, const String& newToolTip)
 #endif
 }
 
-void PageClientImpl::didNotHandleTapAsClick(const WebCore::IntPoint& point)
-{
-    [contentView() _didNotHandleTapAsClick:point];
-}
-
-void PageClientImpl::didHandleTapAsHover()
-{
-    [contentView() _didHandleTapAsHover];
-}
-
-void PageClientImpl::didCompleteSyntheticClick()
-{
-    [contentView() _didCompleteSyntheticClick];
-}
-
 void PageClientImpl::decidePolicyForGeolocationPermissionRequest(WebFrameProxy& frame, const FrameInfoData& frameInfo, Function<void(bool)>& completionHandler)
 {
     if (auto webView = this->webView()) {
@@ -409,16 +394,6 @@ void PageClientImpl::didCommitLoadForMainFrame(const String& mimeType, bool useC
 void PageClientImpl::didChangeContentSize(const WebCore::IntSize&)
 {
     notImplemented();
-}
-
-void PageClientImpl::disableDoubleTapGesturesDuringTapIfNecessary(WebKit::TapIdentifier requestID)
-{
-    [contentView() _disableDoubleTapGesturesDuringTapIfNecessary:requestID];
-}
-
-void PageClientImpl::handleSmartMagnificationInformationForPotentialTap(WebKit::TapIdentifier requestID, const WebCore::FloatRect& renderRect, bool fitEntireRect, double viewportMinimumScale, double viewportMaximumScale, bool nodeIsRootLevel, bool nodeIsPluginElement)
-{
-    [contentView() _handleSmartMagnificationInformationForPotentialTap:requestID renderRect:renderRect fitEntireRect:fitEntireRect viewportMinimumScale:viewportMinimumScale viewportMaximumScale:viewportMaximumScale nodeIsRootLevel:nodeIsRootLevel nodeIsPluginElement:nodeIsPluginElement];
 }
 
 double PageClientImpl::minimumZoomScale() const
@@ -755,16 +730,6 @@ RefPtr<ViewSnapshot> PageClientImpl::takeViewSnapshot(std::optional<WebCore::Int
 void PageClientImpl::wheelEventWasNotHandledByWebCore(const NativeWebWheelEvent& event)
 {
     notImplemented();
-}
-
-void PageClientImpl::commitPotentialTapFailed()
-{
-    [contentView() _commitPotentialTapFailed];
-}
-
-void PageClientImpl::didGetTapHighlightGeometries(WebKit::TapIdentifier requestID, const WebCore::Color& color, const Vector<WebCore::FloatQuad>& highlightedQuads, const WebCore::IntSize& topLeftRadius, const WebCore::IntSize& topRightRadius, const WebCore::IntSize& bottomLeftRadius, const WebCore::IntSize& bottomRightRadius, bool nodeHasBuiltInClickHandling)
-{
-    [contentView() _didGetTapHighlightForRequest:requestID color:color quads:highlightedQuads topLeftRadius:topLeftRadius topRightRadius:topRightRadius bottomLeftRadius:bottomLeftRadius bottomRightRadius:bottomRightRadius nodeHasBuiltInClickHandling:nodeHasBuiltInClickHandling];
 }
 
 void PageClientImpl::didCommitLayerTree(const RemoteLayerTreeTransaction& layerTreeTransaction, const std::optional<MainFrameData>& mainFrameData, const PageData& pageData, const TransactionID& transactionID)
@@ -1435,11 +1400,6 @@ String PageClientImpl::spatialTrackingLabel() const
 void PageClientImpl::scheduleVisibleContentRectUpdate()
 {
     [webView() _scheduleVisibleContentRectUpdate];
-}
-
-bool PageClientImpl::isPotentialTapInProgress() const
-{
-    return [protect(m_contentView) isPotentialTapInProgress];
 }
 
 bool PageClientImpl::canStartNavigationSwipeAtLastInteractionLocation() const


### PR DESCRIPTION
#### 710aecaf1caf6d8ff2c982c0376a3f244555da34
<pre>
Wire two-phase click response handlers through PageClientImplCocoa
<a href="https://bugs.webkit.org/show_bug.cgi?id=307940">https://bugs.webkit.org/show_bug.cgi?id=307940</a>
<a href="https://rdar.apple.com/170419753">rdar://170419753</a>

Reviewed by Aditya Keerthi and Richard Robinson.

Move two-phase tap response handling from PageClientImplIOS to the
shared PageClientImplCocoa layer, routing through WKWebView for
better platform abstraction.

This is a pure refactor and does not introduce any behavior change
because WKWebViewIOS simply forwards to WKContentView, but it opens the
doors for other ENABLE_TWO_PHASE_CLICK handler implementations.

Canonical link: <a href="https://commits.webkit.org/307809@main">https://commits.webkit.org/307809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/be09314d7d1fbf8e035ba380ae5be9140bab1945

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18232 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99187 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/913bdf19-23f0-4829-b465-84423015bc39) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18717 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18125 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111930 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a5895261-8ff4-4f71-b920-27cef10d0be0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148513 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14298 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130741 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92835 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/10ea9e17-0652-4963-a3bc-ccdb6903b599) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13617 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11385 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1669 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123163 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156535 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18082 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8633 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119934 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18128 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15090 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120281 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16019 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128806 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73811 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22449 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17703 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/6998 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17440 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81483 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17648 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17503 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->