### PR TITLE
[GTK][WPE] Implement GPU atlas creation and replay substitution for batched raster image uploads

### DIFF
--- a/Source/WebCore/platform/Skia.cmake
+++ b/Source/WebCore/platform/Skia.cmake
@@ -15,6 +15,7 @@ list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
     platform/graphics/skia/GraphicsContextSkia.h
     platform/graphics/skia/ImageBufferSkiaBackend.h
     platform/graphics/skia/PathSkia.h
+    platform/graphics/skia/SkiaGPUAtlas.h
     platform/graphics/skia/SkiaHarfBuzzFont.h
     platform/graphics/skia/SkiaHarfBuzzFontCache.h
     platform/graphics/skia/SkiaImageAtlasLayout.h

--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -58,12 +58,14 @@ platform/graphics/skia/PathSkia.cpp
 platform/graphics/skia/PatternSkia.cpp
 platform/graphics/skia/PlatformDisplaySkia.cpp
 platform/graphics/skia/ShareableBitmapSkia.cpp
+platform/graphics/skia/SkiaGPUAtlas.cpp
 platform/graphics/skia/SkiaHarfBuzzFont.cpp
 platform/graphics/skia/SkiaHarfBuzzFontCache.cpp
 platform/graphics/skia/SkiaImageAtlasLayout.cpp
 platform/graphics/skia/SkiaImageAtlasLayoutBuilder.cpp
 platform/graphics/skia/SkiaPaintingEngine.cpp
 platform/graphics/skia/SkiaRecordingResult.cpp
+platform/graphics/skia/SkiaReplayAtlas.cpp
 platform/graphics/skia/SkiaReplayCanvas.cpp
 platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
 platform/graphics/skia/SkiaTextureAtlasPacker.cpp

--- a/Source/WebCore/platform/graphics/NativeImage.h
+++ b/Source/WebCore/platform/graphics/NativeImage.h
@@ -77,7 +77,7 @@ public:
 
     WEBCORE_EXPORT void replacePlatformImage(PlatformImagePtr&&) const;
 
-#if USE(COORDINATED_GRAPHICS)
+#if USE(SKIA) || USE(COORDINATED_GRAPHICS)
     uint64_t uniqueID() const;
 #endif
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -283,8 +283,8 @@ void GraphicsContextSkia::drawNativeImage(const NativeImage& nativeImage, const 
         return;
 
     // Collect raster images for atlas batching during recording.
-    if (m_contextMode == ContextMode::RecordingMode && !image->isTextureBacked() && m_atlasLayoutBuilder) {
-        // FIXME: Remove m_atlasLayoutBuilder check and turn into ASSERT(m_atlasLayoutBuilder), once atlas mode is activated.
+    if (m_contextMode == ContextMode::RecordingMode && m_renderingMode == RenderingMode::Accelerated && !image->isTextureBacked()) {
+        ASSERT(m_atlasLayoutBuilder);
         m_atlasLayoutBuilder->collectRasterImage(image);
     }
 
@@ -1236,8 +1236,11 @@ void GraphicsContextSkia::beginRecording()
 {
     ASSERT(m_contextMode == ContextMode::PaintingMode);
     m_contextMode = ContextMode::RecordingMode;
-    // FIXME: Enable atlas mode, once upstreaming completed.
-    // m_atlasLayoutBuilder = makeUnique<SkiaImageAtlasLayoutBuilder>();
+
+    if (m_renderingMode == RenderingMode::Accelerated)
+        m_atlasLayoutBuilder = makeUnique<SkiaImageAtlasLayoutBuilder>();
+    else
+        ASSERT(!m_atlasLayoutBuilder);
 }
 
 SkiaRecordingData GraphicsContextSkia::endRecording()
@@ -1245,7 +1248,6 @@ SkiaRecordingData GraphicsContextSkia::endRecording()
     ASSERT(m_contextMode == ContextMode::RecordingMode);
     m_contextMode = ContextMode::PaintingMode;
 
-    // FIXME: Remove m_atlasLayoutBuilder check and turn into ASSERT(m_atlasLayoutBuilder), once atlas mode is activated.
     Vector<Ref<SkiaImageAtlasLayout>> atlasLayouts;
     if (m_atlasLayoutBuilder) {
         atlasLayouts = m_atlasLayoutBuilder->finalize();

--- a/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp
@@ -118,14 +118,12 @@ void NativeImage::clearSubimages()
 {
 }
 
-#if USE(COORDINATED_GRAPHICS)
 uint64_t NativeImage::uniqueID() const
 {
     if (auto& image = platformImage())
         return image->uniqueID();
     return 0;
 }
-#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2025, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaGPUAtlas.h"
+
+#if USE(SKIA)
+#include "SkiaImageAtlasLayout.h"
+#if USE(GBM)
+#include "MemoryMappedGPUBuffer.h"
+#endif
+#include <wtf/TZoneMallocInlines.h>
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
+#include <skia/core/SkPixmap.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+#if USE(LIBEPOXY)
+#include <epoxy/gl.h>
+#else
+#include <GLES3/gl3.h>
+#endif
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaGPUAtlas);
+
+SkiaGPUAtlas::SkiaGPUAtlas(Ref<BitmapTexture>&& atlasTexture, GrBackendTexture&& backendTexture, const SkiaImageAtlasLayout& layout, const IntSize& size)
+    : m_atlasTexture(WTF::move(atlasTexture))
+    , m_backendTexture(WTF::move(backendTexture))
+    , m_layout(layout)
+    , m_size(size)
+{
+    m_imageToRect.reserveInitialCapacity(layout.entries().size());
+    for (const auto& entry : layout.entries()) {
+        const auto& rect = entry.atlasRect;
+        m_imageToRect.add(entry.rasterImage.get(), SkRect::MakeXYWH(rect.x(), rect.y(), rect.width(), rect.height()));
+    }
+}
+
+SkiaGPUAtlas::~SkiaGPUAtlas() = default;
+
+RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Ref<BitmapTexture>&& atlasTexture)
+{
+    const auto& atlasSize = layout.atlasSize();
+    if (atlasSize.isEmpty())
+        return nullptr;
+
+    RELEASE_ASSERT(atlasSize == atlasTexture->size());
+
+    GrGLTextureInfo externalTexture;
+    externalTexture.fTarget = GL_TEXTURE_2D;
+    externalTexture.fID = atlasTexture->id();
+    externalTexture.fFormat = GL_RGBA8;
+    auto backendTexture = GrBackendTextures::MakeGL(atlasSize.width(), atlasSize.height(), skgpu::Mipmapped::kNo, externalTexture);
+    if (!backendTexture.isValid())
+        return nullptr;
+
+    return adoptRef(*new SkiaGPUAtlas(WTF::move(atlasTexture), WTF::move(backendTexture), layout, atlasSize));
+}
+
+bool SkiaGPUAtlas::uploadImages()
+{
+    Vector<uint8_t> conversionBuffer;
+
+    // Returns pixel data for atlas upload — either a zero-copy reference to the original
+    // pixels (fast path) or a converted sRGB copy (for non-sRGB images).
+    auto pixelDataInSRGB = [&conversionBuffer](const sk_sp<SkImage>& image) -> std::optional<std::pair<const void*, size_t>> {
+        SkPixmap pixmap;
+        if (!image->peekPixels(&pixmap))
+            return std::nullopt;
+
+        if (auto* colorSpace = image->colorSpace(); !colorSpace || colorSpace->isSRGB())
+            return std::pair { pixmap.addr(), pixmap.rowBytes() };
+
+        // Convert to sRGB using Skia's built-in color space conversion.
+        auto srgbInfo = SkImageInfo::Make(image->width(), image->height(), image->colorType(), image->alphaType(), SkColorSpace::MakeSRGB());
+        size_t srgbRowBytes = srgbInfo.minRowBytes();
+        conversionBuffer.resize(srgbInfo.computeMinByteSize());
+
+        if (!image->readPixels(static_cast<GrDirectContext*>(nullptr), srgbInfo, conversionBuffer.mutableSpan().data(), srgbRowBytes, 0, 0))
+            return std::nullopt;
+
+        return std::pair { static_cast<const void*>(conversionBuffer.mutableSpan().data()), srgbRowBytes };
+    };
+
+#if USE(GBM)
+    if (auto* gpuBuffer = m_atlasTexture->memoryMappedGPUBuffer()) {
+        if (gpuBuffer->isLinear() || gpuBuffer->isVivanteSuperTiled()) {
+            auto writeScope = makeGPUBufferWriteScope(*gpuBuffer);
+            if (!writeScope)
+                return false;
+
+            for (const auto& entry : m_layout.entries()) {
+                if (auto pixels = pixelDataInSRGB(entry.rasterImage))
+                    gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
+            }
+
+            return true;
+        }
+    }
+#endif
+
+    // GL fallback: use BitmapTexture::updateContents() per entry.
+    for (const auto& entry : m_layout.entries()) {
+        if (auto pixels = pixelDataInSRGB(entry.rasterImage))
+            m_atlasTexture->updateContents(pixels->first, entry.atlasRect, IntPoint::zero(), pixels->second, PixelFormat::BGRA8);
+    }
+
+    return true;
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+#include "BitmapTexture.h"
+#include "IntSize.h"
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkImage.h>
+#include <skia/core/SkRect.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+#include <wtf/HashMap.h>
+#include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
+#include <wtf/ThreadSafeRefCounted.h>
+
+namespace WebCore {
+
+class SkiaImageAtlasLayout;
+
+using ImageToRectMap = HashMap<const SkImage*, SkRect>;
+
+// GPU atlas that uploads raster images into a BitmapTexture.
+// Uses MemoryMappedGPUBuffer directly for DMA-buf (GBM) path and
+// BitmapTexture::updateContents() for GL fallback.
+class SkiaGPUAtlas : public ThreadSafeRefCounted<SkiaGPUAtlas, WTF::DestructionThread::Main> {
+    WTF_MAKE_TZONE_ALLOCATED(SkiaGPUAtlas);
+    WTF_MAKE_NONCOPYABLE(SkiaGPUAtlas);
+public:
+    static RefPtr<SkiaGPUAtlas> create(const SkiaImageAtlasLayout&, Ref<BitmapTexture>&&);
+
+    // Upload images into the atlas texture. Can run from any thread for DMA-buf backed textures.
+    bool uploadImages();
+
+    virtual ~SkiaGPUAtlas();
+
+    const GrBackendTexture& backendTexture() const { return m_backendTexture; }
+    const ImageToRectMap& imageToRect() const { return m_imageToRect; }
+    const IntSize& size() const { return m_size; }
+    BitmapTexture& atlasTexture() const { return m_atlasTexture.get(); }
+
+private:
+    SkiaGPUAtlas(Ref<BitmapTexture>&&, GrBackendTexture&&, const SkiaImageAtlasLayout&, const IntSize&);
+
+    Ref<BitmapTexture> m_atlasTexture;
+    GrBackendTexture m_backendTexture;
+    ImageToRectMap m_imageToRect;
+    const SkiaImageAtlasLayout& m_layout;
+    IntSize m_size;
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -37,12 +37,18 @@
 #include "PlatformDisplay.h"
 #include "ProcessCapabilities.h"
 #include "RenderingMode.h"
+#include "SkiaGPUAtlas.h"
+#include "SkiaImageAtlasLayout.h"
 #include "SkiaRecordingResult.h"
 #include "SkiaReplayCanvas.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPictureRecorder.h>
+#include <skia/core/SkSurface.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/GrDirectContext.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/NumberOfCores.h>
 #include <wtf/SystemTracing.h>
@@ -70,13 +76,13 @@ SkiaPaintingEngine::SkiaPaintingEngine()
         m_texturePool = makeUnique<BitmapTexturePool>();
 
         if (auto numberOfGPUThreads = numberOfGPUPaintingThreads())
-            m_workerPool = WorkerPool::create("SkiaGPUWorker"_s, numberOfGPUThreads);
+            m_paintingWorkerPool = WorkerPool::create("SkiaGPUWorker"_s, numberOfGPUThreads);
 
         return;
     }
 
     if (auto numberOfCPUThreads = numberOfCPUPaintingThreads())
-        m_workerPool = WorkerPool::create("SkiaCPUWorker"_s, numberOfCPUThreads);
+        m_paintingWorkerPool = WorkerPool::create("SkiaCPUWorker"_s, numberOfCPUThreads);
 }
 
 SkiaPaintingEngine::~SkiaPaintingEngine() = default;
@@ -121,6 +127,50 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode render
     return CoordinatedUnacceleratedTileBuffer::create(size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
 }
 
+RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout& layout, AtlasUploadCondition& uploadCondition)
+{
+    if (!m_texturePool)
+        return { };
+
+    const auto& atlasSize = layout.atlasSize();
+
+    OptionSet<BitmapTexture::Flags> textureFlags { BitmapTexture::Flags::UseBGRALayout, BitmapTexture::Flags::NearestFiltering, BitmapTexture::Flags::SupportsAlpha };
+    bool isDMABufBackedTexture = false;
+#if USE(GBM)
+    if (shouldUseDMABufAtlasTextures()) {
+        isDMABufBackedTexture = true;
+        textureFlags.add({ BitmapTexture::Flags::BackedByDMABuf, BitmapTexture::Flags::ForceLinearBuffer });
+    }
+#endif
+
+    // Verify the texture actually has DMA-buf backing. BitmapTexture silently
+    // falls back to GL if DMA-buf allocation fails, but we must not dispatch
+    // GL operations to the upload worker thread (which has no GL context).
+    auto texture = m_texturePool->acquireTexture(atlasSize, textureFlags);
+    if (!texture->memoryMappedGPUBuffer())
+        isDMABufBackedTexture = false;
+
+    auto atlas = SkiaGPUAtlas::create(layout, WTF::move(texture));
+    if (!atlas)
+        return nullptr;
+
+    // GL path: upload synchronously.
+    if (!isDMABufBackedTexture) [[unlikely]] {
+        atlas->uploadImages();
+        return atlas;
+    }
+
+    // DMA-buf path: create atlas without uploading, dispatch pixel writes to worker.
+    if (!m_uploadWorkQueue)
+        m_uploadWorkQueue = WorkQueue::create("AtlasUpload"_s);
+    uploadCondition.addPending();
+    m_uploadWorkQueue->dispatch([atlas = Ref { *atlas }, condition = Ref { uploadCondition }]() mutable {
+        atlas->uploadImages();
+        condition->signal();
+    });
+    return atlas;
+}
+
 Ref<CoordinatedTileBuffer> SkiaPaintingEngine::paint(const GraphicsLayerCoordinated& layer, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale)
 {
     // ### Synchronous rendering on main thread ###
@@ -155,7 +205,7 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
 {
     // ### Asynchronous rendering on worker threads ###
     ASSERT(useThreadedRendering());
-    ASSERT(m_workerPool);
+    ASSERT(m_paintingWorkerPool);
 
     auto renderingMode = canPerformAcceleratedRendering() ? RenderingMode::Accelerated : RenderingMode::Unaccelerated;
 
@@ -166,10 +216,46 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
     recordingContext.beginRecording();
     paintIntoGraphicsContext(layer, recordingContext, recordRect, contentsOpaque, contentsScale);
     auto recordingData = recordingContext.endRecording();
+
     auto picture = pictureRecorder.finishRecordingAsPicture();
     WTFEndSignpost(this, RecordTile);
 
-    return SkiaRecordingResult::create(WTF::move(picture), WTF::move(recordingData), recordRect, renderingMode, contentsOpaque, contentsScale);
+    auto result = SkiaRecordingResult::create(WTF::move(picture), WTF::move(recordingData), recordRect, renderingMode, contentsOpaque, contentsScale);
+
+    // Prepare GPU atlases on main thread before dispatching to workers.
+    // Textures are acquired from BitmapTexturePool which handles recycling.
+    if (result->hasAtlasLayouts()) {
+        PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
+
+        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+        RELEASE_ASSERT(grContext);
+
+        Vector<Ref<SkiaGPUAtlas>> gpuAtlases;
+        auto uploadCondition = AtlasUploadCondition::create();
+        gpuAtlases.reserveInitialCapacity(result->atlasLayouts().size());
+
+        for (const auto& layout : result->atlasLayouts()) {
+            if (auto atlas = createAtlas(layout.get(), uploadCondition.get()))
+                gpuAtlases.append(atlas.releaseNonNull());
+        }
+
+        if (!gpuAtlases.isEmpty()) {
+            result->setGPUAtlases(WTF::move(gpuAtlases), WTF::move(uploadCondition));
+
+            // Flush and fence for the GL upload path, where
+            // BitmapTexture::updateContents() issues GL upload commands.
+            // On the DMA-buf path, uploading is CPU-side (memory-mapped),
+            // so this is a no-op flush but harmless.
+            auto& glDisplay = PlatformDisplay::sharedDisplay().glDisplay();
+            if (GLFence::isSupported(glDisplay)) {
+                grContext->flushAndSubmit(GrSyncCpu::kNo);
+                result->setUploadFence(GLFence::create(glDisplay));
+            } else
+                grContext->flushAndSubmit(GrSyncCpu::kYes);
+        }
+    }
+
+    return result;
 }
 
 Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordinated& layer, const RefPtr<SkiaRecordingResult>& recording, const IntRect& dirtyRect)
@@ -184,7 +270,7 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordin
     auto buffer = createBuffer(renderingMode, dirtyRect.size(), recording->contentsOpaque());
     buffer->beginPainting();
 
-    m_workerPool->postTask([platformLayer = WTF::move(platformLayer), buffer = Ref { buffer }, dirtyRect, recording = RefPtr { recording }]() mutable {
+    m_paintingWorkerPool->postTask([platformLayer = WTF::move(platformLayer), buffer = Ref { buffer }, dirtyRect, recording = RefPtr { recording }]() mutable {
         if (auto* canvas = buffer->canvas()) {
             auto replayPicture = [](const sk_sp<SkPicture>& picture, SkCanvas* canvas, const IntRect& recordRect, const IntRect& paintRect) {
                 canvas->save();
@@ -196,7 +282,8 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordin
             };
 
             WTFBeginSignpost(canvas, PaintTile, "Skia/%s threaded, dirty region %ix%i+%i+%i", buffer->isBackedByOpenGL() ? "GPU" : "CPU", dirtyRect.x(), dirtyRect.y(), dirtyRect.width(), dirtyRect.height());
-            if (recording->hasFences()) {
+            // Use SkiaReplayCanvas if there are GPU fences or GPU atlases to handle.
+            if (recording->hasFences() || recording->hasGPUAtlases()) {
                 auto replayCanvas = SkiaReplayCanvas::create(dirtyRect.size(), recording);
                 replayCanvas->addCanvas(canvas);
                 replayPicture(replayCanvas->picture(), &replayCanvas.get(), recording->recordRect(), dirtyRect);
@@ -252,6 +339,26 @@ unsigned SkiaPaintingEngine::numberOfGPUPaintingThreads()
     });
 
     return numberOfThreads;
+}
+
+bool SkiaPaintingEngine::shouldUseDMABufAtlasTextures()
+{
+#if USE(GBM)
+    static std::once_flag onceFlag;
+    static bool shouldUseDMABufAtlas = true;
+
+    std::call_once(onceFlag, [] {
+        if (const char* envString = getenv("WEBKIT_DISABLE_DMABUF_ATLAS")) {
+            auto envStringView = StringView::fromLatin1(envString);
+            if (envStringView == "1"_s)
+                shouldUseDMABufAtlas = false;
+        }
+    });
+
+    return shouldUseDMABufAtlas;
+#else
+    return false;
+#endif
 }
 
 bool SkiaPaintingEngine::shouldUseLinearTileTextures()

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -28,10 +28,12 @@
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WorkQueue.h>
 #include <wtf/WorkerPool.h>
 
 namespace WebCore {
 
+class AtlasUploadCondition;
 class BitmapTexturePool;
 class CoordinatedTileBuffer;
 class GraphicsContext;
@@ -39,6 +41,8 @@ class GraphicsLayer;
 class GraphicsLayerCoordinated;
 class IntRect;
 class IntSize;
+class SkiaGPUAtlas;
+class SkiaImageAtlasLayout;
 class SkiaRecordingResult;
 enum class RenderingMode : uint8_t;
 
@@ -53,10 +57,11 @@ public:
 
     static unsigned numberOfCPUPaintingThreads();
     static unsigned numberOfGPUPaintingThreads();
+    static bool shouldUseDMABufAtlasTextures();
     static bool shouldUseLinearTileTextures();
     static bool shouldUseVivanteSuperTiledTileTextures();
 
-    bool useThreadedRendering() const { return m_workerPool; }
+    bool useThreadedRendering() const { return m_paintingWorkerPool; }
 
     Ref<CoordinatedTileBuffer> paint(const GraphicsLayerCoordinated&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
     Ref<SkiaRecordingResult> record(const GraphicsLayerCoordinated&, const IntRect& recordRect, bool contentsOpaque, float contentsScale);
@@ -65,8 +70,11 @@ public:
 private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
+    RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&);
 
-    RefPtr<WorkerPool> m_workerPool;
+    RefPtr<WorkerPool> m_paintingWorkerPool;
+    RefPtr<WorkQueue> m_uploadWorkQueue;
+
     std::unique_ptr<BitmapTexturePool> m_texturePool;
 };
 

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp
@@ -61,6 +61,19 @@ void SkiaRecordingResult::waitForFenceIfNeeded(const SkImage& image)
         fence->serverWait();
 }
 
+void SkiaRecordingResult::waitForUploadFence()
+{
+    if (m_uploadFence)
+        m_uploadFence->serverWait();
+}
+
+
+void SkiaRecordingResult::waitForUploadCondition()
+{
+    if (m_uploadCondition)
+        m_uploadCondition->wait();
+}
+
 } // namespace WebCore
 
 #endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h
@@ -29,6 +29,7 @@
 #include "GLFence.h"
 #include "IntRect.h"
 #include "RenderingMode.h"
+#include "SkiaGPUAtlas.h"
 #include "SkiaImageAtlasLayout.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
@@ -36,6 +37,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPicture.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
+#include <wtf/Condition.h>
 #include <wtf/HashMap.h>
 #include <wtf/Lock.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -43,6 +45,40 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 namespace WebCore {
 
 using SkiaImageToFenceMap = HashMap<const SkImage*, std::unique_ptr<GLFence>>;
+
+class AtlasUploadCondition : public ThreadSafeRefCounted<AtlasUploadCondition> {
+public:
+    static Ref<AtlasUploadCondition> create() { return adoptRef(*new AtlasUploadCondition); }
+
+    void addPending()
+    {
+        Locker locker { m_lock };
+        ++m_pendingCount;
+    }
+
+    void signal()
+    {
+        Locker locker { m_lock };
+        ASSERT(m_pendingCount);
+        if (!--m_pendingCount)
+            m_condition.notifyAll();
+    }
+
+    void wait()
+    {
+        Locker locker { m_lock };
+        m_condition.wait(m_lock, [this]() WTF_REQUIRES_LOCK(m_lock) {
+            return !m_pendingCount;
+        });
+    }
+
+private:
+    AtlasUploadCondition() = default;
+
+    Lock m_lock;
+    Condition m_condition;
+    unsigned m_pendingCount WTF_GUARDED_BY_LOCK(m_lock) { 0 };
+};
 
 struct SkiaRecordingData {
     SkiaImageToFenceMap imageToFenceMap;
@@ -67,6 +103,28 @@ public:
     bool hasAtlasLayouts() const { return !m_atlasLayouts.isEmpty(); }
     const Vector<Ref<SkiaImageAtlasLayout>>& atlasLayouts() const { return m_atlasLayouts; }
 
+    // GPU atlases prepared on main thread for worker threads to rewrap.
+    void setGPUAtlases(Vector<Ref<SkiaGPUAtlas>>&& atlases, Ref<AtlasUploadCondition>&& condition)
+    {
+        m_gpuAtlases = WTF::move(atlases);
+        m_uploadCondition = WTF::move(condition);
+    }
+
+    // Set the upload fence for async GPU operations (created by SkiaPaintingEngine).
+    void setUploadFence(std::unique_ptr<GLFence>&& fence) { m_uploadFence = WTF::move(fence); }
+
+    // Check if GPU atlases are ready.
+    bool hasGPUAtlases() const { return !m_gpuAtlases.isEmpty(); }
+
+    // Get prepared GPU atlases (for worker threads to rewrap).
+    const Vector<Ref<SkiaGPUAtlas>>& gpuAtlases() const { return m_gpuAtlases; }
+
+    // Wait for GPU upload fence (call from worker threads before using atlases).
+    void waitForUploadFence();
+
+    // Wait for async DMA-buf atlas upload to complete.
+    void waitForUploadCondition();
+
 private:
     SkiaRecordingResult(sk_sp<SkPicture>&&, SkiaRecordingData&&, const IntRect& recordRect, RenderingMode, bool contentsOpaque, float contentsScale);
 
@@ -74,6 +132,9 @@ private:
     SkiaImageToFenceMap m_imageToFenceMap WTF_GUARDED_BY_LOCK(m_imageToFenceMapLock);
     Lock m_imageToFenceMapLock;
     Vector<Ref<SkiaImageAtlasLayout>> m_atlasLayouts;
+    Vector<Ref<SkiaGPUAtlas>> m_gpuAtlases;
+    std::unique_ptr<GLFence> m_uploadFence; // Fence for async GPU upload
+    RefPtr<AtlasUploadCondition> m_uploadCondition; // Non-null when m_gpuAtlases is non-empty.
     IntRect m_recordRect;
     RenderingMode m_renderingMode { RenderingMode::Unaccelerated };
     bool m_contentsOpaque : 1 { true };

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaReplayAtlas.h"
+
+#if USE(SKIA)
+
+#include "PlatformDisplay.h"
+#include "SkiaGPUAtlas.h"
+#include <wtf/TZoneMallocInlines.h>
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
+#include <skia/gpu/ganesh/GrDirectContext.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaReplayAtlas);
+
+SkiaReplayAtlas::SkiaReplayAtlas(Ref<const SkiaGPUAtlas>&& gpuAtlas, sk_sp<SkImage>&& rewrappedTexture)
+    : m_gpuAtlas(WTF::move(gpuAtlas))
+    , m_rewrappedTexture(WTF::move(rewrappedTexture))
+{
+}
+
+SkiaReplayAtlas::~SkiaReplayAtlas() = default;
+
+std::unique_ptr<SkiaReplayAtlas> SkiaReplayAtlas::create(const SkiaGPUAtlas& gpuAtlas)
+{
+    if (!gpuAtlas.backendTexture().isValid())
+        return nullptr;
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    RELEASE_ASSERT(grContext);
+
+    // Always rewrap the texture for this worker context.
+    // The underlying GL texture was created on the main thread context but is
+    // shareable via GL context sharing. However, the Skia SkImage wrapper is
+    // context-specific and must be rewrapped for each worker's GrDirectContext.
+    auto rewrapped = SkImages::BorrowTextureFrom(grContext, gpuAtlas.backendTexture(), kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    if (!rewrapped)
+        return nullptr;
+
+    return std::unique_ptr<SkiaReplayAtlas>(new SkiaReplayAtlas(gpuAtlas, WTF::move(rewrapped)));
+}
+
+std::optional<SkRect> SkiaReplayAtlas::rectForImage(const SkImage& image) const
+{
+    auto it = m_gpuAtlas->imageToRect().find(&image);
+    if (it == m_gpuAtlas->imageToRect().end())
+        return std::nullopt;
+    return it->value;
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025, 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+
+#include "IntSize.h"
+#include <optional>
+
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkImage.h>
+#include <skia/core/SkRect.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+
+#include <wtf/Ref.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+
+class SkiaGPUAtlas;
+
+// Per-worker atlas wrapper for GPU texture access during replay.
+// Takes a pre-uploaded GPU atlas (from SkiaRecordingResult) and rewraps
+// the texture for the worker thread's GrDirectContext.
+class SkiaReplayAtlas {
+    WTF_MAKE_TZONE_ALLOCATED(SkiaReplayAtlas);
+public:
+    // Create atlas wrapper from pre-prepared GPU atlas, rewraps the texture for the current context.
+    static std::unique_ptr<SkiaReplayAtlas> create(const SkiaGPUAtlas&);
+
+    ~SkiaReplayAtlas();
+
+    const sk_sp<SkImage>& atlasTexture() const { return m_rewrappedTexture; }
+
+    // Lookup: original raster image -> rect within atlas texture.
+    // Returns nullopt if image is not in this atlas.
+    std::optional<SkRect> rectForImage(const SkImage&) const;
+
+private:
+    SkiaReplayAtlas(Ref<const SkiaGPUAtlas>&&, sk_sp<SkImage>&&);
+
+    Ref<const SkiaGPUAtlas> m_gpuAtlas;
+    sk_sp<SkImage> m_rewrappedTexture;
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2025 Igalia S.L.
+ * Copyright (C) 2025, 2026 Igalia S.L.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -42,13 +42,31 @@ SkiaReplayCanvas::SkiaReplayCanvas(const IntSize& size, const RefPtr<SkiaRecordi
     : SkNWayCanvas(size.width(), size.height())
     , m_recording(recording)
 {
+    // Create atlas wrappers from pre-prepared GPU atlases.
+    // GPU atlases were uploaded on main thread; we just rewrap for this worker's context.
+    if (m_recording && m_recording->hasGPUAtlases()) {
+        auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
+        if (!glContext || !glContext->makeContextCurrent())
+            return;
+
+        m_recording->waitForUploadCondition();
+        m_recording->waitForUploadFence();
+
+        const auto& gpuAtlases = m_recording->gpuAtlases();
+        m_atlases.reserveInitialCapacity(gpuAtlases.size());
+
+        for (const auto& gpuAtlas : gpuAtlases) {
+            if (auto atlas = SkiaReplayAtlas::create(gpuAtlas))
+                m_atlases.append(WTF::move(atlas));
+        }
+    }
 }
 
 SkiaReplayCanvas::~SkiaReplayCanvas() = default;
 
-Ref<SkiaReplayCanvas> SkiaReplayCanvas::create(const IntSize& size, const RefPtr<SkiaRecordingResult>& recodingResult)
+Ref<SkiaReplayCanvas> SkiaReplayCanvas::create(const IntSize& size, const RefPtr<SkiaRecordingResult>& recordingResult)
 {
-    return adoptRef(*new SkiaReplayCanvas(size, recodingResult));
+    return adoptRef(*new SkiaReplayCanvas(size, recordingResult));
 }
 
 sk_sp<SkImage> SkiaReplayCanvas::waitForRenderingCompletionAndRewrapImageIfNeeded(const SkImage* image)
@@ -175,6 +193,20 @@ void SkiaReplayCanvas::onDrawGlyphRunList(const sktext::GlyphRunList& glyphRunLi
 
 void SkiaReplayCanvas::onDrawImage2(const SkImage* image, SkScalar x, SkScalar y, const SkSamplingOptions& sampling, const SkPaint* paint)
 {
+    // Check for atlas substitution for raster images.
+    if (!m_atlases.isEmpty() && image && !image->isTextureBacked()) {
+        for (auto& atlas : m_atlases) {
+            if (auto atlasRect = atlas->rectForImage(*image)) {
+                // Draw from atlas instead of original image.
+                const auto& atlasTexture = atlas->atlasTexture();
+                ASSERT(atlasTexture);
+                auto dst = SkRect::MakeXYWH(x, y, atlasRect->width(), atlasRect->height());
+                SkNWayCanvas::onDrawImageRect2(atlasTexture.get(), *atlasRect, dst, sampling, paint, SkCanvas::kStrict_SrcRectConstraint);
+                return;
+            }
+        }
+    }
+
     invokeDrawFunctionWithImage(image, [&](const SkImage* image) {
         SkNWayCanvas::onDrawImage2(image, x, y, sampling, paint);
     });
@@ -189,6 +221,42 @@ void SkiaReplayCanvas::onDrawImageLattice2(const SkImage* image, const Lattice& 
 
 void SkiaReplayCanvas::onDrawImageRect2(const SkImage* image, const SkRect& src, const SkRect& dst, const SkSamplingOptions& sampling, const SkPaint* paint, SrcRectConstraint constraint)
 {
+    // Check for atlas substitution for raster images.
+    if (!m_atlases.isEmpty() && image && !image->isTextureBacked()) {
+        for (auto& atlas : m_atlases) {
+            if (auto atlasRect = atlas->rectForImage(*image)) {
+                // Draw from atlas instead of original image.
+                const auto& atlasTexture = atlas->atlasTexture();
+                ASSERT(atlasTexture);
+
+                // Map src rect from image coordinates to atlas coordinates.
+                SkScalar atlasX = atlasRect->x() + src.x();
+                SkScalar atlasY = atlasRect->y() + src.y();
+                auto atlasSrc = SkRect::MakeXYWH(atlasX, atlasY, src.width(), src.height());
+
+                // Clamp to image bounds within atlas to prevent reading adjacent images.
+                SkRect imageBoundsInAtlas = *atlasRect;
+                if (!atlasSrc.intersect(imageBoundsInAtlas))
+                    return;
+
+                // Adjust destination proportionally if source was clamped.
+                if (atlasSrc.width() != src.width() || atlasSrc.height() != src.height()) {
+                    SkScalar leftClip = atlasSrc.x() - atlasX;
+                    SkScalar topClip = atlasSrc.y() - atlasY;
+                    SkScalar scaleX = dst.width() / src.width();
+                    SkScalar scaleY = dst.height() / src.height();
+
+                    auto adjustedDst = SkRect::MakeXYWH(dst.x() + leftClip * scaleX, dst.y() + topClip * scaleY, atlasSrc.width() * scaleX, atlasSrc.height() * scaleY);
+                    SkNWayCanvas::onDrawImageRect2(atlasTexture.get(), atlasSrc, adjustedDst, sampling, paint, SkCanvas::kStrict_SrcRectConstraint);
+                    return;
+                }
+
+                SkNWayCanvas::onDrawImageRect2(atlasTexture.get(), atlasSrc, dst, sampling, paint, SkCanvas::kStrict_SrcRectConstraint);
+                return;
+            }
+        }
+    }
+
     invokeDrawFunctionWithImage(image, [&](const SkImage* image) {
         SkNWayCanvas::onDrawImageRect2(image, src, dst, sampling, paint, constraint);
     });

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
@@ -28,6 +28,7 @@
 #if USE(SKIA)
 #include "IntSize.h"
 #include "SkiaRecordingResult.h"
+#include "SkiaReplayAtlas.h"
 #include <wtf/Assertions.h>
 #include <wtf/Function.h>
 
@@ -79,6 +80,7 @@ private:
     void onDrawVerticesObject(const SkVertices*, SkBlendMode, const SkPaint&) override;
 
     RefPtr<SkiaRecordingResult> m_recording;
+    Vector<std::unique_ptr<SkiaReplayAtlas>> m_atlases;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -98,7 +98,7 @@ GLenum depthBufferFormat()
 BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
     : m_flags(flags)
     , m_size(size)
-    , m_pixelFormat(PixelFormat::RGBA8)
+    , m_pixelFormat(flags.contains(Flags::UseBGRALayout) ? PixelFormat::BGRA8 : PixelFormat::RGBA8)
 {
     determineRenderTargetAndBinding();
 #if USE(GBM)
@@ -223,7 +223,7 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
 
     m_flags = flags;
     m_shouldClear = true;
-    m_pixelFormat = PixelFormat::RGBA8;
+    m_pixelFormat = flags.contains(Flags::UseBGRALayout) ? PixelFormat::BGRA8 : PixelFormat::RGBA8;
     m_filterOperation = nullptr;
 
     if (!flags.contains(Flags::DepthBuffer)) {


### PR DESCRIPTION
#### 48bf47fef51c61baf918a618ab851081493bf1ca
<pre>
[GTK][WPE] Implement GPU atlas creation and replay substitution for batched raster image uploads
<a href="https://bugs.webkit.org/show_bug.cgi?id=308166">https://bugs.webkit.org/show_bug.cgi?id=308166</a>

Reviewed by Carlos Garcia Campos.

This builds on the previous atlas layout computation to complete
the texture atlas pipeline for batching raster image uploads in
the Skia painting engine.

During the recording phase, raster images are collected and packed
into atlas layouts. After recording, SkiaPaintingEngine now creates
GPU atlases on the main thread by acquiring BitmapTextures from the
texture pool and composing the raster image pixels into them. Two
composition paths are supported: a DMA-buf path that memory-maps
the GPU buffer for direct pixel writes (optimized - dispatched to a
dedicated composition worker thread), and a GL fallback path that
uses BitmapTexture::updateContents() synchronously. A single GL
fence is inserted after all atlas uploads to allow worker threads
to wait for completion before using the textures.

The DMA-buf atlas composition path is enabled by default on
platforms supporting GBM. It can be disabled at runtime by setting
the WEBKIT_DISABLE_DMABUF_ATLAS environment variable to 1.

Async DMA-buf atlas composition is synchronized using an
AtlasCompositionFence countdown latch (Lock + Condition). A single
fence is shared across all atlas compositions for a given recording,
with addPending()/signal() counting dispatched work and wait()
blocking replay workers until all compositions complete.

On the replay side, SkiaReplayCanvas now creates per-worker
SkiaReplayAtlas wrappers that rewrap the pre-uploaded GPU textures
for each worker thread&apos;s GrDirectContext. During picture playback,
onDrawImage2() and onDrawImageRect2() intercept raster image draws
and substitute them with atlas texture draws, mapping source
coordinates into atlas space.

All atlas draw paths use kStrict_SrcRectConstraint to prevent
texture bleeding artifacts. When drawing from a standalone image,
kFast_SrcRectConstraint is safe because sampling beyond the source
rect just clamps to the image&apos;s own edge pixels. However, when
drawing a sub-region from an atlas texture, sampling beyond the
source rect would read pixels from adjacent images in the atlas,
producing visible edge artifacts. kStrict_SrcRectConstraint tells
Skia to clamp texture sampling strictly within the source rect.

Images with non-sRGB color spaces (e.g. linear RGB from SVG filter
results rendered with color-interpolation-filters: linearRGB) are
converted to sRGB during atlas composition. The atlas texture is
always tagged sRGB, so without conversion the raw pixel data would
be misinterpreted, causing visible color shifts (darker colors).
The conversion uses Skia&apos;s built-in readPixels() with an sRGB
target SkImageInfo. sRGB and untagged images use a zero-copy
peekPixels() fast path.

Covered by existing tests.

* Source/WebCore/platform/Skia.cmake:
* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/NativeImage.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::drawNativeImage):
(WebCore::GraphicsContextSkia::beginRecording):
(WebCore::GraphicsContextSkia::endRecording):
* Source/WebCore/platform/graphics/skia/NativeImageSkia.cpp:
(WebCore::NativeImage::uniqueID const):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp: Added.
(WebCore::SkiaGPUAtlas::SkiaGPUAtlas):
(WebCore::SkiaGPUAtlas::create):
(WebCore::SkiaGPUAtlas::uploadImages):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h: Added.
(WebCore::SkiaGPUAtlas::backendTexture const):
(WebCore::SkiaGPUAtlas::imageToRect const):
(WebCore::SkiaGPUAtlas::size const):
(WebCore::SkiaGPUAtlas::atlasTexture const):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::SkiaPaintingEngine):
(WebCore::SkiaPaintingEngine::createAtlas):
(WebCore::SkiaPaintingEngine::record):
(WebCore::SkiaPaintingEngine::replay):
(WebCore::SkiaPaintingEngine::shouldUseDMABufAtlasTextures):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
(WebCore::SkiaPaintingEngine::useThreadedRendering const):
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp:
(WebCore::SkiaRecordingResult::waitForUploadFence):
(WebCore::SkiaRecordingResult::waitForUploadCondition):
* Source/WebCore/platform/graphics/skia/SkiaRecordingResult.h:
(WebCore::AtlasUploadCondition::create):
(WebCore::AtlasUploadCondition::addPending):
(WebCore::AtlasUploadCondition::signal):
(WebCore::AtlasUploadCondition::wait):
(WebCore::AtlasUploadCondition::WTF_GUARDED_BY_LOCK):
* Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp: Added.
(WebCore::SkiaReplayAtlas::SkiaReplayAtlas):
(WebCore::SkiaReplayAtlas::create):
(WebCore::SkiaReplayAtlas::rectForImage const):
* Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.h: Copied from Source/WebCore/platform/graphics/skia/SkiaRecordingResult.cpp.
(WebCore::SkiaReplayAtlas::atlasTexture const):
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp:
(WebCore::SkiaReplayCanvas::SkiaReplayCanvas):
(WebCore::SkiaReplayCanvas::create):
(WebCore::SkiaReplayCanvas::onDrawImage2):
(WebCore::SkiaReplayCanvas::onDrawImageRect2):
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::reset):
Fix a problem with the untested code path, pixelFormat was wrong
when using the BGRALayout flag

Canonical link: <a href="https://commits.webkit.org/308458@main">https://commits.webkit.org/308458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ec68e8347dba3f48a6523553ba4fff6a364755cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147638 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20323 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13914 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156320 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20780 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20223 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113807 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16049 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132606 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94568 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15214 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/12999 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3761 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124810 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10523 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158654 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1790 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11995 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121833 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122034 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31238 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20133 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76238 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17573 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9084 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83500 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19467 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19618 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19525 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->