### PR TITLE
[YARR] Eliminate redundant add32 in body alternative backtrack path

### DIFF
--- a/JSTests/stress/regexp-body-alternative-backtrack-reduced-index.js
+++ b/JSTests/stress/regexp-body-alternative-backtrack-reduced-index.js
@@ -1,0 +1,129 @@
+function shouldBe(actual, expected, message) {
+    if (JSON.stringify(actual) !== JSON.stringify(expected))
+        throw new Error(message + ": expected " + JSON.stringify(expected) + " but got " + JSON.stringify(actual));
+}
+
+(function testDecreasingMinimumSize() {
+    var re = /dddd|ccc|bb|a/;
+    shouldBe(re.exec("a"), ["a"], "dddd|ccc|bb|a on 'a'");
+    shouldBe(re.exec("bb"), ["bb"], "dddd|ccc|bb|a on 'bb'");
+    shouldBe(re.exec("ccc"), ["ccc"], "dddd|ccc|bb|a on 'ccc'");
+    shouldBe(re.exec("dddd"), ["dddd"], "dddd|ccc|bb|a on 'dddd'");
+    shouldBe(re.exec("x"), null, "dddd|ccc|bb|a on 'x'");
+    shouldBe(re.exec(""), null, "dddd|ccc|bb|a on ''");
+})();
+
+(function testIncreasingMinimumSize() {
+    var re = /a|bb|ccc|dddd/;
+    shouldBe(re.exec("a"), ["a"], "a|bb|ccc|dddd on 'a'");
+    shouldBe(re.exec("bb"), ["bb"], "a|bb|ccc|dddd on 'bb'");
+    shouldBe(re.exec("ccc"), ["ccc"], "a|bb|ccc|dddd on 'ccc'");
+    shouldBe(re.exec("dddd"), ["dddd"], "a|bb|ccc|dddd on 'dddd'");
+})();
+
+(function testMixedMinimumSizes() {
+    var re = /abc|d|efgh|ij/;
+    shouldBe(re.exec("abc"), ["abc"], "abc|d|efgh|ij on 'abc'");
+    shouldBe(re.exec("d"), ["d"], "abc|d|efgh|ij on 'd'");
+    shouldBe(re.exec("efgh"), ["efgh"], "abc|d|efgh|ij on 'efgh'");
+    shouldBe(re.exec("ij"), ["ij"], "abc|d|efgh|ij on 'ij'");
+    shouldBe(re.exec("x"), null, "abc|d|efgh|ij on 'x'");
+})();
+
+(function testBoundaryInputLength() {
+    var re = /abcdef|abc|a/;
+    shouldBe(re.exec("abc"), ["abc"], "abcdef|abc|a on 'abc'");
+    shouldBe(re.exec("ab"), ["a"], "abcdef|abc|a on 'ab'");
+    shouldBe(re.exec("a"), ["a"], "abcdef|abc|a on 'a'");
+    shouldBe(re.exec(""), null, "abcdef|abc|a on ''");
+})();
+
+(function testRepeatingAlternatives() {
+    var re = /xxxx|xx|x/;
+    shouldBe(re.exec("---x---"), ["x"], "xxxx|xx|x on '---x---'");
+    shouldBe(re.exec("---xx---"), ["xx"], "xxxx|xx|x on '---xx---'");
+    shouldBe(re.exec("---xxxx---"), ["xxxx"], "xxxx|xx|x on '---xxxx---'");
+    shouldBe(re.exec("---xxx---"), ["xx"], "xxxx|xx|x on '---xxx---' matches 'xx' (first matching alt)");
+
+    var result = re.exec("---xx---");
+    shouldBe(result.index, 3, "xxxx|xx|x match position in '---xx---'");
+})();
+
+(function testWithCaptures() {
+    var re = /(abcd)|(ab)|(a)/;
+    var result = re.exec("ab");
+    shouldBe(result[0], "ab", "capture: full match");
+    shouldBe(result[1], undefined, "capture: group 1 should not match");
+    shouldBe(result[2], "ab", "capture: group 2 should match");
+    shouldBe(result[3], undefined, "capture: group 3 should not match");
+
+    result = re.exec("a");
+    shouldBe(result[0], "a", "capture: full match for 'a'");
+    shouldBe(result[1], undefined, "capture: group 1 should not match for 'a'");
+    shouldBe(result[2], undefined, "capture: group 2 should not match for 'a'");
+    shouldBe(result[3], "a", "capture: group 3 should match for 'a'");
+})();
+
+(function testManyAlternatives() {
+    var re = /abcdefgh|abcdefg|abcdef|abcde|abcd|abc|ab|a/;
+    shouldBe(re.exec("a"), ["a"], "8 alts on 'a'");
+    shouldBe(re.exec("ab"), ["ab"], "8 alts on 'ab'");
+    shouldBe(re.exec("abc"), ["abc"], "8 alts on 'abc'");
+    shouldBe(re.exec("abcd"), ["abcd"], "8 alts on 'abcd'");
+    shouldBe(re.exec("abcde"), ["abcde"], "8 alts on 'abcde'");
+    shouldBe(re.exec("abcdef"), ["abcdef"], "8 alts on 'abcdef'");
+    shouldBe(re.exec("abcdefg"), ["abcdefg"], "8 alts on 'abcdefg'");
+    shouldBe(re.exec("abcdefgh"), ["abcdefgh"], "8 alts on 'abcdefgh'");
+})();
+
+(function testZeroMinimumSize() {
+    var re = /abc|/;
+    shouldBe(re.exec("abc"), ["abc"], "abc| on 'abc'");
+    shouldBe(re.exec("x"), [""], "abc| on 'x' (empty match)");
+    shouldBe(re.exec(""), [""], "abc| on '' (empty match)");
+})();
+
+(function testJITTierUp() {
+    var re = /xxxxx|xxx|x/;
+    for (var i = 0; i < 1000; i++) {
+        shouldBe(re.exec("x"), ["x"], "JIT tier-up iteration " + i);
+        shouldBe(re.exec("xxx"), ["xxx"], "JIT tier-up iteration " + i);
+        shouldBe(re.exec("xxxxx"), ["xxxxx"], "JIT tier-up iteration " + i);
+        shouldBe(re.exec("xx"), ["x"], "JIT tier-up iteration " + i);
+        shouldBe(re.exec("xxxx"), ["xxx"], "JIT tier-up iteration " + i);
+    }
+})();
+
+(function testUnicode() {
+    var re = /\u{1F600}\u{1F601}|\u{1F600}|a/u;
+    shouldBe(re.exec("a"), ["a"], "unicode on 'a'");
+    shouldBe(re.exec("\u{1F600}"), ["\u{1F600}"], "unicode on single emoji");
+    shouldBe(re.exec("\u{1F600}\u{1F601}"), ["\u{1F600}\u{1F601}"], "unicode on two emojis");
+})();
+
+(function testGlobalMatching() {
+    var re = /aaa|aa|a/g;
+    var str = "aaaaaa";
+    var matches = str.match(re);
+    shouldBe(matches, ["aaa", "aaa"], "global matching 'aaaaaa'");
+
+    re = /aaa|aa|a/g;
+    str = "aaaaa";
+    matches = str.match(re);
+    shouldBe(matches, ["aaa", "aa"], "global matching 'aaaaa'");
+})();
+
+(function testStickyFlag() {
+    var re = /xxxx|xx|x/y;
+    re.lastIndex = 2;
+    shouldBe(re.exec("--xx--"), ["xx"], "sticky at index 2");
+    shouldBe(re.lastIndex, 4, "sticky lastIndex after match");
+    shouldBe(re.exec("--xx--"), null, "sticky at index 4 (no match)");
+})();
+
+(function testCaseInsensitive() {
+    var re = /ABCD|AB|A/i;
+    shouldBe(re.exec("ab"), ["ab"], "case insensitive on 'ab'");
+    shouldBe(re.exec("a"), ["a"], "case insensitive on 'a'");
+    shouldBe(re.exec("abcd"), ["abcd"], "case insensitive on 'abcd'");
+})();

--- a/Source/JavaScriptCore/yarr/YarrJIT.cpp
+++ b/Source/JavaScriptCore/yarr/YarrJIT.cpp
@@ -1645,6 +1645,7 @@ class YarrGenerator final : public YarrJITInfo {
         // into the code for a node (likely where a backtrack will trigger
         // rematching).
         MacroAssembler::Label m_reentry;
+        MacroAssembler::Label m_adjustedReentry;
         MacroAssembler::JumpList m_jumps;
 
         // Used for backtracking when the prior alternative did not consume any
@@ -3631,8 +3632,10 @@ class YarrGenerator final : public YarrJITInfo {
                     if (alternative->m_minimumSize > priorAlternative->m_minimumSize) {
                         m_jit.add32(MacroAssembler::Imm32(alternative->m_minimumSize - priorAlternative->m_minimumSize), m_regs.index);
                         op.m_jumps.append(jumpIfNoAvailableInput());
-                    } else if (priorAlternative->m_minimumSize > alternative->m_minimumSize)
+                    } else if (priorAlternative->m_minimumSize > alternative->m_minimumSize) {
                         m_jit.sub32(MacroAssembler::Imm32(priorAlternative->m_minimumSize - alternative->m_minimumSize), m_regs.index);
+                        op.m_adjustedReentry = m_jit.label();
+                    }
                 } else if (op.m_nextOp == notFound) {
                     // This is the reentry point for the End of 'once through' alternatives,
                     // jumped to when the last alternative fails to match.
@@ -4397,14 +4400,10 @@ class YarrGenerator final : public YarrJITInfo {
                     // We only get here if an input check fails, it is only worth checking again
                     // if the next alternative has a minimum size less than the last.
                     if (prevOp->m_alternative->m_minimumSize > nextOp->m_alternative->m_minimumSize) {
-                        // FIXME: if we added an extra label to YarrOp, we could avoid needing to
-                        // subtract delta back out, and reduce this code. Should performance test
-                        // the benefit of this.
                         unsigned delta = prevOp->m_alternative->m_minimumSize - nextOp->m_alternative->m_minimumSize;
                         m_jit.sub32(MacroAssembler::Imm32(delta), m_regs.index);
                         MacroAssembler::Jump fail = jumpIfNoAvailableInput();
-                        m_jit.add32(MacroAssembler::Imm32(delta), m_regs.index);
-                        m_jit.jump(nextOp->m_reentry);
+                        m_jit.jump(nextOp->m_adjustedReentry);
                         fail.link(&m_jit);
                     } else if (prevOp->m_alternative->m_minimumSize < nextOp->m_alternative->m_minimumSize)
                         m_jit.add32(MacroAssembler::Imm32(nextOp->m_alternative->m_minimumSize - prevOp->m_alternative->m_minimumSize), m_regs.index);


### PR DESCRIPTION
#### 6e7d1761735375a8f525a1151ac73267c05939e5
<pre>
[YARR] Eliminate redundant add32 in body alternative backtrack path
<a href="https://bugs.webkit.org/show_bug.cgi?id=308177">https://bugs.webkit.org/show_bug.cgi?id=308177</a>

Reviewed by NOBODY (OOPS!).

When backtracking between body alternatives with decreasing minimumSize,
the JIT previously emitted a sub32 to adjust the index, checked input
availability, then emitted an add32 to restore the index before jumping
to m_reentry (which would sub32 again).

This adds an m_adjustedReentry label after the sub32 in the forward path,
allowing the backtrack path to jump directly past the adjustment. This
resolves an existing FIXME in the code.

For /dddd|ccc|bb|a/, each alternative transition in the backtracking
section changes from:

    sub   w1, w1, #0x1      // adjust index
    cmp   w1, w2            // check input
    b.hi  &lt;fail&gt;
    add   w1, w1, #0x1      // restore index (redundant)
    b     &lt;m_reentry&gt;       // jumps to code that sub32s again

to:

    sub   w1, w1, #0x1      // adjust index
    cmp   w1, w2            // check input
    b.hi  &lt;fail&gt;
    b     &lt;m_adjustedReentry&gt; // skip straight past the sub32

Test: JSTests/stress/regexp-body-alternative-backtrack-reduced-index.js

* JSTests/stress/regexp-body-alternative-backtrack-reduced-index.js: Added.
(shouldBe):
(testDecreasingMinimumSize):
(testIncreasingMinimumSize):
(testMixedMinimumSizes):
(testBoundaryInputLength):
(testRepeatingAlternatives):
(testWithCaptures):
(testManyAlternatives):
(testZeroMinimumSize):
(testJITTierUp):
(testUnicode):
(testGlobalMatching):
(testStickyFlag):
(testCaseInsensitive):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e7d1761735375a8f525a1151ac73267c05939e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18376 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10276 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99334 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18861 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112046 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80277 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148657 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14417 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130860 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92952 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13722 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11487 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1813 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137685 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123269 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7698 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156679 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6503 "Built successfully and passed tests") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8816 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120048 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18226 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15208 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120400 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128994 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73966 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16126 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7115 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176997 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81627 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45458 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17584 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17792 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17647 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->