### PR TITLE
[macOS Debug] scrollingcoordinator/mac/latching/simple-page-rubberbands.html is a flaky text failure

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2493,5 +2493,3 @@ webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/
 webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/console/message-from-worker.html [ Failure ]
 
 webkit.org/b/308086 [ Tahoe Release arm64 ] compositing/visible-rect/animated-from-none.html [ Pass Failure ]
-
-webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]

--- a/LayoutTests/scrollingcoordinator/mac/latching/simple-page-rubberbands.html
+++ b/LayoutTests/scrollingcoordinator/mac/latching/simple-page-rubberbands.html
@@ -15,12 +15,14 @@
         var minYOffset;
         var maxYOffset;
 
-        function reset()
+        async function reset()
         {
+            window.scrollTo(0, 0);
+            await UIHelper.animationFrame();
             minXOffset = 0;
-            maxXOffset = -1000;
+            maxXOffset = 0;
             minYOffset = 0;
-            maxYOffset = -1000;
+            maxYOffset = 0;
         }
 
         async function scrollTest()
@@ -41,17 +43,17 @@
                 return;
             }
 
-            reset();
+            await reset();
             debug('');
             debug('Swipe to the left');
-            
+
             await UIHelper.mouseWheelScrollAt(10, 10, 1, 0, 10, 0);
             shouldBeTrue('minXOffset < 0');
             shouldBe('maxXOffset', '0');
             shouldBe('minYOffset', '0');
             shouldBe('maxYOffset', '0');
 
-            reset();
+            await reset();
             debug('');
             debug('Swipe to the right');
             await UIHelper.mouseWheelScrollAt(10, 10, -1, 0, -10, 0);
@@ -60,7 +62,7 @@
             shouldBe('minYOffset', '0');
             shouldBe('maxYOffset', '0');
 
-            reset();
+            await reset();
             debug('');
             debug('Swipe down');
             await UIHelper.mouseWheelScrollAt(10, 10, 0, -1, 0, -10);
@@ -69,7 +71,7 @@
             shouldBe('minYOffset', '0');
             shouldBeTrue('maxYOffset > 0');
 
-            reset();
+            await reset();
             debug('');
             debug('Swipe up');
             await UIHelper.mouseWheelScrollAt(10, 10, 0, 1, 0, 10);


### PR DESCRIPTION
#### 79dd74028538f61ea90727ee1ae66d57167a64e9
<pre>
[macOS Debug] scrollingcoordinator/mac/latching/simple-page-rubberbands.html is a flaky text failure
<a href="https://rdar.apple.com/170669755">rdar://170669755</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308165">https://bugs.webkit.org/show_bug.cgi?id=308165</a>

Reviewed by NOBODY (OOPS!).

Addresses flaky failure with the following test with the following changes:
    1. Added window.scrollTo(0, 0) - The sister test rubberbanding-always-bounce-short-content.html has this.
       Without it, residual rubber-band animation from the previous swipe can contaminate the next test&apos;s measurements.
    2. Made reset() async with await UIHelper.animationFrame() - scrollTo(0,0) initiates scroll but rubber-band animations continue
       asynchronously. Without waiting, scroll events from the previous test&apos;s rubber-band can still fire after we reset the
       tracking variables.
    3. Changed initialization from -1000 to 0 - The -1000 sentinel relies on a scroll event firing when rubber-band returns to
       position 0.
       With 0 initialization:
        - shouldBeTrue(&apos;minXOffset &lt; 0&apos;) still verifies scroll events fired during rubber-band
        - shouldBe(&apos;maxXOffset&apos;, &apos;0&apos;) correctly verifies &quot;scroll never went positive&quot;

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/scrollingcoordinator/mac/latching/simple-page-rubberbands.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79dd74028538f61ea90727ee1ae66d57167a64e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145563 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18245 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154235 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99200 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18730 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18138 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111941 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80208 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14308 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92846 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13626 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11395 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1682 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123173 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156548 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18095 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119946 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18141 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15101 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120294 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16028 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73824 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17716 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7008 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17453 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17661 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17516 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->