### PR TITLE
Include PCM domains in website data fetch to fix "Remove All" clearing

### DIFF
--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -1762,6 +1762,19 @@ void NetworkProcess::fetchWebsiteData(PAL::SessionID sessionID, OptionSet<Websit
             callbackAggregator->m_websiteData.entries.appendVector(WTF::move(entries));
         });
     }
+
+    if (websiteDataTypes.contains(WebsiteDataType::PrivateClickMeasurements) && session) {
+        session->privateClickMeasurement().fetchRegistrableDomains([callbackAggregator](auto&& domains) mutable {
+            for (auto& domain : domains) {
+                WebsiteData::Entry entry {
+                    WebCore::SecurityOriginData::fromURL(URL { makeString("https://"_s, domain.string()) }),
+                    WebsiteDataType::PrivateClickMeasurements,
+                    0
+                };
+                callbackAggregator->m_websiteData.entries.append(WTF::move(entry));
+            }
+        });
+    }
 }
 
 void NetworkProcess::performDeleteWebsiteDataTask(TaskIdentifier taskIdentifier, TaskTrigger trigger)

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp
@@ -493,6 +493,24 @@ void Database::markAttributedPrivateClickMeasurementsAsExpiredForTesting()
     }
 }
 
+Vector<WebCore::RegistrableDomain> Database::fetchRegistrableDomains() const
+{
+    ASSERT(!RunLoop::isMain());
+
+    auto statement = m_database->prepareStatement("SELECT registrableDomain FROM PCMObservedDomains;"_s);
+
+    if (!statement)
+        return { };
+
+    Vector<WebCore::RegistrableDomain> domains;
+    while (statement->step() == SQLITE_ROW) {
+        String domainString = statement->columnText(0);
+        if (!domainString.isEmpty())
+            domains.append(WebCore::RegistrableDomain::uncheckedCreateFromHost(domainString));
+    }
+    return domains;
+}
+
 void Database::clearPrivateClickMeasurement(std::optional<WebCore::RegistrableDomain> domain)
 {
     ASSERT(!RunLoop::isMain());

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h
@@ -65,6 +65,7 @@ public:
     void markAllUnattributedPrivateClickMeasurementAsExpiredForTesting();
     void markAttributedPrivateClickMeasurementsAsExpiredForTesting();
 
+    Vector<WebCore::RegistrableDomain> fetchRegistrableDomains() const;
 private:
     using UnattributedPrivateClickMeasurement = WebCore::PrivateClickMeasurement;
     using AttributedPrivateClickMeasurement = WebCore::PrivateClickMeasurement;

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.cpp
@@ -150,6 +150,18 @@ void EphemeralStore::clearSentAttribution(WebCore::PrivateClickMeasurement&& att
     m_clickMeasurement = WTF::move(attributionToClear);
 }
 
+void EphemeralStore::fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    Vector<WebCore::RegistrableDomain> domains;
+
+    if (m_clickMeasurement) {
+        domains.append(m_clickMeasurement->sourceSite().registrableDomain);
+        domains.append(m_clickMeasurement->destinationSite().registrableDomain);
+    }
+
+    completionHandler(WTF::move(domains));
+}
+
 void EphemeralStore::close(CompletionHandler<void()>&& completionHandler)
 {
     reset();

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.h
@@ -60,6 +60,8 @@ public:
     void clearPrivateClickMeasurementForRegistrableDomain(WebCore::RegistrableDomain&&, CompletionHandler<void()>&&) final;
     void clearSentAttribution(WebCore::PrivateClickMeasurement&& attributionToClear, WebCore::PCM::AttributionReportEndpoint) final;
 
+    void fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&&) final;
+
     void close(CompletionHandler<void()>&&) final;
 
 private:

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp
@@ -812,4 +812,16 @@ void PrivateClickMeasurementManager::allowTLSCertificateChainForLocalPCMTesting(
     PCM::NetworkLoader::allowTLSCertificateChainForLocalPCMTesting(certificateInfo);
 }
 
+void PrivateClickMeasurementManager::fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    initializeStore();
+
+    if (!m_store) {
+        completionHandler({ });
+        return;
+    }
+
+    protect(store())->fetchRegistrableDomains(WTF::move(completionHandler));
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h
@@ -69,6 +69,7 @@ public:
     void setPrivateClickMeasurementAppBundleIDForTesting(ApplicationBundleIdentifier&&);
     void destroyStoreForTesting(CompletionHandler<void()>&&) final;
     void allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo&) final;
+    void fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&&);
 
 private:
     PrivateClickMeasurementManager(UniqueRef<PCM::Client>&&, const String& storageDirectory);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp
@@ -125,6 +125,11 @@ FUNCTION(allowTLSCertificateChainForLocalPCMTesting)
 ARGUMENTS(WebCore::CertificateInfo)
 END
 
+FUNCTION(fetchRegistrableDomains)
+ARGUMENTS()
+REPLY(Vector<WebCore::RegistrableDomain>)
+END
+
 #undef FUNCTION
 #undef ARGUMENTS
 #undef REPLY
@@ -138,11 +143,22 @@ EMPTY_REPLY(destroyStoreForTesting);
 EMPTY_REPLY(storeUnattributed);
 #undef EMPTY_REPLY
 
-PCM::EncodedMessage toStringForTesting::encodeReply(String reply)
+template<typename T>
+static PCM::EncodedMessage encodeReplyImpl(T&& payload)
 {
     Daemon::Encoder encoder;
-    encoder << reply;
+    encoder << std::forward<T>(payload);
     return encoder.takeBuffer();
+}
+
+PCM::EncodedMessage toStringForTesting::encodeReply(String reply)
+{
+    return encodeReplyImpl(WTF::move(reply));
+}
+
+PCM::EncodedMessage fetchRegistrableDomains::encodeReply(Vector<WebCore::RegistrableDomain> domains)
+{
+    return encodeReplyImpl(WTF::move(domains));
 }
 
 } // namespace MessageInfo
@@ -169,6 +185,7 @@ bool messageTypeSendsReply(MessageType messageType)
     case MessageType::ToStringForTesting:
     case MessageType::Clear:
     case MessageType::ClearForRegistrableDomain:
+    case MessageType::FetchRegistrableDomains:
         return true;
     }
     ASSERT_NOT_REACHED();
@@ -305,6 +322,9 @@ void decodeMessageAndSendToManager(const Daemon::Connection& connection, Message
         break;
     case PCM::MessageType::AllowTLSCertificateChainForLocalPCMTesting:
         handlePCMMessage<MessageInfo::allowTLSCertificateChainForLocalPCMTesting>(encodedMessage);
+        break;
+    case PCM::MessageType::FetchRegistrableDomains:
+        handlePCMMessageWithReply<MessageInfo::fetchRegistrableDomains>(encodedMessage, WTF::move(replySender));
         break;
     }
 }

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h
@@ -75,6 +75,7 @@ public:
     virtual void setPrivateClickMeasurementAppBundleIDForTesting(ApplicationBundleIdentifier&&) = 0;
     virtual void destroyStoreForTesting(CompletionHandler<void()>&&) = 0;
     virtual void allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo&) = 0;
+    virtual void fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&&) = 0;
 };
 
 constexpr auto protocolVersionKey { "version"_s };
@@ -102,7 +103,8 @@ enum class MessageType : uint8_t {
     StartTimerImmediatelyForTesting,
     SetPrivateClickMeasurementAppBundleIDForTesting,
     DestroyStoreForTesting,
-    AllowTLSCertificateChainForLocalPCMTesting
+    AllowTLSCertificateChainForLocalPCMTesting,
+    FetchRegistrableDomains
 };
 
 constexpr auto protocolEncodedMessageKey { "encoded message"_s };

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp
@@ -60,6 +60,16 @@ template<> struct ReplyCaller<String> {
         completionHandler(WTF::move(*string));
     }
 };
+template<> struct ReplyCaller<Vector<WebCore::RegistrableDomain>&&> {
+    static void callReply(Daemon::Decoder&& decoder, CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&& completionHandler)
+    {
+        std::optional<Vector<WebCore::RegistrableDomain>> domains;
+        decoder >> domains;
+        if (!domains)
+            return completionHandler({ });
+        completionHandler(WTF::move(*domains));
+    }
+};
 
 template<MessageType messageType, typename... Args, typename... ReplyArgs>
 void ManagerProxy::sendMessageWithReply(CompletionHandler<void(ReplyArgs...)>&& completionHandler, Args&&... args) const
@@ -169,6 +179,11 @@ void ManagerProxy::destroyStoreForTesting(CompletionHandler<void()>&& completion
 void ManagerProxy::allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo& certificateInfo)
 {
     sendMessage<MessageType::AllowTLSCertificateChainForLocalPCMTesting>(certificateInfo);
+}
+
+void ManagerProxy::fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    sendMessageWithReply<MessageType::FetchRegistrableDomains>(WTF::move(completionHandler));
 }
 
 } // namespace WebKit::PCM

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.h
@@ -62,6 +62,7 @@ public:
     void setPrivateClickMeasurementAppBundleIDForTesting(ApplicationBundleIdentifier&&) final;
     void destroyStoreForTesting(CompletionHandler<void()>&&) final;
     void allowTLSCertificateChainForLocalPCMTesting(const WebCore::CertificateInfo&) final;
+    void fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&&) final;
 
 private:
     ManagerProxy(const String& machServiceName, NetworkSession&);

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp
@@ -179,6 +179,24 @@ void PersistentStore::clearSentAttribution(WebCore::PrivateClickMeasurement&& at
     });
 }
 
+void PersistentStore::fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&& completionHandler)
+{
+    postTask([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
+        RefPtr database = m_database;
+        if (!database) {
+            postTaskReply([completionHandler = WTF::move(completionHandler)]() mutable {
+                completionHandler({ });
+            });
+            return;
+        }
+
+        auto domains = database->fetchRegistrableDomains();
+        postTaskReply([domains = crossThreadCopy(WTF::move(domains)), completionHandler = WTF::move(completionHandler)]() mutable {
+            completionHandler(WTF::move(domains));
+        });
+    });
+}
+
 void PersistentStore::close(CompletionHandler<void()>&& completionHandler)
 {
     postTask([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] () mutable {

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.h
@@ -63,6 +63,8 @@ public:
     void clearPrivateClickMeasurementForRegistrableDomain(WebCore::RegistrableDomain&&, CompletionHandler<void()>&&) final;
     void clearSentAttribution(WebCore::PrivateClickMeasurement&& attributionToClear, WebCore::PCM::AttributionReportEndpoint) final;
 
+    void fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&&) final;
+
     void close(CompletionHandler<void()>&&) final;
 
 private:

--- a/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementStore.h
+++ b/Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementStore.h
@@ -55,6 +55,8 @@ public:
     virtual void clearPrivateClickMeasurementForRegistrableDomain(WebCore::RegistrableDomain&&, CompletionHandler<void()>&&) = 0;
     virtual void clearSentAttribution(WebCore::PrivateClickMeasurement&& attributionToClear, WebCore::PCM::AttributionReportEndpoint) = 0;
 
+    virtual void fetchRegistrableDomains(CompletionHandler<void(Vector<WebCore::RegistrableDomain>&&)>&&) = 0;
+
     virtual void close(CompletionHandler<void()>&&) = 0;
 };
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm
@@ -31,7 +31,9 @@
 #import <WebCore/SQLiteTransaction.h>
 #import <WebKit/WKFoundation.h>
 #import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/WKWebsiteDataRecordPrivate.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/RetainPtr.h>
@@ -425,3 +427,64 @@ TEST(PrivateClickMeasurement, MigrateWithDestinationToken)
     pollUntilPCMIsMigrated(webView.get(), MigratingFromResourceLoadStatistics::No, UsingDestinationToken::Yes);
     cleanUp(webView);
 }
+
+#if PLATFORM(MAC)
+TEST(PrivateClickMeasurement, FetchAndRemoveSafariCampaignDomains)
+{
+    auto webView = webViewWithResourceLoadStatisticsEnabledInNetworkProcess();
+    auto dataStore = webView.get().configuration.websiteDataStore;
+
+    [webView _storePrivateClickMeasurementWithSourceID:100 destinationURL:[NSURL URLWithString:@"https://pcmdestination.example"] reportEndpoint:[NSURL URLWithString:@"https://safaricampaign.apple"]];
+
+    TestWebKitAPI::Util::runFor(0.5_s);
+
+    // Verify Safari Campaign domains appear in fetchDataRecords
+    __block bool fetchDone = false;
+    __block bool foundSafariCampaign = false;
+    __block bool foundPCMDestination = false;
+
+    [dataStore fetchDataRecordsOfTypes:[NSSet setWithObject:_WKWebsiteDataTypePrivateClickMeasurements]
+        completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+            for (WKWebsiteDataRecord *record in records) {
+                NSString *domain = record.displayName;
+                if ([domain isEqualToString:@"safaricampaign.apple"])
+                    foundSafariCampaign = true;
+                if ([domain isEqualToString:@"pcmdestination.example"])
+                    foundPCMDestination = true;
+            }
+            fetchDone = true;
+    }];
+
+    TestWebKitAPI::Util::run(&fetchDone);
+
+    EXPECT_TRUE(foundSafariCampaign);
+    EXPECT_TRUE(foundPCMDestination);
+
+    __block bool removeDone = false;
+    [dataStore removeDataOfTypes:[NSSet setWithObject:_WKWebsiteDataTypePrivateClickMeasurements]
+        modifiedSince:[NSDate distantPast]
+        completionHandler:^{
+        removeDone = true;
+    }];
+
+    TestWebKitAPI::Util::run(&removeDone);
+
+    // Verify all PCM domains are removed
+    fetchDone = false;
+    __block NSUInteger recordCount = 0;
+    [dataStore fetchDataRecordsOfTypes:[NSSet setWithObject:_WKWebsiteDataTypePrivateClickMeasurements]
+        completionHandler:^(NSArray<WKWebsiteDataRecord *> *records) {
+            recordCount = records.count;
+            fetchDone = true;
+    }];
+
+    TestWebKitAPI::Util::run(&fetchDone);
+    EXPECT_EQ(0U, recordCount);
+
+    // Verify via dump that database is empty
+    const char* emptyPCMDatabase = "\nNo stored Private Click Measurement data.\n";
+    EXPECT_WK_STREQ(dumpedPCM(webView).get(), emptyPCMDatabase);
+
+    cleanUp(webView);
+}
+#endif


### PR DESCRIPTION
#### 59bb58fb6fd43a4953238fda50b28fa15ed30553
<pre>
Include PCM domains in website data fetch to fix &quot;Remove All&quot; clearing
<a href="https://bugs.webkit.org/show_bug.cgi?id=308335">https://bugs.webkit.org/show_bug.cgi?id=308335</a>
<a href="https://rdar.apple.com/169487327">rdar://169487327</a>

Reviewed by Charlie Wolfe.

In Safari Campaign, PCM domains were not cleared by &quot;Remove All Website Data&quot; because
they store only PCM attribution data without traditional website data (cookies, etc.).
This fix add a query to PCM database for all registrable domains during the website fetch
operation. This makes PCM-only domains visible in the data list, allowing &quot;Removing All&quot; to
clear them automatically.

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm

* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::fetchWebsiteData):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.cpp:
(WebKit::PCM::Database::fetchRegistrableDomains const):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementDatabase.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.cpp:
(WebKit::PCM::EphemeralStore::fetchRegistrableDomains):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementEphemeralStore.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.cpp:
(WebKit::PrivateClickMeasurementManager::fetchRegistrableDomains):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManager.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.cpp:
(WebKit::PCM::MessageInfo::encodeReplyImpl):
(WebKit::PCM::MessageInfo::toStringForTesting::encodeReply):
(WebKit::PCM::MessageInfo::fetchRegistrableDomains::encodeReply):
(WebKit::PCM::messageTypeSendsReply):
(WebKit::PCM::decodeMessageAndSendToManager):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerInterface.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.cpp:
(WebKit::PCM::ReplyCaller&lt;Vector&lt;WebCore::RegistrableDomain&gt;::callReply):
(WebKit::PCM::ManagerProxy::fetchRegistrableDomains):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementManagerProxy.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.cpp:
(WebKit::PCM::PersistentStore::fetchRegistrableDomains):
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementPersistentStore.h:
* Source/WebKit/NetworkProcess/PrivateClickMeasurement/PrivateClickMeasurementStore.h:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/PrivateClickMeasurement.mm:
(TEST(PrivateClickMeasurement, FetchAndRemoveSafariCampaignDomains)):

Canonical link: <a href="https://commits.webkit.org/308923@main">https://commits.webkit.org/308923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5bfd588481b7dd0e9be7a3324560b55f16a729e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/148583 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14865 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157267 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102013 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d276efcd-e0aa-4851-9249-93839e477720) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/150456 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/21748 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21174 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114535 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81560 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/227c7219-cf71-437c-ac11-29880c46ddd3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/151543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16749 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95305 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/789e542c-f0b3-4891-b2ae-73f62acd9a95) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15852 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13691 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/4703 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/125466 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11283 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/159602 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/2746 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12804 "Found 1 new test failure: fast/attachment/mac/wide-attachment-image-controls-basic.html (failure)") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/122590 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 19 flakes 1 failures; Uploaded test results; 1 failures; Compiled WebKit; 1 failures; Running analyze-layout-tests-results") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21099 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/17686 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122815 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33457 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133078 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/77235 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18147 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9845 "Passed tests") | [⏳ 🛠 jsc-armv7 ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/20707 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/84510 "Built successfully") | [⏳ 🧪 jsc-armv7-tests ](https://ews-build.webkit.org/#/builders/JSC-ARMv7-32bits-Build-EWS "Waiting in queue, processing has not started yet") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/20440 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/20585 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/20496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->