### PR TITLE
[YARR] Skip dead errorCodePoint check in JIT backreference loop for non-Unicode patterns

### DIFF
--- a/JSTests/stress/regexp-backreference-errorCodePoint-reorder.js
+++ b/JSTests/stress/regexp-backreference-errorCodePoint-reorder.js
@@ -1,0 +1,66 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+function shouldBeArray(actual, expected, msg) {
+    if (actual === null && expected !== null)
+        throw new Error(`FAIL: ${msg}: expected ${JSON.stringify(expected)}, got null`);
+    if (actual === null && expected === null)
+        return;
+    if (actual.length !== expected.length)
+        throw new Error(`FAIL: ${msg}: length mismatch: expected ${expected.length}, got ${actual.length}`);
+    for (let i = 0; i < expected.length; i++) {
+        if (actual[i] !== expected[i])
+            throw new Error(`FAIL: ${msg}: index ${i}: expected ${JSON.stringify(expected[i])}, got ${JSON.stringify(actual[i])}`);
+    }
+}
+
+for (let i = 0; i < testLoopCount; i++) {
+    shouldBeArray(/(abc)\1/.exec("abcabc"), ["abcabc", "abc"], "basic backref match");
+    shouldBe(/(abc)\1/.exec("abcdef"), null, "basic backref mismatch");
+    shouldBe(/(abcd)\1/.exec("abcdabce"), null, "partial backref mismatch");
+
+    shouldBeArray(/(\u00e9)\1/u.exec("\u00e9\u00e9"), ["\u00e9\u00e9", "\u00e9"], "unicode BMP backref");
+    shouldBeArray(/(.)\1/u.exec("\u{1F600}\u{1F600}"), ["\u{1F600}\u{1F600}", "\u{1F600}"], "non-BMP backref match");
+    shouldBe(/(.)\1/u.exec("\u{1F600}\u{1F601}"), null, "non-BMP backref mismatch");
+    shouldBeArray(/(.\u0041)\1/u.exec("\u{10000}A\u{10000}A"), ["\u{10000}A\u{10000}A", "\u{10000}A"], "astral+BMP backref");
+
+    shouldBeArray(/(a)\1{9}/.exec("aaaaaaaaaa"), ["aaaaaaaaaa", "a"], "quantified backref x10");
+    shouldBe(/(a)\1{9}/.exec("aaaaaaaab"), null, "quantified backref mismatch at end");
+
+    shouldBeArray(/(abc)\1/i.exec("abcABC"), ["abcABC", "abc"], "case-insensitive backref");
+    shouldBe(/(abc)\1/i.exec("abcDEF"), null, "case-insensitive backref mismatch");
+
+    shouldBeArray(/(?:(abc)|(def))\1/.exec("abcabc"), ["abcabc", "abc", undefined], "backref in alternation");
+    shouldBeArray(/()\1/.exec("abc"), ["", ""], "empty capture backref");
+
+    shouldBeArray(/(a)(b)\2\1/.exec("abba"), ["abba", "a", "b"], "multiple backrefs");
+    shouldBe(/(a)(b)\2\1/.exec("abab"), null, "multiple backrefs mismatch");
+
+    shouldBeArray(/(\u{1F600})\1/u.exec("\u{1F600}\u{1F600}"), ["\u{1F600}\u{1F600}", "\u{1F600}"], "unicode emoji backref");
+
+    shouldBe(/(abc)\1/.test("abcabc"), true, "test() backref match");
+    shouldBe(/(abc)\1/.test("abcdef"), false, "test() backref mismatch");
+}
+
+{
+    let highSurrogate = "\uD800";
+    let input = highSurrogate + "x" + highSurrogate + "x";
+    for (let i = 0; i < testLoopCount; i++)
+        shouldBeArray(/(..)\1/.exec(input), [input, highSurrogate + "x"], "lone high surrogate backref");
+}
+
+{
+    let lowSurrogate = "\uDC00";
+    let input = lowSurrogate + "y" + lowSurrogate + "y";
+    for (let i = 0; i < testLoopCount; i++)
+        shouldBeArray(/(..)\1/.exec(input), [input, lowSurrogate + "y"], "lone low surrogate backref");
+}
+
+{
+    let chunk = "abcdefghij";
+    let input = chunk + chunk;
+    for (let i = 0; i < testLoopCount; i++)
+        shouldBeArray(new RegExp("(" + chunk + ")\\1").exec(input), [input, chunk], "long repeated chunk backref");
+}


### PR DESCRIPTION
#### 314bda38516d1c74e79c026b8d507afe5e64340c
<pre>
[YARR] Skip dead errorCodePoint check in JIT backreference loop for non-Unicode patterns
<a href="https://bugs.webkit.org/show_bug.cgi?id=308181">https://bugs.webkit.org/show_bug.cgi?id=308181</a>

Reviewed by Yusuke Suzuki.

In the case-sensitive backreference matching loop, YarrJIT unconditionally
emitted an errorCodePoint check (cmn + b.eq) before comparing the input
character against the pattern character. However, errorCodePoint (-1) can
only be produced by tryReadUnicodeChar() when decoding surrogate pairs.
In non-Unicode mode, readCharacter() emits load8 or load16 which
zero-extend the result, so the value is always in [0, 0xFFFF] and can
never equal errorCodePoint.

Guard the errorCodePoint check with m_decodeSurrogatePairs so it is only
emitted in Unicode mode. On AArch64 this reduces the inner loop from 11
to 9 instructions and from 3 to 2 branches per iteration.

Test: JSTests/stress/regexp-backreference-errorCodePoint-reorder.js

* JSTests/stress/regexp-backreference-errorCodePoint-reorder.js: Added.
(shouldBe):
(shouldBe.abc.1.test):
(shouldBeArray):
* Source/JavaScriptCore/yarr/YarrJIT.cpp:

Canonical link: <a href="https://commits.webkit.org/307900@main">https://commits.webkit.org/307900@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4718975c08012b45d8730402941e11e93f9db12

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145571 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18253 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10099 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154243 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99208 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18146 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111947 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80212 "2 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148534 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92852 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13630 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11399 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1690 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137562 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123177 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7550 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156556 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6380 "Built successfully and passed tests") | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8657 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119949 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18103 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15105 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120300 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30899 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18149 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73832 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16031 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7012 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/176861 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17724 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81504 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45441 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17461 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17669 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17524 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->