### PR TITLE
[Tahoe arm64] compositing/visible-rect/animated-from-none.html is a flaky text failure

### DIFF
--- a/LayoutTests/compositing/visible-rect/animated-from-none.html
+++ b/LayoutTests/compositing/visible-rect/animated-from-none.html
@@ -26,23 +26,22 @@
             to   { -webkit-transform: translateX(400px); }
         }
     </style>
+    <script src="../../webanimations/threaded-animations/threaded-animations-utils.js"></script>
     <script>
-        if (window.testRunner) {
-            testRunner.dumpAsText();
-            testRunner.waitUntilDone();
-        }
+        window.testRunner?.dumpAsText();
+        window.testRunner?.waitUntilDone();
 
-        function doTest()
+        async function doTest()
         {
             const animated = document.getElementById('animated');
             animated.classList.add('animating');
-            animated.getAnimations()[0].ready.then(() => {
-                if (window.internals)
-                    document.getElementById('layers').innerText = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_VISIBLE_RECTS)
 
-                if (window.testRunner)
-                    testRunner.notifyDone();
-            });
+            // Wait for the animation to be committed to the remote layer tree and then for its first frame to apply.
+            await animationAcceleration(animated.getAnimations()[0]);
+            await new Promise(requestAnimationFrame);
+
+            document.getElementById('layers').innerText = internals.layerTreeAsText(document, window.internals?.LAYER_TREE_INCLUDES_VISIBLE_RECTS)
+            window.testRunner?.notifyDone();
         }
         window.addEventListener('load', doTest, false);
     </script>

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2494,6 +2494,4 @@ webkit.org/b/307889 http/tests/multipart/multipart-async-image.html [ Pass Failu
 webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/console/message-from-iframe.html [ Failure ]
 webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/console/message-from-worker.html [ Failure ]
 
-webkit.org/b/308086 [ Tahoe Release arm64 ] compositing/visible-rect/animated-from-none.html [ Pass Failure ]
-
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]


### PR DESCRIPTION
#### d01c2d50dc76892efdc335fa524d841a7e9df211
<pre>
[Tahoe arm64] compositing/visible-rect/animated-from-none.html is a flaky text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=308086">https://bugs.webkit.org/show_bug.cgi?id=308086</a>
<a href="https://rdar.apple.com/170589380">rdar://170589380</a>

Reviewed by Anne van Kesteren.

This test merely used an animation&apos;s `ready` promise to determine that its effect would be
accounted for in the layer tree. It needs to account for the accelerated representation of
that animation to be uploaded to the remote layer tree using the `animationAcceleration()`
helper and then for one rendering frame to ensure the remote animation has been applied.
This yields stable results.

* LayoutTests/compositing/visible-rect/animated-from-none.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/307820@main">https://commits.webkit.org/307820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/afd479689c784a5b5fd43937da7b90ce605b3992

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18314 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154304 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18799 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18207 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111995 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99269 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148595 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14363 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130806 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92900 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11440 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1751 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7621 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156617 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18164 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8731 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119996 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15152 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120348 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16078 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128908 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73897 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22455 "Built successfully and passed tests") | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17785 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7057 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17522 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17730 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17585 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->