### PR TITLE
[AutoFill Debugging] Adjust debug UI styles (and include related elements)

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -202,7 +202,7 @@ static String stringOnlyIfHumanReadable(const String& string)
     return { };
 }
 
-static void addBoxShadowIfNeeded(Node& node, String&& styleValue)
+static void addBoxShadowIfNeeded(Node& node, const String& colorAsString)
 {
     Ref document = node.document();
     if (!document->settings().textExtractionDebugUIEnabled())
@@ -215,7 +215,19 @@ static void addBoxShadowIfNeeded(Node& node, String&& styleValue)
     if (element == document->body())
         return;
 
-    element->setInlineStyleProperty(CSSPropertyBoxShadow, WTF::move(styleValue), IsImportant::Yes);
+    auto styleValue = makeString("0 0 20px "_s, colorAsString, ", inset 0 0 8px "_s, colorAsString);
+    element->setInlineStyleProperty(CSSPropertyBoxShadow, styleValue, IsImportant::Yes);
+
+    auto relatedElementAttributes = std::array {
+        HTMLNames::aria_labeledbyAttr.get(),
+        HTMLNames::aria_labelledbyAttr.get(),
+        HTMLNames::aria_describedbyAttr.get()
+    };
+
+    for (auto& attributeName : relatedElementAttributes) {
+        if (RefPtr otherElement = dynamicDowncast<HTMLElement>(element->elementForAttributeInternal(attributeName).get()))
+            otherElement->setInlineStyleProperty(CSSPropertyBoxShadow, styleValue, IsImportant::Yes);
+    }
 }
 
 using ClientNodeAttributesMap = WeakHashMap<Node, HashMap<String, String>, WeakPtrImplWithEventTargetData>;
@@ -1160,7 +1172,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
 #endif
 
     if (extractionRootNode)
-        addBoxShadowIfNeeded(*extractionRootNode, "0 0 10px #0088FF"_s);
+        addBoxShadowIfNeeded(*extractionRootNode, "#0088FF"_s);
 
     if (!extractionRootNode)
         return { root, 0 };
@@ -1215,7 +1227,7 @@ Result extractItem(Request&& request, LocalFrame& frame)
             for (Ref passwordField : passwordFields) {
                 static constexpr FloatSize minimumSize { 280, 200 };
                 if (RefPtr container = findLargeContainerAboveNode(passwordField, minimumSize)) {
-                    addBoxShadowIfNeeded(*container, "0 0 10px #cb30e0"_s);
+                    addBoxShadowIfNeeded(*container, "#cb30e0"_s);
                     additionalContainersToCollect.add(container.releaseNonNull());
                 }
             }
@@ -1575,7 +1587,7 @@ static void dispatchSimulatedClick(Node& targetNode, const String& searchText, C
     if (!frame)
         return completion(false, nullFrameDescription);
 
-    addBoxShadowIfNeeded(targetNode, "0 0 16px #34c759"_s);
+    addBoxShadowIfNeeded(targetNode, "#34c759"_s);
 
     std::optional<FloatRect> targetRectInRootView;
     if (!searchText.isEmpty()) {
@@ -1640,7 +1652,7 @@ static SelectOptionResult selectOptionByValue(NodeIdentifier identifier, const S
         if (optionText.isEmpty())
             return { };
 
-        addBoxShadowIfNeeded(*select, "0 0 16px #34c759"_s);
+        addBoxShadowIfNeeded(*select, "#34c759"_s);
         select->setValue(optionText);
         return { select->selectedIndex() != -1, { } };
     }
@@ -1681,7 +1693,7 @@ static void selectText(LocalFrame& frame, std::optional<NodeIdentifier>&& identi
     if (RefPtr control = dynamicDowncast<HTMLTextFormControlElement>(*foundNode)) {
         // FIXME: This should probably honor `searchText`.
         control->select();
-        addBoxShadowIfNeeded(*control, "0 0 16px #34c759"_s);
+        addBoxShadowIfNeeded(*control, "#34c759"_s);
         return completion(true, { });
     }
 
@@ -1732,7 +1744,7 @@ static void scrollBy(LocalFrame& frame, std::optional<NodeIdentifier>&& identifi
     if (!scroller)
         return completion(false, "No scrollable area found"_s);
 
-    addBoxShadowIfNeeded(*foundNode, "0 0 16px #34c759"_s);
+    addBoxShadowIfNeeded(*foundNode, "#34c759"_s);
     scroller->scrollToOffsetWithoutAnimation(FloatPoint { scroller->scrollOffset() } + scrollDelta);
     completion(true, { });
 }
@@ -2054,7 +2066,7 @@ static String textDescription(Node* node, Vector<String>& stringsToValidate)
     if (!node)
         return { };
 
-    addBoxShadowIfNeeded(*node, "0 0 16px #ff383c"_s);
+    addBoxShadowIfNeeded(*node, "#ff383c"_s);
 
     auto addRenderedTextOrLabeledChild = [&](const String& description) {
         StringBuilder extendedDescription;


### PR DESCRIPTION
#### da6f60af558c5800786e1c83039aa8fccbff1291
<pre>
[AutoFill Debugging] Adjust debug UI styles (and include related elements)
<a href="https://bugs.webkit.org/show_bug.cgi?id=308185">https://bugs.webkit.org/show_bug.cgi?id=308185</a>
<a href="https://rdar.apple.com/170686343">rdar://170686343</a>

Reviewed by Pascoe, Megan Gardner, Lily Spiniolas, Abrar Rahman Protyasha, Richard Robinson, and Aditya Keerthi.

Make some minor adjustments to inline styles applied to targeted elements during text extraction.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::addBoxShadowIfNeeded):
(WebCore::TextExtraction::extractItem):
(WebCore::TextExtraction::dispatchSimulatedClick):
(WebCore::TextExtraction::selectOptionByValue):
(WebCore::TextExtraction::selectText):
(WebCore::TextExtraction::scrollBy):
(WebCore::TextExtraction::textDescription):

Canonical link: <a href="https://commits.webkit.org/307805@main">https://commits.webkit.org/307805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4729e66b709179b3e4fff0b2e4f25de1219c4b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18271 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154261 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/314c3cc7-5e00-4c92-88bd-577168b84d4d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18164 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111960 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f7201347-31b9-4ccf-9665-967693d3a928) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148552 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14332 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/130773 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92865 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9964a378-b875-4103-8dbf-ffd108e1923e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13645 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1708 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123192 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7573 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156574 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18121 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8681 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119964 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18167 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15118 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120316 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30838 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16045 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128858 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73850 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17742 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/7028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17479 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81522 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17687 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17542 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->