### PR TITLE
[grid-lanes] Remove display: inline-grid-lanes legacy keyword

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-computed-expected.txt
@@ -1,6 +1,6 @@
 
 PASS Property display value 'grid-lanes'
-PASS Property display value 'inline-grid-lanes'
+PASS Property display value 'inline grid-lanes'
 PASS position absolute affects computed display
 PASS position fixed affects computed display
 PASS float left affects computed display

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-computed.html
@@ -18,15 +18,15 @@
 
 // https://tabatkins.github.io/specs/css-masonry/#masonry-containers
 test_computed_value("display", "grid-lanes");
-test_computed_value("display", "inline-grid-lanes");
+test_computed_value("display", "inline grid-lanes");
 
 // https://www.w3.org/TR/CSS2/visuren.html#dis-pos-flo
 function test_display_affected(property, value) {
   const target = document.getElementById('target');
   test(() => {
     target.style[property] = value;
-    target.style.display = 'inline-grid-lanes';
-    assert_equals(getComputedStyle(target).display, 'grid-lanes', 'inline-grid-lanes -> grid-lanes');
+    target.style.display = 'inline grid-lanes';
+    assert_equals(getComputedStyle(target).display, 'grid-lanes', 'inline grid-lanes -> grid-lanes');
 
     target.style[property] = '';
     target.style.display = '';

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-valid-expected.txt
@@ -1,4 +1,4 @@
 
 PASS e.style['display'] = "grid-lanes" should set the property value
-PASS e.style['display'] = "inline-grid-lanes" should set the property value
+PASS e.style['display'] = "inline grid-lanes" should set the property value
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-valid.html
@@ -5,7 +5,7 @@
 <title>CSS Display: Parsing display with valid values</title>
 <link rel="author" title="Ethan Jimenez" href="mailto:ethavar@microsoft.com">
 <link rel="help" href="https://tabatkins.github.io/specs/css-masonry/#masonry-containers">
-<meta name="assert" content="display supports the new values 'grid-lanes | inline-grid-lanes'.">
+<meta name="assert" content="display supports the new values 'grid-lanes | inline grid-lanes'.">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/support/parsing-testcommon.js"></script>
@@ -14,7 +14,7 @@
 <script>
 // https://tabatkins.github.io/specs/css-masonry/#masonry-containers
 test_valid_value("display", "grid-lanes");
-test_valid_value("display", "inline-grid-lanes");
+test_valid_value("display", "inline grid-lanes");
 </script>
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-001.html
@@ -20,7 +20,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-002.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-003.html
@@ -20,7 +20,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-004.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,20px);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-001.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-002.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-003.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,20px);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-004.html
@@ -19,7 +19,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,20px);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-001.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       background-color: grey;
       position: relative;
       border: solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-002.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       background-color: grey;
       position: relative;
       border: solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-003.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       background-color: grey;
       position: relative;
       border: solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-001.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       background-color: grey;
       position: relative;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-002.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       background-color: grey;
       position: relative;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-003.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
   <style>
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       background-color: grey;
       position: relative;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-001.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 10px 20px;
   grid-template-columns: repeat(4,auto);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-002.html
@@ -22,7 +22,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-template-columns: repeat(4,auto);
   color: #444;
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/grid-lanes-not-inhibited-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/grid-lanes-not-inhibited-001.html
@@ -7,7 +7,7 @@
 <style>
 grid {
   vertical-align: top;
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-template-columns: 60px 60px;
   border: 2px solid black;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr 1fr 1fr;
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix1.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr min-content max-content;
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */
   grid-template-columns: 1.1ch auto 1.4ch 1fr;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr 1fr 1fr;
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr min-content max-content;
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */
   grid-template-columns: 1.1ch auto 1.4ch 1fr;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr 1fr 1fr;
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr min-content max-content;
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */
   grid-template-columns: 1.1ch auto 1.4ch 1fr;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr 1fr 1fr;
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: 1fr 2fr min-content max-content;
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */
   grid-template-columns: 1.1ch auto 1.4ch 1fr;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-005.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,auto);
   border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-006.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   border: 1px solid;
   padding: 0 1px 0 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-007.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   border: 1px solid;
   padding: 0 1px 0 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr 1fr 1fr;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr min-content max-content;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-auto.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr 1fr 1fr;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix1.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr min-content max-content;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-auto.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-fr.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr 1fr 1fr;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix1.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr min-content max-content;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-auto.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-auto.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-fr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-fr.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr 1fr 1fr;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix1.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix1.html
@@ -15,7 +15,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: 1fr 2fr min-content max-content;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix2.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix2.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   /* keep fixed values small enough for spanners to have an effect */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-005.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-006.html
@@ -14,7 +14,7 @@
 @import "support/grid-lanes-intrinsic-sizing-visual.css";
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   gap: 1px 2px;
   grid-template-rows: repeat(4,auto);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-001.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px;
       grid-template-columns: repeat(2, 100px);
       flow-tolerance: normal; /* Should resolve to 1em (16px) */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-002.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px;
       grid-template-columns: repeat(3, 100px);
       flow-tolerance: normal; /* Should resolve to 1em (16px) */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-003.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px;
       grid-template-columns: repeat(3, 100px);
       flow-tolerance: 51px; /* Tracks within 51px are considered equal */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-004.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px;
       grid-template-columns: repeat(2, 100px);
       flow-tolerance: infinite; /* Always place in order */

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-expected.html
@@ -12,7 +12,7 @@
     }
 
     .grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-rows: repeat(2, 100px);
       gap: 10px;
       border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-ref.html
@@ -12,7 +12,7 @@
     }
 
     .grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-rows: repeat(2, 100px);
       gap: 10px;
       border: 1px solid;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update.html
@@ -15,7 +15,7 @@
     }
 
     .grid-lanes {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-rows: repeat(2, 100px);
       gap: 10px;
       flow-tolerance: normal;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-001.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       grid-auto-flow: column;
       gap: 10px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-002.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       grid-auto-flow: column;
       gap: 10px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-003.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       grid-auto-flow: column;
       gap: 10px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-004.html
@@ -11,7 +11,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-lanes-direction: row;
       grid-auto-flow: column;
       gap: 10px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-001.html
@@ -15,7 +15,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px 20px;
       grid-template-columns: repeat(4,80px);
       color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-002.html
@@ -15,7 +15,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px 20px;
       grid-auto-columns: 80px;
       color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-003.html
@@ -15,7 +15,7 @@
     }
 
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       gap: 10px 20px;
       grid-auto-flow: dense;
       grid-auto-columns: 80px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-004.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-005.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-006.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-007.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 1px 2px;
   grid-template-columns: repeat(4,20px);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-008.html
@@ -10,7 +10,7 @@
 <body>
 <style>
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-template-columns: repeat( auto-fill, minmax(200px, 400px) );
   gap: 30px;
   max-width: 50vw;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-fit-content-percentage.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-fit-content-percentage.html
@@ -10,7 +10,7 @@
   margin-top: 10px;
 }
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   background: blue;
 }
 .item {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-intrinsic-track-sizes-min-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-intrinsic-track-sizes-min-size.html
@@ -6,7 +6,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes{
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-template-columns: minmax(auto,0) minmax(auto,0);
   background: red;
   height: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-001.html
@@ -7,7 +7,7 @@
 <link rel="match" href="../../../../reference/ref-filled-green-100px-square.xht">
 <style>
 #grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-template-columns: minmax(auto, 0);
     width: 200px;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-002.html
@@ -7,7 +7,7 @@
 <link rel="match" href="column-item-minmax-img-002-ref.html">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-template-columns: minmax(auto, 0);
     border: 5px solid goldenrod;
     vertical-align: top;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-001.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   height: 10px;
   width: 10px;
   grid-template-columns: 3px auto 4px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-002.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   height: 10px;
   width: 10px;
   grid-template-columns: 3px auto 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-003.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   height: 10px;
   width: 10px;
   grid-template-columns: 3px auto 4px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-001.html
@@ -7,7 +7,7 @@
 <link rel="match" href="../../../../reference/ref-filled-green-100px-square.xht">
 <style>
 #grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     grid-template-rows: minmax(auto, 0);
     height: 200px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-002.html
@@ -7,7 +7,7 @@
 <link rel="match" href="row-item-minmax-img-002-ref.html">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     grid-template-rows: minmax(auto, 0);
     border: 5px solid goldenrod;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-001.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   height: 10px;
   width: 10px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-002.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   height: 10px;
   width: 10px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-003.html
@@ -11,7 +11,7 @@ html,body {
 }
 
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   height: 10px;
   width: 10px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/order/grid-lanes-order-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/order/grid-lanes-order-001.html
@@ -16,7 +16,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   gap: 10px 20px;
   grid-template-columns:  repeat(4,auto);
   color: #444;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001a.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001b.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001c.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001d.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001d.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001e.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001e.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002a.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002b.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002c.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002d.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002d.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002e.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002e.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002f.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002f.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002g.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002g.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002h.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002h.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002i.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002i.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001a.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001b.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001c.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001d.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001d.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 50px 80px 40px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002b.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002b.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002c.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002c.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002d.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002d.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002e.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002e.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002f.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002f.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002g.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002g.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002h.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002h.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002i.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002i.html
@@ -15,7 +15,7 @@ html,body {
 }
 
 grid {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   grid-lanes-direction: row;
   grid-template-rows: 40px 30px 20px;
   gap: 4px 2px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-flex.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-flex.html
@@ -12,7 +12,7 @@
   <link rel="match" href="grid-lanes-subgrid-flex-ref.html">
   <style>
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-columns: 1fr 2fr 3fr;
       border: 1px solid;
       background: lightgrey;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html
@@ -12,7 +12,7 @@
   <link rel="match" href="grid-lanes-subgrid-intrinsic-sizing-ref.html">
   <style>
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-columns: auto min-content max-content;
       border: 1px solid;
       background: lightgrey;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid.html
@@ -12,7 +12,7 @@
   <link rel="match" href="grid-lanes-subgrid-ref.html">
   <style>
     grid {
-      display: inline-grid-lanes;
+      display: inline grid-lanes;
       grid-template-columns: 50px 100px 200px;
       border: 1px solid;
       background: lightgrey;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-003.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-template-columns: repeat(auto-fill, 50px);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-004.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-template-columns: repeat(auto-fill, 50px);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-006.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     height: 100px;
     min-width: 60%;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-007.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     width: 100px;
     min-height: 60%;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-010.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-010.html
@@ -8,7 +8,7 @@
 <style>
 .grid-lanes {
     position: relative;
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-template-columns: repeat(auto-fill, 25%);
     min-width: 50%;
     height: 200px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-015.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-015.html
@@ -5,7 +5,7 @@
 <link rel="match" href="column-auto-repeat-015-ref.html">
 <style>
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   border: 1px solid black;
   grid-template-columns: [u] repeat(auto-fill, [v] 10px [w] 10px [x] 10px [y]) [z];
   grid-column-gap: 3px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-006.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-template-columns: repeat(auto-fill, auto);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-007.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-template-columns: repeat(auto-fill, auto);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-008.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     height: 100px;
     min-width: 60%;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-006.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-lanes-direction: row;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-007.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-007.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-lanes-direction: row;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-008.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-008.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     background: green;
     width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-003.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-lanes-direction: row;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-004.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-004.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     background: green;
     aspect-ratio: 1/1;
     grid-lanes-direction: row;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-006.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-006.html
@@ -5,7 +5,7 @@
 <link rel="author" title="Alison Maher" href="mailto:almaher@microsoft.com">
 <style>
 .grid-lanes {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     background: green;
     width: 100px;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-009.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-009.html
@@ -8,7 +8,7 @@
 <style>
 .grid-lanes {
     position: relative;
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-lanes-direction: row;
     grid-template-rows: repeat(auto-fill, 20%);
     min-height: 50%;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-014.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-014.html
@@ -5,7 +5,7 @@
 <link rel="match" href="row-auto-repeat-014-ref.html">
 <style>
 .grid-lanes {
-  display: inline-grid-lanes;
+  display: inline grid-lanes;
   border: 1px solid black;
   grid-template-rows: [u] repeat(auto-fill, [v] 10px [w] 10px [x] 10px [y]) [z];
   grid-lanes-direction: row;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/grid-lanes-track-sizing-check-grid-height-on-resize.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/grid-lanes-track-sizing-check-grid-height-on-resize.html
@@ -12,7 +12,7 @@
 
 <style>
   grid {
-    display: inline-grid-lanes;
+    display: inline grid-lanes;
     grid-template-columns: auto;
     grid-gap: 10px;
     border: 10px;

--- a/LayoutTests/inspector/css/getSupportedCSSProperties-expected.txt
+++ b/LayoutTests/inspector/css/getSupportedCSSProperties-expected.txt
@@ -37,7 +37,6 @@
  - "grid"
  - "inline-grid"
  - "grid-lanes"
- - "inline-grid-lanes"
  - "contents"
  - "none"
  - "-webkit-box"

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -1047,6 +1047,10 @@ String CSSPrimitiveValue::customCSSText(const CSS::SerializationContext& context
     case CSSUnitType::CSS_UNKNOWN:
         return String();
     case CSSUnitType::CSS_VALUE_ID:
+        // `inline-grid-lanes` is not a <display-legacy> keyword; serialize
+        // using the two-keyword form `inline grid-lanes`.
+        if (m_value.valueID == CSSValueInlineGridLanes)
+            return "inline grid-lanes"_s;
         return nameStringForSerialization(m_value.valueID);
     case CSSUnitType::CSS_PROPERTY_ID:
         return nameString(m_value.propertyID);

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -497,10 +497,6 @@
                     "settings-flag": "gridLanesEnabled"
                 },
                 {
-                    "value": "inline-grid-lanes",
-                    "settings-flag": "gridLanesEnabled"
-                },
-                {
                     "value": "ruby",
                     "status": "unimplemented"
                 },
@@ -15088,7 +15084,7 @@
             }
         },
         "<display-legacy>": {
-            "grammar": "inline-block | inline-table | inline-flex | inline-grid | inline-grid-lanes",
+            "grammar": "inline-block | inline-table | inline-flex | inline-grid",
             "specification": {
                 "category": "css-display",
                 "url": "https://www.w3.org/TR/css-display-3/#typedef-display-legacy"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp
@@ -238,11 +238,11 @@ RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange& range, CSS::PropertyParserS
     //                      ruby-base | ruby-text | ruby-base-container |
     //                      ruby-text-container
     // <display-box>      = contents | none
-    // <display-legacy>   = inline-block | inline-table | inline-flex | inline-grid | inline-grid-lanes
+    // <display-legacy>   = inline-block | inline-table | inline-flex | inline-grid
     // <display-non-standard> = -webkit-box | -webkit-inline-box | -webkit-flex | -webkit-inline-flex
     // https://drafts.csswg.org/css-display/#propdef-display
     //  and
-    // https://drafts.csswg.org/css-grid-3/#grid-lanes-containers (for additions of grid-lanes and inline-grid-lanes)
+    // https://drafts.csswg.org/css-grid-3/#grid-lanes-containers (for additions of grid-lanes)
 
     switch (range.peek().id()) {
     // <display-outside>
@@ -305,11 +305,6 @@ RefPtr<CSSValue> consumeDisplay(CSSParserTokenRange& range, CSS::PropertyParserS
     case CSSValueInlineFlex:
     case CSSValueInlineGrid:
         return CSSPrimitiveValue::create(range.consumeIncludingWhitespace().id());
-    case CSSValueInlineGridLanes:
-        if (!state.context.gridLanesEnabled)
-            return nullptr;
-        return CSSPrimitiveValue::create(range.consumeIncludingWhitespace().id());
-
     // <display-non-standard>
     case CSSValueWebkitBox:
     case CSSValueWebkitInlineBox:

--- a/Source/WebCore/style/values/display/StyleDisplay.cpp
+++ b/Source/WebCore/style/values/display/StyleDisplay.cpp
@@ -28,6 +28,7 @@
 
 #include "AnimationUtilities.h"
 #include "StyleBuilderChecking.h"
+#include "StylePrimitiveKeyword+Serialization.h"
 
 namespace WebCore {
 namespace Style {
@@ -114,6 +115,24 @@ auto CSSValueConversion<Display>::operator()(BuilderState& state, const CSSValue
 
     state.setCurrentPropertyInvalidAtComputedValueTime();
     return Style::DisplayType::InlineFlow;
+}
+
+// MARK: - Serialization
+
+void Serialize<DisplayType>::operator()(StringBuilder& builder, const CSS::SerializationContext& context, const RenderStyle& style, DisplayType value)
+{
+    if (value == DisplayType::InlineGridLanes) {
+        // `inline-grid-lanes` is not a <display-legacy> keyword; serialize as
+        // the two-keyword form `inline grid-lanes`.
+        serializationForCSS(builder, context, style, CSS::Keyword::Inline { });
+        builder.append(' ');
+        serializationForCSS(builder, context, style, CSS::Keyword::GridLanes { });
+        return;
+    }
+
+    valueRepresentation(value, [&](const auto& alternative) {
+        serializationForCSS(builder, context, style, alternative);
+    });
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/display/StyleDisplay.h
+++ b/Source/WebCore/style/values/display/StyleDisplay.h
@@ -426,6 +426,12 @@ template<> struct ValueRepresentation<DisplayType> {
     }
 };
 
+// MARK: - Serialization
+
+template<> struct Serialize<DisplayType> {
+    void operator()(StringBuilder&, const CSS::SerializationContext&, const RenderStyle&, DisplayType);
+};
+
 // MARK: - Blending
 
 template<> struct Blending<Display> {

--- a/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
+++ b/Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js
@@ -1228,7 +1228,7 @@ WI.CSSKeywordCompletions._propertyKeywordMap = {
         "ltr", "rtl",
     ],
     "display": [
-        "none", "inline", "block", "list-item", "compact", "inline-block", "table", "inline-table", "table-row-group", "table-header-group", "table-footer-group", "table-row", "table-column-group", "table-column", "table-cell", "table-caption", "-webkit-box", "-webkit-inline-box", "flex", "-webkit-flex", "inline-flex", "-webkit-inline-flex", "contents", "grid", "inline-grid", "grid-lanes", "inline-grid-lanes",
+        "none", "inline", "block", "list-item", "compact", "inline-block", "table", "inline-table", "table-row-group", "table-header-group", "table-footer-group", "table-row", "table-column-group", "table-column", "table-cell", "table-caption", "-webkit-box", "-webkit-inline-box", "flex", "-webkit-flex", "inline-flex", "-webkit-inline-flex", "contents", "grid", "inline-grid", "grid-lanes",
     ],
     "dominant-baseline": [
         "middle", "auto", "alphabetic", "central", "text-before-edge", "text-after-edge", "ideographic", "hanging", "mathematical", "use-script", "no-change", "reset-size",


### PR DESCRIPTION
#### 1d63a6df7b551bf3a36521a05c89794f132e0850
<pre>
[grid-lanes] Remove display: inline-grid-lanes legacy keyword
<a href="https://bugs.webkit.org/show_bug.cgi?id=308195">https://bugs.webkit.org/show_bug.cgi?id=308195</a>
<a href="https://rdar.apple.com/problem/170694085">rdar://problem/170694085</a>

Reviewed by NOBODY (OOPS!).

Only the two-keyword form display: inline grid-lanes should be valid,
not the single hyphenated keyword inline-grid-lanes. The internal
CSSValueInlineGridLanes enum is kept since it&apos;s still used as the
canonical representation produced by the two-keyword parsing path
(inline + grid-lanes), but it now serializes as &quot;inline grid-lanes&quot;
for both specified and computed values.

* LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-computed-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-computed.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-valid-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-display/parsing/tentative/display-valid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-align-content-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/alignment/grid-lanes-justify-content-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/column-grid-lanes-item-baseline-cyclic-dependency-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/baseline/row-grid-lanes-item-baseline-cyclic-dependency-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/gap/grid-lanes-gap-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/grid-lanes-not-inhibited-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-001-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-002-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-003-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-004-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-005.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-cols-007.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-001-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-002-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-003-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-auto.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-fr.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix1.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-004-mix2.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-005.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/intrinsic-sizing/grid-lanes-intrinsic-sizing-rows-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-column-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-dynamic-update.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/flow-tolerance/flow-tolerance-row-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-005.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-007.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/item-placement/grid-lanes-item-placement-008.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-fit-content-percentage.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-intrinsic-track-sizes-min-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-minmax-img-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/column-item-percentage-sizes-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-minmax-img-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/items/row-item-percentage-sizes-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/order/grid-lanes-order-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001b.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001c.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001d.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-001e.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002b.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002c.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002d.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002e.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002f.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002g.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002h.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/column/grid-lanes-subgrid-002i.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001b.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001c.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-001d.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002a.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002b.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002c.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002d.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002e.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002f.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002g.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002h.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/row/grid-lanes-subgrid-002i.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-flex.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid-intrinsic-sizing.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/subgrid/track-sizing/grid-lanes-subgrid.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-007.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-010.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/column-auto-repeat-015.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-007.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/column-auto-repeat-auto-008.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-007.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/intrinsic-auto-repeat/row-auto-repeat-auto-008.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-004.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-006.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-009.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/auto-repeat/row-auto-repeat-014.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/grid-lanes/tentative/track-sizing/grid-lanes-track-sizing-check-grid-height-on-resize.html:
* LayoutTests/inspector/css/getSupportedCSSProperties-expected.txt:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSPrimitiveValue::customCSSText const):
* Source/WebCore/css/CSSProperties.json:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp:
(WebCore::CSSPropertyParserHelpers::consumeDisplay):
* Source/WebCore/style/values/display/StyleDisplay.cpp:
(WebCore::Style::Serialize&lt;DisplayType&gt;::operator):
* Source/WebCore/style/values/display/StyleDisplay.h:
* Source/WebInspectorUI/UserInterface/Models/CSSKeywordCompletions.js:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d63a6df7b551bf3a36521a05c89794f132e0850

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145604 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10147 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154276 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99241 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147479 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18771 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/111971 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80226 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6cb88243-748b-4ec7-bc55-f407427592d3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148567 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92876 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13655 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11419 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1723 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123203 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156589 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18136 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8702 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/119972 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18182 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120324 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16057 "Passed tests") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73866 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17757 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7038 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17494 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81537 "Found 1 new failure in style/values/display/StyleDisplay.cpp") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17702 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->