### PR TITLE
Adopt `NODELETE` annotation in more places in WTF/

### DIFF
--- a/Source/WTF/wtf/Assertions.cpp
+++ b/Source/WTF/wtf/Assertions.cpp
@@ -594,7 +594,7 @@ WTFLogChannel* WTFLogChannelByName(WTFLogChannel* channels[], size_t count, cons
     return nullptr;
 }
 
-static void setStateOfAllChannels(WTFLogChannel* channels[], size_t channelCount, WTFLogChannelState state)
+static void NODELETE setStateOfAllChannels(WTFLogChannel* channels[], size_t channelCount, WTFLogChannelState state)
 {
     for (size_t i = 0; i < channelCount; ++i)
         channels[i]->state = state;

--- a/Source/WTF/wtf/Assertions.h
+++ b/Source/WTF/wtf/Assertions.h
@@ -229,8 +229,8 @@ WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFLogAlwaysAndCrash(const char* 
 WTF_EXPORT_PRIVATE WTFLogChannel* WTFLogChannelByName(WTFLogChannel*[], size_t count, const char*);
 WTF_EXPORT_PRIVATE void WTFInitializeLogChannelStatesFromString(WTFLogChannel*[], size_t count, const char*);
 WTF_EXPORT_PRIVATE void WTFLogWithLevel(WTFLogChannel*, WTFLogLevel, const char* format, ...) WTF_ATTRIBUTE_NSSTRING(3, 4);
-WTF_EXPORT_PRIVATE void WTFSetLogChannelLevel(WTFLogChannel*, WTFLogLevel);
-WTF_EXPORT_PRIVATE bool WTFWillLogWithLevel(WTFLogChannel*, WTFLogLevel);
+WTF_EXPORT_PRIVATE void NODELETE WTFSetLogChannelLevel(WTFLogChannel*, WTFLogLevel);
+WTF_EXPORT_PRIVATE bool NODELETE WTFWillLogWithLevel(WTFLogChannel*, WTFLogLevel);
 
 WTF_EXPORT_PRIVATE NEVER_INLINE void WTFGetBacktrace(void** stack, int* size);
 WTF_EXPORT_PRIVATE void WTFReportBacktraceWithPrefix(const char*);
@@ -342,7 +342,7 @@ WTF_EXPORT_PRIVATE bool WTFIsDebuggerAttached(void);
 
 #endif // !defined(CRASH)
 
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrash(void);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void NODELETE WTFCrash(void);
 
 #ifndef CRASH_WITH_SECURITY_IMPLICATION
 #define CRASH_WITH_SECURITY_IMPLICATION() WTFCrashWithSecurityImplication()
@@ -353,7 +353,7 @@ extern WTF_EXPORT_PRIVATE int wtfConjectureAssertIsEnabled;
 WTF_EXPORT_PRIVATE NEVER_INLINE NO_RETURN_DUE_TO_CRASH void WTFCrashDueToConjectureAssert(const char* file, int line, const char* function, const char* assertion);
 #endif
 
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void WTFCrashWithSecurityImplication(void);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH void NODELETE WTFCrashWithSecurityImplication(void);
 
 #ifdef __cplusplus
 }
@@ -902,7 +902,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END \
 
 // The combination of line, file, and function should be a unique number per call to this crash. This tricks the compiler into not coalescing calls to WTFCrashWithInfo.
 // The easiest way to fill these values per translation unit is to pass __LINE__, __FILE__, and WTF_PRETTY_FUNCTION.
-WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6);
+WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void NODELETE WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5, uint64_t misc6);
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4, uint64_t misc5);
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3, uint64_t misc4);
 WTF_EXPORT_PRIVATE NO_RETURN_DUE_TO_CRASH NOT_TAIL_CALLED void WTFCrashWithInfoImpl(int line, const char* file, const char* function, uint64_t reason, uint64_t misc1, uint64_t misc2, uint64_t misc3);
@@ -1000,7 +1000,7 @@ void isIntegralOrPointerType(T, Types... types)
 }
 
 #if PLATFORM(COCOA) || OS(ANDROID)
-WTF_EXPORT_PRIVATE void disableForwardingVPrintfStdErrToOSLog();
+WTF_EXPORT_PRIVATE void NODELETE disableForwardingVPrintfStdErrToOSLog();
 #endif
 
 } // namespace WTF

--- a/Source/WTF/wtf/AutomaticThread.h
+++ b/Source/WTF/wtf/AutomaticThread.h
@@ -123,9 +123,9 @@ public:
     // running. Returns true if the thread has been stopped. A good idiom for stopping your automatic
     // thread is to first try this, and if that doesn't work, to tell the thread using your own
     // mechanism (set some flag and then notify the condition).
-    bool tryStop(const AbstractLocker&);
+    bool NODELETE tryStop(const AbstractLocker&);
 
-    bool isWaiting(const AbstractLocker&);
+    bool NODELETE isWaiting(const AbstractLocker&);
 
     bool notify(const AbstractLocker&);
 

--- a/Source/WTF/wtf/CPUTime.h
+++ b/Source/WTF/wtf/CPUTime.h
@@ -37,7 +37,7 @@ struct CPUTime {
     Seconds userTime;
     Seconds systemTime;
 
-    WTF_EXPORT_PRIVATE double percentageCPUUsageSince(const CPUTime&) const;
+    WTF_EXPORT_PRIVATE double NODELETE percentageCPUUsageSince(const CPUTime&) const;
 
     WTF_EXPORT_PRIVATE static std::optional<CPUTime> get();
 

--- a/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
+++ b/Source/WTF/wtf/CryptographicallyRandomNumber.cpp
@@ -62,10 +62,10 @@ public:
     void randomValues(std::span<uint8_t>);
 
 private:
-    inline void addRandomData(std::span<const uint8_t, 128>);
+    inline void NODELETE addRandomData(std::span<const uint8_t, 128>);
     void stir() WTF_REQUIRES_LOCK(m_lock);
     void stirIfNeeded() WTF_REQUIRES_LOCK(m_lock);
-    inline uint8_t getByte() WTF_REQUIRES_LOCK(m_lock);
+    inline uint8_t NODELETE getByte() WTF_REQUIRES_LOCK(m_lock);
 
     Lock m_lock;
     ARC4Stream m_stream;

--- a/Source/WTF/wtf/DateMath.cpp
+++ b/Source/WTF/wtf/DateMath.cpp
@@ -96,7 +96,7 @@
 namespace WTF {
 
 static Lock innerTimeZoneOverrideLock;
-static Vector<char16_t>& innerTimeZoneOverride() WTF_REQUIRES_LOCK(innerTimeZoneOverrideLock)
+static Vector<char16_t>& NODELETE innerTimeZoneOverride() WTF_REQUIRES_LOCK(innerTimeZoneOverrideLock)
 {
     static NeverDestroyed<Vector<char16_t>> timeZoneOverride;
     return timeZoneOverride;
@@ -148,7 +148,7 @@ static inline double msToMilliseconds(double ms)
 
 // There is a hard limit at 2038 that we currently do not have a workaround
 // for (rdar://problem/5052975).
-static inline int maximumYearForDST()
+static inline int NODELETE maximumYearForDST()
 {
     return 2037;
 }
@@ -389,7 +389,7 @@ static constexpr auto knownZones = std::to_array<KnownZone>({
     { "pdt"_s, -420 }
 });
 
-inline static void skipSpacesAndComments(std::span<const Latin1Character>& s)
+inline static void NODELETE skipSpacesAndComments(std::span<const Latin1Character>& s)
 {
     int nesting = 0;
     while (!s.empty()) {

--- a/Source/WTF/wtf/FastBitVector.h
+++ b/Source/WTF/wtf/FastBitVector.h
@@ -505,7 +505,7 @@ public:
     void fill(bool value) { value ? setAll() : clearAll(); }
     void grow(size_t newSize) { resize(newSize); }
 
-    WTF_EXPORT_PRIVATE void clearRange(size_t begin, size_t end);
+    WTF_EXPORT_PRIVATE void NODELETE clearRange(size_t begin, size_t end);
 
     // Returns true if the contents of this bitvector changed.
     template<typename OtherWords>

--- a/Source/WTF/wtf/FastMalloc.h
+++ b/Source/WTF/wtf/FastMalloc.h
@@ -189,7 +189,7 @@ struct FastMallocStatistics {
 };
 WTF_EXPORT_PRIVATE FastMallocStatistics fastMallocStatistics();
 
-WTF_EXPORT_PRIVATE void fastMallocDumpMallocStats();
+WTF_EXPORT_PRIVATE void NODELETE fastMallocDumpMallocStats();
 
 // This defines a type which holds an unsigned integer and is the same
 // size as the minimally aligned memory allocation.

--- a/Source/WTF/wtf/FileSystem.cpp
+++ b/Source/WTF/wtf/FileSystem.cpp
@@ -119,7 +119,7 @@ constexpr std::array<bool, 128> needsEscaping = {
     false, false, false, false, true,  false, false, true,  /* 78-7F */
 };
 
-static inline bool shouldEscapeChar16(char16_t character, char16_t previousCharacter, char16_t nextCharacter)
+static inline bool NODELETE shouldEscapeChar16(char16_t character, char16_t previousCharacter, char16_t nextCharacter)
 {
     if (character <= 127)
         return needsEscaping[character];

--- a/Source/WTF/wtf/FileSystem.h
+++ b/Source/WTF/wtf/FileSystem.h
@@ -96,7 +96,7 @@ WTF_EXPORT_PRIVATE bool moveFile(const String& oldPath, const String& newPath);
 WTF_EXPORT_PRIVATE std::optional<uint64_t> fileSize(const String&); // Follows symlinks.
 WTF_EXPORT_PRIVATE std::optional<uint64_t> directorySize(const String&);
 WTF_EXPORT_PRIVATE std::optional<WallTime> fileModificationTime(const String&);
-WTF_EXPORT_PRIVATE bool fileIDsAreEqual(std::optional<PlatformFileID>, std::optional<PlatformFileID>);
+WTF_EXPORT_PRIVATE bool NODELETE fileIDsAreEqual(std::optional<PlatformFileID>, std::optional<PlatformFileID>);
 WTF_EXPORT_PRIVATE bool updateFileModificationTime(const String& path); // Sets modification time to now.
 WTF_EXPORT_PRIVATE std::optional<WallTime> fileCreationTime(const String&); // Not all platforms store file creation time.
 WTF_EXPORT_PRIVATE bool isHiddenFile(const String&);
@@ -198,8 +198,8 @@ WTF_EXPORT_PRIVATE bool deleteNonEmptyDirectory(const String&);
 
 WTF_EXPORT_PRIVATE String realPath(const String&);
 
-WTF_EXPORT_PRIVATE bool isSafeToUseMemoryMapForPath(const String&);
-[[nodiscard]] WTF_EXPORT_PRIVATE bool makeSafeToUseMemoryMapForPath(const String&);
+WTF_EXPORT_PRIVATE bool NODELETE isSafeToUseMemoryMapForPath(const String&);
+[[nodiscard]] WTF_EXPORT_PRIVATE bool NODELETE makeSafeToUseMemoryMapForPath(const String&);
 
 WTF_EXPORT_PRIVATE std::optional<MappedFileData> mapFile(const String& path, MappedFileMode);
 

--- a/Source/WTF/wtf/HexNumber.cpp
+++ b/Source/WTF/wtf/HexNumber.cpp
@@ -31,7 +31,7 @@ namespace WTF {
 
 namespace Internal {
 
-static const std::array<Latin1Character, 16>& hexDigitsForMode(HexConversionMode mode)
+static const std::array<Latin1Character, 16>& NODELETE hexDigitsForMode(HexConversionMode mode)
 {
     static constexpr std::array<Latin1Character, 16> lowercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
     static constexpr std::array<Latin1Character, 16> uppercaseHexDigits { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };

--- a/Source/WTF/wtf/Int128.cpp
+++ b/Source/WTF/wtf/Int128.cpp
@@ -37,7 +37,7 @@ namespace {
 // For example:
 //   Given: 5 (decimal) == 101 (binary)
 //   Returns: 2
-static ALWAYS_INLINE int Fls128(UInt128Impl n) {
+static ALWAYS_INLINE int NODELETE Fls128(UInt128Impl n) {
   if (uint64_t hi = UInt128High64(n)) {
     ASSERT(hi != 0);
     return 127 - clz(hi);
@@ -199,7 +199,7 @@ std::ostream& operator<<(std::ostream& os, UInt128Impl v) {
 
 namespace {
 
-static UInt128Impl UnsignedAbsoluteValue(Int128Impl v) {
+static UInt128Impl NODELETE UnsignedAbsoluteValue(Int128Impl v) {
   // Cast to UInt128Impl before possibly negating because -Int128Min() is undefined.
   return Int128High64(v) < 0 ? -UInt128Impl(v) : UInt128Impl(v);
 }

--- a/Source/WTF/wtf/JSONValues.h
+++ b/Source/WTF/wtf/JSONValues.h
@@ -268,7 +268,7 @@ public:
 
     size_t length() const { return m_map.size(); }
 
-    Ref<Value> get(size_t index) const;
+    Ref<Value> NODELETE get(size_t index) const;
 
 protected:
     ~ArrayBase();

--- a/Source/WTF/wtf/Language.cpp
+++ b/Source/WTF/wtf/Language.cpp
@@ -43,17 +43,17 @@
 namespace WTF {
 
 static Lock languagesLock;
-static Vector<String>& cachedFullPlatformPreferredLanguages() WTF_REQUIRES_LOCK(languagesLock)
+static Vector<String>& NODELETE cachedFullPlatformPreferredLanguages() WTF_REQUIRES_LOCK(languagesLock)
 {
     static NeverDestroyed<Vector<String>> languages;
     return languages;
 }
-static Vector<String>& cachedMinimizedPlatformPreferredLanguages() WTF_REQUIRES_LOCK(languagesLock)
+static Vector<String>& NODELETE cachedMinimizedPlatformPreferredLanguages() WTF_REQUIRES_LOCK(languagesLock)
 {
     static NeverDestroyed<Vector<String>> languages;
     return languages;
 }
-static Vector<String>& preferredLanguagesOverride() WTF_REQUIRES_LOCK(languagesLock)
+static Vector<String>& NODELETE preferredLanguagesOverride() WTF_REQUIRES_LOCK(languagesLock)
 {
     static NeverDestroyed<Vector<String>> override;
     return override;
@@ -61,7 +61,7 @@ static Vector<String>& preferredLanguagesOverride() WTF_REQUIRES_LOCK(languagesL
 static std::optional<bool> cachedUserPrefersSimplifiedChinese WTF_GUARDED_BY_LOCK(languagesLock);
 
 using ObserverMap = HashMap<void*, LanguageChangeObserverFunction>;
-static ObserverMap& observerMap()
+static ObserverMap& NODELETE observerMap()
 {
     static NeverDestroyed<ObserverMap> map;
     return map.get();

--- a/Source/WTF/wtf/LogInitialization.h
+++ b/Source/WTF/wtf/LogInitialization.h
@@ -33,7 +33,7 @@ namespace WTF {
 #if !LOG_DISABLED || !RELEASE_LOG_DISABLED
 
 WTF_EXPORT_PRIVATE LogChannels& logChannels();
-WTF_EXPORT_PRIVATE String logLevelString();
+WTF_EXPORT_PRIVATE String NODELETE logLevelString();
 
 #endif // !LOG_DISABLED || !RELEASE_LOG_DISABLED
 

--- a/Source/WTF/wtf/Logger.h
+++ b/Source/WTF/wtf/Logger.h
@@ -427,14 +427,14 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         sendMessageToObservers(channel, level, arguments...);
     }
 
-    WTF_EXPORT_PRIVATE static Vector<std::reference_wrapper<Observer>>& observers() WTF_REQUIRES_LOCK(observerLock());
+    WTF_EXPORT_PRIVATE static Vector<std::reference_wrapper<Observer>>& NODELETE observers() WTF_REQUIRES_LOCK(observerLock());
 
     static Lock& observerLock() WTF_RETURNS_LOCK(loggerObserverLock)
     {
         return loggerObserverLock;
     }
 
-    WTF_EXPORT_PRIVATE static Vector<std::reference_wrapper<MessageHandlerObserver>>& messageHandlerObservers() WTF_REQUIRES_LOCK(messageHandlerObserverLock());
+    WTF_EXPORT_PRIVATE static Vector<std::reference_wrapper<MessageHandlerObserver>>& NODELETE messageHandlerObservers() WTF_REQUIRES_LOCK(messageHandlerObserverLock());
 
     static Lock& messageHandlerObserverLock() WTF_RETURNS_LOCK(messageHandlerLoggerObserverLock)
     {

--- a/Source/WTF/wtf/MachSendRight.h
+++ b/Source/WTF/wtf/MachSendRight.h
@@ -54,7 +54,7 @@ public:
 
     mach_port_t sendRight() const LIFETIME_BOUND { return m_port; }
 
-    [[nodiscard]] WTF_EXPORT_PRIVATE mach_port_t leakSendRight();
+    [[nodiscard]] WTF_EXPORT_PRIVATE mach_port_t NODELETE leakSendRight();
 
 private:
     explicit MachSendRight(mach_port_t);

--- a/Source/WTF/wtf/MainThread.h
+++ b/Source/WTF/wtf/MainThread.h
@@ -71,7 +71,7 @@ inline bool isWebThread() { return isMainThread(); }
 inline bool isUIThread() { return isMainThread(); }
 #endif // USE(WEB_THREAD)
 
-WTF_EXPORT_PRIVATE bool isMainThreadOrGCThread();
+WTF_EXPORT_PRIVATE bool NODELETE isMainThreadOrGCThread();
 
 // NOTE: these functions are internal to the callOnMainThread implementation.
 void initializeMainThreadPlatform();

--- a/Source/WTF/wtf/MainThreadDispatcher.h
+++ b/Source/WTF/wtf/MainThreadDispatcher.h
@@ -36,7 +36,7 @@ public:
 
 private:
     MainThreadDispatcher() = default;
-    bool isCurrent() const final;
+    bool NODELETE isCurrent() const final;
     void dispatch(Function<void ()>&&) final;
 };
 

--- a/Source/WTF/wtf/MediaTime.cpp
+++ b/Source/WTF/wtf/MediaTime.cpp
@@ -43,7 +43,7 @@ namespace WTF {
 
 static_assert(std::is_trivially_destructible_v<MediaTime>, "MediaTime should be trivially destructible.");
 
-static uint32_t greatestCommonDivisor(uint32_t a, uint32_t b)
+static uint32_t NODELETE greatestCommonDivisor(uint32_t a, uint32_t b)
 {
     ASSERT(a);
     ASSERT(b);
@@ -59,7 +59,7 @@ static uint32_t greatestCommonDivisor(uint32_t a, uint32_t b)
     return a;
 }
 
-static bool leastCommonMultiple(uint32_t a, uint32_t b, uint32_t& result)
+static bool NODELETE leastCommonMultiple(uint32_t a, uint32_t b, uint32_t& result)
 {
     if (a == b) {
         result = a;
@@ -68,7 +68,7 @@ static bool leastCommonMultiple(uint32_t a, uint32_t b, uint32_t& result)
     return safeMultiply(a, b / greatestCommonDivisor(a, b), result);
 }
 
-static int64_t signum(int64_t val)
+static int64_t NODELETE signum(int64_t val)
 {
     return (0 < val) - (val < 0);
 }

--- a/Source/WTF/wtf/MediaTime.h
+++ b/Source/WTF/wtf/MediaTime.h
@@ -64,9 +64,9 @@ public:
     static MediaTime createWithDouble(double doubleTime, uint32_t timeScale);
     static MediaTime createWithSeconds(Seconds seconds) { return createWithDouble(seconds.value()); }
 
-    float toFloat() const;
-    double toDouble() const;
-    int64_t toMicroseconds() const;
+    float NODELETE toFloat() const;
+    double NODELETE toDouble() const;
+    int64_t NODELETE toMicroseconds() const;
 
     MediaTime& operator=(const MediaTime&) = default;
     MediaTime& operator+=(const MediaTime& rhs) { return *this = *this + rhs; }
@@ -92,11 +92,11 @@ public:
     bool hasDoubleValue() const { return m_timeFlags & DoubleValue; }
     uint8_t timeFlags() const { return m_timeFlags; }
 
-    static const MediaTime& zeroTime();
-    static const MediaTime& invalidTime();
-    static const MediaTime& positiveInfiniteTime();
-    static const MediaTime& negativeInfiniteTime();
-    static const MediaTime& indefiniteTime();
+    static const MediaTime& NODELETE zeroTime();
+    static const MediaTime& NODELETE invalidTime();
+    static const MediaTime& NODELETE positiveInfiniteTime();
+    static const MediaTime& NODELETE negativeInfiniteTime();
+    static const MediaTime& NODELETE indefiniteTime();
 
     const int64_t& timeValue() const { return m_timeValue; }
     const uint32_t& timeScale() const { return m_timeScale; }
@@ -112,7 +112,7 @@ public:
     operator int() const = delete;
     MediaTime(int) = delete;
 
-    friend WTF_EXPORT_PRIVATE MediaTime abs(const MediaTime& rhs);
+    friend WTF_EXPORT_PRIVATE MediaTime NODELETE abs(const MediaTime& rhs);
 
     static const uint32_t DefaultTimeScale = 10000000;
     static const uint32_t MaximumTimeScale;
@@ -126,7 +126,7 @@ public:
     };
 
     MediaTime toTimeScale(uint32_t, RoundingFlags = RoundingFlags::HalfAwayFromZero) const;
-    MediaTime isolatedCopy() const;
+    MediaTime NODELETE isolatedCopy() const;
 
 private:
     void setTimeScale(uint32_t, RoundingFlags = RoundingFlags::HalfAwayFromZero);

--- a/Source/WTF/wtf/MemoryPressureHandler.h
+++ b/Source/WTF/wtf/MemoryPressureHandler.h
@@ -95,7 +95,7 @@ public:
 
     WTF_EXPORT_PRIVATE void install();
 
-    WTF_EXPORT_PRIVATE void setMemoryFootprintPollIntervalForTesting(Seconds);
+    WTF_EXPORT_PRIVATE void NODELETE setMemoryFootprintPollIntervalForTesting(Seconds);
     WTF_EXPORT_PRIVATE void setShouldUsePeriodicMemoryMonitor(bool);
 
 #if OS(LINUX) || OS(FREEBSD) || OS(HAIKU) || OS(QNX)
@@ -205,7 +205,7 @@ public:
     WTF_EXPORT_PRIVATE void beginSimulatedMemoryPressure();
     WTF_EXPORT_PRIVATE void endSimulatedMemoryPressure();
 
-    WTF_EXPORT_PRIVATE void setProcessState(WebsamProcessState);
+    WTF_EXPORT_PRIVATE void NODELETE setProcessState(WebsamProcessState);
     WebsamProcessState processState() const { return m_processState; }
 
     WTF_EXPORT_PRIVATE static ASCIILiteral processStateDescription();
@@ -220,8 +220,8 @@ public:
 
 private:
     std::optional<size_t> thresholdForMemoryKill();
-    size_t thresholdForPolicy(MemoryUsagePolicy);
-    MemoryUsagePolicy policyForFootprint(size_t);
+    size_t NODELETE thresholdForPolicy(MemoryUsagePolicy);
+    MemoryUsagePolicy NODELETE policyForFootprint(size_t);
 
     void memoryPressureStatusChanged();
 
@@ -235,7 +235,7 @@ private:
     void didExceedProcessMemoryLimit(ProcessMemoryLimit);
     void respondToMemoryPressure(Critical, Synchronous = Synchronous::No);
     void platformReleaseMemory(Critical);
-    void platformInitialize();
+    void NODELETE platformInitialize();
 
     void measurementTimerFired();
     void shrinkOrDie(size_t killThreshold);

--- a/Source/WTF/wtf/MetaAllocator.h
+++ b/Source/WTF/wtf/MetaAllocator.h
@@ -110,7 +110,7 @@ public:
 
     // This is meant only for implementing tests. Never call this in release
     // builds.
-    WTF_EXPORT_PRIVATE size_t debugFreeSpaceSize();
+    WTF_EXPORT_PRIVATE size_t NODELETE debugFreeSpaceSize();
 
     WTF_EXPORT_PRIVATE bool isInAllocatedMemory(const AbstractLocker&, void* address);
     
@@ -187,7 +187,7 @@ private:
 
     // Utilities.
     
-    size_t roundUp(size_t sizeInBytes);
+    size_t NODELETE roundUp(size_t sizeInBytes);
     
     FreeSpaceNode* allocFreeSpaceNode();
     WTF_EXPORT_PRIVATE void freeFreeSpaceNode(CheckedPtr<FreeSpaceNode>&&);

--- a/Source/WTF/wtf/NativePromise.h
+++ b/Source/WTF/wtf/NativePromise.h
@@ -255,7 +255,7 @@ public:
     virtual void assertIsDead() = 0;
     virtual ~NativePromiseBase() = default;
 #if !LOG_DISABLED || !RELEASE_LOG_DISABLED
-    WTF_EXPORT_PRIVATE static WTFLogChannel& logChannel();
+    WTF_EXPORT_PRIVATE static WTFLogChannel& NODELETE logChannel();
 #endif
     template<typename... Args>
     static inline void log(UNUSED_VARIADIC_PARAMS const Args&... arguments)

--- a/Source/WTF/wtf/ObjectIdentifier.h
+++ b/Source/WTF/wtf/ObjectIdentifier.h
@@ -40,7 +40,7 @@ struct ObjectIdentifierThreadSafeAccessTraits {
 
 template<>
 struct ObjectIdentifierThreadSafeAccessTraits<uint64_t> {
-    WTF_EXPORT_PRIVATE static uint64_t generateIdentifierInternal();
+    WTF_EXPORT_PRIVATE static uint64_t NODELETE generateIdentifierInternal();
 };
 
 template<>

--- a/Source/WTF/wtf/ParallelHelperPool.cpp
+++ b/Source/WTF/wtf/ParallelHelperPool.cpp
@@ -186,7 +186,7 @@ public:
     {
     }
     
-    ASCIILiteral name() const final
+    ASCIILiteral NODELETE name() const final
     {
         return m_pool->m_threadName;
     }

--- a/Source/WTF/wtf/ParallelHelperPool.h
+++ b/Source/WTF/wtf/ParallelHelperPool.h
@@ -88,8 +88,8 @@ private:
 
     void didMakeWorkAvailable(const AbstractLocker&) WTF_REQUIRES_LOCK(m_lock);
 
-    bool hasClientWithTask() WTF_REQUIRES_LOCK(m_lock);
-    ParallelHelperClient* getClientWithTask() WTF_REQUIRES_LOCK(m_lock);
+    bool NODELETE hasClientWithTask() WTF_REQUIRES_LOCK(m_lock);
+    ParallelHelperClient* NODELETE getClientWithTask() WTF_REQUIRES_LOCK(m_lock);
     
     Box<Lock> m_lock; // AutomaticThread wants this in a box for safety.
     const Ref<AutomaticThreadCondition> m_workAvailableCondition;

--- a/Source/WTF/wtf/ParkingLot.cpp
+++ b/Source/WTF/wtf/ParkingLot.cpp
@@ -255,7 +255,7 @@ const unsigned maxLoadFactor = 3;
 
 const unsigned growthFactor = 2;
 
-unsigned hashAddress(const void* address)
+unsigned NODELETE hashAddress(const void* address)
 {
     return WTF::PtrHash<const void*>::hash(address);
 }

--- a/Source/WTF/wtf/PrintStream.h
+++ b/Source/WTF/wtf/PrintStream.h
@@ -65,7 +65,7 @@ public:
 
     // Typically a no-op for many subclasses of PrintStream, this is a hint that
     // the implementation should flush its buffers if it had not done so already.
-    WTF_EXPORT_PRIVATE virtual void flush();
+    WTF_EXPORT_PRIVATE virtual void NODELETE flush();
     
     template<typename Func>
     void atomically(NOESCAPE const Func& func)
@@ -100,7 +100,7 @@ protected:
     }
     
     WTF_EXPORT_PRIVATE virtual PrintStream& begin();
-    WTF_EXPORT_PRIVATE virtual void end();
+    WTF_EXPORT_PRIVATE virtual void NODELETE end();
 };
 
 WTF_EXPORT_PRIVATE void printInternal(PrintStream&, const char*);

--- a/Source/WTF/wtf/RefCountDebugger.cpp
+++ b/Source/WTF/wtf/RefCountDebugger.cpp
@@ -46,7 +46,7 @@ public:
     {
     }
 
-    const void* ptr() { return m_ptr; }
+    const void* NODELETE ptr() { return m_ptr; }
 
     void print()
     {

--- a/Source/WTF/wtf/RunLoop.cpp
+++ b/Source/WTF/wtf/RunLoop.cpp
@@ -53,7 +53,7 @@ public:
         m_runLoop->threadWillExit();
     }
 
-    RunLoop& runLoop() { return m_runLoop; }
+    RunLoop& NODELETE runLoop() { return m_runLoop; }
 
 private:
     const Ref<RunLoop> m_runLoop;

--- a/Source/WTF/wtf/RunLoop.h
+++ b/Source/WTF/wtf/RunLoop.h
@@ -94,7 +94,7 @@ public:
 #endif
 
     WTF_EXPORT_PRIVATE static RunLoop& currentSingleton();
-    WTF_EXPORT_PRIVATE static RunLoop& mainSingleton();
+    WTF_EXPORT_PRIVATE static RunLoop& NODELETE mainSingleton();
 #if USE(WEB_THREAD)
     WTF_EXPORT_PRIVATE static RunLoop& webSingleton();
     WTF_EXPORT_PRIVATE static RunLoop* webIfExists();

--- a/Source/WTF/wtf/RuntimeApplicationChecks.cpp
+++ b/Source/WTF/wtf/RuntimeApplicationChecks.cpp
@@ -36,7 +36,7 @@ namespace WTF {
 static bool presentingApplicationPIDOverrideWasQueried;
 #endif
 
-static std::optional<int>& presentingApplicationPIDOverride()
+static std::optional<int>& NODELETE presentingApplicationPIDOverride()
 {
     static NeverDestroyed<std::optional<int>> pid;
 #if !ASSERT_MSG_DISABLED
@@ -68,7 +68,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 }
 #endif
 
-static std::optional<AuxiliaryProcessType>& auxiliaryProcessType()
+static std::optional<AuxiliaryProcessType>& NODELETE auxiliaryProcessType()
 {
     static std::optional<AuxiliaryProcessType> auxiliaryProcessType;
     return auxiliaryProcessType;

--- a/Source/WTF/wtf/RuntimeApplicationChecks.h
+++ b/Source/WTF/wtf/RuntimeApplicationChecks.h
@@ -37,11 +37,11 @@
 
 namespace WTF {
 
-WTF_EXPORT_PRIVATE void setLegacyPresentingApplicationPID(int);
+WTF_EXPORT_PRIVATE void NODELETE setLegacyPresentingApplicationPID(int);
 WTF_EXPORT_PRIVATE int legacyPresentingApplicationPID();
 
 #if HAVE(AUDIT_TOKEN)
-WTF_EXPORT_PRIVATE ProcessID pidFromAuditToken(const audit_token_t&);
+WTF_EXPORT_PRIVATE ProcessID NODELETE pidFromAuditToken(const audit_token_t&);
 #endif
 
 enum class AuxiliaryProcessType : uint8_t {
@@ -56,13 +56,13 @@ enum class AuxiliaryProcessType : uint8_t {
 #endif
 };
 
-WTF_EXPORT_PRIVATE void setAuxiliaryProcessType(AuxiliaryProcessType);
-WTF_EXPORT_PRIVATE void setAuxiliaryProcessTypeForTesting(std::optional<AuxiliaryProcessType>);
-WTF_EXPORT_PRIVATE bool checkAuxiliaryProcessType(AuxiliaryProcessType);
-WTF_EXPORT_PRIVATE std::optional<AuxiliaryProcessType> processType();
+WTF_EXPORT_PRIVATE void NODELETE setAuxiliaryProcessType(AuxiliaryProcessType);
+WTF_EXPORT_PRIVATE void NODELETE setAuxiliaryProcessTypeForTesting(std::optional<AuxiliaryProcessType>);
+WTF_EXPORT_PRIVATE bool NODELETE checkAuxiliaryProcessType(AuxiliaryProcessType);
+WTF_EXPORT_PRIVATE std::optional<AuxiliaryProcessType> NODELETE processType();
 WTF_EXPORT_PRIVATE ASCIILiteral processTypeDescription(std::optional<AuxiliaryProcessType>);
 
-WTF_EXPORT_PRIVATE bool isInAuxiliaryProcess();
+WTF_EXPORT_PRIVATE bool NODELETE isInAuxiliaryProcess();
 inline bool isInWebProcess() { return checkAuxiliaryProcessType(AuxiliaryProcessType::WebContent); }
 inline bool isInNetworkProcess() { return checkAuxiliaryProcessType(AuxiliaryProcessType::Network); }
 inline bool isInGPUProcess()

--- a/Source/WTF/wtf/SixCharacterHash.h
+++ b/Source/WTF/wtf/SixCharacterHash.h
@@ -38,7 +38,7 @@ WTF_EXPORT_PRIVATE unsigned sixCharacterHashStringToInteger(std::span<const char
 
 // Takes a 32-bit integer and constructs a six-character string that contains
 // the character hash.
-WTF_EXPORT_PRIVATE std::array<char, 6> integerToSixCharacterHashString(unsigned);
+WTF_EXPORT_PRIVATE std::array<char, 6> NODELETE integerToSixCharacterHashString(unsigned);
 
 } // namespace WTF
 

--- a/Source/WTF/wtf/StringPrintStream.h
+++ b/Source/WTF/wtf/StringPrintStream.h
@@ -44,7 +44,7 @@ public:
     WTF_EXPORT_PRIVATE Expected<String, UTF8ConversionError> tryToString() const;
     WTF_EXPORT_PRIVATE String toString() const;
     WTF_EXPORT_PRIVATE String toStringWithLatin1Fallback() const;
-    WTF_EXPORT_PRIVATE void reset();
+    WTF_EXPORT_PRIVATE void NODELETE reset();
     
 private:
     void increaseSize(size_t);

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -101,7 +101,7 @@ ThreadSuspendLocker::~ThreadSuspendLocker()
 }
 #endif
 
-static std::optional<size_t> stackSize(ThreadType threadType)
+static std::optional<size_t> NODELETE stackSize(ThreadType threadType)
 {
     // Return the stack size for the created thread based on its type.
     // If the stack size is not specified, then use the system default. Platforms can tune the values here.
@@ -295,7 +295,7 @@ Ref<Thread> Thread::create(ASCIILiteral name, Function<void()>&& entryPoint, Thr
     return thread;
 }
 
-static bool shouldRemoveThreadFromThreadGroup()
+static bool NODELETE shouldRemoveThreadFromThreadGroup()
 {
 #if OS(WINDOWS)
     // On Windows the thread specific destructor is also called when the
@@ -408,7 +408,7 @@ void Thread::setCurrentThreadIsUserInitiated(int relativePriority)
 }
 
 #if HAVE(QOS_CLASSES)
-static Thread::QOS toQOS(qos_class_t qosClass)
+static Thread::QOS NODELETE toQOS(qos_class_t qosClass)
 {
     switch (qosClass) {
     case QOS_CLASS_USER_INTERACTIVE:

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -242,7 +242,7 @@ public:
     // Called in the thread during initialization.
     // Helpful for platforms where the thread name must be set from within the thread.
     static void initializeCurrentThreadInternal(const char* threadName);
-    static void initializeCurrentThreadEvenIfNonWTFCreated();
+    static void NODELETE initializeCurrentThreadEvenIfNonWTFCreated();
     
     WTF_EXPORT_PRIVATE static void yield();
 
@@ -250,7 +250,7 @@ public:
     WTF_EXPORT_PRIVATE static void registerGCThread(GCThreadType);
     WTF_EXPORT_PRIVATE static bool mayBeGCThread();
 
-    WTF_EXPORT_PRIVATE static void registerJSThread(Thread&);
+    WTF_EXPORT_PRIVATE static void NODELETE registerJSThread(Thread&);
 
     WTF_EXPORT_PRIVATE void dump(PrintStream& out) const;
 
@@ -344,7 +344,7 @@ protected:
     static qos_class_t adjustedQOSClass(qos_class_t);
 #endif
 
-    static const char* normalizeThreadName(const char* threadName);
+    static const char* NODELETE normalizeThreadName(const char* threadName);
 
     enum JoinableState : uint8_t {
         // The default thread state. The thread can be joined on.

--- a/Source/WTF/wtf/TimeWithDynamicClockType.h
+++ b/Source/WTF/wtf/TimeWithDynamicClockType.h
@@ -92,11 +92,11 @@ public:
     }
     
     // Asserts that the time is of the type you want.
-    WTF_EXPORT_PRIVATE WallTime wallTime() const;
-    WTF_EXPORT_PRIVATE MonotonicTime monotonicTime() const;
-    WTF_EXPORT_PRIVATE ApproximateTime approximateTime() const;
-    WTF_EXPORT_PRIVATE ContinuousTime continuousTime() const;
-    WTF_EXPORT_PRIVATE ContinuousApproximateTime continuousApproximateTime() const;
+    WTF_EXPORT_PRIVATE WallTime NODELETE wallTime() const;
+    WTF_EXPORT_PRIVATE MonotonicTime NODELETE monotonicTime() const;
+    WTF_EXPORT_PRIVATE ApproximateTime NODELETE approximateTime() const;
+    WTF_EXPORT_PRIVATE ContinuousTime NODELETE continuousTime() const;
+    WTF_EXPORT_PRIVATE ContinuousApproximateTime NODELETE continuousApproximateTime() const;
 
     WTF_EXPORT_PRIVATE WallTime approximateWallTime() const;
     WTF_EXPORT_PRIVATE MonotonicTime approximateMonotonicTime() const;

--- a/Source/WTF/wtf/URL.cpp
+++ b/Source/WTF/wtf/URL.cpp
@@ -74,7 +74,7 @@ URL::URL(String&& absoluteURL, const URLTextEncoding* encoding)
     *this = URLParser(WTF::move(absoluteURL), URL(), encoding).result();
 }
 
-static bool shouldTrimFromURL(char16_t character)
+static bool NODELETE shouldTrimFromURL(char16_t character)
 {
     // Ignore leading/trailing whitespace and control characters.
     return character <= ' ';
@@ -197,7 +197,7 @@ String URL::protocolHostAndPort() const
     );
 }
 
-static std::optional<Latin1Character> decodeEscapeSequence(StringView input, unsigned index, unsigned length)
+static std::optional<Latin1Character> NODELETE decodeEscapeSequence(StringView input, unsigned index, unsigned length)
 {
     if (index + 3 > length || input[index] != '%')
         return std::nullopt;
@@ -311,7 +311,7 @@ String URL::fileSystemPath() const
 
 #if !ASSERT_ENABLED
 
-static inline void assertProtocolIsGood(StringView)
+static inline void NODELETE assertProtocolIsGood(StringView)
 {
 }
 
@@ -335,13 +335,13 @@ static void assertProtocolIsGood(StringView protocol)
 static Lock defaultPortForProtocolMapForTestingLock;
 
 using DefaultPortForProtocolMapForTesting = HashMap<String, uint16_t>;
-static DefaultPortForProtocolMapForTesting*& defaultPortForProtocolMapForTesting() WTF_REQUIRES_LOCK(defaultPortForProtocolMapForTestingLock)
+static DefaultPortForProtocolMapForTesting*& NODELETE defaultPortForProtocolMapForTesting() WTF_REQUIRES_LOCK(defaultPortForProtocolMapForTestingLock)
 {
     static DefaultPortForProtocolMapForTesting* defaultPortForProtocolMap;
     return defaultPortForProtocolMap;
 }
 
-static DefaultPortForProtocolMapForTesting& ensureDefaultPortForProtocolMapForTesting() WTF_REQUIRES_LOCK(defaultPortForProtocolMapForTestingLock)
+static DefaultPortForProtocolMapForTesting& NODELETE ensureDefaultPortForProtocolMapForTesting() WTF_REQUIRES_LOCK(defaultPortForProtocolMapForTestingLock)
 {
     DefaultPortForProtocolMapForTesting*& defaultPortForProtocolMap = defaultPortForProtocolMapForTesting();
     if (!defaultPortForProtocolMap)
@@ -484,14 +484,14 @@ unsigned URL::credentialsEnd() const
     return end;
 }
 
-static bool forwardSlashHashOrQuestionMark(char16_t c)
+static bool NODELETE forwardSlashHashOrQuestionMark(char16_t c)
 {
     return c == '/'
         || c == '#'
         || c == '?';
 }
 
-static bool slashHashOrQuestionMark(char16_t c)
+static bool NODELETE slashHashOrQuestionMark(char16_t c)
 {
     return forwardSlashHashOrQuestionMark(c) || c == '\\';
 }
@@ -543,7 +543,7 @@ void URL::setPort(std::optional<uint16_t> port)
     ));
 }
 
-static unsigned countASCIIDigits(StringView string)
+static unsigned NODELETE countASCIIDigits(StringView string)
 {
     unsigned length = string.length();
     for (unsigned count = 0; count < length; ++count) {

--- a/Source/WTF/wtf/URL.h
+++ b/Source/WTF/wtf/URL.h
@@ -179,7 +179,7 @@ public:
 
     // Returns true if the current URL's protocol is the same as the null-
     // terminated ASCII argument. The argument must be lower-case.
-    WTF_EXPORT_PRIVATE bool protocolIs(StringView) const;
+    WTF_EXPORT_PRIVATE bool NODELETE protocolIs(StringView) const;
     bool protocolIsAbout() const { return protocolIs("about"_s); }
     bool protocolIsBlob() const { return protocolIs("blob"_s); }
     bool protocolIsData() const { return protocolIs("data"_s); }
@@ -224,7 +224,7 @@ public:
     WTF_EXPORT_PRIVATE static bool hostIsIPAddress(StringView);
     WTF_EXPORT_PRIVATE static bool isIPv6Address(StringView);
 
-    WTF_EXPORT_PRIVATE unsigned pathStart() const;
+    WTF_EXPORT_PRIVATE unsigned NODELETE pathStart() const;
     unsigned pathEnd() const;
     unsigned pathAfterLastSlash() const;
 
@@ -258,9 +258,9 @@ public:
 private:
     friend class URLParser;
 
-    WTF_EXPORT_PRIVATE void invalidate();
-    unsigned hostStart() const;
-    unsigned credentialsEnd() const;
+    WTF_EXPORT_PRIVATE void NODELETE invalidate();
+    unsigned NODELETE hostStart() const;
+    unsigned NODELETE credentialsEnd() const;
     void remove(unsigned start, unsigned length);
     void parse(String&&);
     void parseAllowingC0AtEnd(String&&);
@@ -317,7 +317,7 @@ WTF_EXPORT_PRIVATE const URL& aboutSrcDocURL();
 
 WTF_EXPORT_PRIVATE bool protocolIs(StringView url, ASCIILiteral protocol);
 WTF_EXPORT_PRIVATE bool protocolIsJavaScript(StringView url);
-WTF_EXPORT_PRIVATE bool protocolIsInHTTPFamily(StringView url);
+WTF_EXPORT_PRIVATE bool NODELETE protocolIsInHTTPFamily(StringView url);
 
 WTF_EXPORT_PRIVATE std::optional<uint16_t> defaultPortForProtocol(StringView protocol);
 WTF_EXPORT_PRIVATE bool isDefaultPortForProtocol(uint16_t port, StringView protocol);

--- a/Source/WTF/wtf/URLHelpers.cpp
+++ b/Source/WTF/wtf/URLHelpers.cpp
@@ -461,7 +461,7 @@ static inline bool isSecondLevelDomainNameAllowedByTLDRules(std::span<const char
             return isSecondLevelDomainNameAllowedByTLDRules(buffer.first(buffer.size() - suffixLength), function); \
     }
 
-static bool isRussianDomainNameCharacter(char16_t ch)
+static bool NODELETE isRussianDomainNameCharacter(char16_t ch)
 {
     // Only modern Russian letters, digits and dashes are allowed.
     return (ch >= 0x0430 && ch <= 0x044f) || ch == 0x0451 || isASCIIDigit(ch) || ch == '-';

--- a/Source/WTF/wtf/URLParser.cpp
+++ b/Source/WTF/wtf/URLParser.cpp
@@ -2130,7 +2130,7 @@ void URLParser::serializeIPv4(IPv4Address address)
     appendNumberToASCIIBuffer<uint8_t>(address);
 }
     
-static size_t zeroSequenceLength(const std::array<uint16_t, 8>& address, size_t begin)
+static size_t NODELETE zeroSequenceLength(const std::array<uint16_t, 8>& address, size_t begin)
 {
     size_t end = begin;
     for (; end < 8; end++) {
@@ -2140,7 +2140,7 @@ static size_t zeroSequenceLength(const std::array<uint16_t, 8>& address, size_t 
     return end - begin;
 }
 
-static std::optional<size_t> findLongestZeroSequence(const std::array<uint16_t, 8>& address)
+static std::optional<size_t> NODELETE findLongestZeroSequence(const std::array<uint16_t, 8>& address)
 {
     std::optional<size_t> longest;
     size_t longestLength = 0;

--- a/Source/WTF/wtf/URLParser.h
+++ b/Source/WTF/wtf/URLParser.h
@@ -52,21 +52,21 @@ public:
 #define URLTextEncodingSentinelAllowingC0AtEnd reinterpret_cast<const URLTextEncoding*>(-1)
 
     WTF_EXPORT_PRIVATE static bool allValuesEqual(const URL&, const URL&);
-    WTF_EXPORT_PRIVATE static bool internalValuesConsistent(const URL&);
+    WTF_EXPORT_PRIVATE static bool NODELETE internalValuesConsistent(const URL&);
     
     using URLEncodedForm = Vector<KeyValuePair<String, String>>;
     WTF_EXPORT_PRIVATE static URLEncodedForm parseURLEncodedForm(StringView);
     WTF_EXPORT_PRIVATE static std::optional<KeyValuePair<String, String>> parseQueryNameAndValue(StringView);
     WTF_EXPORT_PRIVATE static String serialize(const URLEncodedForm&);
 
-    WTF_EXPORT_PRIVATE static bool isSpecialScheme(StringView);
+    WTF_EXPORT_PRIVATE static bool NODELETE isSpecialScheme(StringView);
     WTF_EXPORT_PRIVATE static std::optional<String> maybeCanonicalizeScheme(StringView scheme);
 
     static const UIDNA& internationalDomainNameTranscoder();
-    static bool isInUserInfoEncodeSet(char16_t);
-    static bool isSpecialCharacterForFragmentDirective(char16_t);
+    static bool NODELETE isInUserInfoEncodeSet(char16_t);
+    static bool NODELETE isSpecialCharacterForFragmentDirective(char16_t);
 
-    static std::optional<uint16_t> defaultPortForProtocol(StringView);
+    static std::optional<uint16_t> NODELETE defaultPortForProtocol(StringView);
     WTF_EXPORT_PRIVATE static std::optional<String> formURLDecode(StringView input);
 
 private:
@@ -108,7 +108,7 @@ private:
     template<typename CharacterType> bool shouldCopyFileURL(CodePointIterator<CharacterType>);
     template<typename CharacterType> bool checkLocalhostCodePoint(CodePointIterator<CharacterType>&, char32_t);
     template<typename CharacterType> bool isAtLocalhost(CodePointIterator<CharacterType>);
-    bool isLocalhost(StringView);
+    bool NODELETE isLocalhost(StringView);
     template<typename CharacterType> void consumeSingleDotPathSegment(CodePointIterator<CharacterType>&);
     template<typename CharacterType> void consumeDoubleDotPathSegment(CodePointIterator<CharacterType>&);
     template<typename CharacterType> void appendWindowsDriveLetter(CodePointIterator<CharacterType>&);
@@ -119,7 +119,7 @@ private:
     template<typename CharacterType> std::optional<Latin1Buffer> domainToASCII(StringImpl&, const CodePointIterator<CharacterType>& iteratorForSyntaxViolationPosition);
     template<typename CharacterType> Latin1Buffer percentDecode(std::span<const Latin1Character>, const CodePointIterator<CharacterType>& iteratorForSyntaxViolationPosition);
     static Latin1Buffer percentDecode(std::span<const Latin1Character>);
-    bool hasForbiddenHostCodePoint(const Latin1Buffer&);
+    bool NODELETE hasForbiddenHostCodePoint(const Latin1Buffer&);
     void percentEncodeByte(uint8_t);
     void appendToASCIIBuffer(char32_t);
     void appendToASCIIBuffer(std::span<const Latin1Character>);
@@ -131,7 +131,7 @@ private:
     template<typename CharacterType> bool subdomainStartsWithXNDashDash(CodePointIterator<CharacterType>);
     bool subdomainStartsWithXNDashDash(StringImpl&);
 
-    bool needsNonSpecialDotSlash() const;
+    bool NODELETE needsNonSpecialDotSlash() const;
     void addNonSpecialDotSlash();
 
     using IPv4Address = uint32_t;
@@ -151,9 +151,9 @@ private:
     template<typename CharacterType> void copyURLPartsUntil(const URL& base, URLPart, const CodePointIterator<CharacterType>&, const URLTextEncoding*&);
     template<typename CharacterType> bool isForbiddenHostCodePoint(CharacterType);
     template<typename CharacterType> bool isForbiddenDomainCodePoint(CharacterType);
-    static size_t urlLengthUntilPart(const URL&, URLPart);
+    static size_t NODELETE urlLengthUntilPart(const URL&, URLPart);
     void popPath();
-    bool shouldPopPath(unsigned);
+    bool NODELETE shouldPopPath(unsigned);
 };
 
 WTF_EXPORT_PRIVATE bool isForbiddenHostCodePoint(char16_t);

--- a/Source/WTF/wtf/UUID.cpp
+++ b/Source/WTF/wtf/UUID.cpp
@@ -48,7 +48,7 @@
 
 namespace WTF {
 
-static ALWAYS_INLINE UInt128 convertRandomUInt128ToUUIDVersion4(UInt128 buffer)
+static ALWAYS_INLINE UInt128 NODELETE convertRandomUInt128ToUUIDVersion4(UInt128 buffer)
 {
     // By default, we generate a v4 UUID value, as per https://datatracker.ietf.org/doc/html/rfc4122#section-4.4.
     auto high = static_cast<uint64_t>((buffer >> 64) & 0xffffffffffff0fff) | 0x4000;

--- a/Source/WTF/wtf/UUID.h
+++ b/Source/WTF/wtf/UUID.h
@@ -62,7 +62,7 @@ public:
         return UUID { generateWeakRandomUUIDVersion4() };
     }
 
-    WTF_EXPORT_PRIVATE static UUID createVersion5(const SHA1::Digest&);
+    WTF_EXPORT_PRIVATE static UUID NODELETE createVersion5(const SHA1::Digest&);
     WTF_EXPORT_PRIVATE static UUID createVersion5(UUID, std::span<const uint8_t>);
 
 #ifdef __OBJC__

--- a/Source/WTF/wtf/WTFConfig.h
+++ b/Source/WTF/wtf/WTFConfig.h
@@ -71,7 +71,7 @@ struct Config {
     WTF_EXPORT_PRIVATE static void permanentlyFreeze();
     WTF_EXPORT_PRIVATE static void initialize();
     WTF_EXPORT_PRIVATE static void finalize();
-    WTF_EXPORT_PRIVATE static void disableFreezingForTesting();
+    WTF_EXPORT_PRIVATE static void NODELETE disableFreezingForTesting();
 
     struct AssertNotFrozenScope {
         AssertNotFrozenScope();

--- a/Source/WTF/wtf/WorkQueue.h
+++ b/Source/WTF/wtf/WorkQueue.h
@@ -78,7 +78,7 @@ protected:
     uint32_t m_threadID { 0 };
 private:
     void platformInitialize(ASCIILiteral name, Type, QOS);
-    void platformInvalidate();
+    void NODELETE platformInvalidate();
 };
 
 /**

--- a/Source/WTF/wtf/WorkerPool.cpp
+++ b/Source/WTF/wtf/WorkerPool.cpp
@@ -77,7 +77,7 @@ public:
     }
 
     // Called with the lock held.
-    void threadIsStopping(const AbstractLocker&) final
+    void NODELETE threadIsStopping(const AbstractLocker&) final
     {
         ASSERT(m_pool);
         m_pool->m_numberOfActiveWorkers--;
@@ -90,7 +90,7 @@ public:
         return Ref { *m_pool }->shouldSleep(locker);
     }
 
-    ASCIILiteral name() const final
+    ASCIILiteral NODELETE name() const final
     {
         ASSERT(m_pool);
         return m_pool->name();

--- a/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
+++ b/Source/WTF/wtf/cocoa/FileSystemCocoa.mm
@@ -196,7 +196,7 @@ std::pair<FileHandle, CString> createTemporaryFileInDirectory(const String& dire
 }
 
 #ifdef IOPOL_TYPE_VFS_MATERIALIZE_DATALESS_FILES
-static int toIOPolicyScope(PolicyScope scope)
+static int NODELETE toIOPolicyScope(PolicyScope scope)
 {
     switch (scope) {
     case PolicyScope::Process:

--- a/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
+++ b/Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm
@@ -49,13 +49,13 @@ void MemoryPressureHandler::platformReleaseMemory(Critical critical)
     }
 }
 
-static OSObjectPtr<dispatch_source_t>& memoryPressureEventSource()
+static OSObjectPtr<dispatch_source_t>& NODELETE memoryPressureEventSource()
 {
     static NeverDestroyed<OSObjectPtr<dispatch_source_t>> source;
     return source.get();
 }
 
-static OSObjectPtr<dispatch_source_t>& timerEventSource()
+static OSObjectPtr<dispatch_source_t>& NODELETE timerEventSource()
 {
     static NeverDestroyed<OSObjectPtr<dispatch_source_t>> source;
     return source.get();

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h
@@ -142,20 +142,20 @@ enum class SDKAlignedBehavior {
 using SDKAlignedBehaviors = WTF::BitSet<static_cast<size_t>(SDKAlignedBehavior::NumberOfBehaviors), uint32_t>;
 
 WTF_EXPORT_PRIVATE const SDKAlignedBehaviors& sdkAlignedBehaviors();
-WTF_EXPORT_PRIVATE void setSDKAlignedBehaviors(SDKAlignedBehaviors);
+WTF_EXPORT_PRIVATE void NODELETE setSDKAlignedBehaviors(SDKAlignedBehaviors);
 
 WTF_EXPORT_PRIVATE void enableAllSDKAlignedBehaviors();
 WTF_EXPORT_PRIVATE void disableAllSDKAlignedBehaviors();
 
 WTF_EXPORT_PRIVATE bool linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior);
 
-WTF_EXPORT_PRIVATE bool processIsExtension();
-WTF_EXPORT_PRIVATE void setProcessIsExtension(bool);
+WTF_EXPORT_PRIVATE bool NODELETE processIsExtension();
+WTF_EXPORT_PRIVATE void NODELETE setProcessIsExtension(bool);
 
-WTF_EXPORT_PRIVATE void setApplicationBundleIdentifier(const String&);
-WTF_EXPORT_PRIVATE void setApplicationBundleIdentifierOverride(const String&);
+WTF_EXPORT_PRIVATE void NODELETE setApplicationBundleIdentifier(const String&);
+WTF_EXPORT_PRIVATE void NODELETE setApplicationBundleIdentifierOverride(const String&);
 WTF_EXPORT_PRIVATE String applicationBundleIdentifier();
-WTF_EXPORT_PRIVATE void clearApplicationBundleIdentifierTestingOverride();
+WTF_EXPORT_PRIVATE void NODELETE clearApplicationBundleIdentifierTestingOverride();
 
 #if USE(SOURCE_APPLICATION_AUDIT_DATA)
 WTF_EXPORT_PRIVATE void setApplicationAuditToken(audit_token_t);

--- a/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
+++ b/Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm
@@ -62,7 +62,7 @@ static bool linkedBefore(dyld_build_version_t version, uint32_t fallbackIOSVersi
 #if USE(APPLE_INTERNAL_SDK) && __has_include(<WebKitAdditions/RuntimeApplicationChecksCocoaAdditions.cpp>)
 #import <WebKitAdditions/RuntimeApplicationChecksCocoaAdditions.cpp>
 #else
-static void disableAdditionalSDKAlignedBehaviors(SDKAlignedBehaviors&)
+static void NODELETE disableAdditionalSDKAlignedBehaviors(SDKAlignedBehaviors&)
 {
 }
 #endif
@@ -247,7 +247,7 @@ static SDKAlignedBehaviors computeSDKAlignedBehaviors()
     return behaviors;
 }
 
-static std::optional<SDKAlignedBehaviors>& sdkAlignedBehaviorsValue()
+static std::optional<SDKAlignedBehaviors>& NODELETE sdkAlignedBehaviorsValue()
 {
     static NeverDestroyed<std::optional<SDKAlignedBehaviors>> behaviors;
     return behaviors.get();
@@ -289,7 +289,7 @@ bool linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior behavior)
     return sdkAlignedBehaviors().get(static_cast<size_t>(behavior));
 }
 
-static bool& processIsExtensionValue()
+static bool& NODELETE processIsExtensionValue()
 {
     static bool processIsExtension;
     return processIsExtension;
@@ -311,7 +311,7 @@ static bool applicationBundleIdentifierOverrideWasQueried;
 
 // The application bundle identifier gets set to the UIProcess bundle identifier by the WebProcess and
 // the Networking upon initialization. It is unset otherwise.
-static String& bundleIdentifierOverride()
+static String& NODELETE bundleIdentifierOverride()
 {
     static NeverDestroyed<String> identifierOverride;
 #if !ASSERT_MSG_DISABLED
@@ -320,7 +320,7 @@ static String& bundleIdentifierOverride()
     return identifierOverride;
 }
 
-static String& bundleIdentifier()
+static String& NODELETE bundleIdentifier()
 {
     static NeverDestroyed<String> identifier;
     return identifier;

--- a/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
+++ b/Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm
@@ -161,7 +161,7 @@ void LibraryPathDiagnosticsLogger::logDYLDSharedCacheInfo(void)
 }
 
 #if HAVE(SHARED_REGION_SPI)
-static bool isAddressInSharedRegion(const void* addr)
+static bool NODELETE isAddressInSharedRegion(const void* addr)
 {
     return std::bit_cast<uintptr_t>(addr) >= SHARED_REGION_BASE && std::bit_cast<uintptr_t>(addr) < (SHARED_REGION_BASE + SHARED_REGION_SIZE);
 }

--- a/Source/WTF/wtf/dtoa/bignum-dtoa.cc
+++ b/Source/WTF/wtf/dtoa/bignum-dtoa.cc
@@ -37,7 +37,7 @@
 namespace WTF {
 namespace double_conversion {
 
-static int NormalizedExponent(uint64_t significand, int exponent) {
+static int NODELETE NormalizedExponent(uint64_t significand, int exponent) {
   ASSERT(significand != 0);
   while ((significand & Double::kHiddenBit) == 0) {
     significand = significand << 1;

--- a/Source/WTF/wtf/dtoa/bignum.cc
+++ b/Source/WTF/wtf/dtoa/bignum.cc
@@ -91,7 +91,7 @@ void Bignum::AssignBignum(const Bignum& other) {
 }
 
 
-static uint64_t ReadUInt64(BufferReference<const char> buffer,
+static uint64_t NODELETE ReadUInt64(BufferReference<const char> buffer,
                            int from,
                            int digits_to_read) {
   uint64_t result = 0;
@@ -560,7 +560,7 @@ static int SizeInHexChars(S number) {
 }
 
 
-static char HexCharOfValue(int value) {
+static char NODELETE HexCharOfValue(int value) {
   ASSERT(0 <= value && value <= 16);
   if (value < 10) return static_cast<char>(value + '0');
   return static_cast<char>(value - 10 + 'A');

--- a/Source/WTF/wtf/dtoa/bignum.h
+++ b/Source/WTF/wtf/dtoa/bignum.h
@@ -44,7 +44,7 @@ class Bignum {
   Bignum();
   void AssignUInt16(uint16_t value);
   void AssignUInt64(uint64_t value);
-  void AssignBignum(const Bignum& other);
+  void NODELETE AssignBignum(const Bignum& other);
 
   void AssignDecimalString(BufferReference<const char> value);
   void AssignHexString(BufferReference<const char> value);
@@ -68,13 +68,13 @@ class Bignum {
   // In the worst case this function is in O(this/other).
   uint16_t DivideModuloIntBignum(const Bignum& other);
 
-  bool ToHexString(std::span<char> buffer) const;
+  bool NODELETE ToHexString(std::span<char> buffer) const;
 
   // Returns
   //  -1 if a < b,
   //   0 if a == b, and
   //  +1 if a > b.
-  static int Compare(const Bignum& a, const Bignum& b);
+  static int NODELETE Compare(const Bignum& a, const Bignum& b);
   static bool Equal(const Bignum& a, const Bignum& b) {
     return Compare(a, b) == 0;
   }
@@ -85,7 +85,7 @@ class Bignum {
     return Compare(a, b) < 0;
   }
   // Returns Compare(a + b, c);
-  static int PlusCompare(const Bignum& a, const Bignum& b, const Bignum& c);
+  static int NODELETE PlusCompare(const Bignum& a, const Bignum& b, const Bignum& c);
   // Returns a + b == c
   static bool PlusEqual(const Bignum& a, const Bignum& b, const Bignum& c) {
     return PlusCompare(a, b, c) == 0;
@@ -118,16 +118,16 @@ class Bignum {
     }
   }
   void Align(const Bignum& other);
-  void Clamp();
-  bool IsClamped() const;
-  void Zero();
+  void NODELETE Clamp();
+  bool NODELETE IsClamped() const;
+  void NODELETE Zero();
   // Requires this to have enough capacity (no tests done).
   // Updates used_digits_ if necessary.
   // shift_amount must be < kBigitSize.
-  void BigitsShiftLeft(int shift_amount);
+  void NODELETE BigitsShiftLeft(int shift_amount);
   // BigitLength includes the "hidden" digits encoded in the exponent.
   int BigitLength() const { return used_digits_ + exponent_; }
-  Chunk BigitAt(int index) const;
+  Chunk NODELETE BigitAt(int index) const;
   void SubtractTimes(const Bignum& other, int factor);
 
   std::array<Chunk, kBigitCapacity> bigits_buffer_;

--- a/Source/WTF/wtf/dtoa/cached-powers.h
+++ b/Source/WTF/wtf/dtoa/cached-powers.h
@@ -55,7 +55,7 @@ class PowersOfTenCache {
   // The given decimal_exponent must satisfy
   //   kMinDecimalExponent <= requested_exponent, and
   //   requested_exponent < kMaxDecimalExponent + kDecimalExponentDistance.
-  static void GetCachedPowerForDecimalExponent(int requested_exponent,
+  static void NODELETE GetCachedPowerForDecimalExponent(int requested_exponent,
                                                DiyFp* power,
                                                int* found_exponent);
 };

--- a/Source/WTF/wtf/dtoa/diy-fp.h
+++ b/Source/WTF/wtf/dtoa/diy-fp.h
@@ -66,7 +66,7 @@ class DiyFp {
 
 
   // this = this * other.
-  void Multiply(const DiyFp& other);
+  void NODELETE Multiply(const DiyFp& other);
 
   // returns a * b;
   static DiyFp Times(const DiyFp& a, const DiyFp& b) {

--- a/Source/WTF/wtf/dtoa/double-conversion.cc
+++ b/Source/WTF/wtf/dtoa/double-conversion.cc
@@ -446,7 +446,7 @@ void DoubleToStringConverter::DoubleToAscii(double v,
 const int kMaxSignificantDigits = 772;
 
 
-static double SignedZero(bool sign) {
+static double NODELETE SignedZero(bool sign) {
   return sign ? -0.0 : 0.0;
 }
 

--- a/Source/WTF/wtf/dtoa/double-conversion.h
+++ b/Source/WTF/wtf/dtoa/double-conversion.h
@@ -130,10 +130,10 @@ class DoubleToStringConverter {
   }
 
   // Returns a converter following the EcmaScript specification.
-  WTF_EXPORT_PRIVATE static const DoubleToStringConverter& EcmaScriptConverter();
-  WTF_EXPORT_PRIVATE static const DoubleToStringConverter& EcmaScriptConverterWithTrailingPoint();
+  WTF_EXPORT_PRIVATE static const DoubleToStringConverter& NODELETE EcmaScriptConverter();
+  WTF_EXPORT_PRIVATE static const DoubleToStringConverter& NODELETE EcmaScriptConverterWithTrailingPoint();
 
-  WTF_EXPORT_PRIVATE static const DoubleToStringConverter& CSSConverter();
+  WTF_EXPORT_PRIVATE static const DoubleToStringConverter& NODELETE CSSConverter();
 
   // Computes the shortest string of digits that correctly represent the input
   // number. Depending on decimal_in_shortest_low and decimal_in_shortest_high

--- a/Source/WTF/wtf/dtoa/fast-dtoa.cc
+++ b/Source/WTF/wtf/dtoa/fast-dtoa.cc
@@ -61,7 +61,7 @@ static constexpr int kMaximalTargetExponent = -32;
 // Output: returns true if the buffer is guaranteed to contain the closest
 //    representable number to the input.
 //  Modifies the generated digits in the buffer to approach (round towards) w.
-static bool RoundWeed(BufferReference<char> buffer,
+static bool NODELETE RoundWeed(BufferReference<char> buffer,
                       int length,
                       uint64_t distance_too_high_w,
                       uint64_t unsafe_interval,
@@ -181,7 +181,7 @@ static bool RoundWeed(BufferReference<char> buffer,
 // unambiguously determined.
 //
 // Precondition: rest < ten_kappa.
-static bool RoundWeedCounted(BufferReference<char> buffer,
+static bool NODELETE RoundWeedCounted(BufferReference<char> buffer,
                              int length,
                              uint64_t rest,
                              uint64_t ten_kappa,
@@ -240,7 +240,7 @@ static constexpr std::array<unsigned, 11> kSmallPowersOfTen {
     0, 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000
 };
 
-static void BiggestPowerTen(uint32_t number,
+static void NODELETE BiggestPowerTen(uint32_t number,
                             int number_bits,
                             uint32_t& power,
                             int& exponent_plus_one) {
@@ -300,7 +300,7 @@ static void BiggestPowerTen(uint32_t number,
 // represent 'w' we can stop. Everything inside the interval low - high
 // represents w. However we have to pay attention to low, high and w's
 // imprecision.
-static bool DigitGen(DiyFp low,
+static bool NODELETE DigitGen(DiyFp low,
                      DiyFp w,
                      DiyFp high,
                      BufferReference<char> buffer,
@@ -427,7 +427,7 @@ static bool DigitGen(DiyFp low,
 //   numbers. If the precision is not enough to guarantee all the postconditions
 //   then false is returned. This usually happens rarely, but the failure-rate
 //   increases with higher requested_digits.
-static bool DigitGenCounted(DiyFp w,
+static bool NODELETE DigitGenCounted(DiyFp w,
                             int requested_digits,
                             BufferReference<char> buffer,
                             int& length,

--- a/Source/WTF/wtf/dtoa/fixed-dtoa.cc
+++ b/Source/WTF/wtf/dtoa/fixed-dtoa.cc
@@ -42,7 +42,7 @@ class UInt128 {
   UInt128() : high_bits_(0), low_bits_(0) { }
   UInt128(uint64_t high, uint64_t low) : high_bits_(high), low_bits_(low) { }
 
-  void Multiply(uint32_t multiplicand) {
+  void NODELETE Multiply(uint32_t multiplicand) {
     uint64_t accumulator;
 
     accumulator = (low_bits_ & kMask32) * multiplicand;
@@ -59,7 +59,7 @@ class UInt128 {
     ASSERT((accumulator >> 32) == 0);
   }
 
-  void Shift(int shift_amount) {
+  void NODELETE Shift(int shift_amount) {
     ASSERT(-64 <= shift_amount && shift_amount <= 64);
     if (shift_amount == 0) {
       return;
@@ -82,7 +82,7 @@ class UInt128 {
 
   // Modifies *this to *this MOD (2^power).
   // Returns *this DIV (2^power).
-  int DivModPowerOf2(int power) {
+  int NODELETE DivModPowerOf2(int power) {
     if (power >= 64) {
       int result = static_cast<int>(high_bits_ >> (power - 64));
       high_bits_ -= static_cast<uint64_t>(result) << (power - 64);
@@ -97,11 +97,11 @@ class UInt128 {
     }
   }
 
-  bool IsZero() const {
+  bool NODELETE IsZero() const {
     return high_bits_ == 0 && low_bits_ == 0;
   }
 
-  int BitAt(int position) const {
+  int NODELETE BitAt(int position) const {
     if (position >= 64) {
       return static_cast<int>(high_bits_ >> (position - 64)) & 1;
     } else {
@@ -120,7 +120,7 @@ class UInt128 {
 static const int kDoubleSignificandSize = 53;  // Includes the hidden bit.
 
 
-static void FillDigits32FixedLength(uint32_t number, int requested_length, BufferReference<char> buffer, int& length)
+static void NODELETE FillDigits32FixedLength(uint32_t number, int requested_length, BufferReference<char> buffer, int& length)
 {
   for (int i = requested_length - 1; i >= 0; --i) {
     buffer[length + i] = '0' + number % 10;
@@ -130,7 +130,7 @@ static void FillDigits32FixedLength(uint32_t number, int requested_length, Buffe
 }
 
 
-static void FillDigits32(uint32_t number, BufferReference<char> buffer, int& length)
+static void NODELETE FillDigits32(uint32_t number, BufferReference<char> buffer, int& length)
 {
   int number_length = 0;
   // We fill the digits in reverse order and exchange them afterwards.
@@ -154,7 +154,7 @@ static void FillDigits32(uint32_t number, BufferReference<char> buffer, int& len
 }
 
 
-static void FillDigits64FixedLength(uint64_t number, BufferReference<char> buffer, int& length)
+static void NODELETE FillDigits64FixedLength(uint64_t number, BufferReference<char> buffer, int& length)
 {
   const uint32_t kTen7 = 10000000;
   // For efficiency cut the number into 3 uint32_t parts, and print those.
@@ -169,7 +169,7 @@ static void FillDigits64FixedLength(uint64_t number, BufferReference<char> buffe
 }
 
 
-static void FillDigits64(uint64_t number, BufferReference<char> buffer, int& length)
+static void NODELETE FillDigits64(uint64_t number, BufferReference<char> buffer, int& length)
 {
   const uint32_t kTen7 = 10000000;
   // For efficiency cut the number into 3 uint32_t parts, and print those.
@@ -191,7 +191,7 @@ static void FillDigits64(uint64_t number, BufferReference<char> buffer, int& len
 }
 
 
-static void RoundUp(BufferReference<char> buffer, int& length, int& decimal_point) {
+static void NODELETE RoundUp(BufferReference<char> buffer, int& length, int& decimal_point) {
   // An empty buffer represents 0.
   if (length == 0) {
     buffer[0] = '1';
@@ -232,7 +232,7 @@ static void RoundUp(BufferReference<char> buffer, int& length, int& decimal_poin
 // might be updated. If this function generates the digits 99 and the buffer
 // already contained "199" (thus yielding a buffer of "19999") then a
 // rounding-up will change the contents of the buffer to "20000".
-static void FillFractionals(uint64_t fractionals, int exponent,
+static void NODELETE FillFractionals(uint64_t fractionals, int exponent,
                             int fractional_count, BufferReference<char> buffer,
                             int& length, int& decimal_point) {
   ASSERT(-128 <= exponent && exponent <= 0);
@@ -290,7 +290,7 @@ static void FillFractionals(uint64_t fractionals, int exponent,
 
 // Removes leading and trailing zeros.
 // If leading zeros are removed then the decimal point position is adjusted.
-static void TrimZeros(BufferReference<char> buffer, int& length, int& decimal_point) {
+static void NODELETE TrimZeros(BufferReference<char> buffer, int& length, int& decimal_point) {
   while (length > 0 && buffer[length - 1] == '0') {
     length--;
   }

--- a/Source/WTF/wtf/dtoa/strtod.cc
+++ b/Source/WTF/wtf/dtoa/strtod.cc
@@ -95,7 +95,7 @@ static constexpr int kExactPowersOfTenSize = exact_powers_of_ten.size();
 // we round up to 780.
 static constexpr int kMaxSignificantDecimalDigits = 780;
 
-static BufferReference<const char> TrimLeadingZeros(BufferReference<const char> buffer) {
+static BufferReference<const char> NODELETE TrimLeadingZeros(BufferReference<const char> buffer) {
   for (size_t i = 0; i < buffer.length(); ++i) {
     if (buffer[i] != '0') {
       return buffer.SubBufferReference(i, buffer.length());
@@ -105,7 +105,7 @@ static BufferReference<const char> TrimLeadingZeros(BufferReference<const char> 
 }
 
 
-static BufferReference<const char> TrimTrailingZeros(BufferReference<const char> buffer) {
+static BufferReference<const char> NODELETE TrimTrailingZeros(BufferReference<const char> buffer) {
   for (int i = buffer.length() - 1; i >= 0; --i) {
     if (buffer[i] != '0') {
       return buffer.SubBufferReference(0, i + 1);
@@ -115,7 +115,7 @@ static BufferReference<const char> TrimTrailingZeros(BufferReference<const char>
 }
 
 
-static void CutToMaxSignificantDigits(BufferReference<const char> buffer,
+static void NODELETE CutToMaxSignificantDigits(BufferReference<const char> buffer,
                                        int exponent,
                                        std::span<char> significant_buffer,
                                        int& significant_exponent) {
@@ -136,7 +136,7 @@ static void CutToMaxSignificantDigits(BufferReference<const char> buffer,
 // If possible the input-buffer is reused, but if the buffer needs to be
 // modified (due to cutting), then the input needs to be copied into the
 // buffer_copy_space.
-static void TrimAndCut(BufferReference<const char> buffer, int exponent,
+static void NODELETE TrimAndCut(BufferReference<const char> buffer, int exponent,
                        std::span<char> buffer_copy_space, int space_size,
                        BufferReference<const char>& trimmed, int& updated_exponent) {
   BufferReference<const char> left_trimmed = TrimLeadingZeros(buffer);
@@ -159,7 +159,7 @@ static void TrimAndCut(BufferReference<const char> buffer, int exponent,
 // When the string starts with "1844674407370955161" no further digit is read.
 // Since 2^64 = 18446744073709551616 it would still be possible read another
 // digit if it was less or equal than 6, but this would complicate the code.
-static uint64_t ReadUint64(BufferReference<const char> buffer, size_t& number_of_read_digits) {
+static uint64_t NODELETE ReadUint64(BufferReference<const char> buffer, size_t& number_of_read_digits) {
   uint64_t result = 0;
   size_t i = 0;
   while (i < buffer.length() && result <= (kMaxUint64 / 10 - 1)) {
@@ -176,7 +176,7 @@ static uint64_t ReadUint64(BufferReference<const char> buffer, size_t& number_of
 // The returned DiyFp is not necessarily normalized.
 // If remaining_decimals is zero then the returned DiyFp is accurate.
 // Otherwise it has been rounded and has error of at most 1/2 ulp.
-static void ReadDiyFp(BufferReference<const char> buffer,
+static void NODELETE ReadDiyFp(BufferReference<const char> buffer,
                       DiyFp& result,
                       int& remaining_decimals) {
   size_t read_digits;
@@ -197,7 +197,7 @@ static void ReadDiyFp(BufferReference<const char> buffer,
 }
 
 
-static bool DoubleStrtod(BufferReference<const char> trimmed,
+static bool NODELETE DoubleStrtod(BufferReference<const char> trimmed,
                          int exponent,
                          double& result) {
 #if !defined(DOUBLE_CONVERSION_CORRECT_DOUBLE_OPERATIONS)

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -265,7 +265,7 @@ dispatch_qos_class_t Thread::dispatchQOSClass(QOS qos)
 #endif
 
 #if HAVE(SCHEDULING_POLICIES) || OS(LINUX)
-static int schedPolicy(Thread::SchedulingPolicy schedulingPolicy)
+static int NODELETE schedPolicy(Thread::SchedulingPolicy schedulingPolicy)
 {
     switch (schedulingPolicy) {
     case Thread::SchedulingPolicy::FIFO:
@@ -530,7 +530,7 @@ struct ThreadStateMetadata {
     thread_state_flavor_t flavor;
 };
 
-static ThreadStateMetadata threadStateMetadata()
+static ThreadStateMetadata NODELETE threadStateMetadata()
 {
 #if CPU(X86)
     unsigned userCount = sizeof(PlatformRegisters) / sizeof(int);

--- a/Source/WTF/wtf/text/AtomStringImpl.cpp
+++ b/Source/WTF/wtf/text/AtomStringImpl.cpp
@@ -90,7 +90,7 @@ static inline Ref<AtomStringImpl> addToStringTable(const T& value)
 
 using UTF16Buffer = HashTranslatorCharBuffer<char16_t>;
 struct UTF16BufferTranslator {
-    static unsigned hash(const UTF16Buffer& buf)
+    static unsigned NODELETE hash(const UTF16Buffer& buf)
     {
         return buf.hash;
     }
@@ -115,7 +115,7 @@ struct HashedUTF8Characters {
 };
 
 struct HashedUTF8CharactersTranslator {
-    static unsigned hash(const HashedUTF8Characters& characters)
+    static unsigned NODELETE hash(const HashedUTF8Characters& characters)
     {
         return characters.length.hash;
     }
@@ -244,7 +244,7 @@ RefPtr<AtomStringImpl> AtomStringImpl::add(StringImpl* baseString, unsigned star
     
 using Latin1Buffer = HashTranslatorCharBuffer<Latin1Character>;
 struct Latin1BufferTranslator {
-    static unsigned hash(const Latin1Buffer& buf)
+    static unsigned NODELETE hash(const Latin1Buffer& buf)
     {
         return buf.hash;
     }

--- a/Source/WTF/wtf/text/Base64.cpp
+++ b/Source/WTF/wtf/text/Base64.cpp
@@ -97,7 +97,7 @@ static constexpr std::array<char, decodeMapSize> base64URLDecMap {
     0x31, 0x32, 0x33, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet, nonAlphabet
 };
 
-static inline simdutf::base64_options toSIMDUTFEncodeOptions(OptionSet<Base64EncodeOption> options)
+static inline simdutf::base64_options NODELETE toSIMDUTFEncodeOptions(OptionSet<Base64EncodeOption> options)
 {
     if (options.contains(Base64EncodeOption::URL)) {
         if (options.contains(Base64EncodeOption::OmitPadding))
@@ -313,7 +313,7 @@ String base64DecodeToString(StringView input, OptionSet<Base64DecodeOption> opti
     return toString(base64DecodeInternal<char16_t, StringImplMalloc>(input.span16(), options));
 }
 
-static inline simdutf::base64_options toSIMDUTFDecodeOptions(Alphabet alphabet)
+static inline simdutf::base64_options NODELETE toSIMDUTFDecodeOptions(Alphabet alphabet)
 {
     switch (alphabet) {
     case Alphabet::Base64:
@@ -324,7 +324,7 @@ static inline simdutf::base64_options toSIMDUTFDecodeOptions(Alphabet alphabet)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static inline simdutf::last_chunk_handling_options toSIMDUTFLastChunkHandling(LastChunkHandling lastChunkHandling)
+static inline simdutf::last_chunk_handling_options NODELETE toSIMDUTFLastChunkHandling(LastChunkHandling lastChunkHandling)
 {
     switch (lastChunkHandling) {
     case LastChunkHandling::Loose:

--- a/Source/WTF/wtf/text/Base64.h
+++ b/Source/WTF/wtf/text/Base64.h
@@ -57,7 +57,7 @@ WTF_EXPORT_PRIVATE unsigned calculateBase64EncodedSize(unsigned inputLength, Opt
 
 template<typename CharacterType> bool isBase64OrBase64URLCharacter(CharacterType);
 
-WTF_EXPORT_PRIVATE void base64Encode(std::span<const std::byte>, std::span<char16_t>, OptionSet<Base64EncodeOption> = { });
+WTF_EXPORT_PRIVATE void NODELETE base64Encode(std::span<const std::byte>, std::span<char16_t>, OptionSet<Base64EncodeOption> = { });
 WTF_EXPORT_PRIVATE void base64Encode(std::span<const std::byte>, std::span<Latin1Character>, OptionSet<Base64EncodeOption> = { });
 
 WTF_EXPORT_PRIVATE Vector<uint8_t> base64EncodeToVector(std::span<const std::byte>, OptionSet<Base64EncodeOption> = { });

--- a/Source/WTF/wtf/text/StringBuilder.cpp
+++ b/Source/WTF/wtf/text/StringBuilder.cpp
@@ -176,7 +176,7 @@ void StringBuilder::append(std::span<const Latin1Character> characters)
     }
 }
 
-bool StringBuilder::shouldShrinkToFit() const
+bool NODELETE StringBuilder::shouldShrinkToFit() const
 {
     // Shrink the buffer if it's 80% full or less.
     static_assert(static_cast<size_t>(String::MaxLength) + (String::MaxLength >> 2) <= static_cast<size_t>(std::numeric_limits<unsigned>::max()));

--- a/Source/WTF/wtf/text/StringBuilder.h
+++ b/Source/WTF/wtf/text/StringBuilder.h
@@ -47,7 +47,7 @@ public:
     void clear();
     void swap(StringBuilder&);
 
-    void didOverflow();
+    void NODELETE didOverflow();
     bool hasOverflowed() const { return m_length > String::MaxLength; }
     bool crashesOnOverflow() const { return m_shouldCrashOnOverflow; }
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -379,7 +379,7 @@ Ref<StringImpl> StringImpl::substring(unsigned start, unsigned length)
     return create(span16().subspan(start, length));
 }
 
-char32_t StringImpl::characterStartingAt(unsigned i)
+char32_t NODELETE StringImpl::characterStartingAt(unsigned i)
 {
     if (is8Bit())
         return span8()[i];
@@ -595,7 +595,7 @@ Ref<StringImpl> StringImpl::convertToUppercaseWithoutLocaleUpconvert()
     return newImpl;
 }
 
-static inline bool needsTurkishCasingRules(const AtomString& locale)
+static inline bool NODELETE needsTurkishCasingRules(const AtomString& locale)
 {
     // Either "tr" or "az" locale, with ASCII case insensitive comparison and allowing for an ignored subtag.
     char16_t first = locale[0];
@@ -605,14 +605,14 @@ static inline bool needsTurkishCasingRules(const AtomString& locale)
         && (locale.length() == 2 || locale[2] == '-');
 }
 
-static inline bool needsGreekUppercasingRules(const AtomString& locale)
+static inline bool NODELETE needsGreekUppercasingRules(const AtomString& locale)
 {
     // The "el" locale, with ASCII case insensitive comparison and allowing for an ignored subtag.
     return isASCIIAlphaCaselessEqual(locale[0], 'e') && isASCIIAlphaCaselessEqual(locale[1], 'l')
         && (locale.length() == 2 || locale[2] == '-');
 }
 
-static inline bool needsLithuanianCasingRules(const AtomString& locale)
+static inline bool NODELETE needsLithuanianCasingRules(const AtomString& locale)
 {
     // The "lt" locale, with ASCII case insensitive comparison and allowing for an ignored subtag.
     return isASCIIAlphaCaselessEqual(locale[0], 'l') && isASCIIAlphaCaselessEqual(locale[1], 't')
@@ -1096,7 +1096,7 @@ bool StringImpl::startsWithIgnoringASCIICase(StringView prefix) const
     return prefix && ::WTF::startsWithIgnoringASCIICase(*this, prefix);
 }
 
-bool StringImpl::startsWith(char16_t character) const
+bool NODELETE StringImpl::startsWith(char16_t character) const
 {
     return m_length && (*this)[0] == character;
 }
@@ -1121,7 +1121,7 @@ bool StringImpl::endsWithIgnoringASCIICase(StringView suffix) const
     return suffix && ::WTF::endsWithIgnoringASCIICase(*this, suffix);
 }
 
-bool StringImpl::endsWith(char16_t character) const
+bool NODELETE StringImpl::endsWith(char16_t character) const
 {
     return m_length && (*this)[m_length - 1] == character;
 }
@@ -1528,7 +1528,7 @@ bool equalIgnoringASCIICase(const StringImpl* a, const StringImpl* b)
     return a == b || (a && b && equalIgnoringASCIICase(*a, *b));
 }
 
-bool equalIgnoringASCIICaseNonNull(const StringImpl* a, const StringImpl* b)
+bool NODELETE equalIgnoringASCIICaseNonNull(const StringImpl* a, const StringImpl* b)
 {
     ASSERT(a);
     ASSERT(b);
@@ -1562,7 +1562,7 @@ Ref<StringImpl> StringImpl::adopt(StringBuffer<char16_t>&& buffer)
     return adoptRef(*new StringImpl(buffer.release()));
 }
 
-size_t StringImpl::sizeInBytes() const
+size_t NODELETE StringImpl::sizeInBytes() const
 {
     // FIXME: support substrings
     size_t size = length();

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -631,7 +631,7 @@ WTF_EXPORT_PRIVATE bool equal(const StringImpl& a, const StringImpl& b);
 WTF_EXPORT_PRIVATE bool equalIgnoringNullity(StringImpl*, StringImpl*);
 WTF_EXPORT_PRIVATE bool equalIgnoringNullity(std::span<const char16_t>, StringImpl*);
 
-bool equalIgnoringASCIICase(const StringImpl&, const StringImpl&);
+bool NODELETE equalIgnoringASCIICase(const StringImpl&, const StringImpl&);
 WTF_EXPORT_PRIVATE bool NODELETE equalIgnoringASCIICase(const StringImpl*, const StringImpl*);
 bool equalIgnoringASCIICase(const StringImpl&, ASCIILiteral);
 bool equalIgnoringASCIICase(const StringImpl*, ASCIILiteral);

--- a/Source/WTF/wtf/text/StringView.h
+++ b/Source/WTF/wtf/text/StringView.h
@@ -176,7 +176,7 @@ public:
     WTF_EXPORT_PRIVATE String convertToASCIIUppercase() const;
     WTF_EXPORT_PRIVATE AtomString convertToASCIILowercaseAtom() const;
 
-    WTF_EXPORT_PRIVATE std::optional<char32_t> convertToSingleCodePoint() const;
+    WTF_EXPORT_PRIVATE std::optional<char32_t> NODELETE convertToSingleCodePoint() const;
 
     bool contains(char16_t) const;
     template<typename CodeUnitMatchFunction>
@@ -229,8 +229,8 @@ private:
     template<typename CharacterType, typename MatchedCharacterPredicate>
     StringView trim(std::span<const CharacterType>, const MatchedCharacterPredicate&) const;
 
-    WTF_EXPORT_PRIVATE bool underlyingStringIsValidImpl() const;
-    WTF_EXPORT_PRIVATE void setUnderlyingStringImpl(const StringImpl*);
+    WTF_EXPORT_PRIVATE bool NODELETE underlyingStringIsValidImpl() const;
+    WTF_EXPORT_PRIVATE void NODELETE setUnderlyingStringImpl(const StringImpl*);
     WTF_EXPORT_PRIVATE void setUnderlyingStringImpl(const StringView&);
 
 #if CHECK_STRINGVIEW_LIFETIME
@@ -1287,7 +1287,7 @@ inline bool startsWith(StringView reference, StringView prefix)
     return equal(reference.span16().data(), prefix.span16());
 }
 
-inline bool startsWithIgnoringASCIICase(StringView reference, StringView prefix)
+inline bool NODELETE startsWithIgnoringASCIICase(StringView reference, StringView prefix)
 {
     if (prefix.length() > reference.length())
         return false;
@@ -1321,7 +1321,7 @@ inline bool endsWith(StringView reference, StringView suffix)
     return equal(reference.span16().subspan(startOffset).data(), suffix.span16());
 }
 
-inline bool endsWithIgnoringASCIICase(StringView reference, StringView suffix)
+inline bool NODELETE endsWithIgnoringASCIICase(StringView reference, StringView suffix)
 {
     unsigned suffixLength = suffix.length();
     unsigned referenceLength = reference.length();

--- a/Source/WTF/wtf/text/SymbolImpl.h
+++ b/Source/WTF/wtf/text/SymbolImpl.h
@@ -72,7 +72,7 @@ public:
     };
 
 protected:
-    WTF_EXPORT_PRIVATE static unsigned nextHashForSymbol();
+    WTF_EXPORT_PRIVATE static unsigned NODELETE nextHashForSymbol();
 
     friend class StringImpl;
 

--- a/Source/WTF/wtf/text/SymbolRegistry.cpp
+++ b/Source/WTF/wtf/text/SymbolRegistry.cpp
@@ -61,7 +61,7 @@ Ref<RegisteredSymbolImpl> SymbolRegistry::symbolForKey(const String& rep)
 // When removing a registered symbol from the table, we know it's already the one in the table, so no need for a string equality check.
 struct SymbolRegistryTableRemovalHashTranslator {
     static unsigned hash(const RegisteredSymbolImpl* key) { return key->hash(); }
-    static bool equal(const RefPtr<StringImpl>& a, const RegisteredSymbolImpl* b) { return a == b; }
+    static bool NODELETE equal(const RefPtr<StringImpl>& a, const RegisteredSymbolImpl* b) { return a == b; }
 };
 
 void SymbolRegistry::remove(RegisteredSymbolImpl& uid)

--- a/Source/WTF/wtf/text/TextBreakIterator.h
+++ b/Source/WTF/wtf/text/TextBreakIterator.h
@@ -144,7 +144,7 @@ private:
     friend class NeverDestroyed<TextBreakIteratorCache>;
     friend class CachedTextBreakIterator;
 
-    WTF_EXPORT_PRIVATE static TextBreakIteratorCache& singleton();
+    WTF_EXPORT_PRIVATE static TextBreakIteratorCache& NODELETE singleton();
 
     TextBreakIteratorCache(const TextBreakIteratorCache&) = delete;
     TextBreakIteratorCache(TextBreakIteratorCache&&) = delete;

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -131,7 +131,7 @@ public:
     char16_t characterAt(unsigned index) const;
     char16_t operator[](unsigned index) const { return characterAt(index); }
 
-    WTF_EXPORT_PRIVATE static String number(int);
+    WTF_EXPORT_PRIVATE static String NODELETE number(int);
     WTF_EXPORT_PRIVATE static String number(unsigned);
     WTF_EXPORT_PRIVATE static String number(long);
     WTF_EXPORT_PRIVATE static String number(unsigned long);
@@ -234,7 +234,7 @@ public:
     [[nodiscard]] WTF_EXPORT_PRIVATE String isolatedCopy() const &;
     [[nodiscard]] WTF_EXPORT_PRIVATE String isolatedCopy() &&;
 
-    WTF_EXPORT_PRIVATE bool isSafeToSendToAnotherThread() const;
+    WTF_EXPORT_PRIVATE bool NODELETE isSafeToSendToAnotherThread() const;
 
     // Prevent Strings from being implicitly convertable to bool as it will be ambiguous on any platform that
     // allows implicit conversion to another pointer type (e.g., Mac allows implicit conversion to NSString *).

--- a/Source/WTF/wtf/text/cf/StringImplCF.cpp
+++ b/Source/WTF/wtf/text/cf/StringImplCF.cpp
@@ -37,7 +37,7 @@ namespace StringWrapperCFAllocator {
     DECLARE_ALLOCATOR_WITH_HEAP_IDENTIFIER_AND_EXPORT(StringWrapperCFAllocator, WTF_INTERNAL);
     DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(StringWrapperCFAllocator);
 
-    static RefPtr<StringImpl>& currentString()
+    static RefPtr<StringImpl>& NODELETE currentString()
     {
         static NeverDestroyed<RefPtr<StringImpl>> currentString;
         return currentString;
@@ -47,18 +47,18 @@ namespace StringWrapperCFAllocator {
         RefPtr<StringImpl> m_stringImpl;
     };
 
-    static const void* retain(const void* info)
+    static const void* NODELETE retain(const void* info)
     {
         return info;
     }
 
     NO_RETURN_DUE_TO_ASSERT
-    static void release(const void*)
+    static void NODELETE release(const void*)
     {
         ASSERT_NOT_REACHED();
     }
 
-    static CFStringRef copyDescription(const void*)
+    static CFStringRef NODELETE copyDescription(const void*)
     {
         return CFSTR("WTF::String-based allocator");
     }
@@ -93,7 +93,7 @@ namespace StringWrapperCFAllocator {
         }
     }
 
-    static CFIndex preferredSize(CFIndex size, CFOptionFlags, void*)
+    static CFIndex NODELETE preferredSize(CFIndex size, CFOptionFlags, void*)
     {
         // FIXME: If FastMalloc provided a "good size" callback, we'd want to use it here.
         // Note that this optimization would help performance for strings created with the

--- a/Source/WTF/wtf/text/icu/UTextProvider.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProvider.cpp
@@ -33,7 +33,7 @@ namespace WTF {
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 // Relocate pointer from source into destination as required.
-static inline void fixPointer(const UText* source, UText* destination, const void*& pointer)
+static inline void NODELETE fixPointer(const UText* source, UText* destination, const void*& pointer)
 {
     if (pointer >= source->pExtra && pointer < static_cast<char*>(source->pExtra) + source->extraSize) {
         // Pointer references source extra buffer.

--- a/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp
@@ -32,12 +32,12 @@
 
 namespace WTF {
 
-static std::span<const Latin1Character> latin1ContextSpan(UText* uText)
+static std::span<const Latin1Character> NODELETE latin1ContextSpan(UText* uText)
 {
     return unsafeMakeSpan(static_cast<const Latin1Character*>(uText->context), uText->a);
 }
 
-static std::span<char16_t> chunkSpan(UText* uText)
+static std::span<char16_t> NODELETE chunkSpan(UText* uText)
 {
     return unsafeMakeSpan(const_cast<char16_t*>(uText->chunkContents), uText->chunkLength);
 }
@@ -100,7 +100,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return result;
 }
 
-static int64_t uTextLatin1NativeLength(UText* uText)
+static int64_t NODELETE uTextLatin1NativeLength(UText* uText)
 {
     return uText->a;
 }
@@ -206,19 +206,19 @@ static int32_t uTextLatin1Extract(UText* uText, int64_t start, int64_t limit, ch
     return static_cast<int32_t>(length);
 }
 
-static int64_t uTextLatin1MapOffsetToNative(const UText* uText)
+static int64_t NODELETE uTextLatin1MapOffsetToNative(const UText* uText)
 {
     return uText->chunkNativeStart + uText->chunkOffset;
 }
 
-static int32_t uTextLatin1MapNativeIndexToUTF16(const UText* uText, int64_t nativeIndex)
+static int32_t NODELETE uTextLatin1MapNativeIndexToUTF16(const UText* uText, int64_t nativeIndex)
 {
     ASSERT_UNUSED(uText, uText->chunkNativeStart >= nativeIndex);
     ASSERT_UNUSED(uText, nativeIndex < uText->chunkNativeLimit);
     return static_cast<int32_t>(nativeIndex);
 }
 
-static void uTextLatin1Close(UText* uText)
+static void NODELETE uTextLatin1Close(UText* uText)
 {
     uText->context = nullptr;
 }
@@ -276,7 +276,7 @@ static const struct UTextFuncs textLatin1ContextAwareFuncs = {
     nullptr
 };
 
-static inline UTextProviderContext textLatin1ContextAwareGetCurrentContext(const UText* text)
+static inline UTextProviderContext NODELETE textLatin1ContextAwareGetCurrentContext(const UText* text)
 {
     if (!text->chunkContents)
         return UTextProviderContext::NoContext;
@@ -344,7 +344,7 @@ static UText* uTextLatin1ContextAwareClone(UText* destination, const UText* sour
     return uTextCloneImpl(destination, source, deep, status);
 }
 
-static int64_t uTextLatin1ContextAwareNativeLength(UText* text)
+static int64_t NODELETE uTextLatin1ContextAwareNativeLength(UText* text)
 {
     return text->a + text->b;
 }
@@ -375,7 +375,7 @@ static UBool uTextLatin1ContextAwareAccess(UText* text, int64_t nativeIndex, UBo
     return true;
 }
 
-static int32_t uTextLatin1ContextAwareExtract(UText*, int64_t, int64_t, char16_t*, int32_t, UErrorCode* errorCode)
+static int32_t NODELETE uTextLatin1ContextAwareExtract(UText*, int64_t, int64_t, char16_t*, int32_t, UErrorCode* errorCode)
 {
     // In the present context, this text provider is used only with ICU functions
     // that do not perform an extract operation.
@@ -384,7 +384,7 @@ static int32_t uTextLatin1ContextAwareExtract(UText*, int64_t, int64_t, char16_t
     return 0;
 }
 
-static void uTextLatin1ContextAwareClose(UText* text)
+static void NODELETE uTextLatin1ContextAwareClose(UText* text)
 {
     text->context = nullptr;
 }

--- a/Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp
+++ b/Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp
@@ -58,7 +58,7 @@ static const struct UTextFuncs textUTF16ContextAwareFuncs = {
     nullptr
 };
 
-static inline UTextProviderContext textUTF16ContextAwareGetCurrentContext(const UText* text)
+static inline UTextProviderContext NODELETE textUTF16ContextAwareGetCurrentContext(const UText* text)
 {
     if (!text->chunkContents)
         return UTextProviderContext::NoContext;
@@ -117,7 +117,7 @@ static UText* uTextUTF16ContextAwareClone(UText* destination, const UText* sourc
     return uTextCloneImpl(destination, source, deep, status);
 }
 
-static inline int64_t uTextUTF16ContextAwareNativeLength(UText* text)
+static inline int64_t NODELETE uTextUTF16ContextAwareNativeLength(UText* text)
 {
     return text->a + text->b;
 }
@@ -148,7 +148,7 @@ static UBool uTextUTF16ContextAwareAccess(UText* text, int64_t nativeIndex, UBoo
     return true;
 }
 
-static int32_t uTextUTF16ContextAwareExtract(UText*, int64_t, int64_t, char16_t*, int32_t, UErrorCode* errorCode)
+static int32_t NODELETE uTextUTF16ContextAwareExtract(UText*, int64_t, int64_t, char16_t*, int32_t, UErrorCode* errorCode)
 {
     // In the present context, this text provider is used only with ICU functions
     // that do not perform an extract operation.
@@ -157,7 +157,7 @@ static int32_t uTextUTF16ContextAwareExtract(UText*, int64_t, int64_t, char16_t*
     return 0;
 }
 
-static void uTextUTF16ContextAwareClose(UText* text)
+static void NODELETE uTextUTF16ContextAwareClose(UText* text)
 {
     text->context = nullptr;
 }

--- a/Source/WTF/wtf/threads/Signals.cpp
+++ b/Source/WTF/wtf/threads/Signals.cpp
@@ -195,7 +195,7 @@ static void initMachExceptionHandlerThread()
     dispatch_resume(source);
 }
 
-static exception_mask_t toMachMask(Signal signal)
+static exception_mask_t NODELETE toMachMask(Signal signal)
 {
     switch (signal) {
     case Signal::AccessFault: return EXC_MASK_BAD_ACCESS;
@@ -207,7 +207,7 @@ static exception_mask_t toMachMask(Signal signal)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-static Signal fromMachException(exception_type_t type)
+static Signal NODELETE fromMachException(exception_type_t type)
 {
     switch (type) {
     case EXC_BAD_ACCESS: return Signal::AccessFault;
@@ -434,7 +434,7 @@ inline std::tuple<int, std::optional<int>> toSystemSignal(Signal signal)
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-inline Signal fromSystemSignal(int signal)
+inline Signal NODELETE fromSystemSignal(int signal)
 {
     switch (signal) {
     case SIGSEGV: return Signal::AccessFault;
@@ -450,7 +450,7 @@ inline Signal fromSystemSignal(int signal)
     }
 }
 
-inline size_t offsetForSystemSignal(int sig)
+inline size_t NODELETE offsetForSystemSignal(int sig)
 {
     Signal signal = fromSystemSignal(sig);
     return static_cast<size_t>(signal) + (sig == SIGBUS);

--- a/Source/WTF/wtf/threads/Signals.h
+++ b/Source/WTF/wtf/threads/Signals.h
@@ -84,7 +84,7 @@ using SignalHandler = Function<SignalAction(Signal, SigInfo&, PlatformRegisters&
 using SignalHandlerMemory = AlignedStorage<SignalHandler>;
 
 struct SignalHandlers {
-    static void initialize();
+    static void NODELETE initialize();
     static void finalize();
 
     void add(Signal, SignalHandler&&);

--- a/Source/WTF/wtf/unicode/UTF8Conversion.h
+++ b/Source/WTF/wtf/unicode/UTF8Conversion.h
@@ -45,12 +45,12 @@ template<typename CharacterType> struct ConversionResult {
     bool isAllASCII { };
 };
 
-WTF_EXPORT_PRIVATE ConversionResult<char16_t> convert(std::span<const char8_t>, std::span<char16_t>);
+WTF_EXPORT_PRIVATE ConversionResult<char16_t> NODELETE convert(std::span<const char8_t>, std::span<char16_t>);
 WTF_EXPORT_PRIVATE ConversionResult<char8_t> convert(std::span<const char16_t>, std::span<char8_t>);
 WTF_EXPORT_PRIVATE ConversionResult<char8_t> convert(std::span<const Latin1Character>, std::span<char8_t>);
 
 // Invalid sequences are converted to the replacement character.
-WTF_EXPORT_PRIVATE ConversionResult<char16_t> convertReplacingInvalidSequences(std::span<const char8_t>, std::span<char16_t>);
+WTF_EXPORT_PRIVATE ConversionResult<char16_t> NODELETE convertReplacingInvalidSequences(std::span<const char8_t>, std::span<char16_t>);
 WTF_EXPORT_PRIVATE ConversionResult<char8_t> convertReplacingInvalidSequences(std::span<const char16_t>, std::span<char8_t>);
 
 WTF_EXPORT_PRIVATE bool equal(std::span<const char16_t>, std::span<const char8_t>);

--- a/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
+++ b/Source/WTF/wtf/unicode/icu/CollatorICU.cpp
@@ -149,7 +149,7 @@ Collator::~Collator()
     cachedCollatorShouldSortLowercaseFirst = m_shouldSortLowercaseFirst;
 }
 
-static int32_t getIndexLatin1(UCharIterator* iterator, UCharIteratorOrigin origin)
+static int32_t NODELETE getIndexLatin1(UCharIterator* iterator, UCharIteratorOrigin origin)
 {
     switch (origin) {
     case UITER_START:
@@ -167,23 +167,23 @@ static int32_t getIndexLatin1(UCharIterator* iterator, UCharIteratorOrigin origi
     return U_SENTINEL;
 }
 
-static int32_t moveLatin1(UCharIterator* iterator, int32_t delta, UCharIteratorOrigin origin)
+static int32_t NODELETE moveLatin1(UCharIterator* iterator, int32_t delta, UCharIteratorOrigin origin)
 {
     return iterator->index = getIndexLatin1(iterator, origin) + delta;
 }
 
-static UBool hasNextLatin1(UCharIterator* iterator)
+static UBool NODELETE hasNextLatin1(UCharIterator* iterator)
 {
     return iterator->index < iterator->limit;
 }
 
-static UBool hasPreviousLatin1(UCharIterator* iterator)
+static UBool NODELETE hasPreviousLatin1(UCharIterator* iterator)
 {
     return iterator->index > iterator->start;
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-static UChar32 currentLatin1(UCharIterator* iterator)
+static UChar32 NODELETE currentLatin1(UCharIterator* iterator)
 {
     ASSERT(iterator->index >= iterator->start);
     if (iterator->index >= iterator->limit)
@@ -191,7 +191,7 @@ static UChar32 currentLatin1(UCharIterator* iterator)
     return static_cast<const Latin1Character*>(iterator->context)[iterator->index];
 }
 
-static UChar32 nextLatin1(UCharIterator* iterator)
+static UChar32 NODELETE nextLatin1(UCharIterator* iterator)
 {
     ASSERT(iterator->index >= iterator->start);
     if (iterator->index >= iterator->limit)
@@ -199,7 +199,7 @@ static UChar32 nextLatin1(UCharIterator* iterator)
     return static_cast<const Latin1Character*>(iterator->context)[iterator->index++];
 }
 
-static UChar32 previousLatin1(UCharIterator* iterator)
+static UChar32 NODELETE previousLatin1(UCharIterator* iterator)
 {
     if (iterator->index <= iterator->start)
         return U_SENTINEL;
@@ -207,17 +207,17 @@ static UChar32 previousLatin1(UCharIterator* iterator)
 }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-static uint32_t getStateLatin1(const UCharIterator* iterator)
+static uint32_t NODELETE getStateLatin1(const UCharIterator* iterator)
 {
     return iterator->index;
 }
 
-static void setStateLatin1(UCharIterator* iterator, uint32_t state, UErrorCode*)
+static void NODELETE setStateLatin1(UCharIterator* iterator, uint32_t state, UErrorCode*)
 {
     iterator->index = state;
 }
 
-static UCharIterator createLatin1Iterator(std::span<const Latin1Character> characters)
+static UCharIterator NODELETE createLatin1Iterator(std::span<const Latin1Character> characters)
 {
     UCharIterator iterator;
     iterator.context = characters.data();


### PR DESCRIPTION
#### 19bf18b1d9d0075cb947f59139f0660351141401
<pre>
Adopt `NODELETE` annotation in more places in WTF/
<a href="https://bugs.webkit.org/show_bug.cgi?id=308194">https://bugs.webkit.org/show_bug.cgi?id=308194</a>

Reviewed by Anne van Kesteren and Ryosuke Niwa.

* Source/WTF/wtf/Assertions.cpp:
* Source/WTF/wtf/Assertions.h:
* Source/WTF/wtf/AutomaticThread.h:
* Source/WTF/wtf/CPUTime.h:
* Source/WTF/wtf/CryptographicallyRandomNumber.cpp:
* Source/WTF/wtf/DateMath.cpp:
(WTF::WTF_REQUIRES_LOCK):
(WTF::maximumYearForDST):
(WTF::skipSpacesAndComments):
* Source/WTF/wtf/FastBitVector.h:
* Source/WTF/wtf/FastMalloc.h:
* Source/WTF/wtf/FileSystem.cpp:
(WTF::FileSystemImpl::shouldEscapeChar16):
* Source/WTF/wtf/FileSystem.h:
* Source/WTF/wtf/HexNumber.cpp:
(WTF::Internal::hexDigitsForMode):
* Source/WTF/wtf/Int128.cpp:
* Source/WTF/wtf/JSONValues.h:
* Source/WTF/wtf/Language.cpp:
(WTF::WTF_REQUIRES_LOCK):
(WTF::observerMap):
* Source/WTF/wtf/LogInitialization.h:
* Source/WTF/wtf/Logger.h:
* Source/WTF/wtf/MachSendRight.h:
* Source/WTF/wtf/MainThread.h:
* Source/WTF/wtf/MainThreadDispatcher.h:
* Source/WTF/wtf/MediaTime.cpp:
(WTF::greatestCommonDivisor):
(WTF::leastCommonMultiple):
(WTF::signum):
* Source/WTF/wtf/MediaTime.h:
* Source/WTF/wtf/MemoryPressureHandler.h:
* Source/WTF/wtf/MetaAllocator.h:
* Source/WTF/wtf/NativePromise.h:
* Source/WTF/wtf/ObjectIdentifier.h:
* Source/WTF/wtf/ParallelHelperPool.cpp:
* Source/WTF/wtf/ParallelHelperPool.h:
* Source/WTF/wtf/ParkingLot.cpp:
* Source/WTF/wtf/PrintStream.h:
* Source/WTF/wtf/RefCountDebugger.cpp:
(WTF::RefLogStackShot::ptr):
* Source/WTF/wtf/RunLoop.cpp:
(WTF::RunLoop::Holder::runLoop):
* Source/WTF/wtf/RunLoop.h:
* Source/WTF/wtf/RuntimeApplicationChecks.cpp:
(WTF::presentingApplicationPIDOverride):
(WTF::auxiliaryProcessType):
* Source/WTF/wtf/RuntimeApplicationChecks.h:
* Source/WTF/wtf/SixCharacterHash.h:
* Source/WTF/wtf/StringPrintStream.h:
* Source/WTF/wtf/Threading.cpp:
(WTF::stackSize):
(WTF::shouldRemoveThreadFromThreadGroup):
(WTF::toQOS):
* Source/WTF/wtf/Threading.h:
* Source/WTF/wtf/TimeWithDynamicClockType.h:
* Source/WTF/wtf/URL.cpp:
(WTF::shouldTrimFromURL):
(WTF::decodeEscapeSequence):
(WTF::assertProtocolIsGood):
(WTF::WTF_REQUIRES_LOCK):
(WTF::forwardSlashHashOrQuestionMark):
(WTF::slashHashOrQuestionMark):
(WTF::countASCIIDigits):
* Source/WTF/wtf/URL.h:
* Source/WTF/wtf/URLHelpers.cpp:
(WTF::URLHelpers::isRussianDomainNameCharacter):
* Source/WTF/wtf/URLParser.cpp:
(WTF::zeroSequenceLength):
(WTF::findLongestZeroSequence):
* Source/WTF/wtf/URLParser.h:
* Source/WTF/wtf/UUID.cpp:
(WTF::convertRandomUInt128ToUUIDVersion4):
* Source/WTF/wtf/UUID.h:
* Source/WTF/wtf/WTFConfig.h:
* Source/WTF/wtf/WorkQueue.h:
* Source/WTF/wtf/WorkerPool.cpp:
* Source/WTF/wtf/cocoa/FileSystemCocoa.mm:
(WTF::FileSystemImpl::toIOPolicyScope):
* Source/WTF/wtf/cocoa/MemoryPressureHandlerCocoa.mm:
(WTF::memoryPressureEventSource):
(WTF::timerEventSource):
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.h:
* Source/WTF/wtf/cocoa/RuntimeApplicationChecksCocoa.mm:
(WTF::disableAdditionalSDKAlignedBehaviors):
(WTF::sdkAlignedBehaviorsValue):
(WTF::processIsExtensionValue):
(WTF::bundleIdentifierOverride):
(WTF::bundleIdentifier):
* Source/WTF/wtf/darwin/LibraryPathDiagnostics.mm:
(WTF::isAddressInSharedRegion):
* Source/WTF/wtf/dtoa/bignum-dtoa.cc:
* Source/WTF/wtf/dtoa/bignum.cc:
* Source/WTF/wtf/dtoa/bignum.h:
* Source/WTF/wtf/dtoa/cached-powers.h:
* Source/WTF/wtf/dtoa/diy-fp.h:
* Source/WTF/wtf/dtoa/double-conversion.cc:
* Source/WTF/wtf/dtoa/double-conversion.h:
* Source/WTF/wtf/dtoa/fast-dtoa.cc:
* Source/WTF/wtf/dtoa/fixed-dtoa.cc:
* Source/WTF/wtf/dtoa/strtod.cc:
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(WTF::schedPolicy):
(WTF::threadStateMetadata):
* Source/WTF/wtf/text/AtomStringImpl.cpp:
(WTF::UTF16BufferTranslator::hash):
(WTF::HashedUTF8CharactersTranslator::hash):
(WTF::Latin1BufferTranslator::hash):
* Source/WTF/wtf/text/Base64.cpp:
(WTF::toSIMDUTFEncodeOptions):
(WTF::toSIMDUTFDecodeOptions):
(WTF::toSIMDUTFLastChunkHandling):
* Source/WTF/wtf/text/Base64.h:
(WTF::base64Encode):
* Source/WTF/wtf/text/StringBuilder.cpp:
(WTF::StringBuilder::shouldShrinkToFit const):
* Source/WTF/wtf/text/StringBuilder.h:
* Source/WTF/wtf/text/StringImpl.cpp:
(WTF::StringImpl::characterStartingAt):
(WTF::needsTurkishCasingRules):
(WTF::needsGreekUppercasingRules):
(WTF::needsLithuanianCasingRules):
(WTF::StringImpl::startsWith const):
(WTF::StringImpl::endsWith const):
(WTF::equalIgnoringASCIICaseNonNull):
(WTF::StringImpl::sizeInBytes const):
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/StringView.h:
(WTF::startsWithIgnoringASCIICase):
(WTF::endsWithIgnoringASCIICase):
* Source/WTF/wtf/text/SymbolImpl.h:
* Source/WTF/wtf/text/SymbolRegistry.cpp:
(WTF::SymbolRegistryTableRemovalHashTranslator::equal):
* Source/WTF/wtf/text/TextBreakIterator.h:
* Source/WTF/wtf/text/WTFString.h:
* Source/WTF/wtf/text/cf/StringImplCF.cpp:
(WTF::StringWrapperCFAllocator::currentString):
(WTF::StringWrapperCFAllocator::retain):
(WTF::StringWrapperCFAllocator::release):
(WTF::StringWrapperCFAllocator::copyDescription):
(WTF::StringWrapperCFAllocator::preferredSize):
* Source/WTF/wtf/text/icu/UTextProvider.cpp:
(WTF::fixPointer):
* Source/WTF/wtf/text/icu/UTextProviderLatin1.cpp:
(WTF::latin1ContextSpan):
(WTF::chunkSpan):
(WTF::uTextLatin1NativeLength):
(WTF::uTextLatin1MapOffsetToNative):
(WTF::uTextLatin1MapNativeIndexToUTF16):
(WTF::uTextLatin1Close):
(WTF::textLatin1ContextAwareGetCurrentContext):
(WTF::uTextLatin1ContextAwareNativeLength):
(WTF::uTextLatin1ContextAwareExtract):
(WTF::uTextLatin1ContextAwareClose):
* Source/WTF/wtf/text/icu/UTextProviderUTF16.cpp:
(WTF::textUTF16ContextAwareGetCurrentContext):
(WTF::uTextUTF16ContextAwareNativeLength):
(WTF::uTextUTF16ContextAwareExtract):
(WTF::uTextUTF16ContextAwareClose):
* Source/WTF/wtf/threads/Signals.cpp:
(WTF::toMachMask):
(WTF::fromMachException):
(WTF::fromSystemSignal):
(WTF::offsetForSystemSignal):
* Source/WTF/wtf/threads/Signals.h:
* Source/WTF/wtf/unicode/UTF8Conversion.h:
* Source/WTF/wtf/unicode/icu/CollatorICU.cpp:
(WTF::getIndexLatin1):
(WTF::moveLatin1):
(WTF::hasNextLatin1):
(WTF::hasPreviousLatin1):
(WTF::currentLatin1):
(WTF::nextLatin1):
(WTF::previousLatin1):
(WTF::getStateLatin1):
(WTF::setStateLatin1):
(WTF::createLatin1Iterator):

Canonical link: <a href="https://commits.webkit.org/307975@main">https://commits.webkit.org/307975@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6911b33f1b84a476ddba62300ec3f4c1c9cc3b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146089 "19 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18767 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11011 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154759 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99572 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef69aa5f-2c3e-4a1c-a5b8-3e064229a441) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19241 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18661 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112400 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80421 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2646f46-b621-48c6-9bd3-c6a360bec7df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149052 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131232 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93271 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a981fe63-2851-4e95-8d12-0601510f6dde) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14020 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11774 "Found 2 new API test failures: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii, TestWebKitAPI.GetUserMedia.ClearRemoteVideoFrameObjectHeapPixelConformerUnderMemoryPressure (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2205 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/138060 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8238 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157077 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6884 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/253 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9497 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120440 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18589 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15556 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120723 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30937 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18610 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129673 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74288 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7530 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177377 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18207 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81962 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45528 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17943 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18113 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18001 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->