### PR TITLE
Adopt `NODELETE` annotation in more places in Source/WebCore/dom

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -124,8 +124,6 @@ dom/RangeBoundaryPoint.h
 dom/ScriptElement.cpp
 dom/SelectorQuery.cpp
 dom/ShadowRoot.cpp
-dom/SimpleRange.cpp
-dom/SimulatedClick.cpp
 dom/TreeScope.cpp
 dom/TreeScopeOrderedMap.cpp
 dom/TypedElementDescendantIteratorInlines.h
@@ -358,7 +356,6 @@ page/PointerLockController.cpp
 page/PrintContext.cpp
 page/Quirks.cpp
 page/RemoteFrame.cpp
-page/ResizeObservation.cpp
 page/ResizeObserver.cpp
 page/ScrollBehavior.cpp
 page/SettingsBase.cpp
@@ -630,7 +627,6 @@ style/StyleChangedAnimatableProperties.cpp
 style/StyleCustomPropertyRegistry.cpp
 style/StyleExtractor.cpp
 style/StyleExtractorCustom.h
-style/StyleInterpolation.cpp
 style/StyleInvalidationFunctions.h
 style/StyleInvalidator.cpp
 style/StyleResolveForDocument.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -124,7 +124,6 @@ bindings/js/JSKeyframeEffectCustom.cpp
 bindings/js/JSLazyEventListener.cpp
 bindings/js/JSLocationCustom.cpp
 bindings/js/JSMessageChannelCustom.cpp
-bindings/js/JSMessagePortCustom.cpp
 bindings/js/JSMutationObserverCustom.cpp
 bindings/js/JSMutationRecordCustom.cpp
 bindings/js/JSNavigatorCustom.cpp
@@ -153,7 +152,6 @@ bindings/js/JSWindowProxy.cpp
 bindings/js/JSWorkerGlobalScopeBase.cpp
 bindings/js/JSWorkerGlobalScopeCustom.cpp
 bindings/js/JSWorkerNavigatorCustom.cpp
-bindings/js/JSWorkletGlobalScopeBase.cpp
 bindings/js/JSXMLHttpRequestCustom.cpp
 bindings/js/ScheduledAction.cpp
 bindings/js/ScriptBufferSourceProvider.h
@@ -288,8 +286,6 @@ dom/RangeBoundaryPoint.h
 dom/SelectorQuery.cpp
 dom/ShadowRoot.cpp
 dom/ShadowRoot.h
-dom/SimpleRange.cpp
-dom/SimulatedClick.cpp
 dom/SpaceSplitString.h
 dom/StyledElement.cpp
 dom/TreeScope.cpp
@@ -486,7 +482,6 @@ page/Quirks.cpp
 page/RemoteDOMWindow.cpp
 page/RemoteFrame.cpp
 page/RenderingUpdateScheduler.cpp
-page/ResizeObservation.cpp
 page/ResizeObserver.cpp
 page/ResourceUsageOverlay.cpp
 page/ScrollBehavior.cpp
@@ -748,7 +743,6 @@ style/StyleBuilderState.cpp
 style/StyleDifference.cpp
 style/StyleExtractor.cpp
 style/StyleExtractorCustom.h
-style/StyleInterpolation.cpp
 style/StyleInvalidator.cpp
 style/StylePendingResources.cpp
 style/StyleResolveForDocument.cpp

--- a/Source/WebCore/dom/AbortController.h
+++ b/Source/WebCore/dom/AbortController.h
@@ -48,7 +48,7 @@ public:
     AbortSignal& signal() { return m_signal; }
     void abort(JSC::JSValue reason);
 
-    WebCoreOpaqueRoot opaqueRoot();
+    WebCoreOpaqueRoot NODELETE opaqueRoot();
 
 private:
     explicit AbortController(ScriptExecutionContext&);

--- a/Source/WebCore/dom/AbortSignal.h
+++ b/Source/WebCore/dom/AbortSignal.h
@@ -114,7 +114,7 @@ private:
     bool m_isDependent { false };
 };
 
-WebCoreOpaqueRoot root(AbortSignal*);
+WebCoreOpaqueRoot NODELETE root(AbortSignal*);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/ActiveDOMCallback.h
+++ b/Source/WebCore/dom/ActiveDOMCallback.h
@@ -52,10 +52,10 @@ public:
     WEBCORE_EXPORT ActiveDOMCallback(ScriptExecutionContext*);
     WEBCORE_EXPORT virtual ~ActiveDOMCallback();
 
-    WEBCORE_EXPORT bool canInvokeCallback() const;
+    WEBCORE_EXPORT bool NODELETE canInvokeCallback() const;
 
-    WEBCORE_EXPORT bool activeDOMObjectsAreSuspended() const;
-    WEBCORE_EXPORT bool activeDOMObjectAreStopped() const;
+    WEBCORE_EXPORT bool NODELETE activeDOMObjectsAreSuspended() const;
+    WEBCORE_EXPORT bool NODELETE activeDOMObjectAreStopped() const;
     
     virtual void visitJSFunction(JSC::AbstractSlotVisitor&) { }
     virtual void visitJSFunction(JSC::SlotVisitor&) { }

--- a/Source/WebCore/dom/ActiveDOMObject.cpp
+++ b/Source/WebCore/dom/ActiveDOMObject.cpp
@@ -37,7 +37,7 @@
 
 namespace WebCore {
 
-static inline ScriptExecutionContext* suitableScriptExecutionContext(ScriptExecutionContext* scriptExecutionContext)
+static inline ScriptExecutionContext* NODELETE suitableScriptExecutionContext(ScriptExecutionContext* scriptExecutionContext)
 {
     // For detached documents, make sure we observe their context document instead.
     if (auto* document = dynamicDowncast<Document>(scriptExecutionContext))

--- a/Source/WebCore/dom/ActiveDOMObject.h
+++ b/Source/WebCore/dom/ActiveDOMObject.h
@@ -103,8 +103,8 @@ public:
         return adoptRef(*new PendingActivity<T>(thisObject));
     }
 
-    bool isContextStopped() const;
-    bool isAllowedToRunScript() const;
+    bool NODELETE isContextStopped() const;
+    bool NODELETE isAllowedToRunScript() const;
 
     template<typename T, typename Task>
     static void queueTaskKeepingObjectAlive(T& object, TaskSource source, Task&& task)

--- a/Source/WebCore/dom/BoundaryPoint.cpp
+++ b/Source/WebCore/dom/BoundaryPoint.cpp
@@ -50,7 +50,7 @@ std::optional<BoundaryPoint> makeBoundaryPointAfterNode(Node& node)
     return BoundaryPoint { parent.releaseNonNull(), node.computeNodeIndex() + 1 };
 }
 
-static bool isOffsetBeforeChild(ContainerNode& container, unsigned offset, Node& child)
+static bool NODELETE isOffsetBeforeChild(ContainerNode& container, unsigned offset, Node& child)
 {
     if (!offset)
         return true;

--- a/Source/WebCore/dom/BroadcastChannel.cpp
+++ b/Source/WebCore/dom/BroadcastChannel.cpp
@@ -51,13 +51,13 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(BroadcastChannel);
 
 static Lock allBroadcastChannelsLock;
-static HashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>& allBroadcastChannels() WTF_REQUIRES_LOCK(allBroadcastChannelsLock)
+static HashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>& NODELETE allBroadcastChannels() WTF_REQUIRES_LOCK(allBroadcastChannelsLock)
 {
     static NeverDestroyed<HashMap<BroadcastChannelIdentifier, ThreadSafeWeakPtr<BroadcastChannel>>> map;
     return map;
 }
 
-static HashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>& channelToContextIdentifier()
+static HashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>& NODELETE channelToContextIdentifier()
 {
     ASSERT(isMainThread());
     static NeverDestroyed<HashMap<BroadcastChannelIdentifier, ScriptExecutionContextIdentifier>> map;

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -59,7 +59,7 @@ public:
     void deref() const final { ThreadSafeRefCountedAndCanMakeThreadSafeWeakPtr::deref(); }
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
-    BroadcastChannelIdentifier identifier() const;
+    BroadcastChannelIdentifier NODELETE identifier() const;
     String name() const;
 
     ExceptionOr<void> postMessage(JSC::JSGlobalObject&, JSC::JSValue message);

--- a/Source/WebCore/dom/ChildListMutationScope.cpp
+++ b/Source/WebCore/dom/ChildListMutationScope.cpp
@@ -41,7 +41,7 @@
 namespace WebCore {
 
 using AccumulatorMap = HashMap<WeakRef<ContainerNode, WeakPtrImplWithEventTargetData>, SingleThreadWeakRef<ChildListMutationAccumulator>>;
-static AccumulatorMap& accumulatorMap()
+static AccumulatorMap& NODELETE accumulatorMap()
 {
     static NeverDestroyed<AccumulatorMap> map;
     return map;

--- a/Source/WebCore/dom/ChildListMutationScope.h
+++ b/Source/WebCore/dom/ChildListMutationScope.h
@@ -58,9 +58,9 @@ private:
     ChildListMutationAccumulator(ContainerNode&, std::unique_ptr<MutationObserverInterestGroup>);
 
     void enqueueMutationRecord();
-    bool isEmpty();
-    bool isAddedNodeInOrder(Node&);
-    bool isRemovedNodeInOrder(Node&);
+    bool NODELETE isEmpty();
+    bool NODELETE isAddedNodeInOrder(Node&);
+    bool NODELETE isRemovedNodeInOrder(Node&);
 
     const Ref<ContainerNode> m_target;
 

--- a/Source/WebCore/dom/ChildNodeList.h
+++ b/Source/WebCore/dom/ChildNodeList.h
@@ -69,13 +69,13 @@ public:
 
     ContainerNode& ownerNode() { return m_parent; }
 
-    void invalidateCache();
+    void NODELETE invalidateCache();
 
     // For CollectionIndexCache
-    Node* collectionBegin() const;
-    Node* collectionLast() const;
-    void collectionTraverseForward(Node*&, unsigned count, unsigned& traversedCount) const;
-    void collectionTraverseBackward(Node*&, unsigned count) const;
+    Node* NODELETE collectionBegin() const;
+    Node* NODELETE collectionLast() const;
+    void NODELETE collectionTraverseForward(Node*&, unsigned count, unsigned& traversedCount) const;
+    void NODELETE collectionTraverseBackward(Node*&, unsigned count) const;
     bool collectionCanTraverseBackward() const { return true; }
     void willValidateIndexCache() const { }
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -398,7 +398,7 @@ void ContainerNode::removeDetachedChildren()
     removeDetachedChildrenInContainer(*this);
 }
 
-static inline bool hasDisplayContents(Element *element)
+static inline bool NODELETE hasDisplayContents(Element *element)
 {
     return element && element->hasDisplayContents();
 }

--- a/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
+++ b/Source/WebCore/dom/ContainerNodeAlgorithms.cpp
@@ -91,13 +91,13 @@ void notifyChildNodeInserted(ContainerNode& parentOfInsertedTree, Node& node, No
         notifyNodeInsertedIntoTree(parentOfInsertedTree, node, treeScopeChange);
 }
 
-inline RemovedSubtreeObservability observabilityOfRemovedNode(Node& node)
+inline RemovedSubtreeObservability NODELETE observabilityOfRemovedNode(Node& node)
 {
     bool isRootOfRemovedTree = !node.parentNode();
     return node.refCount() > 1 && !isRootOfRemovedTree ? RemovedSubtreeObservability::MaybeObservableByRefPtr : RemovedSubtreeObservability::NotObservable;
 }
 
-inline void updateObservability(RemovedSubtreeObservability& currentObservability, RemovedSubtreeObservability newStatus)
+inline void NODELETE updateObservability(RemovedSubtreeObservability& currentObservability, RemovedSubtreeObservability newStatus)
 {
     if (newStatus == RemovedSubtreeObservability::MaybeObservableByRefPtr)
         currentObservability = newStatus;

--- a/Source/WebCore/dom/CustomElementReactionQueue.h
+++ b/Source/WebCore/dom/CustomElementReactionQueue.h
@@ -137,12 +137,12 @@ public:
     static void enqueueFormStateRestoreCallbackIfNeeded(Element&, CustomElementFormValue&&);
     static void enqueuePostUpgradeReactions(Element&);
 
-    bool observesStyleAttribute() const;
-    bool isElementInternalsDisabled() const;
+    bool NODELETE observesStyleAttribute() const;
+    bool NODELETE isElementInternalsDisabled() const;
     bool isElementInternalsAttached() const { return m_elementInternalsAttached; }
-    void setElementInternalsAttached();
-    bool isFormAssociated() const;
-    bool hasFormStateRestoreCallback() const;
+    void NODELETE setElementInternalsAttached();
+    bool NODELETE isFormAssociated() const;
+    bool NODELETE hasFormStateRestoreCallback() const;
 
     void invokeAll(Element&);
     void clear();

--- a/Source/WebCore/dom/CustomElementRegistry.h
+++ b/Source/WebCore/dom/CustomElementRegistry.h
@@ -69,7 +69,7 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     bool isScoped() const { return !m_window; }
-    Document* document() const;
+    Document* NODELETE document() const;
 
     static CustomElementRegistry* registryForElement(const Element& element)
     {

--- a/Source/WebCore/dom/DOMException.h
+++ b/Source/WebCore/dom/DOMException.h
@@ -57,7 +57,7 @@ public:
         LegacyCode legacyCode;
     };
 
-    WEBCORE_EXPORT static const Description& description(ExceptionCode);
+    WEBCORE_EXPORT static const Description& NODELETE description(ExceptionCode);
 
     static ASCIILiteral name(ExceptionCode ec) { return description(ec).name; }
     static ASCIILiteral message(ExceptionCode ec) { return description(ec).message; }

--- a/Source/WebCore/dom/DOMPointReadOnly.h
+++ b/Source/WebCore/dom/DOMPointReadOnly.h
@@ -78,7 +78,7 @@ protected:
     double m_w;
 };
 
-WebCoreOpaqueRoot root(DOMPointReadOnly*);
+WebCoreOpaqueRoot NODELETE root(DOMPointReadOnly*);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/DOMRectReadOnly.h
+++ b/Source/WebCore/dom/DOMRectReadOnly.h
@@ -76,6 +76,6 @@ protected:
     double m_height { 0 }; // Can be negative.
 };
 
-WebCoreOpaqueRoot root(DOMRectReadOnly*);
+WebCoreOpaqueRoot NODELETE root(DOMRectReadOnly*);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/DOMStringList.h
+++ b/Source/WebCore/dom/DOMStringList.h
@@ -54,7 +54,7 @@ public:
 
     // Implements the IDL.
     size_t length() const { return m_strings.size(); }
-    String item(unsigned index) const;
+    String NODELETE item(unsigned index) const;
     bool contains(const String& str) const;
 
     operator const Vector<String>&() const { return m_strings; }

--- a/Source/WebCore/dom/DataTransfer.h
+++ b/Source/WebCore/dom/DataTransfer.h
@@ -58,7 +58,7 @@ public:
     String dropEffect() const;
     void setDropEffect(const String&);
 
-    String effectAllowed() const;
+    String NODELETE effectAllowed() const;
     void setEffectAllowed(const String&);
 
     DataTransferItemList& items(Document&);
@@ -80,9 +80,9 @@ public:
 
     void makeInvalidForSecurity() { m_storeMode = StoreMode::Invalid; }
 
-    bool canReadTypes() const;
-    bool canReadData() const;
-    bool canWriteData() const;
+    bool NODELETE canReadTypes() const;
+    bool NODELETE canReadData() const;
+    bool NODELETE canWriteData() const;
 
     bool hasFileOfType(const String&);
     bool hasStringOfType(Document&, const String&);
@@ -106,10 +106,10 @@ public:
     void setDragHasStarted() { m_shouldUpdateDragImage = true; }
     DragImageRef createDragImage(const Document*, IntPoint& dragLocation) const;
     void updateDragImage(const Document*);
-    RefPtr<Element> dragImageElement() const;
+    RefPtr<Element> NODELETE dragImageElement() const;
 
     void moveDragState(Ref<DataTransfer>&&);
-    bool hasDragImage() const;
+    bool NODELETE hasDragImage() const;
 
     IntPoint dragLocation() const { return m_dragLocation; }
 #endif

--- a/Source/WebCore/dom/DataTransferItem.h
+++ b/Source/WebCore/dom/DataTransferItem.h
@@ -59,9 +59,9 @@ public:
     RefPtr<File> file() { return m_file; }
     void clearListAndPutIntoDisabledMode();
 
-    bool isFile() const;
+    bool NODELETE isFile() const;
     String kind() const;
-    String type() const;
+    String NODELETE type() const;
     void getAsString(Document&, RefPtr<StringCallback>&&) const;
     RefPtr<File> getAsFile() const;
     RefPtr<FileSystemEntry> getAsEntry(ScriptExecutionContext&) const;

--- a/Source/WebCore/dom/DataTransferItemList.h
+++ b/Source/WebCore/dom/DataTransferItemList.h
@@ -79,7 +79,7 @@ public:
 
 private:
     Vector<Ref<DataTransferItem>>& ensureItems() const;
-    Document* document() const;
+    Document* NODELETE document() const;
 
     WeakRef<DataTransfer> m_dataTransfer;
     mutable std::optional<Vector<Ref<DataTransferItem>>> m_items;

--- a/Source/WebCore/dom/DatasetDOMStringMap.cpp
+++ b/Source/WebCore/dom/DatasetDOMStringMap.cpp
@@ -72,7 +72,7 @@ static String convertAttributeNameToPropertyName(const String& name)
     return stringBuilder.toString();
 }
 
-static bool isValidPropertyName(const String& name)
+static bool NODELETE isValidPropertyName(const String& name)
 {
     unsigned length = name.length();
     for (unsigned i = 0; i < length; ++i) {

--- a/Source/WebCore/dom/DatasetDOMStringMap.h
+++ b/Source/WebCore/dom/DatasetDOMStringMap.h
@@ -44,7 +44,7 @@ public:
 
     ~DatasetDOMStringMap();
 
-    void ref();
+    void NODELETE ref();
     void deref();
 
     bool isSupportedPropertyName(const String& name) const;

--- a/Source/WebCore/dom/DeviceMotionEvent.cpp
+++ b/Source/WebCore/dom/DeviceMotionEvent.cpp
@@ -66,7 +66,7 @@ DeviceMotionEvent::DeviceMotionEvent(const AtomString& eventType, DeviceMotionDa
 {
 }
 
-static std::optional<DeviceMotionEvent::Acceleration> convert(const DeviceMotionData::Acceleration* acceleration)
+static std::optional<DeviceMotionEvent::Acceleration> NODELETE convert(const DeviceMotionData::Acceleration* acceleration)
 {
     if (!acceleration)
         return std::nullopt;
@@ -74,7 +74,7 @@ static std::optional<DeviceMotionEvent::Acceleration> convert(const DeviceMotion
     return DeviceMotionEvent::Acceleration { acceleration->x(), acceleration->y(), acceleration->z() };
 }
 
-static std::optional<DeviceMotionEvent::RotationRate> convert(const DeviceMotionData::RotationRate* rotationRate)
+static std::optional<DeviceMotionEvent::RotationRate> NODELETE convert(const DeviceMotionData::RotationRate* rotationRate)
 {
     if (!rotationRate)
         return std::nullopt;

--- a/Source/WebCore/dom/DeviceMotionEvent.h
+++ b/Source/WebCore/dom/DeviceMotionEvent.h
@@ -64,10 +64,10 @@ public:
         return adoptRef(*new DeviceMotionEvent);
     }
 
-    std::optional<Acceleration> acceleration() const;
-    std::optional<Acceleration> accelerationIncludingGravity() const;
-    std::optional<RotationRate> rotationRate() const;
-    std::optional<double> interval() const;
+    std::optional<Acceleration> NODELETE acceleration() const;
+    std::optional<Acceleration> NODELETE accelerationIncludingGravity() const;
+    std::optional<RotationRate> NODELETE rotationRate() const;
+    std::optional<double> NODELETE interval() const;
 
     void initDeviceMotionEvent(const AtomString& type, bool bubbles, bool cancelable, std::optional<Acceleration>&&, std::optional<Acceleration>&&, std::optional<RotationRate>&&, std::optional<double>);
 

--- a/Source/WebCore/dom/DeviceOrientationEvent.h
+++ b/Source/WebCore/dom/DeviceOrientationEvent.h
@@ -50,9 +50,9 @@ public:
 
     virtual ~DeviceOrientationEvent();
 
-    std::optional<double> alpha() const;
-    std::optional<double> beta() const;
-    std::optional<double> gamma() const;
+    std::optional<double> NODELETE alpha() const;
+    std::optional<double> NODELETE beta() const;
+    std::optional<double> NODELETE gamma() const;
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<double> compassHeading() const;
@@ -60,7 +60,7 @@ public:
 
     void initDeviceOrientationEvent(const AtomString& type, bool bubbles, bool cancelable, std::optional<double> alpha, std::optional<double> beta, std::optional<double> gamma, std::optional<double> compassHeading, std::optional<double> compassAccuracy);
 #else
-    std::optional<bool> absolute() const;
+    std::optional<bool> NODELETE absolute() const;
 
     void initDeviceOrientationEvent(const AtomString& type, bool bubbles, bool cancelable, std::optional<double> alpha, std::optional<double> beta, std::optional<double> gamma, std::optional<bool> absolute);
 #endif

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -523,7 +523,7 @@ static void CallbackForContainIntrinsicSize(const Vector<Ref<ResizeObserverEntry
 
 // https://www.w3.org/TR/xml/#NT-NameStartChar
 // NameStartChar       ::=       ":" | [A-Z] | "_" | [a-z] | [#xC0-#xD6] | [#xD8-#xF6] | [#xF8-#x2FF] | [#x370-#x37D] | [#x37F-#x1FFF] | [#x200C-#x200D] | [#x2070-#x218F] | [#x2C00-#x2FEF] | [#x3001-#xD7FF] | [#xF900-#xFDCF] | [#xFDF0-#xFFFD] | [#x10000-#xEFFFF]
-static inline bool isValidNameStart(char32_t c)
+static inline bool NODELETE isValidNameStart(char32_t c)
 {
     return c == ':' || (c >= 'A' && c <= 'Z') || c == '_' || (c >= 'a' && c <= 'z') || (c >= 0x00C0 && c <= 0x00D6)
         || (c >= 0x00D8 && c <= 0x00F6) || (c >= 0x00F8 && c <= 0x02FF) || (c >= 0x0370 && c <= 0x037D) || (c >= 0x037F && c <= 0x1FFF)
@@ -533,13 +533,13 @@ static inline bool isValidNameStart(char32_t c)
 
 // https://www.w3.org/TR/xml/#NT-NameChar
 // NameChar       ::=       NameStartChar | "-" | "." | [0-9] | #xB7 | [#x0300-#x036F] | [#x203F-#x2040]
-static inline bool isValidNamePart(char32_t c)
+static inline bool NODELETE isValidNamePart(char32_t c)
 {
     return isValidNameStart(c) || c == '-' || c == '.' || (c >= '0' && c <= '9') || c == 0x00B7
         || (c >= 0x0300 && c <= 0x036F) || (c >= 0x203F && c <= 0x2040);
 }
 
-static Widget* widgetForElement(Element* focusedElement)
+static Widget* NODELETE widgetForElement(Element* focusedElement)
 {
     auto* renderer = focusedElement ? dynamicDowncast<RenderWidget>(focusedElement->renderer()) : nullptr;
     return renderer ? renderer->widget() : nullptr;
@@ -603,7 +603,7 @@ static const void* sharedLoggerOwner()
     return reinterpret_cast<const void*>(owner);
 }
 
-static Logger*& staticSharedLogger()
+static Logger*& NODELETE staticSharedLogger()
 {
     static Logger* logger;
     return logger;
@@ -1550,12 +1550,12 @@ static ALWAYS_INLINE Ref<HTMLElement> createUpgradeCandidateElement(Document& do
     return createUpgradeCandidateElement(document, registry, QualifiedName { nullAtom(), localName, xhtmlNamespaceURI });
 }
 
-static inline bool isValidHTMLElementName(const AtomString& localName)
+static inline bool NODELETE isValidHTMLElementName(const AtomString& localName)
 {
     return Document::isValidName(localName);
 }
 
-static inline bool isValidHTMLElementName(const QualifiedName& name)
+static inline bool NODELETE isValidHTMLElementName(const QualifiedName& name)
 {
     return Document::isValidName(name.localName());
 }
@@ -1895,7 +1895,7 @@ enum class CustomElementNameCharacterKind : uint8_t {
     Upper,
 };
 
-static ALWAYS_INLINE CustomElementNameCharacterKind customElementNameCharacterKind(Latin1Character character)
+static ALWAYS_INLINE CustomElementNameCharacterKind NODELETE customElementNameCharacterKind(Latin1Character character)
 {
     using Kind = CustomElementNameCharacterKind;
     static constexpr std::array<Kind, 256> table {
@@ -2557,13 +2557,13 @@ void Document::setTitle(String&& title)
 template<typename> struct TitleTraits;
 
 template<> struct TitleTraits<HTMLTitleElement> {
-    static bool isInEligibleLocation(HTMLTitleElement& element) { return element.isConnected() && !element.isInShadowTree(); }
-    static HTMLTitleElement* findTitleElement(Document& document) { return descendantsOfType<HTMLTitleElement>(document).first(); }
+    static bool NODELETE isInEligibleLocation(HTMLTitleElement& element) { return element.isConnected() && !element.isInShadowTree(); }
+    static HTMLTitleElement* NODELETE findTitleElement(Document& document) { return descendantsOfType<HTMLTitleElement>(document).first(); }
 };
 
 template<> struct TitleTraits<SVGTitleElement> {
-    static bool isInEligibleLocation(SVGTitleElement& element) { return element.parentNode() == element.document().documentElement(); }
-    static SVGTitleElement* findTitleElement(Document& document) { return childrenOfType<SVGTitleElement>(*document.documentElement()).first(); }
+    static bool NODELETE isInEligibleLocation(SVGTitleElement& element) { return element.parentNode() == element.document().documentElement(); }
+    static SVGTitleElement* NODELETE findTitleElement(Document& document) { return childrenOfType<SVGTitleElement>(*document.documentElement()).first(); }
 };
 
 template<typename TitleElement> Element* selectNewTitleElement(Document& document, Element* oldTitleElement, Element& changingElement)
@@ -6708,7 +6708,7 @@ bool Document::setFocusedElement(Element* newFocusedElement, const FocusOptions&
     return true;
 }
 
-static bool shouldResetFocusNavigationStartingNode(Node& node)
+static bool NODELETE shouldResetFocusNavigationStartingNode(Node& node)
 {
     // Setting focus navigation starting node to the following nodes means that we should start
     // the search from the beginning of the document.
@@ -6927,7 +6927,7 @@ void Document::parentlessNodeMovedToNewDocument(Node& node)
         range->updateRangeForParentlessNodeMovedToNewDocument(node);
 }
 
-static Node* fallbackFocusNavigationStartingNodeAfterRemoval(Node& node)
+static Node* NODELETE fallbackFocusNavigationStartingNodeAfterRemoval(Node& node)
 {
     return node.previousSibling() ? node.previousSibling() : node.parentNode();
 }
@@ -7474,7 +7474,7 @@ void Document::updateCachedCookiesEnabled()
     });
 }
 
-static bool isValidNameNonASCII(std::span<const Latin1Character> characters)
+static bool NODELETE isValidNameNonASCII(std::span<const Latin1Character> characters)
 {
     if (!isValidNameStart(characters[0]))
         return false;
@@ -7487,7 +7487,7 @@ static bool isValidNameNonASCII(std::span<const Latin1Character> characters)
     return true;
 }
 
-static bool isValidNameNonASCII(std::span<const char16_t> characters)
+static bool NODELETE isValidNameNonASCII(std::span<const char16_t> characters)
 {
     for (size_t i = 0; i < characters.size();) {
         bool first = !i;
@@ -7516,7 +7516,7 @@ static inline bool isValidNameASCII(std::span<const CharType> characters)
     return true;
 }
 
-static bool isValidNameASCIIWithoutColon(std::span<const Latin1Character> characters)
+static bool NODELETE isValidNameASCIIWithoutColon(std::span<const Latin1Character> characters)
 {
     auto c = characters.front();
     if (!(isASCIIAlpha(c) || c == '_'))
@@ -11217,7 +11217,7 @@ static MessageSource messageSourceForWTFLogChannel(const WTFLogChannel& channel)
     return MessageSource::Other;
 }
 
-static MessageLevel messageLevelFromWTFLogLevel(WTFLogLevel level)
+static MessageLevel NODELETE messageLevelFromWTFLogLevel(WTFLogLevel level)
 {
     switch (level) {
     case WTFLogLevel::Always:

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -506,7 +506,7 @@ public:
 
     using DocumentsMap = HashMap<ScriptExecutionContextIdentifier, WeakRef<Document, WeakPtrImplWithEventTargetData>>;
     WEBCORE_EXPORT static DocumentsMap::ValuesIteratorRange allDocuments();
-    WEBCORE_EXPORT static DocumentsMap& allDocumentsMap();
+    WEBCORE_EXPORT static DocumentsMap& NODELETE allDocumentsMap();
 
     MediaQueryMatcher& mediaQueryMatcher();
 
@@ -552,11 +552,11 @@ public:
     ExceptionOr<SelectorQuery&> selectorQueryForString(const String&);
 
     void setViewportArguments(const ViewportArguments& viewportArguments) { m_viewportArguments = viewportArguments; }
-    WEBCORE_EXPORT ViewportArguments viewportArguments() const;
+    WEBCORE_EXPORT ViewportArguments NODELETE viewportArguments() const;
 
     OptionSet<DisabledAdaptations> disabledAdaptations() const { return m_disabledAdaptations; }
 
-    WEBCORE_EXPORT DocumentType* doctype() const;
+    WEBCORE_EXPORT DocumentType* NODELETE doctype() const;
 
     WEBCORE_EXPORT DOMImplementation& implementation();
     
@@ -584,7 +584,7 @@ public:
     WEBCORE_EXPORT Ref<Element> createElement(const QualifiedName&, bool createdByParser, CustomElementRegistry* = nullptr);
 
     RefPtr<CustomElementRegistry> customElementRegistryForBindings();
-    CustomElementRegistry* effectiveGlobalCustomElementRegistry();
+    CustomElementRegistry* NODELETE effectiveGlobalCustomElementRegistry();
     static CustomElementNameValidationStatus validateCustomElementName(const AtomString&);
     void setActiveCustomElementRegistry(CustomElementRegistry*);
     CustomElementRegistry* activeCustomElementRegistry() { return m_activeCustomElementRegistry.get(); }
@@ -617,7 +617,7 @@ public:
     const AtomString& contentLanguage() const { return m_contentLanguage; }
     void setContentLanguage(const AtomString&);
 
-    const AtomString& effectiveDocumentElementLanguage() const;
+    const AtomString& NODELETE effectiveDocumentElementLanguage() const;
     void setDocumentElementLanguage(const AtomString&);
     TextDirection documentElementTextDirection() const { return m_documentElementTextDirection; }
     void setDocumentElementTextDirection(TextDirection textDirection) { m_documentElementTextDirection = textDirection; }
@@ -637,7 +637,7 @@ public:
 
     void setXMLEncoding(const String& encoding) { m_xmlEncoding = encoding; } // read-only property, only to be set from XMLDocumentParser
     WEBCORE_EXPORT ExceptionOr<void> setXMLVersion(const String&);
-    WEBCORE_EXPORT void setXMLStandalone(bool);
+    WEBCORE_EXPORT void NODELETE setXMLStandalone(bool);
     void setHasXMLDeclaration(bool hasXMLDeclaration) { m_hasXMLDeclaration = hasXMLDeclaration; }
 
     WEBCORE_EXPORT String documentURI() const;
@@ -651,7 +651,7 @@ public:
     bool isTimerThrottlingEnabled() const { return m_isTimerThrottlingEnabled; }
 
     void setVisibilityHiddenDueToDismissal(bool);
-    void clearRevealForReactivation();
+    void NODELETE clearRevealForReactivation();
 
     WEBCORE_EXPORT ExceptionOr<Ref<Node>> adoptNode(Node& source);
 
@@ -688,7 +688,7 @@ public:
 #endif
     bool isPDFDocument() const { return m_documentClasses.contains(DocumentClass::PDF); }
 
-    bool hasSVGRootNode() const;
+    bool NODELETE hasSVGRootNode() const;
     virtual bool isFrameSet() const { return false; }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
@@ -725,8 +725,8 @@ public:
     ExtensionStyleSheets* extensionStyleSheetsIfExists() { return m_extensionStyleSheets.get(); }
     inline ExtensionStyleSheets& extensionStyleSheets(); // Defined in DocumentInlines.h.
 
-    const Style::CustomPropertyRegistry& customPropertyRegistry() const;
-    const CSSCounterStyleRegistry& counterStyleRegistry() const;
+    const Style::CustomPropertyRegistry& NODELETE customPropertyRegistry() const;
+    const CSSCounterStyleRegistry& NODELETE counterStyleRegistry() const;
     CSSCounterStyleRegistry& counterStyleRegistry();
 
     WEBCORE_EXPORT const CSSParserContext& cssParserContext() const;
@@ -744,16 +744,16 @@ public:
 
     inline LocalFrameView* view() const; // Defined in DocumentView.h.
     inline Page* page() const; // Defined in DocumentPage.h.
-    WEBCORE_EXPORT RefPtr<LocalFrame> localMainFrame() const;
+    WEBCORE_EXPORT RefPtr<LocalFrame> NODELETE localMainFrame() const;
     const Settings& settings() const { return m_settings.get(); }
-    EditingBehavior editingBehavior() const;
+    EditingBehavior NODELETE editingBehavior() const;
 
     inline Quirks& quirks(); // Defined in DocumentQuirks.h
     inline const Quirks& quirks() const; // Defined in DocumentQuirks.h
 
-    WEBCORE_EXPORT float deviceScaleFactor() const;
+    WEBCORE_EXPORT float NODELETE deviceScaleFactor() const;
 
-    WEBCORE_EXPORT bool useElevatedUserInterfaceLevel() const;
+    WEBCORE_EXPORT bool NODELETE useElevatedUserInterfaceLevel() const;
     WEBCORE_EXPORT bool useDarkAppearance(const RenderStyle*) const;
     WEBCORE_EXPORT bool useDarkAppearance(const Style::ComputedStyle*) const;
 #if ENABLE(DARK_MODE_CSS)
@@ -781,7 +781,7 @@ public:
     WEBCORE_EXPORT void resolveStyle(ResolveStyleType = ResolveStyleType::Normal);
     WEBCORE_EXPORT bool updateStyleIfNeeded();
     bool updateStyleIfNeededIgnoringPendingStylesheets();
-    bool needsStyleRecalc() const;
+    bool NODELETE needsStyleRecalc() const;
     unsigned lastStyleUpdateSizeForTesting() const { return m_lastStyleUpdateSizeForTesting; }
 
     enum class UpdateLayoutResult {
@@ -839,14 +839,14 @@ public:
     WEBCORE_EXPORT AXObjectCache* axObjectCache() const;
     void clearAXObjectCache();
 
-    WEBCORE_EXPORT std::optional<PageIdentifier> pageID() const;
+    WEBCORE_EXPORT std::optional<PageIdentifier> NODELETE pageID() const;
     std::optional<FrameIdentifier> frameID() const { return m_frameIdentifier; }
 
     // to get visually ordered hebrew and arabic pages right
-    void setVisuallyOrdered();
+    void NODELETE setVisuallyOrdered();
     bool visuallyOrdered() const { return m_visuallyOrdered; }
 
-    WEBCORE_EXPORT DocumentLoader* loader() const;
+    WEBCORE_EXPORT DocumentLoader* NODELETE loader() const;
 
     WEBCORE_EXPORT ExceptionOr<RefPtr<WindowProxy>> openForBindings(LocalDOMWindow& activeWindow, LocalDOMWindow& firstDOMWindow, const String& url, const AtomString& name, const String& features);
     WEBCORE_EXPORT ExceptionOr<Document&> openForBindings(Document* entryDocument, const String&, const String&);
@@ -906,7 +906,7 @@ public:
 
     inline bool shouldMaskURLForBindings(const URL&) const;
     inline const URL& maskedURLForBindingsIfNeeded(const URL&) const;
-    static StaticStringImpl& maskedURLStringForBindings();
+    static StaticStringImpl& NODELETE maskedURLStringForBindings();
     static const URL& maskedURLForBindings();
 
     WEBCORE_EXPORT String userAgent(const URL&) const final;
@@ -924,7 +924,7 @@ public:
 
 #if ENABLE(WEB_RTC)
     RTCNetworkManager* rtcNetworkManager() { return m_rtcNetworkManager.get(); }
-    WEBCORE_EXPORT void setRTCNetworkManager(Ref<RTCNetworkManager>&&);
+    WEBCORE_EXPORT void NODELETE setRTCNetworkManager(Ref<RTCNetworkManager>&&);
     void startGatheringRTCLogs(Function<void(String&& logType, String&& logMessage, String&& logLevel, RefPtr<RTCPeerConnection>&&)>&&);
     void stopGatheringRTCLogs();
 #endif
@@ -932,7 +932,7 @@ public:
     CanNavigateState canNavigate(Frame* targetFrame, const URL& destinationURL = URL());
 
     bool usesStyleBasedEditability() const;
-    void setHasElementUsingStyleBasedEditability();
+    void NODELETE setHasElementUsingStyleBasedEditability();
     
     virtual Ref<DocumentParser> createParser();
     DocumentParser* parser() const { return m_parser.get(); }
@@ -1003,7 +1003,7 @@ public:
     Element* focusNavigationStartingNode(FocusDirection) const;
 
     void didRejectSyncXHRDuringPageDismissal();
-    bool shouldIgnoreSyncXHRs() const;
+    bool NODELETE shouldIgnoreSyncXHRs() const;
 
     enum class NodeRemoval : bool { Node, ChildrenOfNode };
     void adjustFocusedNodeOnNodeRemoval(Node&, NodeRemoval = NodeRemoval::Node);
@@ -1028,17 +1028,17 @@ public:
     WEBCORE_EXPORT void scheduleFullStyleRebuild();
     void scheduleStyleRecalc();
     void unscheduleStyleRecalc();
-    bool hasPendingStyleRecalc() const;
-    bool hasPendingFullStyleRebuild() const;
+    bool NODELETE hasPendingStyleRecalc() const;
+    bool NODELETE hasPendingFullStyleRebuild() const;
 
     void registerNodeListForInvalidation(LiveNodeList&);
     void unregisterNodeListForInvalidation(LiveNodeList&);
     WEBCORE_EXPORT void registerCollection(HTMLCollection&);
     WEBCORE_EXPORT void unregisterCollection(HTMLCollection&);
-    void collectionCachedIdNameMap(const HTMLCollection&);
-    void collectionWillClearIdNameMap(const HTMLCollection&);
-    bool shouldInvalidateNodeListAndCollectionCaches() const;
-    bool shouldInvalidateNodeListAndCollectionCachesForAttribute(const QualifiedName& attrName) const;
+    void NODELETE collectionCachedIdNameMap(const HTMLCollection&);
+    void NODELETE collectionWillClearIdNameMap(const HTMLCollection&);
+    bool NODELETE shouldInvalidateNodeListAndCollectionCaches() const;
+    bool NODELETE shouldInvalidateNodeListAndCollectionCachesForAttribute(const QualifiedName& attrName) const;
 
     template <typename InvalidationFunction>
     void invalidateNodeListAndCollectionCaches(InvalidationFunction);
@@ -1073,7 +1073,7 @@ public:
     LocalDOMWindow* window() const { return m_domWindow.get(); }
 
     // In DOM Level 2, the Document's LocalDOMWindow is called the defaultView.
-    WEBCORE_EXPORT WindowProxy* windowProxy() const;
+    WEBCORE_EXPORT WindowProxy* NODELETE windowProxy() const;
 
     inline bool hasBrowsingContext() const; // Defined in DocumentInlines.h.
 
@@ -1114,11 +1114,11 @@ public:
 
     bool hasListenerType(ListenerType listenerType) const { return m_listenerTypes.contains(listenerType); }
     bool hasAnyListenerOfType(OptionSet<ListenerType> listenerTypes) const { return m_listenerTypes.containsAny(listenerTypes); }
-    bool hasListenerTypeForEventType(PlatformEventType) const;
+    bool NODELETE hasListenerTypeForEventType(PlatformEventType) const;
     void addListenerTypeIfNeeded(const AtomString& eventType);
 
     void didAddEventListenersOfType(const AtomString&, unsigned = 1);
-    void didRemoveEventListenersOfType(const AtomString&, unsigned = 1);
+    void NODELETE didRemoveEventListenersOfType(const AtomString&, unsigned = 1);
     bool hasNodeWithEventListeners() const { return !m_eventListenerCounts.isEmpty(); }
     bool hasEventListenersOfType(const AtomString& type) const { return m_eventListenerCounts.inlineGet(type); }
 
@@ -1173,7 +1173,7 @@ public:
 
     // Returns the owning element in the parent document.
     // Returns nullptr if this is the top level document.
-    WEBCORE_EXPORT HTMLFrameOwnerElement* ownerElement() const;
+    WEBCORE_EXPORT HTMLFrameOwnerElement* NODELETE ownerElement() const;
     WEBCORE_EXPORT std::optional<OwnerPermissionsPolicyData> ownerPermissionsPolicy() const;
 
     // Used by DOM bindings; no direction known.
@@ -1243,7 +1243,7 @@ public:
     // The following implements the rule from HTML 4 for what valid names are.
     // To get this right for all the XML cases, we probably have to improve this or move it
     // and make it sensitive to the type of document.
-    static bool isValidName(const String&);
+    static bool NODELETE isValidName(const String&);
 
     // The following breaks a qualified name into a prefix and a local name.
     // It also does a validity check, and returns an error if the qualified name is invalid.
@@ -1256,7 +1256,7 @@ public:
 
     // This is the "HTML body element" as defined by CSSOM View spec, the first body child of the
     // document element. See http://dev.w3.org/csswg/cssom-view/#the-html-body-element.
-    WEBCORE_EXPORT HTMLBodyElement* body() const;
+    WEBCORE_EXPORT HTMLBodyElement* NODELETE body() const;
 
     // This is the "body element" as defined by HTML5, the first body or frameset child of the
     // document element. See https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2.
@@ -1265,7 +1265,7 @@ public:
 
     Location* location() const;
 
-    WEBCORE_EXPORT HTMLHeadElement* head();
+    WEBCORE_EXPORT HTMLHeadElement* NODELETE head();
 
     inline const DocumentMarkerController* markersIfExists() const { return m_markers.get(); }
     inline DocumentMarkerController* markersIfExists() { return m_markers.get(); }
@@ -1284,7 +1284,7 @@ public:
     // designMode support
     enum class DesignMode : bool { Off, On };
     bool inDesignMode() const { return m_designMode == DesignMode::On; }
-    WEBCORE_EXPORT String designMode() const;
+    WEBCORE_EXPORT String NODELETE designMode() const;
     WEBCORE_EXPORT void setDesignMode(const String&);
 
     WEBCORE_EXPORT Document* parentDocument() const;
@@ -1305,7 +1305,7 @@ public:
     bool shouldDeferAsynchronousScriptsUntilParsingFinishes() const;
 
     bool supportsPaintTiming() const;
-    bool supportsLargestContentfulPaint() const;
+    bool NODELETE supportsLargestContentfulPaint() const;
 
 #if ENABLE(XSLT)
     void scheduleToApplyXSLTransforms();
@@ -1378,7 +1378,7 @@ public:
 
     void privateBrowsingStateDidChange(PAL::SessionID);
 
-    void storageBlockingStateDidChange();
+    void NODELETE storageBlockingStateDidChange();
 
 #if ENABLE(VIDEO)
     void registerForCaptionPreferencesChangedCallbacks(HTMLMediaElement&);
@@ -1393,7 +1393,7 @@ public:
     void registerForVisibilityStateChangedCallbacks(VisibilityChangeClient&);
     void unregisterForVisibilityStateChangedCallbacks(VisibilityChangeClient&);
 
-    WEBCORE_EXPORT void setShouldCreateRenderers(bool);
+    WEBCORE_EXPORT void NODELETE setShouldCreateRenderers(bool);
     bool shouldCreateRenderers() const { return m_createRenderers; }
 
     void setDecoder(RefPtr<TextResourceDecoder>&&);
@@ -1525,7 +1525,7 @@ public:
 
     int requestIdleCallback(Ref<IdleRequestCallback>&&, Seconds timeout);
     void cancelIdleCallback(int id);
-    bool hasPendingIdleCallback() const;
+    bool NODELETE hasPendingIdleCallback() const;
     IdleCallbackController* idleCallbackController() const { return m_idleCallbackController.get(); }
 
     EventTarget* NODELETE errorEventTarget() final;
@@ -1545,9 +1545,9 @@ public:
 
     // Used for testing. Count handlers in the main document, and one per frame which contains handlers.
     WEBCORE_EXPORT unsigned wheelEventHandlerCount() const;
-    WEBCORE_EXPORT unsigned touchEventHandlerCount() const;
+    WEBCORE_EXPORT unsigned NODELETE touchEventHandlerCount() const;
 
-    WEBCORE_EXPORT void startTrackingStyleRecalcs();
+    WEBCORE_EXPORT void NODELETE startTrackingStyleRecalcs();
     WEBCORE_EXPORT unsigned styleRecalcCount() const { return m_styleRecalcCount; }
 
 #if ENABLE(TOUCH_EVENTS)
@@ -1572,8 +1572,8 @@ public:
     bool mayHaveRenderedSVGForeignObjects() const { return m_mayHaveRenderedSVGForeignObjects; }
     void setMayHaveRenderedSVGForeignObjects() { m_mayHaveRenderedSVGForeignObjects = true; }
 
-    void didAddTouchEventHandler(Node&);
-    void didRemoveTouchEventHandler(Node&, EventHandlerRemoval = EventHandlerRemoval::One);
+    void NODELETE didAddTouchEventHandler(Node&);
+    void NODELETE didRemoveTouchEventHandler(Node&, EventHandlerRemoval = EventHandlerRemoval::One);
 
     void didRemoveEventTargetNode(Node&);
 
@@ -1591,7 +1591,7 @@ public:
     void suspendScheduledTasks(ReasonForSuspension);
     void resumeScheduledTasks(ReasonForSuspension);
 
-    std::optional<float> zoomForClient(const RenderStyle&) const;
+    std::optional<float> NODELETE zoomForClient(const RenderStyle&) const;
     void convertAbsoluteToClientQuads(Vector<FloatQuad>&, const RenderStyle&);
     void convertAbsoluteToClientRects(Vector<FloatRect>&, const RenderStyle&);
     void convertAbsoluteToClientRect(FloatRect&, const RenderStyle&);
@@ -1618,7 +1618,7 @@ public:
     bool isInStyleInterleavedLayout() const { return m_isInStyleInterleavedLayout; };
     bool isInStyleInterleavedLayoutForSelfOrAncestor() const;
     bool isResolvingTreeStyle() const { return m_isResolvingTreeStyle; }
-    void setIsResolvingTreeStyle(bool);
+    void NODELETE setIsResolvingTreeStyle(bool);
 
     void updateTextRenderer(Text&, unsigned offsetOfReplacedText, unsigned lengthOfReplacedText);
     void updateSVGRenderer(SVGElement&);
@@ -1701,7 +1701,7 @@ public:
     void setActiveSpeechRecognition(SpeechRecognition*);
     MediaProducerMediaStateFlags mediaState() const { return m_mediaState; }
     void noteUserInteractionWithMediaElement();
-    bool isCapturing() const;
+    bool NODELETE isCapturing() const;
     WEBCORE_EXPORT void updateIsPlayingMedia();
 
 #if ENABLE(MEDIA_STREAM) && ENABLE(MEDIA_SESSION)
@@ -1711,7 +1711,7 @@ public:
     void screenshareCaptureStateDidChange();
     void setShouldListenToVoiceActivity(bool);
     void voiceActivityDetected();
-    bool hasMutedAudioCaptureDevice() const;
+    bool NODELETE hasMutedAudioCaptureDevice() const;
 #endif
     void pageMutedStateDidChange();
     void visibilityAdjustmentStateDidChange();
@@ -1755,11 +1755,11 @@ public:
     void addResizeObserver(ResizeObserver&);
     void removeResizeObserver(ResizeObserver&);
     unsigned numberOfResizeObservers() const { return m_resizeObservers.size(); }
-    bool hasResizeObservers();
+    bool NODELETE hasResizeObservers();
     // Return the minDepth of the active observations.
     size_t gatherResizeObservations(size_t deeperThan);
     void deliverResizeObservations();
-    bool hasSkippedResizeObservations() const;
+    bool NODELETE hasSkippedResizeObservations() const;
     void setHasSkippedResizeObservations(bool);
     void updateResizeObservations(Page&);
 
@@ -1775,12 +1775,12 @@ public:
     void setActiveViewTransition(RefPtr<ViewTransition>&&);
 
     bool hasViewTransitionPseudoElementTree() const { return m_hasViewTransitionPseudoElementTree; }
-    void setHasViewTransitionPseudoElementTree(bool);
+    void NODELETE setHasViewTransitionPseudoElementTree(bool);
 
     void performPendingViewTransitions();
 
     bool renderingIsSuppressedForViewTransition() const { return m_renderingIsSuppressedForViewTransition; }
-    void setRenderingIsSuppressedForViewTransitionAfterUpdateRendering();
+    void NODELETE setRenderingIsSuppressedForViewTransitionAfterUpdateRendering();
     void setRenderingIsSuppressedForViewTransitionImmediately();
     void clearRenderingIsSuppressedForViewTransition();
     void flushDeferredRenderingIsSuppressedForViewTransitionChanges();
@@ -1803,7 +1803,7 @@ public:
     //      document if it has the appropriate meta tag.
     //    - isTelephoneNumberParsingEnabled() == isTelephoneNumberParsingAllowed() && page()->settings()->isTelephoneNumberParsingEnabled()
     WEBCORE_EXPORT bool isTelephoneNumberParsingAllowed() const { return m_isTelephoneNumberParsingAllowed; }
-    WEBCORE_EXPORT bool isTelephoneNumberParsingEnabled() const;
+    WEBCORE_EXPORT bool NODELETE isTelephoneNumberParsingEnabled() const;
 #endif
 
     using ContainerNode::setAttributeEventListener;
@@ -1873,7 +1873,7 @@ public:
     const ListHashSet<Ref<HTMLElement>>& autoPopoverList() const { return m_autoPopoverList; }
 
     HTMLDialogElement* activeModalDialog() const;
-    HTMLElement* topmostAutoPopover() const;
+    HTMLElement* NODELETE topmostAutoPopover() const;
 
     void hideAllPopoversUntil(HTMLElement*, FocusPreviousElement, FireEvents);
     void handlePopoverLightDismiss(const PointerEvent&, Node&);
@@ -1892,7 +1892,7 @@ public:
     WEBCORE_EXPORT void navigateFromServiceWorker(const URL&, CompletionHandler<void(ScheduleLocationChangeResult)>&&);
 
     bool allowsAddingRenderBlockedElements() const;
-    bool isRenderBlocked() const;
+    bool NODELETE isRenderBlocked() const;
 
     enum class ImplicitRenderBlocking : bool { No, Yes };
     void blockRenderingOn(Element&, ImplicitRenderBlocking = ImplicitRenderBlocking::No);
@@ -1908,7 +1908,7 @@ public:
 #endif
 
     WEBCORE_EXPORT bool hasRequestedPageSpecificStorageAccessWithUserInteraction(const RegistrableDomain&);
-    WEBCORE_EXPORT void setHasRequestedPageSpecificStorageAccessWithUserInteraction(const RegistrableDomain&);
+    WEBCORE_EXPORT void NODELETE setHasRequestedPageSpecificStorageAccessWithUserInteraction(const RegistrableDomain&);
     WEBCORE_EXPORT void wasLoadedWithDataTransferFromPrevalentResource();
     void downgradeReferrerToRegistrableDomain();
 
@@ -1943,7 +1943,7 @@ public:
     WEBCORE_EXPORT TextManipulationController& textManipulationController();
     TextManipulationController* textManipulationControllerIfExists() { return m_textManipulationController.get(); }
 
-    bool hasHighlight() const;
+    bool NODELETE hasHighlight() const;
     HighlightRegistry* highlightRegistryIfExists() const { return m_highlightRegistry.get(); }
     HighlightRegistry& highlightRegistry();
     void updateHighlightPositions();
@@ -2011,7 +2011,7 @@ public:
 
     void createNewIdentifier();
 
-    WEBCORE_EXPORT bool hasElementWithPendingUserAgentShadowTreeUpdate(Element&) const;
+    WEBCORE_EXPORT bool NODELETE hasElementWithPendingUserAgentShadowTreeUpdate(Element&) const;
     void addElementWithPendingUserAgentShadowTreeUpdate(Element&);
     WEBCORE_EXPORT void removeElementWithPendingUserAgentShadowTreeUpdate(Element&);
 
@@ -2040,7 +2040,7 @@ public:
     void invalidateDOMCookieCache();
 
     void detachFromFrame();
-    void willBeDisconnectedFromFrame(Document&);
+    void NODELETE willBeDisconnectedFromFrame(Document&);
 
     PermissionsPolicy permissionsPolicy() const;
 
@@ -2060,10 +2060,10 @@ public:
     double lookupCSSRandomBaseValue(const CSSCalc::RandomCachingKey&) const;
 
     // Cache of the first (in tree order) Element with 'attribute'.
-    Element* cachedFirstElementWithAttribute(const QualifiedName& attribute) const;
+    Element* NODELETE cachedFirstElementWithAttribute(const QualifiedName& attribute) const;
     void setCachedFirstElementWithAttribute(const QualifiedName& attribute, Element&);
-    void attributeAddedToElement(const QualifiedName& attribute);
-    void elementDisconnectedFromDocument(const Element&);
+    void NODELETE attributeAddedToElement(const QualifiedName& attribute);
+    void NODELETE elementDisconnectedFromDocument(const Element&);
 
     WEBCORE_EXPORT void prefetch(const URL&, const Vector<String>&, std::optional<ReferrerPolicy>, bool lowPriority = false);
 
@@ -2094,7 +2094,7 @@ private:
     friend class UnloadCountIncrementer;
 
     void updateTitleElement(Element& changingTitleElement);
-    RefPtr<Element> protectedTitleElement() const;
+    RefPtr<Element> NODELETE protectedTitleElement() const;
     void willDetachPage() final;
     void frameDestroyed() final;
 
@@ -2141,7 +2141,7 @@ private:
     String nodeName() const final;
     bool NODELETE childTypeAllowed(NodeType) const final;
     Ref<Node> cloneNodeInternal(Document&, CloningOperation, CustomElementRegistry*) const final;
-    ClonedDocumentType clonedDocumentType() const;
+    ClonedDocumentType NODELETE clonedDocumentType() const;
 
     SerializedNode serializeNode(CloningOperation) const final;
 
@@ -2161,7 +2161,7 @@ private:
     void spatialBackdropSourceChanged();
 #endif
 
-    void invalidateAccessKeyCacheSlowCase();
+    void NODELETE invalidateAccessKeyCacheSlowCase();
     void buildAccessKeyCache();
 
     void intersectionObserversInitialUpdateTimerFired();
@@ -2241,7 +2241,7 @@ private:
     RefPtr<ResizeObserver> ensureResizeObserverForContainIntrinsicSize();
     void parentOrShadowHostNode() const = delete; // Call parentNode() instead.
 
-    bool isObservingContentVisibilityTargets() const;
+    bool NODELETE isObservingContentVisibilityTargets() const;
 
 #if ENABLE(MEDIA_STREAM)
     void updateCaptureAccordingToMutedState();
@@ -2250,7 +2250,7 @@ private:
     void securityOriginDidChange() final;
 
     inline Ref<DocumentSyncData> syncData();
-    void populateDocumentSyncDataForNewlyConstructedDocument(DocumentSyncDataType);
+    void NODELETE populateDocumentSyncDataForNewlyConstructedDocument(DocumentSyncDataType);
 
     bool mainFrameDocumentHasHadUserInteraction() const;
 

--- a/Source/WebCore/dom/DocumentFontLoader.h
+++ b/Source/WebCore/dom/DocumentFontLoader.h
@@ -44,7 +44,7 @@ public:
     DocumentFontLoader(Document&);
     ~DocumentFontLoader();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     CachedFont* cachedFont(URL&&, bool, bool, LoadedFromOpaqueSource);

--- a/Source/WebCore/dom/DocumentFullscreen.h
+++ b/Source/WebCore/dom/DocumentFullscreen.h
@@ -62,7 +62,7 @@ public:
     // Helpers.
     Document& document() { return m_document; }
     const Document& document() const { return m_document; }
-    LocalFrame* frame() const;
+    LocalFrame* NODELETE frame() const;
     Element* documentElement() const { return document().documentElement(); }
     bool isSimpleFullscreenDocument() const;
     Document::BackForwardCacheState backForwardCacheState() const { return document().backForwardCacheState(); }
@@ -99,7 +99,7 @@ public:
 
     void exitRemovedFullscreenElement(Element&);
 
-    WEBCORE_EXPORT bool isAnimatingFullscreen() const;
+    WEBCORE_EXPORT bool NODELETE isAnimatingFullscreen() const;
     WEBCORE_EXPORT void setAnimatingFullscreen(bool);
 
     void clear();
@@ -116,10 +116,10 @@ private:
     const Logger& logger() const { return protect(document())->logger(); }
     uint64_t logIdentifier() const { return m_logIdentifier; }
     ASCIILiteral logClassName() const { return "DocumentFullscreen"_s; }
-    WTFLogChannel& logChannel() const;
+    WTFLogChannel& NODELETE logChannel() const;
 #endif
 
-    Page* page() const;
+    Page* NODELETE page() const;
     Document* mainFrameDocument() { return protect(document())->mainFrameDocument(); }
 
     RefPtr<Element> fullscreenOrPendingElement() const { return m_fullscreenElement ? m_fullscreenElement : m_pendingFullscreenElement; }

--- a/Source/WebCore/dom/DocumentMarkerController.h
+++ b/Source/WebCore/dom/DocumentMarkerController.h
@@ -120,7 +120,7 @@ private:
 
     using MarkerMap = HashMap<Ref<Node>, std::unique_ptr<Vector<RenderedDocumentMarker>>>;
 
-    bool possiblyHasMarkers(OptionSet<DocumentMarkerType>) const;
+    bool NODELETE possiblyHasMarkers(OptionSet<DocumentMarkerType>) const;
     OptionSet<DocumentMarkerType> removeMarkersFromList(MarkerMap::iterator, OptionSet<DocumentMarkerType>, NOESCAPE const Function<FilterMarkerResult(const RenderedDocumentMarker&)>& filterFunction = nullptr);
 
     void forEachOfTypes(OptionSet<DocumentMarkerType>, Function<bool(Node&, RenderedDocumentMarker&)>&&);

--- a/Source/WebCore/dom/DocumentMediaElement.h
+++ b/Source/WebCore/dom/DocumentMediaElement.h
@@ -57,7 +57,7 @@ private:
     bool isDocumentMediaElement() const final { return true; }
     static ASCIILiteral supplementName();
 
-    Document& document() const;
+    Document& NODELETE document() const;
 
     DOMWrapperWorld& ensureIsolatedWorld();
     bool ensureMediaControlsScript();

--- a/Source/WebCore/dom/DocumentParser.h
+++ b/Source/WebCore/dom/DocumentParser.h
@@ -74,7 +74,7 @@ public:
     bool isDetached() const { return m_state == ParserState::Detached; }
 
     // FIXME: Is this necessary? Does XMLDocumentParserLibxml2 really need to set this?
-    virtual void startParsing();
+    virtual void NODELETE startParsing();
 
     // prepareToStop() is used when the EOF token is encountered and parsing is to be
     // stopped normally.

--- a/Source/WebCore/dom/DocumentSharedObjectPool.cpp
+++ b/Source/WebCore/dom/DocumentSharedObjectPool.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DocumentSharedObjectPool);
 
-static HashMap<RegistrableDomain, size_t>& peakSizeInPast()
+static HashMap<RegistrableDomain, size_t>& NODELETE peakSizeInPast()
 {
     static MainThreadNeverDestroyed<HashMap<RegistrableDomain, size_t>> map;
     return map;

--- a/Source/WebCore/dom/DocumentStorageAccess.h
+++ b/Source/WebCore/dom/DocumentStorageAccess.h
@@ -69,7 +69,7 @@ public:
     explicit DocumentStorageAccess(Document&);
     ~DocumentStorageAccess();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     static void hasStorageAccess(Document&, Ref<DeferredPromise>&&);

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -205,13 +205,13 @@ static_assert(sizeof(Element) == sizeof(SameSizeAsElement), "Element should stay
 using namespace HTMLNames;
 using namespace XMLNames;
 
-static HashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, Vector<Ref<Attr>>>& attrNodeListMap()
+static HashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, Vector<Ref<Attr>>>& NODELETE attrNodeListMap()
 {
     static NeverDestroyed<HashMap<WeakRef<Element, WeakPtrImplWithEventTargetData>, Vector<Ref<Attr>>>> map;
     return map;
 }
 
-static Vector<Ref<Attr>>* attrNodeListForElement(Element& element)
+static Vector<Ref<Attr>>* NODELETE attrNodeListForElement(Element& element)
 {
     if (!element.hasSyntheticAttrChildNodes())
         return nullptr;
@@ -238,7 +238,7 @@ static void removeAttrNodeListForElement(Element& element)
     element.setHasSyntheticAttrChildNodes(false);
 }
 
-static Attr* findAttrNodeInList(Vector<Ref<Attr>>& attrNodeList, const QualifiedName& name)
+static Attr* NODELETE findAttrNodeInList(Vector<Ref<Attr>>& attrNodeList, const QualifiedName& name)
 {
     for (auto& node : attrNodeList) {
         if (node->qualifiedName().matches(name))
@@ -469,7 +469,7 @@ bool Element::shouldUseInputMethod()
     return computeEditability(UserSelectAllTreatment::NotEditable, ShouldUpdateStyle::Update) != Editability::ReadOnly;
 }
 
-static bool isForceEvent(const PlatformMouseEvent& platformEvent)
+static bool NODELETE isForceEvent(const PlatformMouseEvent& platformEvent)
 {
     return platformEvent.type() == PlatformEvent::Type::MouseForceChanged || platformEvent.type() == PlatformEvent::Type::MouseForceDown || platformEvent.type() == PlatformEvent::Type::MouseForceUp;
 }
@@ -1083,7 +1083,7 @@ void Element::setBeingDragged(bool value)
     protect(document())->userActionElements().setBeingDragged(*this, value);
 }
 
-inline ScrollAlignment toScrollAlignmentForInlineDirection(std::optional<ScrollLogicalPosition> position, WritingMode writingMode)
+inline ScrollAlignment NODELETE toScrollAlignmentForInlineDirection(std::optional<ScrollLogicalPosition> position, WritingMode writingMode)
 {
     switch (position.value_or(ScrollLogicalPosition::Nearest)) {
     case ScrollLogicalPosition::Start: {
@@ -1126,7 +1126,7 @@ inline ScrollAlignment toScrollAlignmentForInlineDirection(std::optional<ScrollL
     }
 }
 
-inline ScrollAlignment toScrollAlignmentForBlockDirection(std::optional<ScrollLogicalPosition> position, WritingMode writingMode)
+inline ScrollAlignment NODELETE toScrollAlignmentForBlockDirection(std::optional<ScrollLogicalPosition> position, WritingMode writingMode)
 {
     switch (position.value_or(ScrollLogicalPosition::Start)) {
     case ScrollLogicalPosition::Start: {
@@ -1811,7 +1811,7 @@ inline RefPtr<const SVGElement> elementWithSVGLayoutBox(const Element& element)
     return svg && svg->hasAssociatedSVGLayoutBox() ? svg : nullptr;
 }
 
-inline bool shouldObtainBoundsFromBoxModel(const Element* element)
+inline bool NODELETE shouldObtainBoundsFromBoxModel(const Element* element)
 {
     ASSERT(element);
     if (!element->renderer())

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -422,7 +422,7 @@ public:
     virtual bool attributeContainsJavaScriptURL(const Attribute&) const;
 
 #if ENABLE(ATTACHMENT_ELEMENT)
-    virtual AttachmentAssociatedElement* asAttachmentAssociatedElement();
+    virtual AttachmentAssociatedElement* NODELETE asAttachmentAssociatedElement();
 #endif
 
     // Remove attributes that might introduce scripting from the vector leaving the element unchanged.

--- a/Source/WebCore/dom/ElementData.cpp
+++ b/Source/WebCore/dom/ElementData.cpp
@@ -66,7 +66,7 @@ struct SameSizeAsElementData : public RefCounted<SameSizeAsElementData> {
 
 static_assert(sizeof(ElementData) == sizeof(SameSizeAsElementData), "element attribute data should stay small");
 
-static size_t sizeForShareableElementDataWithAttributeCount(unsigned count)
+static size_t NODELETE sizeForShareableElementDataWithAttributeCount(unsigned count)
 {
     return sizeof(ShareableElementData) + sizeof(Attribute) * count;
 }

--- a/Source/WebCore/dom/ElementData.h
+++ b/Source/WebCore/dom/ElementData.h
@@ -105,7 +105,7 @@ private:
         else
             m_arraySizeAndFlags &= ~flag;
     }
-    static inline uint32_t arraySizeAndFlagsFromOther(const ElementData& other, bool isUnique);
+    static inline uint32_t NODELETE arraySizeAndFlagsFromOther(const ElementData& other, bool isUnique);
 
 protected:
     ElementData();

--- a/Source/WebCore/dom/EventDispatcher.cpp
+++ b/Source/WebCore/dom/EventDispatcher.cpp
@@ -82,7 +82,7 @@ static void callDefaultEventHandlersInBubblingOrder(Event& event, const EventPat
     }
 }
 
-static bool isInShadowTree(EventTarget* target)
+static bool NODELETE isInShadowTree(EventTarget* target)
 {
     auto* node = dynamicDowncast<Node>(target);
     return node && node->isInShadowTree();
@@ -136,7 +136,7 @@ static bool shouldSuppressEventDispatchInDOM(Node& node, Event& event)
     return is<CompositionEvent>(event) || is<InputEvent>(event) || is<KeyboardEvent>(event);
 }
 
-static HTMLInputElement* findInputElementInEventPath(const EventPath& path)
+static HTMLInputElement* NODELETE findInputElementInEventPath(const EventPath& path)
 {
     size_t size = path.size();
     for (size_t i = 0; i < size; ++i) {

--- a/Source/WebCore/dom/EventListenerMap.h
+++ b/Source/WebCore/dom/EventListenerMap.h
@@ -63,8 +63,8 @@ public:
 
     bool isEmpty() const { return m_entries.isEmpty(); }
     bool contains(const AtomString& eventType) const { return find(eventType); }
-    bool containsCapturing(const AtomString& eventType) const;
-    bool containsActive(const AtomString& eventType) const;
+    bool NODELETE containsCapturing(const AtomString& eventType) const;
+    bool NODELETE containsActive(const AtomString& eventType) const;
 
     void clear();
     void clearEntriesForTearDown()
@@ -76,7 +76,7 @@ public:
     void replace(const AtomString& eventType, EventListener& oldListener, Ref<EventListener>&& newListener, const RegisteredEventListener::Options&);
     bool add(const AtomString& eventType, Ref<EventListener>&&, const RegisteredEventListener::Options&);
     bool remove(const AtomString& eventType, EventListener&, bool useCapture);
-    WEBCORE_EXPORT EventListenerVector* find(const AtomString& eventType);
+    WEBCORE_EXPORT EventListenerVector* NODELETE find(const AtomString& eventType);
     const EventListenerVector* find(const AtomString& eventType) const { return const_cast<EventListenerMap*>(this)->find(eventType); }
     Vector<AtomString> eventTypes() const;
 

--- a/Source/WebCore/dom/EventLoop.cpp
+++ b/Source/WebCore/dom/EventLoop.cpp
@@ -47,9 +47,9 @@ public:
     enum class Type : bool { OneShot, Repeating };
     static Ref<EventLoopTimer> create(Type type, std::unique_ptr<EventLoopTask>&& task) { return adoptRef(*new EventLoopTimer(type, WTF::move(task))); }
 
-    Type type() const { return m_type; }
-    EventLoopTaskGroup* group() const { return m_task ? m_task->group() : nullptr; }
-    bool isSuspended() const { return m_suspended; }
+    Type NODELETE type() const { return m_type; }
+    EventLoopTaskGroup* NODELETE group() const { return m_task ? m_task->group() : nullptr; }
+    bool NODELETE isSuspended() const { return m_suspended; }
 
     void stop()
     {

--- a/Source/WebCore/dom/EventPath.cpp
+++ b/Source/WebCore/dom/EventPath.cpp
@@ -40,14 +40,14 @@
 
 namespace WebCore {
 
-static inline bool shouldEventCrossShadowBoundary(Event& event, ShadowRoot& shadowRoot, EventTarget& target)
+static inline bool NODELETE shouldEventCrossShadowBoundary(Event& event, ShadowRoot& shadowRoot, EventTarget& target)
 {
     auto* targetNode = dynamicDowncast<Node>(target);
     bool targetIsInShadowRoot = targetNode && &targetNode->treeScope().rootNode() == &shadowRoot;
     return !targetIsInShadowRoot || event.composed();
 }
 
-static Node* nodeOrHostIfPseudoElement(Node* node)
+static Node* NODELETE nodeOrHostIfPseudoElement(Node* node)
 {
     auto* pseudoElement = dynamicDowncast<PseudoElement>(*node);
     return pseudoElement ? pseudoElement->hostElement() : node;
@@ -310,7 +310,7 @@ EventPath::EventPath(EventTarget& target)
     m_path = { EventContext { EventContext::Type::Normal, nullptr, &target, &target, 0 } };
 }
 
-static Node* moveOutOfAllShadowRoots(Node& startingNode)
+static Node* NODELETE moveOutOfAllShadowRoots(Node& startingNode)
 {
     CheckedPtr node = &startingNode;
     while (node && node->isInShadowTree())
@@ -372,7 +372,7 @@ RelatedNodeRetargeter::RelatedNodeRetargeter(Ref<Node>&& relatedNode, Node& targ
     m_retargetedRelatedNode = nodeInLowestCommonAncestor();
 }
 
-inline Node* RelatedNodeRetargeter::currentNode(Node& currentTarget)
+inline Node* NODELETE RelatedNodeRetargeter::currentNode(Node& currentTarget)
 {
     checkConsistency(currentTarget);
     return m_retargetedRelatedNode.get();
@@ -412,7 +412,7 @@ void RelatedNodeRetargeter::moveToNewTreeScope(TreeScope* previousTreeScope, Tre
     }
 }
 
-inline Node* RelatedNodeRetargeter::nodeInLowestCommonAncestor()
+inline Node* NODELETE RelatedNodeRetargeter::nodeInLowestCommonAncestor()
 {
     if (!m_lowestCommonAncestorIndex)
         return m_relatedNode.ptr();
@@ -430,7 +430,7 @@ void RelatedNodeRetargeter::collectTreeScopes()
 
 #if !ASSERT_ENABLED
 
-inline void RelatedNodeRetargeter::checkConsistency(Node&)
+inline void NODELETE RelatedNodeRetargeter::checkConsistency(Node&)
 {
 }
 

--- a/Source/WebCore/dom/EventTarget.h
+++ b/Source/WebCore/dom/EventTarget.h
@@ -96,7 +96,7 @@ public:
     virtual enum EventTargetInterfaceType NODELETE eventTargetInterface() const = 0;
     virtual ScriptExecutionContext* scriptExecutionContext() const = 0;
 
-    virtual bool isPaymentRequest() const;
+    virtual bool NODELETE isPaymentRequest() const;
 
     using AddEventListenerOptionsOrBoolean = Variant<AddEventListenerOptions, bool>;
     void addEventListenerForBindings(const AtomString& eventType, RefPtr<EventListener>&&, AddEventListenerOptionsOrBoolean&&);

--- a/Source/WebCore/dom/ExtensionStyleSheets.h
+++ b/Source/WebCore/dom/ExtensionStyleSheets.h
@@ -64,7 +64,7 @@ public:
     const Vector<Ref<CSSStyleSheet>>& injectedAuthorStyleSheets() const;
     const Vector<Ref<CSSStyleSheet>>& authorStyleSheetsForTesting() const { return m_authorStyleSheetsForTesting; }
 
-    bool hasCachedInjectedStyleSheets() const;
+    bool NODELETE hasCachedInjectedStyleSheets() const;
 
     void clearPageUserSheet();
     void updatePageUserSheet();
@@ -83,7 +83,7 @@ public:
     void injectPageSpecificUserStyleSheet(const UserStyleSheet&);
     void removePageSpecificUserStyleSheet(const UserStyleSheet&);
 
-    String contentForInjectedStyleSheet(CSSStyleSheet&) const;
+    String NODELETE contentForInjectedStyleSheet(CSSStyleSheet&) const;
 
     void detachFromDocument();
 

--- a/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
+++ b/Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp
@@ -60,7 +60,7 @@ enum class BoundaryPointIsAtEnd : bool { No, Yes };
 enum class WordBounded : bool { No, Yes };
 
 // https://wicg.github.io/scroll-to-text-fragment/#search-invisible
-static bool isSearchInvisible(const Node& node)
+static bool NODELETE isSearchInvisible(const Node& node)
 {
     if (!node.renderStyle() || node.renderStyle()->display() == Style::DisplayType::None)
         return true;
@@ -87,7 +87,7 @@ static bool isSearchInvisible(const Node& node)
 }
 
 // https://wicg.github.io/scroll-to-text-fragment/#non-searchable-subtree
-static bool isNonSearchableSubtree(const Node& node)
+static bool NODELETE isNonSearchableSubtree(const Node& node)
 {
     const Node* traversingNode = &node;
     while (traversingNode) {
@@ -122,14 +122,14 @@ static bool indexIsAtWordBoundary(const String& string, unsigned index)
 }
 
 // https://wicg.github.io/scroll-to-text-fragment/#visible-text-node
-static bool isVisibleTextNode(const Node& node)
+static bool NODELETE isVisibleTextNode(const Node& node)
 {
     if (CheckedPtr renderText = dynamicDowncast<RenderText>(node.renderer()))
         return renderText->style().visibility() == Visibility::Visible;
     return false;
 }
 
-static bool isVisibleTextNode(const Text& node)
+static bool NODELETE isVisibleTextNode(const Text& node)
 {
     return node.renderer() && node.renderer()->style().visibility() == Visibility::Visible;
 }

--- a/Source/WebCore/dom/GCReachableRef.h
+++ b/Source/WebCore/dom/GCReachableRef.h
@@ -49,7 +49,7 @@ public:
     }
 
 private:
-    WEBCORE_EXPORT static HashCountedSet<EventTarget*>& map();
+    WEBCORE_EXPORT static HashCountedSet<EventTarget*>& NODELETE map();
 };
 
 template <typename T>

--- a/Source/WebCore/dom/InternalObserverDrop.cpp
+++ b/Source/WebCore/dom/InternalObserverDrop.cpp
@@ -114,7 +114,7 @@ private:
         m_subscriber->visitAdditionalChildren(visitor);
     }
 
-    Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
+    Ref<Subscriber> NODELETE protectedSubscriber() const { return m_subscriber; }
 
     InternalObserverDrop(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverFilter.cpp
+++ b/Source/WebCore/dom/InternalObserverFilter.cpp
@@ -140,8 +140,8 @@ private:
         m_predicate->visitJSFunction(visitor);
     }
 
-    Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
-    Ref<PredicateCallback> protectedPredicate() const { return m_predicate; }
+    Ref<Subscriber> NODELETE protectedSubscriber() const { return m_subscriber; }
+    Ref<PredicateCallback> NODELETE protectedPredicate() const { return m_predicate; }
 
     InternalObserverFilter(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<PredicateCallback> predicate)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverFirst.cpp
+++ b/Source/WebCore/dom/InternalObserverFirst.cpp
@@ -71,7 +71,7 @@ private:
     {
     }
 
-    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
+    Ref<DeferredPromise> NODELETE protectedPromise() const { return m_promise; }
 
     InternalObserverFirst(ScriptExecutionContext& context, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverForEach.cpp
+++ b/Source/WebCore/dom/InternalObserverForEach.cpp
@@ -92,8 +92,8 @@ private:
         m_callback->visitJSFunction(visitor);
     }
 
-    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
-    Ref<VisitorCallback> protectedCallback() const { return m_callback; }
+    Ref<DeferredPromise> NODELETE protectedPromise() const { return m_promise; }
+    Ref<VisitorCallback> NODELETE protectedCallback() const { return m_callback; }
 
     InternalObserverForEach(ScriptExecutionContext& context, Ref<VisitorCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverInspect.cpp
+++ b/Source/WebCore/dom/InternalObserverInspect.cpp
@@ -205,7 +205,7 @@ private:
         return globalObject->vm();
     }
 
-    Ref<Subscriber> protectedSubscriber() const
+    Ref<Subscriber> NODELETE protectedSubscriber() const
     {
         return m_subscriber;
     }

--- a/Source/WebCore/dom/InternalObserverLast.cpp
+++ b/Source/WebCore/dom/InternalObserverLast.cpp
@@ -77,7 +77,7 @@ private:
         m_lastValue.visit(visitor);
     }
 
-    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
+    Ref<DeferredPromise> NODELETE protectedPromise() const { return m_promise; }
 
     InternalObserverLast(ScriptExecutionContext& context, Ref<DeferredPromise>&& promise)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverMap.cpp
+++ b/Source/WebCore/dom/InternalObserverMap.cpp
@@ -135,8 +135,8 @@ private:
         m_mapper->visitJSFunction(visitor);
     }
 
-    Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
-    Ref<MapperCallback> protectedMapper() const { return m_mapper; }
+    Ref<Subscriber> NODELETE protectedSubscriber() const { return m_subscriber; }
+    Ref<MapperCallback> NODELETE protectedMapper() const { return m_mapper; }
 
     InternalObserverMap(ScriptExecutionContext& context, Ref<Subscriber> subscriber, Ref<MapperCallback> mapper)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverReduce.cpp
+++ b/Source/WebCore/dom/InternalObserverReduce.cpp
@@ -106,8 +106,8 @@ private:
         m_accumulator.visit(visitor);
     }
 
-    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
-    Ref<ReducerCallback> protectedCallback() const { return m_callback; }
+    Ref<DeferredPromise> NODELETE protectedPromise() const { return m_promise; }
+    Ref<ReducerCallback> NODELETE protectedCallback() const { return m_callback; }
 
     InternalObserverReduce(ScriptExecutionContext& context, Ref<AbortSignal>&& signal, Ref<ReducerCallback>&& callback, JSC::JSValue initialValue, Ref<DeferredPromise>&& promise)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverSome.cpp
+++ b/Source/WebCore/dom/InternalObserverSome.cpp
@@ -104,9 +104,9 @@ private:
         m_callback->visitJSFunction(visitor);
     }
 
-    Ref<DeferredPromise> protectedPromise() const { return m_promise; }
-    Ref<PredicateCallback> protectedCallback() const { return m_callback; }
-    Ref<AbortSignal> protectedSignal() const { return m_signal; }
+    Ref<DeferredPromise> NODELETE protectedPromise() const { return m_promise; }
+    Ref<PredicateCallback> NODELETE protectedCallback() const { return m_callback; }
+    Ref<AbortSignal> NODELETE protectedSignal() const { return m_signal; }
 
     InternalObserverSome(ScriptExecutionContext& context, Ref<PredicateCallback>&& callback, Ref<AbortSignal>&& signal, Ref<DeferredPromise>&& promise)
         : InternalObserver(context)

--- a/Source/WebCore/dom/InternalObserverTake.cpp
+++ b/Source/WebCore/dom/InternalObserverTake.cpp
@@ -115,7 +115,7 @@ private:
         m_subscriber->visitAdditionalChildren(visitor);
     }
 
-    Ref<Subscriber> protectedSubscriber() const { return m_subscriber; }
+    Ref<Subscriber> NODELETE protectedSubscriber() const { return m_subscriber; }
 
     InternalObserverTake(ScriptExecutionContext& context, Ref<Subscriber> subscriber, uint64_t amount)
         : InternalObserver(context)

--- a/Source/WebCore/dom/KeyboardEvent.cpp
+++ b/Source/WebCore/dom/KeyboardEvent.cpp
@@ -57,7 +57,7 @@ static inline const AtomString& eventTypeForKeyboardEventType(PlatformEvent::Typ
     return eventNames().keydownEvent;
 }
 
-static inline int windowsVirtualKeyCodeWithoutLocation(int keycode)
+static inline int NODELETE windowsVirtualKeyCodeWithoutLocation(int keycode)
 {
     switch (keycode) {
     case VK_LCONTROL:
@@ -74,7 +74,7 @@ static inline int windowsVirtualKeyCodeWithoutLocation(int keycode)
     }
 }
 
-static inline KeyboardEvent::KeyLocationCode keyLocationCode(const PlatformKeyboardEvent& key)
+static inline KeyboardEvent::KeyLocationCode NODELETE keyLocationCode(const PlatformKeyboardEvent& key)
 {
     if (key.isKeypad())
         return KeyboardEvent::DOM_KEY_LOCATION_NUMPAD;

--- a/Source/WebCore/dom/KeyboardEvent.h
+++ b/Source/WebCore/dom/KeyboardEvent.h
@@ -84,7 +84,7 @@ public:
     PlatformKeyboardEvent* underlyingPlatformEvent() { return m_underlyingPlatformEvent.get(); }
 
     WEBCORE_EXPORT int keyCode() const; // key code for keydown and keyup, character for keypress
-    int keyCodeForKeyDown() const; // key code for the keydown that matches the keypress
+    int NODELETE keyCodeForKeyDown() const; // key code for the keydown that matches the keypress
     WEBCORE_EXPORT int charCode() const; // character code for keypress, 0 for keydown and keyup
 
     unsigned which() const final;
@@ -97,7 +97,7 @@ public:
     Vector<KeypressCommand>& keypressCommands() { return m_keypressCommands; }
 #endif
 
-    FocusEventData focusEventData() const;
+    FocusEventData NODELETE focusEventData() const;
 
 private:
     KeyboardEvent();

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -50,13 +50,13 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MessagePort);
 
 static Lock allMessagePortsLock;
-static HashMap<MessagePortIdentifier, ThreadSafeWeakPtr<MessagePort>>& allMessagePorts() WTF_REQUIRES_LOCK(allMessagePortsLock)
+static HashMap<MessagePortIdentifier, ThreadSafeWeakPtr<MessagePort>>& NODELETE allMessagePorts() WTF_REQUIRES_LOCK(allMessagePortsLock)
 {
     static NeverDestroyed<HashMap<MessagePortIdentifier, ThreadSafeWeakPtr<MessagePort>>> map;
     return map;
 }
 
-static HashMap<MessagePortIdentifier, ScriptExecutionContextIdentifier>& portToContextIdentifier() WTF_REQUIRES_LOCK(allMessagePortsLock)
+static HashMap<MessagePortIdentifier, ScriptExecutionContextIdentifier>& NODELETE portToContextIdentifier() WTF_REQUIRES_LOCK(allMessagePortsLock)
 {
     static NeverDestroyed<HashMap<MessagePortIdentifier, ScriptExecutionContextIdentifier>> map;
     return map;

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -90,7 +90,7 @@ public:
     // Returns null if there is no entangled port, or if the entangled port is run by a different thread.
     // This is used solely to enable a GC optimization. Some platforms may not be able to determine ownership
     // of the remote port (since it may live cross-process) - those platforms may always return null.
-    MessagePort* locallyEntangledPort() const;
+    MessagePort* NODELETE locallyEntangledPort() const;
 
     const MessagePortIdentifier& identifier() const { return m_identifier; }
     const MessagePortIdentifier& remoteIdentifier() const { return m_remoteIdentifier; }
@@ -132,7 +132,7 @@ private:
     MessageHandler m_messageHandler;
 };
 
-WebCoreOpaqueRoot root(MessagePort*);
+WebCoreOpaqueRoot NODELETE root(MessagePort*);
 
 } // namespace WebCore
 

--- a/Source/WebCore/dom/Microtasks.h
+++ b/Source/WebCore/dom/Microtasks.h
@@ -49,7 +49,7 @@ public:
         return currentRunnability() == JSC::QueuedTask::Result::Executed;
     }
 
-    JSC::QueuedTask::Result currentRunnability() const;
+    JSC::QueuedTask::Result NODELETE currentRunnability() const;
 
 private:
     WeakPtr<EventLoopTaskGroup> m_group;

--- a/Source/WebCore/dom/MutationObserver.h
+++ b/Source/WebCore/dom/MutationObserver.h
@@ -103,7 +103,7 @@ private:
     explicit MutationObserver(Ref<MutationCallback>&&);
     void deliver();
 
-    static bool validateOptions(MutationObserverOptions);
+    static bool NODELETE validateOptions(MutationObserverOptions);
 
     const Ref<MutationCallback> m_callback;
     Vector<Ref<MutationRecord>> m_records;

--- a/Source/WebCore/dom/MutationObserverRegistration.h
+++ b/Source/WebCore/dom/MutationObserverRegistration.h
@@ -59,7 +59,7 @@ public:
     HashSet<GCReachableRef<Node>> takeTransientRegistrations();
     bool hasTransientRegistrations() const { return !m_transientRegistrationNodes.isEmpty(); }
 
-    bool shouldReceiveMutationFrom(Node&, MutationObserverOptionType, const QualifiedName* attributeName) const;
+    bool NODELETE shouldReceiveMutationFrom(Node&, MutationObserverOptionType, const QualifiedName* attributeName) const;
     bool isSubtree() const { return m_options.contains(MutationObserverOptionType::Subtree); }
 
     MutationObserver& observer() { return m_observer.get(); }

--- a/Source/WebCore/dom/MutationRecord.h
+++ b/Source/WebCore/dom/MutationRecord.h
@@ -61,7 +61,7 @@ public:
     virtual ~MutationRecord();
 
     virtual const AtomString& type() = 0;
-    virtual Node& target() = 0;
+    virtual Node& NODELETE target() = 0;
 
     virtual NodeList& addedNodes() = 0;
     virtual NodeList& removedNodes() = 0;

--- a/Source/WebCore/dom/NamedNodeMap.h
+++ b/Source/WebCore/dom/NamedNodeMap.h
@@ -41,7 +41,7 @@ public:
     {
     }
 
-    WEBCORE_EXPORT void ref();
+    WEBCORE_EXPORT void NODELETE ref();
     WEBCORE_EXPORT void deref();
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }

--- a/Source/WebCore/dom/Node.cpp
+++ b/Source/WebCore/dom/Node.cpp
@@ -393,7 +393,7 @@ Node::Node(Document& document, NodeType type, OptionSet<TypeFlag> flags)
 #endif
 }
 
-static HashMap<WeakRef<Node, WeakPtrImplWithEventTargetData>, NodeIdentifier>& nodeIdentifiersMap()
+static HashMap<WeakRef<Node, WeakPtrImplWithEventTargetData>, NodeIdentifier>& NODELETE nodeIdentifiersMap()
 {
     static MainThreadNeverDestroyed<HashMap<WeakRef<Node, WeakPtrImplWithEventTargetData>, NodeIdentifier>> map;
     return map;
@@ -1327,7 +1327,7 @@ bool Node::isClosedShadowHidden(const Node& otherNode) const
     return true;
 }
 
-static inline ShadowRoot* parentShadowRoot(const Node& node)
+static inline ShadowRoot* NODELETE parentShadowRoot(const Node& node)
 {
     if (auto* parent = node.parentElement())
         return parent->shadowRoot();
@@ -3053,7 +3053,7 @@ template Node* commonInclusiveAncestor<Tree>(const Node&, const Node&);
 template Node* commonInclusiveAncestor<ComposedTree>(const Node&, const Node&);
 template Node* commonInclusiveAncestor<ShadowIncludingTree>(const Node&, const Node&);
 
-static bool isSiblingSubsequent(const Node& siblingA, const Node& siblingB)
+static bool NODELETE isSiblingSubsequent(const Node& siblingA, const Node& siblingB)
 {
     ASSERT(siblingA.parentNode());
     ASSERT(siblingA.parentNode() == siblingB.parentNode());

--- a/Source/WebCore/dom/Node.h
+++ b/Source/WebCore/dom/Node.h
@@ -152,7 +152,7 @@ public:
         DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20,
     };
 
-    static void dumpStatistics();
+    static void NODELETE dumpStatistics();
 
     virtual ~Node();
     void willBeDeletedFrom(Document&);
@@ -292,10 +292,10 @@ public:
 
     HTMLSlotElement* assignedSlot() const;
     HTMLSlotElement* assignedSlotForBindings() const;
-    HTMLSlotElement* manuallyAssignedSlot() const;
+    HTMLSlotElement* NODELETE manuallyAssignedSlot() const;
     void setManuallyAssignedSlot(HTMLSlotElement*);
 
-    bool hasEverPaintedImages() const;
+    bool NODELETE hasEverPaintedImages() const;
     void setHasEverPaintedImages(bool);
 
     bool isUncustomizedCustomElement() const { return customElementState() == CustomElementState::Uncustomized; }
@@ -345,7 +345,7 @@ public:
     // Use when it's guaranteed to that shadowHost is null.
     inline ContainerNode* parentNodeGuaranteedHostFree() const;
     // Returns the parent node, but null if the parent node is a ShadowRoot.
-    ContainerNode* nonShadowBoundaryParentNode() const;
+    ContainerNode* NODELETE nonShadowBoundaryParentNode() const;
 
     bool selfOrPrecedingNodesAffectDirAuto() const { return hasStateFlag(StateFlag::SelfOrPrecedingNodesAffectDirAuto); }
     void setSelfOrPrecedingNodesAffectDirAuto(bool flag) { setStateFlag(StateFlag::SelfOrPrecedingNodesAffectDirAuto, flag); }
@@ -393,7 +393,7 @@ public:
     bool hasDidMutateSubtreeAfterSetInnerHTML() const { return hasStateFlag(StateFlag::DidMutateSubtreeAfterSetInnerHTML); }
     void setDidMutateSubtreeAfterSetInnerHTML() { setStateFlag(StateFlag::DidMutateSubtreeAfterSetInnerHTML); }
     void clearDidMutateSubtreeAfterSetInnerHTML() { clearStateFlag(StateFlag::DidMutateSubtreeAfterSetInnerHTML); }
-    void setDidMutateSubtreeAfterSetInnerHTMLOnAncestors();
+    void NODELETE setDidMutateSubtreeAfterSetInnerHTMLOnAncestors();
 
     bool hasWasParsedWithFastPath() const { return hasStateFlag(StateFlag::WasParsedWithFastPath); }
     void setWasParsedWithFastPath() { setStateFlag(StateFlag::WasParsedWithFastPath); }
@@ -805,7 +805,7 @@ private:
     bool checkIsInUserAgentShadowTree(bool value) const { return value; }
 #endif
 
-    void trackForDebugging();
+    void NODELETE trackForDebugging();
     void materializeRareData();
 
     Vector<Ref<MutationObserverRegistration>>* NODELETE mutationObserverRegistry();
@@ -851,7 +851,7 @@ template<TreeType = Tree> std::partial_ordering treeOrder(const Node&, const Nod
 
 WEBCORE_EXPORT std::partial_ordering treeOrderForTesting(TreeType, const Node&, const Node&);
 
-bool isTouchRelatedEventType(const EventTypeInfo&, const EventTarget&);
+bool NODELETE isTouchRelatedEventType(const EventTypeInfo&, const EventTarget&);
 
 #if ASSERT_ENABLED
 

--- a/Source/WebCore/dom/NodeTraversal.cpp
+++ b/Source/WebCore/dom/NodeTraversal.cpp
@@ -151,7 +151,7 @@ Node* nextPostOrder(const Node& current, const Node* stayWithin)
     return next;
 }
 
-static Node* previousAncestorSiblingPostOrder(const Node& current, const Node* stayWithin)
+static Node* NODELETE previousAncestorSiblingPostOrder(const Node& current, const Node* stayWithin)
 {
     ASSERT(!current.previousSibling());
     for (auto* ancestor = current.parentNode(); ancestor; ancestor = ancestor->parentNode()) {

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -81,9 +81,9 @@ public:
 
     // These are always DOM compliant values.  Editing positions like [img, 0] (aka [img, before])
     // will return img->parentNode() and img->computeNodeIndex() from these functions.
-    WEBCORE_EXPORT Node* containerNode() const; // null for a before/after position anchored to a node with no parent
-    Text* containerText() const;
-    Element* containerOrParentElement() const;
+    WEBCORE_EXPORT Node* NODELETE containerNode() const; // null for a before/after position anchored to a node with no parent
+    Text* NODELETE containerText() const;
+    Element* NODELETE containerOrParentElement() const;
 
     int computeOffsetInContainerNode() const;  // O(n) for before/after-anchored positions, O(1) for parent-anchored positions
     WEBCORE_EXPORT Position parentAnchoredEquivalent() const; // Convenience method for DOM positions that also fixes up some positions for editing
@@ -106,8 +106,8 @@ public:
     RefPtr<Node> firstNode() const;
 
     // These are convenience methods which are smart about whether the position is neighbor anchored or parent anchored
-    WEBCORE_EXPORT Node* computeNodeBeforePosition() const;
-    WEBCORE_EXPORT Node* computeNodeAfterPosition() const;
+    WEBCORE_EXPORT Node* NODELETE computeNodeBeforePosition() const;
+    WEBCORE_EXPORT Node* NODELETE computeNodeAfterPosition() const;
 
     Node* anchorNode() const { return m_anchorNode.get(); }
 
@@ -173,7 +173,7 @@ public:
     InlineBoxAndOffset inlineBoxAndOffset(Affinity) const;
     InlineBoxAndOffset inlineBoxAndOffset(Affinity, TextDirection primaryDirection) const;
 
-    TextDirection primaryDirection() const;
+    TextDirection NODELETE primaryDirection() const;
 
     // Returns the number of positions that exist between two positions.
     static unsigned positionCountBetweenPositions(const Position&, const Position&);

--- a/Source/WebCore/dom/PositionIterator.h
+++ b/Source/WebCore/dom/PositionIterator.h
@@ -44,9 +44,9 @@ public:
     Node* node() const { return m_anchorNode.get(); }
     int offsetInLeafNode() const { return m_offsetInAnchor; }
 
-    bool atStart() const;
+    bool NODELETE atStart() const;
     bool atEnd() const;
-    bool atStartOfNode() const;
+    bool NODELETE atStartOfNode() const;
     bool atEndOfNode() const;
     bool isCandidate() const;
 

--- a/Source/WebCore/dom/QualifiedName.cpp
+++ b/Source/WebCore/dom/QualifiedName.cpp
@@ -42,7 +42,7 @@ QualifiedName::QualifiedNameImpl::QualifiedNameImpl(const AtomString& prefix, co
     ASSERT(!namespaceURI.isEmpty() || namespaceURI.isNull());
 }
 
-static QualifiedNameComponents makeComponents(const AtomString& prefix, const AtomString& localName, const AtomString& namespaceURI)
+static QualifiedNameComponents NODELETE makeComponents(const AtomString& prefix, const AtomString& localName, const AtomString& namespaceURI)
 {
     return { prefix.impl(), localName.impl(), namespaceURI.isEmpty() ? nullptr : namespaceURI.impl() };
 }

--- a/Source/WebCore/dom/QualifiedNameCache.cpp
+++ b/Source/WebCore/dom/QualifiedNameCache.cpp
@@ -41,7 +41,7 @@ struct QNameComponentsTranslator {
         return computeHash(components);
     }
 
-    static bool equal(QualifiedName::QualifiedNameImpl* name, const QualifiedNameComponents& c)
+    static bool NODELETE equal(QualifiedName::QualifiedNameImpl* name, const QualifiedNameComponents& c)
     {
         return c.m_prefix == name->m_prefix.impl() && c.m_localName == name->m_localName.impl() && c.m_namespaceURI == name->m_namespaceURI.impl();
     }

--- a/Source/WebCore/dom/RadioButtonGroups.cpp
+++ b/Source/WebCore/dom/RadioButtonGroups.cpp
@@ -37,9 +37,9 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(RadioButtonGroups);
 class RadioButtonGroup {
     WTF_MAKE_TZONE_ALLOCATED(RadioButtonGroup);
 public:
-    bool isEmpty() const { return m_members.isEmptyIgnoringNullReferences(); }
-    bool isRequired() const { return m_requiredCount; }
-    RefPtr<HTMLInputElement> checkedButton() const { return m_checkedButton; }
+    bool NODELETE isEmpty() const { return m_members.isEmptyIgnoringNullReferences(); }
+    bool NODELETE isRequired() const { return m_requiredCount; }
+    RefPtr<HTMLInputElement> NODELETE checkedButton() const { return m_checkedButton; }
     void add(HTMLInputElement&);
     void updateCheckedState(HTMLInputElement&);
     void requiredStateChanged(HTMLInputElement&);
@@ -60,7 +60,7 @@ private:
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RadioButtonGroup);
 
-inline bool RadioButtonGroup::isValid() const
+inline bool NODELETE RadioButtonGroup::isValid() const
 {
     return !isRequired() || m_checkedButton;
 }
@@ -191,7 +191,7 @@ void RadioButtonGroup::updateValidityForAllButtons()
     }
 }
 
-bool RadioButtonGroup::contains(HTMLInputElement& button) const
+bool NODELETE RadioButtonGroup::contains(HTMLInputElement& button) const
 {
     return m_members.contains(button);
 }

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -272,7 +272,7 @@ bool Range::intersectsNode(Node& node) const
     return intersects(makeSimpleRange(*this), node);
 }
 
-static inline Node* highestAncestorUnderCommonRoot(Node* node, Node* commonRoot)
+static inline Node* NODELETE highestAncestorUnderCommonRoot(Node* node, Node* commonRoot)
 {
     if (node == commonRoot)
         return 0;
@@ -954,7 +954,7 @@ void Range::updateRangeForParentlessNodeMovedToNewDocument(Node& node)
     protect(m_ownerDocument)->attachRange(*this);
 }
 
-static inline void boundaryTextInserted(RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
+static inline void NODELETE boundaryTextInserted(RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
 {
     if (&boundary.container() != &text)
         return;
@@ -972,7 +972,7 @@ void Range::textInserted(Node& text, unsigned offset, unsigned length)
     m_didChangeForHighlight = true;
 }
 
-static inline void boundaryTextRemoved(RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
+static inline void NODELETE boundaryTextRemoved(RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
 {
     if (&boundary.container() != &text)
         return;

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -105,8 +105,8 @@ public:
     bool parentlessNodeMovedToNewDocumentAffectsRange(Node&);
     void updateRangeForParentlessNodeMovedToNewDocument(Node&);
 
-    void textInserted(Node&, unsigned offset, unsigned length);
-    void textRemoved(Node&, unsigned offset, unsigned length);
+    void NODELETE textInserted(Node&, unsigned offset, unsigned length);
+    void NODELETE textRemoved(Node&, unsigned offset, unsigned length);
     void textNodesMerged(NodeWithIndex& oldNode, unsigned offset);
     void textNodeSplit(Text& oldNode);
 
@@ -121,7 +121,7 @@ public:
     }
 
     // For use by garbage collection. Returns nullptr for ranges not assocated with selection.
-    LocalDOMWindow* window() const;
+    LocalDOMWindow* NODELETE window() const;
 
     static ExceptionOr<RefPtr<Node>> checkNodeOffsetPair(Node&, unsigned offset);
 

--- a/Source/WebCore/dom/RejectedPromiseTracker.cpp
+++ b/Source/WebCore/dom/RejectedPromiseTracker.cpp
@@ -66,12 +66,12 @@ public:
 
     UnhandledPromise(UnhandledPromise&&) = default;
 
-    ScriptCallStack* callStack()
+    ScriptCallStack* NODELETE callStack()
     {
         return m_stack.get();
     }
 
-    DOMPromise& promise()
+    DOMPromise& NODELETE promise()
     {
         return m_promise.get();
     }

--- a/Source/WebCore/dom/ScriptElement.h
+++ b/Source/WebCore/dom/ScriptElement.h
@@ -83,7 +83,7 @@ public:
 
     JSC::SourceTaintedOrigin sourceTaintedOrigin() const { return m_taintedOrigin; }
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     static std::optional<ScriptType> determineScriptType(const String& typeAttribute, const String& languageAttribute, bool isHTMLDocument = true, bool speculationRulesPrefetchEnabled = false);
@@ -109,7 +109,7 @@ protected:
     void childrenChanged(const ContainerNode::ChildChange&);
     void finishParsingChildren();
     void handleSourceAttribute(const String& sourceURL);
-    void handleAsyncAttribute();
+    void NODELETE handleAsyncAttribute();
 
     void setTrustedScriptText(const String&);
 
@@ -120,7 +120,7 @@ private:
     void executeScriptAndDispatchEvent(LoadableScript&);
 
     std::optional<ScriptType> determineScriptType() const;
-    bool ignoresLoadRequest() const;
+    bool NODELETE ignoresLoadRequest() const;
     void dispatchLoadEventRespectingUserGestureIndicator();
 
     bool requestClassicScript(const String& sourceURL);
@@ -167,7 +167,7 @@ private:
 };
 
 // FIXME: replace with is/downcast<ScriptElement>.
-bool isScriptElement(Node&);
-ScriptElement* dynamicDowncastScriptElement(Element&);
+bool NODELETE isScriptElement(Node&);
+ScriptElement* NODELETE dynamicDowncastScriptElement(Element&);
 
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -106,7 +106,7 @@ using namespace Inspector;
 static std::atomic<CrossOriginMode> globalCrossOriginMode { CrossOriginMode::Shared };
 
 static Lock allScriptExecutionContextsMapLock;
-static HashMap<ScriptExecutionContextIdentifier, WeakRef<ScriptExecutionContext>>& allScriptExecutionContextsMap() WTF_REQUIRES_LOCK(allScriptExecutionContextsMapLock)
+static HashMap<ScriptExecutionContextIdentifier, WeakRef<ScriptExecutionContext>>& NODELETE allScriptExecutionContextsMap() WTF_REQUIRES_LOCK(allScriptExecutionContextsMapLock)
 {
     static NeverDestroyed<HashMap<ScriptExecutionContextIdentifier, WeakRef<ScriptExecutionContext>>> contexts;
     ASSERT(allScriptExecutionContextsMapLock.isLocked());
@@ -874,7 +874,7 @@ void ScriptExecutionContext::postTaskToResponsibleDocument(Function<void(Documen
         callback(document.releaseNonNull());
 }
 
-static bool isOriginEquivalentToLocal(const SecurityOrigin& origin)
+static bool NODELETE isOriginEquivalentToLocal(const SecurityOrigin& origin)
 {
     return origin.isLocal() && !origin.needsStorageAccessFromFileURLsQuirk() && !origin.hasUniversalAccess();
 }

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -204,7 +204,7 @@ public:
     bool activeDOMObjectsAreSuspended() const { return m_activeDOMObjectsAreSuspended; }
     bool activeDOMObjectsAreStopped() const { return m_activeDOMObjectsAreStopped; }
 
-    JSC::ScriptExecutionStatus jscScriptExecutionStatus() const;
+    JSC::ScriptExecutionStatus NODELETE jscScriptExecutionStatus() const;
 
     enum class CallStackPosition : bool { BottomMost, TopMost };
     URL currentSourceURL(CallStackPosition = CallStackPosition::BottomMost) const;
@@ -232,9 +232,9 @@ public:
     virtual void beginLoadingFontSoon(FontLoadRequest&) { }
 
     WEBCORE_EXPORT static void setCrossOriginMode(CrossOriginMode);
-    static CrossOriginMode crossOriginMode();
+    static CrossOriginMode NODELETE crossOriginMode();
 
-    WEBCORE_EXPORT void ref();
+    WEBCORE_EXPORT void NODELETE ref();
     WEBCORE_EXPORT void deref();
 
     uint32_t checkedPtrCount() const final { return CanMakeThreadSafeCheckedPtr::checkedPtrCount(); }
@@ -289,7 +289,7 @@ public:
     void postTaskToResponsibleDocument(Function<void(Document&)>&&);
 
     // Gets the next id in a circular sequence from 1 to 2^31-1.
-    int circularSequentialID();
+    int NODELETE circularSequentialID();
 
     inline bool addTimeout(int timeoutId, DOMTimer&); // Defined in ScriptExecutionContextInlines.h
     inline RefPtr<DOMTimer> takeTimeout(int timeoutId); // Defined in ScriptExecutionContextInlines.h
@@ -426,7 +426,7 @@ private:
 
     RejectedPromiseTracker* ensureRejectedPromiseTrackerSlow();
 
-    void checkConsistency() const;
+    void NODELETE checkConsistency() const;
     WEBCORE_EXPORT GuaranteedSerialFunctionDispatcher& nativePromiseDispatcher();
 
     WeakHashSet<MessagePort, WeakPtrImplWithEventTargetData> m_messagePorts;
@@ -476,6 +476,6 @@ private:
     JSC::Weak<JSC::JSGlobalObject> m_microtaskGlobalObject;
 };
 
-WebCoreOpaqueRoot root(ScriptExecutionContext*);
+WebCoreOpaqueRoot NODELETE root(ScriptExecutionContext*);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/ScriptRunner.h
+++ b/Source/WebCore/dom/ScriptRunner.h
@@ -50,7 +50,7 @@ public:
     explicit ScriptRunner(Document&);
     ~ScriptRunner();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     // CheckedPtr interface

--- a/Source/WebCore/dom/ScriptedAnimationController.h
+++ b/Source/WebCore/dom/ScriptedAnimationController.h
@@ -55,9 +55,9 @@ public:
     void clearDocumentPointer() { m_document = nullptr; }
 
     WEBCORE_EXPORT Seconds interval() const;
-    WEBCORE_EXPORT OptionSet<ThrottlingReason> throttlingReasons() const;
+    WEBCORE_EXPORT OptionSet<ThrottlingReason> NODELETE throttlingReasons() const;
 
-    void suspend();
+    void NODELETE suspend();
     void resume();
 
     void addThrottlingReason(ThrottlingReason reason) { m_throttlingReasons.add(reason); }
@@ -71,7 +71,7 @@ public:
 private:
     ScriptedAnimationController(Document&);
 
-    Page* page() const;
+    Page* NODELETE page() const;
     Seconds preferredScriptedAnimationInterval() const;
     bool isThrottledRelativeToPage() const;
     bool shouldRescheduleRequestAnimationFrame(ReducedResolutionSeconds) const;

--- a/Source/WebCore/dom/SecurityContext.h
+++ b/Source/WebCore/dom/SecurityContext.h
@@ -92,7 +92,7 @@ public:
     void setIntegrityPolicyReportOnly(std::unique_ptr<IntegrityPolicy>&&);
 
     virtual ReferrerPolicy referrerPolicy() const { return m_referrerPolicy; }
-    void setReferrerPolicy(ReferrerPolicy);
+    void NODELETE setReferrerPolicy(ReferrerPolicy);
 
     IPAddressSpace ipAddressSpace() const { return m_ipAddressSpace; }
     void setIPAddressSpace(IPAddressSpace ipAddressSpace) { m_ipAddressSpace = ipAddressSpace; }

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -80,13 +80,13 @@ template<typename Output> static ALWAYS_INLINE void appendOutputForElement(Outpu
         output.append(element);
 }
 
-static bool canBeUsedForIdFastPath(const CSSSelector& selector)
+static bool NODELETE canBeUsedForIdFastPath(const CSSSelector& selector)
 {
     return selector.match() == CSSSelector::Match::Id
         || (selector.match() == CSSSelector::Match::Exact && selector.attribute() == HTMLNames::idAttr && !selector.attributeValueMatchingIsCaseInsensitive());
 }
 
-static IdMatchingType findIdMatchingType(const CSSSelector& firstSelector)
+static IdMatchingType NODELETE findIdMatchingType(const CSSSelector& firstSelector)
 {
     bool inRightmost = true;
     for (const CSSSelector* selector = &firstSelector; selector; selector = selector->precedingInComplexSelector()) {
@@ -230,7 +230,7 @@ Element* SelectorDataList::queryFirst(ContainerNode& rootNode) const
     return result;
 }
 
-static const CSSSelector* selectorForIdLookup(const ContainerNode& rootNode, const CSSSelector& firstSelector)
+static const CSSSelector* NODELETE selectorForIdLookup(const ContainerNode& rootNode, const CSSSelector& firstSelector)
 {
     if (!rootNode.isConnected())
         return nullptr;

--- a/Source/WebCore/dom/SelectorQuery.h
+++ b/Source/WebCore/dom/SelectorQuery.h
@@ -55,7 +55,7 @@ public:
     Element* queryFirst(ContainerNode& rootNode) const;
 
     bool shouldStoreInDocument() const { return m_matchType == MatchType::TagNameMatch || m_matchType == MatchType::ClassNameMatch; }
-    AtomString classNameToMatch() const;
+    AtomString NODELETE classNameToMatch() const;
 
 private:
     struct SelectorData {
@@ -122,7 +122,7 @@ private:
 class SelectorQueryCache {
     WTF_MAKE_TZONE_ALLOCATED(SelectorQueryCache);
 public:
-    static SelectorQueryCache& singleton();
+    static SelectorQueryCache& NODELETE singleton();
 
     SelectorQuery* add(const String&, const Document&);
     void clear();

--- a/Source/WebCore/dom/SimpleRange.cpp
+++ b/Source/WebCore/dom/SimpleRange.cpp
@@ -84,7 +84,7 @@ OffsetRange characterDataOffsetRange(const SimpleRange& range, const Node& node)
         &node == range.end.container.ptr() ? range.end.offset : std::numeric_limits<unsigned>::max() };
 }
 
-static RefPtr<Node> firstIntersectingNode(const SimpleRange& range)
+static RefPtr<Node> NODELETE firstIntersectingNode(const SimpleRange& range)
 {
     if (range.start.container->isCharacterDataNode())
         return range.start.container.ptr();
@@ -93,7 +93,7 @@ static RefPtr<Node> firstIntersectingNode(const SimpleRange& range)
     return NodeTraversal::nextSkippingChildren(range.start.container);
 }
 
-static RefPtr<Node> nodePastLastIntersectingNode(const SimpleRange& range)
+static RefPtr<Node> NODELETE nodePastLastIntersectingNode(const SimpleRange& range)
 {
     if (range.end.container->isCharacterDataNode())
         return NodeTraversal::nextSkippingChildren(range.end.container);
@@ -102,7 +102,7 @@ static RefPtr<Node> nodePastLastIntersectingNode(const SimpleRange& range)
     return NodeTraversal::nextSkippingChildren(range.end.container);
 }
 
-static RefPtr<Node> firstIntersectingNodeWithDeprecatedZeroOffsetStartQuirk(const SimpleRange& range)
+static RefPtr<Node> NODELETE firstIntersectingNodeWithDeprecatedZeroOffsetStartQuirk(const SimpleRange& range)
 {
     if (range.start.container->isCharacterDataNode())
         return range.start.container.ptr();

--- a/Source/WebCore/dom/SimpleRange.h
+++ b/Source/WebCore/dom/SimpleRange.h
@@ -111,7 +111,7 @@ struct OffsetRange {
     unsigned start { 0 };
     unsigned end { 0 };
 };
-OffsetRange characterDataOffsetRange(const SimpleRange&, const Node&);
+OffsetRange NODELETE characterDataOffsetRange(const SimpleRange&, const Node&);
 
 // FIXME: Start of functions that are deprecated since they silently default to ComposedTree.
 

--- a/Source/WebCore/dom/SlotAssignment.cpp
+++ b/Source/WebCore/dom/SlotAssignment.cpp
@@ -53,7 +53,7 @@ struct SameSizeAsNamedSlotAssignment {
 
 static_assert(sizeof(NamedSlotAssignment) == sizeof(SameSizeAsNamedSlotAssignment), "NamedSlotAssignment should remain small");
 
-static const AtomString& slotNameFromAttributeValue(const AtomString& value)
+static const AtomString& NODELETE slotNameFromAttributeValue(const AtomString& value)
 {
     return value == nullAtom() ? NamedSlotAssignment::defaultSlotName() : value;
 }

--- a/Source/WebCore/dom/SlotAssignment.h
+++ b/Source/WebCore/dom/SlotAssignment.h
@@ -127,7 +127,7 @@ private:
 
     virtual const AtomString& slotNameForHostChild(const Node&) const;
 
-    HTMLSlotElement* findFirstSlotElement(Slot&);
+    HTMLSlotElement* NODELETE findFirstSlotElement(Slot&);
 
     void assignSlots(ShadowRoot&);
     void assignToSlot(Node& child, const AtomString& slotName);

--- a/Source/WebCore/dom/SpaceSplitString.cpp
+++ b/Source/WebCore/dom/SpaceSplitString.cpp
@@ -88,7 +88,7 @@ struct SpaceSplitStringTableKeyTraits : public HashTraits<AtomString>
 
 typedef HashMap<AtomString, SpaceSplitStringData*, AtomStringHash, SpaceSplitStringTableKeyTraits> SpaceSplitStringTable;
 
-static SpaceSplitStringTable& spaceSplitStringTable()
+static SpaceSplitStringTable& NODELETE spaceSplitStringTable()
 {
     static NeverDestroyed<SpaceSplitStringTable> table;
     return table;
@@ -122,7 +122,7 @@ public:
         return true;
     }
 
-    bool referenceStringWasFound() const { return m_referenceStringWasFound; }
+    bool NODELETE referenceStringWasFound() const { return m_referenceStringWasFound; }
 
 private:
     const ReferenceCharacterType* m_referenceCharacters;
@@ -159,7 +159,7 @@ public:
         return true;
     }
 
-    unsigned tokenCount() const { return m_tokenCount; }
+    unsigned NODELETE tokenCount() const { return m_tokenCount; }
 
 private:
     unsigned m_tokenCount;
@@ -183,7 +183,7 @@ public:
         return true;
     }
 
-    const AtomString* nextMemoryBucket() const { return m_memoryBucket.data(); }
+    const AtomString* NODELETE nextMemoryBucket() const { return m_memoryBucket.data(); }
 
 private:
     const AtomString& m_keyString;

--- a/Source/WebCore/dom/StaticRange.cpp
+++ b/Source/WebCore/dom/StaticRange.cpp
@@ -50,7 +50,7 @@ Ref<StaticRange> StaticRange::create(const SimpleRange& range)
     return create(SimpleRange { range });
 }
 
-static bool isDocumentTypeOrAttr(Node& node)
+static bool NODELETE isDocumentTypeOrAttr(Node& node)
 {
     switch (node.nodeType()) {
     case Node::ATTRIBUTE_NODE:

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -60,7 +60,7 @@ public:
 
     // JSCustomMarkFunction; for JSSubscriberCustom
     Vector<VoidCallback*> teardownCallbacksConcurrently();
-    InternalObserver* observerConcurrently();
+    InternalObserver* NODELETE observerConcurrently();
     void visitAdditionalChildren(JSC::AbstractSlotVisitor&);
 
 private:

--- a/Source/WebCore/dom/Text.cpp
+++ b/Source/WebCore/dom/Text.cpp
@@ -79,7 +79,7 @@ ExceptionOr<Ref<Text>> Text::splitText(unsigned offset)
     return newText;
 }
 
-static const Text* earliestLogicallyAdjacentTextNode(const Text* text)
+static const Text* NODELETE earliestLogicallyAdjacentTextNode(const Text* text)
 {
     const Node* node = text;
     while ((node = node->previousSibling())) {
@@ -91,7 +91,7 @@ static const Text* earliestLogicallyAdjacentTextNode(const Text* text)
     return text;
 }
 
-static const Text* latestLogicallyAdjacentTextNode(const Text* text)
+static const Text* NODELETE latestLogicallyAdjacentTextNode(const Text* text)
 {
     const Node* node = text;
     while ((node = node->nextSibling())) {
@@ -162,14 +162,14 @@ SerializedNode Text::serializeNode(CloningOperation) const
     return { SerializedNode::Text { data() } };
 }
 
-static bool isSVGShadowText(const Text& text)
+static bool NODELETE isSVGShadowText(const Text& text)
 {
     ASSERT(text.parentNode());
     auto* parentShadowRoot = dynamicDowncast<ShadowRoot>(*text.parentNode());
     return parentShadowRoot && parentShadowRoot->host()->hasTagName(SVGNames::trefTag);
 }
 
-static bool isSVGText(const Text& text)
+static bool NODELETE isSVGText(const Text& text)
 {
     ASSERT(text.parentNode());
     auto* parentElement = dynamicDowncast<SVGElement>(*text.parentNode());

--- a/Source/WebCore/dom/TreeScope.cpp
+++ b/Source/WebCore/dom/TreeScope.cpp
@@ -519,7 +519,7 @@ bool TreeScope::isMatchingAnchor(HTMLAnchorElement& anchor, StringView name)
     return false;
 }
 
-static Element* focusedFrameOwnerElement(Frame* focusedFrame, LocalFrame* currentFrame)
+static Element* NODELETE focusedFrameOwnerElement(Frame* focusedFrame, LocalFrame* currentFrame)
 {
     for (; focusedFrame; focusedFrame = focusedFrame->tree().parent()) {
         if (focusedFrame->tree().parent() == currentFrame)

--- a/Source/WebCore/dom/TreeScope.h
+++ b/Source/WebCore/dom/TreeScope.h
@@ -74,7 +74,7 @@ public:
     TreeScope* parentTreeScope() const { return m_parentTreeScope; }
     void setParentTreeScope(TreeScope&);
 
-    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void NODELETE ref() const;
     WEBCORE_EXPORT void deref() const;
 
     Element* focusedElementInScope();
@@ -105,8 +105,8 @@ public:
     // https://dom.spec.whatwg.org/#retarget
     Ref<Node> retargetToScope(Node&) const;
 
-    WEBCORE_EXPORT Node* ancestorNodeInThisScope(Node*) const;
-    WEBCORE_EXPORT Element* ancestorElementInThisScope(Element*) const;
+    WEBCORE_EXPORT Node* NODELETE ancestorNodeInThisScope(Node*) const;
+    WEBCORE_EXPORT Element* NODELETE ancestorElementInThisScope(Element*) const;
 
     void addImageMap(HTMLMapElement&);
     void removeImageMap(HTMLMapElement&);
@@ -141,7 +141,7 @@ public:
     RadioButtonGroups& radioButtonGroups();
 
     JSC::JSValue adoptedStyleSheetWrapper(JSDOMGlobalObject&);
-    std::span<const Ref<CSSStyleSheet>> adoptedStyleSheets() const;
+    std::span<const Ref<CSSStyleSheet>> NODELETE adoptedStyleSheets() const;
     ExceptionOr<void> setAdoptedStyleSheets(Vector<Ref<CSSStyleSheet>>&&);
 
     void addSVGResource(const AtomString& id, LegacyRenderSVGResourceContainer&);

--- a/Source/WebCore/dom/TreeWalker.h
+++ b/Source/WebCore/dom/TreeWalker.h
@@ -45,7 +45,7 @@ public:
     Node& currentNode() { return m_current.get(); }
     const Node& currentNode() const { return m_current.get(); }
 
-    WEBCORE_EXPORT void setCurrentNode(Node&);
+    WEBCORE_EXPORT void NODELETE setCurrentNode(Node&);
 
     WEBCORE_EXPORT ExceptionOr<Node*> parentNode();
     WEBCORE_EXPORT ExceptionOr<Node*> firstChild();

--- a/Source/WebCore/dom/TrustedTypePolicy.h
+++ b/Source/WebCore/dom/TrustedTypePolicy.h
@@ -74,6 +74,6 @@ private:
     mutable Lock m_lock;
 };
 
-WebCoreOpaqueRoot root(TrustedTypePolicy*);
+WebCoreOpaqueRoot NODELETE root(TrustedTypePolicy*);
 
 } // namespace WebCore

--- a/Source/WebCore/dom/TrustedTypePolicyFactory.h
+++ b/Source/WebCore/dom/TrustedTypePolicyFactory.h
@@ -51,9 +51,9 @@ public:
     void deref() const final { RefCounted::deref(); }
 
     ExceptionOr<Ref<TrustedTypePolicy>> createPolicy(ScriptExecutionContext&, const String& policyName, const TrustedTypePolicyOptions&);
-    bool isHTML(JSC::JSValue) const;
-    bool isScript(JSC::JSValue) const;
-    bool isScriptURL(JSC::JSValue) const;
+    bool NODELETE isHTML(JSC::JSValue) const;
+    bool NODELETE isScript(JSC::JSValue) const;
+    bool NODELETE isScriptURL(JSC::JSValue) const;
     Ref<TrustedHTML> emptyHTML() const;
     Ref<TrustedScript> emptyScript() const;
 

--- a/Source/WebCore/dom/UserActionElementSet.h
+++ b/Source/WebCore/dom/UserActionElementSet.h
@@ -74,7 +74,7 @@ private:
     void setFlags(Element& element, bool enable, OptionSet<Flag> flags) { enable ? setFlags(element, flags) : clearFlags(element, flags); }
     void setFlags(Element&, OptionSet<Flag>);
     void clearFlags(Element&, OptionSet<Flag>);
-    bool hasFlag(const Element&, Flag) const;
+    bool NODELETE hasFlag(const Element&, Flag) const;
 
     WeakHashMap<Element, OptionSet<Flag>, WeakPtrImplWithEventTargetData> m_elements;
 };

--- a/Source/WebCore/dom/UserGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserGestureIndicator.cpp
@@ -42,7 +42,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(UserGestureIndicator);
 
-static RefPtr<UserGestureToken>& currentToken()
+static RefPtr<UserGestureToken>& NODELETE currentToken()
 {
     ASSERT(isMainThread());
     static NeverDestroyed<RefPtr<UserGestureToken>> token;

--- a/Source/WebCore/dom/UserGestureIndicator.h
+++ b/Source/WebCore/dom/UserGestureIndicator.h
@@ -49,8 +49,8 @@ enum class UserGestureType : uint8_t { EscapeKey, ActivationTriggering, Other };
 class UserGestureToken : public RefCountedAndCanMakeWeakPtr<UserGestureToken> {
 public:
     static constexpr Seconds maximumIntervalForUserGestureForwarding { 1_s }; // One second matches Gecko.
-    static const Seconds& maximumIntervalForUserGestureForwardingForFetch();
-    WEBCORE_EXPORT static void setMaximumIntervalForUserGestureForwardingForFetchForTesting(Seconds);
+    static const Seconds& NODELETE maximumIntervalForUserGestureForwardingForFetch();
+    WEBCORE_EXPORT static void NODELETE setMaximumIntervalForUserGestureForwardingForFetchForTesting(Seconds);
 
     static Ref<UserGestureToken> create(IsProcessingUserGesture isProcessingUserGesture, UserGestureType gestureType, Document* document = nullptr, std::optional<WTF::UUID> authorizationToken = std::nullopt, CanRequestDOMPaste canRequestDOMPaste = CanRequestDOMPaste::Yes)
     {
@@ -107,7 +107,7 @@ public:
 
     bool canRequestDOMPaste() const { return m_canRequestDOMPaste == CanRequestDOMPaste::Yes; }
 
-    bool isValidForDocument(const Document&) const;
+    bool NODELETE isValidForDocument(const Document&) const;
 
     void forEachImpactedDocument(Function<void(Document&)>&&);
 
@@ -130,11 +130,11 @@ class UserGestureIndicator {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(UserGestureIndicator, WEBCORE_EXPORT);
     WTF_MAKE_NONCOPYABLE(UserGestureIndicator);
 public:
-    WEBCORE_EXPORT static RefPtr<UserGestureToken> currentUserGesture();
-    static RefPtr<UserGestureToken> currentUserGestureForMainThread();
+    WEBCORE_EXPORT static RefPtr<UserGestureToken> NODELETE currentUserGesture();
+    static RefPtr<UserGestureToken> NODELETE currentUserGestureForMainThread();
 
-    WEBCORE_EXPORT static bool processingUserGesture(const Document* = nullptr);
-    WEBCORE_EXPORT static bool processingUserGestureForMedia();
+    WEBCORE_EXPORT static bool NODELETE processingUserGesture(const Document* = nullptr);
+    WEBCORE_EXPORT static bool NODELETE processingUserGestureForMedia();
 
     // If a document is provided, its last known user gesture timestamp is updated.
     enum class ProcessInteractionStyle { Immediate, Delayed, Never };
@@ -142,7 +142,7 @@ public:
     WEBCORE_EXPORT explicit UserGestureIndicator(RefPtr<UserGestureToken>, UserGestureToken::GestureScope = UserGestureToken::GestureScope::All, UserGestureToken::ShouldPropagateToMicroTask = UserGestureToken::ShouldPropagateToMicroTask::No);
     WEBCORE_EXPORT ~UserGestureIndicator();
 
-    WEBCORE_EXPORT std::optional<WTF::UUID> authorizationToken() const;
+    WEBCORE_EXPORT std::optional<WTF::UUID> NODELETE authorizationToken() const;
 
 private:
     RefPtr<UserGestureToken> m_previousToken;

--- a/Source/WebCore/dom/UserTypingGestureIndicator.cpp
+++ b/Source/WebCore/dom/UserTypingGestureIndicator.cpp
@@ -40,7 +40,7 @@ bool UserTypingGestureIndicator::processingUserTypingGesture()
     return s_processingUserTypingGesture;
 }
 
-static RefPtr<Node>& focusedNode()
+static RefPtr<Node>& NODELETE focusedNode()
 {
     static NeverDestroyed<RefPtr<Node>> node;
     return node;

--- a/Source/WebCore/dom/UserTypingGestureIndicator.h
+++ b/Source/WebCore/dom/UserTypingGestureIndicator.h
@@ -36,8 +36,8 @@ class Node;
 class UserTypingGestureIndicator {
     WTF_MAKE_NONCOPYABLE(UserTypingGestureIndicator);
 public:
-    WEBCORE_EXPORT static bool processingUserTypingGesture();
-    WEBCORE_EXPORT static Node* focusedElementAtGestureStart();
+    WEBCORE_EXPORT static bool NODELETE processingUserTypingGesture();
+    WEBCORE_EXPORT static Node* NODELETE focusedElementAtGestureStart();
 
     WEBCORE_EXPORT explicit UserTypingGestureIndicator(LocalFrame&);
     WEBCORE_EXPORT ~UserTypingGestureIndicator();

--- a/Source/WebCore/dom/ViewTransition.h
+++ b/Source/WebCore/dom/ViewTransition.h
@@ -195,19 +195,19 @@ public:
 
     UniqueRef<ViewTransitionParams> takeViewTransitionParams();
 
-    DOMPromise& ready();
-    DOMPromise& updateCallbackDone();
-    DOMPromise& finished();
+    DOMPromise& NODELETE ready();
+    DOMPromise& NODELETE updateCallbackDone();
+    DOMPromise& NODELETE finished();
 
     ViewTransitionPhase phase() const { return m_phase; }
     const OrderedNamedElementsMap& namedElements() const { return m_namedElements; };
 
-    Document* document() const;
+    Document* NODELETE document() const;
 
     bool documentElementIsCaptured() const;
 
     const ViewTransitionTypeSet& types() const { return m_types; }
-    void setTypes(Ref<ViewTransitionTypeSet>&&);
+    void NODELETE setTypes(Ref<ViewTransitionTypeSet>&&);
 
     RenderViewTransitionCapture* viewTransitionNewPseudoForCapturedElement(RenderLayerModelObject&);
 

--- a/Source/WebCore/dom/ViewportArguments.cpp
+++ b/Source/WebCore/dom/ViewportArguments.cpp
@@ -342,7 +342,7 @@ static ASCIILiteral viewportErrorMessageTemplate(ViewportErrorCode errorCode)
     return "Unknown viewport error."_s;
 }
 
-static MessageLevel viewportErrorMessageLevel(ViewportErrorCode errorCode)
+static MessageLevel NODELETE viewportErrorMessageLevel(ViewportErrorCode errorCode)
 {
     switch (errorCode) {
     case ViewportErrorCode::TruncatedViewportArgumentValue:

--- a/Source/WebCore/dom/ViewportArguments.h
+++ b/Source/WebCore/dom/ViewportArguments.h
@@ -156,7 +156,7 @@ struct ViewportArguments {
 WEBCORE_EXPORT ViewportAttributes computeViewportAttributes(ViewportArguments args, int desktopWidth, int deviceWidth, int deviceHeight, float devicePixelRatio, IntSize visibleViewport);
 
 WEBCORE_EXPORT void restrictMinimumScaleFactorToViewportSize(ViewportAttributes& result, IntSize visibleViewport, float devicePixelRatio);
-WEBCORE_EXPORT void restrictScaleFactorToInitialScaleIfNotUserScalable(ViewportAttributes& result);
+WEBCORE_EXPORT void NODELETE restrictScaleFactorToInitialScaleIfNotUserScalable(ViewportAttributes& result);
 WEBCORE_EXPORT float computeMinimumScaleFactorForContentContained(const ViewportAttributes& result, const IntSize& viewportSize, const IntSize& contentSize);
 
 typedef Function<void(ViewportErrorCode, const String&)> ViewportErrorHandler;

--- a/Source/WebCore/dom/WheelEvent.cpp
+++ b/Source/WebCore/dom/WheelEvent.cpp
@@ -36,12 +36,12 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WheelEvent);
 
-inline static unsigned determineDeltaMode(const PlatformWheelEvent& event)
+inline static unsigned NODELETE determineDeltaMode(const PlatformWheelEvent& event)
 {
     return event.granularity() == PlatformWheelEventGranularity::ScrollByPageWheelEvent ? WheelEvent::DOM_DELTA_PAGE : WheelEvent::DOM_DELTA_PIXEL;
 }
 
-static double wheelDeltaToDelta(int wheelDelta)
+static double NODELETE wheelDeltaToDelta(int wheelDelta)
 {
     // Avoid returning negative zero.
     if (!wheelDelta)

--- a/Source/WebCore/dom/messageports/MessagePortChannel.h
+++ b/Source/WebCore/dom/messageports/MessagePortChannel.h
@@ -48,8 +48,8 @@ public:
     const MessagePortIdentifier& port1() const { return m_ports[0]; }
     const MessagePortIdentifier& port2() const { return m_ports[1]; }
 
-    WEBCORE_EXPORT std::optional<ProcessIdentifier> processForPort(const MessagePortIdentifier&);
-    bool includesPort(const MessagePortIdentifier&);
+    WEBCORE_EXPORT std::optional<ProcessIdentifier> NODELETE processForPort(const MessagePortIdentifier&);
+    bool NODELETE includesPort(const MessagePortIdentifier&);
     void entanglePortWithProcess(const MessagePortIdentifier&, ProcessIdentifier);
     void disentanglePort(const MessagePortIdentifier&);
     void closePort(const MessagePortIdentifier&);
@@ -57,7 +57,7 @@ public:
 
     void takeAllMessagesForPort(const MessagePortIdentifier&, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&&);
 
-    WEBCORE_EXPORT bool hasAnyMessagesPendingOrInFlight() const;
+    WEBCORE_EXPORT bool NODELETE hasAnyMessagesPendingOrInFlight() const;
 
     uint64_t beingTransferredCount();
 

--- a/Source/WebCore/dom/messageports/MessagePortChannelProvider.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProvider.cpp
@@ -35,7 +35,7 @@
 
 namespace WebCore {
 
-static RefPtr<MessagePortChannelProvider>& globalProvider()
+static RefPtr<MessagePortChannelProvider>& NODELETE globalProvider()
 {
     static MainThreadNeverDestroyed<RefPtr<MessagePortChannelProvider>> globalProvider;
     return globalProvider;


### PR DESCRIPTION
#### a62671a26ed30400cd9829aa3bbcaa638d45032d
<pre>
Adopt `NODELETE` annotation in more places in Source/WebCore/dom
<a href="https://bugs.webkit.org/show_bug.cgi?id=308199">https://bugs.webkit.org/show_bug.cgi?id=308199</a>

Reviewed by Anne van Kesteren and Darin Adler.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/dom/AbortController.h:
* Source/WebCore/dom/AbortSignal.h:
* Source/WebCore/dom/ActiveDOMCallback.h:
* Source/WebCore/dom/ActiveDOMObject.cpp:
(WebCore::suitableScriptExecutionContext):
* Source/WebCore/dom/ActiveDOMObject.h:
* Source/WebCore/dom/BoundaryPoint.cpp:
(WebCore::isOffsetBeforeChild):
* Source/WebCore/dom/BroadcastChannel.cpp:
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::channelToContextIdentifier):
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/ChildListMutationScope.cpp:
(WebCore::accumulatorMap):
* Source/WebCore/dom/ChildListMutationScope.h:
* Source/WebCore/dom/ChildNodeList.h:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::hasDisplayContents):
(WebCore::checkAcceptChildGuaranteedNodeTypes):
* Source/WebCore/dom/ContainerNodeAlgorithms.cpp:
(WebCore::observabilityOfRemovedNode):
(WebCore::updateObservability):
* Source/WebCore/dom/CustomElementReactionQueue.h:
* Source/WebCore/dom/CustomElementRegistry.h:
* Source/WebCore/dom/DOMException.h:
* Source/WebCore/dom/DOMPointReadOnly.h:
* Source/WebCore/dom/DOMRectReadOnly.h:
* Source/WebCore/dom/DOMStringList.h:
* Source/WebCore/dom/DataTransfer.h:
* Source/WebCore/dom/DataTransferItem.h:
* Source/WebCore/dom/DataTransferItemList.h:
* Source/WebCore/dom/DatasetDOMStringMap.cpp:
(WebCore::isValidPropertyName):
* Source/WebCore/dom/DatasetDOMStringMap.h:
* Source/WebCore/dom/DeviceMotionEvent.cpp:
(WebCore::convert):
* Source/WebCore/dom/DeviceMotionEvent.h:
* Source/WebCore/dom/DeviceOrientationEvent.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::isValidNameStart):
(WebCore::isValidNamePart):
(WebCore::widgetForElement):
(WebCore::staticSharedLogger):
(WebCore::currentOrientation):
(WebCore::isValidHTMLElementName):
(WebCore::customElementNameCharacterKind):
(WebCore::TitleTraits&lt;HTMLTitleElement&gt;::isInEligibleLocation):
(WebCore::TitleTraits&lt;HTMLTitleElement&gt;::findTitleElement):
(WebCore::TitleTraits&lt;SVGTitleElement&gt;::isInEligibleLocation):
(WebCore::TitleTraits&lt;SVGTitleElement&gt;::findTitleElement):
(WebCore::shouldResetFocusNavigationStartingNode):
(WebCore::fallbackFocusNavigationStartingNodeAfterRemoval):
(WebCore::isValidNameNonASCII):
(WebCore::isValidNameASCIIWithoutColon):
(WebCore::messageLevelFromWTFLogLevel):
* Source/WebCore/dom/Document.h:
* Source/WebCore/dom/DocumentFontLoader.h:
* Source/WebCore/dom/DocumentFullscreen.h:
* Source/WebCore/dom/DocumentMarkerController.h:
* Source/WebCore/dom/DocumentMediaElement.h:
* Source/WebCore/dom/DocumentParser.h:
* Source/WebCore/dom/DocumentSharedObjectPool.cpp:
(WebCore::peakSizeInPast):
* Source/WebCore/dom/DocumentStorageAccess.h:
* Source/WebCore/dom/Element.cpp:
(WebCore::attrNodeListMap):
(WebCore::attrNodeListForElement):
(WebCore::findAttrNodeInList):
(WebCore::isForceEvent):
(WebCore::toScrollAlignmentForInlineDirection):
(WebCore::toScrollAlignmentForBlockDirection):
(WebCore::localZoomForRenderer):
(WebCore::shouldObtainBoundsFromBoxModel):
* Source/WebCore/dom/Element.h:
* Source/WebCore/dom/ElementData.cpp:
(WebCore::sizeForShareableElementDataWithAttributeCount):
* Source/WebCore/dom/ElementData.h:
* Source/WebCore/dom/EventDispatcher.cpp:
(WebCore::isInShadowTree):
(WebCore::findInputElementInEventPath):
* Source/WebCore/dom/EventListenerMap.h:
* Source/WebCore/dom/EventLoop.cpp:
* Source/WebCore/dom/EventPath.cpp:
(WebCore::shouldEventCrossShadowBoundary):
(WebCore::nodeOrHostIfPseudoElement):
(WebCore::moveOutOfAllShadowRoots):
(WebCore::RelatedNodeRetargeter::currentNode):
(WebCore::RelatedNodeRetargeter::nodeInLowestCommonAncestor):
(WebCore::RelatedNodeRetargeter::checkConsistency):
* Source/WebCore/dom/EventTarget.h:
* Source/WebCore/dom/ExtensionStyleSheets.h:
* Source/WebCore/dom/FragmentDirectiveRangeFinder.cpp:
(WebCore::FragmentDirectiveRangeFinder::isSearchInvisible):
(WebCore::FragmentDirectiveRangeFinder::isNonSearchableSubtree):
(WebCore::FragmentDirectiveRangeFinder::isVisibleTextNode):
* Source/WebCore/dom/GCReachableRef.h:
* Source/WebCore/dom/InternalObserverDrop.cpp:
* Source/WebCore/dom/InternalObserverFilter.cpp:
* Source/WebCore/dom/InternalObserverFirst.cpp:
* Source/WebCore/dom/InternalObserverForEach.cpp:
* Source/WebCore/dom/InternalObserverInspect.cpp:
* Source/WebCore/dom/InternalObserverLast.cpp:
* Source/WebCore/dom/InternalObserverMap.cpp:
* Source/WebCore/dom/InternalObserverReduce.cpp:
* Source/WebCore/dom/InternalObserverSome.cpp:
* Source/WebCore/dom/InternalObserverTake.cpp:
* Source/WebCore/dom/KeyboardEvent.cpp:
(WebCore::windowsVirtualKeyCodeWithoutLocation):
(WebCore::keyLocationCode):
* Source/WebCore/dom/KeyboardEvent.h:
* Source/WebCore/dom/MessagePort.cpp:
(WebCore::WTF_REQUIRES_LOCK):
* Source/WebCore/dom/MessagePort.h:
* Source/WebCore/dom/Microtasks.h:
* Source/WebCore/dom/MutationObserver.h:
* Source/WebCore/dom/MutationObserverRegistration.h:
* Source/WebCore/dom/MutationRecord.h:
* Source/WebCore/dom/NamedNodeMap.h:
* Source/WebCore/dom/Node.cpp:
(WebCore::nodeIdentifiersMap):
(WebCore::parentShadowRoot):
(WebCore::isSiblingSubsequent):
* Source/WebCore/dom/Node.h:
* Source/WebCore/dom/NodeTraversal.cpp:
(WebCore::NodeTraversal::previousAncestorSiblingPostOrder):
* Source/WebCore/dom/Position.h:
* Source/WebCore/dom/PositionIterator.h:
* Source/WebCore/dom/QualifiedName.cpp:
(WebCore::makeComponents):
* Source/WebCore/dom/QualifiedNameCache.cpp:
(WebCore::QNameComponentsTranslator::equal):
* Source/WebCore/dom/RadioButtonGroups.cpp:
(WebCore::RadioButtonGroup::isEmpty const):
(WebCore::RadioButtonGroup::isRequired const):
(WebCore::RadioButtonGroup::checkedButton const):
(WebCore::RadioButtonGroup::isValid const):
(WebCore::RadioButtonGroup::contains const):
* Source/WebCore/dom/Range.cpp:
(WebCore::highestAncestorUnderCommonRoot):
(WebCore::boundaryTextInserted):
(WebCore::boundaryTextRemoved):
* Source/WebCore/dom/Range.h:
* Source/WebCore/dom/RejectedPromiseTracker.cpp:
(WebCore::UnhandledPromise::callStack):
(WebCore::UnhandledPromise::promise):
* Source/WebCore/dom/ScriptElement.h:
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::WTF_REQUIRES_LOCK):
(WebCore::isOriginEquivalentToLocal):
* Source/WebCore/dom/ScriptExecutionContext.h:
* Source/WebCore/dom/ScriptRunner.h:
* Source/WebCore/dom/ScriptedAnimationController.h:
* Source/WebCore/dom/SecurityContext.h:
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::canBeUsedForIdFastPath):
(WebCore::findIdMatchingType):
(WebCore::selectorForIdLookup):
* Source/WebCore/dom/SelectorQuery.h:
* Source/WebCore/dom/SimpleRange.cpp:
(WebCore::firstIntersectingNode):
(WebCore::nodePastLastIntersectingNode):
(WebCore::firstIntersectingNodeWithDeprecatedZeroOffsetStartQuirk):
* Source/WebCore/dom/SimpleRange.h:
* Source/WebCore/dom/SlotAssignment.cpp:
(WebCore::slotNameFromAttributeValue):
* Source/WebCore/dom/SlotAssignment.h:
* Source/WebCore/dom/SpaceSplitString.cpp:
(WebCore::spaceSplitStringTable):
(WebCore::TokenIsEqualToCharactersTokenProcessor::referenceStringWasFound const):
(WebCore::TokenCounter::tokenCount const):
(WebCore::TokenAtomStringInitializer::nextMemoryBucket const):
* Source/WebCore/dom/StaticRange.cpp:
(WebCore::isDocumentTypeOrAttr):
* Source/WebCore/dom/Subscriber.h:
* Source/WebCore/dom/Text.cpp:
(WebCore::earliestLogicallyAdjacentTextNode):
(WebCore::latestLogicallyAdjacentTextNode):
(WebCore::isSVGShadowText):
(WebCore::isSVGText):
* Source/WebCore/dom/TreeScope.cpp:
(WebCore::focusedFrameOwnerElement):
* Source/WebCore/dom/TreeScope.h:
* Source/WebCore/dom/TreeWalker.h:
* Source/WebCore/dom/TrustedTypePolicy.h:
* Source/WebCore/dom/TrustedTypePolicyFactory.h:
* Source/WebCore/dom/UserActionElementSet.h:
* Source/WebCore/dom/UserGestureIndicator.cpp:
(WebCore::currentToken):
* Source/WebCore/dom/UserGestureIndicator.h:
* Source/WebCore/dom/UserTypingGestureIndicator.cpp:
(WebCore::focusedNode):
* Source/WebCore/dom/UserTypingGestureIndicator.h:
* Source/WebCore/dom/ViewTransition.h:
* Source/WebCore/dom/ViewportArguments.cpp:
(WebCore::viewportErrorMessageLevel):
* Source/WebCore/dom/ViewportArguments.h:
* Source/WebCore/dom/WheelEvent.cpp:
(WebCore::determineDeltaMode):
(WebCore::wheelDeltaToDelta):
* Source/WebCore/dom/messageports/MessagePortChannel.h:
* Source/WebCore/dom/messageports/MessagePortChannelProvider.cpp:
(WebCore::globalProvider):

Canonical link: <a href="https://commits.webkit.org/308005@main">https://commits.webkit.org/308005@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a551db368016320a1bc710ccb94b6dd7ad472e7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146201 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11503 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99662 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4393df78-57ae-4ef3-aa31-c39098a518f3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112496 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80482 "1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fbec1b0b-432f-4100-b687-ff754bfaca3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14849 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131352 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93367 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dac8f149-087d-4b43-aba1-53e624f04b84) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14115 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11874 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2316 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8593 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157189 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/360 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9944 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120519 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18696 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15658 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120820 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30950 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18716 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/130162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74425 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16501 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7723 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18317 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82068 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18049 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18106 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->