### PR TITLE
Adopt `NODELETE` annotation in more places in Source/WebCore/page

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -327,7 +327,6 @@ page/Location.cpp
 page/MemoryRelease.cpp
 page/NavigateEvent.cpp
 [ iOS ] page/Page.cpp
-page/PageColorSampler.cpp
 page/PageSerializer.cpp
 page/Performance.cpp
 page/PerformanceMonitor.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -154,7 +154,6 @@ bindings/js/ScriptCachedFrameData.cpp
 bindings/js/ScriptModuleLoader.cpp
 bindings/js/SerializedScriptValue.cpp
 bindings/js/WebAssemblyScriptBufferSourceProvider.h
-bindings/js/WebCoreJSClientData.cpp
 bindings/js/WebCoreTypedArrayController.cpp
 bindings/js/WindowProxy.cpp
 bridge/jsc/BridgeJSC.cpp
@@ -437,7 +436,6 @@ mathml/MathMLSelectElement.cpp
 page/AutoscrollController.cpp
 [ Mac ] page/ContextMenuController.cpp
 [ iOS ] page/DOMTimer.cpp
-page/DebugPageOverlays.h
 page/DragController.cpp
 page/ElementTargetingController.cpp
 page/EventHandler.cpp
@@ -456,7 +454,6 @@ page/Location.cpp
 page/NavigateEvent.cpp
 page/NavigationDestination.cpp
 page/NavigationDestination.h
-page/PageColorSampler.cpp
 page/PageSerializer.cpp
 page/PartitionedSecurityOrigin.h
 page/Performance.cpp

--- a/Source/WebCore/page/AutoscrollController.h
+++ b/Source/WebCore/page/AutoscrollController.h
@@ -61,8 +61,8 @@ class AutoscrollController final : public CanMakeCheckedPtr<AutoscrollController
 public:
     AutoscrollController();
     RenderBox* NODELETE autoscrollRenderer() const;
-    bool autoscrollInProgress() const;
-    bool panScrollInProgress() const;
+    bool NODELETE autoscrollInProgress() const;
+    bool NODELETE panScrollInProgress() const;
     void startAutoscrollForSelection(RenderObject*);
     void stopAutoscrollTimer(bool rendererIsBeingDestroyed = false);
     void updateAutoscrollRenderer();

--- a/Source/WebCore/page/CaptionUserPreferences.h
+++ b/Source/WebCore/page/CaptionUserPreferences.h
@@ -111,7 +111,7 @@ public:
     virtual bool testingMode() const { return m_testingModeCount; }
 
     friend class CaptionUserPreferencesTestingModeToken;
-    WEBCORE_EXPORT UniqueRef<CaptionUserPreferencesTestingModeToken> createTestingModeToken();
+    WEBCORE_EXPORT UniqueRef<CaptionUserPreferencesTestingModeToken> NODELETE createTestingModeToken();
 
     virtual String captionPreviewTitle() const;
 
@@ -121,8 +121,8 @@ protected:
     explicit CaptionUserPreferences(PageGroup&);
 
     void updateCaptionStyleSheetOverride();
-    void beginBlockingNotifications();
-    void endBlockingNotifications();
+    void NODELETE beginBlockingNotifications();
+    void NODELETE endBlockingNotifications();
 
 private:
     void incrementTestingModeCount() { ++m_testingModeCount; }

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp
@@ -87,13 +87,13 @@ static std::unique_ptr<CaptionPreferencesDelegate>& captionPreferencesDelegate()
     return delegate.get();
 }
 
-static std::optional<CaptionUserPreferencesMediaAF::CaptionDisplayMode>& cachedCaptionDisplayMode()
+static std::optional<CaptionUserPreferencesMediaAF::CaptionDisplayMode>& NODELETE cachedCaptionDisplayMode()
 {
     static NeverDestroyed<std::optional<CaptionUserPreferencesMediaAF::CaptionDisplayMode>> captionDisplayMode;
     return captionDisplayMode;
 }
 
-static std::optional<Vector<String>>& cachedPreferredLanguages()
+static std::optional<Vector<String>>& NODELETE cachedPreferredLanguages()
 {
     static NeverDestroyed<std::optional<Vector<String>>> preferredLanguages;
     return preferredLanguages;

--- a/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
+++ b/Source/WebCore/page/CaptionUserPreferencesMediaAF.h
@@ -52,7 +52,7 @@ public:
 
     WEBCORE_EXPORT static CaptionDisplayMode platformCaptionDisplayMode();
     WEBCORE_EXPORT static void platformSetCaptionDisplayMode(CaptionDisplayMode);
-    WEBCORE_EXPORT static void setCachedCaptionDisplayMode(CaptionDisplayMode);
+    WEBCORE_EXPORT static void NODELETE setCachedCaptionDisplayMode(CaptionDisplayMode);
 
     WEBCORE_EXPORT static Vector<String> platformProfileIDs();
     WEBCORE_EXPORT static String platformActiveProfileID();

--- a/Source/WebCore/page/Chrome.h
+++ b/Source/WebCore/page/Chrome.h
@@ -144,7 +144,7 @@ public:
     RefPtr<ShapeDetection::FaceDetector> createFaceDetector(const ShapeDetection::FaceDetectorOptions&) const;
     RefPtr<ShapeDetection::TextDetector> createTextDetector() const;
 
-    PlatformDisplayID displayID() const override;
+    PlatformDisplayID NODELETE displayID() const override;
     void windowScreenDidChange(PlatformDisplayID, std::optional<FramesPerSecond>) override;
 
     FloatSize screenSize() const override;
@@ -233,7 +233,7 @@ public:
     void setDispatchViewportDataDidChangeSuppressed(bool dispatchViewportDataDidChangeSuppressed) { m_isDispatchViewportDataDidChangeSuppressed = dispatchViewportDataDidChangeSuppressed; }
 #endif
 
-    void didReceiveDocType(LocalFrame&);
+    void NODELETE didReceiveDocType(LocalFrame&);
 
     void registerPopupOpeningObserver(PopupOpeningObserver&);
     void unregisterPopupOpeningObserver(PopupOpeningObserver&);

--- a/Source/WebCore/page/ChromeClient.h
+++ b/Source/WebCore/page/ChromeClient.h
@@ -514,7 +514,7 @@ public:
     // Returns true if layer tree updates are disabled.
     virtual bool layerTreeStateIsFrozen() const { return false; }
 
-    WEBCORE_EXPORT virtual RefPtr<ScrollingCoordinator> createScrollingCoordinator(Page&) const;
+    WEBCORE_EXPORT virtual RefPtr<ScrollingCoordinator> NODELETE createScrollingCoordinator(Page&) const;
     WEBCORE_EXPORT virtual void ensureScrollbarsController(Page&, ScrollableArea&, bool update = false) const;
 
     virtual bool canEnterVideoFullscreen(HTMLVideoElement&, HTMLMediaElementEnums::VideoFullscreenMode) const { return false; }

--- a/Source/WebCore/page/DOMTimer.cpp
+++ b/Source/WebCore/page/DOMTimer.cpp
@@ -80,13 +80,13 @@ public:
         m_context->setTimerNestingLevel(0);
     }
 
-    const Document* contextDocument() const { return m_contextIsDocument ? downcast<Document>(m_context.ptr()) : nullptr; }
+    const Document* NODELETE contextDocument() const { return m_contextIsDocument ? downcast<Document>(m_context.ptr()) : nullptr; }
 
-    void setScriptMadeUserObservableChanges() { m_scriptMadeUserObservableChanges = true; }
-    void setScriptMadeNonUserObservableChanges() { m_scriptMadeNonUserObservableChanges = true; }
+    void NODELETE setScriptMadeUserObservableChanges() { m_scriptMadeUserObservableChanges = true; }
+    void NODELETE setScriptMadeNonUserObservableChanges() { m_scriptMadeNonUserObservableChanges = true; }
 
-    bool scriptMadeNonUserObservableChanges() const { return m_scriptMadeNonUserObservableChanges; }
-    bool scriptMadeUserObservableChanges() const
+    bool NODELETE scriptMadeNonUserObservableChanges() const { return m_scriptMadeNonUserObservableChanges; }
+    bool NODELETE scriptMadeUserObservableChanges() const
     {
         if (m_scriptMadeUserObservableChanges)
             return true;
@@ -112,7 +112,7 @@ DOMTimerFireState* DOMTimerFireState::current = nullptr;
 struct NestedTimersMap {
     typedef HashMap<int, Ref<DOMTimer>>::const_iterator const_iterator;
 
-    static NestedTimersMap* instanceForContext(ScriptExecutionContext& context)
+    static NestedTimersMap* NODELETE instanceForContext(ScriptExecutionContext& context)
     {
         // For worker threads, we don't use NestedTimersMap as doing so would not
         // be thread safe.
@@ -149,10 +149,10 @@ struct NestedTimersMap {
     }
 
     const_iterator begin() const LIFETIME_BOUND { return nestedTimers.begin(); }
-    const_iterator end() const LIFETIME_BOUND { return nestedTimers.end(); }
+    const_iterator NODELETE end() const LIFETIME_BOUND { return nestedTimers.end(); }
 
 private:
-    static NestedTimersMap& instance()
+    static NestedTimersMap& NODELETE instance()
     {
         static NeverDestroyed<NestedTimersMap> map;
         return map;

--- a/Source/WebCore/page/DOMTimer.h
+++ b/Source/WebCore/page/DOMTimer.h
@@ -68,7 +68,7 @@ public:
     // setting for the context has changed).
     void updateTimerIntervalIfNecessary();
 
-    static void scriptDidInteractWithPlugin();
+    static void NODELETE scriptDidInteractWithPlugin();
 
     EventLoopTimerHandle timer() const { return m_timer; }
     bool hasReachedMaxNestingLevel() const { return m_hasReachedMaxNestingLevel; }
@@ -79,7 +79,7 @@ private:
 
     WEBCORE_EXPORT Seconds intervalClampedToMinimum() const;
 
-    bool isDOMTimersThrottlingEnabled(const Document&) const;
+    bool NODELETE isDOMTimersThrottlingEnabled(const Document&) const;
     void updateThrottlingStateIfNecessary(const DOMTimerFireState&);
 
     void fired();

--- a/Source/WebCore/page/DOMWindow.h
+++ b/Source/WebCore/page/DOMWindow.h
@@ -116,18 +116,18 @@ public:
     WEBCORE_EXPORT Location& location();
     virtual void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking = SetLocationLocking::LockHistoryBasedOnGestureState, CanNavigateState = CanNavigateState::Unchecked) = 0;
 
-    bool closed() const;
+    bool NODELETE closed() const;
     WEBCORE_EXPORT void close();
     void close(Document&);
     virtual void closePage() = 0;
 
-    FrameConsoleClient* console() const;
+    FrameConsoleClient* NODELETE console() const;
 
-    WindowProxy* opener() const;
-    WEBCORE_EXPORT Document* documentIfLocal();
+    WindowProxy* NODELETE opener() const;
+    WEBCORE_EXPORT Document* NODELETE documentIfLocal();
 
-    WindowProxy* top() const;
-    WindowProxy* parent() const;
+    WindowProxy* NODELETE top() const;
+    WindowProxy* NODELETE parent() const;
     unsigned length() const;
     void focus(LocalDOMWindow& incumbentWindow);
     void blur();
@@ -247,7 +247,7 @@ private:
     const DOMWindowType m_type;
 };
 
-WebCoreOpaqueRoot root(DOMWindow*);
+WebCoreOpaqueRoot NODELETE root(DOMWindow*);
 
 } // namespace WebCore
 

--- a/Source/WebCore/page/DOMWindowExtension.h
+++ b/Source/WebCore/page/DOMWindowExtension.h
@@ -54,7 +54,7 @@ public:
     void willDestroyGlobalObjectInFrame() final;
     void willDetachGlobalObjectFromFrame() final;
 
-    WEBCORE_EXPORT LocalFrame* frame() const;
+    WEBCORE_EXPORT LocalFrame* NODELETE frame() const;
     DOMWrapperWorld& world() const { return m_world; }
 
 private:

--- a/Source/WebCore/page/DebugPageOverlays.cpp
+++ b/Source/WebCore/page/DebugPageOverlays.cpp
@@ -68,9 +68,9 @@ public:
     virtual ~RegionOverlay();
 
     void recomputeRegion();
-    PageOverlay& overlay() { return *m_overlay; }
+    PageOverlay& NODELETE overlay() { return *m_overlay; }
 
-    void setRegionChanged() { m_regionChanged = true; }
+    void NODELETE setRegionChanged() { m_regionChanged = true; }
 
     virtual bool shouldPaintOverlayIntoLayer() const { return true; }
 
@@ -116,7 +116,7 @@ private:
     bool updateRegion() override;
 };
 
-bool MouseWheelRegionOverlay::updateRegion()
+bool NODELETE MouseWheelRegionOverlay::updateRegion()
 {
     RefPtr page = m_page;
     if (!page)
@@ -364,7 +364,7 @@ std::optional<std::pair<RenderLayer&, GraphicsLayer&>> InteractionRegionOverlay:
     return { { *layer, *graphicsLayer } };
 }
 
-std::optional<InteractionRegion> InteractionRegionOverlay::activeRegion() const
+std::optional<InteractionRegion> NODELETE InteractionRegionOverlay::activeRegion() const
 {
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
     RefPtr page = m_page;
@@ -763,7 +763,7 @@ void RegionOverlay::willMoveToPage(PageOverlay&, Page* page)
         m_overlay = nullptr;
 }
 
-void RegionOverlay::didMoveToPage(PageOverlay&, Page* page)
+void NODELETE RegionOverlay::didMoveToPage(PageOverlay&, Page* page)
 {
     if (page)
         setRegionChanged();
@@ -789,12 +789,12 @@ void RegionOverlay::drawRegion(GraphicsContext& context, const Region& region, c
     }
 }
 
-bool RegionOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent&)
+bool NODELETE RegionOverlay::mouseEvent(PageOverlay&, const PlatformMouseEvent&)
 {
     return false;
 }
 
-void RegionOverlay::didScrollFrame(PageOverlay&, LocalFrame&)
+void NODELETE RegionOverlay::didScrollFrame(PageOverlay&, LocalFrame&)
 {
 }
 
@@ -821,7 +821,7 @@ DebugPageOverlays& DebugPageOverlays::singleton()
     return *sharedDebugOverlays;
 }
 
-static inline size_t indexOf(DebugPageOverlays::RegionType regionType)
+static inline size_t NODELETE indexOf(DebugPageOverlays::RegionType regionType)
 {
     return static_cast<size_t>(regionType);
 }

--- a/Source/WebCore/page/DebugPageOverlays.h
+++ b/Source/WebCore/page/DebugPageOverlays.h
@@ -69,7 +69,7 @@ private:
 
     void regionChanged(LocalFrame&, RegionType);
 
-    bool hasOverlaysForPage(Page&) const;
+    bool NODELETE hasOverlaysForPage(Page&) const;
     
     void updateOverlayRegionVisibility(Page&, OptionSet<DebugOverlayRegions>);
 

--- a/Source/WebCore/page/DeviceController.h
+++ b/Source/WebCore/page/DeviceController.h
@@ -50,7 +50,7 @@ public:
     void addDeviceEventListener(LocalDOMWindow&);
     void removeDeviceEventListener(LocalDOMWindow&);
     void removeAllDeviceEventListeners(LocalDOMWindow&);
-    bool hasDeviceEventListener(LocalDOMWindow&) const;
+    bool NODELETE hasDeviceEventListener(LocalDOMWindow&) const;
 
     void dispatchDeviceEvent(Event&);
     bool isActive() { return !m_listeners.isEmpty(); }

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -234,7 +234,7 @@ void DragController::dragExited(LocalFrame& frame, DragData&& dragData)
         fileInput->setCanReceiveDroppedFiles(false);
 }
 
-inline static bool dragIsHandledByDocument(DragHandlingMethod dragHandlingMethod)
+inline static bool NODELETE dragIsHandledByDocument(DragHandlingMethod dragHandlingMethod)
 {
     return dragHandlingMethod != DragHandlingMethod::None && dragHandlingMethod != DragHandlingMethod::PageLoad;
 }
@@ -796,7 +796,7 @@ static bool modelElementIsDraggable(const HTMLModelElement& modelElement)
 
 #if ENABLE(ATTACHMENT_ELEMENT)
 
-static RefPtr<HTMLAttachmentElement> enclosingAttachmentElement(Element& element)
+static RefPtr<HTMLAttachmentElement> NODELETE enclosingAttachmentElement(Element& element)
 {
     if (RefPtr attachment = dynamicDowncast<HTMLAttachmentElement>(element))
         return attachment;
@@ -880,7 +880,7 @@ RefPtr<Element> DragController::draggableElement(const LocalFrame* sourceFrame, 
     return selectionDragElement;
 }
 
-static CachedImage* getCachedImage(Element& element)
+static CachedImage* NODELETE getCachedImage(Element& element)
 {
     CheckedPtr renderImage = dynamicDowncast<RenderImage>(element.renderer());
     return renderImage ? renderImage->cachedImage() : nullptr;
@@ -904,7 +904,7 @@ static void selectElement(Element& element)
     }
 }
 
-static IntPoint dragLocForDHTMLDrag(const IntPoint& mouseDraggedPoint, const IntPoint& dragOrigin, const IntPoint& dragImageOffset, bool isLinkImage)
+static IntPoint NODELETE dragLocForDHTMLDrag(const IntPoint& mouseDraggedPoint, const IntPoint& dragOrigin, const IntPoint& dragImageOffset, bool isLinkImage)
 {
     // dragImageOffset is the cursor position relative to the lower-left corner of the image.
 #if PLATFORM(MAC)

--- a/Source/WebCore/page/DragController.h
+++ b/Source/WebCore/page/DragController.h
@@ -68,7 +68,7 @@ public:
     DragController(Page&, std::unique_ptr<DragClient>&&);
     ~DragController();
 
-    static DragOperation platformGenericDragOperation();
+    static DragOperation NODELETE platformGenericDragOperation();
 
     WEBCORE_EXPORT Variant<std::optional<DragOperation>, RemoteUserInputEventData> dragEnteredOrUpdated(LocalFrame&, DragData&&);
     WEBCORE_EXPORT void dragExited(LocalFrame&, DragData&&);
@@ -114,7 +114,7 @@ public:
     static const float DragImageAlpha;
 
 private:
-    void updateSupportedTypeIdentifiersForDragHandlingMethod(DragHandlingMethod, const DragData&) const;
+    void NODELETE updateSupportedTypeIdentifiersForDragHandlingMethod(DragHandlingMethod, const DragData&) const;
     bool dispatchTextInputEventFor(LocalFrame*, const DragData&);
     bool canProcessDrag(const DragData&);
     bool concludeEditDrag(const DragData&);

--- a/Source/WebCore/page/ElementTargetingController.cpp
+++ b/Source/WebCore/page/ElementTargetingController.cpp
@@ -97,33 +97,33 @@ static constexpr auto minimumAreaRatioForElementToCoverViewport = 0.95;
 static constexpr auto minimumAreaForInterpolation = 200000;
 static constexpr auto maximumAreaForInterpolation = 800000;
 
-static float linearlyInterpolatedViewportRatio(float viewportArea, float minimumValue, float maximumValue)
+static float NODELETE linearlyInterpolatedViewportRatio(float viewportArea, float minimumValue, float maximumValue)
 {
     auto areaRatio = (viewportArea - minimumAreaForInterpolation) / (maximumAreaForInterpolation - minimumAreaForInterpolation);
     return clampTo(maximumValue - areaRatio * (maximumValue - minimumValue), minimumValue, maximumValue);
 }
 
-static float maximumAreaRatioForAbsolutelyPositionedContent(float viewportArea)
+static float NODELETE maximumAreaRatioForAbsolutelyPositionedContent(float viewportArea)
 {
     return linearlyInterpolatedViewportRatio(viewportArea, 0.75, 1);
 }
 
-static float maximumAreaRatioForInFlowContent(float viewportArea)
+static float NODELETE maximumAreaRatioForInFlowContent(float viewportArea)
 {
     return linearlyInterpolatedViewportRatio(viewportArea, 0.5, 1);
 }
 
-static float maximumAreaRatioForNearbyTargets(float viewportArea)
+static float NODELETE maximumAreaRatioForNearbyTargets(float viewportArea)
 {
     return linearlyInterpolatedViewportRatio(viewportArea, 0.25, 0.5);
 }
 
-static float minimumAreaRatioForInFlowContent(float viewportArea)
+static float NODELETE minimumAreaRatioForInFlowContent(float viewportArea)
 {
     return linearlyInterpolatedViewportRatio(viewportArea, 0.005, 0.01);
 }
 
-static float maximumAreaRatioForTrackingAdjustmentAreas(float viewportArea)
+static float NODELETE maximumAreaRatioForTrackingAdjustmentAreas(float viewportArea)
 {
     return linearlyInterpolatedViewportRatio(viewportArea, 0.25, 0.3);
 }
@@ -333,7 +333,7 @@ static inline String computeTagAndClassSelector(Element& element)
 static String siblingRelativeSelectorRecursive(Element&, ElementSelectorCache&);
 static String parentRelativeSelectorRecursive(Element&, ElementSelectorCache&);
 
-static String shortestSelector(const Vector<String>& selectors)
+static String NODELETE shortestSelector(const Vector<String>& selectors)
 {
     auto minLength = std::numeric_limits<size_t>::max();
     String shortestSelector;
@@ -567,7 +567,7 @@ TargetedElementSelectors ElementTargetingController::selectorsForElement(Element
     });
 }
 
-static inline RectEdges<bool> computeOffsetEdges(const RenderStyle& style)
+static inline RectEdges<bool> NODELETE computeOffsetEdges(const RenderStyle& style)
 {
     return {
         style.top().isSpecified(),
@@ -860,7 +860,7 @@ static inline std::optional<IntRect> inflatedClientRectForAdjustmentRegionTracki
     return { inflatedClientRect };
 }
 
-static bool shouldIgnoreExistingVisibilityAdjustments(const TargetedElementRequest& request)
+static bool NODELETE shouldIgnoreExistingVisibilityAdjustments(const TargetedElementRequest& request)
 {
     return std::holds_alternative<String>(request.data) || std::holds_alternative<TargetedElementSelectors>(request.data);
 }
@@ -1429,7 +1429,7 @@ static inline Ref<Element> elementToAdjust(Element& element)
     return element;
 }
 
-static inline VisibilityAdjustment adjustmentToApply(Element& element)
+static inline VisibilityAdjustment NODELETE adjustmentToApply(Element& element)
 {
     if (element.isAfterPseudoElement())
         return VisibilityAdjustment::AfterPseudo;

--- a/Source/WebCore/page/ElementTargetingController.h
+++ b/Source/WebCore/page/ElementTargetingController.h
@@ -62,7 +62,7 @@ public:
     void adjustVisibilityInRepeatedlyTargetedRegions(Document&);
 
     void reset();
-    void didChangeMainDocument(Document* newDocument);
+    void NODELETE didChangeMainDocument(Document* newDocument);
 
     WEBCORE_EXPORT uint64_t numberOfVisibilityAdjustmentRects();
     WEBCORE_EXPORT bool resetVisibilityAdjustments(const Vector<TargetedElementIdentifiers>&);
@@ -84,7 +84,7 @@ private:
     FindElementFromSelectorsResult findElementFromSelectors(const TargetedElementSelectors&);
     static FindElementFromSelectorsResult findElementFromSelectors(Document&, const TargetedElementSelectors&);
 
-    RefPtr<Document> mainDocument() const;
+    RefPtr<Document> NODELETE mainDocument() const;
 
     void dispatchVisibilityAdjustmentStateDidChange();
     void selectorBasedVisibilityAdjustmentTimerFired();

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -238,7 +238,7 @@ private:
     MonotonicTime m_start;
 };
 
-static UserGestureType userGestureTypeForPlatformEvent(const PlatformKeyboardEvent& keyEvent)
+static UserGestureType NODELETE userGestureTypeForPlatformEvent(const PlatformKeyboardEvent& keyEvent)
 {
     // https://html.spec.whatwg.org/multipage/interaction.html#activation-triggering-input-event
     // An activation triggering input event is any event whose isTrusted attribute is true and whose type is one of:
@@ -252,7 +252,7 @@ static UserGestureType userGestureTypeForPlatformEvent(const PlatformKeyboardEve
     return UserGestureType::Other;
 }
 
-static UserGestureType userGestureTypeForPlatformEvent(const PlatformMouseEvent& mouseEvent)
+static UserGestureType NODELETE userGestureTypeForPlatformEvent(const PlatformMouseEvent& mouseEvent)
 {
     // ...
     // * "mousedown".
@@ -342,7 +342,7 @@ public:
 };
 #endif // ENABLE(TOUCH_EVENTS) && !ENABLE(IOS_TOUCH_EVENTS)
 
-static inline ScrollGranularity wheelGranularityToScrollGranularity(unsigned deltaMode)
+static inline ScrollGranularity NODELETE wheelGranularityToScrollGranularity(unsigned deltaMode)
 {
     switch (deltaMode) {
     case WheelEvent::DOM_DELTA_PAGE:
@@ -386,7 +386,7 @@ bool EventHandler::eventLoopHandleMouseDragged(const MouseEventWithHitTestResult
 // If a mouse event handler changes the input element type to one that has a widget associated,
 // we'd like to EventHandler::handleMousePressEvent to pass the event to the widget and thus the
 // event target node can't still be the shadow node.
-static inline bool shouldRefetchEventTarget(const MouseEventWithHitTestResults& mouseEvent)
+static inline bool NODELETE shouldRefetchEventTarget(const MouseEventWithHitTestResults& mouseEvent)
 {
     RefPtr targetNode = mouseEvent.targetNode();
     ASSERT(targetNode);
@@ -1959,7 +1959,7 @@ static Scrollbar* scrollbarForMouseEvent(const MouseEventWithHitTestResults& mou
 
 }
 
-static LastKnownMousePositionSource mousePositionSource(const PlatformMouseEvent& event)
+static LastKnownMousePositionSource NODELETE mousePositionSource(const PlatformMouseEvent& event)
 {
     using enum LastKnownMousePositionSource;
     return event.syntheticClickType() == SyntheticClickType::NoTap ? Mouse : Touch;
@@ -2693,7 +2693,7 @@ bool EventHandler::canDropCurrentlyDraggedImageAsFile() const
     return !sourceOrigin || protect(protect(m_frame->document())->securityOrigin())->canReceiveDragData(*sourceOrigin);
 }
 
-static std::pair<bool, RefPtr<Frame>> contentFrameForNode(Node* target)
+static std::pair<bool, RefPtr<Frame>> NODELETE contentFrameForNode(Node* target)
 {
     RefPtr frameElement = dynamicDowncast<HTMLFrameElementBase>(target);
     if (!frameElement)
@@ -3453,7 +3453,7 @@ Widget* EventHandler::widgetForEventTarget(Element* eventTarget)
     return renderWidget->widget();
 }
 
-static RefPtr<Widget> widgetForElement(const Element& element)
+static RefPtr<Widget> NODELETE widgetForElement(const Element& element)
 {
     auto* renderWidget = dynamicDowncast<RenderWidget>(element.renderer());
     if (!renderWidget || !renderWidget->widget())

--- a/Source/WebCore/page/EventHandler.h
+++ b/Source/WebCore/page/EventHandler.h
@@ -176,7 +176,7 @@ public:
 #endif
 
     WEBCORE_EXPORT void stopAutoscrollTimer(bool rendererIsBeingDestroyed = false);
-    RenderBox* autoscrollRenderer() const;
+    RenderBox* NODELETE autoscrollRenderer() const;
     void updateAutoscrollRenderer();
     bool autoscrollInProgress() const;
     bool mouseDownWasInSubframe() const { return m_mouseDownWasInSubframe; }
@@ -192,7 +192,7 @@ public:
 
     WEBCORE_EXPORT ScrollableArea* focusedScrollableArea() const;
 
-    WEBCORE_EXPORT void setCapturingMouseEventsElement(RefPtr<Element>&&);
+    WEBCORE_EXPORT void NODELETE setCapturingMouseEventsElement(RefPtr<Element>&&);
     void pointerCaptureElementDidChange(Element*);
 
 #if ENABLE(DRAG_SUPPORT)
@@ -210,7 +210,7 @@ public:
     void scheduleHoverStateUpdate();
     void scheduleCursorUpdate();
 
-    void setResizingFrameSet(HTMLFrameSetElement*);
+    void NODELETE setResizingFrameSet(HTMLFrameSetElement*);
 
     void setLastTouchedNode(Node* node) { m_lastTouchedNode = node; }
     Node* lastTouchedNode() const { return m_lastTouchedNode.get(); }
@@ -223,7 +223,7 @@ public:
     Cursor currentMouseCursor() const { return m_currentMouseCursor; }
 
     IntPoint targetPositionInWindowForSelectionAutoscroll() const;
-    bool shouldUpdateAutoscroll();
+    bool NODELETE shouldUpdateAutoscroll();
 
     WEBCORE_EXPORT static RefPtr<Frame> subframeForTargetNode(Node*);
     static RefPtr<Frame> subframeForHitTestResult(const MouseEventWithHitTestResults&);
@@ -253,7 +253,7 @@ public:
     void defaultWheelEventHandler(Node*, WheelEvent&);
     void wheelEventWasProcessedByMainThread(const PlatformWheelEvent&, OptionSet<EventHandling>);
 
-    WEBCORE_EXPORT void setLastKnownMousePosition(const DoublePoint& position, const DoublePoint& globalPosition, std::optional<LastKnownMousePositionSource>&& = std::nullopt);
+    WEBCORE_EXPORT void NODELETE setLastKnownMousePosition(const DoublePoint& position, const DoublePoint& globalPosition, std::optional<LastKnownMousePositionSource>&& = std::nullopt);
 
     bool handlePasteGlobalSelection();
 
@@ -317,8 +317,8 @@ public:
 #if ENABLE(DRAG_SUPPORT)
     WEBCORE_EXPORT bool eventMayStartDrag(const PlatformMouseEvent&) const;
     
-    WEBCORE_EXPORT void didStartDrag();
-    WEBCORE_EXPORT void dragCancelled();
+    WEBCORE_EXPORT void NODELETE didStartDrag();
+    WEBCORE_EXPORT void NODELETE dragCancelled();
     WEBCORE_EXPORT std::optional<RemoteUserInputEventData> dragSourceEndedAt(const PlatformMouseEvent&, OptionSet<DragOperation>, MayExtendDragSession = MayExtendDragSession::No);
 #endif
 
@@ -379,10 +379,10 @@ public:
 
     bool isProcessingKeyRepeatForPotentialScroll() const { return m_isProcessingKeyRepeatForPotentialScroll; }
 
-    WEBCORE_EXPORT void setImmediateActionStage(ImmediateActionStage stage);
+    WEBCORE_EXPORT void NODELETE setImmediateActionStage(ImmediateActionStage);
     ImmediateActionStage immediateActionStage() const { return m_immediateActionStage; }
 
-    static Widget* widgetForEventTarget(Element* eventTarget);
+    static Widget* NODELETE widgetForEventTarget(Element* eventTarget);
 
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE_INTERACTION)
     WEBCORE_EXPORT std::optional<NodeIdentifier> requestInteractiveModelElementAtPoint(const IntPoint& clientPosition);
@@ -465,7 +465,7 @@ private:
 
 #if ENABLE(DRAG_SUPPORT)
     bool handleMouseDraggedEvent(const MouseEventWithHitTestResults&, CheckDragHysteresis = ShouldCheckDragHysteresis);
-    bool shouldAllowMouseDownToStartDrag() const;
+    bool NODELETE shouldAllowMouseDownToStartDrag() const;
 #endif
 
     WEBCORE_EXPORT bool handleMouseReleaseEvent(const MouseEventWithHitTestResults&);
@@ -557,14 +557,14 @@ private:
     bool handleWheelEventInAppropriateEnclosingBox(Node* startNode, const WheelEvent&, FloatSize& filteredPlatformDelta, const FloatSize& filteredVelocity, OptionSet<EventHandling>);
 
     bool handleWheelEventInScrollableArea(const PlatformWheelEvent&, ScrollableArea&, OptionSet<EventHandling>);
-    std::optional<WheelScrollGestureState> updateWheelGestureState(const PlatformWheelEvent&, OptionSet<EventHandling>);
+    std::optional<WheelScrollGestureState> NODELETE updateWheelGestureState(const PlatformWheelEvent&, OptionSet<EventHandling>);
 
     bool platformCompletePlatformWidgetWheelEvent(const PlatformWheelEvent&, const Widget&, const WeakPtr<ScrollableArea>&);
 
     bool defaultKeyboardScrollEventHandler(KeyboardEvent&, ScrollLogicalDirection, ScrollGranularity);
 
-    void defaultPageUpDownEventHandler(KeyboardEvent&);
-    void defaultHomeEndEventHandler(KeyboardEvent&);
+    void NODELETE defaultPageUpDownEventHandler(KeyboardEvent&);
+    void NODELETE defaultHomeEndEventHandler(KeyboardEvent&);
     void defaultSpaceEventHandler(KeyboardEvent&);
     void defaultBackspaceEventHandler(KeyboardEvent&);
     void defaultTabEventHandler(KeyboardEvent&);
@@ -572,7 +572,7 @@ private:
 
 #if ENABLE(DRAG_SUPPORT)
     OptionSet<DragSourceAction> updateDragSourceActionsAllowed() const;
-    bool supportsSelectionUpdatesOnMouseDrag() const;
+    bool NODELETE supportsSelectionUpdatesOnMouseDrag() const;
 #endif
 
     // The following are called at the beginning of handleMouseUp and handleDrag.  
@@ -651,12 +651,12 @@ private:
     void clearLatchedState();
     void clearElementUnderMouse();
 
-    bool isElementAnAncestorOfLastElementUnderMouse(Element*) const;
+    bool NODELETE isElementAnAncestorOfLastElementUnderMouse(Element*) const;
 
-    bool shouldSendMouseEventsToInactiveWindows() const;
+    bool NODELETE shouldSendMouseEventsToInactiveWindows() const;
 
     bool canMouseDownStartSelect(const MouseEventWithHitTestResults&);
-    bool mouseDownMayStartSelect() const;
+    bool NODELETE mouseDownMayStartSelect() const;
 
     std::optional<RemoteFrameGeometryTransformer> geometryTransformerForRemoteFrame(RemoteFrame*);
 

--- a/Source/WebCore/page/EventSource.h
+++ b/Source/WebCore/page/EventSource.h
@@ -79,7 +79,7 @@ private:
     EventSource(ScriptExecutionContext&, const URL&, Init&&);
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::EventSource; }
-    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
 
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
@@ -95,9 +95,9 @@ private:
 
     // ActiveDOMObject
     void stop() final;
-    void suspend(ReasonForSuspension) final;
+    void NODELETE suspend(ReasonForSuspension) final;
     void resume() final;
-    bool virtualHasPendingActivity() const final;
+    bool NODELETE virtualHasPendingActivity() const final;
 
     void connect();
     void networkRequestEnded();

--- a/Source/WebCore/page/FocusController.cpp
+++ b/Source/WebCore/page/FocusController.cpp
@@ -81,7 +81,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(FocusController);
 
 using namespace HTMLNames;
 
-static HTMLElement* invokerForOpenPopover(const Node* candidatePopover)
+static HTMLElement* NODELETE invokerForOpenPopover(const Node* candidatePopover)
 {
     RefPtr popover = dynamicDowncast<HTMLElement>(candidatePopover);
     if (popover && popover->isPopoverShowing())
@@ -344,7 +344,7 @@ FocusNavigationScope::FocusNavigationScope(Element& element)
 {
 }
 
-Element* FocusNavigationScope::owner() const
+Element* NODELETE FocusNavigationScope::owner() const
 {
     if (m_slotElement)
         return m_slotElement.get();
@@ -1005,7 +1005,7 @@ static bool relinquishesEditingFocus(Element& element)
     return frame->editor().shouldEndEditing(makeRangeSelectingNodeContents(*root));
 }
 
-static bool shouldClearSelectionWhenChangingFocusedElement(const Page& page, RefPtr<Element> oldFocusedElement, RefPtr<Element> newFocusedElement)
+static bool NODELETE shouldClearSelectionWhenChangingFocusedElement(const Page& page, RefPtr<Element> oldFocusedElement, RefPtr<Element> newFocusedElement)
 {
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
     if (newFocusedElement || !oldFocusedElement)

--- a/Source/WebCore/page/FocusController.h
+++ b/Source/WebCore/page/FocusController.h
@@ -61,7 +61,7 @@ public:
     WEBCORE_EXPORT void setFocusedFrame(Frame*, BroadcastFocusedFrame = BroadcastFocusedFrame::Yes);
     Frame* focusedFrame() const { return m_focusedFrame.get(); }
     LocalFrame* focusedLocalFrame() const { return dynamicDowncast<LocalFrame>(m_focusedFrame.get()); }
-    WEBCORE_EXPORT LocalFrame* focusedOrMainFrame() const;
+    WEBCORE_EXPORT LocalFrame* NODELETE focusedOrMainFrame() const;
 
     WEBCORE_EXPORT bool setInitialFocus(FocusDirection, KeyboardEvent*);
     bool advanceFocus(FocusDirection, KeyboardEvent*, bool initialFocus = false);

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -224,7 +224,7 @@ Vector<uint64_t> Frame::pathToFrame() const
     return path;
 }
 
-RenderWidget* Frame::ownerRenderer() const
+RenderWidget* NODELETE Frame::ownerRenderer() const
 {
     RefPtr ownerElement = this->ownerElement();
     if (!ownerElement)

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -93,7 +93,7 @@ public:
     WEBCORE_EXPORT void setOpenerForWebKitLegacy(Frame*);
     const Frame* opener() const { return m_opener.get(); }
     Frame* opener() { return m_opener.get(); }
-    bool hasOpenedFrames() const;
+    bool NODELETE hasOpenedFrames() const;
     WEBCORE_EXPORT void detachFromAllOpenedFrames();
     virtual bool isRootFrame() const = 0;
 #if ASSERT_ENABLED
@@ -142,7 +142,7 @@ public:
 
     void stopForBackForwardCache();
 
-    WEBCORE_EXPORT void updateFrameTreeSyncData(Ref<FrameTreeSyncData>&&);
+    WEBCORE_EXPORT void NODELETE updateFrameTreeSyncData(Ref<FrameTreeSyncData>&&);
     WEBCORE_EXPORT void updateFrameTreeSyncData(const FrameTreeSyncSerializationData&);
 
     virtual bool frameCanCreatePaymentSession() const;
@@ -152,7 +152,7 @@ public:
     WEBCORE_EXPORT virtual String frameURLProtocol() const = 0;
 
     WEBCORE_EXPORT virtual void setPrinting(bool printing, FloatSize pageSize, FloatSize originalPageSize, float maximumShrinkRatio, AdjustViewSize, NotifyUIProcess = NotifyUIProcess::Yes);
-    WEBCORE_EXPORT bool isPrinting() const;
+    WEBCORE_EXPORT bool NODELETE isPrinting() const;
 
 protected:
     Frame(Page&, FrameIdentifier, FrameType, HTMLFrameOwnerElement*, Frame* parent, Frame* opener, Ref<FrameTreeSyncData>&&, AddToFrameTree = AddToFrameTree::Yes);

--- a/Source/WebCore/page/FrameConsoleClient.h
+++ b/Source/WebCore/page/FrameConsoleClient.h
@@ -62,11 +62,11 @@ public:
     FrameConsoleClient(FrameConsoleClient&&) = delete;
     FrameConsoleClient& operator=(FrameConsoleClient&&) = delete;
 
-    static bool shouldPrintExceptions();
-    static void setShouldPrintExceptions(bool);
+    static bool NODELETE shouldPrintExceptions();
+    static void NODELETE setShouldPrintExceptions(bool);
 
-    static void mute();
-    static void unmute();
+    static void NODELETE mute();
+    static void NODELETE unmute();
 
     void addMessage(std::unique_ptr<Inspector::ConsoleMessage>&&);
 

--- a/Source/WebCore/page/FrameDestructionObserver.h
+++ b/Source/WebCore/page/FrameDestructionObserver.h
@@ -37,7 +37,7 @@ public:
     WEBCORE_EXPORT explicit FrameDestructionObserver(LocalFrame*);
 
     WEBCORE_EXPORT virtual void frameDestroyed();
-    WEBCORE_EXPORT virtual void willDetachPage();
+    WEBCORE_EXPORT virtual void NODELETE willDetachPage();
 
     bool hasFrame() const { return !!m_frame; }
 

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -48,12 +48,12 @@ FrameTree::~FrameTree()
         child->disconnectView();
 }
 
-void FrameTree::setSpecifiedName(const AtomString& specifiedName)
+void NODELETE FrameTree::setSpecifiedName(const AtomString& specifiedName)
 {
     m_specifiedName = specifiedName;
 }
 
-void FrameTree::clearName()
+void NODELETE FrameTree::clearName()
 {
     m_specifiedName = nullAtom();
 }
@@ -224,7 +224,7 @@ unsigned FrameTree::scopedChildCount() const
     return m_scopedChildCount;
 }
 
-unsigned FrameTree::childCount() const
+unsigned NODELETE FrameTree::childCount() const
 {
     unsigned count = 0;
     for (auto* child = firstChild(); child; child = child->tree().nextSibling())
@@ -268,7 +268,7 @@ Frame* FrameTree::childBySpecifiedName(const AtomString& name) const
 
 // FrameTree::find() only returns frames in pages that are related to the active
 // page by an opener <-> openee relationship.
-static bool isFrameFamiliarWith(Frame& frameA, Frame& frameB)
+static bool NODELETE isFrameFamiliarWith(Frame& frameA, Frame& frameB)
 {
     if (frameA.page() == frameB.page())
         return true;
@@ -341,7 +341,7 @@ RefPtr<Frame> FrameTree::findBySpecifiedName(const AtomString& specifiedName, Fr
     }, activeFrame);
 }
 
-bool FrameTree::isDescendantOf(const Frame* ancestor) const
+bool NODELETE FrameTree::isDescendantOf(const Frame* ancestor) const
 {
     if (!ancestor)
         return false;

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -91,9 +91,9 @@ public:
     unsigned scopedChildCount() const;
 
 private:
-    Frame* deepFirstChild() const;
-    Frame* deepLastChild() const;
-    Frame* nextAncestorSibling(const Frame* stayWithin) const;
+    Frame* NODELETE deepFirstChild() const;
+    Frame* NODELETE deepLastChild() const;
+    Frame* NODELETE nextAncestorSibling(const Frame* stayWithin) const;
 
     RefPtr<Frame> scopedChild(unsigned index, TreeScope*) const;
     RefPtr<Frame> scopedChild(NOESCAPE const Function<bool(const FrameTree&)>& isMatch, TreeScope*) const;

--- a/Source/WebCore/page/History.h
+++ b/Source/WebCore/page/History.h
@@ -81,7 +81,7 @@ private:
     bool stateChanged() const;
 
     SerializedScriptValue* stateInternal() const;
-    uint32_t totalStateObjectPayloadLimit() const;
+    uint32_t NODELETE totalStateObjectPayloadLimit() const;
 
     RefPtr<SerializedScriptValue> m_lastStateObjectRequested;
     JSValueInWrappedObject m_cachedState;

--- a/Source/WebCore/page/ImageOverlayController.h
+++ b/Source/WebCore/page/ImageOverlayController.h
@@ -68,7 +68,7 @@ public:
 
 #if PLATFORM(MAC)
     // DataDetectorHighlightClient.
-    void ref() const final;
+    void NODELETE ref() const final;
     void deref() const final;
 #else
     void ref() const;

--- a/Source/WebCore/page/IntersectionObserver.h
+++ b/Source/WebCore/page/IntersectionObserver.h
@@ -82,7 +82,7 @@ public:
 
     ~IntersectionObserver();
 
-    Document* trackingDocument() const;
+    Document* NODELETE trackingDocument() const;
 
     ContainerNode* root() const { return m_root.get(); }
     String rootMargin() const;

--- a/Source/WebCore/page/LargestContentfulPaint.h
+++ b/Source/WebCore/page/LargestContentfulPaint.h
@@ -44,26 +44,26 @@ public:
     ~LargestContentfulPaint();
 
     // PaintTimingMixin
-    DOMHighResTimeStamp paintTime() const;
-    std::optional<DOMHighResTimeStamp> presentationTime() const;
+    DOMHighResTimeStamp NODELETE paintTime() const;
+    std::optional<DOMHighResTimeStamp> NODELETE presentationTime() const;
 
     // LargestContentfulPaint
-    DOMHighResTimeStamp loadTime() const;
-    void setLoadTime(DOMHighResTimeStamp);
+    DOMHighResTimeStamp NODELETE loadTime() const;
+    void NODELETE setLoadTime(DOMHighResTimeStamp);
 
-    DOMHighResTimeStamp renderTime() const;
-    void setRenderTime(DOMHighResTimeStamp);
+    DOMHighResTimeStamp NODELETE renderTime() const;
+    void NODELETE setRenderTime(DOMHighResTimeStamp);
 
-    DOMHighResTimeStamp startTime() const final;
+    DOMHighResTimeStamp NODELETE startTime() const final;
 
-    unsigned size() const;
-    void setSize(unsigned);
+    unsigned NODELETE size() const;
+    void NODELETE setSize(unsigned);
 
-    String id() const;
-    void setID(const String&);
+    String NODELETE id() const;
+    void NODELETE setID(const String&);
 
-    String url() const;
-    void setURLString(const String&);
+    String NODELETE url() const;
+    void NODELETE setURLString(const String&);
 
     Element* element() const;
     void setElement(Element*);

--- a/Source/WebCore/page/LargestContentfulPaintData.h
+++ b/Source/WebCore/page/LargestContentfulPaintData.h
@@ -79,7 +79,7 @@ private:
     static FloatRect computeViewportIntersectionRect(Element&, FloatRect localRect);
     static FloatRect computeViewportIntersectionRectForTextContainer(Element&, const WeakHashSet<Text, WeakPtrImplWithEventTargetData>&);
 
-    static bool isEligibleForLargestContentfulPaint(const Element&, float effectiveVisualArea);
+    static bool NODELETE isEligibleForLargestContentfulPaint(const Element&, float effectiveVisualArea);
     static bool canCompareWithLargestPaintArea(const Element&);
 
     void potentiallyAddLargestContentfulPaintEntry(Element&, CachedImage*, FloatRect imageLocalRect, FloatRect intersectionRect, MonotonicTime loadTime, DOMHighResTimeStamp paintTimestamp, std::optional<FloatSize>& viewportSize);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -202,7 +202,7 @@ void LocalDOMWindow::forEachWindowInterestedInStorageEvents(NOESCAPE const Funct
         apply(window);
 }
 
-static std::optional<Seconds>& transientActivationDurationOverrideForTesting()
+static std::optional<Seconds>& NODELETE transientActivationDurationOverrideForTesting()
 {
     static NeverDestroyed<std::optional<Seconds>> overrideForTesting;
     return overrideForTesting;
@@ -219,13 +219,13 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(LocalDOMWindow);
 
 typedef HashCountedSet<LocalDOMWindow*> LocalDOMWindowSet;
 
-static LocalDOMWindowSet& windowsWithUnloadEventListeners()
+static LocalDOMWindowSet& NODELETE windowsWithUnloadEventListeners()
 {
     static NeverDestroyed<LocalDOMWindowSet> windowsWithUnloadEventListeners;
     return windowsWithUnloadEventListeners;
 }
 
-static LocalDOMWindowSet& windowsWithBeforeUnloadEventListeners()
+static LocalDOMWindowSet& NODELETE windowsWithBeforeUnloadEventListeners()
 {
     static NeverDestroyed<LocalDOMWindowSet> windowsWithBeforeUnloadEventListeners;
     return windowsWithBeforeUnloadEventListeners;
@@ -267,7 +267,7 @@ static void removeAllBeforeUnloadEventListeners(LocalDOMWindow* domWindow)
         domWindow->enableSuddenTermination();
 }
 
-static bool allowsBeforeUnloadListeners(LocalDOMWindow* window)
+static bool NODELETE allowsBeforeUnloadListeners(LocalDOMWindow* window)
 {
     ASSERT_ARG(window, window);
     RefPtr frame = window->frame();

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -125,7 +125,7 @@ public:
     bool allowPopUp(); // Call on first window, not target window.
     static bool allowPopUp(LocalFrame& firstFrame);
     static bool canShowModalDialog(const LocalFrame&);
-    WEBCORE_EXPORT void setCanShowModalDialogOverride(bool);
+    WEBCORE_EXPORT void NODELETE setCanShowModalDialogOverride(bool);
 
     Screen& screen();
     WEBCORE_EXPORT History& history();
@@ -140,9 +140,9 @@ public:
     WEBCORE_EXPORT Ref<Navigator> protectedNavigator();
     Navigator* optionalNavigator() const { return m_navigator.get(); }
 
-    WEBCORE_EXPORT static void overrideTransientActivationDurationForTesting(std::optional<Seconds>&&);
+    WEBCORE_EXPORT static void NODELETE overrideTransientActivationDurationForTesting(std::optional<Seconds>&&);
     void setLastActivationTimestamp(MonotonicTime lastActivationTimestamp) { m_lastActivationTimestamp = lastActivationTimestamp; }
-    void consumeLastActivationIfNecessary();
+    void NODELETE consumeLastActivationIfNecessary();
     MonotonicTime lastActivationTimestamp() const { return m_lastActivationTimestamp; }
     void notifyActivated(MonotonicTime);
     WEBCORE_EXPORT bool hasTransientActivation() const;
@@ -150,18 +150,18 @@ public:
     WEBCORE_EXPORT bool consumeTransientActivation();
     WEBCORE_EXPORT bool hasHistoryActionActivation() const;
     WEBCORE_EXPORT bool consumeHistoryActionUserActivation();
-    WEBCORE_EXPORT static Seconds transientActivationDuration();
+    WEBCORE_EXPORT static Seconds NODELETE transientActivationDuration();
 
     struct ClickEventData {
         MonotonicTime time;
         OptionSet<PlatformEventModifier> modifiers;
     };
     void updateLastUserClickEvent(OptionSet<PlatformEventModifier>);
-    WEBCORE_EXPORT std::optional<ClickEventData> consumeLastUserClickEvent();
+    WEBCORE_EXPORT std::optional<ClickEventData> NODELETE consumeLastUserClickEvent();
 
     DOMSelection* getSelection();
 
-    HTMLFrameOwnerElement* frameElement() const;
+    HTMLFrameOwnerElement* NODELETE frameElement() const;
 
     WEBCORE_EXPORT void focus(bool allowFocus = false);
     void focus(LocalDOMWindow& incumbentWindow);
@@ -182,7 +182,7 @@ public:
 
     bool find(const String&, bool caseSensitive, bool backwards, bool wrap, bool wholeWord, bool searchInFrames, bool showDialog) const;
 
-    bool offscreenBuffering() const;
+    bool NODELETE offscreenBuffering() const;
 
     int outerHeight() const;
     int outerWidth() const;
@@ -197,11 +197,11 @@ public:
 
     unsigned length() const;
 
-    AtomString name() const;
+    AtomString NODELETE name() const;
     void setName(const AtomString&);
 
     String status() const;
-    void setStatus(const String&);
+    void NODELETE setStatus(const String&);
 
     void disownOpener();
 
@@ -280,8 +280,8 @@ public:
 
     void dispatchLoadEvent();
 
-    void captureEvents();
-    void releaseEvents();
+    void NODELETE captureEvents();
+    void NODELETE releaseEvents();
 
     void finishedLoading();
 
@@ -317,7 +317,7 @@ public:
 
     WEBCORE_EXPORT ReducedResolutionSeconds nowTimestamp() const;
     void freezeNowTimestamp();
-    void unfreezeNowTimestamp();
+    void NODELETE unfreezeNowTimestamp();
     ReducedResolutionSeconds frozenNowTimestamp() const;
 
 #if PLATFORM(IOS_FAMILY)
@@ -339,7 +339,7 @@ public:
     DeviceMotionController* deviceMotionController() const;
 #endif
 
-    void resetAllGeolocationPermission();
+    void NODELETE resetAllGeolocationPermission();
 
 #if ENABLE(IOS_TOUCH_EVENTS) || ENABLE(IOS_GESTURE_EVENTS)
     bool hasTouchOrGestureEventListeners() const { return m_touchAndGestureEventListenerCount > 0; }
@@ -369,7 +369,7 @@ public:
     void setMayReuseForNavigation(bool mayReuseForNavigation) { m_mayReuseForNavigation = mayReuseForNavigation; }
     bool mayReuseForNavigation() const { return m_mayReuseForNavigation; }
 
-    Page* page() const;
+    Page* NODELETE page() const;
 
     WEBCORE_EXPORT static void forEachWindowInterestedInStorageEvents(NOESCAPE const Function<void(LocalDOMWindow&)>&);
 
@@ -384,20 +384,20 @@ public:
 private:
     explicit LocalDOMWindow(Document&);
 
-    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
 
     void closePage() final;
     void eventListenersDidChange() final;
     void setLocation(LocalDOMWindow& activeWindow, const URL& completedURL, NavigationHistoryBehavior, SetLocationLocking, CanNavigateState) final;
 
-    bool allowedToChangeWindowGeometry() const;
+    bool NODELETE allowedToChangeWindowGeometry() const;
 
     static ExceptionOr<RefPtr<Frame>> createWindow(const String& urlString, const AtomString& frameName, const WindowFeatures&, LocalDOMWindow& activeWindow, LocalFrame& firstFrame, LocalFrame& openerFrame, NOESCAPE const Function<void(LocalDOMWindow&)>& prepareDialogFunction = nullptr);
 
 #if ENABLE(DEVICE_ORIENTATION)
     bool isAllowedToUseDeviceMotionOrOrientation(String& message) const;
     bool hasPermissionToReceiveDeviceMotionOrOrientationEvents(String& message) const;
-    void failedToRegisterDeviceMotionEventListener();
+    void NODELETE failedToRegisterDeviceMotionEventListener();
 #endif
 
     EventTimingInteractionID computeInteractionID(Event&, EventType);

--- a/Source/WebCore/page/LocalFrame.cpp
+++ b/Source/WebCore/page/LocalFrame.cpp
@@ -158,7 +158,7 @@ struct OverrideScreenSize {
     FloatSize size;
 };
 
-static inline float parentPageZoomFactor(LocalFrame* frame)
+static inline float NODELETE parentPageZoomFactor(LocalFrame* frame)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto* parent = dynamicDowncast<LocalFrame>(frame->tree().parent());
     if (!parent)
@@ -166,7 +166,7 @@ static inline float parentPageZoomFactor(LocalFrame* frame)
     return parent->pageZoomFactor();
 }
 
-static inline float parentTextZoomFactor(LocalFrame* frame)
+static inline float NODELETE parentTextZoomFactor(LocalFrame* frame)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto* parent = dynamicDowncast<LocalFrame>(frame->tree().parent());
     if (!parent)
@@ -174,7 +174,7 @@ static inline float parentTextZoomFactor(LocalFrame* frame)
     return parent->textZoomFactor();
 }
 
-static const LocalFrame& rootFrame(const LocalFrame& frame, Frame* parent)
+static const LocalFrame& NODELETE rootFrame(const LocalFrame& frame, Frame* parent)
 {
     SUPPRESS_UNCOUNTED_LOCAL auto* localParent = dynamicDowncast<LocalFrame>(parent);
     if (localParent)
@@ -845,7 +845,7 @@ void LocalFrame::injectUserScriptImmediately(DOMWrapperWorld& world, const UserS
     WTFEndSignpost(this, UserScript);
 }
 
-RenderView* LocalFrame::contentRenderer() const
+RenderView* NODELETE LocalFrame::contentRenderer() const
 {
     return document() ? document()->renderView() : nullptr;
 }

--- a/Source/WebCore/page/LocalFrame.h
+++ b/Source/WebCore/page/LocalFrame.h
@@ -150,7 +150,7 @@ public:
 
     WEBCORE_EXPORT ~LocalFrame();
 
-    WEBCORE_EXPORT LocalDOMWindow* window() const;
+    WEBCORE_EXPORT LocalDOMWindow* NODELETE window() const;
 
     void addDestructionObserver(FrameDestructionObserver&);
     void removeDestructionObserver(FrameDestructionObserver&);
@@ -159,7 +159,7 @@ public:
 
     inline Document* document() const; // Defined in LocalFrameInlines.h
     inline LocalFrameView* view() const; // Defined in DocumentView.h
-    WEBCORE_EXPORT RefPtr<const LocalFrame> localMainFrame() const;
+    WEBCORE_EXPORT RefPtr<const LocalFrame> NODELETE localMainFrame() const;
     WEBCORE_EXPORT RefPtr<LocalFrame> localMainFrame();
 
     inline Editor& editor(); // Defined in LocalFrameInlines.h
@@ -224,7 +224,7 @@ public:
     float textZoomFactor() const { return m_textZoomFactor; }
 
     // Scale factor of this frame with respect to the container.
-    WEBCORE_EXPORT float frameScaleFactor() const;
+    WEBCORE_EXPORT float NODELETE frameScaleFactor() const;
 
     void deviceOrPageScaleFactorChanged();
 
@@ -326,7 +326,7 @@ public:
     WEBCORE_EXPORT FloatSize screenSize() const;
     void setOverrideScreenSize(FloatSize&&);
 
-    void selfOnlyRef();
+    void NODELETE selfOnlyRef();
     void selfOnlyDeref();
 
     void documentURLOrOriginDidChange();
@@ -345,11 +345,11 @@ public:
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final;
     AutoplayPolicy autoplayPolicy() const final;
 
-    WEBCORE_EXPORT SandboxFlags effectiveSandboxFlags() const;
+    WEBCORE_EXPORT SandboxFlags NODELETE effectiveSandboxFlags() const;
     SandboxFlags sandboxFlagsFromSandboxAttributeNotCSP() { return m_sandboxFlags; }
     WEBCORE_EXPORT void updateSandboxFlags(SandboxFlags, NotifyUIProcess) final;
 
-    WEBCORE_EXPORT ReferrerPolicy effectiveReferrerPolicy() const;
+    WEBCORE_EXPORT ReferrerPolicy NODELETE effectiveReferrerPolicy() const;
     WEBCORE_EXPORT void updateReferrerPolicy(ReferrerPolicy) final;
 
     ScrollbarMode scrollingMode() const { return m_scrollingMode; }
@@ -390,9 +390,9 @@ private:
     String frameURLProtocol() const final;
 
     void disconnectView() final;
-    DOMWindow* virtualWindow() const final;
+    DOMWindow* NODELETE virtualWindow() const final;
     void reinitializeDocumentSecurityContext() final;
-    FrameLoaderClient& loaderClient() final;
+    FrameLoaderClient& NODELETE loaderClient() final;
     void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
 
     WeakHashSet<FrameDestructionObserver> m_destructionObservers;

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -3391,7 +3391,7 @@ void LocalFrameView::cancelScheduledTextFragmentIndicatorTimer()
     m_delayedTextFragmentIndicatorTimer.stop();
 }
 
-static void adjustScrollRectToVisibleOptionsForHiddenOverflow(ScrollRectToVisibleOptions& options, const RenderStyle& style)
+static void NODELETE adjustScrollRectToVisibleOptionsForHiddenOverflow(ScrollRectToVisibleOptions& options, const RenderStyle& style)
 {
     if (options.allowScrollingOverflowHidden == AllowScrollingOverflowHidden::Yes)
         return;

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -88,7 +88,7 @@ enum class StyleColorOptions : uint8_t;
 enum class TemporarySelectionOption : uint16_t;
 enum class TiledBackingScrollability : uint8_t;
 
-Pagination::Mode paginationModeForRenderStyle(const RenderStyle&);
+Pagination::Mode NODELETE paginationModeForRenderStyle(const RenderStyle&);
 
 enum class LayoutViewportConstraint : bool { Unconstrained, ConstrainedToDocumentRect };
 
@@ -109,12 +109,12 @@ public:
     Type viewType() const final { return Type::Local; }
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
 
-    WEBCORE_EXPORT LocalFrame& frame() const final;
+    WEBCORE_EXPORT LocalFrame& NODELETE frame() const final;
 
-    WEBCORE_EXPORT RenderView* renderView() const;
+    WEBCORE_EXPORT RenderView* NODELETE renderView() const;
 
-    int mapFromLayoutToCSSUnits(LayoutUnit) const;
-    LayoutUnit mapFromCSSToLayoutUnits(int) const;
+    int NODELETE mapFromLayoutToCSSUnits(LayoutUnit) const;
+    LayoutUnit NODELETE mapFromCSSToLayoutUnits(int) const;
 
     WEBCORE_EXPORT void setCanHaveScrollbars(bool) final;
     WEBCORE_EXPORT void updateCanHaveScrollbars();
@@ -129,7 +129,7 @@ public:
     const LocalFrameViewLayoutContext& layoutContext() const { return m_layoutContext; }
     LocalFrameViewLayoutContext& layoutContext() { return m_layoutContext; }
 
-    WEBCORE_EXPORT bool didFirstLayout() const;
+    WEBCORE_EXPORT bool NODELETE didFirstLayout() const;
 
     WEBCORE_EXPORT bool needsLayout() const;
     WEBCORE_EXPORT void setNeedsLayoutAfterViewConfigurationChange();
@@ -174,7 +174,7 @@ public:
 
     WEBCORE_EXPORT TiledBacking* tiledBacking() const;
 
-    WEBCORE_EXPORT std::optional<ScrollingNodeID> scrollingNodeID() const override;
+    WEBCORE_EXPORT std::optional<ScrollingNodeID> NODELETE scrollingNodeID() const override;
     WEBCORE_EXPORT ScrollableArea* scrollableAreaForScrollingNodeID(ScrollingNodeID) const;
     void setPluginScrollableAreaForScrollingNodeID(ScrollingNodeID nodeID, ScrollableArea& area) { m_scrollingNodeIDToPluginScrollableAreaMap.add(nodeID, &area); }
     void removePluginScrollableAreaForScrollingNodeID(ScrollingNodeID nodeID) { m_scrollingNodeIDToPluginScrollableAreaMap.remove(nodeID); }
@@ -204,16 +204,16 @@ public:
 #endif
 
     void clear();
-    void resetLayoutMilestones();
+    void NODELETE resetLayoutMilestones();
 
     // This represents externally-imposed transparency. iframes are transparent by default, but that's handled in RenderView::shouldPaintBaseBackground().
-    WEBCORE_EXPORT bool isTransparent() const;
+    WEBCORE_EXPORT bool NODELETE isTransparent() const;
     WEBCORE_EXPORT void setTransparent(bool isTransparent);
     
     // True if the FrameView is not transparent, and the base background color is opaque.
-    bool hasOpaqueBackground() const;
+    bool NODELETE hasOpaqueBackground() const;
 
-    WEBCORE_EXPORT Color baseBackgroundColor() const;
+    WEBCORE_EXPORT Color NODELETE baseBackgroundColor() const;
     WEBCORE_EXPORT void setBaseBackgroundColor(const Color&);
     WEBCORE_EXPORT void updateBackgroundRecursively(const std::optional<Color>& backgroundColor);
 
@@ -232,8 +232,8 @@ public:
     bool hasExtendedBackgroundRectForPainting() const;
     IntRect extendedBackgroundRectForPainting() const;
 
-    bool shouldUpdateWhileOffscreen() const;
-    WEBCORE_EXPORT void setShouldUpdateWhileOffscreen(bool);
+    bool NODELETE shouldUpdateWhileOffscreen() const;
+    WEBCORE_EXPORT void NODELETE setShouldUpdateWhileOffscreen(bool);
     bool shouldUpdate() const;
 
     WEBCORE_EXPORT void adjustViewSize();
@@ -313,7 +313,7 @@ public:
     WEBCORE_EXPORT void setLayoutViewportOverrideRect(std::optional<LayoutRect>, TriggerLayoutOrNot = TriggerLayoutOrNot::Yes);
     std::optional<LayoutRect> layoutViewportOverrideRect() const { return m_layoutViewportOverrideRect; }
 
-    WEBCORE_EXPORT void setVisualViewportOverrideRect(std::optional<LayoutRect>);
+    WEBCORE_EXPORT void NODELETE setVisualViewportOverrideRect(std::optional<LayoutRect>);
     std::optional<LayoutRect> visualViewportOverrideRect() const { return m_visualViewportOverrideRect; }
 
     // These are in document coordinates, unaffected by page scale (but affected by zooming).
@@ -341,7 +341,7 @@ public:
 #endif
 
     AtomString mediaType() const;
-    WEBCORE_EXPORT void setMediaType(const AtomString&);
+    WEBCORE_EXPORT void NODELETE setMediaType(const AtomString&);
     void adjustMediaTypeForPrinting(bool printing);
 
     void setCannotBlitToWindow();
@@ -350,19 +350,19 @@ public:
 
     void addSlowRepaintObject(RenderElement&);
     void removeSlowRepaintObject(RenderElement&);
-    bool hasSlowRepaintObject(const RenderElement& renderer) const;
-    bool hasSlowRepaintObjects() const;
+    bool NODELETE hasSlowRepaintObject(const RenderElement& renderer) const;
+    bool NODELETE hasSlowRepaintObjects() const;
     SingleThreadWeakKeyHashSet<RenderElement>* slowRepaintObjects() const { return m_slowRepaintObjects.get(); }
 
     // Includes fixed- and sticky-position objects.
     void addViewportConstrainedObject(RenderLayerModelObject&);
     void removeViewportConstrainedObject(RenderLayerModelObject&);
     const SingleThreadWeakHashSet<RenderLayerModelObject>* viewportConstrainedObjects() const { return m_viewportConstrainedObjects.get(); }
-    WEBCORE_EXPORT bool hasViewportConstrainedObjects() const;
+    WEBCORE_EXPORT bool NODELETE hasViewportConstrainedObjects() const;
     bool hasAnchorPositionedViewportConstrainedObjects() const;
-    void clearCachedHasAnchorPositionedViewportConstrainedObjects();
+    void NODELETE clearCachedHasAnchorPositionedViewportConstrainedObjects();
 
-    float frameScaleFactor() const;
+    float NODELETE frameScaleFactor() const;
 
     // Functions for querying the current scrolled position, negating the effects of overhang
     // and adjusting for page scale.
@@ -398,14 +398,14 @@ public:
 
     IntSize scrollGeometryContentSize() const { return m_scrollGeometryContentSize; }
 
-    bool fixedElementsLayoutRelativeToFrame() const;
+    bool NODELETE fixedElementsLayoutRelativeToFrame() const;
 
     bool speculativeTilingEnabled() const { return m_speculativeTilingEnabled; }
     void loadProgressingStatusChanged();
 
     WEBCORE_EXPORT void updateControlTints();
 
-    WEBCORE_EXPORT bool wasScrolledByUser() const;
+    WEBCORE_EXPORT bool NODELETE wasScrolledByUser() const;
     bool wasEverScrolledExplicitlyByUser() const { return m_wasEverScrolledExplicitlyByUser; }
 
     enum class UserScrollType : uint8_t { Explicit, Implicit };
@@ -437,12 +437,12 @@ public:
     WEBCORE_EXPORT void didReplaceMultipartContent();
 #endif
 
-    WEBCORE_EXPORT void setPaintBehavior(OptionSet<PaintBehavior>);
-    WEBCORE_EXPORT OptionSet<PaintBehavior> paintBehavior() const;
-    bool isPainting() const;
+    WEBCORE_EXPORT void NODELETE setPaintBehavior(OptionSet<PaintBehavior>);
+    WEBCORE_EXPORT OptionSet<PaintBehavior> NODELETE paintBehavior() const;
+    bool NODELETE isPainting() const;
     bool hasEverPainted() const { return !!m_lastPaintTime; }
     void setLastPaintTime(MonotonicTime lastPaintTime) { m_lastPaintTime = lastPaintTime; }
-    WEBCORE_EXPORT void setNodeToDraw(Node*);
+    WEBCORE_EXPORT void NODELETE setNodeToDraw(Node*);
 
     enum SelectionInSnapshot { IncludeSelection, ExcludeSelection };
     enum CoordinateSpaceForSnapshot { DocumentCoordinates, ViewCoordinates };
@@ -463,7 +463,7 @@ public:
     bool isVisuallyNonEmpty() const { return m_contentQualifiesAsVisuallyNonEmpty; }
 
     inline bool hasEnoughContentForVisualMilestones() const; // Defined in LocalFrameViewInlines.h
-    bool hasContentfulDescendants() const;
+    bool NODELETE hasContentfulDescendants() const;
     void checkAndDispatchDidReachVisuallyNonEmptyState();
 
     WEBCORE_EXPORT void enableFixedWidthAutoSizeMode(bool enable, const IntSize& minSize);
@@ -531,11 +531,11 @@ public:
     //    Similar to client coordinates, but affected by page zoom (but not page scale).
     //
 
-    float documentToAbsoluteScaleFactor(std::optional<float> usedZoom = { }) const;
-    float absoluteToDocumentScaleFactor(std::optional<float> usedZoom = { }) const;
+    float NODELETE documentToAbsoluteScaleFactor(std::optional<float> usedZoom = { }) const;
+    float NODELETE absoluteToDocumentScaleFactor(std::optional<float> usedZoom = { }) const;
 
     WEBCORE_EXPORT FloatRect absoluteToDocumentRect(FloatRect, std::optional<float> usedZoom = { }) const;
-    WEBCORE_EXPORT FloatPoint absoluteToDocumentPoint(FloatPoint, std::optional<float> usedZoom = { }) const;
+    WEBCORE_EXPORT FloatPoint NODELETE absoluteToDocumentPoint(FloatPoint, std::optional<float> usedZoom = { }) const;
     WEBCORE_EXPORT DoublePoint absoluteToDocumentPoint(DoublePoint, std::optional<float> usedZoom = { }) const;
 
     FloatRect absoluteToClientRect(FloatRect, std::optional<float> usedZoom = { }) const;
@@ -555,7 +555,7 @@ public:
 
     // Unlike client coordinates, layout viewport coordinates are affected by page zoom.
     WEBCORE_EXPORT FloatRect clientToLayoutViewportRect(FloatRect) const;
-    WEBCORE_EXPORT FloatPoint clientToLayoutViewportPoint(FloatPoint) const;
+    WEBCORE_EXPORT FloatPoint NODELETE clientToLayoutViewportPoint(FloatPoint) const;
 
     bool isFrameViewScrollCorner(const RenderScrollbarPart& scrollCorner) const { return m_scrollCorner.get() == &scrollCorner; }
 
@@ -574,8 +574,8 @@ public:
     void calculateScrollbarModesForLayout(ScrollbarMode& hMode, ScrollbarMode& vMode, ScrollbarModesCalculationStrategy = AnyRule);
 
     IntPoint lastKnownMousePositionInView() const final;
-    bool isHandlingWheelEvent() const final;
-    bool shouldSetCursor() const;
+    bool NODELETE isHandlingWheelEvent() const final;
+    bool NODELETE shouldSetCursor() const;
 
     WEBCORE_EXPORT bool useDarkAppearance() const final;
     OptionSet<StyleColorOptions> styleColorOptions() const;
@@ -583,7 +583,7 @@ public:
     // FIXME: Remove this method once plugin loading is decoupled from layout.
     void flushAnyPendingPostLayoutTasks();
 
-    bool shouldSuspendScrollAnimations() const final;
+    bool NODELETE shouldSuspendScrollAnimations() const final;
 
     RenderBox* embeddedContentBox() const;
     
@@ -593,17 +593,17 @@ public:
     const Vector<FloatRect>& trackedRepaintRects() const { return m_trackedRepaintRects; }
     String trackedRepaintRectsAsText() const;
 
-    WEBCORE_EXPORT void startTrackingLayoutUpdates();
-    WEBCORE_EXPORT unsigned layoutUpdateCount();
-    WEBCORE_EXPORT void startTrackingRenderLayerPositionUpdates();
-    WEBCORE_EXPORT unsigned renderLayerPositionUpdateCount();
+    WEBCORE_EXPORT void NODELETE startTrackingLayoutUpdates();
+    WEBCORE_EXPORT unsigned NODELETE layoutUpdateCount();
+    WEBCORE_EXPORT void NODELETE startTrackingRenderLayerPositionUpdates();
+    WEBCORE_EXPORT unsigned NODELETE renderLayerPositionUpdateCount();
 
     typedef WeakHashSet<ScrollableArea> ScrollableAreaSet;
     // Returns whether the scrollable area has just been newly added.
     WEBCORE_EXPORT bool addScrollableArea(ScrollableArea*);
     // Returns whether the scrollable area has just been removed.
     WEBCORE_EXPORT bool removeScrollableArea(ScrollableArea*);
-    bool containsScrollableArea(ScrollableArea*) const;
+    bool NODELETE containsScrollableArea(ScrollableArea*) const;
     const ScrollableAreaSet* scrollableAreas() const { return m_scrollableAreas.get(); }
     
     void addScrollableAreaForAnimatedScroll(ScrollableArea*);
@@ -645,7 +645,7 @@ public:
     void obscuredInsetsWillChange(FloatBoxExtent&& delta);
     void obscuredContentInsetsDidChange(const FloatBoxExtent&);
 
-    void topContentDirectionDidChange();
+    void NODELETE topContentDirectionDidChange();
 
     WEBCORE_EXPORT void willStartLiveResize() final;
     WEBCORE_EXPORT void willEndLiveResize() final;
@@ -655,7 +655,7 @@ public:
     void updateTiledBackingAdaptiveSizing();
     WEBCORE_EXPORT OptionSet<TiledBackingScrollability> computeScrollability() const;
 
-    void addPaintPendingMilestones(OptionSet<LayoutMilestone>);
+    void NODELETE addPaintPendingMilestones(OptionSet<LayoutMilestone>);
     void firePaintRelatedMilestonesIfNeeded();
     WEBCORE_EXPORT void fireLayoutRelatedMilestonesIfNeeded();
     OptionSet<LayoutMilestone> milestonesPendingPaint() const { return m_milestonesPendingPaint; }
@@ -665,7 +665,7 @@ public:
 
     WEBCORE_EXPORT void setScrollPinningBehavior(ScrollPinningBehavior);
 
-    ScrollBehaviorForFixedElements scrollBehaviorForFixedElements() const;
+    ScrollBehaviorForFixedElements NODELETE scrollBehaviorForFixedElements() const;
 
     bool hasFlippedBlockRenderers() const { return m_hasFlippedBlockRenderers; }
     void setHasFlippedBlockRenderers(bool b) { m_hasFlippedBlockRenderers = b; }
@@ -700,13 +700,13 @@ public:
     void show() final;
     void hide() final;
 
-    bool shouldPlaceVerticalScrollbarOnLeft() const final;
-    bool isHorizontalWritingMode() const final;
+    bool NODELETE shouldPlaceVerticalScrollbarOnLeft() const final;
+    bool NODELETE isHorizontalWritingMode() const final;
 
     void didRestoreFromBackForwardCache();
 
     void willDestroyRenderTree();
-    void didDestroyRenderTree();
+    void NODELETE didDestroyRenderTree();
 
     void setSpeculativeTilingDelayDisabledForTesting(bool disabled) { m_speculativeTilingDelayDisabledForTesting = disabled; }
 
@@ -730,13 +730,13 @@ public:
     // ScrollView
     void updateScrollbarSteps() override;
     
-    OverscrollBehavior horizontalOverscrollBehavior() const final;
-    OverscrollBehavior verticalOverscrollBehavior() const final;
+    OverscrollBehavior NODELETE horizontalOverscrollBehavior() const final;
+    OverscrollBehavior NODELETE verticalOverscrollBehavior() const final;
 
     Color scrollbarThumbColorStyle() const final;
     Color scrollbarTrackColorStyle() const final;
-    Style::ScrollbarGutter scrollbarGutterStyle() const final;
-    ScrollbarWidth scrollbarWidthStyle() const final;
+    Style::ScrollbarGutter NODELETE scrollbarGutterStyle() const final;
+    ScrollbarWidth NODELETE scrollbarWidthStyle() const final;
     std::optional<ScrollbarColor> scrollbarColorStyle() const final;
 
     // overflow:hidden scrollable areas can participate in anchoring, so they need their own set.
@@ -758,7 +758,7 @@ public:
 
     void scrollbarWidthChanged(ScrollbarWidth) override;
 
-    std::optional<FrameIdentifier> rootFrameID() const final;
+    std::optional<FrameIdentifier> NODELETE rootFrameID() const final;
 
     IntSize totalScrollbarSpace() const final;
     int scrollbarGutterWidth(bool isHorizontalWritingMode = true) const;
@@ -806,8 +806,8 @@ private:
     void traverseForPaintInvalidation(NullGraphicsContextPaintInvalidationReasons);
     void repaintSlowRepaintObjects();
 
-    bool isVerticalDocument() const final;
-    bool isFlippedDocument() const final;
+    bool NODELETE isVerticalDocument() const final;
+    bool NODELETE isFlippedDocument() const final;
 
     void incrementVisuallyNonEmptyCharacterCountSlowCase(const String&);
 
@@ -835,7 +835,7 @@ private:
     bool shouldUpdateCompositingLayersAfterScrolling() const;
     bool flushCompositingStateForThisFrame(const LocalFrame& rootFrameForFlush);
 
-    bool shouldDeferScrollUpdateAfterContentSizeChange() final;
+    bool NODELETE shouldDeferScrollUpdateAfterContentSizeChange() final;
 
     void scrollOffsetChangedViaPlatformWidgetImpl(const ScrollOffset& oldOffset, const ScrollOffset& newOffset) final;
 
@@ -871,7 +871,7 @@ private:
 
     void delegatedScrollingModeDidChange() final;
 
-    void unobscuredContentSizeChanged() final;
+    void NODELETE unobscuredContentSizeChanged() final;
     
     void scrollToTextFragmentRetryTimerFired();
     void textFragmentIndicatorTimerFired();
@@ -887,11 +887,11 @@ private:
     void contentsResized() final;
 
 #if ENABLE(DARK_MODE_CSS)
-    RenderElement* rendererForColorScheme() const;
+    RenderElement* NODELETE rendererForColorScheme() const;
 #endif
 
     bool usesCompositedScrolling() const final;
-    bool mockScrollbarsControllerEnabled() const final;
+    bool NODELETE mockScrollbarsControllerEnabled() const final;
     void logMockScrollbarsControllerMessage(const String&) const final;
 
     bool canShowNonOverlayScrollbars() const final;
@@ -946,14 +946,14 @@ private:
 
     void updateScrollCorner() final;
 
-    LocalFrameView* parentFrameView() const;
+    LocalFrameView* NODELETE parentFrameView() const;
 
     void markRootOrBodyRendererDirty() const;
 
     bool qualifiesAsSignificantRenderedText() const;
     void updateHasReachedSignificantRenderedTextThreshold();
 
-    bool isViewForDocumentInFrame() const;
+    bool NODELETE isViewForDocumentInFrame() const;
 
     void notifyWidgetsInAllFrames(WidgetNotification);
     void removeFromAXObjectCache();
@@ -978,7 +978,7 @@ private:
     void didFinishProhibitingScrollingWhenChangingContentSize() final;
 
     // ScrollableArea.
-    float pageScaleFactor() const override;
+    float NODELETE pageScaleFactor() const override;
     void didStartScrollAnimation() final;
 
     static MonotonicTime sCurrentPaintTimeStamp; // used for detecting decoded resource thrash in the cache
@@ -988,7 +988,7 @@ private:
     LayoutRect getPossiblyFixedRectToExpose(const LayoutRect& visibleRect, const LayoutRect& exposeRect, EnumSet<BoxAxis> isFixed, const ScrollAlignment& alignX, const ScrollAlignment& alignY) const;
     LayoutRect getPossiblyFixedRectToExpose(const LayoutRect& visibleRect, const LayoutRect& exposeRect, bool isFixed, const ScrollAlignment& alignX, const ScrollAlignment& alignY) const;
 
-    float deviceScaleFactor() const final;
+    float NODELETE deviceScaleFactor() const final;
 
     const Ref<LocalFrame> m_frame;
     LocalFrameViewLayoutContext m_layoutContext;

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.h
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.h
@@ -85,8 +85,8 @@ public:
     void scheduleSubtreeLayout(RenderElement& layoutRoot);
     void unscheduleLayout();
 
-    void disableSetNeedsLayout();
-    void enableSetNeedsLayout();
+    void NODELETE disableSetNeedsLayout();
+    void NODELETE enableSetNeedsLayout();
 
     enum class LayoutPhase : uint8_t {
         OutsideLayout,
@@ -105,7 +105,7 @@ public:
     bool isSkippedContentForLayout(const RenderElement&) const;
     bool isSkippedContentRootForLayout(const RenderBox&) const;
 
-    bool isPercentHeightResolveDisabledFor(const RenderBox& flexItem);
+    bool NODELETE isPercentHeightResolveDisabledFor(const RenderBox& flexItem);
 
     struct TextBoxTrim {
         bool trimFirstFormattedLine { false };
@@ -128,7 +128,7 @@ public:
     void flushPostLayoutTasks();
     void didLayout(bool canDeferUpdateLayerPositions);
 
-    void requestUpdateLayerPositions(bool needsFullRepaint = false);
+    void NODELETE requestUpdateLayerPositions(bool needsFullRepaint = false);
     void flushUpdateLayerPositions();
     void markForUpdateLayerPositionsAfterSVGTransformChange();
 
@@ -137,7 +137,7 @@ public:
     // Returns true if a pending compositing layer update was done.
     bool updateCompositingLayersAfterLayoutIfNeeded();
 
-    RenderLayoutState* layoutState() const PURE_FUNCTION;
+    RenderLayoutState* NODELETE layoutState() const PURE_FUNCTION;
     // Returns true if layoutState should be used for its cached offset and clip.
     bool isPaintOffsetCacheEnabled() const { return !m_paintOffsetCacheDisableCount && layoutState(); }
 #ifndef NDEBUG
@@ -146,7 +146,7 @@ public:
     // layoutDelta is used transiently during layout to store how far an object has moved from its
     // last layout location, in order to repaint correctly.
     // If we're doing a full repaint m_layoutState will be 0, but in that case layoutDelta doesn't matter.
-    LayoutSize layoutDelta() const;
+    LayoutSize NODELETE layoutDelta() const;
     void addLayoutDelta(const LayoutSize& delta);
 #if ASSERT_ENABLED
     bool layoutDeltaMatches(const LayoutSize& delta);
@@ -185,7 +185,7 @@ private:
     bool needsLayoutInternal() const;
 
     void performLayout(bool canDeferUpdateLayerPositions);
-    bool canPerformLayout() const;
+    bool NODELETE canPerformLayout() const;
     bool isLayoutSchedulingEnabled() const { return m_layoutSchedulingIsEnabled; }
 
     bool hasPendingUpdateLayerPositions() const { return !!m_pendingUpdateLayerPositions; }
@@ -228,10 +228,10 @@ private:
     void disablePercentHeightResolveFor(const RenderBox& flexItem);
     void enablePercentHeightResolveFor(const RenderBox& flexItem);
 
-    LocalFrame& frame() const;
-    LocalFrameView& view() const;
+    LocalFrame& NODELETE frame() const;
+    LocalFrameView& NODELETE view() const;
     RenderView* renderView() const;
-    Document* document() const;
+    Document* NODELETE document() const;
 
     SingleThreadWeakRef<LocalFrameView> m_frameView;
     Timer m_layoutTimer;

--- a/Source/WebCore/page/Location.h
+++ b/Source/WebCore/page/Location.h
@@ -83,7 +83,7 @@ private:
 
     ExceptionOr<void> setLocation(LocalDOMWindow& incumbentWindow, LocalDOMWindow& firstWindow, const String&);
 
-    Frame* frame();
+    Frame* NODELETE frame();
     const Frame* frame() const;
 
     WeakPtr<DOMWindow, WeakPtrImplWithEventTargetData> m_window;

--- a/Source/WebCore/page/NavigateEvent.h
+++ b/Source/WebCore/page/NavigateEvent.h
@@ -140,6 +140,6 @@ private:
     const RefPtr<AbortController> m_abortController;
 };
 
-WebCoreOpaqueRoot root(NavigateEvent*);
+WebCoreOpaqueRoot NODELETE root(NavigateEvent*);
 
 } // namespace WebCore

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -101,7 +101,7 @@ bool Navigation::canGoForward() const
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#getting-the-navigation-api-entry-index
-static std::optional<size_t> getEntryIndexOfHistoryItem(const Vector<Ref<NavigationHistoryEntry>>& entries, const HistoryItem& item)
+static std::optional<size_t> NODELETE getEntryIndexOfHistoryItem(const Vector<Ref<NavigationHistoryEntry>>& entries, const HistoryItem& item)
 {
     // FIXME: We could have a more efficient solution than iterating through a list.
     for (size_t index = 0; index < entries.size(); index++) {

--- a/Source/WebCore/page/Navigation.h
+++ b/Source/WebCore/page/Navigation.h
@@ -169,7 +169,7 @@ public:
     void setFocusChanged(FocusDidChange changed) { m_focusChangedDuringOngoingNavigation = changed; }
 
     // EventTarget.
-    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
 
     void rejectFinishedPromise(NavigationAPIMethodTracker*);
     NavigationAPIMethodTracker* upcomingTraverseMethodTracker(const String& key) const;

--- a/Source/WebCore/page/NavigationHistoryEntry.h
+++ b/Source/WebCore/page/NavigationHistoryEntry.h
@@ -81,11 +81,11 @@ private:
     NavigationHistoryEntry(Navigation&, const DocumentState&, Ref<HistoryItem>&&, String urlString, WTF::UUID key, RefPtr<SerializedScriptValue>&& state = { }, WTF::UUID = WTF::UUID::createVersion4());
 
     // ActiveDOMObject.
-    bool virtualHasPendingActivity() const final;
+    bool NODELETE virtualHasPendingActivity() const final;
 
     // EventTarget.
     enum EventTargetInterfaceType eventTargetInterface() const final;
-    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;

--- a/Source/WebCore/page/Navigator.h
+++ b/Source/WebCore/page/Navigator.h
@@ -57,7 +57,7 @@ public:
     bool javaEnabled() const { return false; }
     const String& userAgent() const final;
     String platform() const final;
-    void userAgentChanged();
+    void NODELETE userAgentChanged();
     bool onLine() const final;
     bool canShare(Document&, const ShareData&);
     void share(Document&, const ShareData&, Ref<DeferredPromise>&&);
@@ -67,7 +67,7 @@ public:
     bool standalone() const;
 #endif
 
-    int maxTouchPoints() const;
+    int NODELETE maxTouchPoints() const;
 
     WEBCORE_EXPORT GPU* gpu();
 

--- a/Source/WebCore/page/NavigatorBase.h
+++ b/Source/WebCore/page/NavigatorBase.h
@@ -63,7 +63,7 @@ public:
     static String product();
     static String productSub();
     static String vendor();
-    static String vendorSub();
+    static String NODELETE vendorSub();
 
     virtual bool onLine() const = 0;
 
@@ -90,6 +90,6 @@ private:
     std::unique_ptr<ServiceWorkerContainer> m_serviceWorkerContainer;
 };
 
-WebCoreOpaqueRoot root(NavigatorBase*);
+WebCoreOpaqueRoot NODELETE root(NavigatorBase*);
 
 } // namespace WebCore

--- a/Source/WebCore/page/NavigatorUAData.h
+++ b/Source/WebCore/page/NavigatorUAData.h
@@ -42,7 +42,7 @@ public:
     static Ref<NavigatorUAData> create();
     static Ref<NavigatorUAData> create(Ref<UserAgentStringData>&&);
     const Vector<NavigatorUABrandVersion>& brands() const;
-    bool mobile() const;
+    bool NODELETE mobile() const;
     String platform() const;
     UALowEntropyJSON toJSON() const;
 

--- a/Source/WebCore/page/OriginAccessPatterns.cpp
+++ b/Source/WebCore/page/OriginAccessPatterns.cpp
@@ -47,7 +47,7 @@ OriginAccessPatternsForWebProcess& OriginAccessPatternsForWebProcess::singleton(
 }
 
 static Lock originAccessPatternLock;
-static Vector<UserContentURLPattern>& originAccessPatterns() WTF_REQUIRES_LOCK(originAccessPatternLock)
+static Vector<UserContentURLPattern>& NODELETE originAccessPatterns() WTF_REQUIRES_LOCK(originAccessPatternLock)
 {
     ASSERT(originAccessPatternLock.isHeld());
     static NeverDestroyed<Vector<UserContentURLPattern>> originAccessPatterns;

--- a/Source/WebCore/page/OriginAccessPatterns.h
+++ b/Source/WebCore/page/OriginAccessPatterns.h
@@ -39,7 +39,7 @@ public:
 
 class WEBCORE_EXPORT OriginAccessPatternsForWebProcess final : public OriginAccessPatterns {
 public:
-    static OriginAccessPatternsForWebProcess& singleton();
+    static OriginAccessPatternsForWebProcess& NODELETE singleton();
     void allowAccessTo(const UserContentURLPattern&);
 private:
     bool anyPatternMatches(const URL&) const final;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -267,7 +267,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(Page);
 
-static HashSet<WeakRef<Page>>& allPages()
+static HashSet<WeakRef<Page>>& NODELETE allPages()
 {
     static NeverDestroyed<HashSet<WeakRef<Page>>> set;
     return set;
@@ -280,7 +280,7 @@ static inline bool isUtilityPageChromeClient(ChromeClient& chromeClient)
     return chromeClient.isEmptyChromeClient() || chromeClient.isSVGImageChromeClient();
 }
 
-unsigned Page::nonUtilityPageCount()
+unsigned NODELETE Page::nonUtilityPageCount()
 {
     return gNonUtilityPageCount;
 }
@@ -771,12 +771,12 @@ Ref<DOMRectList> Page::passiveTouchEventListenerRectsForTesting()
     return DOMRectList::create(rects.map([](auto& rect) { return FloatQuad { FloatRect { rect } }; }));
 }
 
-void Page::setConsoleMessageListenerForTesting(RefPtr<StringCallback>&& listener)
+void NODELETE Page::setConsoleMessageListenerForTesting(RefPtr<StringCallback>&& listener)
 {
     m_consoleMessageListenerForTesting = listener;
 }
 
-RefPtr<StringCallback> Page::consoleMessageListenerForTesting() const
+RefPtr<StringCallback> NODELETE Page::consoleMessageListenerForTesting() const
 {
     return m_consoleMessageListenerForTesting;
 }
@@ -978,7 +978,7 @@ void Page::updateTopDocumentSyncData(Ref<DocumentSyncData>&& data)
     m_topDocumentSyncData = WTF::move(data);
 }
 
-void Page::setMainFrameURLFragment(String&& fragment)
+void NODELETE Page::setMainFrameURLFragment(String&& fragment)
 {
     if (!fragment.isEmpty())
         m_mainFrameURLFragment = WTF::move(fragment);
@@ -1010,7 +1010,7 @@ bool Page::openedByDOM() const
     return m_openedByDOM;
 }
 
-void Page::setOpenedByDOM()
+void NODELETE Page::setOpenedByDOM()
 {
     m_openedByDOM = true;
 }
@@ -1055,7 +1055,7 @@ const String& Page::groupName() const
     return m_group ? m_group->name() : nullAtom().string();
 }
 
-void Page::setBroadcastChannelRegistry(Ref<BroadcastChannelRegistry>&& broadcastChannelRegistry)
+void NODELETE Page::setBroadcastChannelRegistry(Ref<BroadcastChannelRegistry>&& broadcastChannelRegistry)
 {
     m_broadcastChannelRegistry = WTF::move(broadcastChannelRegistry);
 }
@@ -1166,7 +1166,7 @@ void Page::setCanStartMedia(bool canStartMedia)
     }
 }
 
-static Frame* incrementFrame(Frame* current, bool forward, CanWrap canWrap, DidWrap* didWrap = nullptr)
+static Frame* NODELETE incrementFrame(Frame* current, bool forward, CanWrap canWrap, DidWrap* didWrap = nullptr)
 {
     return forward
         ? current->tree().traverseNext(canWrap, didWrap)
@@ -1585,12 +1585,12 @@ void Page::clearUndoRedoOperations()
     m_editorClient->clearUndoRedoOperations();
 }
 
-bool Page::inLowQualityImageInterpolationMode() const
+bool NODELETE Page::inLowQualityImageInterpolationMode() const
 {
     return m_inLowQualityInterpolationMode;
 }
 
-void Page::setInLowQualityImageInterpolationMode(bool mode)
+void NODELETE Page::setInLowQualityImageInterpolationMode(bool mode)
 {
     m_inLowQualityInterpolationMode = mode;
 }
@@ -1696,7 +1696,7 @@ void Page::setPageScaleFactor(float scale, const IntPoint& origin, bool inStable
 #endif
 }
 
-void Page::setDelegatesScaling(bool delegatesScaling)
+void NODELETE Page::setDelegatesScaling(bool delegatesScaling)
 {
     m_delegatesScaling = delegatesScaling;
 }
@@ -1799,7 +1799,7 @@ void Page::windowScreenDidChange(PlatformDisplayID displayID, std::optional<Fram
     setNeedsRecalcStyleInAllFrames();
 }
 
-void Page::setInitialScaleIgnoringContentSize(float scale)
+void NODELETE Page::setInitialScaleIgnoringContentSize(float scale)
 {
     m_initialScaleIgnoringContentSize = scale;
 }
@@ -1994,7 +1994,7 @@ void Page::setVerticalScrollElasticity(ScrollElasticity elasticity)
         view->setVerticalScrollElasticity(elasticity);
 }
     
-void Page::setHorizontalScrollElasticity(ScrollElasticity elasticity)
+void NODELETE Page::setHorizontalScrollElasticity(ScrollElasticity elasticity)
 {
     if (m_horizontalScrollElasticity == elasticity)
         return;
@@ -2140,13 +2140,13 @@ void Page::triggerRenderingUpdateForTesting()
     chrome().client().triggerRenderingUpdate();
 }
 
-void Page::startTrackingRenderingUpdates()
+void NODELETE Page::startTrackingRenderingUpdates()
 {
     m_isTrackingRenderingUpdates = true;
     m_renderingUpdateCount = 0;
 }
 
-unsigned Page::renderingUpdateCount() const
+unsigned NODELETE Page::renderingUpdateCount() const
 {
     return m_renderingUpdateCount;
 }
@@ -3372,7 +3372,7 @@ Ref<DocumentSyncData> Page::protectedTopDocumentSyncData() const
     return m_topDocumentSyncData;
 }
 
-bool Page::isVisibleAndActive() const
+bool NODELETE Page::isVisibleAndActive() const
 {
     return m_activityState.contains(ActivityState::IsVisible) && m_activityState.contains(ActivityState::WindowIsActive);
 }
@@ -3472,7 +3472,7 @@ void Page::setIsPrerender()
     updateDOMTimerAlignmentInterval();
 }
 
-VisibilityState Page::visibilityState() const
+VisibilityState NODELETE Page::visibilityState() const
 {
     if (isVisible())
         return VisibilityState::Visible;
@@ -3540,13 +3540,13 @@ OptionSet<AdvancedPrivacyProtections> Page::advancedPrivacyProtections() const
     return protect(mainFrame())->advancedPrivacyProtections();
 }
 
-void Page::addLayoutMilestones(OptionSet<LayoutMilestone> milestones)
+void NODELETE Page::addLayoutMilestones(OptionSet<LayoutMilestone> milestones)
 {
     // In the future, we may want a function that replaces m_layoutMilestones instead of just adding to it.
     m_requestedLayoutMilestones.add(milestones);
 }
 
-void Page::removeLayoutMilestones(OptionSet<LayoutMilestone> milestones)
+void NODELETE Page::removeLayoutMilestones(OptionSet<LayoutMilestone> milestones)
 {
     m_requestedLayoutMilestones.remove(milestones);
 }
@@ -3607,12 +3607,12 @@ void Page::clearSampledPageTopColor()
 }
 
 #if HAVE(APP_ACCENT_COLORS) && PLATFORM(MAC)
-void Page::setAppUsesCustomAccentColor(bool appUsesCustomAccentColor)
+void NODELETE Page::setAppUsesCustomAccentColor(bool appUsesCustomAccentColor)
 {
     m_appUsesCustomAccentColor = appUsesCustomAccentColor;
 }
 
-bool Page::appUsesCustomAccentColor() const
+bool NODELETE Page::appUsesCustomAccentColor() const
 {
     return m_appUsesCustomAccentColor;
 }
@@ -3779,7 +3779,7 @@ void Page::resumeActiveDOMObjectsAndAnimations()
     resumeAnimatingImages();
 }
 
-bool Page::hasSeenAnyPlugin() const
+bool NODELETE Page::hasSeenAnyPlugin() const
 {
     return !m_seenPlugins.isEmpty();
 }
@@ -3937,7 +3937,7 @@ PluginInfoProvider& Page::pluginInfoProvider()
     return m_pluginInfoProvider;
 }
 
-Ref<UserContentProvider> Page::protectedUserContentProviderForFrame()
+Ref<UserContentProvider> NODELETE Page::protectedUserContentProviderForFrame()
 {
     return m_userContentProvider;
 }
@@ -3980,7 +3980,7 @@ std::optional<uint64_t> Page::noiseInjectionHashSaltForDomain(const RegistrableD
     }).iterator->value;
 }
 
-PAL::SessionID Page::sessionID() const
+PAL::SessionID NODELETE Page::sessionID() const
 {
     return m_sessionID;
 }
@@ -4089,7 +4089,7 @@ void Page::playbackTargetPickerWasDismissed(PlaybackTargetClientContextIdentifie
 
 #endif
 
-RefPtr<WheelEventTestMonitor> Page::wheelEventTestMonitor() const
+RefPtr<WheelEventTestMonitor> NODELETE Page::wheelEventTestMonitor() const
 {
     return m_wheelEventTestMonitor;
 }
@@ -4102,7 +4102,7 @@ void Page::clearWheelEventTestMonitor()
     m_wheelEventTestMonitor = nullptr;
 }
 
-bool Page::isMonitoringWheelEvents() const
+bool NODELETE Page::isMonitoringWheelEvents() const
 {
     return !!m_wheelEventTestMonitor;
 }
@@ -4587,7 +4587,7 @@ void Page::applicationWillResignActive()
 #endif
 }
 
-void Page::applicationDidEnterBackground()
+void NODELETE Page::applicationDidEnterBackground()
 {
 #if ENABLE(WEBXR)
     if (auto session = this->activeImmersiveXRSession())
@@ -4595,7 +4595,7 @@ void Page::applicationDidEnterBackground()
 #endif
 }
 
-void Page::applicationWillEnterForeground()
+void NODELETE Page::applicationWillEnterForeground()
 {
 #if ENABLE(WEBXR)
     if (auto session = this->activeImmersiveXRSession())
@@ -5047,7 +5047,7 @@ void Page::updateElementsWithTextRecognitionResults()
     }
 }
 
-bool Page::hasCachedTextRecognitionResult(const HTMLElement& element) const
+bool NODELETE Page::hasCachedTextRecognitionResult(const HTMLElement& element) const
 {
     return m_textRecognitionResults.contains(element);
 }
@@ -5424,7 +5424,7 @@ Element* Page::lastFixedContainer(BoxSide side) const
     return m_fixedContainerEdgesAndElements.second.at(side).get();
 }
 
-void Page::setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort)
+void NODELETE Page::setPortsForUpgradingInsecureSchemeForTesting(uint16_t upgradeFromInsecurePort, uint16_t upgradeToSecurePort)
 {
     m_portsForUpgradingInsecureSchemeForTesting = { upgradeFromInsecurePort, upgradeToSecurePort };
 }
@@ -5707,13 +5707,13 @@ void Page::setLastAuthentication(LoginStatus::AuthenticationType authType)
 }
 
 #if ENABLE(FULLSCREEN_API)
-bool Page::isDocumentFullscreenEnabled() const
+bool NODELETE Page::isDocumentFullscreenEnabled() const
 {
     return m_settings->fullScreenEnabled() || m_settings->videoFullscreenRequiresElementFullscreen();
 }
 #endif
 
-void Page::startDeferringResizeEvents()
+void NODELETE Page::startDeferringResizeEvents()
 {
     m_shouldDeferResizeEvents = true;
 }
@@ -5726,7 +5726,7 @@ void Page::flushDeferredResizeEvents()
     });
 }
 
-void Page::startDeferringScrollEvents()
+void NODELETE Page::startDeferringScrollEvents()
 {
     m_shouldDeferScrollEvents = true;
 }
@@ -5739,7 +5739,7 @@ void Page::flushDeferredScrollEvents()
     });
 }
 
-void Page::startDeferringIntersectionObservations()
+void NODELETE Page::startDeferringIntersectionObservations()
 {
     m_shouldDeferIntersectionObservations = true;
 }
@@ -5833,12 +5833,12 @@ void Page::applyWindowFeatures(const WindowFeatures& features)
 #endif
 }
 
-bool Page::isAlwaysOnLoggingAllowed() const
+bool NODELETE Page::isAlwaysOnLoggingAllowed() const
 {
     return m_sessionID.isAlwaysOnLoggingAllowed() || settings().allowPrivacySensitiveOperationsInNonPersistentDataStores();
 }
 
-Ref<PageInspectorController> Page::protectedInspectorController()
+Ref<PageInspectorController> NODELETE Page::protectedInspectorController()
 {
     return m_inspectorController.get();
 }
@@ -5866,7 +5866,7 @@ const std::optional<audit_token_t>& Page::presentingApplicationAuditToken() cons
     return m_presentingApplicationAuditToken;
 }
 
-void Page::setPresentingApplicationAuditToken(std::optional<audit_token_t> presentingApplicationAuditToken)
+void NODELETE Page::setPresentingApplicationAuditToken(std::optional<audit_token_t> presentingApplicationAuditToken)
 {
     m_presentingApplicationAuditToken = WTF::move(presentingApplicationAuditToken);
 }
@@ -5888,7 +5888,7 @@ bool Page::requiresUserGestureForVideoPlayback() const
     return m_settings->requiresUserGestureForVideoPlayback();
 }
 
-static RefPtr<PlatformMediaSessionManager>& mediaSessionManagerSingleton()
+static RefPtr<PlatformMediaSessionManager>& NODELETE mediaSessionManagerSingleton()
 {
     static NeverDestroyed<RefPtr<PlatformMediaSessionManager>> manager;
     return manager.get();

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -427,7 +427,7 @@ public:
     WEBCORE_EXPORT void setMainFrame(Ref<Frame>&&);
     WEBCORE_EXPORT const URL& NODELETE mainFrameURL() const;
     SecurityOrigin& mainFrameOrigin() const;
-    WEBCORE_EXPORT RefPtr<Frame> findFrameByPath(const Vector<uint64_t>& path) const;
+    WEBCORE_EXPORT RefPtr<Frame> NODELETE findFrameByPath(const Vector<uint64_t>& path) const;
 
     WEBCORE_EXPORT void setMainFrameURLAndOrigin(const URL&, RefPtr<SecurityOrigin>&&);
 #if ENABLE(DOM_AUDIO_SESSION)
@@ -443,7 +443,7 @@ public:
     bool NODELETE hasInjectedUserScript();
     WEBCORE_EXPORT void setHasInjectedUserScript();
 
-    WEBCORE_EXPORT void updateTopDocumentSyncData(const DocumentSyncSerializationData&);
+    WEBCORE_EXPORT void NODELETE updateTopDocumentSyncData(const DocumentSyncSerializationData&);
     WEBCORE_EXPORT void NODELETE updateTopDocumentSyncData(Ref<DocumentSyncData>&&);
 
     WEBCORE_EXPORT void NODELETE setMainFrameURLFragment(String&&);
@@ -473,7 +473,7 @@ public:
     WEBCORE_EXPORT static unsigned NODELETE nonUtilityPageCount();
     static Page* fromPageIdentifier(PageIdentifier);
 
-    unsigned subframeCount() const;
+    unsigned NODELETE subframeCount() const;
 
     void setCurrentKeyboardScrollingAnimator(KeyboardScrollingAnimator*);
     KeyboardScrollingAnimator* currentKeyboardScrollingAnimator() const; // Deinfed in PageInlines.h
@@ -753,7 +753,7 @@ public:
 
 #if ENABLE(APPLE_PAY)
     PaymentCoordinator& paymentCoordinator() const { return *m_paymentCoordinator; }
-    WEBCORE_EXPORT void setPaymentCoordinator(Ref<PaymentCoordinator>&&);
+    WEBCORE_EXPORT void NODELETE setPaymentCoordinator(Ref<PaymentCoordinator>&&);
 #endif
 
 #if ENABLE(APPLE_PAY_AMS_UI)
@@ -1119,7 +1119,7 @@ public:
     bool canUpdateThrottlingReason(ThrottlingReason reason) const { return !m_throttlingReasonsOverridenForTesting.contains(reason); }
     WEBCORE_EXPORT void setLowPowerModeEnabledOverrideForTesting(std::optional<bool>);
     WEBCORE_EXPORT void setAggressiveThermalMitigationEnabledForTesting(std::optional<bool>);
-    WEBCORE_EXPORT void setOutsideViewportThrottlingEnabledForTesting(bool);
+    WEBCORE_EXPORT void NODELETE setOutsideViewportThrottlingEnabledForTesting(bool);
 
     OptionSet<ThrottlingReason> throttlingReasons() const { return m_throttlingReasons; }
 
@@ -1379,7 +1379,7 @@ public:
 #endif
 
 #if ENABLE(VIDEO)
-    WEBCORE_EXPORT void setCaptionDisplaySettingsClientForTesting(Ref<CaptionDisplaySettingsClient>&&);
+    WEBCORE_EXPORT void NODELETE setCaptionDisplaySettingsClientForTesting(Ref<CaptionDisplaySettingsClient>&&);
     WEBCORE_EXPORT void clearCaptionDisplaySettingsClientForTesting();
     void showCaptionDisplaySettings(HTMLMediaElement&, const ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(ExceptionOr<void>)>&&);
 #endif

--- a/Source/WebCore/page/PageGroup.cpp
+++ b/Source/WebCore/page/PageGroup.cpp
@@ -49,7 +49,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PageGroup);
 
-static unsigned getUniqueIdentifier()
+static unsigned NODELETE getUniqueIdentifier()
 {
     static unsigned currentIdentifier = 0;
     return ++currentIdentifier;
@@ -83,7 +83,7 @@ PageGroup::~PageGroup() = default;
 
 using PageGroupMap = HashMap<String, UniqueRef<PageGroup>>;
 
-static PageGroupMap& pageGroups()
+static PageGroupMap& NODELETE pageGroups()
 {
     static NeverDestroyed<PageGroupMap> pageGroupsMap;
     return pageGroupsMap;

--- a/Source/WebCore/page/PageOverlay.cpp
+++ b/Source/WebCore/page/PageOverlay.cpp
@@ -43,7 +43,7 @@ static const double fadeAnimationFrameRate = 30;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(PageOverlay);
 
-static PageOverlay::PageOverlayID generatePageOverlayID()
+static PageOverlay::PageOverlayID NODELETE generatePageOverlayID()
 {
     static PageOverlay::PageOverlayID pageOverlayID;
     return ++pageOverlayID;

--- a/Source/WebCore/page/PageOverlay.h
+++ b/Source/WebCore/page/PageOverlay.h
@@ -78,7 +78,7 @@ public:
     WEBCORE_EXPORT static Ref<PageOverlay> create(PageOverlayClient&, OverlayType = OverlayType::View, AlwaysTileOverlayLayer = AlwaysTileOverlayLayer::No);
     WEBCORE_EXPORT ~PageOverlay();
 
-    WEBCORE_EXPORT PageOverlayController* controller() const;
+    WEBCORE_EXPORT PageOverlayController* NODELETE controller() const;
 
     typedef uint64_t PageOverlayID;
     PageOverlayID pageOverlayID() const { return m_pageOverlayID; }

--- a/Source/WebCore/page/PageOverlayController.h
+++ b/Source/WebCore/page/PageOverlayController.h
@@ -46,8 +46,8 @@ public:
     PageOverlayController(Page&);
     virtual ~PageOverlayController();
 
-    bool hasDocumentOverlays() const;
-    bool hasViewOverlays() const;
+    bool NODELETE hasDocumentOverlays() const;
+    bool NODELETE hasViewOverlays() const;
 
     GraphicsLayer& layerWithDocumentOverlays();
     GraphicsLayer& layerWithViewOverlays();
@@ -97,8 +97,8 @@ private:
     // GraphicsLayerClient
     void notifyFlushRequired(const GraphicsLayer*) override;
     void paintContents(const GraphicsLayer&, GraphicsContext&, const FloatRect& clipRect, OptionSet<GraphicsLayerPaintBehavior>) override;
-    float deviceScaleFactor() const override;
-    bool shouldSkipLayerInDump(const GraphicsLayer*, OptionSet<LayerTreeAsTextOptions>) const override;
+    float NODELETE deviceScaleFactor() const override;
+    bool NODELETE shouldSkipLayerInDump(const GraphicsLayer*, OptionSet<LayerTreeAsTextOptions>) const override;
     bool shouldDumpPropertyForLayer(const GraphicsLayer*, ASCIILiteral propertyName, OptionSet<LayerTreeAsTextOptions>) const override;
     void tiledBackingUsageChanged(const GraphicsLayer*, bool) override;
 

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -94,7 +94,7 @@ static bool shouldIgnoreElement(const Element& element)
     return element.hasTagName(HTMLNames::scriptTag) || element.hasTagName(HTMLNames::noscriptTag) || isCharsetSpecifyingNode(element);
 }
 
-static const QualifiedName& frameOwnerURLAttributeName(const HTMLFrameOwnerElement& frameOwner)
+static const QualifiedName& NODELETE frameOwnerURLAttributeName(const HTMLFrameOwnerElement& frameOwner)
 {
     // FIXME: We should support all frame owners including applets.
     return is<HTMLObjectElement>(frameOwner) ? HTMLNames::dataAttr : HTMLNames::srcAttr;

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -94,7 +94,7 @@ public:
     PerformanceTiming& timing();
     EventCounts& eventCounts();
 
-    uint64_t interactionCount();
+    uint64_t NODELETE interactionCount();
 
     Vector<Ref<PerformanceEntry>> getEntries() const;
     Vector<Ref<PerformanceEntry>> getEntriesByType(const String& entryType) const;
@@ -105,7 +105,7 @@ public:
     void processEventEntry(const PerformanceEventTimingCandidate&);
 
     void clearResourceTimings();
-    void setResourceTimingBufferSize(unsigned);
+    void NODELETE setResourceTimingBufferSize(unsigned);
 
     ExceptionOr<Ref<PerformanceMark>> mark(JSC::JSGlobalObject&, const String& markName, std::optional<PerformanceMarkOptions>&&);
     void clearMarks(const String& markName);
@@ -126,15 +126,15 @@ public:
     void registerPerformanceObserver(PerformanceObserver&);
     void unregisterPerformanceObserver(PerformanceObserver&);
 
-    static void allowHighPrecisionTime();
-    static Seconds timeResolution();
+    static void NODELETE allowHighPrecisionTime();
+    static Seconds NODELETE timeResolution();
     static Seconds reduceTimeResolution(Seconds);
 
     Seconds relativeTimeFromTimeOriginInReducedResolutionSeconds(MonotonicTime) const;
     DOMHighResTimeStamp relativeTimeFromTimeOriginInReducedResolution(MonotonicTime) const;
-    MonotonicTime monotonicTimeFromRelativeTime(DOMHighResTimeStamp) const;
+    MonotonicTime NODELETE monotonicTimeFromRelativeTime(DOMHighResTimeStamp) const;
 
-    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
 
     void scheduleTaskIfNeeded();
 
@@ -150,7 +150,7 @@ private:
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
-    bool isResourceTimingBufferFull() const;
+    bool NODELETE isResourceTimingBufferFull() const;
     void resourceTimingBufferFullTimerFired();
 
     void queueEntry(PerformanceEntry&);

--- a/Source/WebCore/page/PerformanceEventTiming.h
+++ b/Source/WebCore/page/PerformanceEventTiming.h
@@ -46,9 +46,9 @@ public:
     DOMHighResTimeStamp processingEnd() const { return m_processingEnd.milliseconds(); }
     bool cancelable() const { return m_cancelable; }
     RefPtr<Node> target() const;
-    uint64_t interactionId() const;
+    uint64_t NODELETE interactionId() const;
 
-    Type performanceEntryType() const final;
+    Type NODELETE performanceEntryType() const final;
     ASCIILiteral entryType() const final;
 
     static constexpr DOMHighResTimeStamp durationResolutionInMilliseconds = 8;

--- a/Source/WebCore/page/PerformanceMonitor.cpp
+++ b/Source/WebCore/page/PerformanceMonitor.cpp
@@ -59,7 +59,7 @@ static constexpr const double postPageLoadCPUUsageDomainReportingThreshold { 20.
 static constexpr const uint64_t postPageLoadMemoryUsageDomainReportingThreshold { 2048 * MB };
 #endif
 
-static inline ActivityStateForCPUSampling activityStateForCPUSampling(OptionSet<ActivityState> state)
+static inline ActivityStateForCPUSampling NODELETE activityStateForCPUSampling(OptionSet<ActivityState> state)
 {
     if (!(state & ActivityState::IsVisible))
         return ActivityStateForCPUSampling::NonVisible;

--- a/Source/WebCore/page/PerformanceMonitor.h
+++ b/Source/WebCore/page/PerformanceMonitor.h
@@ -40,7 +40,7 @@ class PerformanceMonitor : public CanMakeWeakPtr<PerformanceMonitor> {
 public:
     explicit PerformanceMonitor(Page&);
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void didStartProvisionalLoad();

--- a/Source/WebCore/page/PerformanceNavigationTiming.cpp
+++ b/Source/WebCore/page/PerformanceNavigationTiming.cpp
@@ -32,7 +32,7 @@
 
 namespace WebCore {
 
-static PerformanceNavigationTiming::NavigationType toPerformanceNavigationTimingNavigationType(NavigationType navigationType)
+static PerformanceNavigationTiming::NavigationType NODELETE toPerformanceNavigationTimingNavigationType(NavigationType navigationType)
 {
     switch (navigationType) {
     case NavigationType::BackForward:

--- a/Source/WebCore/page/PerformanceNavigationTiming.h
+++ b/Source/WebCore/page/PerformanceNavigationTiming.h
@@ -62,10 +62,10 @@ public:
     double domComplete() const;
     double loadEventStart() const;
     double loadEventEnd() const;
-    NavigationType type() const;
-    unsigned short redirectCount() const;
+    NavigationType NODELETE type() const;
+    unsigned short NODELETE redirectCount() const;
 
-    double startTime() const final;
+    double NODELETE startTime() const final;
     double duration() const final;
 
     DocumentEventTiming& documentEventTiming() { return m_documentEventTiming; }
@@ -76,7 +76,7 @@ private:
     PerformanceNavigationTiming(MonotonicTime timeOrigin, CachedResource&, const DocumentLoadTiming&, const NetworkLoadMetrics&, const DocumentEventTiming&, const SecurityOrigin&, WebCore::NavigationType);
 
     double millisecondsSinceOrigin(MonotonicTime) const;
-    bool sameOriginCheckFails() const;
+    bool NODELETE sameOriginCheckFails() const;
 
     DocumentEventTiming m_documentEventTiming;
     DocumentLoadTiming m_documentLoadTiming;

--- a/Source/WebCore/page/PerformanceResourceTiming.h
+++ b/Source/WebCore/page/PerformanceResourceTiming.h
@@ -48,7 +48,7 @@ public:
 
     const String& initiatorType() const { return m_resourceTiming.initiatorType(); }
     String deliveryType() const { return m_resourceTiming.deliveryType(); }
-    const String& nextHopProtocol() const;
+    const String& NODELETE nextHopProtocol() const;
 
     double workerStart() const;
     double redirectStart() const;
@@ -64,13 +64,13 @@ public:
     double firstInterimResponseStart() const;
     double responseStart() const;
     double responseEnd() const;
-    uint64_t transferSize() const;
-    uint64_t encodedBodySize() const;
-    uint64_t decodedBodySize() const;
+    uint64_t NODELETE transferSize() const;
+    uint64_t NODELETE encodedBodySize() const;
+    uint64_t NODELETE decodedBodySize() const;
     double workerRouterEvaluationStart() const;
     double workerCacheLookupStart() const;
-    const String& workerMatchedRouterSource() const;
-    const String& workerFinalRouterSource() const;
+    const String& NODELETE workerMatchedRouterSource() const;
+    const String& NODELETE workerFinalRouterSource() const;
 
     const Vector<Ref<PerformanceServerTiming>>& serverTiming() const { return m_serverTiming; }
     ResourceTiming& resourceTiming() { return m_resourceTiming; }

--- a/Source/WebCore/page/PerformanceUserTiming.cpp
+++ b/Source/WebCore/page/PerformanceUserTiming.cpp
@@ -242,7 +242,7 @@ ExceptionOr<Ref<PerformanceMeasure>> PerformanceUserTiming::measure(JSC::JSGloba
     return measure.releaseReturnValue();
 }
 
-static bool isEmptyDictionary(const PerformanceMeasureOptions& measureOptions)
+static bool NODELETE isEmptyDictionary(const PerformanceMeasureOptions& measureOptions)
 {
     return measureOptions.detail.isUndefined()
         && !measureOptions.start

--- a/Source/WebCore/page/PointerLockController.h
+++ b/Source/WebCore/page/PointerLockController.h
@@ -62,15 +62,15 @@ public:
     ~PointerLockController();
     void requestPointerLock(Element* target, std::optional<PointerLockOptions>&& = std::nullopt, RefPtr<DeferredPromise> = nullptr);
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void requestPointerUnlock();
     void requestPointerUnlockAndForceCursorVisible();
     void elementWasRemoved(Element&);
     void documentDetached(Document&);
-    bool isLocked() const;
-    WEBCORE_EXPORT bool lockPending() const;
+    bool NODELETE isLocked() const;
+    WEBCORE_EXPORT bool NODELETE lockPending() const;
     WEBCORE_EXPORT Element* NODELETE element() const;
 
     WEBCORE_EXPORT void didAcquirePointerLock();

--- a/Source/WebCore/page/PrintContext.cpp
+++ b/Source/WebCore/page/PrintContext.cpp
@@ -310,7 +310,7 @@ void PrintContext::end()
     m_linkedDestinations = nullptr;
 }
 
-static inline RenderBoxModelObject* enclosingBoxModelObject(RenderElement* renderer)
+static inline RenderBoxModelObject* NODELETE enclosingBoxModelObject(RenderElement* renderer)
 {
     while (renderer && !is<RenderBoxModelObject>(*renderer))
         renderer = renderer->parent();

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -130,7 +130,7 @@ static inline OptionSet<AutoplayQuirk> allowedAutoplayQuirks(Document* document)
     return allowedAutoplayQuirks(*document);
 }
 
-static HashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentStringQuirks()
+static HashMap<RegistrableDomain, String>& NODELETE updatableStorageAccessUserAgentStringQuirks()
 {
     // FIXME: Make this a member of Quirks.
     static MainThreadNeverDestroyed<HashMap<RegistrableDomain, String>> map;
@@ -140,13 +140,13 @@ static HashMap<RegistrableDomain, String>& updatableStorageAccessUserAgentString
 #if USE(APPLE_INTERNAL_SDK)
 #import <WebKitAdditions/QuirksAdditions.cpp>
 #else
-static inline bool needsDesktopUserAgentInternal(const URL&) { return false; }
-static inline bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(const URL&) { return false; }
-static inline bool shouldNotAutoUpgradeToHTTPSNavigationInternal(const URL&) { return false; }
-static inline bool shouldDisableBlobFileAccessEnforcementInternal() { return false; }
-static inline bool needsConsistentQueryParameterFilteringInternal(const URL&) { return false; }
+static inline bool NODELETE needsDesktopUserAgentInternal(const URL&) { return false; }
+static inline bool NODELETE shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal(const URL&) { return false; }
+static inline bool NODELETE shouldNotAutoUpgradeToHTTPSNavigationInternal(const URL&) { return false; }
+static inline bool NODELETE shouldDisableBlobFileAccessEnforcementInternal() { return false; }
+static inline bool NODELETE needsConsistentQueryParameterFilteringInternal(const URL&) { return false; }
 #if PLATFORM(COCOA)
-static inline String standardUserAgentWithApplicationNameIncludingCompatOverridesInternal(const String&, const String&, UserAgentType) { return { }; }
+static inline String NODELETE standardUserAgentWithApplicationNameIncludingCompatOverridesInternal(const String&, const String&, UserAgentType) { return { }; }
 #endif
 #endif
 

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -66,9 +66,9 @@ public:
 
     bool hasRelevantQuirks() const;
 
-    bool shouldSilenceResizeObservers() const;
-    bool shouldSilenceWindowResizeEventsDuringApplicationSnapshotting() const;
-    bool shouldSilenceMediaQueryListChangeEvents() const;
+    bool NODELETE shouldSilenceResizeObservers() const;
+    bool NODELETE shouldSilenceWindowResizeEventsDuringApplicationSnapshotting() const;
+    bool NODELETE shouldSilenceMediaQueryListChangeEvents() const;
     bool shouldIgnoreInvalidSignal() const;
     bool needsFormControlToBeMouseFocusable() const;
     bool needsAutoplayPlayPauseEvents() const;
@@ -82,56 +82,56 @@ public:
     bool shouldDispatchedSimulatedMouseEventsAssumeDefaultPrevented(EventTarget*) const;
     bool shouldPreventDispatchOfTouchEvent(const AtomString&, EventTarget*) const;
 #endif
-    bool shouldDisablePointerEventsQuirk() const;
-    bool needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const;
-    WEBCORE_EXPORT bool inputMethodUsesCorrectKeyEventOrder() const;
+    bool NODELETE shouldDisablePointerEventsQuirk() const;
+    bool NODELETE needsDeferKeyDownAndKeyPressTimersUntilNextEditingCommand() const;
+    WEBCORE_EXPORT bool NODELETE inputMethodUsesCorrectKeyEventOrder() const;
     bool shouldExposeShowModalDialog() const;
-    bool shouldIgnoreInputModeNone() const;
-    bool shouldNavigatorPluginsBeEmpty() const;
+    bool NODELETE shouldIgnoreInputModeNone() const;
+    bool NODELETE shouldNavigatorPluginsBeEmpty() const;
     bool returnNullPictureInPictureElementDuringFullscreenChange() const;
 
     bool shouldPreventOrientationMediaQueryFromEvaluatingToLandscape() const;
-    bool shouldFlipScreenDimensions() const;
+    bool NODELETE shouldFlipScreenDimensions() const;
 
     WEBCORE_EXPORT bool shouldDispatchSyntheticMouseEventsWhenModifyingSelection() const;
-    WEBCORE_EXPORT bool shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const;
+    WEBCORE_EXPORT bool NODELETE shouldSuppressAutocorrectionAndAutocapitalizationInHiddenEditableAreas() const;
     WEBCORE_EXPORT bool isTouchBarUpdateSuppressedForHiddenContentEditable() const;
     WEBCORE_EXPORT bool isNeverRichlyEditableForTouchBar() const;
     WEBCORE_EXPORT bool shouldAvoidResizingWhenInputViewBoundsChange() const;
     WEBCORE_EXPORT bool shouldAvoidScrollingWhenFocusedContentIsVisible() const;
     WEBCORE_EXPORT bool shouldUseLayoutViewportForClientRects() const;
     WEBCORE_EXPORT bool shouldUseLegacySelectPopoverDismissalBehaviorInDataActivation() const;
-    WEBCORE_EXPORT bool shouldIgnoreAriaForFastPathContentObservationCheck() const;
-    WEBCORE_EXPORT bool shouldIgnoreViewportArgumentsToAvoidExcessiveZoom() const;
-    WEBCORE_EXPORT bool shouldIgnoreViewportArgumentsToAvoidEnlargedView() const;
+    WEBCORE_EXPORT bool NODELETE shouldIgnoreAriaForFastPathContentObservationCheck() const;
+    WEBCORE_EXPORT bool NODELETE shouldIgnoreViewportArgumentsToAvoidExcessiveZoom() const;
+    WEBCORE_EXPORT bool NODELETE shouldIgnoreViewportArgumentsToAvoidEnlargedView() const;
     WEBCORE_EXPORT bool shouldLayOutAtMinimumWindowWidthWhenIgnoringScalingConstraints() const;
     WEBCORE_EXPORT bool shouldAllowNotificationPermissionWithoutUserGesture() const;
     WEBCORE_EXPORT static bool shouldAllowNavigationToCustomProtocolWithoutUserGesture(StringView protocol, const SecurityOriginData& requesterOrigin);
 
-    WEBCORE_EXPORT bool needsYouTubeMouseOutQuirk() const;
+    WEBCORE_EXPORT bool NODELETE needsYouTubeMouseOutQuirk() const;
 
     WEBCORE_EXPORT bool shouldDisableWritingSuggestionsByDefault() const;
 
     WEBCORE_EXPORT static void updateStorageAccessUserAgentStringQuirks(HashMap<RegistrableDomain, String>&&);
     WEBCORE_EXPORT String storageAccessUserAgentStringQuirkForDomain(const URL&);
     WEBCORE_EXPORT static bool needsIPadMiniUserAgent(const URL&);
-    WEBCORE_EXPORT static bool needsIPhoneUserAgent(const URL&);
-    WEBCORE_EXPORT static bool needsDesktopUserAgent(const URL&);
+    WEBCORE_EXPORT static bool NODELETE needsIPhoneUserAgent(const URL&);
+    WEBCORE_EXPORT static bool NODELETE needsDesktopUserAgent(const URL&);
     WEBCORE_EXPORT static std::optional<String> needsCustomUserAgentOverride(const URL&, const String& applicationNameForUserAgent, const String& currentUserAgent);
 
     WEBCORE_EXPORT static bool needsPartitionedCookies(const ResourceRequest&);
 
-    WEBCORE_EXPORT static std::optional<Vector<HashSet<String>>> defaultVisibilityAdjustmentSelectors(const URL&);
+    WEBCORE_EXPORT static std::optional<Vector<HashSet<String>>> NODELETE defaultVisibilityAdjustmentSelectors(const URL&);
 
-    WEBCORE_EXPORT bool static shouldDisableBlobFileAccessEnforcement();
+    WEBCORE_EXPORT bool static NODELETE shouldDisableBlobFileAccessEnforcement();
 
-    bool needsGMailOverflowScrollQuirk() const;
-    bool needsYouTubeOverflowScrollQuirk() const;
-    bool needsFullscreenDisplayNoneQuirk() const;
-    bool needsFullscreenObjectFitQuirk() const;
+    bool NODELETE needsGMailOverflowScrollQuirk() const;
+    bool NODELETE needsYouTubeOverflowScrollQuirk() const;
+    bool NODELETE needsFullscreenDisplayNoneQuirk() const;
+    bool NODELETE needsFullscreenObjectFitQuirk() const;
     bool needsZomatoEmailLoginLabelQuirk() const;
-    bool needsGoogleMapsScrollingQuirk() const;
-    bool needsGoogleTranslateScrollingQuirk() const;
+    bool NODELETE needsGoogleMapsScrollingQuirk() const;
+    bool NODELETE needsGoogleTranslateScrollingQuirk() const;
     bool needsGeforcenowWarningDisplayNoneQuirk() const;
 
     bool needsPrimeVideoUserSelectNoneQuirk() const;
@@ -141,9 +141,9 @@ public:
     bool needsScrollbarWidthThinDisabledQuirk() const;
     bool needsBodyScrollbarWidthNoneDisabledQuirk() const;
 
-    bool shouldOpenAsAboutBlank(const String&) const;
+    bool NODELETE shouldOpenAsAboutBlank(const String&) const;
 
-    bool needsPreloadAutoQuirk() const;
+    bool NODELETE needsPreloadAutoQuirk() const;
 
     bool shouldBypassBackForwardCache() const;
     bool shouldBypassAsyncScriptDeferring() const;
@@ -235,14 +235,14 @@ public:
     bool shouldEnableCanvas2DAdvancedPrivacyProtectionQuirk() const;
     String advancedPrivacyProtectionSubstituteDataURLForScriptWithFeatures(const String& lastDrawnText, int canvasWidth, int canvasHeight) const;
 
-    bool needsResettingTransitionCancelsRunningTransitionQuirk() const;
+    bool NODELETE needsResettingTransitionCancelsRunningTransitionQuirk() const;
 
     bool shouldDisableDataURLPaddingValidation() const;
 
     bool needsDisableDOMPasteAccessQuirk() const;
 
-    bool shouldDisableElementFullscreenQuirk() const;
-    bool shouldIgnorePlaysInlineRequirementQuirk() const;
+    bool NODELETE shouldDisableElementFullscreenQuirk() const;
+    bool NODELETE shouldIgnorePlaysInlineRequirementQuirk() const;
     WEBCORE_EXPORT bool shouldUseEphemeralPartitionedStorageForDOMCookies(const URL&) const;
 
 #if PLATFORM(IOS_FAMILY)
@@ -255,9 +255,9 @@ public:
     bool mayBenefitFromFingerprintingProtectionQuirk(const URL&) const;
     static String standardUserAgentWithApplicationNameIncludingCompatOverrides(const String&, const String&, UserAgentType);
 
-    String scriptToEvaluateBeforeRunningScriptFromURL(const URL&);
+    String NODELETE scriptToEvaluateBeforeRunningScriptFromURL(const URL&);
 
-    bool shouldHideCoarsePointerCharacteristics() const;
+    bool NODELETE shouldHideCoarsePointerCharacteristics() const;
 
     bool implicitMuteWhenVolumeSetToZero() const;
 
@@ -287,7 +287,7 @@ public:
 
     bool shouldReuseLiveRangeForSelectionUpdate() const;
 
-    bool needsFacebookStoriesCreationFormQuirk(const Element&, const RenderStyle&) const;
+    bool NODELETE needsFacebookStoriesCreationFormQuirk(const Element&, const RenderStyle&) const;
 
     bool needsLimitedMatroskaSupport() const;
 
@@ -303,12 +303,12 @@ public:
 
     bool needsWebKitMediaTextTrackDisplayQuirk() const;
 
-    bool shouldSupportHoverMediaQueries() const;
+    bool NODELETE shouldSupportHoverMediaQueries() const;
 
     bool shouldRewriteMediaRangeRequestForURL(const URL&) const;
     bool shouldDelayReloadWhenRegisteringServiceWorker() const;
 
-    bool ensureCaptionVisibilityInFullscreenAndPictureInPicture() const;
+    bool NODELETE ensureCaptionVisibilityInFullscreenAndPictureInPicture() const;
 
     bool shouldPreventKeyframeEffectAcceleration(const KeyframeEffect&) const;
 

--- a/Source/WebCore/page/RemoteDOMWindow.h
+++ b/Source/WebCore/page/RemoteDOMWindow.h
@@ -59,7 +59,7 @@ public:
     ScriptExecutionContext* scriptExecutionContext() const final { return nullptr; }
 
     // DOM API exposed cross-origin.
-    WindowProxy* self() const;
+    WindowProxy* NODELETE self() const;
     void focus(LocalDOMWindow& incumbentWindow);
     void blur();
     unsigned length() const;

--- a/Source/WebCore/page/RemoteFrame.h
+++ b/Source/WebCore/page/RemoteFrame.h
@@ -63,7 +63,7 @@ public:
     RemoteFrameClient& client() { return m_client.get(); }
 
     RemoteFrameView* view() const { return m_view.get(); }
-    WEBCORE_EXPORT void setView(RefPtr<RemoteFrameView>&&);
+    WEBCORE_EXPORT void NODELETE setView(RefPtr<RemoteFrameView>&&);
 
     Markable<LayerHostingContextIdentifier> layerHostingContextIdentifier() const { return m_layerHostingContextIdentifier; }
 
@@ -76,18 +76,18 @@ public:
     void unbindRemoteAccessibilityFrames(int);
 
     void setCustomUserAgent(String&& customUserAgent) { m_customUserAgent = WTF::move(customUserAgent); }
-    String customUserAgent() const final;
+    String NODELETE customUserAgent() const final;
     void setCustomUserAgentAsSiteSpecificQuirks(String&& customUserAgentAsSiteSpecificQuirks) { m_customUserAgentAsSiteSpecificQuirks = WTF::move(customUserAgentAsSiteSpecificQuirks); }
-    String customUserAgentAsSiteSpecificQuirks() const final;
+    String NODELETE customUserAgentAsSiteSpecificQuirks() const final;
 
     void setCustomNavigatorPlatform(String&& customNavigatorPlatform) { m_customNavigatorPlatform = WTF::move(customNavigatorPlatform); }
-    String customNavigatorPlatform() const final;
+    String NODELETE customNavigatorPlatform() const final;
 
     void setAdvancedPrivacyProtections(OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections) { m_advancedPrivacyProtections = advancedPrivacyProtections; }
-    OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections() const final;
+    OptionSet<AdvancedPrivacyProtections> NODELETE advancedPrivacyProtections() const final;
 
     void setAutoplayPolicy(AutoplayPolicy autoplayPolicy) { m_autoplayPolicy = autoplayPolicy; }
-    AutoplayPolicy autoplayPolicy() const final;
+    AutoplayPolicy NODELETE autoplayPolicy() const final;
 
     void updateScrollingMode() final;
     void reportMixedContentViolation(bool blocked, const URL& target) const final;
@@ -99,19 +99,19 @@ private:
     WEBCORE_EXPORT explicit RemoteFrame(Page&, ClientCreator&&, FrameIdentifier, HTMLFrameOwnerElement*, Frame* parent, Markable<LayerHostingContextIdentifier>, Frame* opener, Ref<FrameTreeSyncData>&&, AddToFrameTree = AddToFrameTree::Yes);
 
     void frameDetached() final;
-    bool preventsParentFromBeingComplete() const final;
+    bool NODELETE preventsParentFromBeingComplete() const final;
     void changeLocation(FrameLoadRequest&&) final;
     void loadFrameRequest(FrameLoadRequest&&, Event*) final;
     void didFinishLoadInAnotherProcess() final;
     bool isRootFrame() const final { return false; }
     void documentURLForConsoleLog(CompletionHandler<void(const URL&)>&&) final;
-    SecurityOrigin* frameDocumentSecurityOrigin() const final;
-    std::optional<DocumentSecurityPolicy> frameDocumentSecurityPolicy() const final;
-    String frameURLProtocol() const final;
+    SecurityOrigin* NODELETE frameDocumentSecurityOrigin() const final;
+    std::optional<DocumentSecurityPolicy> NODELETE frameDocumentSecurityPolicy() const final;
+    String NODELETE frameURLProtocol() const final;
 
     FrameView* NODELETE virtualView() const final;
     void disconnectView() final;
-    DOMWindow* virtualWindow() const final;
+    DOMWindow* NODELETE virtualWindow() const final;
     FrameLoaderClient& NODELETE loaderClient() final;
     void reinitializeDocumentSecurityContext() final { }
 

--- a/Source/WebCore/page/RemoteFrameView.h
+++ b/Source/WebCore/page/RemoteFrameView.h
@@ -44,8 +44,8 @@ public:
     void writeRenderTreeAsText(TextStream&, OptionSet<RenderAsTextFlag>) override;
     RemoteFrame& frame() const final { return m_frame; }
 
-    WEBCORE_EXPORT LayoutRect layoutViewportRect() const final;
-    std::optional<LayoutRect> visibleRectOfChild(const Frame&) const final;
+    WEBCORE_EXPORT LayoutRect NODELETE layoutViewportRect() const final;
+    std::optional<LayoutRect> NODELETE visibleRectOfChild(const Frame&) const final;
 
     // Set the frame rectangle, like setFrameRect, without synching the new rect to other Local/RemoteFrameViews.
     // When frameRect of a RemoteFrameView changes, it syncs the new rect to other Local/RemoteFrameViews.
@@ -56,24 +56,24 @@ private:
     WEBCORE_EXPORT RemoteFrameView(RemoteFrame&);
 
     bool isRemoteFrameView() const final { return true; }
-    bool isScrollableOrRubberbandable() final;
-    bool hasScrollableOrRubberbandableAncestor() final;
-    bool shouldPlaceVerticalScrollbarOnLeft() const final;
-    void invalidateScrollbarRect(Scrollbar&, const IntRect&) final;
+    bool NODELETE isScrollableOrRubberbandable() final;
+    bool NODELETE hasScrollableOrRubberbandableAncestor() final;
+    bool NODELETE shouldPlaceVerticalScrollbarOnLeft() const final;
+    void NODELETE invalidateScrollbarRect(Scrollbar&, const IntRect&) final;
     IntRect windowClipRect() const final;
     void paintContents(GraphicsContext&, const IntRect& damageRect, SecurityOriginPaintPolicy, RegionContext*) final;
-    void addedOrRemovedScrollbar() final;
-    void delegatedScrollingModeDidChange() final;
-    void updateScrollCorner() final;
-    bool scrollContentsFastPath(const IntSize& scrollDelta, const IntRect& rectToScroll, const IntRect& clipRect) final;
-    bool isVerticalDocument() const final;
-    bool isFlippedDocument() const final;
-    bool shouldDeferScrollUpdateAfterContentSizeChange() final;
-    void scrollOffsetChangedViaPlatformWidgetImpl(const ScrollOffset&, const ScrollOffset&) final;
-    void unobscuredContentSizeChanged() final;
-    void didFinishProhibitingScrollingWhenChangingContentSize() final;
-    void updateLayerPositionsAfterScrolling() final;
-    void updateCompositingLayersAfterScrolling() final;
+    void NODELETE addedOrRemovedScrollbar() final;
+    void NODELETE delegatedScrollingModeDidChange() final;
+    void NODELETE updateScrollCorner() final;
+    bool NODELETE scrollContentsFastPath(const IntSize& scrollDelta, const IntRect& rectToScroll, const IntRect& clipRect) final;
+    bool NODELETE isVerticalDocument() const final;
+    bool NODELETE isFlippedDocument() const final;
+    bool NODELETE shouldDeferScrollUpdateAfterContentSizeChange() final;
+    void NODELETE scrollOffsetChangedViaPlatformWidgetImpl(const ScrollOffset&, const ScrollOffset&) final;
+    void NODELETE unobscuredContentSizeChanged() final;
+    void NODELETE didFinishProhibitingScrollingWhenChangingContentSize() final;
+    void NODELETE updateLayerPositionsAfterScrolling() final;
+    void NODELETE updateCompositingLayersAfterScrolling() final;
 
     void setFrameRect(const IntRect&) final;
 

--- a/Source/WebCore/page/RenderingUpdateScheduler.h
+++ b/Source/WebCore/page/RenderingUpdateScheduler.h
@@ -58,7 +58,7 @@ private:
     void displayRefreshFired() final;
     DisplayRefreshMonitorFactory* displayRefreshMonitorFactory() const final;
 
-    bool isScheduled() const;
+    bool NODELETE isScheduled() const;
     void startTimer(Seconds);
     void clearScheduled();
 

--- a/Source/WebCore/page/ResizeObservation.h
+++ b/Source/WebCore/page/ResizeObservation.h
@@ -56,13 +56,13 @@ public:
     };
 
     std::optional<BoxSizes> elementSizeChanged() const;
-    void updateObservationSize(const BoxSizes&);
-    void resetObservationSize();
+    void NODELETE updateObservationSize(const BoxSizes&);
+    void NODELETE resetObservationSize();
 
     FloatRect computeContentRect() const;
-    FloatSize borderBoxSize() const;
-    FloatSize contentBoxSize() const;
-    FloatSize snappedContentBoxSize() const;
+    FloatSize NODELETE borderBoxSize() const;
+    FloatSize NODELETE contentBoxSize() const;
+    FloatSize NODELETE snappedContentBoxSize() const;
 
     Element* target() const { return m_target.get(); }
     ResizeObserverBoxOptions observedBox() const { return m_observedBox; }

--- a/Source/WebCore/page/ResizeObserver.h
+++ b/Source/WebCore/page/ResizeObserver.h
@@ -90,8 +90,8 @@ private:
     void removeAllTargets();
     bool removeObservation(const Element&);
     void observeInternal(Element&, const ResizeObserverBoxOptions);
-    bool isNativeCallback();
-    bool isJSCallback();
+    bool NODELETE isNativeCallback();
+    bool NODELETE isJSCallback();
 
     WeakPtr<Document, WeakPtrImplWithEventTargetData> m_document;
     JSOrNativeResizeObserverCallback m_JSOrNativeCallback;

--- a/Source/WebCore/page/ScreenOrientation.cpp
+++ b/Source/WebCore/page/ScreenOrientation.cpp
@@ -82,7 +82,7 @@ ScreenOrientationManager* ScreenOrientation::manager() const
     return page ? page->screenOrientationManager() : nullptr;
 }
 
-static bool isSupportedLockType(ScreenOrientationLockType lockType)
+static bool NODELETE isSupportedLockType(ScreenOrientationLockType lockType)
 {
     switch (lockType) {
     case ScreenOrientationLockType::Any:

--- a/Source/WebCore/page/ScreenOrientation.h
+++ b/Source/WebCore/page/ScreenOrientation.h
@@ -60,8 +60,8 @@ public:
 private:
     ScreenOrientation(Document*);
 
-    Document* document() const;
-    ScreenOrientationManager* manager() const;
+    Document* NODELETE document() const;
+    ScreenOrientationManager* NODELETE manager() const;
 
     bool shouldListenForChangeNotification() const;
 
@@ -73,13 +73,13 @@ private:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::ScreenOrientation; }
-    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
     void refEventTarget() final { RefCounted::ref(); }
     void derefEventTarget() final { RefCounted::deref(); }
     void eventListenersDidChange() final;
 
     // ActiveDOMObject.
-    bool virtualHasPendingActivity() const final;
+    bool NODELETE virtualHasPendingActivity() const final;
     void suspend(ReasonForSuspension) final;
     void resume() final;
     void stop() final;

--- a/Source/WebCore/page/ScriptTrackingPrivacyCategory.h
+++ b/Source/WebCore/page/ScriptTrackingPrivacyCategory.h
@@ -67,9 +67,9 @@ using ScriptTrackingPrivacyFlags = OptionSet<ScriptTrackingPrivacyFlag>;
 
 String makeLogMessage(const URL&, ScriptTrackingPrivacyCategory);
 ASCIILiteral description(ScriptTrackingPrivacyCategory);
-WEBCORE_EXPORT ScriptTrackingPrivacyFlag scriptCategoryAsFlag(ScriptTrackingPrivacyCategory);
+WEBCORE_EXPORT ScriptTrackingPrivacyFlag NODELETE scriptCategoryAsFlag(ScriptTrackingPrivacyCategory);
 
-bool shouldEnableScriptTrackingPrivacy(ScriptTrackingPrivacyCategory, OptionSet<AdvancedPrivacyProtections>, bool needsConsistentPrivacy = false);
+bool NODELETE shouldEnableScriptTrackingPrivacy(ScriptTrackingPrivacyCategory, OptionSet<AdvancedPrivacyProtections>, bool needsConsistentPrivacy = false);
 
 } // namespace WebCore
 

--- a/Source/WebCore/page/SecurityOrigin.h
+++ b/Source/WebCore/page/SecurityOrigin.h
@@ -123,19 +123,19 @@ public:
     //
     // Note: This method exists only to support backwards compatibility
     //       with older versions of WebKit.
-    void grantLoadLocalResources();
+    void NODELETE grantLoadLocalResources();
 
     // Explicitly grant the ability to access very other SecurityOrigin.
     //
     // WARNING: This is an extremely powerful ability. Use with caution!
-    WEBCORE_EXPORT void grantUniversalAccess();
+    WEBCORE_EXPORT void NODELETE grantUniversalAccess();
     bool hasUniversalAccess() const { return m_universalAccess; }
 
-    void grantStorageAccessFromFileURLsQuirk();
+    void NODELETE grantStorageAccessFromFileURLsQuirk();
     bool needsStorageAccessFromFileURLsQuirk() const { return m_needsStorageAccessFromFileURLsQuirk; }
 
     WEBCORE_EXPORT String domainForCachePartition() const;
-    Policy canShowNotifications() const;
+    Policy NODELETE canShowNotifications() const;
 
     // The local SecurityOrigin is the most privileged SecurityOrigin.
     // The local SecurityOrigin can script any document, navigate to local
@@ -153,7 +153,7 @@ public:
     // Marks a file:// origin as being in a domain defined by its path.
     // FIXME 81578: The naming of this is confusing. Files with restricted access to other local files
     // still can have other privileges that can be remembered, thereby not making them unique.
-    void setEnforcesFilePathSeparation();
+    void NODELETE setEnforcesFilePathSeparation();
     bool enforcesFilePathSeparation() const { return m_enforcesFilePathSeparation; }
 
     // Convert this SecurityOrigin into a string. The string
@@ -217,7 +217,7 @@ private:
     explicit SecurityOrigin(SecurityOriginData&&);
     void initializeShared(const URL&);
 
-    bool hasLocalUnseparatedPath(const SecurityOrigin&) const;
+    bool NODELETE hasLocalUnseparatedPath(const SecurityOrigin&) const;
 
     enum class ShouldAllowFromThirdParty : uint8_t { AlwaysAllowFromThirdParty, MaybeAllowFromThirdParty };
     WEBCORE_EXPORT bool canAccessStorage(const SecurityOrigin*, ShouldAllowFromThirdParty = ShouldAllowFromThirdParty::MaybeAllowFromThirdParty) const;

--- a/Source/WebCore/page/SecurityPolicy.cpp
+++ b/Source/WebCore/page/SecurityPolicy.cpp
@@ -50,7 +50,7 @@ using OriginAccessAllowlist = Vector<OriginAccessEntry>;
 using OriginAccessMap = HashMap<SecurityOriginData, std::unique_ptr<OriginAccessAllowlist>>;
 
 static Lock originAccessMapLock;
-static OriginAccessMap& originAccessMap() WTF_REQUIRES_LOCK(originAccessMapLock)
+static OriginAccessMap& NODELETE originAccessMap() WTF_REQUIRES_LOCK(originAccessMapLock)
 {
     ASSERT(originAccessMapLock.isHeld());
     static NeverDestroyed<OriginAccessMap> originAccessMap;

--- a/Source/WebCore/page/SecurityPolicy.h
+++ b/Source/WebCore/page/SecurityPolicy.h
@@ -64,9 +64,9 @@ public:
         AllowLocalLoadsForLocalOnly,
     };
 
-    WEBCORE_EXPORT static void setLocalLoadPolicy(LocalLoadPolicy);
-    static bool restrictAccessToLocal();
-    static bool allowSubstituteDataAccessToLocal();
+    WEBCORE_EXPORT static void NODELETE setLocalLoadPolicy(LocalLoadPolicy);
+    static bool NODELETE restrictAccessToLocal();
+    static bool NODELETE allowSubstituteDataAccessToLocal();
 
     WEBCORE_EXPORT static void addOriginAccessAllowlistEntry(const SecurityOrigin& sourceOrigin, const String& destinationProtocol, const String& destinationDomain, bool allowDestinationSubdomains);
     WEBCORE_EXPORT static void removeOriginAccessAllowlistEntry(const SecurityOrigin& sourceOrigin, const String& destinationProtocol, const String& destinationDomain, bool allowDestinationSubdomains);

--- a/Source/WebCore/page/SpatialNavigation.cpp
+++ b/Source/WebCore/page/SpatialNavigation.cpp
@@ -103,23 +103,23 @@ static RectsAlignment alignmentForRects(FocusDirection direction, const LayoutRe
     return RectsAlignment::None;
 }
 
-static inline bool isHorizontalMove(FocusDirection direction)
+static inline bool NODELETE isHorizontalMove(FocusDirection direction)
 {
     return direction == FocusDirection::Left || direction == FocusDirection::Right;
 }
 
-static inline LayoutUnit start(FocusDirection direction, const LayoutRect& rect)
+static inline LayoutUnit NODELETE start(FocusDirection direction, const LayoutRect& rect)
 {
     return isHorizontalMove(direction) ? rect.y() : rect.x();
 }
 
-static inline LayoutUnit middle(FocusDirection direction, const LayoutRect& rect)
+static inline LayoutUnit NODELETE middle(FocusDirection direction, const LayoutRect& rect)
 {
     LayoutPoint center(rect.center());
     return isHorizontalMove(direction) ? center.y(): center.x();
 }
 
-static inline LayoutUnit end(FocusDirection direction, const LayoutRect& rect)
+static inline LayoutUnit NODELETE end(FocusDirection direction, const LayoutRect& rect)
 {
     return isHorizontalMove(direction) ? rect.maxY() : rect.maxX();
 }

--- a/Source/WebCore/page/SpatialNavigation.h
+++ b/Source/WebCore/page/SpatialNavigation.h
@@ -126,8 +126,8 @@ void distanceDataForNode(FocusDirection, const FocusCandidate& current, FocusCan
 ContainerNode* scrollableEnclosingBoxOrParentFrameForNodeInDirection(FocusDirection, ContainerNode&);
 LayoutRect nodeRectInAbsoluteCoordinates(const ContainerNode&, bool ignoreBorder = false);
 LayoutRect frameRectInAbsoluteCoordinates(LocalFrame*);
-LayoutRect virtualRectForDirection(FocusDirection, const LayoutRect& startingRect, LayoutUnit width = 0_lu);
+LayoutRect NODELETE virtualRectForDirection(FocusDirection, const LayoutRect& startingRect, LayoutUnit width = 0_lu);
 LayoutRect virtualRectForAreaElementAndDirection(HTMLAreaElement*, FocusDirection);
-HTMLFrameOwnerElement* frameOwnerElement(FocusCandidate&);
+HTMLFrameOwnerElement* NODELETE frameOwnerElement(FocusCandidate&);
 
 } // namespace WebCore

--- a/Source/WebCore/page/TextIndicator.h
+++ b/Source/WebCore/page/TextIndicator.h
@@ -171,8 +171,8 @@ public:
     TextIndicatorPresentationTransition presentationTransition() const { return m_data.presentationTransition; }
     void setPresentationTransition(TextIndicatorPresentationTransition transition) { m_data.presentationTransition = transition; }
 
-    WEBCORE_EXPORT bool wantsBounce() const;
-    WEBCORE_EXPORT bool wantsManualAnimation() const;
+    WEBCORE_EXPORT bool NODELETE wantsBounce() const;
+    WEBCORE_EXPORT bool NODELETE wantsManualAnimation() const;
 
     Color estimatedBackgroundColor() const { return m_data.estimatedBackgroundColor; }
     OptionSet<TextIndicatorOption> options() const { return m_data.options; }

--- a/Source/WebCore/page/UserAgentStringParser.h
+++ b/Source/WebCore/page/UserAgentStringParser.h
@@ -43,15 +43,15 @@ private:
 
     void consumeProduct();
     void consumeComment();
-    void consumeRWS();
+    void NODELETE consumeRWS();
     void consumeToken();
     void consumeQuotedPair();
 
     void populateUserAgentData();
 
-    inline char16_t peek();
-    inline void increment();
-    inline bool atEnd();
+    inline char16_t NODELETE peek();
+    inline void NODELETE increment();
+    inline bool NODELETE atEnd();
     inline String getSubstring();
 
     bool malformed { false };

--- a/Source/WebCore/page/UserContentController.h
+++ b/Source/WebCore/page/UserContentController.h
@@ -53,7 +53,7 @@ private:
     void forEachUserScript(NOESCAPE const Function<void(DOMWrapperWorld&, const UserScript&)>&) const final;
     void forEachUserStyleSheet(NOESCAPE const Function<void(const UserStyleSheet&)>&) const final;
 #if ENABLE(USER_MESSAGE_HANDLERS)
-    void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final;
+    void NODELETE forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final;
 #endif
     bool hasBuffersForWorld(const DOMWrapperWorld&) const override { return false; }
     WebKitBuffer* buffer(const DOMWrapperWorld&, const String&) const override { return nullptr; }

--- a/Source/WebCore/page/UserContentProvider.cpp
+++ b/Source/WebCore/page/UserContentProvider.cpp
@@ -94,7 +94,7 @@ void UserContentProvider::invalidateInjectedStyleSheetCacheInAllFramesInAllPages
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)
-static DocumentLoader* mainDocumentLoader(DocumentLoader& loader)
+static DocumentLoader* NODELETE mainDocumentLoader(DocumentLoader& loader)
 {
     if (auto frame = loader.frame()) {
         if (frame->isMainFrame())

--- a/Source/WebCore/page/UserContentURLPattern.cpp
+++ b/Source/WebCore/page/UserContentURLPattern.cpp
@@ -259,10 +259,10 @@ struct MatchTester {
     {
     }
 
-    bool testStringFinished() const { return m_testIndex >= m_test.length(); }
-    bool patternStringFinished() const { return m_patternIndex >= m_pattern.length(); }
+    bool NODELETE testStringFinished() const { return m_testIndex >= m_test.length(); }
+    bool NODELETE patternStringFinished() const { return m_patternIndex >= m_pattern.length(); }
 
-    void eatWildcard()
+    void NODELETE eatWildcard()
     {
         while (!patternStringFinished()) {
             if (m_pattern[m_patternIndex] != '*')
@@ -271,7 +271,7 @@ struct MatchTester {
         }
     }
 
-    void eatSameChars()
+    void NODELETE eatSameChars()
     {
         while (!patternStringFinished() && !testStringFinished()) {
             if (m_pattern[m_patternIndex] == '*')
@@ -283,7 +283,7 @@ struct MatchTester {
         }
     }
 
-    bool test()
+    bool NODELETE test()
     {
         // Eat all the matching chars.
         eatSameChars();

--- a/Source/WebCore/page/UserMessageHandlerDescriptor.h
+++ b/Source/WebCore/page/UserMessageHandlerDescriptor.h
@@ -47,8 +47,8 @@ public:
     WEBCORE_EXPORT explicit UserMessageHandlerDescriptor(const AtomString&, DOMWrapperWorld&);
     WEBCORE_EXPORT virtual ~UserMessageHandlerDescriptor();
 
-    WEBCORE_EXPORT const AtomString& name() const;
-    WEBCORE_EXPORT const DOMWrapperWorld& world() const;
+    WEBCORE_EXPORT const AtomString& NODELETE name() const;
+    WEBCORE_EXPORT const DOMWrapperWorld& NODELETE world() const;
 
     virtual void didPostMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue, Function<void(JSC::JSValue, const String&)>&&) const = 0;
     virtual JSC::JSValue didPostLegacySynchronousMessage(UserMessageHandler&, JSC::JSGlobalObject&, JSC::JSValue) const = 0;

--- a/Source/WebCore/page/UserMessageHandlersNamespace.h
+++ b/Source/WebCore/page/UserMessageHandlersNamespace.h
@@ -51,9 +51,9 @@ public:
 
     virtual ~UserMessageHandlersNamespace();
 
-    Vector<AtomString> supportedPropertyNames() const;
+    Vector<AtomString> NODELETE supportedPropertyNames() const;
     RefPtr<UserMessageHandler> namedItem(DOMWrapperWorld&, const AtomString&);
-    bool isSupportedPropertyName(const AtomString&);
+    bool NODELETE isSupportedPropertyName(const AtomString&);
 
     // UserContentProviderInvalidationClient, FrameDestructionObserver.
     void ref() const final { RefCounted::ref(); }

--- a/Source/WebCore/page/ViewportConfiguration.cpp
+++ b/Source/WebCore/page/ViewportConfiguration.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ViewportConfiguration);
 
-static inline bool viewportArgumentValueIsValid(float value)
+static inline bool NODELETE viewportArgumentValueIsValid(float value)
 {
     return value > 0;
 }
@@ -57,7 +57,7 @@ static inline void adjustViewportArgumentsToAvoidExcessiveZooming(ViewportArgume
     arguments.width = zoomedWidthFromArguments / arguments.zoom;
 }
 
-static inline void ignoreViewportArgumentsToAvoidEnlargedView(ViewportArguments& arguments, FloatSize viewLayoutSize)
+static inline void NODELETE ignoreViewportArgumentsToAvoidEnlargedView(ViewportArguments& arguments, FloatSize viewLayoutSize)
 {
     if (!viewportArgumentValueIsValid(arguments.width))
         return;
@@ -76,7 +76,7 @@ static bool constraintsAreAllRelative(const ViewportConfiguration::Parameters& c
 }
 #endif // ASSERT_ENABLED
 
-static constexpr float platformDeviceWidthOverride()
+static constexpr float NODELETE platformDeviceWidthOverride()
 {
 #if PLATFORM(WATCHOS)
     return 320;
@@ -85,7 +85,7 @@ static constexpr float platformDeviceWidthOverride()
 #endif
 }
 
-static constexpr double platformMinimumScaleForWebpage()
+static constexpr double NODELETE platformMinimumScaleForWebpage()
 {
 #if PLATFORM(WATCHOS)
     return 0.1;
@@ -94,7 +94,7 @@ static constexpr double platformMinimumScaleForWebpage()
 #endif
 }
 
-static constexpr bool shouldOverrideShrinkToFitArgument()
+static constexpr bool NODELETE shouldOverrideShrinkToFitArgument()
 {
 #if PLATFORM(WATCHOS)
     return true;
@@ -103,7 +103,7 @@ static constexpr bool shouldOverrideShrinkToFitArgument()
 #endif
 }
 
-static bool needsUpdateAfterChangingDisabledAdaptations(const OptionSet<DisabledAdaptations>& oldDisabledAdaptations, const OptionSet<DisabledAdaptations>& newDisabledAdaptations)
+static bool NODELETE needsUpdateAfterChangingDisabledAdaptations(const OptionSet<DisabledAdaptations>& oldDisabledAdaptations, const OptionSet<DisabledAdaptations>& newDisabledAdaptations)
 {
     if (oldDisabledAdaptations == newDisabledAdaptations)
         return false;
@@ -512,7 +512,7 @@ static inline bool applyViewportArgument(double& value, float viewportArgumentVa
     return false;
 }
 
-static inline bool booleanViewportArgumentIsSet(float value)
+static inline bool NODELETE booleanViewportArgumentIsSet(float value)
 {
     return !value || value == 1;
 }

--- a/Source/WebCore/page/ViewportConfiguration.h
+++ b/Source/WebCore/page/ViewportConfiguration.h
@@ -165,11 +165,11 @@ public:
 
 private:
     void updateConfiguration();
-    double viewportArgumentsLength(double length) const;
+    double NODELETE viewportArgumentsLength(double length) const;
     double initialScaleFromSize(double width, double height, bool shouldIgnoreScalingConstraints) const;
 
-    bool shouldOverrideDeviceWidthAndShrinkToFit() const;
-    bool shouldIgnoreScalingConstraintsRegardlessOfContentSize() const;
+    bool NODELETE shouldOverrideDeviceWidthAndShrinkToFit() const;
+    bool NODELETE shouldIgnoreScalingConstraintsRegardlessOfContentSize() const;
     bool shouldIgnoreScalingConstraints() const;
     bool shouldIgnoreVerticalScalingConstraints() const;
     bool shouldIgnoreHorizontalScalingConstraints() const;

--- a/Source/WebCore/page/VisualViewport.h
+++ b/Source/WebCore/page/VisualViewport.h
@@ -39,7 +39,7 @@ public:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final;
-    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
     bool addEventListener(const AtomString& eventType, Ref<EventListener>&&, const AddEventListenerOptions&) final;
     using EventTarget::addEventListener;
 

--- a/Source/WebCore/page/WebKitBufferNamespace.h
+++ b/Source/WebCore/page/WebKitBufferNamespace.h
@@ -45,9 +45,9 @@ public:
 
     ~WebKitBufferNamespace();
 
-    Vector<AtomString> supportedPropertyNames() const;
+    Vector<AtomString> NODELETE supportedPropertyNames() const;
     WebKitBuffer* namedItem(DOMWrapperWorld&, const AtomString&);
-    bool isSupportedPropertyName(const AtomString&);
+    bool NODELETE isSupportedPropertyName(const AtomString&);
 
 private:
     explicit WebKitBufferNamespace(LocalFrame&, UserContentProvider&);

--- a/Source/WebCore/page/WebKitJSHandle.cpp
+++ b/Source/WebCore/page/WebKitJSHandle.cpp
@@ -40,7 +40,7 @@ struct JSHandleData {
     size_t refCount { 0 };
 };
 using HandleMap = HashMap<JSHandleIdentifier, JSHandleData>;
-static HandleMap& handleMap()
+static HandleMap& NODELETE handleMap()
 {
     static MainThreadNeverDestroyed<HandleMap> map;
     return map.get();

--- a/Source/WebCore/page/WebKitNamespace.h
+++ b/Source/WebCore/page/WebKitNamespace.h
@@ -56,8 +56,8 @@ public:
 
     virtual ~WebKitNamespace();
 
-    UserMessageHandlersNamespace* messageHandlers();
-    WebKitBufferNamespace& buffers();
+    UserMessageHandlersNamespace* NODELETE messageHandlers();
+    WebKitBufferNamespace& NODELETE buffers();
     JSC::JSValue evaluateScript(JSC::JSGlobalObject&, const String& source, const String& url);
     Ref<WebKitJSHandle> createJSHandle(JSC::Strong<JSC::JSObject>);
 

--- a/Source/WebCore/page/WheelEventDeltaFilter.cpp
+++ b/Source/WebCore/page/WheelEventDeltaFilter.cpp
@@ -153,7 +153,7 @@ void BasicWheelEventDeltaFilter::reset()
     m_currentFilteredVelocity = { };
 }
 
-static inline bool deltaIsPredominantlyVertical(const FloatSize& delta)
+static inline bool NODELETE deltaIsPredominantlyVertical(const FloatSize& delta)
 {
     return std::abs(delta.height()) > std::abs(delta.width());
 }

--- a/Source/WebCore/page/WheelEventDeltaFilter.h
+++ b/Source/WebCore/page/WheelEventDeltaFilter.h
@@ -43,14 +43,14 @@ public:
 
     WEBCORE_EXPORT virtual void updateFromEvent(const PlatformWheelEvent&) = 0;
 
-    WEBCORE_EXPORT PlatformWheelEvent eventCopyWithFilteredDeltas(const PlatformWheelEvent&) const;
-    WEBCORE_EXPORT PlatformWheelEvent eventCopyWithVelocity(const PlatformWheelEvent&) const;
+    WEBCORE_EXPORT PlatformWheelEvent NODELETE eventCopyWithFilteredDeltas(const PlatformWheelEvent&) const;
+    WEBCORE_EXPORT PlatformWheelEvent NODELETE eventCopyWithVelocity(const PlatformWheelEvent&) const;
 
-    WEBCORE_EXPORT FloatSize filteredVelocity() const;
-    WEBCORE_EXPORT FloatSize filteredDelta() const;
+    WEBCORE_EXPORT FloatSize NODELETE filteredVelocity() const;
+    WEBCORE_EXPORT FloatSize NODELETE filteredDelta() const;
 
-    WEBCORE_EXPORT static bool shouldApplyFilteringForEvent(const PlatformWheelEvent&);
-    WEBCORE_EXPORT static bool shouldIncludeVelocityForEvent(const PlatformWheelEvent&);
+    WEBCORE_EXPORT static bool NODELETE shouldApplyFilteringForEvent(const PlatformWheelEvent&);
+    WEBCORE_EXPORT static bool NODELETE shouldIncludeVelocityForEvent(const PlatformWheelEvent&);
 
 protected:
     FloatSize m_currentFilteredDelta;

--- a/Source/WebCore/page/WindowFeatures.cpp
+++ b/Source/WebCore/page/WindowFeatures.cpp
@@ -42,7 +42,7 @@ static std::optional<bool> boolFeature(const DialogFeaturesMap&, ASCIILiteral ke
 static std::optional<float> floatFeature(const DialogFeaturesMap&, ASCIILiteral key, float min, float max);
 
 // https://html.spec.whatwg.org/#feature-separator
-static bool isSeparator(char16_t character, FeatureMode mode)
+static bool NODELETE isSeparator(char16_t character, FeatureMode mode)
 {
     if (mode == FeatureMode::Viewport)
         return character == ' ' || character == '\t' || character == '\n' || character == '\r' || character == '=' || character == ',';

--- a/Source/WebCore/page/WindowFocusAllowedIndicator.h
+++ b/Source/WebCore/page/WindowFocusAllowedIndicator.h
@@ -35,7 +35,7 @@ public:
     WindowFocusAllowedIndicator();
     ~WindowFocusAllowedIndicator();
 
-    static bool windowFocusAllowed();
+    static bool NODELETE windowFocusAllowed();
 
 private:
     bool m_previousWindowFocusAllowed;

--- a/Source/WebCore/page/WorkerNavigator.h
+++ b/Source/WebCore/page/WorkerNavigator.h
@@ -43,8 +43,8 @@ public:
 
     virtual ~WorkerNavigator();
 
-    const String& userAgent() const final;
-    bool onLine() const final;
+    const String& NODELETE userAgent() const final;
+    bool NODELETE onLine() const final;
     void setIsOnline(bool isOnline) { m_isOnline = isOnline; }
 
     void setAppBadge(std::optional<unsigned long long>, Ref<DeferredPromise>&&);

--- a/Source/WebCore/page/cocoa/PageCocoa.mm
+++ b/Source/WebCore/page/cocoa/PageCocoa.mm
@@ -129,7 +129,7 @@ void Page::removeSchedulePair(Ref<SchedulePair>&& pair)
     }
 }
 
-const String& Page::presentingApplicationBundleIdentifier() const
+const String& NODELETE Page::presentingApplicationBundleIdentifier() const
 {
     return m_presentingApplicationBundleIdentifier;
 }

--- a/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm
@@ -88,7 +88,7 @@ public:
         incrementIndex(m_current);
     }
 
-    T& last()
+    T& NODELETE last()
     {
         unsigned index = m_current;
         decrementIndex(index);
@@ -105,13 +105,13 @@ public:
     }
 
 private:
-    static void incrementIndex(unsigned& index)
+    static void NODELETE incrementIndex(unsigned& index)
     {
         if (++index == size)
             index = 0;
     }
 
-    static void decrementIndex(unsigned& index)
+    static void NODELETE decrementIndex(unsigned& index)
     {
         if (index)
             --index;

--- a/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
+++ b/Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm
@@ -41,7 +41,7 @@
 
 namespace WebCore {
 
-static unsigned categoryForVMTag(unsigned tag)
+static unsigned NODELETE categoryForVMTag(unsigned tag)
 {
     switch (tag) {
     case VM_MEMORY_IOKIT:

--- a/Source/WebCore/page/cocoa/SettingsBaseCocoa.mm
+++ b/Source/WebCore/page/cocoa/SettingsBaseCocoa.mm
@@ -68,7 +68,7 @@ void SettingsBase::initializeDefaultFontFamilies()
 
 #if ENABLE(MEDIA_SOURCE)
 
-bool SettingsBase::platformDefaultMediaSourceEnabled()
+bool NODELETE SettingsBase::platformDefaultMediaSourceEnabled()
 {
 #if PLATFORM(MAC)
     return true;
@@ -77,7 +77,7 @@ bool SettingsBase::platformDefaultMediaSourceEnabled()
 #endif
 }
 
-uint64_t SettingsBase::defaultMaximumSourceBufferSize()
+uint64_t NODELETE SettingsBase::defaultMaximumSourceBufferSize()
 {
 #if PLATFORM(IOS_FAMILY)
     // iOS Devices have lower memory limits, enforced by jetsam rates, and a very limited

--- a/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
+++ b/Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm
@@ -75,7 +75,7 @@ static bool indicatorWantsContentCrossfade(const WebCore::TextIndicator& indicat
     return false;
 }
 
-static bool indicatorWantsFadeIn(const WebCore::TextIndicator& indicator)
+static bool NODELETE indicatorWantsFadeIn(const WebCore::TextIndicator& indicator)
 {
     switch (indicator.presentationTransition()) {
     case WebCore::TextIndicatorPresentationTransition::FadeIn:

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.cpp
@@ -102,7 +102,7 @@ ContentSecurityPolicy::ContentSecurityPolicy(URL&& protectedURL, ContentSecurity
     updateSourceSelf(SecurityOrigin::create(m_protectedURL).get());
 }
 
-static ReportingClient* reportingClientForContext(ScriptExecutionContext& scriptExecutionContext)
+static ReportingClient* NODELETE reportingClientForContext(ScriptExecutionContext& scriptExecutionContext)
 {
     if (auto* document = dynamicDowncast<Document>(scriptExecutionContext))
         return document;

--- a/Source/WebCore/page/csp/ContentSecurityPolicy.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicy.h
@@ -157,7 +157,7 @@ public:
 
     bool allowFrameAncestors(const LocalFrame&, const URL&, bool overrideContentSecurityPolicy = false) const;
     WEBCORE_EXPORT bool allowFrameAncestors(const Vector<Ref<SecurityOrigin>>& ancestorOrigins, const URL&, bool overrideContentSecurityPolicy = false) const;
-    WEBCORE_EXPORT bool overridesXFrameOptions() const;
+    WEBCORE_EXPORT bool NODELETE overridesXFrameOptions() const;
 
     enum class RedirectResponseReceived : bool { No, Yes };
     WEBCORE_EXPORT bool allowScriptFromSource(const URL&, RedirectResponseReceived = RedirectResponseReceived::No, const URL& preRedirectURL = URL(), const String& = nullString(), const String& nonce = nullString()) const;
@@ -182,7 +182,7 @@ public:
     bool requireTrustedTypesForSinkGroup(const String& sinkGroup, IncludeReportOnlyPolicies = IncludeReportOnlyPolicies::Yes) const;
     bool allowMissingTrustedTypesForSinkGroup(const String& stringContext, const String& sink, const String& sinkGroup, StringView source) const;
 
-    void setOverrideAllowInlineStyle(bool);
+    void NODELETE setOverrideAllowInlineStyle(bool);
 
     void gatherReportURIs(DOMStringList&) const;
 
@@ -206,7 +206,7 @@ public:
     void reportInvalidPathCharacter(const String& directiveName, const String& value, const char) const;
     void reportInvalidSourceExpression(const String& directiveName, const String& source) const;
     bool urlMatchesSelf(const URL&, bool forFrameSrc) const;
-    bool allowContentSecurityPolicySourceStarToMatchAnyProtocol() const;
+    bool NODELETE allowContentSecurityPolicySourceStarToMatchAnyProtocol() const;
 
     // Used by ContentSecurityPolicyDirectiveList
     void reportDuplicateDirective(const String&) const;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirective.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirective.h
@@ -52,7 +52,7 @@ public:
 
     const ContentSecurityPolicyDirectiveList& directiveList() const { return m_directiveList; }
 
-    bool isDefaultSrc() const;
+    bool NODELETE isDefaultSrc() const;
 
 private:
     String m_name;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp
@@ -51,22 +51,22 @@ template<typename CharacterType> static bool isDirectiveValueCharacter(Character
     return isASCIIWhitespace(c) || (c >= 0x21 && c <= 0x7e); // Whitespace + VCHAR
 }
 
-static inline bool checkEval(ContentSecurityPolicySourceListDirective* directive)
+static inline bool NODELETE checkEval(ContentSecurityPolicySourceListDirective* directive)
 {
     return !directive || directive->allowEval();
 }
 
-static inline bool checkTrustedEval(ContentSecurityPolicySourceListDirective* directive)
+static inline bool NODELETE checkTrustedEval(ContentSecurityPolicySourceListDirective* directive)
 {
     return !directive || directive->allowTrustedEval();
 }
 
-static inline bool checkWasmEval(ContentSecurityPolicySourceListDirective* directive)
+static inline bool NODELETE checkWasmEval(ContentSecurityPolicySourceListDirective* directive)
 {
     return !directive || directive->allowWasmEval();
 }
 
-static inline bool checkInline(ContentSecurityPolicySourceListDirective* directive)
+static inline bool NODELETE checkInline(ContentSecurityPolicySourceListDirective* directive)
 {
     return !directive || directive->allowInline();
 }
@@ -76,7 +76,7 @@ static inline bool checkUnsafeHashes(ContentSecurityPolicySourceListDirective* d
     return !directive || directive->allowUnsafeHashes(hashes);
 }
 
-static inline bool checkNonParserInsertedScripts(ContentSecurityPolicySourceListDirective* directive, ParserInserted parserInserted)
+static inline bool NODELETE checkNonParserInsertedScripts(ContentSecurityPolicySourceListDirective* directive, ParserInserted parserInserted)
 {
     if (!directive)
         return true;

--- a/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h
@@ -120,10 +120,10 @@ private:
     template <class CSPDirectiveType>
     void setCSPDirective(ParsedDirective&&, std::unique_ptr<CSPDirectiveType>&);
 
-    ContentSecurityPolicySourceListDirective* operativeDirective(ContentSecurityPolicySourceListDirective*, const String&) const;
-    ContentSecurityPolicySourceListDirective* operativeDirectiveScript(ContentSecurityPolicySourceListDirective*, const String&) const;
-    ContentSecurityPolicySourceListDirective* operativeDirectiveStyle(ContentSecurityPolicySourceListDirective*, const String&) const;
-    ContentSecurityPolicySourceListDirective* operativeDirectiveForWorkerSrc(ContentSecurityPolicySourceListDirective*, const String&) const;
+    ContentSecurityPolicySourceListDirective* NODELETE operativeDirective(ContentSecurityPolicySourceListDirective*, const String&) const;
+    ContentSecurityPolicySourceListDirective* NODELETE operativeDirectiveScript(ContentSecurityPolicySourceListDirective*, const String&) const;
+    ContentSecurityPolicySourceListDirective* NODELETE operativeDirectiveStyle(ContentSecurityPolicySourceListDirective*, const String&) const;
+    ContentSecurityPolicySourceListDirective* NODELETE operativeDirectiveForWorkerSrc(ContentSecurityPolicySourceListDirective*, const String&) const;
 
     void setEvalDisabledErrorMessage(const String& errorMessage) { m_evalDisabledErrorMessage = errorMessage; }
     void setWebAssemblyDisabledErrorMessage(const String& errorMessage) { m_webAssemblyDisabledErrorMessage = errorMessage; }

--- a/Source/WebCore/page/csp/ContentSecurityPolicySource.h
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySource.h
@@ -51,7 +51,7 @@ private:
     bool hostMatches(const URL&) const;
     bool pathMatches(const URL&) const;
     bool portMatches(const URL&) const;
-    bool isSchemeOnly() const;
+    bool NODELETE isSchemeOnly() const;
 
     const CheckedRef<const ContentSecurityPolicy> m_policy;
     String m_scheme;

--- a/Source/WebCore/page/mac/CorrectionIndicator.h
+++ b/Source/WebCore/page/mac/CorrectionIndicator.h
@@ -36,7 +36,7 @@ namespace WebCore {
 
 enum class AlternativeTextType : uint8_t;
 
-WEBCORE_EXPORT NSCorrectionIndicatorType correctionIndicatorType(WebCore::AlternativeTextType);
+WEBCORE_EXPORT NSCorrectionIndicatorType NODELETE correctionIndicatorType(WebCore::AlternativeTextType);
 
 }
 

--- a/Source/WebCore/page/mac/DragControllerMac.mm
+++ b/Source/WebCore/page/mac/DragControllerMac.mm
@@ -62,7 +62,7 @@ const int DragController::DragIconBottomInset = 3;
 
 const float DragController::DragImageAlpha = 0.75f;
 
-bool DragController::isCopyKeyDown(const DragData& dragData)
+bool NODELETE DragController::isCopyKeyDown(const DragData& dragData)
 {
     return dragData.flags().contains(DragApplicationFlags::IsCopyKeyDown);
 }
@@ -87,7 +87,7 @@ std::optional<DragOperation> DragController::dragOperation(const DragData& dragD
     return std::nullopt;
 }
 
-const IntSize& DragController::maxDragImageSize()
+const IntSize& NODELETE DragController::maxDragImageSize()
 {
     static const IntSize maxDragImageSize(400, 400);
     

--- a/Source/WebCore/page/mac/EventHandlerMac.mm
+++ b/Source/WebCore/page/mac/EventHandlerMac.mm
@@ -454,7 +454,7 @@ static IMP originalNSScrollViewScrollWheel;
 static bool _nsScrollViewScrollWheelShouldRetainSelf;
 static void selfRetainingNSScrollViewScrollWheel(NSScrollView *, SEL, NSEvent *);
 
-static bool nsScrollViewScrollWheelShouldRetainSelf()
+static bool NODELETE nsScrollViewScrollWheelShouldRetainSelf()
 {
     ASSERT(isMainThread());
 
@@ -745,12 +745,12 @@ PlatformMouseEvent EventHandler::currentPlatformMouseEvent() const
     return PlatformEventFactory::createPlatformMouseEvent(currentNSEvent(), correspondingPressureEvent(), windowView.get());
 }
 
-bool EventHandler::eventActivatedView(const PlatformMouseEvent& event) const
+bool NODELETE EventHandler::eventActivatedView(const PlatformMouseEvent& event) const
 {
     return m_activationEventNumber == event.eventNumber();
 }
 
-bool EventHandler::needsKeyboardEventDisambiguationQuirks() const
+bool NODELETE EventHandler::needsKeyboardEventDisambiguationQuirks() const
 {
     return m_frame->settings().needsKeyboardEventDisambiguationQuirks();
 }
@@ -766,7 +766,7 @@ OptionSet<PlatformEvent::Modifier> EventHandler::accessKeyModifiers()
     return { PlatformEvent::Modifier::ControlKey, PlatformEvent::Modifier::AltKey };
 }
 
-static ScrollableArea* scrollableAreaForBox(RenderBox& box)
+static ScrollableArea* NODELETE scrollableAreaForBox(RenderBox& box)
 {
     if (auto* listBox = dynamicDowncast<RenderListBox>(box))
         return listBox;

--- a/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
+++ b/Source/WebCore/page/mac/ImageOverlayControllerMac.mm
@@ -191,7 +191,7 @@ void ImageOverlayController::textRecognitionResultsChanged(HTMLElement& element)
     uninstallPageOverlayIfNeeded();
 }
 
-bool ImageOverlayController::hasActiveDataDetectorHighlightForTesting() const
+bool NODELETE ImageOverlayController::hasActiveDataDetectorHighlightForTesting() const
 {
     return !!m_activeDataDetectorHighlight;
 }

--- a/Source/WebCore/page/mac/ServicesOverlayController.h
+++ b/Source/WebCore/page/mac/ServicesOverlayController.h
@@ -53,7 +53,7 @@ public:
     ~ServicesOverlayController();
 
     // DataDetectorHighlightClient.
-    void ref() const final;
+    void NODELETE ref() const final;
     void deref() const final;
 
     void selectedTelephoneNumberRangesChanged();
@@ -62,8 +62,8 @@ public:
 private:
     // PageOverlayClient
     void willMoveToPage(PageOverlay&, Page*) override;
-    void didMoveToPage(PageOverlay&, Page*) override;
-    void drawRect(PageOverlay&, GraphicsContext&, const IntRect& dirtyRect) override;
+    void NODELETE didMoveToPage(PageOverlay&, Page*) override;
+    void NODELETE drawRect(PageOverlay&, GraphicsContext&, const IntRect& dirtyRect) override;
     bool mouseEvent(PageOverlay&, const PlatformMouseEvent&) override;
     void didScrollFrame(PageOverlay&, LocalFrame&) override;
 

--- a/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h
@@ -203,7 +203,7 @@ private:
     WEBCORE_EXPORT void setScrollbarEnabled(Scrollbar&) override;
     WEBCORE_EXPORT void setScrollbarWidth(ScrollableArea&, ScrollbarWidth) override;
 
-    void hysterisisTimerFired(PAL::HysteresisState);
+    void NODELETE hysterisisTimerFired(PAL::HysteresisState);
 
     SmallMap<FrameIdentifier, UniqueRef<ScrollingStateTree>> m_scrollingStateTrees;
     RefPtr<ScrollingTree> m_scrollingTree;

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.cpp
@@ -333,7 +333,7 @@ AnchorSearchStatus ScrollAnchoringController::examinePriorityCandidate(RenderEle
     return examineAnchorCandidate(*ancestor);
 }
 
-static bool overflowAnchorProhibitsAnchoring(const RenderElement& object, const RenderBox& scrollingAncestor)
+static bool NODELETE overflowAnchorProhibitsAnchoring(const RenderElement& object, const RenderBox& scrollingAncestor)
 {
     for (CheckedPtr renderer = &object; renderer; renderer = renderer->parent()) {
         if (renderer->style().overflowAnchor() == OverflowAnchor::None)

--- a/Source/WebCore/page/scrolling/ScrollAnchoringController.h
+++ b/Source/WebCore/page/scrolling/ScrollAnchoringController.h
@@ -68,16 +68,16 @@ public:
     void updateBeforeLayout();
     void adjustScrollPositionForAnchoring();
 
-    void willDispatchScrollEvent();
-    void didDispatchScrollEvent();
+    void NODELETE willDispatchScrollEvent();
+    void NODELETE didDispatchScrollEvent();
 
     void notifyChildHadSuppressingStyleChange(RenderElement&);
 
     bool hasAnchorElement() const { return !!m_anchorObject; }
 
     // These nest.
-    void startSuppressingScrollAnchoring();
-    void stopSuppressingScrollAnchoring();
+    void NODELETE startSuppressingScrollAnchoring();
+    void NODELETE stopSuppressingScrollAnchoring();
 
 private:
     static bool isViableStatus(AnchorSearchStatus status)
@@ -85,7 +85,7 @@ private:
         return status == AnchorSearchStatus::Constrain || status == AnchorSearchStatus::Choose;
     }
 
-    LocalFrameView& frameView() const;
+    LocalFrameView& NODELETE frameView() const;
 
     bool findPriorityCandidate(Document&);
 

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.cpp
@@ -193,7 +193,7 @@ void ScrollLatchingController::removeLatchingStateForFrame(const LocalFrame& fra
         clear();
 }
 
-static bool deltaIsPredominantlyVertical(FloatSize delta)
+static bool NODELETE deltaIsPredominantlyVertical(FloatSize delta)
 {
     return std::abs(delta.height()) > std::abs(delta.width());
 }

--- a/Source/WebCore/page/scrolling/ScrollLatchingController.h
+++ b/Source/WebCore/page/scrolling/ScrollLatchingController.h
@@ -56,7 +56,7 @@ public:
 
     void clear();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     void receivedWheelEvent(const PlatformWheelEvent&);
@@ -66,7 +66,7 @@ public:
     LocalFrame* latchedFrame() const;
 
     // Returns true if no frame is latched, or latching is in the given frame (in which case latchedScroller will be non-null).
-    bool latchingAllowsScrollingInFrame(const LocalFrame&, WeakPtr<ScrollableArea>& latchedScroller) const;
+    bool NODELETE latchingAllowsScrollingInFrame(const LocalFrame&, WeakPtr<ScrollableArea>& latchedScroller) const;
 
     void updateAndFetchLatchingStateForFrame(LocalFrame&, const PlatformWheelEvent&, RefPtr<Element>& latchedElement, WeakPtr<ScrollableArea>&, bool& isOverWidget);
 
@@ -86,8 +86,8 @@ private:
     void clearOrScheduleClearIfNeeded(const PlatformWheelEvent&);
     void clearTimerFired();
 
-    bool hasStateForFrame(const LocalFrame&) const;
-    FrameState* stateForFrame(const LocalFrame&);
+    bool NODELETE hasStateForFrame(const LocalFrame&) const;
+    FrameState* NODELETE stateForFrame(const LocalFrame&);
     const FrameState* stateForFrame(const LocalFrame&) const;
 
     bool shouldLatchToScrollableArea(const LocalFrame&, ScrollableArea*, FloatSize) const;

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp
@@ -265,7 +265,7 @@ static LayoutRect computeScrollSnapAreaRect(const RenderStyle& style, const Layo
     return result;
 }
 
-static LayoutUnit computeScrollSnapAlignOffset(LayoutUnit minLocation, LayoutUnit maxLocation, ScrollSnapAxisAlignType alignment, bool axisIsFlipped)
+static LayoutUnit NODELETE computeScrollSnapAlignOffset(LayoutUnit minLocation, LayoutUnit maxLocation, ScrollSnapAxisAlignType alignment, bool axisIsFlipped)
 {
     switch (alignment) {
     case ScrollSnapAxisAlignType::Start:
@@ -439,7 +439,7 @@ static float convertOffsetUnit(LayoutUnit input, float deviceScaleFactor)
     return roundToDevicePixel(input, deviceScaleFactor, false);
 }
 
-static LayoutUnit convertOffsetUnit(float input, float /* scaleFactor */)
+static LayoutUnit NODELETE convertOffsetUnit(float input, float /* scaleFactor */)
 {
     return LayoutUnit(input);
 }

--- a/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
+++ b/Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h
@@ -103,7 +103,7 @@ WEBCORE_EXPORT std::pair<LayoutUnit, std::optional<unsigned>> LayoutScrollSnapOf
 // Update the snap offsets for this scrollable area, given the RenderBox of the scroll container, the RenderStyle
 // which defines the scroll-snap properties, and the viewport rectangle with the origin at the top left of
 // the scrolling container's border box.
-bool hasScrollSnappedBoxes(const RenderBox& scrollingElementBox);
+bool NODELETE hasScrollSnappedBoxes(const RenderBox& scrollingElementBox);
 void updateSnapOffsetsForScrollableArea(ScrollableArea&, const RenderBox& scrollingElementBox, const RenderStyle& scrollingElementStyle, LayoutRect viewportRectInBorderBoxCoordinates, WritingMode, Element*);
 
 template <typename T> WTF::TextStream& operator<<(WTF::TextStream& ts, SnapOffset<T> offset)

--- a/Source/WebCore/page/scrolling/ScrollingConstraints.h
+++ b/Source/WebCore/page/scrolling/ScrollingConstraints.h
@@ -154,7 +154,7 @@ public:
     void setStickyOffsetAtLastLayout(FloatSize offset) { m_stickyOffsetAtLastLayout = offset; }
 
     WEBCORE_EXPORT FloatPoint anchorLayerPositionForConstrainingRect(const FloatRect& constrainingRect) const;
-    FloatPoint anchorLayerPositionAtLastLayout() const;
+    FloatPoint NODELETE anchorLayerPositionAtLastLayout() const;
 
     float leftOffset() const { return m_leftOffset; }
     float rightOffset() const { return m_rightOffset; }

--- a/Source/WebCore/page/scrolling/ScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ScrollingCoordinator.h
@@ -84,7 +84,7 @@ public:
     WEBCORE_EXPORT virtual bool coordinatesScrollingForOverflowLayer(const RenderLayer&) const;
 
     // Returns the ScrollingNodeID of the innermost scrolling node that scrolls the renderer.
-    WEBCORE_EXPORT virtual std::optional<ScrollingNodeID> scrollableContainerNodeID(const RenderObject&) const;
+    WEBCORE_EXPORT virtual std::optional<ScrollingNodeID> NODELETE scrollableContainerNodeID(const RenderObject&) const;
 
     // Should be called whenever the given frame view has been laid out.
     virtual void frameViewLayoutUpdated(LocalFrameView&) { }
@@ -221,12 +221,12 @@ public:
     WEBCORE_EXPORT virtual void setLayerHostingContextIdentifierForFrameHostingNode(ScrollingNodeID, std::optional<LayerHostingContextIdentifier>) { }
     WEBCORE_EXPORT virtual void setScrollbarLayoutDirection(ScrollableArea&, UserInterfaceLayoutDirection) { }
     WEBCORE_EXPORT virtual void setScrollbarWidth(ScrollableArea&, ScrollbarWidth) { }
-    WEBCORE_EXPORT virtual void setScrollbarColor(ScrollableArea&, std::optional<ScrollbarColor>);
+    WEBCORE_EXPORT virtual void NODELETE setScrollbarColor(ScrollableArea&, std::optional<ScrollbarColor>);
 #if USE(COORDINATED_GRAPHICS_ASYNC_SCROLLBAR)
     virtual void setScrollbarOpacity(ScrollableArea&) { }
 #endif
 
-    FrameIdentifier mainFrameIdentifier() const;
+    FrameIdentifier NODELETE mainFrameIdentifier() const;
 
 protected:
     explicit ScrollingCoordinator(Page*);

--- a/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h
@@ -129,7 +129,7 @@ public:
     bool overlayScrollbarsEnabled() const { return m_overlayScrollbarsEnabled; }
     WEBCORE_EXPORT void setOverlayScrollbarsEnabled(bool);
 
-    WEBCORE_EXPORT bool isMainFrame() const;
+    WEBCORE_EXPORT bool NODELETE isMainFrame() const;
     
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -322,7 +322,7 @@ public:
         ASSERT(m_scrollingStateTree);
         return *m_scrollingStateTree;
     }
-    void attachAfterDeserialization(ScrollingStateTree&);
+    void NODELETE attachAfterDeserialization(ScrollingStateTree&);
 
     ScrollingNodeID scrollingNodeID() const { return m_nodeID; }
 

--- a/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h
@@ -113,7 +113,7 @@ public:
     enum class CanMergeScrollData : bool { No, Yes };
     WEBCORE_EXPORT void setRequestedScrollData(RequestedScrollData&&, CanMergeScrollData = CanMergeScrollData::Yes);
 
-    WEBCORE_EXPORT bool hasScrollPositionRequest() const;
+    WEBCORE_EXPORT bool NODELETE hasScrollPositionRequest() const;
 
     bool isMonitoringWheelEvents() const { return m_isMonitoringWheelEvents; }
     WEBCORE_EXPORT void setIsMonitoringWheelEvents(bool);

--- a/Source/WebCore/page/scrolling/ScrollingStateTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateTree.h
@@ -52,7 +52,7 @@ public:
     WEBCORE_EXPORT ScrollingStateTree(ScrollingStateTree&&);
     WEBCORE_EXPORT ~ScrollingStateTree();
 
-    WEBCORE_EXPORT RefPtr<ScrollingStateFrameScrollingNode> rootStateNode() const;
+    WEBCORE_EXPORT RefPtr<ScrollingStateFrameScrollingNode> NODELETE rootStateNode() const;
     WEBCORE_EXPORT RefPtr<ScrollingStateNode> stateNodeForID(std::optional<ScrollingNodeID>) const;
 
     ScrollingNodeID createUnparentedNode(ScrollingNodeType, ScrollingNodeID);
@@ -100,7 +100,7 @@ public:
 private:
     ScrollingStateTree(bool hasNewRootStateNode, bool hasChangedProperties, RefPtr<ScrollingStateFrameScrollingNode>&&);
 
-    void setRootStateNode(Ref<ScrollingStateFrameScrollingNode>&&);
+    void NODELETE setRootStateNode(Ref<ScrollingStateFrameScrollingNode>&&);
     void addNode(ScrollingStateNode&);
 
     Ref<ScrollingStateNode> createNode(ScrollingNodeType, ScrollingNodeID);

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -98,8 +98,8 @@ public:
     WEBCORE_EXPORT virtual void setRubberBandingInProgressForNode(ScrollingNodeID, bool);
 
 #if HAVE(RUBBER_BANDING)
-    void setPendingMainFrameRubberbandingState(std::optional<RubberbandingState>&&) WTF_REQUIRES_LOCK(m_treeLock);
-    std::optional<RubberbandingState> takePendingMainFrameRubberbandingState() WTF_REQUIRES_LOCK(m_treeLock);
+    void NODELETE setPendingMainFrameRubberbandingState(std::optional<RubberbandingState>&&) WTF_REQUIRES_LOCK(m_treeLock);
+    std::optional<RubberbandingState> NODELETE takePendingMainFrameRubberbandingState() WTF_REQUIRES_LOCK(m_treeLock);
 #endif
 
     bool isUserScrollInProgressForNode(std::optional<ScrollingNodeID>);
@@ -315,11 +315,11 @@ private:
     void notifyRelatedNodesRecursive(ScrollingTreeNode&);
     void traverseScrollingTreeRecursive(ScrollingTreeNode&, NOESCAPE const VisitorFunction&) WTF_REQUIRES_LOCK(m_treeLock);
     
-    void setOverlayScrollbarsEnabled(bool);
+    void NODELETE setOverlayScrollbarsEnabled(bool);
     
     virtual void didCommitTree() { }
 
-    WEBCORE_EXPORT virtual RefPtr<ScrollingTreeNode> scrollingNodeForPoint(FloatPoint);
+    WEBCORE_EXPORT virtual RefPtr<ScrollingTreeNode> NODELETE scrollingNodeForPoint(FloatPoint);
 #if ENABLE(WHEEL_EVENT_REGIONS)
     WEBCORE_EXPORT virtual OptionSet<EventListenerRegionType> eventListenerRegionTypesForPoint(FloatPoint) const;
 #endif

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h
@@ -53,7 +53,7 @@ private:
     ScrollingTreeFrameHostingNode(ScrollingTree&, ScrollingNodeID);
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) final;
-    void applyLayerPositions() final;
+    void NODELETE applyLayerPositions() final;
 
     WEBCORE_EXPORT void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 

--- a/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h
@@ -46,7 +46,7 @@ public:
     
     bool visualViewportIsSmallerThanLayoutViewport() const { return m_visualViewportIsSmallerThanLayoutViewport; }
 
-    FloatSize viewToContentsOffset(const FloatPoint& scrollPosition) const;
+    FloatSize NODELETE viewToContentsOffset(const FloatPoint& scrollPosition) const;
 
     FloatRect layoutViewport() const { return m_layoutViewport; };
     void setLayoutViewport(const FloatRect& r) { m_layoutViewport = r; };
@@ -81,7 +81,7 @@ protected:
 
 private:
     void updateViewportForCurrentScrollPosition(std::optional<FloatRect>) override;
-    bool scrollPositionAndLayoutViewportMatch(const FloatPoint& position, std::optional<FloatRect> overrideLayoutViewport) override;
+    bool NODELETE scrollPositionAndLayoutViewportMatch(const FloatPoint& position, std::optional<FloatRect> overrideLayoutViewport) override;
     FloatRect layoutViewportForScrollPosition(const FloatPoint&, float scale, ScrollBehaviorForFixedElements = ScrollBehaviorForFixedElements::StickToDocumentBounds) const;
 
     void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;

--- a/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.h
@@ -44,7 +44,7 @@ private:
     ScrollingTreePluginHostingNode(ScrollingTree&, ScrollingNodeID);
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) final;
-    void applyLayerPositions() final;
+    void NODELETE applyLayerPositions() final;
 
     WEBCORE_EXPORT void dumpProperties(WTF::TextStream&, OptionSet<ScrollingStateTreeAsTextBehavior>) const override;
 };

--- a/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h
@@ -65,7 +65,7 @@ public:
 
     bool commitStateBeforeChildren(const ScrollingStateNode&) override;
     bool commitStateAfterChildren(const ScrollingStateNode&) override;
-    void didCompleteCommitForNode() final;
+    void NODELETE didCompleteCommitForNode() final;
 
     virtual bool canHandleWheelEvent(const PlatformWheelEvent&, EventTargeting) const;
     virtual WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting = EventTargeting::Propagate);

--- a/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.h
@@ -44,7 +44,7 @@ protected:
 
 private:
     WEBCORE_EXPORT void scheduleTreeStateCommit() final;
-    WEBCORE_EXPORT void didScheduleRenderingUpdate() final;
+    WEBCORE_EXPORT void NODELETE didScheduleRenderingUpdate() final;
     WEBCORE_EXPORT void willStartRenderingUpdate() final;
     WEBCORE_EXPORT void didCompleteRenderingUpdate() final;
 

--- a/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ThreadedScrollingTree.h
@@ -61,7 +61,7 @@ public:
 
     void displayDidRefresh(PlatformDisplayID) override;
 
-    void didScheduleRenderingUpdate();
+    void NODELETE didScheduleRenderingUpdate();
     void willStartRenderingUpdate();
     virtual void didCompleteRenderingUpdate();
 
@@ -109,14 +109,14 @@ private:
     void displayDidRefreshOnScrollingThread();
     void waitForRenderingUpdateCompletionOrTimeout() WTF_REQUIRES_LOCK(m_treeLock);
 
-    bool canUpdateLayersOnScrollingThread() const WTF_REQUIRES_LOCK(m_treeLock);
+    bool NODELETE canUpdateLayersOnScrollingThread() const WTF_REQUIRES_LOCK(m_treeLock);
 
     void scheduleDelayedRenderingUpdateDetectionTimer(Seconds) WTF_REQUIRES_LOCK(m_treeLock);
     void delayedRenderingUpdateDetectionTimerFired();
 
     void hasNodeWithAnimatedScrollChanged(bool) override;
 
-    bool isScrollingSynchronizedWithMainThread() final WTF_REQUIRES_LOCK(m_treeLock);
+    bool NODELETE isScrollingSynchronizedWithMainThread() final WTF_REQUIRES_LOCK(m_treeLock);
 
     void receivedWheelEventWithPhases(PlatformWheelEventPhase, PlatformWheelEventPhase) final;
     void deferWheelEventTestCompletionForReason(ScrollingNodeID, WheelEventTestMonitor::DeferReason) final;

--- a/Source/WebCore/page/scrolling/cocoa/ScrollingStateNode.mm
+++ b/Source/WebCore/page/scrolling/cocoa/ScrollingStateNode.mm
@@ -42,12 +42,12 @@ void LayerRepresentation::releasePlatformLayer(void* typelessLayer)
         CFRelease(typelessLayer);
 }
 
-CALayer *LayerRepresentation::makePlatformLayerTyped(void* typelessLayer)
+CALayer *NODELETE LayerRepresentation::makePlatformLayerTyped(void* typelessLayer)
 {
     return (__bridge CALayer *)typelessLayer;
 }
 
-void* LayerRepresentation::makePlatformLayerTypeless(CALayer *layer)
+void* NODELETE LayerRepresentation::makePlatformLayerTypeless(CALayer *layer)
 {
     return (__bridge void*)layer;
 }

--- a/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollerPairMac.h
@@ -76,8 +76,8 @@ public:
     void updateValues();
 
     FloatSize visibleSize() const;
-    bool useDarkAppearance() const;
-    ScrollbarWidth scrollbarWidthStyle() const;
+    bool NODELETE useDarkAppearance() const;
+    ScrollbarWidth NODELETE scrollbarWidthStyle() const;
 
     struct Values {
         float value;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h
@@ -70,7 +70,7 @@ protected:
     unsigned exposedUnfilledArea() const;
 
 private:
-    ScrollingTreeScrollingNodeDelegateMac& delegate() const;
+    ScrollingTreeScrollingNodeDelegateMac& NODELETE delegate() const;
 
     void willBeDestroyed() final;
     void willDoProgrammaticScroll(const FloatPoint&) final;

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h
@@ -55,7 +55,7 @@ protected:
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
 
 private:
-    ScrollingTreeScrollingNodeDelegateMac& delegate() const;
+    ScrollingTreeScrollingNodeDelegateMac& NODELETE delegate() const;
 
     void willBeDestroyed() final;
 };

--- a/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h
+++ b/Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h
@@ -55,7 +55,7 @@ protected:
     WheelEventHandlingResult handleWheelEvent(const PlatformWheelEvent&, EventTargeting) override;
 
 private:
-    ScrollingTreeScrollingNodeDelegateMac& delegate() const;
+    ScrollingTreeScrollingNodeDelegateMac& NODELETE delegate() const;
 
     void willBeDestroyed() final;
 };

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -134,7 +134,7 @@ using TextNodesAndText = Vector<std::pair<Ref<Text>, String>>;
 using TextAndSelectedRange = std::pair<String, std::optional<CharacterRange>>;
 using TextAndSelectedRangeMap = HashMap<Ref<Text>, TextAndSelectedRange>;
 
-static bool hasEnclosingAutoFilledInput(Node& node)
+static bool NODELETE hasEnclosingAutoFilledInput(Node& node)
 {
     RefPtr input = dynamicDowncast<HTMLInputElement>(node.shadowHost());
     if (!input)
@@ -270,7 +270,7 @@ struct TraversalContext {
         return enclosingBlockNumberMap.get(*enclosingBlocks.last());
     }
 
-    void popEnclosingBlock()
+    void NODELETE popEnclosingBlock()
     {
         enclosingBlocks.removeLast();
     }
@@ -456,7 +456,7 @@ enum class SkipExtraction : bool {
     SelfAndSubtree
 };
 
-static bool shouldTreatAsPasswordField(const Element* element)
+static bool NODELETE shouldTreatAsPasswordField(const Element* element)
 {
     RefPtr input = dynamicDowncast<HTMLInputElement>(element);
     return input && input->hasEverBeenPasswordField();
@@ -1272,7 +1272,7 @@ struct TokenAndBlockOffset {
     int offset { 0 };
 };
 
-static IntSize reducePrecision(FloatSize size)
+static IntSize NODELETE reducePrecision(FloatSize size)
 {
     static constexpr auto resolution = 10;
     return {

--- a/Source/WebCore/page/writing-tools/WritingToolsController.mm
+++ b/Source/WebCore/page/writing-tools/WritingToolsController.mm
@@ -114,7 +114,7 @@ String WritingToolsController::plainText(const SimpleRange& range)
 
 #pragma mark - Static utility helper methods.
 
-static bool isZeroToOneCompositionType(WritingTools::Session::CompositionType type)
+static bool NODELETE isZeroToOneCompositionType(WritingTools::Session::CompositionType type)
 {
     switch (type) {
     case WritingTools::Session::CompositionType::Compose:


### PR DESCRIPTION
#### 571b702bf28b18bf34c0f9129b9db06796168e9a
<pre>
Adopt `NODELETE` annotation in more places in Source/WebCore/page
<a href="https://bugs.webkit.org/show_bug.cgi?id=308201">https://bugs.webkit.org/show_bug.cgi?id=308201</a>

Reviewed by Darin Adler.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/page/AutoscrollController.h:
* Source/WebCore/page/CaptionUserPreferences.h:
* Source/WebCore/page/CaptionUserPreferencesMediaAF.cpp:
(WebCore::cachedCaptionDisplayMode):
(WebCore::cachedPreferredLanguages):
* Source/WebCore/page/CaptionUserPreferencesMediaAF.h:
* Source/WebCore/page/Chrome.h:
* Source/WebCore/page/ChromeClient.h:
* Source/WebCore/page/DOMTimer.cpp:
(WebCore::DOMTimerFireState::contextDocument const):
(WebCore::DOMTimerFireState::setScriptMadeUserObservableChanges):
(WebCore::DOMTimerFireState::setScriptMadeNonUserObservableChanges):
(WebCore::DOMTimerFireState::scriptMadeNonUserObservableChanges const):
(WebCore::DOMTimerFireState::scriptMadeUserObservableChanges const):
(WebCore::NestedTimersMap::instanceForContext):
(WebCore::NestedTimersMap::instance):
* Source/WebCore/page/DOMTimer.h:
* Source/WebCore/page/DOMWindow.h:
* Source/WebCore/page/DOMWindowExtension.h:
* Source/WebCore/page/DebugPageOverlays.cpp:
(WebCore::RegionOverlay::overlay):
(WebCore::RegionOverlay::setRegionChanged):
(WebCore::MouseWheelRegionOverlay::updateRegion):
(WebCore::InteractionRegionOverlay::activeRegion const):
(WebCore::RegionOverlay::didMoveToPage):
(WebCore::RegionOverlay::mouseEvent):
(WebCore::RegionOverlay::didScrollFrame):
(WebCore::indexOf):
* Source/WebCore/page/DebugPageOverlays.h:
* Source/WebCore/page/DeviceController.h:
* Source/WebCore/page/DragController.cpp:
(WebCore::dragIsHandledByDocument):
(WebCore::enclosingAttachmentElement):
(WebCore::getCachedImage):
(WebCore::dragLocForDHTMLDrag):
* Source/WebCore/page/DragController.h:
* Source/WebCore/page/ElementTargetingController.cpp:
(WebCore::linearlyInterpolatedViewportRatio):
(WebCore::maximumAreaRatioForAbsolutelyPositionedContent):
(WebCore::maximumAreaRatioForInFlowContent):
(WebCore::maximumAreaRatioForNearbyTargets):
(WebCore::minimumAreaRatioForInFlowContent):
(WebCore::maximumAreaRatioForTrackingAdjustmentAreas):
(WebCore::shortestSelector):
(WebCore::computeOffsetEdges):
(WebCore::shouldIgnoreExistingVisibilityAdjustments):
(WebCore::adjustmentToApply):
* Source/WebCore/page/ElementTargetingController.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::userGestureTypeForPlatformEvent):
(WebCore::wheelGranularityToScrollGranularity):
(WebCore::shouldRefetchEventTarget):
(WebCore::mousePositionSource):
(WebCore::contentFrameForNode):
(WebCore::widgetForElement):
* Source/WebCore/page/EventHandler.h:
* Source/WebCore/page/EventSource.h:
* Source/WebCore/page/FocusController.cpp:
(WebCore::invokerForOpenPopover):
(WebCore::FocusNavigationScope::owner const):
(WebCore::shouldClearSelectionWhenChangingFocusedElement):
* Source/WebCore/page/FocusController.h:
* Source/WebCore/page/Frame.cpp:
(WebCore::Frame::ownerRenderer const):
* Source/WebCore/page/Frame.h:
* Source/WebCore/page/FrameConsoleClient.h:
* Source/WebCore/page/FrameDestructionObserver.h:
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::setSpecifiedName):
(WebCore::FrameTree::clearName):
(WebCore::FrameTree::childCount const):
(WebCore::isFrameFamiliarWith):
(WebCore::FrameTree::isDescendantOf const):
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/History.h:
* Source/WebCore/page/ImageOverlayController.h:
* Source/WebCore/page/IntersectionObserver.h:
* Source/WebCore/page/LargestContentfulPaint.h:
* Source/WebCore/page/LargestContentfulPaintData.h:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::transientActivationDurationOverrideForTesting):
(WebCore::windowsWithUnloadEventListeners):
(WebCore::windowsWithBeforeUnloadEventListeners):
(WebCore::allowsBeforeUnloadListeners):
* Source/WebCore/page/LocalDOMWindow.h:
* Source/WebCore/page/LocalFrame.cpp:
(WebCore::parentPageZoomFactor):
(WebCore::parentTextZoomFactor):
(WebCore::rootFrame):
(WebCore::LocalFrame::contentRenderer const):
* Source/WebCore/page/LocalFrame.h:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::adjustScrollRectToVisibleOptionsForHiddenOverflow):
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.h:
* Source/WebCore/page/Location.h:
* Source/WebCore/page/NavigateEvent.h:
* Source/WebCore/page/Navigation.cpp:
(WebCore::getEntryIndexOfHistoryItem):
* Source/WebCore/page/Navigation.h:
* Source/WebCore/page/NavigationHistoryEntry.h:
* Source/WebCore/page/Navigator.h:
* Source/WebCore/page/NavigatorBase.h:
* Source/WebCore/page/NavigatorUAData.h:
* Source/WebCore/page/OriginAccessPatterns.cpp:
(WebCore::WTF_REQUIRES_LOCK):
* Source/WebCore/page/OriginAccessPatterns.h:
* Source/WebCore/page/Page.cpp:
(WebCore::allPages):
(WebCore::Page::nonUtilityPageCount):
(WebCore::Page::setConsoleMessageListenerForTesting):
(WebCore::Page::consoleMessageListenerForTesting const):
(WebCore::Page::setMainFrameURLFragment):
(WebCore::Page::setOpenedByDOM):
(WebCore::Page::setBroadcastChannelRegistry):
(WebCore::incrementFrame):
(WebCore::Page::inLowQualityImageInterpolationMode const):
(WebCore::Page::setInLowQualityImageInterpolationMode):
(WebCore::Page::setDelegatesScaling):
(WebCore::Page::setInitialScaleIgnoringContentSize):
(WebCore::Page::setHorizontalScrollElasticity):
(WebCore::Page::startTrackingRenderingUpdates):
(WebCore::Page::renderingUpdateCount const):
(WebCore::Page::isVisibleAndActive const):
(WebCore::Page::visibilityState const):
(WebCore::Page::addLayoutMilestones):
(WebCore::Page::removeLayoutMilestones):
(WebCore::Page::setAppUsesCustomAccentColor):
(WebCore::Page::appUsesCustomAccentColor const):
(WebCore::Page::hasSeenAnyPlugin const):
(WebCore::Page::protectedUserContentProviderForFrame):
(WebCore::Page::sessionID const):
(WebCore::Page::wheelEventTestMonitor const):
(WebCore::Page::isMonitoringWheelEvents const):
(WebCore::Page::applicationDidEnterBackground):
(WebCore::Page::applicationWillEnterForeground):
(WebCore::Page::hasCachedTextRecognitionResult const):
(WebCore::Page::setPortsForUpgradingInsecureSchemeForTesting):
(WebCore::Page::isDocumentFullscreenEnabled const):
(WebCore::Page::startDeferringResizeEvents):
(WebCore::Page::startDeferringScrollEvents):
(WebCore::Page::startDeferringIntersectionObservations):
(WebCore::Page::isAlwaysOnLoggingAllowed const):
(WebCore::Page::protectedInspectorController):
(WebCore::Page::setPresentingApplicationAuditToken):
(WebCore::mediaSessionManagerSingleton):
* Source/WebCore/page/Page.h:
* Source/WebCore/page/PageGroup.cpp:
(WebCore::getUniqueIdentifier):
(WebCore::pageGroups):
* Source/WebCore/page/PageOverlay.cpp:
(WebCore::generatePageOverlayID):
* Source/WebCore/page/PageOverlay.h:
* Source/WebCore/page/PageOverlayController.h:
* Source/WebCore/page/PageSerializer.cpp:
(WebCore::frameOwnerURLAttributeName):
* Source/WebCore/page/Performance.h:
* Source/WebCore/page/PerformanceEventTiming.h:
* Source/WebCore/page/PerformanceMonitor.cpp:
(WebCore::activityStateForCPUSampling):
* Source/WebCore/page/PerformanceMonitor.h:
* Source/WebCore/page/PerformanceNavigationTiming.cpp:
(WebCore::toPerformanceNavigationTimingNavigationType):
* Source/WebCore/page/PerformanceNavigationTiming.h:
* Source/WebCore/page/PerformanceResourceTiming.h:
* Source/WebCore/page/PerformanceUserTiming.cpp:
(WebCore::isEmptyDictionary):
* Source/WebCore/page/PointerLockController.h:
* Source/WebCore/page/PrintContext.cpp:
(WebCore::enclosingBoxModelObject):
* Source/WebCore/page/Quirks.cpp:
(WebCore::updatableStorageAccessUserAgentStringQuirks):
(WebCore::needsDesktopUserAgentInternal):
(WebCore::shouldPreventOrientationMediaQueryFromEvaluatingToLandscapeInternal):
(WebCore::shouldNotAutoUpgradeToHTTPSNavigationInternal):
(WebCore::shouldDisableBlobFileAccessEnforcementInternal):
(WebCore::needsConsistentQueryParameterFilteringInternal):
(WebCore::standardUserAgentWithApplicationNameIncludingCompatOverridesInternal):
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/RemoteDOMWindow.h:
* Source/WebCore/page/RemoteFrame.h:
* Source/WebCore/page/RemoteFrameView.h:
* Source/WebCore/page/RenderingUpdateScheduler.h:
* Source/WebCore/page/ResizeObservation.h:
* Source/WebCore/page/ResizeObserver.h:
* Source/WebCore/page/ScreenOrientation.cpp:
(WebCore::isSupportedLockType):
* Source/WebCore/page/ScreenOrientation.h:
* Source/WebCore/page/ScriptTrackingPrivacyCategory.h:
* Source/WebCore/page/SecurityOrigin.h:
* Source/WebCore/page/SecurityPolicy.cpp:
(WebCore::WTF_REQUIRES_LOCK):
* Source/WebCore/page/SecurityPolicy.h:
* Source/WebCore/page/SpatialNavigation.cpp:
(WebCore::isHorizontalMove):
(WebCore::start):
(WebCore::middle):
(WebCore::end):
* Source/WebCore/page/SpatialNavigation.h:
* Source/WebCore/page/TextIndicator.h:
* Source/WebCore/page/UserAgentStringParser.h:
* Source/WebCore/page/UserContentController.h:
* Source/WebCore/page/UserContentProvider.cpp:
(WebCore::mainDocumentLoader):
* Source/WebCore/page/UserContentURLPattern.cpp:
(WebCore::MatchTester::testStringFinished const):
(WebCore::MatchTester::patternStringFinished const):
(WebCore::MatchTester::eatWildcard):
(WebCore::MatchTester::eatSameChars):
(WebCore::MatchTester::test):
* Source/WebCore/page/UserMessageHandlerDescriptor.h:
* Source/WebCore/page/UserMessageHandlersNamespace.h:
* Source/WebCore/page/ViewportConfiguration.cpp:
(WebCore::viewportArgumentValueIsValid):
(WebCore::ignoreViewportArgumentsToAvoidEnlargedView):
(WebCore::platformDeviceWidthOverride):
(WebCore::platformMinimumScaleForWebpage):
(WebCore::shouldOverrideShrinkToFitArgument):
(WebCore::needsUpdateAfterChangingDisabledAdaptations):
(WebCore::booleanViewportArgumentIsSet):
* Source/WebCore/page/ViewportConfiguration.h:
* Source/WebCore/page/VisualViewport.h:
* Source/WebCore/page/WebKitBufferNamespace.h:
* Source/WebCore/page/WebKitJSHandle.cpp:
(WebCore::handleMap):
* Source/WebCore/page/WebKitNamespace.h:
* Source/WebCore/page/WheelEventDeltaFilter.cpp:
(WebCore::deltaIsPredominantlyVertical):
* Source/WebCore/page/WheelEventDeltaFilter.h:
* Source/WebCore/page/WindowFeatures.cpp:
(WebCore::isSeparator):
* Source/WebCore/page/WindowFocusAllowedIndicator.h:
* Source/WebCore/page/WorkerNavigator.h:
* Source/WebCore/page/cocoa/PageCocoa.mm:
(WebCore::Page::presentingApplicationBundleIdentifier const):
* Source/WebCore/page/cocoa/ResourceUsageOverlayCocoa.mm:
(WebCore::RingBuffer::last):
(WebCore::RingBuffer::incrementIndex):
(WebCore::RingBuffer::decrementIndex):
* Source/WebCore/page/cocoa/ResourceUsageThreadCocoa.mm:
(WebCore::categoryForVMTag):
* Source/WebCore/page/cocoa/SettingsBaseCocoa.mm:
(WebCore::SettingsBase::platformDefaultMediaSourceEnabled):
(WebCore::SettingsBase::defaultMaximumSourceBufferSize):
* Source/WebCore/page/cocoa/WebTextIndicatorLayer.mm:
(indicatorWantsFadeIn):
* Source/WebCore/page/csp/ContentSecurityPolicy.cpp:
(WebCore::reportingClientForContext):
* Source/WebCore/page/csp/ContentSecurityPolicy.h:
* Source/WebCore/page/csp/ContentSecurityPolicyDirective.h:
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.cpp:
(WebCore::checkEval):
(WebCore::checkTrustedEval):
(WebCore::checkWasmEval):
(WebCore::checkInline):
(WebCore::checkNonParserInsertedScripts):
* Source/WebCore/page/csp/ContentSecurityPolicyDirectiveList.h:
* Source/WebCore/page/csp/ContentSecurityPolicySource.h:
* Source/WebCore/page/mac/CorrectionIndicator.h:
* Source/WebCore/page/mac/DragControllerMac.mm:
(WebCore::DragController::isCopyKeyDown):
(WebCore::DragController::maxDragImageSize):
* Source/WebCore/page/mac/EventHandlerMac.mm:
(WebCore::nsScrollViewScrollWheelShouldRetainSelf):
(WebCore::EventHandler::eventActivatedView const):
(WebCore::EventHandler::needsKeyboardEventDisambiguationQuirks const):
(WebCore::scrollableAreaForBox):
* Source/WebCore/page/mac/ImageOverlayControllerMac.mm:
(WebCore::ImageOverlayController::hasActiveDataDetectorHighlightForTesting const):
* Source/WebCore/page/mac/ServicesOverlayController.h:
* Source/WebCore/page/scrolling/AsyncScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollAnchoringController.cpp:
(WebCore::overflowAnchorProhibitsAnchoring):
* Source/WebCore/page/scrolling/ScrollAnchoringController.h:
* Source/WebCore/page/scrolling/ScrollLatchingController.cpp:
(WebCore::deltaIsPredominantlyVertical):
* Source/WebCore/page/scrolling/ScrollLatchingController.h:
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.cpp:
(WebCore::computeScrollSnapAlignOffset):
(WebCore::convertOffsetUnit):
* Source/WebCore/page/scrolling/ScrollSnapOffsetsInfo.h:
* Source/WebCore/page/scrolling/ScrollingConstraints.h:
* Source/WebCore/page/scrolling/ScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ScrollingStateFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateNode.h:
* Source/WebCore/page/scrolling/ScrollingStateScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingStateTree.h:
* Source/WebCore/page/scrolling/ScrollingTree.h:
* Source/WebCore/page/scrolling/ScrollingTreeFrameHostingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeFrameScrollingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreePluginHostingNode.h:
* Source/WebCore/page/scrolling/ScrollingTreeScrollingNode.h:
* Source/WebCore/page/scrolling/ThreadedScrollingCoordinator.h:
* Source/WebCore/page/scrolling/ThreadedScrollingTree.h:
* Source/WebCore/page/scrolling/cocoa/ScrollingStateNode.mm:
(WebCore::LayerRepresentation::makePlatformLayerTyped):
(WebCore::LayerRepresentation::makePlatformLayerTypeless):
* Source/WebCore/page/scrolling/mac/ScrollerPairMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeFrameScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreeOverflowScrollingNodeMac.h:
* Source/WebCore/page/scrolling/mac/ScrollingTreePluginScrollingNodeMac.h:
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::hasEnclosingAutoFilledInput):
(WebCore::TextExtraction::TraversalContext::popEnclosingBlock):
(WebCore::TextExtraction::shouldTreatAsPasswordField):
(WebCore::TextExtraction::reducePrecision):
* Source/WebCore/page/writing-tools/WritingToolsController.mm:
(WebCore::isZeroToOneCompositionType):

Canonical link: <a href="https://commits.webkit.org/307881@main">https://commits.webkit.org/307881@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/950a4ffb590d697c384e6b529f947cf904c98135

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18507 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10509 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154495 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d280149e-2814-4ba6-8161-a8f884e1e447) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147691 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112151 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99412 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148779 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14527 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/130988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93056 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5313760-3a1c-484d-96f0-6663903db632) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11588 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1942 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123380 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156808 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/70 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120156 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18353 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15323 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120501 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30887 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74091 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16223 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/7249 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17973 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81759 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17711 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17915 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17769 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->