### PR TITLE
Adopt `NODELETE` annotation in more places in Source/WebCore/loader & Source/WebCore/history

### DIFF
--- a/Source/WebCore/history/CachedFrame.h
+++ b/Source/WebCore/history/CachedFrame.h
@@ -71,7 +71,7 @@ protected:
     Vector<UniqueRef<CachedFrame>> m_childFrames;
 
 private:
-    void initializeWithLocalFrame(LocalFrame&);
+    void NODELETE initializeWithLocalFrame(LocalFrame&);
 };
 
 class CachedFrame : private CachedFrameBase {
@@ -87,15 +87,15 @@ public:
     WEBCORE_EXPORT CachedFramePlatformData* NODELETE cachedFramePlatformData();
 
     HasInsecureContent hasInsecureContent() const;
-    UsedLegacyTLS usedLegacyTLS() const;
-    WasPrivateRelayed wasPrivateRelayed() const;
+    UsedLegacyTLS NODELETE usedLegacyTLS() const;
+    WasPrivateRelayed NODELETE wasPrivateRelayed() const;
 
     using CachedFrameBase::document;
     using CachedFrameBase::view;
     using CachedFrameBase::url;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
 
-    size_t descendantFrameCount() const;
+    size_t NODELETE descendantFrameCount() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/history/HistoryItem.h
+++ b/Source/WebCore/history/HistoryItem.h
@@ -105,31 +105,31 @@ public:
     WEBCORE_EXPORT URL url() const;
     WEBCORE_EXPORT URL originalURL() const;
     WEBCORE_EXPORT const String& NODELETE referrer() const;
-    WEBCORE_EXPORT const AtomString& target() const;
+    WEBCORE_EXPORT const AtomString& NODELETE target() const;
     std::optional<FrameIdentifier> frameID() const { return m_frameID; }
     bool isTargetItem() const { return m_isTargetItem; }
     
     WEBCORE_EXPORT FormData* NODELETE formData();
-    WEBCORE_EXPORT String formContentType() const;
+    WEBCORE_EXPORT String NODELETE formContentType() const;
     
     bool lastVisitWasFailure() const { return m_lastVisitWasFailure; }
 
-    WEBCORE_EXPORT const IntPoint& scrollPosition() const;
-    WEBCORE_EXPORT void setScrollPosition(const IntPoint&);
-    void clearScrollPosition();
+    WEBCORE_EXPORT const IntPoint& NODELETE scrollPosition() const;
+    WEBCORE_EXPORT void NODELETE setScrollPosition(const IntPoint&);
+    void NODELETE clearScrollPosition();
 
-    WEBCORE_EXPORT bool shouldRestoreScrollPosition() const;
+    WEBCORE_EXPORT bool NODELETE shouldRestoreScrollPosition() const;
     WEBCORE_EXPORT void setShouldRestoreScrollPosition(bool);
     
-    WEBCORE_EXPORT float pageScaleFactor() const;
-    WEBCORE_EXPORT void setPageScaleFactor(float);
+    WEBCORE_EXPORT float NODELETE pageScaleFactor() const;
+    WEBCORE_EXPORT void NODELETE setPageScaleFactor(float);
     
-    WEBCORE_EXPORT const Vector<AtomString>& documentState() const;
+    WEBCORE_EXPORT const Vector<AtomString>& NODELETE documentState() const;
     WEBCORE_EXPORT void setDocumentState(const Vector<AtomString>&);
     void clearDocumentState();
 
-    WEBCORE_EXPORT void setShouldOpenExternalURLsPolicy(ShouldOpenExternalURLsPolicy);
-    WEBCORE_EXPORT ShouldOpenExternalURLsPolicy shouldOpenExternalURLsPolicy() const;
+    WEBCORE_EXPORT void NODELETE setShouldOpenExternalURLsPolicy(ShouldOpenExternalURLsPolicy);
+    WEBCORE_EXPORT ShouldOpenExternalURLsPolicy NODELETE shouldOpenExternalURLsPolicy() const;
 
     void setURL(const URL&);
     WEBCORE_EXPORT void setURLString(const String&);
@@ -144,7 +144,7 @@ public:
     WEBCORE_EXPORT void setStateObject(RefPtr<SerializedScriptValue>&&);
     SerializedScriptValue* stateObject() const { return m_stateObject.get(); }
 
-    void setNavigationAPIStateObject(RefPtr<SerializedScriptValue>&&);
+    void NODELETE setNavigationAPIStateObject(RefPtr<SerializedScriptValue>&&);
     SerializedScriptValue* navigationAPIStateObject() const { return m_navigationAPIStateObject.get(); }
 
     void setItemSequenceNumber(long long number) { m_itemSequenceNumber = number; }
@@ -154,20 +154,20 @@ public:
     long long documentSequenceNumber() const { return m_documentSequenceNumber; }
 
     void setFormInfoFromRequest(const ResourceRequest&);
-    WEBCORE_EXPORT void setFormData(RefPtr<FormData>&&);
-    WEBCORE_EXPORT void setFormContentType(const String&);
+    WEBCORE_EXPORT void NODELETE setFormData(RefPtr<FormData>&&);
+    WEBCORE_EXPORT void NODELETE setFormContentType(const String&);
 
     void setLastVisitWasFailure(bool wasFailure) { m_lastVisitWasFailure = wasFailure; }
 
     WEBCORE_EXPORT void addChildItem(Ref<HistoryItem>&&);
     void setChildItem(Ref<HistoryItem>&&);
-    WEBCORE_EXPORT HistoryItem* childItemWithTarget(const AtomString&);
-    WEBCORE_EXPORT HistoryItem* childItemWithFrameID(FrameIdentifier);
-    HistoryItem* childItemWithDocumentSequenceNumber(long long number);
-    WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& children() const;
+    WEBCORE_EXPORT HistoryItem* NODELETE childItemWithTarget(const AtomString&);
+    WEBCORE_EXPORT HistoryItem* NODELETE childItemWithFrameID(FrameIdentifier);
+    HistoryItem* NODELETE childItemWithDocumentSequenceNumber(long long number);
+    WEBCORE_EXPORT const Vector<Ref<HistoryItem>>& NODELETE children() const;
     void clearChildren();
 
-    bool shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const;
+    bool NODELETE shouldDoSameDocumentNavigationTo(HistoryItem& otherItem) const;
 
     bool isCurrentDocument(Document&) const;
     

--- a/Source/WebCore/history/mac/HistoryItemMac.mm
+++ b/Source/WebCore/history/mac/HistoryItemMac.mm
@@ -30,7 +30,7 @@
 
 namespace WebCore {
 
-id HistoryItem::viewState() const
+id NODELETE HistoryItem::viewState() const
 {
     return m_viewState.get();
 }

--- a/Source/WebCore/loader/ContentFilter.h
+++ b/Source/WebCore/loader/ContentFilter.h
@@ -58,7 +58,7 @@ public:
 
     static constexpr ASCIILiteral urlScheme() { return "x-apple-content-filter"_s; }
 
-    WEBCORE_EXPORT void startFilteringMainResource(const URL&);
+    WEBCORE_EXPORT void NODELETE startFilteringMainResource(const URL&);
     void startFilteringMainResource(CachedRawResource&);
     WEBCORE_EXPORT void stopFilteringMainResource();
 
@@ -82,7 +82,7 @@ public:
     WEBCORE_EXPORT static const URL& blockedPageURL();
 
 #if HAVE(AUDIT_TOKEN)
-    WEBCORE_EXPORT void setHostProcessAuditToken(const std::optional<audit_token_t>&);
+    WEBCORE_EXPORT void NODELETE setHostProcessAuditToken(const std::optional<audit_token_t>&);
 #endif
 
 #if HAVE(WEBCONTENTRESTRICTIONS)

--- a/Source/WebCore/loader/CookieJar.cpp
+++ b/Source/WebCore/loader/CookieJar.cpp
@@ -47,7 +47,7 @@
 
 namespace WebCore {
 
-static ShouldRelaxThirdPartyCookieBlocking shouldRelaxThirdPartyCookieBlocking(const Document& document)
+static ShouldRelaxThirdPartyCookieBlocking NODELETE shouldRelaxThirdPartyCookieBlocking(const Document& document)
 {
     if (RefPtr page = document.page())
         return page->shouldRelaxThirdPartyCookieBlocking();

--- a/Source/WebCore/loader/CrossOriginAccessControl.h
+++ b/Source/WebCore/loader/CrossOriginAccessControl.h
@@ -81,8 +81,8 @@ class WEBCORE_EXPORT CrossOriginAccessControlCheckDisabler {
 public:
     static CrossOriginAccessControlCheckDisabler& singleton();
     virtual ~CrossOriginAccessControlCheckDisabler() = default;
-    void setCrossOriginAccessControlCheckEnabled(bool);
-    virtual bool crossOriginAccessControlCheckEnabled() const;
+    void NODELETE setCrossOriginAccessControlCheckEnabled(bool);
+    virtual bool NODELETE crossOriginAccessControlCheckEnabled() const;
 private:
     bool m_accessControlCheckEnabled { true };
 };

--- a/Source/WebCore/loader/CrossOriginPreflightResultCache.h
+++ b/Source/WebCore/loader/CrossOriginPreflightResultCache.h
@@ -68,7 +68,7 @@ private:
 class CrossOriginPreflightResultCache {
     WTF_MAKE_NONCOPYABLE(CrossOriginPreflightResultCache); WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(CrossOriginPreflightResultCache, Loader);
 public:
-    WEBCORE_EXPORT static CrossOriginPreflightResultCache& singleton();
+    WEBCORE_EXPORT static CrossOriginPreflightResultCache& NODELETE singleton();
     WEBCORE_EXPORT void appendEntry(PAL::SessionID, const ClientOrigin&, const URL&, std::unique_ptr<CrossOriginPreflightResultCacheItem>);
     WEBCORE_EXPORT bool canSkipPreflight(PAL::SessionID, const ClientOrigin&, const URL&, StoredCredentialsPolicy, const String& method, const HTTPHeaderMap& requestHeaders);
     WEBCORE_EXPORT void clear();

--- a/Source/WebCore/loader/DefaultResourceLoadPriority.h
+++ b/Source/WebCore/loader/DefaultResourceLoadPriority.h
@@ -30,7 +30,7 @@
 namespace WebCore {
 
 struct DefaultResourceLoadPriority {
-    static ResourceLoadPriority forResourceType(CachedResource::Type);
+    static ResourceLoadPriority NODELETE forResourceType(CachedResource::Type);
 
     static constexpr auto asyncScript = ResourceLoadPriority::Medium;
     static constexpr auto inactiveStyleSheet = ResourceLoadPriority::VeryLow;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -148,7 +148,7 @@
 namespace WebCore {
 
 #if ENABLE(CONTENT_FILTERING)
-static bool& contentFilterInDocumentLoader()
+static bool& NODELETE contentFilterInDocumentLoader()
 {
     static bool filter = false;
     RELEASE_ASSERT(isMainThread());
@@ -168,7 +168,7 @@ static void setAllDefersLoading(const ResourceLoaderMap& loaders, bool defers)
         loader->setDefersLoading(defers);
 }
 
-static HashMap<ScriptExecutionContextIdentifier, SingleThreadWeakPtr<DocumentLoader>>& scriptExecutionContextIdentifierToLoaderMap()
+static HashMap<ScriptExecutionContextIdentifier, SingleThreadWeakPtr<DocumentLoader>>& NODELETE scriptExecutionContextIdentifierToLoaderMap()
 {
     static MainThreadNeverDestroyed<HashMap<ScriptExecutionContextIdentifier, SingleThreadWeakPtr<DocumentLoader>>> map;
     return map.get();
@@ -1249,7 +1249,7 @@ static inline bool shouldUseActiveServiceWorkerFromParent(const Document& docume
 }
 
 #if ENABLE(CONTENT_EXTENSIONS)
-static inline bool shouldEnableResourceMonitor(const Frame& frame)
+static inline bool NODELETE shouldEnableResourceMonitor(const Frame& frame)
 {
     if (frame.isMainFrame())
         return false;
@@ -1494,7 +1494,7 @@ void DocumentLoader::applyPoliciesToSettings()
         m_frame->settings().setInlineMediaPlaybackRequiresPlaysInlineAttribute(m_inlineMediaPlaybackPolicy == InlineMediaPlaybackPolicy::RequiresPlaysInlineAttribute);
 }
 
-ColorSchemePreference DocumentLoader::colorSchemePreference() const
+ColorSchemePreference NODELETE DocumentLoader::colorSchemePreference() const
 {
     return m_colorSchemePreference;
 }

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -213,8 +213,8 @@ public:
 
     WEBCORE_EXPORT virtual void detachFromFrame(LoadWillContinueInAnotherProcess);
 
-    WEBCORE_EXPORT FrameLoader* frameLoader() const;
-    WEBCORE_EXPORT SubresourceLoader* mainResourceLoader() const;
+    WEBCORE_EXPORT FrameLoader* NODELETE frameLoader() const;
+    WEBCORE_EXPORT SubresourceLoader* NODELETE mainResourceLoader() const;
     WEBCORE_EXPORT RefPtr<FragmentedSharedBuffer> mainResourceData() const;
     
     DocumentWriter& writer() const { return m_writer; }
@@ -245,7 +245,7 @@ public:
     void stopLoading();
     void setCommitted(bool committed) { m_committed = committed; }
     bool isCommitted() const { return m_committed; }
-    WEBCORE_EXPORT bool isLoading() const;
+    WEBCORE_EXPORT bool NODELETE isLoading() const;
 
     const ResourceError& mainDocumentError() const { return m_mainDocumentError; }
 
@@ -259,7 +259,7 @@ public:
 
     bool isClientRedirect() const { return m_isClientRedirect; }
     void setIsClientRedirect(bool isClientRedirect) { m_isClientRedirect = isClientRedirect; }
-    void dispatchOnloadEvents();
+    void NODELETE dispatchOnloadEvents();
     bool wasOnloadDispatched() { return m_wasOnloadDispatched; }
     WEBCORE_EXPORT bool isLoadingInAPISense() const;
     WEBCORE_EXPORT void setTitle(const StringWithDirection&);
@@ -412,7 +412,7 @@ public:
     void setColorSchemePreference(ColorSchemePreference preference) { m_colorSchemePreference = preference; }
 
     HTTPSByDefaultMode httpsByDefaultMode() { return m_httpsByDefaultMode; }
-    WEBCORE_EXPORT void setHTTPSByDefaultMode(HTTPSByDefaultMode);
+    WEBCORE_EXPORT void NODELETE setHTTPSByDefaultMode(HTTPSByDefaultMode);
 
     PushAndNotificationsEnabledPolicy pushAndNotificationsEnabledPolicy() const { return m_pushAndNotificationsEnabledPolicy; }
     void setPushAndNotificationsEnabledPolicy(PushAndNotificationsEnabledPolicy policy) { m_pushAndNotificationsEnabledPolicy = policy; }
@@ -425,7 +425,7 @@ public:
         String overrideReferrerForAllRequests;
     };
     const WebpagePreferences& preferences() const { return m_preferences; }
-    WEBCORE_EXPORT void setPreferences(WebpagePreferences&&);
+    WEBCORE_EXPORT void NODELETE setPreferences(WebpagePreferences&&);
 
     void addSubresourceLoader(SubresourceLoader&);
     void removeSubresourceLoader(LoadCompletionType, SubresourceLoader&);
@@ -540,7 +540,7 @@ public:
 #endif
 
     std::optional<NavigationIdentifier> navigationID() const { return m_navigationID.asOptional(); }
-    WEBCORE_EXPORT void setNavigationID(NavigationIdentifier);
+    WEBCORE_EXPORT void NODELETE setNavigationID(NavigationIdentifier);
 
     bool isInitialAboutBlank() const { return m_isInitialAboutBlank; }
 
@@ -559,7 +559,7 @@ protected:
     WEBCORE_EXPORT virtual void attachToFrame();
 
 private:
-    Document* document() const;
+    Document* NODELETE document() const;
 
     void matchRegistration(const URL&, CompletionHandler<void(std::optional<ServiceWorkerRegistrationData>&&)>&&);
     void unregisterReservedServiceWorkerClient();

--- a/Source/WebCore/loader/DocumentWriter.h
+++ b/Source/WebCore/loader/DocumentWriter.h
@@ -57,7 +57,7 @@ public:
     void setFrame(LocalFrame&);
 
     enum class IsEncodingUserChosen : bool { No, Yes };
-    WEBCORE_EXPORT void setEncoding(const String& encoding, IsEncodingUserChosen);
+    WEBCORE_EXPORT void NODELETE setEncoding(const String& encoding, IsEncodingUserChosen);
 
     const String& mimeType() const { return m_mimeType; }
     void setMIMEType(const String& type) { m_mimeType = type; }

--- a/Source/WebCore/loader/EmptyClients.cpp
+++ b/Source/WebCore/loader/EmptyClients.cpp
@@ -121,15 +121,15 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyCryptoClient);
 class UserMessageHandlerDescriptor;
 
 class EmptyBackForwardClient final : public BackForwardClient {
-    void addItem(Ref<HistoryItem>&&) final { }
-    void setChildItem(BackForwardFrameItemIdentifier, Ref<HistoryItem>&&) final { }
-    void goToItem(HistoryItem&) final { }
-    Vector<Ref<HistoryItem>> allItems(FrameIdentifier) { return { }; }
-    RefPtr<HistoryItem> itemAtIndex(int, FrameIdentifier) final { return nullptr; }
-    unsigned backListCount() const final { return 0; }
-    unsigned forwardListCount() const final { return 0; }
-    bool containsItem(const HistoryItem&) const final { return false; }
-    void close() final { }
+    void NODELETE addItem(Ref<HistoryItem>&&) final { }
+    void NODELETE setChildItem(BackForwardFrameItemIdentifier, Ref<HistoryItem>&&) final { }
+    void NODELETE goToItem(HistoryItem&) final { }
+    Vector<Ref<HistoryItem>> NODELETE allItems(FrameIdentifier) { return { }; }
+    RefPtr<HistoryItem> NODELETE itemAtIndex(int, FrameIdentifier) final { return nullptr; }
+    unsigned NODELETE backListCount() const final { return 0; }
+    unsigned NODELETE forwardListCount() const final { return 0; }
+    bool NODELETE containsItem(const HistoryItem&) const final { return false; }
+    void NODELETE close() final { }
 };
 
 #if ENABLE(CONTEXT_MENUS)
@@ -137,15 +137,15 @@ class EmptyBackForwardClient final : public BackForwardClient {
 class EmptyContextMenuClient final : public ContextMenuClient {
     WTF_MAKE_TZONE_ALLOCATED(EmptyContextMenuClient);
 
-    void downloadURL(const URL&) final { }
-    void searchWithGoogle(const LocalFrame*) final { }
-    void lookUpInDictionary(LocalFrame*) final { }
-    bool isSpeaking() const final { return false; }
-    void speak(const String&) final { }
-    void stopSpeaking() final { }
+    void NODELETE downloadURL(const URL&) final { }
+    void NODELETE searchWithGoogle(const LocalFrame*) final { }
+    void NODELETE lookUpInDictionary(LocalFrame*) final { }
+    bool NODELETE isSpeaking() const final { return false; }
+    void NODELETE speak(const String&) final { }
+    void NODELETE stopSpeaking() final { }
 
 #if HAVE(TRANSLATION_UI_SERVICES)
-    void handleTranslation(const TranslationContextMenuInfo&) final { }
+    void NODELETE handleTranslation(const TranslationContextMenuInfo&) final { }
 #endif
 
 #if PLATFORM(GTK)
@@ -153,15 +153,15 @@ class EmptyContextMenuClient final : public ContextMenuClient {
 #endif
 
 #if USE(ACCESSIBILITY_CONTEXT_MENUS)
-    void showContextMenu() final { }
+    void NODELETE showContextMenu() final { }
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS)
-    bool supportsLookUpInImages() final { return false; }
+    bool NODELETE supportsLookUpInImages() final { return false; }
 #endif
 
 #if ENABLE(IMAGE_ANALYSIS_ENHANCEMENTS)
-    bool supportsCopySubject() final { return false; }
+    bool NODELETE supportsCopySubject() final { return false; }
 #endif
 };
 
@@ -176,12 +176,12 @@ public:
         return adoptRef(*new EmptyDisplayRefreshMonitor(displayID));
     }
 
-    void displayLinkFired(const DisplayUpdate&) final { }
-    bool requestRefreshCallback() final { return false; }
-    void stop() final { }
+    void NODELETE displayLinkFired(const DisplayUpdate&) final { }
+    bool NODELETE requestRefreshCallback() final { return false; }
+    void NODELETE stop() final { }
 
-    bool startNotificationMechanism() final { return true; }
-    void stopNotificationMechanism() final { }
+    bool NODELETE startNotificationMechanism() final { return true; }
+    void NODELETE stopNotificationMechanism() final { }
 
 private:
     explicit EmptyDisplayRefreshMonitor(PlatformDisplayID displayID)
@@ -192,7 +192,7 @@ private:
 
 class EmptyDisplayRefreshMonitorFactory final : public DisplayRefreshMonitorFactory {
 public:
-    static DisplayRefreshMonitorFactory* sharedEmptyDisplayRefreshMonitorFactory()
+    static DisplayRefreshMonitorFactory* NODELETE sharedEmptyDisplayRefreshMonitorFactory()
     {
         static NeverDestroyed<EmptyDisplayRefreshMonitorFactory> emptyFactory;
         return &emptyFactory.get();
@@ -209,37 +209,37 @@ class EmptyDatabaseProvider final : public DatabaseProvider {
     struct EmptyIDBConnectionToServerDeletegate final : public IDBClient::IDBConnectionToServerDelegate, public RefCounted<EmptyIDBConnectionToServerDeletegate> {
         static Ref<EmptyIDBConnectionToServerDeletegate> create() { return adoptRef(*new EmptyIDBConnectionToServerDeletegate); }
 
-        void ref() const final { RefCounted::ref(); }
+        void NODELETE ref() const final { RefCounted::ref(); }
         void deref() const final { RefCounted::deref(); }
 
-        std::optional<IDBConnectionIdentifier> identifier() const final { return std::nullopt; }
-        void deleteDatabase(const IDBOpenRequestData&) final { }
-        void openDatabase(const IDBOpenRequestData&) final { }
-        void abortTransaction(const IDBResourceIdentifier&) final { }
-        void commitTransaction(const IDBResourceIdentifier&, uint64_t) final { }
-        void didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier&) final { }
-        void createObjectStore(const IDBRequestData&, const IDBObjectStoreInfo&) final { }
-        void deleteObjectStore(const IDBRequestData&, const String&) final { }
-        void renameObjectStore(const IDBRequestData&, IDBObjectStoreIdentifier, const String&) final { }
-        void clearObjectStore(const IDBRequestData&, IDBObjectStoreIdentifier) final { }
-        void createIndex(const IDBRequestData&, const IDBIndexInfo&) final { }
-        void deleteIndex(const IDBRequestData&, IDBObjectStoreIdentifier, const String&) final { }
-        void renameIndex(const IDBRequestData&, IDBObjectStoreIdentifier, IDBIndexIdentifier, const String&) final { }
-        void putOrAdd(const IDBRequestData&, const IDBKeyData&, const IDBValue&, const IndexIDToIndexKeyMap&, const IndexedDB::ObjectStoreOverwriteMode) final { }
-        void getRecord(const IDBRequestData&, const IDBGetRecordData&) final { }
-        void getAllRecords(const IDBRequestData&, const IDBGetAllRecordsData&) final { }
-        void getCount(const IDBRequestData&, const IDBKeyRangeData&) final { }
-        void deleteRecord(const IDBRequestData&, const IDBKeyRangeData&) final { }
-        void openCursor(const IDBRequestData&, const IDBCursorInfo&) final { }
-        void iterateCursor(const IDBRequestData&, const IDBIterateCursorData&) final { }
-        void establishTransaction(IDBDatabaseConnectionIdentifier, const IDBTransactionInfo&) final { }
-        void databaseConnectionPendingClose(IDBDatabaseConnectionIdentifier) final { }
-        void databaseConnectionClosed(IDBDatabaseConnectionIdentifier) final { }
-        void abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>&) final { }
-        void didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier&, const IndexedDB::ConnectionClosedOnBehalfOfServer) final { }
-        void openDBRequestCancelled(const IDBOpenRequestData&) final { }
-        void getAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, const ClientOrigin&) final { }
-        void didGenerateIndexKeyForRecord(const IDBResourceIdentifier&, const IDBResourceIdentifier&, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t>) { }
+        std::optional<IDBConnectionIdentifier> NODELETE identifier() const final { return std::nullopt; }
+        void NODELETE deleteDatabase(const IDBOpenRequestData&) final { }
+        void NODELETE openDatabase(const IDBOpenRequestData&) final { }
+        void NODELETE abortTransaction(const IDBResourceIdentifier&) final { }
+        void NODELETE commitTransaction(const IDBResourceIdentifier&, uint64_t) final { }
+        void NODELETE didFinishHandlingVersionChangeTransaction(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier&) final { }
+        void NODELETE createObjectStore(const IDBRequestData&, const IDBObjectStoreInfo&) final { }
+        void NODELETE deleteObjectStore(const IDBRequestData&, const String&) final { }
+        void NODELETE renameObjectStore(const IDBRequestData&, IDBObjectStoreIdentifier, const String&) final { }
+        void NODELETE clearObjectStore(const IDBRequestData&, IDBObjectStoreIdentifier) final { }
+        void NODELETE createIndex(const IDBRequestData&, const IDBIndexInfo&) final { }
+        void NODELETE deleteIndex(const IDBRequestData&, IDBObjectStoreIdentifier, const String&) final { }
+        void NODELETE renameIndex(const IDBRequestData&, IDBObjectStoreIdentifier, IDBIndexIdentifier, const String&) final { }
+        void NODELETE putOrAdd(const IDBRequestData&, const IDBKeyData&, const IDBValue&, const IndexIDToIndexKeyMap&, const IndexedDB::ObjectStoreOverwriteMode) final { }
+        void NODELETE getRecord(const IDBRequestData&, const IDBGetRecordData&) final { }
+        void NODELETE getAllRecords(const IDBRequestData&, const IDBGetAllRecordsData&) final { }
+        void NODELETE getCount(const IDBRequestData&, const IDBKeyRangeData&) final { }
+        void NODELETE deleteRecord(const IDBRequestData&, const IDBKeyRangeData&) final { }
+        void NODELETE openCursor(const IDBRequestData&, const IDBCursorInfo&) final { }
+        void NODELETE iterateCursor(const IDBRequestData&, const IDBIterateCursorData&) final { }
+        void NODELETE establishTransaction(IDBDatabaseConnectionIdentifier, const IDBTransactionInfo&) final { }
+        void NODELETE databaseConnectionPendingClose(IDBDatabaseConnectionIdentifier) final { }
+        void NODELETE databaseConnectionClosed(IDBDatabaseConnectionIdentifier) final { }
+        void NODELETE abortOpenAndUpgradeNeeded(IDBDatabaseConnectionIdentifier, const std::optional<IDBResourceIdentifier>&) final { }
+        void NODELETE didFireVersionChangeEvent(IDBDatabaseConnectionIdentifier, const IDBResourceIdentifier&, const IndexedDB::ConnectionClosedOnBehalfOfServer) final { }
+        void NODELETE openDBRequestCancelled(const IDBOpenRequestData&) final { }
+        void NODELETE getAllDatabaseNamesAndVersions(const IDBResourceIdentifier&, const ClientOrigin&) final { }
+        void NODELETE didGenerateIndexKeyForRecord(const IDBResourceIdentifier&, const IDBResourceIdentifier&, const IDBIndexInfo&, const IDBKeyData&, const IndexKey&, std::optional<int64_t>) { }
     private:
         EmptyIDBConnectionToServerDeletegate() = default;
     };
@@ -256,12 +256,12 @@ class EmptyDiagnosticLoggingClient final : public DiagnosticLoggingClient {
     WTF_MAKE_TZONE_ALLOCATED(EmptyDiagnosticLoggingClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EmptyDiagnosticLoggingClient);
 
-    void logDiagnosticMessage(const String&, const String&, ShouldSample) final { }
-    void logDiagnosticMessageWithResult(const String&, const String&, DiagnosticLoggingResultType, ShouldSample) final { }
-    void logDiagnosticMessageWithValue(const String&, const String&, double, unsigned, ShouldSample) final { }
-    void logDiagnosticMessageWithEnhancedPrivacy(const String&, const String&, ShouldSample) final { }
-    void logDiagnosticMessageWithValueDictionary(const String&, const String&, const ValueDictionary&, ShouldSample) final { }
-    void logDiagnosticMessageWithDomain(const String&, DiagnosticLoggingDomain) final { };
+    void NODELETE logDiagnosticMessage(const String&, const String&, ShouldSample) final { }
+    void NODELETE logDiagnosticMessageWithResult(const String&, const String&, DiagnosticLoggingResultType, ShouldSample) final { }
+    void NODELETE logDiagnosticMessageWithValue(const String&, const String&, double, unsigned, ShouldSample) final { }
+    void NODELETE logDiagnosticMessageWithEnhancedPrivacy(const String&, const String&, ShouldSample) final { }
+    void NODELETE logDiagnosticMessageWithValueDictionary(const String&, const String&, const ValueDictionary&, ShouldSample) final { }
+    void NODELETE logDiagnosticMessageWithDomain(const String&, DiagnosticLoggingDomain) final { };
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyDiagnosticLoggingClient);
@@ -269,10 +269,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyDiagnosticLoggingClient);
 #if ENABLE(DRAG_SUPPORT)
 
 class EmptyDragClient final : public DragClient {
-    void willPerformDragDestinationAction(DragDestinationAction, const DragData&) final { }
-    void willPerformDragSourceAction(DragSourceAction, const IntPoint&, DataTransfer&) final { }
+    void NODELETE willPerformDragDestinationAction(DragDestinationAction, const DragData&) final { }
+    void NODELETE willPerformDragSourceAction(DragSourceAction, const IntPoint&, DataTransfer&) final { }
     OptionSet<DragSourceAction> dragSourceActionMaskForPoint(const IntPoint&) final { return { }; }
-    void startDrag(DragItem, DataTransfer&, Frame&, const std::optional<NodeIdentifier>&) final { }
+    void NODELETE startDrag(DragItem, DataTransfer&, Frame&, const std::optional<NodeIdentifier>&) final { }
 };
 
 #endif // ENABLE(DRAG_SUPPORT)
@@ -281,65 +281,65 @@ class EmptyEditorClient final : public EditorClient {
     WTF_MAKE_TZONE_ALLOCATED(EmptyEditorClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(EmptyEditorClient);
 private:
-    bool shouldDeleteRange(const std::optional<SimpleRange>&) final { return false; }
-    bool smartInsertDeleteEnabled() final { return false; }
-    bool isSelectTrailingWhitespaceEnabled() const final { return false; }
-    bool isContinuousSpellCheckingEnabled() final { return false; }
-    void toggleContinuousSpellChecking() final { }
-    bool isGrammarCheckingEnabled() final { return false; }
-    void toggleGrammarChecking() final { }
-    int spellCheckerDocumentTag() final { return -1; }
+    bool NODELETE shouldDeleteRange(const std::optional<SimpleRange>&) final { return false; }
+    bool NODELETE smartInsertDeleteEnabled() final { return false; }
+    bool NODELETE isSelectTrailingWhitespaceEnabled() const final { return false; }
+    bool NODELETE isContinuousSpellCheckingEnabled() final { return false; }
+    void NODELETE toggleContinuousSpellChecking() final { }
+    bool NODELETE isGrammarCheckingEnabled() final { return false; }
+    void NODELETE toggleGrammarChecking() final { }
+    int NODELETE spellCheckerDocumentTag() final { return -1; }
 
-    bool shouldBeginEditing(const SimpleRange&) final { return false; }
-    bool shouldEndEditing(const SimpleRange&) final { return false; }
-    bool shouldInsertNode(Node&, const std::optional<SimpleRange>&, EditorInsertAction) final { return false; }
-    bool shouldInsertText(const String&, const std::optional<SimpleRange>&, EditorInsertAction) final { return false; }
-    bool shouldChangeSelectedRange(const std::optional<SimpleRange>&, const std::optional<SimpleRange>&, Affinity, bool) final { return false; }
+    bool NODELETE shouldBeginEditing(const SimpleRange&) final { return false; }
+    bool NODELETE shouldEndEditing(const SimpleRange&) final { return false; }
+    bool NODELETE shouldInsertNode(Node&, const std::optional<SimpleRange>&, EditorInsertAction) final { return false; }
+    bool NODELETE shouldInsertText(const String&, const std::optional<SimpleRange>&, EditorInsertAction) final { return false; }
+    bool NODELETE shouldChangeSelectedRange(const std::optional<SimpleRange>&, const std::optional<SimpleRange>&, Affinity, bool) final { return false; }
 
-    bool shouldApplyStyle(const StyleProperties&, const std::optional<SimpleRange>&) final { return false; }
-    void didApplyStyle() final { }
-    bool shouldMoveRangeAfterDelete(const SimpleRange&, const SimpleRange&) final { return false; }
+    bool NODELETE shouldApplyStyle(const StyleProperties&, const std::optional<SimpleRange>&) final { return false; }
+    void NODELETE didApplyStyle() final { }
+    bool NODELETE shouldMoveRangeAfterDelete(const SimpleRange&, const SimpleRange&) final { return false; }
 
-    void didBeginEditing() final { }
-    void respondToChangedContents() final { }
-    void respondToChangedSelection(LocalFrame*) final { }
-    void updateEditorStateAfterLayoutIfEditabilityChanged() final { }
-    void discardedComposition(const Document&) final { }
-    void canceledComposition() final { }
-    void didUpdateComposition() final { }
-    void didEndEditing() final { }
-    void didEndUserTriggeredSelectionChanges() final { }
-    void willWriteSelectionToPasteboard(const std::optional<SimpleRange>&) final { }
-    void didWriteSelectionToPasteboard() final { }
-    void getClientPasteboardData(const std::optional<SimpleRange>&, Vector<std::pair<String, RefPtr<SharedBuffer>>>&) final { }
-    void requestCandidatesForSelection(const VisibleSelection&) final { }
-    void handleAcceptedCandidateWithSoftSpaces(TextCheckingResult) final { }
+    void NODELETE didBeginEditing() final { }
+    void NODELETE respondToChangedContents() final { }
+    void NODELETE respondToChangedSelection(LocalFrame*) final { }
+    void NODELETE updateEditorStateAfterLayoutIfEditabilityChanged() final { }
+    void NODELETE discardedComposition(const Document&) final { }
+    void NODELETE canceledComposition() final { }
+    void NODELETE didUpdateComposition() final { }
+    void NODELETE didEndEditing() final { }
+    void NODELETE didEndUserTriggeredSelectionChanges() final { }
+    void NODELETE willWriteSelectionToPasteboard(const std::optional<SimpleRange>&) final { }
+    void NODELETE didWriteSelectionToPasteboard() final { }
+    void NODELETE getClientPasteboardData(const std::optional<SimpleRange>&, Vector<std::pair<String, RefPtr<SharedBuffer>>>&) final { }
+    void NODELETE requestCandidatesForSelection(const VisibleSelection&) final { }
+    void NODELETE handleAcceptedCandidateWithSoftSpaces(TextCheckingResult) final { }
 
     void registerUndoStep(UndoStep&) final;
     void registerRedoStep(UndoStep&) final;
-    void clearUndoRedoOperations() final { }
+    void NODELETE clearUndoRedoOperations() final { }
 
-    DOMPasteAccessResponse requestDOMPasteAccess(DOMPasteAccessCategory, FrameIdentifier, const String&) final { return DOMPasteAccessResponse::DeniedForGesture; }
+    DOMPasteAccessResponse NODELETE requestDOMPasteAccess(DOMPasteAccessCategory, FrameIdentifier, const String&) final { return DOMPasteAccessResponse::DeniedForGesture; }
 
-    bool canCopyCut(LocalFrame*, bool defaultValue) const final { return defaultValue; }
-    bool canPaste(LocalFrame*, bool defaultValue) const final { return defaultValue; }
-    bool canUndo() const final { return false; }
-    bool canRedo() const final { return false; }
+    bool NODELETE canCopyCut(LocalFrame*, bool defaultValue) const final { return defaultValue; }
+    bool NODELETE canPaste(LocalFrame*, bool defaultValue) const final { return defaultValue; }
+    bool NODELETE canUndo() const final { return false; }
+    bool NODELETE canRedo() const final { return false; }
 
-    void undo() final { }
-    void redo() final { }
+    void NODELETE undo() final { }
+    void NODELETE redo() final { }
 
-    void handleKeyboardEvent(KeyboardEvent&) final { }
-    void handleInputMethodKeydown(KeyboardEvent&) final { }
+    void NODELETE handleKeyboardEvent(KeyboardEvent&) final { }
+    void NODELETE handleInputMethodKeydown(KeyboardEvent&) final { }
 
-    void textFieldDidBeginEditing(Element&) final { }
-    void textFieldDidEndEditing(Element&) final { }
-    void textDidChangeInTextField(Element&) final { }
-    bool doTextFieldCommandFromEvent(Element&, KeyboardEvent*) final { return false; }
-    void textWillBeDeletedInTextField(Element&) final { }
-    void textDidChangeInTextArea(Element&) final { }
-    void overflowScrollPositionChanged() final { }
-    void subFrameScrollPositionChanged() final { }
+    void NODELETE textFieldDidBeginEditing(Element&) final { }
+    void NODELETE textFieldDidEndEditing(Element&) final { }
+    void NODELETE textDidChangeInTextField(Element&) final { }
+    bool NODELETE doTextFieldCommandFromEvent(Element&, KeyboardEvent*) final { return false; }
+    void NODELETE textWillBeDeletedInTextField(Element&) final { }
+    void NODELETE textDidChangeInTextArea(Element&) final { }
+    void NODELETE overflowScrollPositionChanged() final { }
+    void NODELETE subFrameScrollPositionChanged() final { }
 
 #if PLATFORM(IOS_FAMILY)
     void startDelayingAndCoalescingContentChangeNotifications() final { }
@@ -351,66 +351,66 @@ private:
     void updateStringForFind(const String&) final { }
 #endif
 
-    bool performTwoStepDrop(DocumentFragment&, const SimpleRange&, bool) final { return false; }
+    bool NODELETE performTwoStepDrop(DocumentFragment&, const SimpleRange&, bool) final { return false; }
 
 #if PLATFORM(COCOA)
-    void setInsertionPasteboard(const String&) final { };
+    void NODELETE setInsertionPasteboard(const String&) final { };
 #endif
 
 #if USE(APPKIT)
-    void uppercaseWord() final { }
-    void lowercaseWord() final { }
-    void capitalizeWord() final { }
-    bool canApplyCaseTransformations(const String&) final { return true; }
-    bool canConvertToTraditionalChinese(const String&) final { return false; }
-    bool canConvertToSimplifiedChinese(const String&) final { return false; }
-    void convertToTraditionalChinese() final { }
-    void convertToSimplifiedChinese() final { }
+    void NODELETE uppercaseWord() final { }
+    void NODELETE lowercaseWord() final { }
+    void NODELETE capitalizeWord() final { }
+    bool NODELETE canApplyCaseTransformations(const String&) final { return true; }
+    bool NODELETE canConvertToTraditionalChinese(const String&) final { return false; }
+    bool NODELETE canConvertToSimplifiedChinese(const String&) final { return false; }
+    void NODELETE convertToTraditionalChinese() final { }
+    void NODELETE convertToSimplifiedChinese() final { }
 #endif
 
 #if USE(AUTOMATIC_TEXT_REPLACEMENT)
-    void showSubstitutionsPanel(bool) final { }
-    bool substitutionsPanelIsShowing() final { return false; }
-    void toggleSmartInsertDelete() final { }
-    bool isAutomaticQuoteSubstitutionEnabled() final { return false; }
-    void toggleAutomaticQuoteSubstitution() final { }
-    bool isAutomaticLinkDetectionEnabled() final { return false; }
-    void toggleAutomaticLinkDetection() final { }
-    bool isAutomaticDashSubstitutionEnabled() final { return false; }
-    void toggleAutomaticDashSubstitution() final { }
-    bool isAutomaticTextReplacementEnabled() final { return false; }
-    void toggleAutomaticTextReplacement() final { }
-    bool isAutomaticSpellingCorrectionEnabled() final { return false; }
-    void toggleAutomaticSpellingCorrection() final { }
-    bool isSmartListsEnabled() final { return false; }
-    void toggleSmartLists() { }
+    void NODELETE showSubstitutionsPanel(bool) final { }
+    bool NODELETE substitutionsPanelIsShowing() final { return false; }
+    void NODELETE toggleSmartInsertDelete() final { }
+    bool NODELETE isAutomaticQuoteSubstitutionEnabled() final { return false; }
+    void NODELETE toggleAutomaticQuoteSubstitution() final { }
+    bool NODELETE isAutomaticLinkDetectionEnabled() final { return false; }
+    void NODELETE toggleAutomaticLinkDetection() final { }
+    bool NODELETE isAutomaticDashSubstitutionEnabled() final { return false; }
+    void NODELETE toggleAutomaticDashSubstitution() final { }
+    bool NODELETE isAutomaticTextReplacementEnabled() final { return false; }
+    void NODELETE toggleAutomaticTextReplacement() final { }
+    bool NODELETE isAutomaticSpellingCorrectionEnabled() final { return false; }
+    void NODELETE toggleAutomaticSpellingCorrection() final { }
+    bool NODELETE isSmartListsEnabled() final { return false; }
+    void NODELETE toggleSmartLists() { }
 #endif
 
 #if PLATFORM(GTK)
     bool shouldShowUnicodeMenu() final { return false; }
 #endif
 
-    TextCheckerClient* textChecker() final { return &m_textCheckerClient; }
+    TextCheckerClient* NODELETE textChecker() final { return &m_textCheckerClient; }
 
-    void updateSpellingUIWithGrammarString(const String&, const GrammarDetail&) final { }
-    void updateSpellingUIWithMisspelledWord(const String&) final { }
-    void showSpellingUI(bool) final { }
-    bool spellingUIIsShowing() final { return false; }
+    void NODELETE updateSpellingUIWithGrammarString(const String&, const GrammarDetail&) final { }
+    void NODELETE updateSpellingUIWithMisspelledWord(const String&) final { }
+    void NODELETE showSpellingUI(bool) final { }
+    bool NODELETE spellingUIIsShowing() final { return false; }
 
-    void setInputMethodState(Element*) final { }
+    void NODELETE setInputMethodState(Element*) final { }
 
     class EmptyTextCheckerClient final : public TextCheckerClient {
-        bool shouldEraseMarkersAfterChangeSelection(TextCheckingType) const final { return true; }
-        void ignoreWordInSpellDocument(const String&) final { }
-        void learnWord(const String&) final { }
-        void checkSpellingOfString(StringView, int*, int*) final { }
-        void checkGrammarOfString(StringView, Vector<GrammarDetail>&, int*, int*) final { }
+        bool NODELETE shouldEraseMarkersAfterChangeSelection(TextCheckingType) const final { return true; }
+        void NODELETE ignoreWordInSpellDocument(const String&) final { }
+        void NODELETE learnWord(const String&) final { }
+        void NODELETE checkSpellingOfString(StringView, int*, int*) final { }
+        void NODELETE checkGrammarOfString(StringView, Vector<GrammarDetail>&, int*, int*) final { }
 
 #if USE(UNIFIED_TEXT_CHECKING)
-        Vector<TextCheckingResult> checkTextOfParagraph(StringView, OptionSet<TextCheckingType>, const VisibleSelection&) final { return Vector<TextCheckingResult>(); }
+        Vector<TextCheckingResult> NODELETE checkTextOfParagraph(StringView, OptionSet<TextCheckingType>, const VisibleSelection&) final { return Vector<TextCheckingResult>(); }
 #endif
 
-        void getGuessesForWord(const String&, const String&, const VisibleSelection&, Vector<String>&) final { }
+        void NODELETE getGuessesForWord(const String&, const String&, const VisibleSelection&, Vector<String>&) final { }
         void requestCheckingOfString(TextCheckingRequest&, const VisibleSelection&) final;
         void requestExtendedCheckingOfString(TextCheckingRequest&, const VisibleSelection&) final;
     };
@@ -427,12 +427,12 @@ public:
 private:
     EmptyFrameNetworkingContext();
 
-    bool shouldClearReferrerOnHTTPSToHTTPRedirect() const { return true; }
-    NetworkStorageSession* storageSession() const final { return nullptr; }
+    bool NODELETE shouldClearReferrerOnHTTPSToHTTPRedirect() const { return true; }
+    NetworkStorageSession* NODELETE storageSession() const final { return nullptr; }
 
 #if PLATFORM(COCOA)
-    bool localFileContentSniffingEnabled() const { return false; }
-    SchedulePairHashSet* scheduledRunLoopPairs() const { return nullptr; }
+    bool NODELETE localFileContentSniffingEnabled() const { return false; }
+    SchedulePairHashSet* NODELETE scheduledRunLoopPairs() const { return nullptr; }
     RetainPtr<CFDataRef> sourceApplicationAuditData() const { return nullptr; };
 #endif
 
@@ -443,11 +443,11 @@ private:
 
 class EmptyInspectorBackendClient final : public InspectorBackendClient {
     WTF_MAKE_TZONE_ALLOCATED(EmptyInspectorBackendClient);
-    void inspectedPageDestroyed() final { }
-    Inspector::FrontendChannel* openLocalFrontend(PageInspectorController*) final { return nullptr; }
-    void bringFrontendToFront() final { }
-    void highlight() final { }
-    void hideHighlight() final { }
+    void NODELETE inspectedPageDestroyed() final { }
+    Inspector::FrontendChannel* NODELETE openLocalFrontend(PageInspectorController*) final { return nullptr; }
+    void NODELETE bringFrontendToFront() final { }
+    void NODELETE highlight() final { }
+    void NODELETE hideHighlight() final { }
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyInspectorBackendClient);
@@ -462,27 +462,27 @@ public:
         return adoptRef(*new EmptyPaymentCoordinatorClient);
     }
 
-    void ref() const final { RefCounted::ref(); }
+    void NODELETE ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
 private:
     EmptyPaymentCoordinatorClient() = default;
 
-    std::optional<String> validatedPaymentNetwork(const String&) const final { return std::nullopt; }
-    bool canMakePayments() final { return false; }
+    std::optional<String> NODELETE validatedPaymentNetwork(const String&) const final { return std::nullopt; }
+    bool NODELETE canMakePayments() final { return false; }
     void canMakePaymentsWithActiveCard(const String&, const String&, CompletionHandler<void(bool)>&& completionHandler) final { callOnMainThread([completionHandler = WTF::move(completionHandler)]() mutable { completionHandler(false); }); }
     void openPaymentSetup(const String&, const String&, CompletionHandler<void(bool)>&& completionHandler) final { callOnMainThread([completionHandler = WTF::move(completionHandler)]() mutable { completionHandler(false); }); }
-    bool showPaymentUI(const URL&, const Vector<URL>&, const ApplePaySessionPaymentRequest&) final { return false; }
-    void completeMerchantValidation(const PaymentMerchantSession&) final { }
-    void completeShippingMethodSelection(std::optional<ApplePayShippingMethodUpdate>&&) final { }
-    void completeShippingContactSelection(std::optional<ApplePayShippingContactUpdate>&&) final { }
-    void completePaymentMethodSelection(std::optional<ApplePayPaymentMethodUpdate>&&) final { }
+    bool NODELETE showPaymentUI(const URL&, const Vector<URL>&, const ApplePaySessionPaymentRequest&) final { return false; }
+    void NODELETE completeMerchantValidation(const PaymentMerchantSession&) final { }
+    void NODELETE completeShippingMethodSelection(std::optional<ApplePayShippingMethodUpdate>&&) final { }
+    void NODELETE completeShippingContactSelection(std::optional<ApplePayShippingContactUpdate>&&) final { }
+    void NODELETE completePaymentMethodSelection(std::optional<ApplePayPaymentMethodUpdate>&&) final { }
 #if ENABLE(APPLE_PAY_COUPON_CODE)
-    void completeCouponCodeChange(std::optional<ApplePayCouponCodeUpdate>&&) final { }
+    void NODELETE completeCouponCodeChange(std::optional<ApplePayCouponCodeUpdate>&&) final { }
 #endif
-    void completePaymentSession(ApplePayPaymentAuthorizationResult&&) final { }
-    void cancelPaymentSession() final { }
-    void abortPaymentSession() final { }
+    void NODELETE completePaymentSession(ApplePayPaymentAuthorizationResult&&) final { }
+    void NODELETE cancelPaymentSession() final { }
+    void NODELETE abortPaymentSession() final { }
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyPaymentCoordinatorClient);
@@ -524,25 +524,25 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(EmptyCredentialRequestCoordinatorClient);
 #endif
 
 class EmptyPluginInfoProvider final : public PluginInfoProvider {
-    void refreshPlugins() final { };
-    Vector<PluginInfo> pluginInfo(Page&, std::optional<Vector<SupportedPluginIdentifier>>&) final { return { }; }
-    Vector<PluginInfo> webVisiblePluginInfo(Page&, const URL&) final { return { }; }
+    void NODELETE refreshPlugins() final { };
+    Vector<PluginInfo> NODELETE pluginInfo(Page&, std::optional<Vector<SupportedPluginIdentifier>>&) final { return { }; }
+    Vector<PluginInfo> NODELETE webVisiblePluginInfo(Page&, const URL&) final { return { }; }
 };
 
 class EmptyPopupMenu : public PopupMenu {
 private:
-    void show(const IntRect&, LocalFrameView&, int) final { }
-    void hide() final { }
-    void updateFromElement() final { }
-    void disconnectClient() final { }
+    void NODELETE show(const IntRect&, LocalFrameView&, int) final { }
+    void NODELETE hide() final { }
+    void NODELETE updateFromElement() final { }
+    void NODELETE disconnectClient() final { }
 };
 
 class EmptyProgressTrackerClient final : public ProgressTrackerClient {
-    void willChangeEstimatedProgress() final { }
-    void didChangeEstimatedProgress() final { }
-    void progressStarted(LocalFrame&) final { }
-    void progressEstimateChanged(LocalFrame&) final { }
-    void progressFinished(LocalFrame&) final { }
+    void NODELETE willChangeEstimatedProgress() final { }
+    void NODELETE didChangeEstimatedProgress() final { }
+    void NODELETE progressStarted(LocalFrame&) final { }
+    void NODELETE progressEstimateChanged(LocalFrame&) final { }
+    void NODELETE progressFinished(LocalFrame&) final { }
 };
 
 class EmptySearchPopupMenu : public SearchPopupMenu {
@@ -553,25 +553,25 @@ public:
     }
 
 private:
-    PopupMenu* popupMenu() final { return m_popup.ptr(); }
-    void saveRecentSearches(const AtomString&, const Vector<RecentSearch>&) final { }
-    void loadRecentSearches(const AtomString&, Vector<RecentSearch>&) final { }
-    bool enabled() final { return false; }
+    PopupMenu* NODELETE popupMenu() final { return m_popup.ptr(); }
+    void NODELETE saveRecentSearches(const AtomString&, const Vector<RecentSearch>&) final { }
+    void NODELETE loadRecentSearches(const AtomString&, Vector<RecentSearch>&) final { }
+    bool NODELETE enabled() final { return false; }
 
     const Ref<EmptyPopupMenu> m_popup;
 };
 
 class EmptyStorageNamespaceProvider final : public StorageNamespaceProvider {
     struct EmptyStorageArea : public StorageArea {
-        unsigned length() final { return 0; }
-        String key(unsigned) final { return { }; }
-        String item(const String&) final { return { }; }
-        void setItem(LocalFrame&, const String&, const String&, bool&) final { }
-        void removeItem(LocalFrame&, const String&) final { }
-        void clear(LocalFrame&) final { }
-        bool contains(const String&) final { return false; }
-        StorageType storageType() const final { return StorageType::Local; }
-        size_t memoryBytesUsedByCache() final { return 0; }
+        unsigned NODELETE length() final { return 0; }
+        String NODELETE key(unsigned) final { return { }; }
+        String NODELETE item(const String&) final { return { }; }
+        void NODELETE setItem(LocalFrame&, const String&, const String&, bool&) final { }
+        void NODELETE removeItem(LocalFrame&, const String&) final { }
+        void NODELETE clear(LocalFrame&) final { }
+        bool NODELETE contains(const String&) final { return false; }
+        StorageType NODELETE storageType() const final { return StorageType::Local; }
+        size_t NODELETE memoryBytesUsedByCache() final { return 0; }
     };
 
     struct EmptyStorageNamespace final : public StorageNamespace {
@@ -580,13 +580,13 @@ class EmptyStorageNamespaceProvider final : public StorageNamespaceProvider {
         {
         }
 
-        const SecurityOrigin* topLevelOrigin() const final { return nullptr; };
+        const SecurityOrigin* NODELETE topLevelOrigin() const final { return nullptr; };
 
     private:
         Ref<StorageArea> storageArea(const SecurityOrigin&) final { return adoptRef(*new EmptyStorageArea); }
         Ref<StorageNamespace> copy(Page&) final { return adoptRef(*new EmptyStorageNamespace { m_sessionID }); }
-        PAL::SessionID sessionID() const final { return m_sessionID; }
-        void setSessionIDForTesting(PAL::SessionID sessionID) final { m_sessionID = sessionID; };
+        PAL::SessionID NODELETE sessionID() const final { return m_sessionID; }
+        void NODELETE setSessionIDForTesting(PAL::SessionID sessionID) final { m_sessionID = sessionID; };
 
         PAL::SessionID m_sessionID;
     };
@@ -597,21 +597,21 @@ class EmptyStorageNamespaceProvider final : public StorageNamespaceProvider {
 };
 
 class EmptyUserContentProvider final : public UserContentProvider {
-    void forEachUserScript(NOESCAPE const Function<void(DOMWrapperWorld&, const UserScript&)>&) const final { }
-    void forEachUserStyleSheet(NOESCAPE const Function<void(const UserStyleSheet&)>&) const final { }
+    void NODELETE forEachUserScript(NOESCAPE const Function<void(DOMWrapperWorld&, const UserScript&)>&) const final { }
+    void NODELETE forEachUserStyleSheet(NOESCAPE const Function<void(const UserStyleSheet&)>&) const final { }
 #if ENABLE(USER_MESSAGE_HANDLERS)
-    void forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final { }
+    void NODELETE forEachUserMessageHandler(NOESCAPE const Function<void(const UserMessageHandlerDescriptor&)>&) const final { }
 #endif
-    bool hasBuffersForWorld(const DOMWrapperWorld&) const final { return false; }
-    WebKitBuffer* buffer(const DOMWrapperWorld&, const String&) const final { return nullptr; }
+    bool NODELETE hasBuffersForWorld(const DOMWrapperWorld&) const final { return false; }
+    WebKitBuffer* NODELETE buffer(const DOMWrapperWorld&, const String&) const final { return nullptr; }
 #if ENABLE(CONTENT_EXTENSIONS)
-    const ContentExtensions::ContentExtensionsBackend& userContentExtensionBackend() const final { static NeverDestroyed<ContentExtensions::ContentExtensionsBackend> backend; return backend.get(); };
+    const ContentExtensions::ContentExtensionsBackend& NODELETE userContentExtensionBackend() const final { static NeverDestroyed<ContentExtensions::ContentExtensionsBackend> backend; return backend.get(); };
 #endif
 };
 
 class EmptyVisitedLinkStore final : public VisitedLinkStore {
-    bool isLinkVisited(Page&, SharedStringHash, const URL&, const AtomString&) final { return false; }
-    void addVisitedLink(Page&, SharedStringHash) final { }
+    bool NODELETE isLinkVisited(Page&, SharedStringHash, const URL&, const AtomString&) final { return false; }
+    void NODELETE addVisitedLink(Page&, SharedStringHash) final { }
 };
 
 RefPtr<PopupMenu> EmptyChromeClient::createPopupMenu(PopupMenuClient&) const
@@ -667,27 +667,27 @@ RefPtr<Icon> EmptyChromeClient::createIconForFiles(const Vector<String>& /* file
 
 // MARK: -
 
-void EmptyFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const NavigationAction&, const ResourceRequest&, FormState*, const String&, std::optional<HitTestResult>&&, FramePolicyFunction&&)
+void NODELETE EmptyFrameLoaderClient::dispatchDecidePolicyForNewWindowAction(const NavigationAction&, const ResourceRequest&, FormState*, const String&, std::optional<HitTestResult>&&, FramePolicyFunction&&)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const NavigationAction&, const ResourceRequest&, const ResourceResponse&, FormState*, const String&, std::optional<NavigationIdentifier>, std::optional<HitTestResult>&&, bool, NavigationUpgradeToHTTPSBehavior, SandboxFlags, PolicyDecisionMode, FramePolicyFunction&&)
+void NODELETE EmptyFrameLoaderClient::dispatchDecidePolicyForNavigationAction(const NavigationAction&, const ResourceRequest&, const ResourceResponse&, FormState*, const String&, std::optional<NavigationIdentifier>, std::optional<HitTestResult>&&, bool, NavigationUpgradeToHTTPSBehavior, SandboxFlags, PolicyDecisionMode, FramePolicyFunction&&)
 {
 }
 
-void EmptyFrameLoaderClient::updateSandboxFlags(SandboxFlags)
+void NODELETE EmptyFrameLoaderClient::updateSandboxFlags(SandboxFlags)
 {
 }
 
-void EmptyFrameLoaderClient::updateOpener(std::optional<FrameIdentifier>)
+void NODELETE EmptyFrameLoaderClient::updateOpener(std::optional<FrameIdentifier>)
 {
 }
 
-void EmptyFrameLoaderClient::setPrinting(bool, FloatSize, FloatSize, float, AdjustViewSize)
+void NODELETE EmptyFrameLoaderClient::setPrinting(bool, FloatSize, FloatSize, float, AdjustViewSize)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchWillSendSubmitEvent(Ref<FormState>&&)
+void NODELETE EmptyFrameLoaderClient::dispatchWillSendSubmitEvent(Ref<FormState>&&)
 {
 }
 
@@ -706,22 +706,22 @@ Ref<DocumentLoader> EmptyFrameLoaderClient::createDocumentLoader(ResourceRequest
     return DocumentLoader::create(WTF::move(request), WTF::move(substituteData), { });
 }
 
-RefPtr<LocalFrame> EmptyFrameLoaderClient::createFrame(const AtomString&, HTMLFrameOwnerElement&)
+RefPtr<LocalFrame> NODELETE EmptyFrameLoaderClient::createFrame(const AtomString&, HTMLFrameOwnerElement&)
 {
     return nullptr;
 }
 
-RefPtr<Widget> EmptyFrameLoaderClient::createPlugin(HTMLPlugInElement&, const URL&, const Vector<AtomString>&, const Vector<AtomString>&, const String&, bool)
+RefPtr<Widget> NODELETE EmptyFrameLoaderClient::createPlugin(HTMLPlugInElement&, const URL&, const Vector<AtomString>&, const Vector<AtomString>&, const String&, bool)
 {
     return nullptr;
 }
 
-bool EmptyFrameLoaderClient::hasWebView() const
+bool NODELETE EmptyFrameLoaderClient::hasWebView() const
 {
     return true; // mainly for assertions
 }
 
-void EmptyFrameLoaderClient::makeRepresentation(DocumentLoader*)
+void NODELETE EmptyFrameLoaderClient::makeRepresentation(DocumentLoader*)
 {
 }
 
@@ -734,46 +734,46 @@ bool EmptyFrameLoaderClient::forceLayoutOnRestoreFromBackForwardCache()
 
 #endif
 
-void EmptyFrameLoaderClient::forceLayoutForNonHTML()
+void NODELETE EmptyFrameLoaderClient::forceLayoutForNonHTML()
 {
 }
 
-void EmptyFrameLoaderClient::setCopiesOnScroll()
+void NODELETE EmptyFrameLoaderClient::setCopiesOnScroll()
 {
 }
 
-void EmptyFrameLoaderClient::detachedFromParent2()
+void NODELETE EmptyFrameLoaderClient::detachedFromParent2()
 {
 }
 
-void EmptyFrameLoaderClient::detachedFromParent3()
+void NODELETE EmptyFrameLoaderClient::detachedFromParent3()
 {
 }
 
-void EmptyFrameLoaderClient::convertMainResourceLoadToDownload(DocumentLoader*, const ResourceRequest&, const ResourceResponse&)
+void NODELETE EmptyFrameLoaderClient::convertMainResourceLoadToDownload(DocumentLoader*, const ResourceRequest&, const ResourceResponse&)
 {
 }
 
-void EmptyFrameLoaderClient::assignIdentifierToInitialRequest(ResourceLoaderIdentifier, DocumentLoader*, const ResourceRequest&)
+void NODELETE EmptyFrameLoaderClient::assignIdentifierToInitialRequest(ResourceLoaderIdentifier, DocumentLoader*, const ResourceRequest&)
 {
 }
 
-bool EmptyFrameLoaderClient::shouldUseCredentialStorage(DocumentLoader*, ResourceLoaderIdentifier)
+bool NODELETE EmptyFrameLoaderClient::shouldUseCredentialStorage(DocumentLoader*, ResourceLoaderIdentifier)
 {
     return false;
 }
 
-void EmptyFrameLoaderClient::dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier, ResourceRequest&, const ResourceResponse&)
+void NODELETE EmptyFrameLoaderClient::dispatchWillSendRequest(DocumentLoader*, ResourceLoaderIdentifier, ResourceRequest&, const ResourceResponse&)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidReceiveAuthenticationChallenge(DocumentLoader*, ResourceLoaderIdentifier, const AuthenticationChallenge&)
+void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveAuthenticationChallenge(DocumentLoader*, ResourceLoaderIdentifier, const AuthenticationChallenge&)
 {
 }
 
 #if USE(PROTECTION_SPACE_AUTH_CALLBACK)
 
-bool EmptyFrameLoaderClient::canAuthenticateAgainstProtectionSpace(DocumentLoader*, ResourceLoaderIdentifier, const ProtectionSpace&)
+bool NODELETE EmptyFrameLoaderClient::canAuthenticateAgainstProtectionSpace(DocumentLoader*, ResourceLoaderIdentifier, const ProtectionSpace&)
 {
     return false;
 }
@@ -789,240 +789,240 @@ RetainPtr<CFDictionaryRef> EmptyFrameLoaderClient::connectionProperties(Document
 
 #endif
 
-void EmptyFrameLoaderClient::dispatchDidReceiveResponse(DocumentLoader*, ResourceLoaderIdentifier, const ResourceResponse&)
+void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveResponse(DocumentLoader*, ResourceLoaderIdentifier, const ResourceResponse&)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidReceiveContentLength(DocumentLoader*, ResourceLoaderIdentifier, int)
+void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveContentLength(DocumentLoader*, ResourceLoaderIdentifier, int)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidFinishLoading(DocumentLoader*, ResourceLoaderIdentifier)
+void NODELETE EmptyFrameLoaderClient::dispatchDidFinishLoading(DocumentLoader*, ResourceLoaderIdentifier)
 {
 }
 
 #if ENABLE(DATA_DETECTION)
 
-void EmptyFrameLoaderClient::dispatchDidFinishDataDetection(NSArray *)
+void NODELETE EmptyFrameLoaderClient::dispatchDidFinishDataDetection(NSArray *)
 {
 }
 
 #endif
 
-void EmptyFrameLoaderClient::dispatchDidFailLoading(DocumentLoader*, ResourceLoaderIdentifier, const ResourceError&)
+void NODELETE EmptyFrameLoaderClient::dispatchDidFailLoading(DocumentLoader*, ResourceLoaderIdentifier, const ResourceError&)
 {
 }
 
-bool EmptyFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache(DocumentLoader*, const ResourceRequest&, const ResourceResponse&, int)
+bool NODELETE EmptyFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache(DocumentLoader*, const ResourceRequest&, const ResourceResponse&, int)
 {
     return false;
 }
 
-void EmptyFrameLoaderClient::dispatchDidDispatchOnloadEvents()
+void NODELETE EmptyFrameLoaderClient::dispatchDidDispatchOnloadEvents()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
+void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidCancelClientRedirect()
+void NODELETE EmptyFrameLoaderClient::dispatchDidCancelClientRedirect()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchWillPerformClientRedirect(const URL&, double, WallTime, LockBackForwardList)
+void NODELETE EmptyFrameLoaderClient::dispatchWillPerformClientRedirect(const URL&, double, WallTime, LockBackForwardList)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidChangeLocationWithinPage()
+void NODELETE EmptyFrameLoaderClient::dispatchDidChangeLocationWithinPage()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidPushStateWithinPage()
+void NODELETE EmptyFrameLoaderClient::dispatchDidPushStateWithinPage()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidReplaceStateWithinPage()
+void NODELETE EmptyFrameLoaderClient::dispatchDidReplaceStateWithinPage()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidPopStateWithinPage()
+void NODELETE EmptyFrameLoaderClient::dispatchDidPopStateWithinPage()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchWillClose()
+void NODELETE EmptyFrameLoaderClient::dispatchWillClose()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidStartProvisionalLoad()
+void NODELETE EmptyFrameLoaderClient::dispatchDidStartProvisionalLoad()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidReceiveTitle(const StringWithDirection&)
+void NODELETE EmptyFrameLoaderClient::dispatchDidReceiveTitle(const StringWithDirection&)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureContent>, std::optional<UsedLegacyTLS>, std::optional<WasPrivateRelayed>)
+void NODELETE EmptyFrameLoaderClient::dispatchDidCommitLoad(std::optional<HasInsecureContent>, std::optional<UsedLegacyTLS>, std::optional<WasPrivateRelayed>)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceError&, WillContinueLoading, WillInternallyHandleFailure)
+void NODELETE EmptyFrameLoaderClient::dispatchDidFailProvisionalLoad(const ResourceError&, WillContinueLoading, WillInternallyHandleFailure)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidFailLoad(const ResourceError&)
+void NODELETE EmptyFrameLoaderClient::dispatchDidFailLoad(const ResourceError&)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidFinishDocumentLoad()
+void NODELETE EmptyFrameLoaderClient::dispatchDidFinishDocumentLoad()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidFinishLoad()
+void NODELETE EmptyFrameLoaderClient::dispatchDidFinishLoad()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>)
+void NODELETE EmptyFrameLoaderClient::dispatchDidReachLayoutMilestone(OptionSet<LayoutMilestone>)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidReachVisuallyNonEmptyState()
+void NODELETE EmptyFrameLoaderClient::dispatchDidReachVisuallyNonEmptyState()
 {
 }
 
-LocalFrame* EmptyFrameLoaderClient::dispatchCreatePage(const NavigationAction&, NewFrameOpenerPolicy)
+LocalFrame* NODELETE EmptyFrameLoaderClient::dispatchCreatePage(const NavigationAction&, NewFrameOpenerPolicy)
 {
     return nullptr;
 }
 
-void EmptyFrameLoaderClient::dispatchShow()
+void NODELETE EmptyFrameLoaderClient::dispatchShow()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceResponse&, const ResourceRequest&, const String&, FramePolicyFunction&&)
+void NODELETE EmptyFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceResponse&, const ResourceRequest&, const String&, FramePolicyFunction&&)
 {
 }
 
-void EmptyFrameLoaderClient::cancelPolicyCheck()
+void NODELETE EmptyFrameLoaderClient::cancelPolicyCheck()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchUnableToImplementPolicy(const ResourceError&)
+void NODELETE EmptyFrameLoaderClient::dispatchUnableToImplementPolicy(const ResourceError&)
 {
 }
 
-void EmptyFrameLoaderClient::revertToProvisionalState(DocumentLoader*)
+void NODELETE EmptyFrameLoaderClient::revertToProvisionalState(DocumentLoader*)
 {
 }
 
-void EmptyFrameLoaderClient::setMainDocumentError(DocumentLoader*, const ResourceError&)
+void NODELETE EmptyFrameLoaderClient::setMainDocumentError(DocumentLoader*, const ResourceError&)
 {
 }
 
-void EmptyFrameLoaderClient::setMainFrameDocumentReady(bool)
+void NODELETE EmptyFrameLoaderClient::setMainFrameDocumentReady(bool)
 {
 }
 
-void EmptyFrameLoaderClient::startDownload(const ResourceRequest&, const String&, FromDownloadAttribute)
+void NODELETE EmptyFrameLoaderClient::startDownload(const ResourceRequest&, const String&, FromDownloadAttribute)
 {
 }
 
-void EmptyFrameLoaderClient::willChangeTitle(DocumentLoader*)
+void NODELETE EmptyFrameLoaderClient::willChangeTitle(DocumentLoader*)
 {
 }
 
-void EmptyFrameLoaderClient::didChangeTitle(DocumentLoader*)
+void NODELETE EmptyFrameLoaderClient::didChangeTitle(DocumentLoader*)
 {
 }
 
-void EmptyFrameLoaderClient::willReplaceMultipartContent()
+void NODELETE EmptyFrameLoaderClient::willReplaceMultipartContent()
 {
 }
 
-void EmptyFrameLoaderClient::didReplaceMultipartContent()
+void NODELETE EmptyFrameLoaderClient::didReplaceMultipartContent()
 {
 }
 
-void EmptyFrameLoaderClient::committedLoad(DocumentLoader*, const SharedBuffer&)
+void NODELETE EmptyFrameLoaderClient::committedLoad(DocumentLoader*, const SharedBuffer&)
 {
 }
 
-void EmptyFrameLoaderClient::finishedLoading(DocumentLoader*)
+void NODELETE EmptyFrameLoaderClient::finishedLoading(DocumentLoader*)
 {
 }
 
-bool EmptyFrameLoaderClient::shouldFallBack(const ResourceError&) const
-{
-    return false;
-}
-
-void EmptyFrameLoaderClient::loadStorageAccessQuirksIfNeeded()
-{
-}
-
-bool EmptyFrameLoaderClient::canHandleRequest(const ResourceRequest&) const
+bool NODELETE EmptyFrameLoaderClient::shouldFallBack(const ResourceError&) const
 {
     return false;
 }
 
-bool EmptyFrameLoaderClient::canShowMIMEType(const String&) const
+void NODELETE EmptyFrameLoaderClient::loadStorageAccessQuirksIfNeeded()
+{
+}
+
+bool NODELETE EmptyFrameLoaderClient::canHandleRequest(const ResourceRequest&) const
 {
     return false;
 }
 
-bool EmptyFrameLoaderClient::canShowMIMETypeAsHTML(const String&) const
+bool NODELETE EmptyFrameLoaderClient::canShowMIMEType(const String&) const
 {
     return false;
 }
 
-bool EmptyFrameLoaderClient::representationExistsForURLScheme(StringView) const
+bool NODELETE EmptyFrameLoaderClient::canShowMIMETypeAsHTML(const String&) const
 {
     return false;
 }
 
-String EmptyFrameLoaderClient::generatedMIMETypeForURLScheme(StringView) const
+bool NODELETE EmptyFrameLoaderClient::representationExistsForURLScheme(StringView) const
+{
+    return false;
+}
+
+String NODELETE EmptyFrameLoaderClient::generatedMIMETypeForURLScheme(StringView) const
 {
     return emptyString();
 }
 
-void EmptyFrameLoaderClient::frameLoadCompleted()
+void NODELETE EmptyFrameLoaderClient::frameLoadCompleted()
 {
 }
 
-void EmptyFrameLoaderClient::restoreViewState()
+void NODELETE EmptyFrameLoaderClient::restoreViewState()
 {
 }
 
-void EmptyFrameLoaderClient::provisionalLoadStarted()
+void NODELETE EmptyFrameLoaderClient::provisionalLoadStarted()
 {
 }
 
-void EmptyFrameLoaderClient::didFinishLoad()
+void NODELETE EmptyFrameLoaderClient::didFinishLoad()
 {
 }
 
-void EmptyFrameLoaderClient::prepareForDataSourceReplacement()
+void NODELETE EmptyFrameLoaderClient::prepareForDataSourceReplacement()
 {
 }
 
-void EmptyFrameLoaderClient::updateCachedDocumentLoader(DocumentLoader&)
+void NODELETE EmptyFrameLoaderClient::updateCachedDocumentLoader(DocumentLoader&)
 {
 }
 
-void EmptyFrameLoaderClient::setTitle(const StringWithDirection&, const URL&)
+void NODELETE EmptyFrameLoaderClient::setTitle(const StringWithDirection&, const URL&)
 {
 }
 
-String EmptyFrameLoaderClient::userAgent(const URL&) const
+String NODELETE EmptyFrameLoaderClient::userAgent(const URL&) const
 {
     return emptyString();
 }
 
-void EmptyFrameLoaderClient::savePlatformDataToCachedFrame(CachedFrame*)
+void NODELETE EmptyFrameLoaderClient::savePlatformDataToCachedFrame(CachedFrame*)
 {
 }
 
-void EmptyFrameLoaderClient::transitionToCommittedFromCachedFrame(CachedFrame*)
+void NODELETE EmptyFrameLoaderClient::transitionToCommittedFromCachedFrame(CachedFrame*)
 {
 }
 
@@ -1034,82 +1034,82 @@ void EmptyFrameLoaderClient::didRestoreFrameHierarchyForCachedFrame()
 
 #endif
 
-void EmptyFrameLoaderClient::transitionToCommittedForNewPage(InitializingIframe)
+void NODELETE EmptyFrameLoaderClient::transitionToCommittedForNewPage(InitializingIframe)
 {
 }
 
-void EmptyFrameLoaderClient::didRestoreFromBackForwardCache()
+void NODELETE EmptyFrameLoaderClient::didRestoreFromBackForwardCache()
 {
 }
 
-void EmptyFrameLoaderClient::updateGlobalHistory()
+void NODELETE EmptyFrameLoaderClient::updateGlobalHistory()
 {
 }
 
-void EmptyFrameLoaderClient::updateGlobalHistoryRedirectLinks()
+void NODELETE EmptyFrameLoaderClient::updateGlobalHistoryRedirectLinks()
 {
 }
 
-ShouldGoToHistoryItem EmptyFrameLoaderClient::shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const
+ShouldGoToHistoryItem NODELETE EmptyFrameLoaderClient::shouldGoToHistoryItem(HistoryItem&, IsSameDocumentNavigation) const
 {
     return ShouldGoToHistoryItem::No;
 }
 
-bool EmptyFrameLoaderClient::supportsAsyncShouldGoToHistoryItem() const
+bool NODELETE EmptyFrameLoaderClient::supportsAsyncShouldGoToHistoryItem() const
 {
     return false;
 }
 
-void EmptyFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const
+void NODELETE EmptyFrameLoaderClient::shouldGoToHistoryItemAsync(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&) const
 {
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-void EmptyFrameLoaderClient::saveViewStateToItem(HistoryItem&)
+void NODELETE EmptyFrameLoaderClient::saveViewStateToItem(HistoryItem&)
 {
 }
 
-bool EmptyFrameLoaderClient::canCachePage() const
+bool NODELETE EmptyFrameLoaderClient::canCachePage() const
 {
     return false;
 }
 
-ObjectContentType EmptyFrameLoaderClient::objectContentType(const URL&, const String&)
+ObjectContentType NODELETE EmptyFrameLoaderClient::objectContentType(const URL&, const String&)
 {
     return ObjectContentType::None;
 }
 
-AtomString EmptyFrameLoaderClient::overrideMediaType() const
+AtomString NODELETE EmptyFrameLoaderClient::overrideMediaType() const
 {
     return nullAtom();
 }
 
-void EmptyFrameLoaderClient::redirectDataToPlugin(Widget&)
+void NODELETE EmptyFrameLoaderClient::redirectDataToPlugin(Widget&)
 {
 }
 
-void EmptyFrameLoaderClient::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld&)
+void NODELETE EmptyFrameLoaderClient::dispatchDidClearWindowObjectInWorld(DOMWrapperWorld&)
 {
 }
 
 #if PLATFORM(COCOA)
 
-RemoteAXObjectRef EmptyFrameLoaderClient::accessibilityRemoteObject()
+RemoteAXObjectRef NODELETE EmptyFrameLoaderClient::accessibilityRemoteObject()
 {
     return nullptr;
 }
 
-IntPoint EmptyFrameLoaderClient::accessibilityRemoteFrameOffset()
+IntPoint NODELETE EmptyFrameLoaderClient::accessibilityRemoteFrameOffset()
 {
     return { };
 }
 
 #if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
-void EmptyFrameLoaderClient::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&)
+void NODELETE EmptyFrameLoaderClient::setIsolatedTree(Ref<WebCore::AXIsolatedTree>&&)
 {
 }
 
-RefPtr<WebCore::AXIsolatedTree> EmptyFrameLoaderClient::isolatedTree() const
+RefPtr<WebCore::AXIsolatedTree> NODELETE EmptyFrameLoaderClient::isolatedTree() const
 {
     return nullptr;
 }
@@ -1122,16 +1122,16 @@ void EmptyFrameLoaderClient::willCacheResponse(DocumentLoader*, ResourceLoaderId
 
 #endif
 
-bool EmptyFrameLoaderClient::isEmptyFrameLoaderClient() const
+bool NODELETE EmptyFrameLoaderClient::isEmptyFrameLoaderClient() const
 {
     return true;
 }
 
-void EmptyFrameLoaderClient::prefetchDNS(const String&)
+void NODELETE EmptyFrameLoaderClient::prefetchDNS(const String&)
 {
 }
 
-RefPtr<HistoryItem> EmptyFrameLoaderClient::createHistoryItemTree(bool, BackForwardItemIdentifier) const
+RefPtr<HistoryItem> NODELETE EmptyFrameLoaderClient::createHistoryItemTree(bool, BackForwardItemIdentifier) const
 {
     return nullptr;
 }
@@ -1145,16 +1145,16 @@ RefPtr<LegacyPreviewLoaderClient> EmptyFrameLoaderClient::createPreviewLoaderCli
 
 #endif
 
-bool EmptyFrameLoaderClient::hasFrameSpecificStorageAccess()
+bool NODELETE EmptyFrameLoaderClient::hasFrameSpecificStorageAccess()
 {
     return false;
 }
 
-void EmptyFrameLoaderClient::revokeFrameSpecificStorageAccess()
+void NODELETE EmptyFrameLoaderClient::revokeFrameSpecificStorageAccess()
 {
 }
 
-void EmptyFrameLoaderClient::dispatchLoadEventToOwnerElementInAnotherProcess()
+void NODELETE EmptyFrameLoaderClient::dispatchLoadEventToOwnerElementInAnotherProcess()
 {
 }
 
@@ -1174,19 +1174,19 @@ void EmptyFrameLoaderClient::sendH2Ping(const URL& url, CompletionHandler<void(E
     completionHandler(makeUnexpected(internalError(url)));
 }
 
-void EmptyEditorClient::EmptyTextCheckerClient::requestCheckingOfString(TextCheckingRequest&, const VisibleSelection&)
+void NODELETE EmptyEditorClient::EmptyTextCheckerClient::requestCheckingOfString(TextCheckingRequest&, const VisibleSelection&)
 {
 }
 
-void EmptyEditorClient::EmptyTextCheckerClient::requestExtendedCheckingOfString(TextCheckingRequest&, const VisibleSelection&)
+void NODELETE EmptyEditorClient::EmptyTextCheckerClient::requestExtendedCheckingOfString(TextCheckingRequest&, const VisibleSelection&)
 {
 }
 
-void EmptyEditorClient::registerUndoStep(UndoStep&)
+void NODELETE EmptyEditorClient::registerUndoStep(UndoStep&)
 {
 }
 
-void EmptyEditorClient::registerRedoStep(UndoStep&)
+void NODELETE EmptyEditorClient::registerRedoStep(UndoStep&)
 {
 }
 
@@ -1206,7 +1206,7 @@ Ref<StorageNamespace> EmptyStorageNamespaceProvider::createTransientLocalStorage
 }
 
 class EmptyStorageSessionProvider final : public StorageSessionProvider {
-    NetworkStorageSession* storageSession() const final { return nullptr; }
+    NetworkStorageSession* NODELETE storageSession() const final { return nullptr; }
 };
 
 class EmptyBroadcastChannelRegistry final : public BroadcastChannelRegistry {
@@ -1218,14 +1218,14 @@ public:
 private:
     EmptyBroadcastChannelRegistry() = default;
 
-    void registerChannel(const PartitionedSecurityOrigin&, const String&, BroadcastChannelIdentifier) final { }
-    void unregisterChannel(const PartitionedSecurityOrigin&, const String&, BroadcastChannelIdentifier) final { }
-    void postMessage(const PartitionedSecurityOrigin&, const String&, BroadcastChannelIdentifier, Ref<SerializedScriptValue>&&, CompletionHandler<void()>&&) final { }
+    void NODELETE registerChannel(const PartitionedSecurityOrigin&, const String&, BroadcastChannelIdentifier) final { }
+    void NODELETE unregisterChannel(const PartitionedSecurityOrigin&, const String&, BroadcastChannelIdentifier) final { }
+    void NODELETE postMessage(const PartitionedSecurityOrigin&, const String&, BroadcastChannelIdentifier, Ref<SerializedScriptValue>&&, CompletionHandler<void()>&&) final { }
 };
 
 class EmptySocketProvider final : public SocketProvider {
 public:
-    RefPtr<ThreadableWebSocketChannel> createWebSocketChannel(Document&, WebSocketChannelClient&) final { return nullptr; }
+    RefPtr<ThreadableWebSocketChannel> NODELETE createWebSocketChannel(Document&, WebSocketChannelClient&) final { return nullptr; }
 
     std::pair<RefPtr<WebTransportSession>, Ref<WebTransportSessionPromise>> initializeWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&, const URL&, const WebTransportOptions&) { return { nullptr, WebTransportSessionPromise::createAndReject() }; }
 
@@ -1238,8 +1238,8 @@ class EmptyHistoryItemClient final : public HistoryItemClient {
 public:
     static Ref<EmptyHistoryItemClient> create() { return adoptRef(*new EmptyHistoryItemClient); }
 private:
-    void historyItemChanged(const HistoryItem&) { }
-    void clearChildren(const HistoryItem&) const { }
+    void NODELETE historyItemChanged(const HistoryItem&) { }
+    void NODELETE clearChildren(const HistoryItem&) const { }
 };
 
 PageConfiguration pageConfigurationWithEmptyClients(std::optional<PageIdentifier> identifier, PAL::SessionID sessionID)

--- a/Source/WebCore/loader/EmptyClients.h
+++ b/Source/WebCore/loader/EmptyClients.h
@@ -140,20 +140,20 @@ class EmptyChromeClient : public ChromeClient {
 
     void reachedMaxAppCacheSize(int64_t) final { }
 
-    RefPtr<ColorChooser> createColorChooser(ColorChooserClient&, const Color&) final;
+    RefPtr<ColorChooser> NODELETE createColorChooser(ColorChooserClient&, const Color&) final;
 
-    RefPtr<DataListSuggestionPicker> createDataListSuggestionPicker(DataListSuggestionsClient&) final;
+    RefPtr<DataListSuggestionPicker> NODELETE createDataListSuggestionPicker(DataListSuggestionsClient&) final;
     bool canShowDataListSuggestionLabels() const final { return false; }
 
-    RefPtr<DateTimeChooser> createDateTimeChooser(DateTimeChooserClient&) final;
+    RefPtr<DateTimeChooser> NODELETE createDateTimeChooser(DateTimeChooserClient&) final;
 
-    void setTextIndicator(RefPtr<TextIndicator>&&) const final;
-    void updateTextIndicator(RefPtr<TextIndicator>&&) const final;
+    void NODELETE setTextIndicator(RefPtr<TextIndicator>&&) const final;
+    void NODELETE updateTextIndicator(RefPtr<TextIndicator>&&) const final;
 
-    DisplayRefreshMonitorFactory* displayRefreshMonitorFactory() const final;
+    DisplayRefreshMonitorFactory* NODELETE displayRefreshMonitorFactory() const final;
 
-    void runOpenPanel(LocalFrame&, FileChooser&) final;
-    void showShareSheet(ShareDataWithParsedURL&&, CompletionHandler<void(bool)>&&) final;
+    void NODELETE runOpenPanel(LocalFrame&, FileChooser&) final;
+    void NODELETE showShareSheet(ShareDataWithParsedURL&&, CompletionHandler<void(bool)>&&) final;
     void loadIconForFiles(const Vector<String>&, FileIconLoader&) final { }
 
     void elementDidFocus(Element&, const FocusOptions&) final { }
@@ -224,7 +224,7 @@ class EmptyChromeClient : public ChromeClient {
     void didAssociateFormControls(const Vector<Ref<Element>>&, LocalFrame&) final { }
     bool shouldNotifyOnFormChanges() final { return false; }
 
-    RefPtr<Icon> createIconForFiles(const Vector<String>& /* filenames */) final;
+    RefPtr<Icon> NODELETE createIconForFiles(const Vector<String>& /* filenames */) final;
 };
 
 DiagnosticLoggingClient& emptyDiagnosticLoggingClient();

--- a/Source/WebCore/loader/FTPDirectoryParser.cpp
+++ b/Source/WebCore/loader/FTPDirectoryParser.cpp
@@ -43,14 +43,14 @@ namespace WebCore {
 #define gmtime_r(x, y) gmtime_s((y), (x))
 #endif
 
-static inline FTPEntryType ParsingFailed(ListState& state)
+static inline FTPEntryType NODELETE ParsingFailed(ListState& state)
 {
     if (state.parsedOne || state.listStyle) /* junk if we fail to parse */
         return FTPJunkEntry; /* this time but had previously parsed sucessfully */
     return FTPMiscEntry; /* its part of a comment or error message */
 }
 
-static bool isSpaceOrTab(Latin1Character c)
+static bool NODELETE isSpaceOrTab(Latin1Character c)
 {
     return c == ' ' || c == '\t';
 }

--- a/Source/WebCore/loader/FormState.h
+++ b/Source/WebCore/loader/FormState.h
@@ -61,7 +61,7 @@ public:
 
 private:
     FormState(HTMLFormElement&, StringPairVector&& textFieldValues, Document&, FormSubmissionTrigger, HTMLFormControlElement* submitter);
-    void willDetachPage() override;
+    void NODELETE willDetachPage() override;
 
     const Ref<HTMLFormElement> m_form;
     StringPairVector m_textFieldValues;

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -190,7 +190,7 @@
 #else
 namespace WebCore {
 
-static void verifyUserAgent(const String&)
+static void NODELETE verifyUserAgent(const String&)
 {
 }
 
@@ -250,7 +250,7 @@ bool isReload(FrameLoadType type)
 // non-member lets us exclude it from the header file, thus keeping FrameLoader.h's
 // API simpler.
 //
-static bool isDocumentSandboxed(LocalFrame& frame, SandboxFlag flag)
+static bool NODELETE isDocumentSandboxed(LocalFrame& frame, SandboxFlag flag)
 {
     return frame.document() && frame.document()->isSandboxed(flag);
 }
@@ -939,7 +939,7 @@ bool FrameLoader::allChildrenAreComplete() const
     return true;
 }
 
-bool FrameLoader::allAncestorsAreComplete() const
+bool NODELETE FrameLoader::allAncestorsAreComplete() const
 {
     for (RefPtr<Frame> ancestor = m_frame.ptr(); ancestor; ancestor = ancestor->tree().parent()) {
         auto* localAncestor = dynamicDowncast<LocalFrame>(*ancestor);
@@ -1218,7 +1218,7 @@ void FrameLoader::setFirstPartyForCookies(const URL& url)
     }
 }
 
-static NavigationNavigationType determineNavigationType(FrameLoadType loadType, NavigationHistoryBehavior historyHandling)
+static NavigationNavigationType NODELETE determineNavigationType(FrameLoadType loadType, NavigationHistoryBehavior historyHandling)
 {
     if (historyHandling == NavigationHistoryBehavior::Push)
         return NavigationNavigationType::Push;
@@ -2794,7 +2794,7 @@ void FrameLoader::willChangeTitle(DocumentLoader* loader)
     m_client->willChangeTitle(loader);
 }
 
-FrameLoadType FrameLoader::loadType() const
+FrameLoadType NODELETE FrameLoader::loadType() const
 {
     return m_loadType;
 }
@@ -3792,7 +3792,7 @@ static bool itemAllowsScrollRestoration(HistoryItem* historyItem, FrameLoadType 
     return true;
 }
 
-static bool isSameDocumentReload(bool isNewNavigation, FrameLoadType loadType)
+static bool NODELETE isSameDocumentReload(bool isNewNavigation, FrameLoadType loadType)
 {
     return !isNewNavigation && !isBackForwardLoadType(loadType);
 }
@@ -3914,7 +3914,7 @@ void FrameLoader::dispatchUnloadEvents(UnloadEventPolicy unloadEventPolicy)
         protect(m_frame->document())->removeAllEventListeners();
 }
 
-static bool shouldAskForNavigationConfirmation(Document& document, const BeforeUnloadEvent& event)
+static bool NODELETE shouldAskForNavigationConfirmation(Document& document, const BeforeUnloadEvent& event)
 {
     // Confirmation dialog should not be displayed when the allow-modals flag is not set.
     if (document.isSandboxed(SandboxFlag::Modals))
@@ -4809,7 +4809,7 @@ void FrameLoader::clearTestingOverrides()
     m_isStrictRawResourceValidationPolicyDisabledForTesting = false;
 }
 
-bool LocalFrameLoaderClient::hasHTMLView() const
+bool NODELETE LocalFrameLoaderClient::hasHTMLView() const
 {
     return true;
 }

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -102,8 +102,8 @@ enum class ShouldUpdateAppInitiatedValue : bool { No, Yes };
 
 struct WindowFeatures;
 
-WEBCORE_EXPORT bool isBackForwardLoadType(FrameLoadType);
-WEBCORE_EXPORT bool isReload(FrameLoadType);
+WEBCORE_EXPORT bool NODELETE isBackForwardLoadType(FrameLoadType);
+WEBCORE_EXPORT bool NODELETE isReload(FrameLoadType);
 
 using ContentPolicyDecisionFunction = CompletionHandler<void(PolicyAction)>;
 
@@ -115,7 +115,7 @@ public:
     FrameLoader(LocalFrame&, CompletionHandler<UniqueRef<LocalFrameLoaderClient>(LocalFrame&, FrameLoader&)>&& clientCreator);
     ~FrameLoader();
 
-    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void NODELETE ref() const;
     WEBCORE_EXPORT void deref() const;
 
     WEBCORE_EXPORT void init();
@@ -180,14 +180,14 @@ public:
     WEBCORE_EXPORT URL outgoingReferrerURL();
     String outgoingOrigin() const;
 
-    WEBCORE_EXPORT DocumentLoader* activeDocumentLoader() const;
+    WEBCORE_EXPORT DocumentLoader* NODELETE activeDocumentLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
     DocumentLoader* policyDocumentLoader() const { return m_policyDocumentLoader.get(); }
     DocumentLoader* provisionalDocumentLoader() const { return m_provisionalDocumentLoader.get(); }
     FrameState state() const { return m_state; }
 
     enum class CanIncludeCurrentDocumentLoader : bool { No, Yes };
-    WEBCORE_EXPORT RefPtr<DocumentLoader> loaderForWebsitePolicies(CanIncludeCurrentDocumentLoader = CanIncludeCurrentDocumentLoader::Yes) const;
+    WEBCORE_EXPORT RefPtr<DocumentLoader> NODELETE loaderForWebsitePolicies(CanIncludeCurrentDocumentLoader = CanIncludeCurrentDocumentLoader::Yes) const;
 
     bool shouldReportResourceTimingToParentFrame() const { return m_shouldReportResourceTimingToParentFrame; };
     
@@ -205,8 +205,8 @@ public:
     static ResourceError blockedByContentFilterError(const ResourceRequest&);
 #endif
 
-    bool isMultipartReplacing() const;
-    void setMultipartReplacing();
+    bool NODELETE isMultipartReplacing() const;
+    void NODELETE setMultipartReplacing();
     bool subframeIsLoading() const;
     void willChangeTitle(DocumentLoader*);
     void didChangeTitle(DocumentLoader*);
@@ -236,7 +236,7 @@ public:
     const LocalFrameLoaderClient& client() const { return m_client.get(); }
     LocalFrameLoaderClient& client() { return m_client.get(); }
 
-    WEBCORE_EXPORT FrameIdentifier frameID() const;
+    WEBCORE_EXPORT FrameIdentifier NODELETE frameID() const;
 
     void setDefersLoading(bool);
 
@@ -311,7 +311,7 @@ public:
     const URL& previousURL() const { return m_previousURL; }
 
     bool isHTTPFallbackInProgress() const { return m_navigationUpgradeToHTTPSBehavior == NavigationUpgradeToHTTPSBehavior::HTTPFallback; }
-    bool shouldNavigateWithHTTP(bool isSameSiteNavigation) const;
+    bool NODELETE shouldNavigateWithHTTP(bool isSameSiteNavigation) const;
     bool isNavigationUpgradeToHTTPSDisabled() const { return m_navigationUpgradeToHTTPSBehavior == NavigationUpgradeToHTTPSBehavior::Disabled; }
     bool isHTTPFallbackInProgressOrUpgradeDisabled() const { return isHTTPFallbackInProgress() || isNavigationUpgradeToHTTPSDisabled(); }
     void resetHTTPFallbackInProgress() { m_navigationUpgradeToHTTPSBehavior = NavigationUpgradeToHTTPSBehavior::BasedOnPolicy; }
@@ -328,12 +328,12 @@ public:
     void setStrictRawResourceValidationPolicyDisabledForTesting(bool disabled) { m_isStrictRawResourceValidationPolicyDisabledForTesting = disabled; }
     bool isStrictRawResourceValidationPolicyDisabledForTesting() { return m_isStrictRawResourceValidationPolicyDisabledForTesting; }
 
-    WEBCORE_EXPORT void clearTestingOverrides();
+    WEBCORE_EXPORT void NODELETE clearTestingOverrides();
 
     const URL& provisionalLoadErrorBeingHandledURL() const { return m_provisionalLoadErrorBeingHandledURL; }
     void setProvisionalLoadErrorBeingHandledURL(const URL& url) { m_provisionalLoadErrorBeingHandledURL = url; }
 
-    bool shouldSuppressTextInputFromEditing() const;
+    bool NODELETE shouldSuppressTextInputFromEditing() const;
     bool isReloadingFromOrigin() const { return m_loadType == FrameLoadType::ReloadFromOrigin; }
 
     // Used in webarchive loading tests.
@@ -372,9 +372,9 @@ private:
         MayNotAttemptCacheOnlyLoadForFormSubmissionItem
     };
 
-    RefPtr<LocalFrame> nonSrcdocFrame() const;
+    RefPtr<LocalFrame> NODELETE nonSrcdocFrame() const;
 
-    std::optional<PageIdentifier> pageID() const;
+    std::optional<PageIdentifier> NODELETE pageID() const;
     void executeJavaScriptURL(const URL&, const NavigationAction&);
 
     bool allChildrenAreComplete() const; // immediate children, not all descendants
@@ -456,14 +456,14 @@ private:
     void dispatchGlobalObjectAvailableInAllWorlds();
 
     bool isNavigationAllowed() const;
-    bool isStopLoadingAllowed() const;
+    bool NODELETE isStopLoadingAllowed() const;
 
     enum class LoadContinuingState : uint8_t { NotContinuing, ContinuingWithRequest, ContinuingWithHistoryItem };
     bool shouldTreatCurrentLoadAsContinuingLoad() const { return m_currentLoadContinuingState != LoadContinuingState::NotContinuing; }
 
     // SubframeLoader specific.
     void loadURLIntoChildFrame(const URL&, const String& referer, LocalFrame&);
-    void started();
+    void NODELETE started();
 
     // PolicyChecker specific.
     void clearProvisionalLoadForPolicyCheck();

--- a/Source/WebCore/loader/FrameLoaderStateMachine.h
+++ b/Source/WebCore/loader/FrameLoaderStateMachine.h
@@ -50,12 +50,12 @@ public:
         FirstLayoutDone
     };
 
-    WEBCORE_EXPORT bool committingFirstRealLoad() const;
-    bool committedFirstRealDocumentLoad() const;
-    WEBCORE_EXPORT bool creatingInitialEmptyDocument() const;
-    WEBCORE_EXPORT bool isDisplayingInitialEmptyDocument() const;
-    WEBCORE_EXPORT bool firstLayoutDone() const;
-    void advanceTo(State);
+    WEBCORE_EXPORT bool NODELETE committingFirstRealLoad() const;
+    bool NODELETE committedFirstRealDocumentLoad() const;
+    WEBCORE_EXPORT bool NODELETE creatingInitialEmptyDocument() const;
+    WEBCORE_EXPORT bool NODELETE isDisplayingInitialEmptyDocument() const;
+    WEBCORE_EXPORT bool NODELETE firstLayoutDone() const;
+    void NODELETE advanceTo(State);
 
     State stateForDebugging() const { return m_state; }
 

--- a/Source/WebCore/loader/FrameMemoryMonitor.h
+++ b/Source/WebCore/loader/FrameMemoryMonitor.h
@@ -37,7 +37,7 @@ public:
     WEBCORE_EXPORT ~FrameMemoryMonitor() = default;
 
     WEBCORE_EXPORT void setUsage(size_t);
-    WEBCORE_EXPORT void lowerAllMemoryLimitsForTesting();
+    WEBCORE_EXPORT void NODELETE lowerAllMemoryLimitsForTesting();
 
 private:
     explicit FrameMemoryMonitor(const LocalFrame&);

--- a/Source/WebCore/loader/HeaderFieldTokenizer.h
+++ b/Source/WebCore/loader/HeaderFieldTokenizer.h
@@ -41,7 +41,7 @@ public:
     // string from the |header_field| input. Return |true| on success. Return
     // |false| if the separator character, the token or the quoted string is
     // missing or invalid.
-    bool consume(char16_t);
+    bool NODELETE consume(char16_t);
     String consumeToken();
     String consumeTokenOrQuotedString();
 
@@ -49,13 +49,13 @@ public:
     // the Vector parameter are found.
     // Because we potentially have to iterate through the entire Vector for each
     // character of the base string, the Vector should be small (< 3 members).
-    void consumeBeforeAnyCharMatch(const Vector<char16_t>&);
+    void NODELETE consumeBeforeAnyCharMatch(const Vector<char16_t>&);
 
     bool isConsumed() const { return m_index >= m_input.length(); }
 
 private:
     String consumeQuotedString();
-    void skipSpaces();
+    void NODELETE skipSpaces();
 
     unsigned m_index = 0;
     const String m_input;

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -66,7 +66,7 @@ static inline void addVisitedLink(Page& page, const URL& url)
     page.protectedVisitedLinkStore()->addVisitedLink(page, computeSharedStringHash(url.string()));
 }
 
-static inline bool canRecordHistoryForFrame(const LocalFrame& frame)
+static inline bool NODELETE canRecordHistoryForFrame(const LocalFrame& frame)
 {
     RefPtr page = frame.page();
     if (!page)

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -55,7 +55,7 @@ public:
     explicit HistoryController(LocalFrame&);
     ~HistoryController();
 
-    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void NODELETE ref() const;
     WEBCORE_EXPORT void deref() const;
 
     WEBCORE_EXPORT void saveScrollPositionAndViewStateToItem(HistoryItem*);
@@ -77,7 +77,7 @@ public:
     void updateForClientRedirect();
     void updateForCommit();
     void updateForSameDocumentNavigation();
-    void updateForFrameLoadCompleted();
+    void NODELETE updateForFrameLoadCompleted();
 
     HistoryItem* currentItem() const { return m_currentItem.get(); }
     WEBCORE_EXPORT void setCurrentItem(Ref<HistoryItem>&&);
@@ -89,7 +89,7 @@ public:
     void clearPreviousItem();
 
     HistoryItem* provisionalItem() const { return m_provisionalItem.get(); }
-    void setProvisionalItem(RefPtr<HistoryItem>&&);
+    void NODELETE setProvisionalItem(RefPtr<HistoryItem>&&);
 
     void pushState(RefPtr<SerializedScriptValue>&&, const String& url);
     void replaceState(RefPtr<SerializedScriptValue>&&, const String& url);
@@ -104,7 +104,7 @@ public:
 
 private:
     friend class Page;
-    bool shouldStopLoadingForHistoryItem(HistoryItem&) const;
+    bool NODELETE shouldStopLoadingForHistoryItem(HistoryItem&) const;
     void goToItem(HistoryItem&, FrameLoadType, ShouldTreatAsContinuingLoad);
     void goToItemForNavigationAPI(HistoryItem&, FrameLoadType, LocalFrame& triggeringFrame, NavigationAPIMethodTracker*);
     void goToItemShared(HistoryItem&, CompletionHandler<void(ShouldGoToHistoryItem)>&&, ShouldTreatAsContinuingLoad = ShouldTreatAsContinuingLoad::No);
@@ -116,8 +116,8 @@ private:
     enum class ForNavigationAPI : bool { No, Yes };
     void recursiveSetProvisionalItem(HistoryItem&, HistoryItem*, ForNavigationAPI = ForNavigationAPI::No);
     void recursiveGoToItem(HistoryItem&, HistoryItem*, FrameLoadType, ShouldTreatAsContinuingLoad);
-    bool isMultipartReplaceLoadTypeWithProvisionalItem(FrameLoadType);
-    bool isReloadTypeWithProvisionalItem(FrameLoadType);
+    bool NODELETE isMultipartReplaceLoadTypeWithProvisionalItem(FrameLoadType);
+    bool NODELETE isReloadTypeWithProvisionalItem(FrameLoadType);
     void recursiveUpdateForCommit();
     void recursiveUpdateForSameDocumentNavigation();
     static bool itemsAreClones(HistoryItem&, HistoryItem*);

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -120,7 +120,7 @@ static ImageEventSender& loadEventSender()
     return sender;
 }
 
-static inline bool pageIsBeingDismissed(Document& document)
+static inline bool NODELETE pageIsBeingDismissed(Document& document)
 {
     auto* frame = document.frame();
     return frame && frame->loader().pageDismissalEventBeingDispatched() != FrameLoader::PageDismissalType::None;

--- a/Source/WebCore/loader/ImageLoader.h
+++ b/Source/WebCore/loader/ImageLoader.h
@@ -53,7 +53,7 @@ public:
     virtual ~ImageLoader();
 
     // CachedResourceClient.
-    void ref() const final;
+    void NODELETE ref() const final;
     void deref() const final;
 
     // This function should be called when the element is attached to a document; starts
@@ -86,7 +86,7 @@ public:
 
     // FIXME: Delete this code. beforeload event no longer exists.
     bool hasPendingBeforeLoadEvent() const { return m_hasPendingBeforeLoadEvent; }
-    bool hasPendingActivity() const;
+    bool NODELETE hasPendingActivity() const;
 
     void dispatchPendingEvent(ImageEventSender*, const AtomString& eventType);
 
@@ -114,11 +114,11 @@ private:
     void dispatchPendingLoadEvent();
     void dispatchPendingErrorEvent();
 
-    RenderImageResource* renderImageResource();
+    RenderImageResource* NODELETE renderImageResource();
     void updateRenderer();
 
     void clearImageWithoutConsideringPendingLoadEvent();
-    void clearFailedLoadURL();
+    void NODELETE clearFailedLoadURL();
 
     bool hasPendingDecodePromises() const { return !m_decodingPromises.isEmpty(); }
     void resolveDecodePromises();

--- a/Source/WebCore/loader/LinkHeader.cpp
+++ b/Source/WebCore/loader/LinkHeader.cpp
@@ -59,7 +59,7 @@ template<typename CharacterType> static bool isParameterValueChar(CharacterType 
 }
 
 // Verify that the parameter is a link-extension which according to spec doesn't have to have a value.
-static bool isExtensionParameter(LinkHeader::LinkParameterName name)
+static bool NODELETE isExtensionParameter(LinkHeader::LinkParameterName name)
 {
     return name >= LinkHeader::LinkParameterUnknown;
 }

--- a/Source/WebCore/loader/LinkHeader.h
+++ b/Source/WebCore/loader/LinkHeader.h
@@ -70,7 +70,7 @@ public:
     };
 
 private:
-    void setValue(LinkParameterName, String&& value);
+    void NODELETE setValue(LinkParameterName, String&& value);
 
     String m_url;
     String m_rel;

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -119,7 +119,7 @@ class WEBCORE_EXPORT LocalFrameLoaderClient : public FrameLoaderClient {
 public:
     ~LocalFrameLoaderClient();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
     virtual bool isWebLocalFrameLoaderClient() const { return false; }

--- a/Source/WebCore/loader/MediaResourceLoader.h
+++ b/Source/WebCore/loader/MediaResourceLoader.h
@@ -70,10 +70,10 @@ public:
     void sendH2Ping(const URL&, CompletionHandler<void(Expected<Seconds, ResourceError>&&)>&&) final;
     void removeResource(MediaResource&);
 
-    Document* document();
-    const String& crossOriginMode() const;
+    Document* NODELETE document();
+    const String& NODELETE crossOriginMode() const;
 
-    WEBCORE_EXPORT static void recordResponsesForTesting();
+    WEBCORE_EXPORT static void NODELETE recordResponsesForTesting();
     WEBCORE_EXPORT Vector<ResourceResponse> responsesForTesting() const;
     void addResponseForTesting(const ResourceResponse&);
 

--- a/Source/WebCore/loader/MixedContentChecker.cpp
+++ b/Source/WebCore/loader/MixedContentChecker.cpp
@@ -81,12 +81,12 @@ static bool isMixedContent(const Frame& frame, const URL& url)
     return false;
 }
 
-static bool destinationIsImageAudioOrVideo(FetchOptions::Destination destination)
+static bool NODELETE destinationIsImageAudioOrVideo(FetchOptions::Destination destination)
 {
     return destination == FetchOptions::Destination::Audio || destination == FetchOptions::Destination::Image || destination == FetchOptions::Destination::Video;
 }
 
-static bool destinationIsImageAndInitiatorIsImageset(FetchOptions::Destination destination, Initiator initiator)
+static bool NODELETE destinationIsImageAndInitiatorIsImageset(FetchOptions::Destination destination, Initiator initiator)
 {
     return destination == FetchOptions::Destination::Image && initiator == Initiator::Imageset;
 }

--- a/Source/WebCore/loader/NavigationAction.h
+++ b/Source/WebCore/loader/NavigationAction.h
@@ -115,10 +115,10 @@ public:
     bool openedByDOMWithOpener() const { return m_openedByDOMWithOpener; }
     void setOpenedByDOMWithOpener() { m_openedByDOMWithOpener = true; }
 
-    void setTargetBackForwardItem(HistoryItem&);
+    void NODELETE setTargetBackForwardItem(HistoryItem&);
     const std::optional<BackForwardItemIdentifier>& targetBackForwardItemIdentifier() const { return m_targetBackForwardItemIdentifier; }
 
-    void setSourceBackForwardItem(HistoryItem*);
+    void NODELETE setSourceBackForwardItem(HistoryItem*);
     const std::optional<BackForwardItemIdentifier>& sourceBackForwardItemIdentifier() const { return m_sourceBackForwardItemIdentifier; }
 
 

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -101,17 +101,17 @@ public:
     virtual bool targetIsCurrentFrame() const { return true; }
     virtual bool isSameDocumentNavigation(Frame&) const { return false; }
 
-    double delay() const { return m_delay; }
-    LockHistory lockHistory() const { return m_lockHistory; }
-    LockBackForwardList lockBackForwardList() const { return m_lockBackForwardList; }
-    bool wasDuringLoad() const { return m_wasDuringLoad; }
-    bool isLocationChange() const { return m_isLocationChange; }
-    UserGestureToken* userGestureToForward() const { return m_userGestureToForward.get(); }
+    double NODELETE delay() const { return m_delay; }
+    LockHistory NODELETE lockHistory() const { return m_lockHistory; }
+    LockBackForwardList NODELETE lockBackForwardList() const { return m_lockBackForwardList; }
+    bool NODELETE wasDuringLoad() const { return m_wasDuringLoad; }
+    bool NODELETE isLocationChange() const { return m_isLocationChange; }
+    UserGestureToken* NODELETE userGestureToForward() const { return m_userGestureToForward.get(); }
 
 protected:
     void clearUserGesture() { m_userGestureToForward = nullptr; }
-    ShouldOpenExternalURLsPolicy shouldOpenExternalURLs() const { return m_shouldOpenExternalURLsPolicy; }
-    InitiatedByMainFrame initiatedByMainFrame() const { return m_initiatedByMainFrame; };
+    ShouldOpenExternalURLsPolicy NODELETE shouldOpenExternalURLs() const { return m_shouldOpenExternalURLsPolicy; }
+    InitiatedByMainFrame NODELETE initiatedByMainFrame() const { return m_initiatedByMainFrame; };
 
 private:
     double m_delay;
@@ -165,10 +165,10 @@ protected:
             localFrame->loader().clientRedirectCancelledOrFinished(newLoadInProgress);
     }
 
-    Document& initiatingDocument() const { return m_initiatingDocument.get(); }
-    SecurityOrigin* securityOrigin() const { return m_securityOrigin.get(); }
-    const URL& url() const { return m_url; }
-    const String& referrer() const { return m_referrer; }
+    Document& NODELETE initiatingDocument() const { return m_initiatingDocument.get(); }
+    SecurityOrigin* NODELETE securityOrigin() const { return m_securityOrigin.get(); }
+    const URL& NODELETE url() const { return m_url; }
+    const String& NODELETE referrer() const { return m_referrer; }
 
     bool isSameDocumentNavigation(Frame&) const final { return equalIgnoringFragmentIdentifier(initiatingDocument().url(), url()); }
 

--- a/Source/WebCore/loader/NavigationScheduler.h
+++ b/Source/WebCore/loader/NavigationScheduler.h
@@ -57,10 +57,10 @@ public:
     explicit NavigationScheduler(Frame&);
     ~NavigationScheduler();
 
-    void ref() const;
+    void NODELETE ref() const;
     void deref() const;
 
-    bool redirectScheduledDuringLoad();
+    bool NODELETE redirectScheduledDuringLoad();
     bool locationChangePending();
 
     void scheduleRedirect(Document& initiatingDocument, double delay, const URL&, IsMetaRefresh);
@@ -76,10 +76,10 @@ public:
     void cancel(NewLoadInProgress = NewLoadInProgress::No);
     void clear();
 
-    bool hasQueuedNavigation() const;
+    bool NODELETE hasQueuedNavigation() const;
 
 private:
-    bool shouldScheduleNavigation() const;
+    bool NODELETE shouldScheduleNavigation() const;
     bool shouldScheduleNavigation(const URL&) const;
 
     void timerFired();

--- a/Source/WebCore/loader/NetscapePlugInStreamLoader.h
+++ b/Source/WebCore/loader/NetscapePlugInStreamLoader.h
@@ -57,7 +57,7 @@ public:
     WEBCORE_EXPORT static void create(LocalFrame&, NetscapePlugInStreamLoaderClient&, ResourceRequest&&, CompletionHandler<void(RefPtr<NetscapePlugInStreamLoader>&&)>&&);
     virtual ~NetscapePlugInStreamLoader();
 
-    WEBCORE_EXPORT bool isDone() const;
+    WEBCORE_EXPORT bool NODELETE isDone() const;
 
 private:
     void init(ResourceRequest&&, CompletionHandler<void(bool)>&&) override;

--- a/Source/WebCore/loader/PrivateClickMeasurement.h
+++ b/Source/WebCore/loader/PrivateClickMeasurement.h
@@ -73,25 +73,25 @@ public:
     {
     }
     
-    WEBCORE_EXPORT static const Seconds maxAge();
+    WEBCORE_EXPORT static const Seconds NODELETE maxAge();
     WEBCORE_EXPORT bool isNeitherSameSiteNorCrossSiteTriggeringEvent(const RegistrableDomain& redirectDomain, const URL& firstPartyURL, const PCM::AttributionTriggerData&);
     WEBCORE_EXPORT static Expected<PCM::AttributionTriggerData, String> parseAttributionRequest(const URL& redirectURL);
     WEBCORE_EXPORT PCM::AttributionSecondsUntilSendData attributeAndGetEarliestTimeToSend(PCM::AttributionTriggerData&&, IsRunningLayoutTest);
-    WEBCORE_EXPORT bool hasHigherPriorityThan(const PrivateClickMeasurement&) const;
+    WEBCORE_EXPORT bool NODELETE hasHigherPriorityThan(const PrivateClickMeasurement&) const;
     WEBCORE_EXPORT URL attributionReportClickSourceURL() const;
     WEBCORE_EXPORT URL attributionReportClickDestinationURL() const;
     WEBCORE_EXPORT Ref<JSON::Object> attributionReportJSON() const;
     const PCM::SourceSite& sourceSite() const { return m_sourceSite; };
     const PCM::AttributionDestinationSite& destinationSite() const { return m_destinationSite; };
     WallTime timeOfAdClick() const { return m_timeOfAdClick; }
-    WEBCORE_EXPORT bool hasPreviouslyBeenReported();
+    WEBCORE_EXPORT bool NODELETE hasPreviouslyBeenReported();
     PCM::AttributionTimeToSendData timesToSend() const { return m_timesToSend; };
     void setTimesToSend(PCM::AttributionTimeToSendData data) { m_timesToSend = data; }
     const SourceID& sourceID() const { return m_sourceID; }
     const std::optional<PCM::AttributionTriggerData>& attributionTriggerData() const { return m_attributionTriggerData; }
     void setAttribution(PCM::AttributionTriggerData&& attributionTriggerData) { m_attributionTriggerData = WTF::move(attributionTriggerData); }
     const String& sourceApplicationBundleID() const { return m_sourceApplicationBundleID; }
-    WEBCORE_EXPORT void setSourceApplicationBundleIDForTesting(const String&);
+    WEBCORE_EXPORT void NODELETE setSourceApplicationBundleIDForTesting(const String&);
 
     PCM::AttributionEphemeral isEphemeral() const { return m_isEphemeral; }
     void setEphemeral(PCM::AttributionEphemeral isEphemeral) { m_isEphemeral = isEphemeral; }
@@ -118,8 +118,8 @@ public:
     PCM::SourceUnlinkableToken& sourceUnlinkableToken() { return m_sourceUnlinkableToken; }
     void setSourceUnlinkableTokenValue(const String& value) { m_sourceUnlinkableToken.valueBase64URL = value; }
     const std::optional<PCM::SourceSecretToken>& sourceSecretToken() const { return m_sourceSecretToken; }
-    WEBCORE_EXPORT void setSourceSecretToken(PCM::SourceSecretToken&&);
-    WEBCORE_EXPORT void setDestinationSecretToken(PCM::DestinationSecretToken&&);
+    WEBCORE_EXPORT void NODELETE setSourceSecretToken(PCM::SourceSecretToken&&);
+    WEBCORE_EXPORT void NODELETE setDestinationSecretToken(PCM::DestinationSecretToken&&);
 
     static std::optional<uint64_t> appStoreURLAdamID(const URL&);
     bool isSKAdNetworkAttribution() const { return !!m_adamID; }

--- a/Source/WebCore/loader/ProgressTracker.h
+++ b/Source/WebCore/loader/ProgressTracker.h
@@ -65,7 +65,7 @@ public:
     long long totalPageAndResourceBytesToLoad() const { return m_totalPageAndResourceBytesToLoad; }
     long long totalBytesReceived() const { return m_totalBytesReceived; }
 
-    bool isMainLoadProgressing() const;
+    bool NODELETE isMainLoadProgressing() const;
 
 private:
     void reset();

--- a/Source/WebCore/loader/ResourceCryptographicDigest.cpp
+++ b/Source/WebCore/loader/ResourceCryptographicDigest.cpp
@@ -134,7 +134,7 @@ std::optional<ResourceCryptographicDigest> decodeEncodedResourceCryptographicDig
     return std::nullopt;
 }
 
-static PAL::CryptoDigest::Algorithm toCryptoDigestAlgorithm(ResourceCryptographicDigest::Algorithm algorithm)
+static PAL::CryptoDigest::Algorithm NODELETE toCryptoDigestAlgorithm(ResourceCryptographicDigest::Algorithm algorithm)
 {
     switch (algorithm) {
     case ResourceCryptographicDigest::Algorithm::SHA256:

--- a/Source/WebCore/loader/ResourceLoadObserver.cpp
+++ b/Source/WebCore/loader/ResourceLoadObserver.cpp
@@ -29,7 +29,7 @@
 
 namespace WebCore {
 
-static ResourceLoadObserver*& sharedObserver()
+static ResourceLoadObserver*& NODELETE sharedObserver()
 {
     static ResourceLoadObserver* observer = nullptr;
     return observer;

--- a/Source/WebCore/loader/ResourceLoadObserver.h
+++ b/Source/WebCore/loader/ResourceLoadObserver.h
@@ -46,9 +46,9 @@ public:
     // https://fetch.spec.whatwg.org/#request-destination-script-like
     enum class FetchDestinationIsScriptLike : bool { No, Yes };
 
-    WEBCORE_EXPORT static ResourceLoadObserver& singleton();
-    WEBCORE_EXPORT static ResourceLoadObserver* singletonIfExists();
-    WEBCORE_EXPORT static void setShared(ResourceLoadObserver&);
+    WEBCORE_EXPORT static ResourceLoadObserver& NODELETE singleton();
+    WEBCORE_EXPORT static ResourceLoadObserver* NODELETE singletonIfExists();
+    WEBCORE_EXPORT static void NODELETE setShared(ResourceLoadObserver&);
     
     virtual ~ResourceLoadObserver() { }
 

--- a/Source/WebCore/loader/ResourceLoader.h
+++ b/Source/WebCore/loader/ResourceLoader.h
@@ -86,7 +86,7 @@ public:
     virtual const ResourceRequest& iOSOriginalRequest() const { return request(); }
 #endif
 
-    WEBCORE_EXPORT FrameLoader* frameLoader() const;
+    WEBCORE_EXPORT FrameLoader* NODELETE frameLoader() const;
     DocumentLoader* documentLoader() const { return m_documentLoader.get(); }
     const ResourceRequest& originalRequest() const { return m_originalRequest; }
 
@@ -113,7 +113,7 @@ public:
     const FragmentedSharedBuffer* resourceData() const;
     void clearResourceData();
     
-    virtual bool isSubresourceLoader() const;
+    virtual bool NODELETE isSubresourceLoader() const;
 
     virtual void willSendRequest(ResourceRequest&&, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&& callback);
     virtual void didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent);
@@ -143,7 +143,7 @@ public:
     bool shouldSniffContent() const { return m_options.sniffContent == ContentSniffingPolicy::SniffContent; }
     ContentEncodingSniffingPolicy contentEncodingSniffingPolicy() const { return m_options.contentEncodingSniffingPolicy; }
     WEBCORE_EXPORT bool isAllowedToAskUserForCredentials() const;
-    WEBCORE_EXPORT bool shouldIncludeCertificateInfo() const;
+    WEBCORE_EXPORT bool NODELETE shouldIncludeCertificateInfo() const;
 
     virtual CachedResource* cachedResource() const { return nullptr; }
 
@@ -163,17 +163,17 @@ public:
     void unschedule(WTF::SchedulePair&);
 #endif
 
-    WEBCORE_EXPORT LocalFrame* frame() const;
+    WEBCORE_EXPORT LocalFrame* NODELETE frame() const;
 
     const ResourceLoaderOptions& options() const { return m_options; }
 
     const ResourceRequest& deferredRequest() const { return m_deferredRequest; }
     ResourceRequest takeDeferredRequest() { return std::exchange(m_deferredRequest, { }); }
 
-    bool isPDFJSResourceLoad() const;
+    bool NODELETE isPDFJSResourceLoad() const;
 
 #if ENABLE(CONTENT_EXTENSIONS)
-    WEBCORE_EXPORT ResourceMonitor* resourceMonitorIfExists();
+    WEBCORE_EXPORT ResourceMonitor* NODELETE resourceMonitorIfExists();
 #endif
 
 protected:

--- a/Source/WebCore/loader/ResourceMonitor.h
+++ b/Source/WebCore/loader/ResourceMonitor.h
@@ -56,7 +56,7 @@ public:
     void setDocumentURL(URL&&);
     WEBCORE_EXPORT void addNetworkUsage(size_t);
     size_t networkUsageThreshold() const { return m_networkUsageThreshold; }
-    WEBCORE_EXPORT UsageLevel networkUsageLevel() const;
+    WEBCORE_EXPORT UsageLevel NODELETE networkUsageLevel() const;
 
     void updateNetworkUsageThreshold(size_t);
 

--- a/Source/WebCore/loader/ResourceMonitorChecker.h
+++ b/Source/WebCore/loader/ResourceMonitorChecker.h
@@ -58,7 +58,7 @@ public:
     WEBCORE_EXPORT void setContentRuleList(ContentExtensions::ContentExtensionsBackend&&);
     WEBCORE_EXPORT void setNetworkUsageThreshold(size_t threshold, double randomness = defaultNetworkUsageThresholdRandomness);
 
-    WEBCORE_EXPORT size_t networkUsageThreshold() const;
+    WEBCORE_EXPORT size_t NODELETE networkUsageThreshold() const;
     WEBCORE_EXPORT size_t networkUsageThresholdWithNoise() const;
 
     static constexpr Seconds ruleListPreparationTimeout = 10_s;

--- a/Source/WebCore/loader/ResourceMonitorThrottler.h
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.h
@@ -49,7 +49,7 @@ public:
     bool tryAccess(const String& host, ContinuousApproximateTime);
     void clearAllData();
 
-    void setCountPerDuration(size_t count, Seconds duration);
+    void NODELETE setCountPerDuration(size_t count, Seconds duration);
 
     static constexpr size_t defaultThrottleAccessCount = 5;
     static constexpr Seconds defaultThrottleDuration = 24_h;
@@ -69,7 +69,7 @@ private:
 
         bool tryAccessAndUpdateHistory(ContinuousApproximateTime, const Config&);
         bool tryExpire(ContinuousApproximateTime, const Config&);
-        ContinuousApproximateTime oldestAccessTime() const;
+        ContinuousApproximateTime NODELETE oldestAccessTime() const;
         ContinuousApproximateTime newestAccessTime() const { return m_newestAccessTime; }
 
     private:

--- a/Source/WebCore/loader/ResourceTiming.h
+++ b/Source/WebCore/loader/ResourceTiming.h
@@ -42,9 +42,9 @@ class SecurityOrigin;
 class ResourceTiming {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(ResourceTiming, Loader);
 public:
-    static ResourceTiming fromMemoryCache(const URL&, const String& initiator, const ResourceLoadTiming&, const ResourceResponse&, const NetworkLoadMetrics&, const SecurityOrigin&);
+    static ResourceTiming NODELETE fromMemoryCache(const URL&, const String& initiator, const ResourceLoadTiming&, const ResourceResponse&, const NetworkLoadMetrics&, const SecurityOrigin&);
     static ResourceTiming fromLoad(CachedResource&, const URL&, const String& initiator, const ResourceLoadTiming&, const NetworkLoadMetrics&, const SecurityOrigin&);
-    static ResourceTiming fromSynchronousLoad(const URL&, const String& initiator, const ResourceLoadTiming&, const NetworkLoadMetrics&, const ResourceResponse&, const SecurityOrigin&);
+    static ResourceTiming NODELETE fromSynchronousLoad(const URL&, const String& initiator, const ResourceLoadTiming&, const NetworkLoadMetrics&, const ResourceResponse&, const SecurityOrigin&);
 
     const URL& url() const { return m_url; }
     const String& initiatorType() const { return m_initiatorType; }

--- a/Source/WebCore/loader/SinkDocument.cpp
+++ b/Source/WebCore/loader/SinkDocument.cpp
@@ -48,7 +48,7 @@ private:
     }
 
     // Ignore all data.
-    void appendBytes(DocumentWriter&, std::span<const uint8_t>) override
+    void NODELETE appendBytes(DocumentWriter&, std::span<const uint8_t>) override
     {
     }
 };

--- a/Source/WebCore/loader/SpeculationRules.h
+++ b/Source/WebCore/loader/SpeculationRules.h
@@ -83,7 +83,7 @@ public:
         DocumentPredicate(DocumentPredicate&&) = default;
         DocumentPredicate& operator=(DocumentPredicate&&) = default;
 
-        const PredicateVariant& value() const;
+        const PredicateVariant& NODELETE value() const;
 
     private:
         PredicateVariant m_value;

--- a/Source/WebCore/loader/SubframeLoader.h
+++ b/Source/WebCore/loader/SubframeLoader.h
@@ -49,7 +49,7 @@ class FrameLoader::SubframeLoader {
 public:
     explicit SubframeLoader(LocalFrame&);
 
-    void clear();
+    void NODELETE clear();
 
     void createFrameIfNecessary(HTMLFrameOwnerElement&, const AtomString& frameName);
     bool requestFrame(HTMLFrameOwnerElement&, const String& url, const AtomString& frameName, LockHistory = LockHistory::Yes, LockBackForwardList = LockBackForwardList::Yes);
@@ -71,7 +71,7 @@ private:
 
     URL completeURL(const String&) const;
 
-    bool shouldConvertInvalidURLsToBlank() const;
+    bool NODELETE shouldConvertInvalidURLsToBlank() const;
 
     bool canCreateSubFrame() const;
 

--- a/Source/WebCore/loader/SubresourceIntegrity.cpp
+++ b/Source/WebCore/loader/SubresourceIntegrity.cpp
@@ -121,7 +121,7 @@ static bool isResponseEligible(const CachedResource& resource)
     return resource.isCORSSameOrigin();
 }
 
-static std::optional<EncodedResourceCryptographicDigest::Algorithm> prioritizedHashFunction(EncodedResourceCryptographicDigest::Algorithm a, EncodedResourceCryptographicDigest::Algorithm b)
+static std::optional<EncodedResourceCryptographicDigest::Algorithm> NODELETE prioritizedHashFunction(EncodedResourceCryptographicDigest::Algorithm a, EncodedResourceCryptographicDigest::Algorithm b)
 {
     if (a == b)
         return std::nullopt;
@@ -203,7 +203,7 @@ static String addHashPrefix(ResourceCryptographicDigest::Algorithm algorithm, St
     return String();
 }
 
-static std::optional<ResourceCryptographicDigest::Algorithm> findStrongestAlgorithm(HashAlgorithmSet algorithmSet)
+static std::optional<ResourceCryptographicDigest::Algorithm> NODELETE findStrongestAlgorithm(HashAlgorithmSet algorithmSet)
 {
     for (int i = ResourceCryptographicDigest::algorithmCount - 1; i >= 0; --i) {
         uint8_t algorithm = (1 << i);

--- a/Source/WebCore/loader/SubresourceLoader.h
+++ b/Source/WebCore/loader/SubresourceLoader.h
@@ -51,7 +51,7 @@ public:
     virtual ~SubresourceLoader();
 
     void cancelIfNotFinishing();
-    bool isSubresourceLoader() const final;
+    bool NODELETE isSubresourceLoader() const final;
     CachedResource* cachedResource() const final { return m_resource.get(); };
 
     WEBCORE_EXPORT const HTTPHeaderMap* originalHeaders() const;

--- a/Source/WebCore/loader/TextResourceDecoder.cpp
+++ b/Source/WebCore/loader/TextResourceDecoder.cpp
@@ -44,7 +44,7 @@ using namespace HTMLNames;
 // similar functions that operate on char16_t, but arguably only the decoder has
 // a reason to process strings of char rather than char16_t.
 
-static size_t find(std::span<const uint8_t> subject, std::span<const uint8_t> target)
+static size_t NODELETE find(std::span<const uint8_t> subject, std::span<const uint8_t> target)
 {
     if (target.size() > subject.size())
         return notFound;
@@ -75,13 +75,13 @@ public:
     static enum Type judge(std::span<const uint8_t>);
     static constexpr int ESC = 0x1b;
     static const std::array<uint8_t, 256> sjisMap;
-    static int ISkanji(int code)
+    static int NODELETE ISkanji(int code)
     {
         if (code >= 0x100)
             return 0;
         return sjisMap[code & 0xff] & 1;
     }
-    static int ISkana(int code)
+    static int NODELETE ISkana(int code)
     {
         if (code >= 0x100)
             return 0;
@@ -343,7 +343,7 @@ bool TextResourceDecoder::hasEqualEncodingForCharset(const String& charset) cons
 }
 
 // Returns the position of the encoding string.
-static size_t findXMLEncoding(std::span<const uint8_t> string, size_t& encodingLength)
+static size_t NODELETE findXMLEncoding(std::span<const uint8_t> string, size_t& encodingLength)
 {
     size_t position = find(string, byteCast<uint8_t>("encoding"_span));
     if (position == notFound)

--- a/Source/WebCore/loader/TextResourceDecoder.h
+++ b/Source/WebCore/loader/TextResourceDecoder.h
@@ -84,7 +84,7 @@ private:
     bool checkForHeadCharset(std::span<const uint8_t>, bool& movedDataToBuffer);
     bool checkForMetaCharset(std::span<const uint8_t>);
     void detectJapaneseEncoding(std::span<const uint8_t>);
-    bool shouldAutoDetect() const;
+    bool NODELETE shouldAutoDetect() const;
 
     ContentType m_contentType;
     PAL::TextEncoding m_encoding;

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -85,7 +85,7 @@ static const CFStringRef LegacyWebArchiveResourceTextEncodingNameKey = CFSTR("We
 static const CFStringRef LegacyWebArchiveResourceResponseKey = CFSTR("WebResourceResponse");
 static const CFStringRef LegacyWebArchiveResourceResponseVersionKey = CFSTR("WebResourceResponseVersion");
 
-static bool isUnreservedURICharacter(char16_t character)
+static bool NODELETE isUnreservedURICharacter(char16_t character)
 {
     return isASCIIAlphanumeric(character) || character == '-' || character == '.' || character == '_' || character == '~';
 }

--- a/Source/WebCore/loader/cache/CachedFont.h
+++ b/Source/WebCore/loader/cache/CachedFont.h
@@ -76,7 +76,7 @@ private:
     String calculateItemInCollection() const;
 
     void checkNotify(const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No) override;
-    bool mayTryReplaceEncodedData() const override;
+    bool NODELETE mayTryReplaceEncodedData() const override;
 
     void load(CachedResourceLoader&) override;
     NO_RETURN_DUE_TO_ASSERT void setBodyDataFrom(const CachedResource&) final { ASSERT_NOT_REACHED(); }

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -69,7 +69,7 @@ public:
     bool currentFrameIsComplete(const RenderElement*);
 
     std::pair<WeakPtr<Image>, float> brokenImage(float deviceScaleFactor) const; // Returns an image and the image's resolution scale factor.
-    bool willPaintBrokenImage() const;
+    bool NODELETE willPaintBrokenImage() const;
 
     bool canRender(const RenderElement* renderer, float multiplier) { return !errorOccurred() && !imageSizeForRenderer(renderer, multiplier).isEmpty(); }
 
@@ -102,7 +102,7 @@ public:
 
     bool isOriginClean(SecurityOrigin*);
 
-    bool isClientWaitingForAsyncDecoding(const CachedImageClient&) const;
+    bool NODELETE isClientWaitingForAsyncDecoding(const CachedImageClient&) const;
     void addClientWaitingForAsyncDecoding(CachedImageClient&);
     void removeAllClientsWaitingForAsyncDecoding();
 

--- a/Source/WebCore/loader/cache/CachedRawResource.cpp
+++ b/Source/WebCore/loader/cache/CachedRawResource.cpp
@@ -284,7 +284,7 @@ void CachedRawResource::setDataBufferingPolicy(DataBufferingPolicy dataBuffering
     m_options.dataBufferingPolicy = dataBufferingPolicy;
 }
 
-static bool shouldIgnoreHeaderForCacheReuse(HTTPHeaderName name)
+static bool NODELETE shouldIgnoreHeaderForCacheReuse(HTTPHeaderName name)
 {
     switch (name) {
     // FIXME: This list of headers that don't affect cache policy almost certainly isn't complete.

--- a/Source/WebCore/loader/cache/CachedRawResource.h
+++ b/Source/WebCore/loader/cache/CachedRawResource.h
@@ -37,7 +37,7 @@ public:
 
     void setDefersLoading(bool);
 
-    void setDataBufferingPolicy(DataBufferingPolicy);
+    void NODELETE setDataBufferingPolicy(DataBufferingPolicy);
 
     // FIXME: This is exposed for the InspectorInstrumentation for preflights in DocumentThreadableLoader. It's also really lame.
     std::optional<ResourceLoaderIdentifier> resourceLoaderIdentifier() const { return m_resourceLoaderIdentifier; }

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -190,8 +190,8 @@ public:
     }
 
     unsigned size() const { return encodedSize() + decodedSize() + overheadSize(); }
-    unsigned encodedSize() const;
-    unsigned decodedSize() const;
+    unsigned NODELETE encodedSize() const;
+    unsigned NODELETE decodedSize() const;
     unsigned overheadSize() const;
 
     bool isLoaded() const { return !m_loading; } // FIXME. Method name is inaccurate. Loading might not have started yet.
@@ -226,7 +226,7 @@ public:
 
     // Computes the status of an object after loading.
     // Updates the expire date on the cache entry file
-    void finish();
+    void NODELETE finish();
 
     // Called by the cache if the object has been removed from the cache
     // while still being referenced. This means the object should delete itself
@@ -246,9 +246,9 @@ public:
     WEBCORE_EXPORT const ResourceResponse& response() const;
     Box<NetworkLoadMetrics> takeNetworkLoadMetrics() { return mutableResponse().takeNetworkLoadMetrics(); }
 
-    void setCrossOrigin();
-    bool isCrossOrigin() const;
-    bool isCORSCrossOrigin() const;
+    void NODELETE setCrossOrigin();
+    bool NODELETE isCrossOrigin() const;
+    bool NODELETE isCORSCrossOrigin() const;
     bool isCORSSameOrigin() const;
     ResourceResponse::Tainting responseTainting() const { return m_responseTainting; }
 

--- a/Source/WebCore/loader/cache/CachedResourceClient.h
+++ b/Source/WebCore/loader/cache/CachedResourceClient.h
@@ -52,9 +52,9 @@ public:
     virtual void notifyFinished(CachedResource&, const NetworkLoadMetrics&, LoadWillContinueInAnotherProcess = LoadWillContinueInAnotherProcess::No);
     virtual void deprecatedDidReceiveCachedResource(CachedResource&);
 
-    static CachedResourceClientType expectedType();
-    virtual CachedResourceClientType resourceClientType() const;
-    virtual bool shouldMarkAsReferenced() const;
+    static CachedResourceClientType NODELETE expectedType();
+    virtual CachedResourceClientType NODELETE resourceClientType() const;
+    virtual bool NODELETE shouldMarkAsReferenced() const;
 
 #if ASSERT_ENABLED
     void addAssociatedResource(CachedResource&);

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -263,7 +263,7 @@ CachedResource* CachedResourceLoader::cachedResource(const URL& url) const
     return m_documentResources.get(url.string()).get();
 }
 
-LocalFrame* CachedResourceLoader::frame() const
+LocalFrame* NODELETE CachedResourceLoader::frame() const
 {
     return m_documentLoader ? m_documentLoader->frame() : nullptr;
 }
@@ -431,7 +431,7 @@ ResourceErrorOr<CachedResourceHandle<CachedRawResource>> CachedResourceLoader::r
 }
 #endif
 
-static MixedContentChecker::IsUpgradable isUpgradableTypeFromResourceType(CachedResource::Type type)
+static MixedContentChecker::IsUpgradable NODELETE isUpgradableTypeFromResourceType(CachedResource::Type type)
 {
     // https://www.w3.org/TR/mixed-content/#category-upgradeable
     // Editor’s Draft, 23 February 2023
@@ -905,7 +905,7 @@ bool CachedResourceLoader::shouldUpdateCachedResourceWithCurrentRequest(const Ca
     return false;
 }
 
-static inline bool isResourceSuitableForDirectReuse(const CachedResource& resource, const CachedResourceRequest& request)
+static inline bool NODELETE isResourceSuitableForDirectReuse(const CachedResource& resource, const CachedResourceRequest& request)
 {
     // FIXME: For being loaded requests, the response tainting may not be correctly computed if the fetch mode is not the same.
     // Even if the fetch mode is the same, we are not sure that the resource can be reused (Vary: Origin header for instance).
@@ -987,7 +987,7 @@ void CachedResourceLoader::updateHTTPRequestHeaders(FrameLoader& frameLoader, Ca
     request.updateAcceptEncodingHeader();
 }
 
-static FetchOptions::Destination destinationForType(CachedResource::Type type, LocalFrame& frame)
+static FetchOptions::Destination NODELETE destinationForType(CachedResource::Type type, LocalFrame& frame)
 {
     switch (type) {
     case CachedResource::Type::MainResource:
@@ -1046,7 +1046,7 @@ static inline SVGImage* cachedResourceSVGImage(CachedResource* resource)
     return cachedImage ? dynamicDowncast<SVGImage>(cachedImage->image()) : nullptr;
 }
 
-static bool computeMayAddToMemoryCache(const CachedResourceRequest& newRequest, const CachedResource* existingResource)
+static bool NODELETE computeMayAddToMemoryCache(const CachedResourceRequest& newRequest, const CachedResource* existingResource)
 {
     return !existingResource || !existingResource->isPreloaded() || newRequest.options().serviceWorkersMode != ServiceWorkersMode::None || existingResource->options().serviceWorkersMode == ServiceWorkersMode::None;
 }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.h
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.h
@@ -152,8 +152,8 @@ public:
 
     WEBCORE_EXPORT void garbageCollectDocumentResources();
 
-    void incrementRequestCount(const CachedResource&);
-    void decrementRequestCount(const CachedResource&);
+    void NODELETE incrementRequestCount(const CachedResource&);
+    void NODELETE decrementRequestCount(const CachedResource&);
     int requestCount() const { return m_requestCount; }
 
     WEBCORE_EXPORT bool isPreloaded(const String& urlString) const;
@@ -207,7 +207,7 @@ private:
 
     void performPostLoadActions();
 
-    ImageLoading clientDefersImage(const URL&) const;
+    ImageLoading NODELETE clientDefersImage(const URL&) const;
     void reloadImagesIfNotDeferred();
 
     bool canRequestAfterRedirection(CachedResource::Type, const URL&, const ResourceLoaderOptions&, const URL& preRedirectURL) const;

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -68,7 +68,7 @@ public:
     RequestPriority fetchPriority() const { return m_options.fetchPriority; }
 
     void setInitiator(Element&);
-    void setInitiatorType(const AtomString&);
+    void NODELETE setInitiatorType(const AtomString&);
     const AtomString& initiatorType() const;
 
     bool allowsCaching() const { return m_options.cachingPolicy == CachingPolicy::AllowCaching || m_options.cachingPolicy == CachingPolicy::AllowCachingMainResourcePrefetch; }
@@ -78,20 +78,20 @@ public:
     bool ignoreForRequestCount() const { return m_ignoreForRequestCount; }
     void setIgnoreForRequestCount(bool ignoreForRequestCount) { m_ignoreForRequestCount = ignoreForRequestCount; }
 
-    void setDestinationIfNotSet(FetchOptions::Destination);
+    void NODELETE setDestinationIfNotSet(FetchOptions::Destination);
 
     void updateForAccessControl(Document&);
 
-    void updateReferrerPolicy(ReferrerPolicy);
+    void NODELETE updateReferrerPolicy(ReferrerPolicy);
     void updateReferrerAndOriginHeaders(FrameLoader&);
     void updateUserAgentHeader(FrameLoader&);
     void upgradeInsecureRequestIfNeeded(Document&, ContentSecurityPolicy::AlwaysUpgradeRequest = ContentSecurityPolicy::AlwaysUpgradeRequest::No);
     void setAcceptHeaderIfNone(CachedResource::Type);
     void updateAccordingCacheMode();
     void updateAcceptEncodingHeader();
-    void updateCacheModeIfNeeded(CachePolicy);
+    void NODELETE updateCacheModeIfNeeded(CachePolicy);
 
-    void disableCachingIfNeeded();
+    void NODELETE disableCachingIfNeeded();
 
     void removeFragmentIdentifierIfNeeded();
 #if ENABLE(CONTENT_EXTENSIONS)
@@ -114,9 +114,9 @@ public:
     static String splitFragmentIdentifierFromRequestURL(ResourceRequest&);
     static String acceptHeaderValueFromType(CachedResource::Type, bool usingSecureProtocol);
 
-    void setClientIdentifierIfNeeded(ScriptExecutionContextIdentifier);
-    void setSelectedServiceWorkerRegistrationIdentifierIfNeeded(ServiceWorkerRegistrationIdentifier);
-    void setNavigationServiceWorkerRegistrationData(const std::optional<ServiceWorkerRegistrationData>&);
+    void NODELETE setClientIdentifierIfNeeded(ScriptExecutionContextIdentifier);
+    void NODELETE setSelectedServiceWorkerRegistrationIdentifierIfNeeded(ServiceWorkerRegistrationIdentifier);
+    void NODELETE setNavigationServiceWorkerRegistrationData(const std::optional<ServiceWorkerRegistrationData>&);
 
 private:
     ResourceRequest m_resourceRequest;

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -106,7 +106,7 @@ public:
     bool add(CachedResource&);
     void remove(CachedResource&);
 
-    static bool shouldRemoveFragmentIdentifier(const URL&);
+    static bool NODELETE shouldRemoveFragmentIdentifier(const URL&);
     WEBCORE_EXPORT static URL removeFragmentIdentifierIfNeeded(const URL&);
 
     void revalidationSucceeded(CachedResource& revalidatingResource, const ResourceResponse&);
@@ -143,7 +143,7 @@ public:
     void removeFromLRUList(CachedResource&);
 
     // Called to adjust the cache totals when a resource changes size.
-    void adjustSize(bool live, long long delta);
+    void NODELETE adjustSize(bool live, long long delta);
 
     // Track decoded resources that are in the cache and referenced by a Web page.
     void insertInLiveDecodedResourcesList(CachedResource&);
@@ -159,7 +159,7 @@ public:
     WEBCORE_EXPORT Statistics getStatistics();
     
     void resourceAccessed(CachedResource&);
-    bool inLiveDecodedResourcesList(CachedResource&) const;
+    bool NODELETE inLiveDecodedResourcesList(CachedResource&) const;
 
     using SecurityOriginSet = HashSet<Ref<SecurityOrigin>>;
     WEBCORE_EXPORT void removeResourcesWithOrigin(const SecurityOrigin&);
@@ -191,12 +191,12 @@ private:
 
     unsigned liveCapacity() const;
     unsigned deadCapacity() const;
-    bool needsPruning() const;
+    bool NODELETE needsPruning() const;
 
     CachedResource* resourceForRequestImpl(const ResourceRequest&, CachedResourceMap&);
 
     CachedResourceMap& ensureSessionResourceMap(PAL::SessionID);
-    CachedResourceMap* sessionResourceMap(PAL::SessionID) const;
+    CachedResourceMap* NODELETE sessionResourceMap(PAL::SessionID) const;
 
     bool m_disabled { false };
     bool m_inPruneResources { false };


### PR DESCRIPTION
#### e255ef0af5b08df42a90d713f83b6716bb9f8837
<pre>
Adopt `NODELETE` annotation in more places in Source/WebCore/loader &amp; Source/WebCore/history
<a href="https://bugs.webkit.org/show_bug.cgi?id=308202">https://bugs.webkit.org/show_bug.cgi?id=308202</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/history/CachedFrame.h:
* Source/WebCore/history/HistoryItem.h:
* Source/WebCore/history/mac/HistoryItemMac.mm:
(WebCore::HistoryItem::viewState const):
* Source/WebCore/loader/ContentFilter.h:
* Source/WebCore/loader/CookieJar.cpp:
(WebCore::shouldRelaxThirdPartyCookieBlocking):
* Source/WebCore/loader/CrossOriginAccessControl.h:
* Source/WebCore/loader/CrossOriginPreflightResultCache.h:
* Source/WebCore/loader/DefaultResourceLoadPriority.h:
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::contentFilterInDocumentLoader):
(WebCore::scriptExecutionContextIdentifierToLoaderMap):
(WebCore::shouldEnableResourceMonitor):
(WebCore::DocumentLoader::colorSchemePreference const):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/DocumentWriter.h:
* Source/WebCore/loader/EmptyClients.cpp:
(WebCore::EmptyFrameLoaderClient::dispatchDecidePolicyForNewWindowAction):
(WebCore::EmptyFrameLoaderClient::dispatchDecidePolicyForNavigationAction):
(WebCore::EmptyFrameLoaderClient::updateSandboxFlags):
(WebCore::EmptyFrameLoaderClient::updateOpener):
(WebCore::EmptyFrameLoaderClient::setPrinting):
(WebCore::EmptyFrameLoaderClient::dispatchWillSendSubmitEvent):
(WebCore::EmptyFrameLoaderClient::createFrame):
(WebCore::EmptyFrameLoaderClient::createPlugin):
(WebCore::EmptyFrameLoaderClient::hasWebView const):
(WebCore::EmptyFrameLoaderClient::makeRepresentation):
(WebCore::EmptyFrameLoaderClient::forceLayoutForNonHTML):
(WebCore::EmptyFrameLoaderClient::setCopiesOnScroll):
(WebCore::EmptyFrameLoaderClient::detachedFromParent2):
(WebCore::EmptyFrameLoaderClient::detachedFromParent3):
(WebCore::EmptyFrameLoaderClient::convertMainResourceLoadToDownload):
(WebCore::EmptyFrameLoaderClient::assignIdentifierToInitialRequest):
(WebCore::EmptyFrameLoaderClient::shouldUseCredentialStorage):
(WebCore::EmptyFrameLoaderClient::dispatchWillSendRequest):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveAuthenticationChallenge):
(WebCore::EmptyFrameLoaderClient::canAuthenticateAgainstProtectionSpace):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveResponse):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveContentLength):
(WebCore::EmptyFrameLoaderClient::dispatchDidFinishLoading):
(WebCore::EmptyFrameLoaderClient::dispatchDidFinishDataDetection):
(WebCore::EmptyFrameLoaderClient::dispatchDidFailLoading):
(WebCore::EmptyFrameLoaderClient::dispatchDidLoadResourceFromMemoryCache):
(WebCore::EmptyFrameLoaderClient::dispatchDidDispatchOnloadEvents):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveServerRedirectForProvisionalLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidCancelClientRedirect):
(WebCore::EmptyFrameLoaderClient::dispatchWillPerformClientRedirect):
(WebCore::EmptyFrameLoaderClient::dispatchDidChangeLocationWithinPage):
(WebCore::EmptyFrameLoaderClient::dispatchDidPushStateWithinPage):
(WebCore::EmptyFrameLoaderClient::dispatchDidReplaceStateWithinPage):
(WebCore::EmptyFrameLoaderClient::dispatchDidPopStateWithinPage):
(WebCore::EmptyFrameLoaderClient::dispatchWillClose):
(WebCore::EmptyFrameLoaderClient::dispatchDidStartProvisionalLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidReceiveTitle):
(WebCore::EmptyFrameLoaderClient::dispatchDidCommitLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidFailProvisionalLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidFailLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidFinishDocumentLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidFinishLoad):
(WebCore::EmptyFrameLoaderClient::dispatchDidReachLayoutMilestone):
(WebCore::EmptyFrameLoaderClient::dispatchDidReachVisuallyNonEmptyState):
(WebCore::EmptyFrameLoaderClient::dispatchCreatePage):
(WebCore::EmptyFrameLoaderClient::dispatchShow):
(WebCore::EmptyFrameLoaderClient::dispatchDecidePolicyForResponse):
(WebCore::EmptyFrameLoaderClient::cancelPolicyCheck):
(WebCore::EmptyFrameLoaderClient::dispatchUnableToImplementPolicy):
(WebCore::EmptyFrameLoaderClient::revertToProvisionalState):
(WebCore::EmptyFrameLoaderClient::setMainDocumentError):
(WebCore::EmptyFrameLoaderClient::setMainFrameDocumentReady):
(WebCore::EmptyFrameLoaderClient::startDownload):
(WebCore::EmptyFrameLoaderClient::willChangeTitle):
(WebCore::EmptyFrameLoaderClient::didChangeTitle):
(WebCore::EmptyFrameLoaderClient::willReplaceMultipartContent):
(WebCore::EmptyFrameLoaderClient::didReplaceMultipartContent):
(WebCore::EmptyFrameLoaderClient::committedLoad):
(WebCore::EmptyFrameLoaderClient::finishedLoading):
(WebCore::EmptyFrameLoaderClient::shouldFallBack const):
(WebCore::EmptyFrameLoaderClient::loadStorageAccessQuirksIfNeeded):
(WebCore::EmptyFrameLoaderClient::canHandleRequest const):
(WebCore::EmptyFrameLoaderClient::canShowMIMEType const):
(WebCore::EmptyFrameLoaderClient::canShowMIMETypeAsHTML const):
(WebCore::EmptyFrameLoaderClient::representationExistsForURLScheme const):
(WebCore::EmptyFrameLoaderClient::generatedMIMETypeForURLScheme const):
(WebCore::EmptyFrameLoaderClient::frameLoadCompleted):
(WebCore::EmptyFrameLoaderClient::restoreViewState):
(WebCore::EmptyFrameLoaderClient::provisionalLoadStarted):
(WebCore::EmptyFrameLoaderClient::didFinishLoad):
(WebCore::EmptyFrameLoaderClient::prepareForDataSourceReplacement):
(WebCore::EmptyFrameLoaderClient::updateCachedDocumentLoader):
(WebCore::EmptyFrameLoaderClient::setTitle):
(WebCore::EmptyFrameLoaderClient::userAgent const):
(WebCore::EmptyFrameLoaderClient::savePlatformDataToCachedFrame):
(WebCore::EmptyFrameLoaderClient::transitionToCommittedFromCachedFrame):
(WebCore::EmptyFrameLoaderClient::transitionToCommittedForNewPage):
(WebCore::EmptyFrameLoaderClient::didRestoreFromBackForwardCache):
(WebCore::EmptyFrameLoaderClient::updateGlobalHistory):
(WebCore::EmptyFrameLoaderClient::updateGlobalHistoryRedirectLinks):
(WebCore::EmptyFrameLoaderClient::shouldGoToHistoryItem const):
(WebCore::EmptyFrameLoaderClient::supportsAsyncShouldGoToHistoryItem const):
(WebCore::EmptyFrameLoaderClient::shouldGoToHistoryItemAsync const):
(WebCore::EmptyFrameLoaderClient::saveViewStateToItem):
(WebCore::EmptyFrameLoaderClient::canCachePage const):
(WebCore::EmptyFrameLoaderClient::objectContentType):
(WebCore::EmptyFrameLoaderClient::overrideMediaType const):
(WebCore::EmptyFrameLoaderClient::redirectDataToPlugin):
(WebCore::EmptyFrameLoaderClient::dispatchDidClearWindowObjectInWorld):
(WebCore::EmptyFrameLoaderClient::accessibilityRemoteObject):
(WebCore::EmptyFrameLoaderClient::accessibilityRemoteFrameOffset):
(WebCore::EmptyFrameLoaderClient::setIsolatedTree):
(WebCore::EmptyFrameLoaderClient::isolatedTree const):
(WebCore::EmptyFrameLoaderClient::isEmptyFrameLoaderClient const):
(WebCore::EmptyFrameLoaderClient::prefetchDNS):
(WebCore::EmptyFrameLoaderClient::createHistoryItemTree const):
(WebCore::EmptyFrameLoaderClient::hasFrameSpecificStorageAccess):
(WebCore::EmptyFrameLoaderClient::revokeFrameSpecificStorageAccess):
(WebCore::EmptyFrameLoaderClient::dispatchLoadEventToOwnerElementInAnotherProcess):
(WebCore::EmptyEditorClient::EmptyTextCheckerClient::requestCheckingOfString):
(WebCore::EmptyEditorClient::EmptyTextCheckerClient::requestExtendedCheckingOfString):
(WebCore::EmptyEditorClient::registerUndoStep):
(WebCore::EmptyEditorClient::registerRedoStep):
* Source/WebCore/loader/EmptyClients.h:
* Source/WebCore/loader/FTPDirectoryParser.cpp:
(WebCore::ParsingFailed):
(WebCore::isSpaceOrTab):
* Source/WebCore/loader/FormState.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::verifyUserAgent):
(WebCore::isDocumentSandboxed):
(WebCore::FrameLoader::allAncestorsAreComplete const):
(WebCore::determineNavigationType):
(WebCore::FrameLoader::loadType const):
(WebCore::isSameDocumentReload):
(WebCore::shouldAskForNavigationConfirmation):
(WebCore::LocalFrameLoaderClient::hasHTMLView const):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/loader/FrameLoaderStateMachine.h:
* Source/WebCore/loader/FrameMemoryMonitor.h:
* Source/WebCore/loader/HeaderFieldTokenizer.h:
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::canRecordHistoryForFrame):
* Source/WebCore/loader/HistoryController.h:
* Source/WebCore/loader/ImageLoader.cpp:
(WebCore::pageIsBeingDismissed):
* Source/WebCore/loader/ImageLoader.h:
* Source/WebCore/loader/LinkHeader.cpp:
(WebCore::isExtensionParameter):
* Source/WebCore/loader/LinkHeader.h:
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/MediaResourceLoader.h:
* Source/WebCore/loader/MixedContentChecker.cpp:
(WebCore::destinationIsImageAudioOrVideo):
(WebCore::destinationIsImageAndInitiatorIsImageset):
* Source/WebCore/loader/NavigationAction.h:
* Source/WebCore/loader/NavigationScheduler.cpp:
(WebCore::ScheduledNavigation::delay const):
(WebCore::ScheduledNavigation::lockHistory const):
(WebCore::ScheduledNavigation::lockBackForwardList const):
(WebCore::ScheduledNavigation::wasDuringLoad const):
(WebCore::ScheduledNavigation::isLocationChange const):
(WebCore::ScheduledNavigation::userGestureToForward const):
(WebCore::ScheduledNavigation::shouldOpenExternalURLs const):
(WebCore::ScheduledNavigation::initiatedByMainFrame const):
(WebCore::ScheduledURLNavigation::initiatingDocument const):
(WebCore::ScheduledURLNavigation::securityOrigin const):
(WebCore::ScheduledURLNavigation::url const):
(WebCore::ScheduledURLNavigation::referrer const):
* Source/WebCore/loader/NavigationScheduler.h:
* Source/WebCore/loader/NetscapePlugInStreamLoader.h:
* Source/WebCore/loader/PrivateClickMeasurement.h:
* Source/WebCore/loader/ProgressTracker.h:
* Source/WebCore/loader/ResourceCryptographicDigest.cpp:
(WebCore::toCryptoDigestAlgorithm):
* Source/WebCore/loader/ResourceLoadObserver.cpp:
(WebCore::sharedObserver):
* Source/WebCore/loader/ResourceLoadObserver.h:
* Source/WebCore/loader/ResourceLoader.h:
* Source/WebCore/loader/ResourceMonitor.h:
* Source/WebCore/loader/ResourceMonitorChecker.h:
* Source/WebCore/loader/ResourceMonitorThrottler.h:
* Source/WebCore/loader/ResourceTiming.h:
* Source/WebCore/loader/SinkDocument.cpp:
* Source/WebCore/loader/SpeculationRules.h:
* Source/WebCore/loader/SubframeLoader.h:
* Source/WebCore/loader/SubresourceIntegrity.cpp:
(WebCore::prioritizedHashFunction):
(WebCore::findStrongestAlgorithm):
* Source/WebCore/loader/SubresourceLoader.h:
* Source/WebCore/loader/TextResourceDecoder.cpp:
(WebCore::find):
(WebCore::KanjiCode::ISkanji):
(WebCore::KanjiCode::ISkana):
(WebCore::findXMLEncoding):
* Source/WebCore/loader/TextResourceDecoder.h:
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::isUnreservedURICharacter):
* Source/WebCore/loader/cache/CachedFont.h:
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedRawResource.cpp:
(WebCore::shouldIgnoreHeaderForCacheReuse):
* Source/WebCore/loader/cache/CachedRawResource.h:
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/loader/cache/CachedResourceClient.h:
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::frame const):
(WebCore::isUpgradableTypeFromResourceType):
(WebCore::isResourceSuitableForDirectReuse):
(WebCore::destinationForType):
(WebCore::computeMayAddToMemoryCache):
* Source/WebCore/loader/cache/CachedResourceLoader.h:
* Source/WebCore/loader/cache/CachedResourceRequest.h:
* Source/WebCore/loader/cache/MemoryCache.h:

Canonical link: <a href="https://commits.webkit.org/307887@main">https://commits.webkit.org/307887@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3466ea5381bd433a5f601f63c3fc9dc573e46253

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18344 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10227 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99299 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a2ecc61-f3b3-4af7-a50b-8725a550b4fd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147537 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18829 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112020 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80263 "4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b998a659-a26c-4d14-8f3f-01a16372ed61) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148625 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14399 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92925 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f0119435-734a-4460-b31b-a76e0724a525) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13708 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11467 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1781 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123254 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7672 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156647 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8781 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120022 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15181 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120374 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30891 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18240 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128958 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73934 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16103 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7093 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17815 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81595 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17552 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17760 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->