### PR TITLE
Adopt `NODELETE` annotation in more places in Source/WebCore/css

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -738,7 +738,6 @@ style/StyleResolveForDocument.cpp
 style/StyleResolver.cpp
 style/StyleScope.cpp
 style/StyleScopeRuleSets.cpp
-style/StyleSheetContentsCache.cpp
 style/StyleTreeResolver.cpp
 style/StyleUpdate.cpp
 style/Styleable.cpp

--- a/Source/WebCore/css/CSSBackgroundRepeatValue.h
+++ b/Source/WebCore/css/CSSBackgroundRepeatValue.h
@@ -36,7 +36,7 @@ public:
     static Ref<CSSBackgroundRepeatValue> create(CSSValueID repeatXValue, CSSValueID repeatYValue);
 
     String customCSSText(const CSS::SerializationContext&) const;
-    bool equals(const CSSBackgroundRepeatValue&) const;
+    bool NODELETE equals(const CSSBackgroundRepeatValue&) const;
 
     CSSValueID xValue() const { return m_xValue; }
     CSSValueID yValue() const { return m_yValue; }

--- a/Source/WebCore/css/CSSColorSchemeValue.h
+++ b/Source/WebCore/css/CSSColorSchemeValue.h
@@ -36,7 +36,7 @@ public:
     static Ref<CSSColorSchemeValue> create(CSS::ColorScheme);
 
     String customCSSText(const CSS::SerializationContext&) const;
-    bool equals(const CSSColorSchemeValue&) const;
+    bool NODELETE equals(const CSSColorSchemeValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
 
     const CSS::ColorScheme& colorScheme() const { return m_colorScheme; }

--- a/Source/WebCore/css/CSSComputedStyleDeclaration.h
+++ b/Source/WebCore/css/CSSComputedStyleDeclaration.h
@@ -56,26 +56,26 @@ private:
     CSSComputedStyleDeclaration(Element&, const std::optional<Style::PseudoElementIdentifier>&);
 
     // CSSOM functions. Don't make these public.
-    CSSRule* parentRule() const final;
-    CSSRuleList* cssRules() const final;
+    CSSRule* NODELETE parentRule() const final;
+    CSSRuleList* NODELETE cssRules() const final;
     unsigned length() const final;
     String item(unsigned index) const final;
     RefPtr<DeprecatedCSSOMValue> getPropertyCSSValue(const String& propertyName) final;
     String getPropertyValue(const String& propertyName) final;
-    String getPropertyPriority(const String& propertyName) final;
-    String getPropertyShorthand(const String& propertyName) final;
-    bool isPropertyImplicit(const String& propertyName) final;
-    ExceptionOr<void> setProperty(const String& propertyName, const String& value, const String& priority) final;
+    String NODELETE getPropertyPriority(const String& propertyName) final;
+    String NODELETE getPropertyShorthand(const String& propertyName) final;
+    bool NODELETE isPropertyImplicit(const String& propertyName) final;
+    ExceptionOr<void> NODELETE setProperty(const String& propertyName, const String& value, const String& priority) final;
     ExceptionOr<String> removeProperty(const String& propertyName) final;
-    String cssText() const final;
-    ExceptionOr<void> setCssText(const String&) final;
+    String NODELETE cssText() const final;
+    ExceptionOr<void> NODELETE setCssText(const String&) final;
     String getPropertyValueInternal(CSSPropertyID) final;
-    ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant) final;
+    ExceptionOr<void> NODELETE setPropertyInternal(CSSPropertyID, const String& value, IsImportant) final;
     Ref<MutableStyleProperties> copyProperties() const final;
 
     Ref<Element> protectedElement() const { return m_element; }
 
-    const Settings* settings() const final;
+    const Settings* NODELETE settings() const final;
     const FixedVector<CSSPropertyID>& exposedComputedCSSPropertyIDs() const;
 
     Style::Extractor extractor() const;

--- a/Source/WebCore/css/CSSContainerRule.h
+++ b/Source/WebCore/css/CSSContainerRule.h
@@ -41,7 +41,7 @@ public:
     String containerQuery() const;
 
 private:
-    const StyleRuleContainer& styleRuleContainer() const;
+    const StyleRuleContainer& NODELETE styleRuleContainer() const;
 
     CSSContainerRule(StyleRuleContainer&, CSSStyleSheet*);
     StyleRuleType styleRuleType() const final { return StyleRuleType::Container; }

--- a/Source/WebCore/css/CSSCounterStyle.h
+++ b/Source/WebCore/css/CSSCounterStyle.h
@@ -92,10 +92,10 @@ private:
     CSSCounterStyle(const CSSCounterStyleDescriptors&, bool isPredefinedCounterStyle);
 
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-range
-    bool isInRange(int) const;
+    bool NODELETE isInRange(int) const;
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-negative
     bool usesNegativeSign();
-    bool shouldApplyNegativeSymbols(int) const;
+    bool NODELETE shouldApplyNegativeSymbols(int) const;
     // https://www.w3.org/TR/css-counter-styles-3/#counter-style-fallback
     WeakPtr<CSSCounterStyle> fallback() const { return m_fallbackReference; };
     String fallbackText(int, WritingMode);
@@ -105,8 +105,8 @@ private:
     // Initial text representation for the counter, before applying pad and/or negative symbols. Suffix and Prefix are also not considered as described by https://www.w3.org/TR/css-counter-styles-3/#counter-styles.
     String initialRepresentation(int, WritingMode) const;
 
-    String counterForSystemCyclic(int) const;
-    String counterForSystemFixed(int) const;
+    String NODELETE counterForSystemCyclic(int) const;
+    String NODELETE counterForSystemFixed(int) const;
     String counterForSystemSymbolic(unsigned) const;
     String counterForSystemAlphabetic(unsigned) const;
     String counterForSystemNumeric(unsigned) const;

--- a/Source/WebCore/css/CSSCounterStyleDescriptors.h
+++ b/Source/WebCore/css/CSSCounterStyleDescriptors.h
@@ -116,18 +116,18 @@ struct CSSCounterStyleDescriptors {
             && m_explicitlySetDescriptors == other.m_explicitlySetDescriptors;
     }
     void setExplicitlySetDescriptors(const StyleProperties&);
-    bool isValid() const;
-    static bool areSymbolsValidForSystem(System, const Vector<Symbol>&, const AdditiveSymbols&);
+    bool NODELETE isValid() const;
+    static bool NODELETE areSymbolsValidForSystem(System, const Vector<Symbol>&, const AdditiveSymbols&);
 
-    void setName(Name);
+    void NODELETE setName(Name);
     void setSystem(System);
-    void setSystemData(SystemData);
+    void NODELETE setSystemData(SystemData);
     void setNegative(NegativeSymbols);
     void setPrefix(Symbol);
     void setSuffix(Symbol);
     void setRanges(Ranges);
     void setPad(Pad);
-    void setFallbackName(Name);
+    void NODELETE setFallbackName(Name);
     void setSymbols(Vector<Symbol>);
     void setAdditiveSymbols(AdditiveSymbols);
 

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -63,7 +63,7 @@ public:
     bool operator==(const CSSCounterStyleRegistry&) const;
 
 private:
-    static CounterStyleMap& userAgentCounterStyles();
+    static CounterStyleMap& NODELETE userAgentCounterStyles();
 
     // If no map is passed on, user-agent counter styles map will be used
     static void resolveFallbackReference(CSSCounterStyle&, CounterStyleMap* = nullptr);
@@ -72,7 +72,7 @@ private:
 
     static Ref<CSSCounterStyle> counterStyle(const AtomString&, CounterStyleMap* = nullptr);
 
-    void invalidate();
+    void NODELETE invalidate();
 
     CounterStyleMap m_authorCounterStyles;
     bool m_hasUnresolvedReferences { true };

--- a/Source/WebCore/css/CSSCounterStyleRule.h
+++ b/Source/WebCore/css/CSSCounterStyleRule.h
@@ -71,7 +71,7 @@ public:
     virtual ~CSSCounterStyleRule();
 
     String cssText() const final;
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
     StyleRuleType styleRuleType() const final { return StyleRuleType::CounterStyle; }
 
     String name() const { return m_counterStyleRule->name(); }
@@ -96,7 +96,7 @@ public:
     void setFallback(const String&);
     void setSymbols(const String&);
     void setAdditiveSymbols(const String&);
-    void setSpeakAs(const String&);
+    void NODELETE setSpeakAs(const String&);
 
 private:
     CSSCounterStyleRule(StyleRuleCounterStyle&, CSSStyleSheet* parent);
@@ -109,7 +109,7 @@ private:
     Ref<StyleRuleCounterStyle> m_counterStyleRule;
 };
 
-CSSCounterStyleDescriptors::System toCounterStyleSystemEnum(const CSSValue*);
+CSSCounterStyleDescriptors::System NODELETE toCounterStyleSystemEnum(const CSSValue*);
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/CSSCustomPropertyValue.h
+++ b/Source/WebCore/css/CSSCustomPropertyValue.h
@@ -55,9 +55,9 @@ public:
 
     bool isCurrentColor() const;
 
-    bool isVariableReference() const;
-    bool isVariableData() const;
-    bool isCSSWideKeyword() const;
+    bool NODELETE isVariableReference() const;
+    bool NODELETE isVariableData() const;
+    bool NODELETE isCSSWideKeyword() const;
 
     std::optional<CSSWideKeyword> tryCSSWideKeyword() const;
 

--- a/Source/WebCore/css/CSSFontFace.cpp
+++ b/Source/WebCore/css/CSSFontFace.cpp
@@ -687,7 +687,7 @@ void CSSFontFace::load()
     pump(ExternalResourceDownloadPolicy::Allow);
 }
 
-static Font::Visibility visibility(CSSFontFace::Status status, CSSFontFace::FontLoadTiming timing)
+static Font::Visibility NODELETE visibility(CSSFontFace::Status status, CSSFontFace::FontLoadTiming timing)
 {
     switch (status) {
     case CSSFontFace::Status::Pending:

--- a/Source/WebCore/css/CSSFontFace.h
+++ b/Source/WebCore/css/CSSFontFace.h
@@ -117,7 +117,7 @@ public:
     void addClient(CSSFontFaceClient&);
     void removeClient(CSSFontFaceClient&);
 
-    bool computeFailureState() const;
+    bool NODELETE computeFailureState() const;
 
     void opportunisticallyStartFontDataURLLoading(DownloadableBinaryFontTrustedTypes);
 
@@ -133,7 +133,7 @@ public:
 
     static void appendSources(CSSFontFace&, CSSValueList&, ScriptExecutionContext*, bool isInitiatingElementInUserAgentShadowTree);
 
-    bool rangesMatchCodePoint(char32_t) const;
+    bool NODELETE rangesMatchCodePoint(char32_t) const;
 
     // We don't guarantee that the FontFace wrapper will be the same every time you ask for it.
     Ref<FontFace> wrapper(ScriptExecutionContext*);
@@ -144,7 +144,7 @@ public:
         Seconds blockPeriod;
         Seconds swapPeriod;
     };
-    FontLoadTiming fontLoadTiming() const;
+    FontLoadTiming NODELETE fontLoadTiming() const;
     bool shouldIgnoreFontLoadCompletions() const { return m_shouldIgnoreFontLoadCompletions; }
 
     bool purgeable() const;
@@ -171,7 +171,7 @@ private:
     const StyleProperties& properties() const;
     MutableStyleProperties& mutableProperties();
 
-    RefPtr<Document> protectedDocument();
+    RefPtr<Document> NODELETE protectedDocument();
 
     const Variant<Ref<MutableStyleProperties>, Ref<StyleRuleFontFace>> m_propertiesOrCSSConnection;
     RefPtr<CSSValue> m_family;

--- a/Source/WebCore/css/CSSFontFaceDescriptors.h
+++ b/Source/WebCore/css/CSSFontFaceDescriptors.h
@@ -65,7 +65,7 @@ public:
 private:
     CSSFontFaceDescriptors(MutableStyleProperties&, CSSFontFaceRule&);
 
-    StyleRuleType ruleType() const final;
+    StyleRuleType NODELETE ruleType() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -67,7 +67,7 @@ public:
     // Calling updateStyleIfNeeded() might delete |this|.
     void updateStyleIfNeeded();
 
-    bool hasFace(const CSSFontFace&) const;
+    bool NODELETE hasFace(const CSSFontFace&) const;
     size_t faceCount() const { return m_faces.size(); }
     void add(CSSFontFace&);
     void remove(const CSSFontFace&);

--- a/Source/WebCore/css/CSSFontFaceSource.h
+++ b/Source/WebCore/css/CSSFontFaceSource.h
@@ -56,7 +56,7 @@ public:
     virtual ~CSSFontFaceSource();
 
     // FontLoadRequestClient.
-    void ref() const final;
+    void NODELETE ref() const final;
     void deref() const final;
 
     //                      => Success
@@ -80,16 +80,16 @@ public:
     FontLoadRequest* fontLoadRequest() const { return m_fontRequest.get(); }
     bool requiresExternalResource() const { return m_fontRequest.get(); }
 
-    bool isSVGFontFaceSource() const;
+    bool NODELETE isSVGFontFaceSource() const;
 
 private:
     bool shouldIgnoreFontLoadCompletions() const;
 
     void fontLoaded(FontLoadRequest&) override;
 
-    void setStatus(Status);
+    void NODELETE setStatus(Status);
 
-    Ref<CSSFontFace> protectedCSSFontFace() const;
+    Ref<CSSFontFace> NODELETE protectedCSSFontFace() const;
 
     RefPtr<FontCustomPlatformData> loadCustomFont(SharedBuffer&, DownloadableBinaryFontTrustedTypes);
 

--- a/Source/WebCore/css/CSSFontFaceSrcValue.h
+++ b/Source/WebCore/css/CSSFontFaceSrcValue.h
@@ -51,7 +51,7 @@ public:
     void setSVGFontFaceElement(SVGFontFaceElement&);
 
     String customCSSText(const CSS::SerializationContext&) const;
-    bool equals(const CSSFontFaceSrcLocalValue&) const;
+    bool NODELETE equals(const CSSFontFaceSrcLocalValue&) const;
 
 private:
     explicit CSSFontFaceSrcLocalValue(AtomString&&);

--- a/Source/WebCore/css/CSSFontFeatureValuesRule.h
+++ b/Source/WebCore/css/CSSFontFeatureValuesRule.h
@@ -62,7 +62,7 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontFeatureValues; }
     String cssText() const final;
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleFontFeatureValues> m_fontFeatureValuesRule;
 };

--- a/Source/WebCore/css/CSSFontPaletteValuesRule.h
+++ b/Source/WebCore/css/CSSFontPaletteValuesRule.h
@@ -39,7 +39,7 @@ public:
 
     virtual ~CSSFontPaletteValuesRule();
 
-    String name() const;
+    String NODELETE name() const;
     String fontFamily() const;
     String basePalette() const;
     String overrideColors() const;
@@ -49,7 +49,7 @@ private:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::FontPaletteValues; }
     String cssText() const final;
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleFontPaletteValues> m_fontPaletteValuesRule;
 };

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -78,7 +78,7 @@ public:
 
     void fontCacheInvalidated() final;
 
-    bool isEmpty() const;
+    bool NODELETE isEmpty() const;
 
     void registerForInvalidationCallbacks(FontSelectorClient&) final;
     void unregisterForInvalidationCallbacks(FontSelectorClient&) final;

--- a/Source/WebCore/css/CSSFunctionDescriptors.h
+++ b/Source/WebCore/css/CSSFunctionDescriptors.h
@@ -49,7 +49,7 @@ public:
 
     CSSFunctionDescriptors(MutableStyleProperties&, CSSFunctionDeclarations&);
 
-    StyleRuleType ruleType() const final;
+    StyleRuleType NODELETE ruleType() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSFunctionRule.h
+++ b/Source/WebCore/css/CSSFunctionRule.h
@@ -41,14 +41,14 @@ public:
         std::optional<String> defaultValue;
     };
 
-    String name() const;
+    String NODELETE name() const;
     Vector<FunctionParameter> getParameters() const;
     String returnType() const;
 
     String cssText() const final;
 
 private:
-    const StyleRuleFunction& styleRuleFunction() const;
+    const StyleRuleFunction& NODELETE styleRuleFunction() const;
 
     CSSFunctionRule(StyleRuleFunction&, CSSStyleSheet*);
     StyleRuleType styleRuleType() const final { return StyleRuleType::Function; }

--- a/Source/WebCore/css/CSSGridAutoRepeatValue.h
+++ b/Source/WebCore/css/CSSGridAutoRepeatValue.h
@@ -49,7 +49,7 @@ class CSSGridAutoRepeatValue final : public CSSValueContainingVector {
 public:
     static Ref<CSSGridAutoRepeatValue> create(CSSValueID, CSSValueListBuilder);
 
-    CSSValueID autoRepeatID() const;
+    CSSValueID NODELETE autoRepeatID() const;
 
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSGridAutoRepeatValue&) const;

--- a/Source/WebCore/css/CSSImageSetOptionValue.h
+++ b/Source/WebCore/css/CSSImageSetOptionValue.h
@@ -44,10 +44,10 @@ public:
     CSSValue& image() const { return m_image; }
 
     CSSPrimitiveValue& resolution() const { return m_resolution; }
-    void setResolution(Ref<CSSPrimitiveValue>&&);
+    void NODELETE setResolution(Ref<CSSPrimitiveValue>&&);
 
     String type() const { return m_mimeType; }
-    void setType(String);
+    void NODELETE setType(String);
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
     {

--- a/Source/WebCore/css/CSSImageValue.h
+++ b/Source/WebCore/css/CSSImageValue.h
@@ -51,7 +51,7 @@ public:
 
     Ref<CSSImageValue> copyForComputedStyle(const CSS::URL& resolvedURL) const;
 
-    bool isPending() const;
+    bool NODELETE isPending() const;
     CachedImage* loadImage(CachedResourceLoader&, const ResourceLoaderOptions&);
     CachedImage* cachedImage() const { return m_cachedImage ? m_cachedImage.value().get() : nullptr; }
 
@@ -71,7 +71,7 @@ public:
 
     RefPtr<Style::Image> createStyleImage(const Style::BuilderState&) const;
 
-    bool isLoadedFromOpaqueSource() const;
+    bool NODELETE isLoadedFromOpaqueSource() const;
 
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
     {

--- a/Source/WebCore/css/CSSImportRule.h
+++ b/Source/WebCore/css/CSSImportRule.h
@@ -39,11 +39,11 @@ public:
 
     virtual ~CSSImportRule();
 
-    WEBCORE_EXPORT String href() const;
+    WEBCORE_EXPORT String NODELETE href() const;
     WEBCORE_EXPORT MediaList& media() const;
     WEBCORE_EXPORT CSSStyleSheet* styleSheet() const;
     String layerName() const;
-    String supportsText() const;
+    String NODELETE supportsText() const;
 
 private:
     friend class MediaList;
@@ -53,11 +53,11 @@ private:
     StyleRuleType styleRuleType() const final { return StyleRuleType::Import; }
     String cssText() const final;
     String cssText(const CSS::SerializationContext&) const final;
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
     void getChildStyleSheets(HashSet<Ref<CSSStyleSheet>>&) final;
 
     String cssTextInternal(const String& urlString) const;
-    const MQ::MediaQueryList& mediaQueries() const;
+    const MQ::MediaQueryList& NODELETE mediaQueries() const;
     void setMediaQueries(MQ::MediaQueryList&&);
 
     const Ref<StyleRuleImport> m_importRule;

--- a/Source/WebCore/css/CSSKeyframeRule.h
+++ b/Source/WebCore/css/CSSKeyframeRule.h
@@ -80,7 +80,7 @@ public:
     virtual ~CSSKeyframeRule();
 
     String cssText() const final { return m_keyframe->cssText(); }
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
 
     String keyText() const { return m_keyframe->keyText(); }
     void setKeyText(const String& text) { m_keyframe->setKeyText(text); }

--- a/Source/WebCore/css/CSSKeyframesRule.h
+++ b/Source/WebCore/css/CSSKeyframesRule.h
@@ -42,7 +42,7 @@ public:
     static Ref<StyleRuleKeyframes> create(const AtomString& name);
     ~StyleRuleKeyframes();
     
-    const Vector<Ref<StyleRuleKeyframe>>& keyframes() const;
+    const Vector<Ref<StyleRuleKeyframe>>& NODELETE keyframes() const;
 
     void parserAppendKeyframe(RefPtr<StyleRuleKeyframe>&&);
     void wrapperAppendKeyframe(Ref<StyleRuleKeyframe>&&);
@@ -73,7 +73,7 @@ public:
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Keyframes; }
     String cssText() const final;
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
 
     const AtomString& name() const { return m_keyframesRule->name(); }
     void setName(const AtomString&);
@@ -85,7 +85,7 @@ public:
     CSSKeyframeRule* findRule(const String& key);
 
     // For IndexedGetter and CSSRuleList.
-    unsigned length() const;
+    unsigned NODELETE length() const;
     CSSKeyframeRule* item(unsigned index) const;
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
 

--- a/Source/WebCore/css/CSSLayerStatementRule.h
+++ b/Source/WebCore/css/CSSLayerStatementRule.h
@@ -46,7 +46,7 @@ public:
 private:
     CSSLayerStatementRule(StyleRuleLayer&, CSSStyleSheet*);
     StyleRuleType styleRuleType() const final { return StyleRuleType::LayerStatement; }
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleLayer> m_layerRule;
 };

--- a/Source/WebCore/css/CSSMarkup.cpp
+++ b/Source/WebCore/css/CSSMarkup.cpp
@@ -52,7 +52,7 @@ static inline bool isCSSTokenizerIdentifier(std::span<const CharacterType> chara
 }
 
 // "ident" from the CSS tokenizer, minus backslash-escape sequences
-static bool isCSSTokenizerIdentifier(const String& string)
+static bool NODELETE isCSSTokenizerIdentifier(const String& string)
 {
     if (string.isEmpty())
         return false;

--- a/Source/WebCore/css/CSSMediaRule.h
+++ b/Source/WebCore/css/CSSMediaRule.h
@@ -51,7 +51,7 @@ private:
     String cssText(const CSS::SerializationContext&) const final;
     String conditionText() const final;
 
-    const MQ::MediaQueryList& mediaQueries() const;
+    const MQ::MediaQueryList& NODELETE mediaQueries() const;
     void setMediaQueries(MQ::MediaQueryList&&);
 
     mutable RefPtr<MediaList> m_mediaCSSOMWrapper;

--- a/Source/WebCore/css/CSSNamespaceRule.h
+++ b/Source/WebCore/css/CSSNamespaceRule.h
@@ -37,15 +37,15 @@ public:
 
     virtual ~CSSNamespaceRule();
 
-    AtomString namespaceURI() const;
-    AtomString prefix() const;
+    AtomString NODELETE namespaceURI() const;
+    AtomString NODELETE prefix() const;
 
 private:
     CSSNamespaceRule(StyleRuleNamespace&, CSSStyleSheet*);
 
     StyleRuleType styleRuleType() const final { return StyleRuleType::Namespace; }
     String cssText() const final;
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleNamespace> m_namespaceRule;
 };

--- a/Source/WebCore/css/CSSPageDescriptors.h
+++ b/Source/WebCore/css/CSSPageDescriptors.h
@@ -58,7 +58,7 @@ public:
 private:
     CSSPageDescriptors(MutableStyleProperties&, CSSPageRule&);
 
-    StyleRuleType ruleType() const final;
+    StyleRuleType NODELETE ruleType() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPositionTryDescriptors.h
+++ b/Source/WebCore/css/CSSPositionTryDescriptors.h
@@ -128,7 +128,7 @@ private:
     // when property value changes.
     ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant) override;
 
-    StyleRuleType ruleType() const final;
+    StyleRuleType NODELETE ruleType() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSPositionTryRule.h
+++ b/Source/WebCore/css/CSSPositionTryRule.h
@@ -66,7 +66,7 @@ public:
 
     Ref<StyleRulePositionTry> protectedPositionTryRule() const { return m_positionTryRule; }
 
-    WEBCORE_EXPORT AtomString name() const;
+    WEBCORE_EXPORT AtomString NODELETE name() const;
     WEBCORE_EXPORT CSSPositionTryDescriptors& style();
 
 private:

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -52,7 +52,7 @@
 
 namespace WebCore {
 
-static inline bool isValidCSSUnitTypeForDoubleConversion(CSSUnitType unitType)
+static inline bool NODELETE isValidCSSUnitTypeForDoubleConversion(CSSUnitType unitType)
 {
     switch (unitType) {
     case CSSUnitType::CSS_CALC:
@@ -235,7 +235,7 @@ static inline bool isStringType(CSSUnitType type)
 
 #endif // ASSERT_ENABLED
 
-static HashMap<const CSSPrimitiveValue*, String>& serializedPrimitiveValues()
+static HashMap<const CSSPrimitiveValue*, String>& NODELETE serializedPrimitiveValues()
 {
     static NeverDestroyed<HashMap<const CSSPrimitiveValue*, String>> map;
     return map;

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -169,10 +169,10 @@ public:
     template<typename T = double> T valueDividingBy100IfPercentageDeprecated() const { return clampTo<T>(doubleValueDividingBy100IfPercentageDeprecated()); }
 
     // These return nullopt for calc, for which range checking is not done at parse time: <https://www.w3.org/TR/css3-values/#calc-range>.
-    std::optional<bool> isZero() const;
-    std::optional<bool> isOne() const;
-    std::optional<bool> isPositive() const;
-    std::optional<bool> isNegative() const;
+    std::optional<bool> NODELETE isZero() const;
+    std::optional<bool> NODELETE isOne() const;
+    std::optional<bool> NODELETE isPositive() const;
+    std::optional<bool> NODELETE isNegative() const;
 
     WEBCORE_EXPORT String stringValue() const;
     const CSSCalc::Value* cssCalcValue() const { return isCalculated() ? m_value.calc : nullptr; }
@@ -227,12 +227,12 @@ private:
     double doubleValueDividingBy100IfPercentageDeprecated() const;
     template<typename T = double> inline T valueDeprecated() const { return clampTo<T>(doubleValueDeprecated()); }
 
-    static std::optional<double> conversionToCanonicalUnitsScaleFactor(CSSUnitType);
+    static std::optional<double> NODELETE conversionToCanonicalUnitsScaleFactor(CSSUnitType);
 
     std::optional<double> doubleValueInternal(CSSUnitType targetUnit, const CSSToLengthConversionData&) const;
     std::optional<double> doubleValueInternalDeprecated(CSSUnitType targetUnit) const;
 
-    bool addDerivedHash(Hasher&) const;
+    bool NODELETE addDerivedHash(Hasher&) const;
 
     ALWAYS_INLINE String serializeInternal(const CSS::SerializationContext&) const;
     NEVER_INLINE String formatNumberValue(ASCIILiteral suffix) const;

--- a/Source/WebCore/css/CSSPropertyInitialValues.cpp
+++ b/Source/WebCore/css/CSSPropertyInitialValues.cpp
@@ -42,7 +42,7 @@
 
 namespace WebCore {
 
-static bool isValueIDPair(const CSSValue& value, CSSValueID valueID)
+static bool NODELETE isValueIDPair(const CSSValue& value, CSSValueID valueID)
 {
     return value.isPair() && isValueID(value.first(), valueID) && isValueID(value.second(), valueID);
 }
@@ -70,7 +70,7 @@ static bool isNumber(const RectBase& quad, double number, CSSUnitType type)
         && isNumber(quad.left(), number, type);
 }
 
-static bool isValueID(const RectBase& quad, CSSValueID valueID)
+static bool NODELETE isValueID(const RectBase& quad, CSSValueID valueID)
 {
     return isValueID(quad.top(), valueID)
         && isValueID(quad.right(), valueID)

--- a/Source/WebCore/css/CSSPropertyRule.h
+++ b/Source/WebCore/css/CSSPropertyRule.h
@@ -36,9 +36,9 @@ public:
     static Ref<CSSPropertyRule> create(StyleRuleProperty&, CSSStyleSheet* parent);
     virtual ~CSSPropertyRule();
 
-    String name() const;
-    String syntax() const;
-    bool inherits() const;
+    String NODELETE name() const;
+    String NODELETE syntax() const;
+    bool NODELETE inherits() const;
     String initialValue() const;
 
     String cssText() const final;
@@ -46,7 +46,7 @@ public:
 private:
     CSSPropertyRule(StyleRuleProperty&, CSSStyleSheet*);
     StyleRuleType styleRuleType() const final { return StyleRuleType::Property; }
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
 
     Ref<StyleRuleProperty> m_propertyRule;
 };

--- a/Source/WebCore/css/CSSPropertySourceData.h
+++ b/Source/WebCore/css/CSSPropertySourceData.h
@@ -45,7 +45,7 @@ class StyleRuleBase;
 struct SourceRange {
     SourceRange();
     SourceRange(unsigned start, unsigned end);
-    unsigned length() const;
+    unsigned NODELETE length() const;
 
     unsigned start;
     unsigned end;

--- a/Source/WebCore/css/CSSRule.h
+++ b/Source/WebCore/css/CSSRule.h
@@ -63,7 +63,7 @@ public:
     virtual RefPtr<StyleRuleWithNesting> prepareChildStyleRuleForNesting(StyleRule&);
     virtual void getChildStyleSheets(HashSet<Ref<CSSStyleSheet>>&) { }
 
-    WEBCORE_EXPORT ExceptionOr<void> setCssText(const String&);
+    WEBCORE_EXPORT ExceptionOr<void> NODELETE setCssText(const String&);
 
 protected:
     explicit CSSRule(CSSStyleSheet*);

--- a/Source/WebCore/css/CSSScopeRule.h
+++ b/Source/WebCore/css/CSSScopeRule.h
@@ -40,7 +40,7 @@ public:
     String end() const;
 
 private:
-    const StyleRuleScope& styleRuleScope() const;
+    const StyleRuleScope& NODELETE styleRuleScope() const;
 
     CSSScopeRule(StyleRuleScope&, CSSStyleSheet*);
     StyleRuleType styleRuleType() const final { return StyleRuleType::Scope; }

--- a/Source/WebCore/css/CSSSegmentedFontFace.cpp
+++ b/Source/WebCore/css/CSSSegmentedFontFace.cpp
@@ -88,7 +88,7 @@ private:
     {
     }
 
-    bool isLoading() const final
+    bool NODELETE isLoading() const final
     {
         return m_result && m_result.value() && m_result.value()->isInterstitial();
     }

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -89,7 +89,7 @@ struct SelectorSpecificity {
     SelectorSpecificity(SelectorSpecificityIncrement);
     SelectorSpecificity& operator+=(SelectorSpecificity);
 
-    std::array<uint8_t, 3> specificityTuple() const
+    std::array<uint8_t, 3> NODELETE specificityTuple() const
     {
         uint8_t a = specificity >> 16;
         uint8_t b = specificity >> 8;
@@ -1041,7 +1041,7 @@ bool isElementBackedPseudoElement(CSSSelector::PseudoElement pseudoElement)
     }
 }
 
-static bool shouldSkipForEqualMode(const CSSSelector& simpleSelector, ComplexSelectorsEqualMode mode)
+static bool NODELETE shouldSkipForEqualMode(const CSSSelector& simpleSelector, ComplexSelectorsEqualMode mode)
 {
     if (mode == ComplexSelectorsEqualMode::IgnoreNonElementBackedPseudoElements)
         return simpleSelector.matchesPseudoElement() && !isElementBackedPseudoElement(simpleSelector.pseudoElement());

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -70,7 +70,7 @@ public:
 
     unsigned computeSpecificity() const;
     std::array<uint8_t, 3> computeSpecificityTuple() const;
-    unsigned specificityForPage() const;
+    unsigned NODELETE specificityForPage() const;
 
     enum class VisitFunctionalPseudoClasses { No, Yes };
     enum class VisitOnlySubject { No, Yes };
@@ -126,7 +126,7 @@ public:
     enum AttributeMatchType { CaseSensitive, CaseInsensitive };
 
     // Maps from the selector pseudo-element type to the style type. Only pseudo-elements that are not element-backed have a type in style.
-    static std::optional<PseudoElementType> stylePseudoElementTypeFor(PseudoElement);
+    static std::optional<PseudoElementType> NODELETE stylePseudoElementTypeFor(PseudoElement);
     static bool isPseudoClassEnabled(PseudoClass, const CSSSelectorParserContext&);
     static bool isPseudoElementEnabled(PseudoElement, StringView, const CSSSelectorParserContext&);
     static std::optional<PseudoElement> parsePseudoElementName(StringView, const CSSSelectorParserContext&);
@@ -144,9 +144,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const CSSSelector* precedingInComplexSelector() const { return m_isFirstInComplexSelector ? nullptr : this + 1; }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-    const CSSSelector* firstInCompound() const;
-    const CSSSelector* lastInCompound() const;
-    const CSSSelector* precedingInCompound() const;
+    const CSSSelector* NODELETE firstInCompound() const;
+    const CSSSelector* NODELETE lastInCompound() const;
+    const CSSSelector* NODELETE precedingInCompound() const;
 
     const QualifiedName& tagQName() const;
     const AtomString& tagLowercaseLocalName() const;
@@ -162,9 +162,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     const CSSSelectorList* selectorList() const { return m_hasRareData ? m_data.rareData->selectorList.get() : nullptr; }
     CSSSelectorList* selectorList() { return m_hasRareData ? m_data.rareData->selectorList.get() : nullptr; }
 
-    bool matchNth(int count) const;
-    int nthA() const;
-    int nthB() const;
+    bool NODELETE matchNth(int count) const;
+    int NODELETE nthA() const;
+    int NODELETE nthB() const;
 
     bool hasDescendantRelation() const { return relation() == Relation::DescendantSpace; }
     bool hasDescendantOrChildRelation() const { return relation() == Relation::Child || hasDescendantRelation(); }
@@ -176,8 +176,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     bool matchesPseudoElement() const;
     bool isSiblingSelector() const;
     bool isAttributeSelector() const;
-    bool isHostPseudoClass() const;
-    bool isScopePseudoClass() const;
+    bool NODELETE isHostPseudoClass() const;
+    bool NODELETE isScopePseudoClass() const;
 
     Relation relation() const { return static_cast<Relation>(m_relation); }
     Match match() const { return static_cast<Match>(m_match); }
@@ -335,7 +335,7 @@ inline bool isLogicalCombinationPseudoClass(CSSSelector::PseudoClass pseudoClass
     }
 }
 
-bool isElementBackedPseudoElement(CSSSelector::PseudoElement);
+bool NODELETE isElementBackedPseudoElement(CSSSelector::PseudoElement);
 
 inline bool CSSSelector::isSiblingSelector() const
 {

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -95,7 +95,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     const_iterator end() const LIFETIME_BOUND { return { m_selectorArray.end() }; }
 
     bool hasExplicitNestingParent() const;
-    bool hasOnlyNestingSelector() const;
+    bool NODELETE hasOnlyNestingSelector() const;
 
     String selectorsText() const;
     void buildSelectorsText(StringBuilder&) const;

--- a/Source/WebCore/css/CSSStyleProperties.cpp
+++ b/Source/WebCore/css/CSSStyleProperties.cpp
@@ -60,7 +60,7 @@ namespace {
 
 enum class PropertyNamePrefix { None, Epub, WebKit };
 
-static inline bool matchesCSSPropertyNamePrefix(const StringImpl& propertyName, ASCIILiteral prefix)
+static inline bool NODELETE matchesCSSPropertyNamePrefix(const StringImpl& propertyName, ASCIILiteral prefix)
 {
     ASSERT(toASCIILower(propertyName[0]) == prefix[0zu]);
     const size_t offset = 1;

--- a/Source/WebCore/css/CSSStyleProperties.h
+++ b/Source/WebCore/css/CSSStyleProperties.h
@@ -85,7 +85,7 @@ public:
     {
     }
 
-    void ref() const override;
+    void NODELETE ref() const override;
     void deref() const override;
 
     StyleSheetContents* contextStyleSheet() const;
@@ -144,7 +144,7 @@ public:
 private:
     StyleRuleCSSStyleProperties(MutableStyleProperties&, CSSRule&);
 
-    CSSStyleSheet* parentStyleSheet() const final;
+    CSSStyleSheet* NODELETE parentStyleSheet() const final;
 
     CSSRule* NODELETE parentRule() const final;
 

--- a/Source/WebCore/css/CSSStyleRule.cpp
+++ b/Source/WebCore/css/CSSStyleRule.cpp
@@ -42,7 +42,7 @@
 namespace WebCore {
 
 typedef HashMap<const CSSStyleRule*, String> SelectorTextCache;
-static SelectorTextCache& selectorTextCache()
+static SelectorTextCache& NODELETE selectorTextCache()
 {
     static NeverDestroyed<SelectorTextCache> cache;
     return cache;

--- a/Source/WebCore/css/CSSStyleRule.h
+++ b/Source/WebCore/css/CSSStyleRule.h
@@ -56,7 +56,7 @@ public:
     unsigned length() const;
     CSSRule* item(unsigned index) const;
 
-    StylePropertyMap& styleMap();
+    StylePropertyMap& NODELETE styleMap();
 
 private:
     CSSStyleRule(StyleRule&, CSSStyleSheet*);

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -50,7 +50,7 @@
 
 namespace WebCore {
 
-static Style::Scope& styleScopeFor(ContainerNode& treeScope)
+static Style::Scope& NODELETE styleScopeFor(ContainerNode& treeScope)
 {
     ASSERT(is<Document>(treeScope) || is<ShadowRoot>(treeScope));
     if (auto* shadowRoot = dynamicDowncast<ShadowRoot>(treeScope))
@@ -65,13 +65,13 @@ public:
     StyleSheetCSSRuleList(CSSStyleSheet* sheet) : m_styleSheet(sheet) { }
     
 private:
-    void ref() const final { m_styleSheet->ref(); }
+    void NODELETE ref() const final { m_styleSheet->ref(); }
     void deref() const final { m_styleSheet->deref(); }
 
     unsigned length() const final { return m_styleSheet->length(); }
     CSSRule* item(unsigned index) const final { return m_styleSheet->item(index); }
 
-    CSSStyleSheet* styleSheet() const final { return m_styleSheet.get(); }
+    CSSStyleSheet* NODELETE styleSheet() const final { return m_styleSheet.get(); }
 
     SingleThreadWeakPtr<CSSStyleSheet> m_styleSheet;
 };

--- a/Source/WebCore/css/CSSStyleSheet.h
+++ b/Source/WebCore/css/CSSStyleSheet.h
@@ -71,10 +71,10 @@ public:
 
     virtual ~CSSStyleSheet();
 
-    CSSStyleSheet* parentStyleSheet() const final;
+    CSSStyleSheet* NODELETE parentStyleSheet() const final;
     Node* NODELETE ownerNode() const final;
     MediaList* media() const final;
-    String href() const final;
+    String NODELETE href() const final;
     String title() const final { return !m_title.isEmpty() ? m_title : String(); }
     bool disabled() const final { return m_isDisabled; }
     void setDisabled(bool) final;
@@ -102,7 +102,7 @@ public:
 
     void clearOwnerNode() final;
     WEBCORE_EXPORT CSSImportRule* NODELETE ownerRule() const final;
-    URL baseURL() const final;
+    URL NODELETE baseURL() const final;
     bool isLoading() const final;
 
     void clearOwnerRule() { m_ownerRule = nullptr; }
@@ -111,8 +111,8 @@ public:
     void addAdoptingTreeScope(ContainerNode&);
     const WeakHashSet<ContainerNode, WeakPtrImplWithEventTargetData>& adoptingTreeScopes() const { return m_adoptingTreeScopes; }
 
-    Document* ownerDocument() const;
-    CSSStyleSheet& rootStyleSheet();
+    Document* NODELETE ownerDocument() const;
+    CSSStyleSheet& NODELETE rootStyleSheet();
     const CSSStyleSheet& rootStyleSheet() const;
     Style::Scope* NODELETE styleScope();
 
@@ -149,7 +149,7 @@ public:
     void reattachChildRuleCSSOMWrappers();
 
     StyleSheetContents& contents() { return m_contents; }
-    Ref<StyleSheetContents> protectedContents();
+    Ref<StyleSheetContents> NODELETE protectedContents();
 
     bool isInline() const { return m_isInlineStylesheet; }
     TextPosition startPosition() const { return m_startPosition; }
@@ -162,7 +162,7 @@ public:
     String cssText(const CSS::SerializationContext&);
     void getChildStyleSheets(HashSet<Ref<CSSStyleSheet>>&);
 
-    bool isDetached() const;
+    bool NODELETE isDetached() const;
 
 private:
     CSSStyleSheet(Ref<StyleSheetContents>&&, CSSImportRule* ownerRule, std::optional<bool> isOriginClean);

--- a/Source/WebCore/css/CSSStyleSheetObservableArray.h
+++ b/Source/WebCore/css/CSSStyleSheetObservableArray.h
@@ -52,7 +52,7 @@ private:
     unsigned length() const final { return m_sheets.size(); }
     void shrinkTo(unsigned) final;
 
-    TreeScope* treeScope() const;
+    TreeScope* NODELETE treeScope() const;
 
     void didAddSheet(CSSStyleSheet&);
     void willRemoveSheet(CSSStyleSheet&);

--- a/Source/WebCore/css/CSSSupportsRule.h
+++ b/Source/WebCore/css/CSSSupportsRule.h
@@ -42,7 +42,7 @@ public:
 
     String cssText() const final;
     String cssText(const CSS::SerializationContext&) const final;
-    String conditionText() const final;
+    String NODELETE conditionText() const final;
 
 private:
     CSSSupportsRule(StyleRuleSupports&, CSSStyleSheet*);

--- a/Source/WebCore/css/CSSToLengthConversionData.cpp
+++ b/Source/WebCore/css/CSSToLengthConversionData.cpp
@@ -43,7 +43,7 @@ CSSToLengthConversionData::CSSToLengthConversionData(const CSSToLengthConversion
 CSSToLengthConversionData::CSSToLengthConversionData(CSSToLengthConversionData&&) = default;
 
 // FIXME: Only rely on the RenderView for style resolution if we have an active LocalFrameView.
-static RenderView* renderViewForDocument(const Document& document)
+static RenderView* NODELETE renderViewForDocument(const Document& document)
 {
     if (document.view()) [[likely]]
         return document.renderView();

--- a/Source/WebCore/css/CSSToLengthConversionData.h
+++ b/Source/WebCore/css/CSSToLengthConversionData.h
@@ -64,16 +64,16 @@ public:
     const RenderStyle* style() const { return m_style; }
     const RenderStyle* rootStyle() const { return m_rootStyle; }
     const RenderStyle* parentStyle() const { return m_parentStyle; }
-    float zoom() const;
+    float NODELETE zoom() const;
     CSS::RangeZoomOptions rangeZoomOption() const { return m_rangeZoomOption; }
     bool computingFontSize() const { return m_propertyToCompute == CSSPropertyFontSize; }
     bool computingLineHeight() const { return m_propertyToCompute == CSSPropertyLineHeight; }
     CSSPropertyID propertyToCompute() const { return m_propertyToCompute.value_or(CSSPropertyInvalid); }
-    bool evaluationTimeZoomEnabled() const;
+    bool NODELETE evaluationTimeZoomEnabled() const;
     const RenderView* renderView() const { return m_renderView; }
     const Element* elementForContainerUnitResolution() const { return m_elementForContainerUnitResolution.get(); }
 
-    const FontCascade& fontCascadeForFontUnits() const;
+    const FontCascade& NODELETE fontCascadeForFontUnits() const;
     float computedLineHeightForFontUnits() const;
 
     FloatSize defaultViewportFactor() const;
@@ -106,7 +106,7 @@ public:
         return copy;
     }
 
-    void setUsesContainerUnits() const;
+    void NODELETE setUsesContainerUnits() const;
 
     Style::BuilderState* styleBuilderState() const { return m_styleBuilderState.get(); }
 

--- a/Source/WebCore/css/CSSUnicodeRangeValue.h
+++ b/Source/WebCore/css/CSSUnicodeRangeValue.h
@@ -42,7 +42,7 @@ public:
 
     String customCSSText(const CSS::SerializationContext&) const;
 
-    bool equals(const CSSUnicodeRangeValue&) const;
+    bool NODELETE equals(const CSSUnicodeRangeValue&) const;
 
 private:
     CSSUnicodeRangeValue(char32_t from, char32_t to)

--- a/Source/WebCore/css/CSSUnits.h
+++ b/Source/WebCore/css/CSSUnits.h
@@ -166,11 +166,11 @@ enum class CSSUnitCategory : uint8_t {
     Other
 };
 
-CSSUnitCategory unitCategory(CSSUnitType);
-CSSUnitType canonicalUnitTypeForCategory(CSSUnitCategory);
-CSSUnitType canonicalUnitTypeForUnitType(CSSUnitType);
-double conversionToCanonicalUnitsScaleFactor(CSSUnitType);
-bool conversionToCanonicalUnitRequiresConversionData(CSSUnitType);
+CSSUnitCategory NODELETE unitCategory(CSSUnitType);
+CSSUnitType NODELETE canonicalUnitTypeForCategory(CSSUnitCategory);
+CSSUnitType NODELETE canonicalUnitTypeForUnitType(CSSUnitType);
+double NODELETE conversionToCanonicalUnitsScaleFactor(CSSUnitType);
+bool NODELETE conversionToCanonicalUnitRequiresConversionData(CSSUnitType);
 
 WTF::TextStream& operator<<(WTF::TextStream&, CSSUnitCategory);
 WTF::TextStream& operator<<(WTF::TextStream&, CSSUnitType);

--- a/Source/WebCore/css/CSSValue.h
+++ b/Source/WebCore/css/CSSValue.h
@@ -291,8 +291,8 @@ private:
     template<typename Visitor> constexpr decltype(auto) visitDerived(Visitor&&);
     template<typename Visitor> constexpr decltype(auto) visitDerived(Visitor&&) const;
 
-    static inline bool customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>&);
-    bool addDerivedHash(Hasher&) const;
+    static inline bool NODELETE customTraverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>&);
+    bool NODELETE addDerivedHash(Hasher&) const;
 
     mutable unsigned m_refCount { refCountIncrement };
 

--- a/Source/WebCore/css/CSSValuePool.h
+++ b/Source/WebCore/css/CSSValuePool.h
@@ -70,7 +70,7 @@ class CSSValuePool {
     WTF_MAKE_NONCOPYABLE(CSSValuePool);
 public:
     CSSValuePool();
-    static CSSValuePool& singleton();
+    static CSSValuePool& NODELETE singleton();
     void drain();
 
     Ref<CSSColorValue> createColorValue(const WebCore::Color&);

--- a/Source/WebCore/css/CSSVariableReferenceValue.h
+++ b/Source/WebCore/css/CSSVariableReferenceValue.h
@@ -57,7 +57,7 @@ public:
     String customCSSText(const CSS::SerializationContext&) const;
 
     RefPtr<CSSVariableData> resolveVariableReferences(Style::Builder&) const;
-    const CSSParserContext& context() const;
+    const CSSParserContext& NODELETE context() const;
 
     RefPtr<CSSValue> resolveSingleValue(Style::Builder&, CSSPropertyID) const;
 

--- a/Source/WebCore/css/CSSViewTransitionRule.cpp
+++ b/Source/WebCore/css/CSSViewTransitionRule.cpp
@@ -38,7 +38,7 @@
 
 namespace WebCore {
 
-static std::optional<ViewTransitionNavigation> toViewTransitionNavigationEnum(RefPtr<CSSValue> navigation)
+static std::optional<ViewTransitionNavigation> NODELETE toViewTransitionNavigationEnum(RefPtr<CSSValue> navigation)
 {
     if (!navigation || !navigation->isPrimitiveValue())
         return std::nullopt;

--- a/Source/WebCore/css/CSSViewTransitionRule.h
+++ b/Source/WebCore/css/CSSViewTransitionRule.h
@@ -64,7 +64,7 @@ public:
     virtual ~CSSViewTransitionRule();
 
     String cssText() const final;
-    void reattach(StyleRuleBase&) final;
+    void NODELETE reattach(StyleRuleBase&) final;
     StyleRuleType styleRuleType() const final { return StyleRuleType::ViewTransition; }
 
     AtomString navigation() const;

--- a/Source/WebCore/css/ComputedStyleDependencies.h
+++ b/Source/WebCore/css/ComputedStyleDependencies.h
@@ -39,7 +39,7 @@ struct ComputedStyleDependencies {
     bool isComputationallyIndependent() const { return properties.isEmpty() && rootProperties.isEmpty() && !containerDimensions && !anchors; }
 
     // Checks to see if the provided conversion data is sufficient to resolve the provided dependencies.
-    bool canResolveDependenciesWithConversionData(const CSSToLengthConversionData&) const;
+    bool NODELETE canResolveDependenciesWithConversionData(const CSSToLengthConversionData&) const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/DOMCSSPaintWorklet.h
+++ b/Source/WebCore/css/DOMCSSPaintWorklet.h
@@ -48,7 +48,7 @@ public:
 
     // Worklet.
     void addModule(const String& moduleURL, WorkletOptions&&, DOMPromiseDeferred<void>&&) final;
-    Vector<Ref<WorkletGlobalScopeProxy>> createGlobalScopes() final;
+    Vector<Ref<WorkletGlobalScopeProxy>> NODELETE createGlobalScopes() final;
 
 private:
     explicit PaintWorklet(Document& document)

--- a/Source/WebCore/css/DOMMatrixReadOnly.cpp
+++ b/Source/WebCore/css/DOMMatrixReadOnly.cpp
@@ -104,7 +104,7 @@ Ref<DOMMatrix> DOMMatrixReadOnly::cloneAsDOMMatrix() const
 }
 
 // https://tc39.github.io/ecma262/#sec-samevaluezero
-static bool sameValueZero(double a, double b)
+static bool NODELETE sameValueZero(double a, double b)
 {
     if (std::isnan(a) && std::isnan(b))
         return true;

--- a/Source/WebCore/css/DOMMatrixReadOnly.h
+++ b/Source/WebCore/css/DOMMatrixReadOnly.h
@@ -93,7 +93,7 @@ public:
     double m44() const { return m_matrix.m44(); }
 
     bool is2D() const { return m_is2D; }
-    bool isIdentity() const;
+    bool NODELETE isIdentity() const;
 
     ExceptionOr<void> setMatrixValue(const String&);
     ExceptionOr<void> setMatrixValue(const Vector<double>&);

--- a/Source/WebCore/css/DeprecatedCSSOMValue.h
+++ b/Source/WebCore/css/DeprecatedCSSOMValue.h
@@ -47,7 +47,7 @@ public:
         CSS_CUSTOM = 3
     };
 
-    WEBCORE_EXPORT unsigned short cssValueType() const;
+    WEBCORE_EXPORT unsigned short NODELETE cssValueType() const;
 
     WEBCORE_EXPORT String cssText() const;
     ExceptionOr<void> setCssText(const String&) { return { }; } // Will never implement.

--- a/Source/WebCore/css/FontFace.h
+++ b/Source/WebCore/css/FontFace.h
@@ -83,10 +83,10 @@ public:
     String sizeAdjust() const;
 
     enum class LoadStatus { Unloaded, Loading, Loaded, Error };
-    LoadStatus status() const;
+    LoadStatus NODELETE status() const;
 
     using LoadedPromise = DOMPromiseProxyWithResolveCallback<IDLInterface<FontFace>>;
-    LoadedPromise& loadedForBindings();
+    LoadedPromise& NODELETE loadedForBindings();
     LoadedPromise& loadForBindings();
 
     void adopt(CSSFontFace&);
@@ -100,10 +100,10 @@ private:
     explicit FontFace(ScriptExecutionContext*, CSSFontFace&);
 
     // ActiveDOMObject.
-    bool virtualHasPendingActivity() const final;
+    bool NODELETE virtualHasPendingActivity() const final;
 
     // Callback for LoadedPromise.
-    FontFace& loadedPromiseResolve();
+    FontFace& NODELETE loadedPromiseResolve();
     void setErrorState();
 
     Ref<CSSFontFace> m_backing;

--- a/Source/WebCore/css/FontFaceSet.h
+++ b/Source/WebCore/css/FontFaceSet.h
@@ -108,12 +108,12 @@ private:
 
     // EventTarget
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::FontFaceSet; }
-    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
 
     // Callback for ReadyPromise.
-    FontFaceSet& readyPromiseResolve();
+    FontFaceSet& NODELETE readyPromiseResolve();
 
     const Ref<CSSFontFaceSet> m_backing;
     HashMap<Ref<FontFace>, Vector<Ref<PendingPromise>>> m_pendingPromises;

--- a/Source/WebCore/css/ImmutableStyleProperties.cpp
+++ b/Source/WebCore/css/ImmutableStyleProperties.cpp
@@ -61,7 +61,7 @@ Ref<ImmutableStyleProperties> ImmutableStyleProperties::create(std::span<const C
     return adoptRef(*new (NotNull, slot) ImmutableStyleProperties(properties, mode));
 }
 
-static auto& deduplicationMap()
+static auto& NODELETE deduplicationMap()
 {
     static NeverDestroyed<HashMap<unsigned, Ref<ImmutableStyleProperties>, AlreadyHashed>> map;
     return map.get();

--- a/Source/WebCore/css/ImmutableStyleProperties.h
+++ b/Source/WebCore/css/ImmutableStyleProperties.h
@@ -46,7 +46,7 @@ public:
     static constexpr std::nullptr_t end() { return nullptr; }
     unsigned size() const { return propertyCount(); }
 
-    int findPropertyIndex(CSSPropertyID) const;
+    int NODELETE findPropertyIndex(CSSPropertyID) const;
     int findCustomPropertyIndex(StringView propertyName) const;
 
     static constexpr size_t objectSize(unsigned propertyCount);

--- a/Source/WebCore/css/MediaQueryList.h
+++ b/Source/WebCore/css/MediaQueryList.h
@@ -60,16 +60,16 @@ public:
 private:
     MediaQueryList(Document&, MediaQueryMatcher&, MQ::MediaQueryList&&, bool matches);
 
-    void setMatches(bool);
+    void NODELETE setMatches(bool);
 
     enum EventTargetInterfaceType eventTargetInterface() const final { return EventTargetInterfaceType::MediaQueryList; }
-    ScriptExecutionContext* scriptExecutionContext() const final;
+    ScriptExecutionContext* NODELETE scriptExecutionContext() const final;
     void refEventTarget() final { ref(); }
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;
 
     // ActiveDOMObject.
-    bool virtualHasPendingActivity() const final;
+    bool NODELETE virtualHasPendingActivity() const final;
 
     RefPtr<MediaQueryMatcher> m_matcher;
     const MQ::MediaQueryList m_mediaQueries;

--- a/Source/WebCore/css/MutableStyleProperties.h
+++ b/Source/WebCore/css/MutableStyleProperties.h
@@ -82,7 +82,7 @@ public:
     WEBCORE_EXPORT CSSStyleProperties& ensureCSSStyleProperties();
     CSSStyleProperties& ensureInlineCSSStyleProperties(StyledElement& parentElement);
 
-    int findPropertyIndex(CSSPropertyID) const;
+    int NODELETE findPropertyIndex(CSSPropertyID) const;
     int findCustomPropertyIndex(StringView propertyName) const;
 
     // Methods for querying and altering CSS custom properties.
@@ -97,7 +97,7 @@ private:
     bool removeLonghandProperty(CSSPropertyID, String* returnText);
     bool removeShorthandProperty(CSSPropertyID, String* returnText);
     bool removePropertyAtIndex(int index, String* returnText);
-    CSSProperty* findCSSPropertyWithID(CSSPropertyID);
+    CSSProperty* NODELETE findCSSPropertyWithID(CSSPropertyID);
     CSSProperty* findCustomCSSPropertyWithName(const String&);
     bool canUpdateInPlace(const CSSProperty&, CSSProperty* toReplace) const;
 

--- a/Source/WebCore/css/PropertySetCSSDescriptors.h
+++ b/Source/WebCore/css/PropertySetCSSDescriptors.h
@@ -46,14 +46,14 @@ public:
     virtual ~PropertySetCSSDescriptors();
 
     void clearParentRule() { m_parentRule = nullptr; }
-    void reattach(MutableStyleProperties&);
+    void NODELETE reattach(MutableStyleProperties&);
 
     virtual StyleRuleType ruleType() const = 0;
 
 protected:
     PropertySetCSSDescriptors(MutableStyleProperties&, CSSRule&);
 
-    CSSStyleSheet* parentStyleSheet() const final;
+    CSSStyleSheet* NODELETE parentStyleSheet() const final;
     CSSRule* NODELETE parentRule() const final;
     // FIXME: To implement.
     CSSRuleList* cssRules() const override { return nullptr; }
@@ -81,7 +81,7 @@ protected:
     virtual ExceptionOr<void> setPropertyInternal(CSSPropertyID, const String& value, IsImportant);
 
     CSSParserContext cssParserContext() const;
-    Ref<MutableStyleProperties> protectedPropertySet() const;
+    Ref<MutableStyleProperties> NODELETE protectedPropertySet() const;
 
     WeakPtr<CSSRule> m_parentRule;
     HashMap<CSSValue*, WeakPtr<DeprecatedCSSOMValue>> m_cssomValueWrappers;

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -128,17 +128,17 @@ static inline void addStyleRelation(SelectorChecker::CheckingContext& checkingCo
     checkingContext.styleRelations.append({ element, type, value });
 }
 
-static inline bool isFirstChildElement(const Element& element)
+static inline bool NODELETE isFirstChildElement(const Element& element)
 {
     return !ElementTraversal::previousSibling(element);
 }
 
-static inline bool isLastChildElement(const Element& element)
+static inline bool NODELETE isLastChildElement(const Element& element)
 {
     return !ElementTraversal::nextSibling(element);
 }
 
-static inline bool isFirstOfType(const Element& element, const QualifiedName& type)
+static inline bool NODELETE isFirstOfType(const Element& element, const QualifiedName& type)
 {
     for (const Element* sibling = ElementTraversal::previousSibling(element); sibling; sibling = ElementTraversal::previousSibling(*sibling)) {
         if (sibling->hasTagName(type))
@@ -147,7 +147,7 @@ static inline bool isFirstOfType(const Element& element, const QualifiedName& ty
     return true;
 }
 
-static inline bool isLastOfType(const Element& element, const QualifiedName& type)
+static inline bool NODELETE isLastOfType(const Element& element, const QualifiedName& type)
 {
     for (const Element* sibling = ElementTraversal::nextSibling(element); sibling; sibling = ElementTraversal::nextSibling(*sibling)) {
         if (sibling->hasTagName(type))
@@ -156,7 +156,7 @@ static inline bool isLastOfType(const Element& element, const QualifiedName& typ
     return true;
 }
 
-static inline int countElementsBefore(const Element& element)
+static inline int NODELETE countElementsBefore(const Element& element)
 {
     int count = 0;
     for (CheckedPtr<const Element> sibling = ElementTraversal::previousSibling(element); sibling; sibling = ElementTraversal::previousSibling(*sibling)) {
@@ -170,7 +170,7 @@ static inline int countElementsBefore(const Element& element)
     return count;
 }
 
-static inline int countElementsOfTypeBefore(const Element& element, const QualifiedName& type)
+static inline int NODELETE countElementsOfTypeBefore(const Element& element, const QualifiedName& type)
 {
     int count = 0;
     for (const Element* sibling = ElementTraversal::previousSibling(element); sibling; sibling = ElementTraversal::previousSibling(*sibling)) {
@@ -180,7 +180,7 @@ static inline int countElementsOfTypeBefore(const Element& element, const Qualif
     return count;
 }
 
-static inline int countElementsAfter(const Element& element)
+static inline int NODELETE countElementsAfter(const Element& element)
 {
     int count = 0;
     for (const Element* sibling = ElementTraversal::nextSibling(element); sibling; sibling = ElementTraversal::nextSibling(*sibling))
@@ -188,7 +188,7 @@ static inline int countElementsAfter(const Element& element)
     return count;
 }
 
-static inline int countElementsOfTypeAfter(const Element& element, const QualifiedName& type)
+static inline int NODELETE countElementsOfTypeAfter(const Element& element, const QualifiedName& type)
 {
     int count = 0;
     for (const Element* sibling = ElementTraversal::nextSibling(element); sibling; sibling = ElementTraversal::nextSibling(*sibling)) {
@@ -295,7 +295,7 @@ inline static bool hasScrollbarPseudoElement(EnumSet<PseudoElementType> collecte
     return collectedPseudoElements.contains(PseudoElementType::WebKitResizer);
 }
 
-static SelectorChecker::LocalContext localContextForParent(const SelectorChecker::LocalContext& context)
+static SelectorChecker::LocalContext NODELETE localContextForParent(const SelectorChecker::LocalContext& context)
 {
     SelectorChecker::LocalContext updatedContext(context);
     // Disable :visited matching when we see the first link.

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -93,8 +93,8 @@ public:
 
         const SelectorChecker::Mode resolvingMode;
 
-        void setRequestedPseudoElement(Style::PseudoElementIdentifier);
-        std::optional<Style::PseudoElementIdentifier> requestedPseudoElement() const;
+        void NODELETE setRequestedPseudoElement(Style::PseudoElementIdentifier);
+        std::optional<Style::PseudoElementIdentifier> NODELETE requestedPseudoElement() const;
 
     private:
         friend class SelectorCompiler::SelectorCodeGenerator;
@@ -140,7 +140,7 @@ private:
     bool matchSelectorList(CheckingContext&, const LocalContext&, const Element&, const CSSSelectorList&) const;
     bool matchHasPseudoClass(CheckingContext&, const Element&, const CSSSelector&) const;
 
-    bool checkScrollbarPseudoClass(const CheckingContext&, const Element&, const CSSSelector&) const;
+    bool NODELETE checkScrollbarPseudoClass(const CheckingContext&, const Element&, const CSSSelector&) const;
     bool checkViewTransitionPseudoClass(const CheckingContext&, const Element&, const CSSSelector&) const;
 
     bool m_strictParsing;

--- a/Source/WebCore/css/SelectorFilter.cpp
+++ b/Source/WebCore/css/SelectorFilter.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 // Salt to separate otherwise identical string hashes so a class-selector like .article won't match <article> elements.
 enum { TagNameSalt = 13, IdSalt = 17, ClassSalt = 19, AttributeSalt = 23 };
 
-static bool isExcludedAttribute(const AtomString& name)
+static bool NODELETE isExcludedAttribute(const AtomString& name)
 {
     return name == HTMLNames::classAttr->localName() || name == HTMLNames::idAttr->localName() || name == HTMLNames::styleAttr->localName();
 }

--- a/Source/WebCore/css/SelectorFilter.h
+++ b/Source/WebCore/css/SelectorFilter.h
@@ -41,10 +41,10 @@ class SelectorFilter {
 public:
     void pushParent(Element* parent);
     void pushParentInitializingIfNeeded(Element& parent);
-    void popParent();
-    void popParentsUntil(Element* parent);
+    void NODELETE popParent();
+    void NODELETE popParentsUntil(Element* parent);
     bool parentStackIsEmpty() const { return m_parentStack.isEmpty(); }
-    bool parentStackIsConsistent(const ContainerNode* parentNode) const;
+    bool NODELETE parentStackIsConsistent(const ContainerNode* parentNode) const;
     void parentStackReserveInitialCapacity(size_t initialCapacity) { m_parentStack.reserveInitialCapacity(initialCapacity); }
 
     using Hashes = std::array<unsigned, 4>;

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -80,23 +80,23 @@ private:
     };
     template<typename IteratorType> struct LonghandRange {
         IteratorType begin() const { return { { serializer } }; }
-        static constexpr std::nullptr_t end() { return nullptr; }
-        unsigned size() const { return serializer.length(); }
+        static constexpr std::nullptr_t NODELETE end() { return nullptr; }
+        unsigned NODELETE size() const { return serializer.length(); }
         const ShorthandSerializer& serializer;
     };
 
     static bool isInitialValue(Longhand);
     String serializeValue(Longhand) const;
 
-    unsigned length() const { return m_shorthand.length(); }
-    Longhand longhand(unsigned index) const { return { longhandProperty(index), longhandValue(index) }; }
+    unsigned NODELETE length() const { return m_shorthand.length(); }
+    Longhand NODELETE longhand(unsigned index) const { return { longhandProperty(index), longhandValue(index) }; }
     CSSPropertyID longhandProperty(unsigned index) const;
     CSSValue& longhandValue(unsigned index) const;
 
     unsigned longhandIndex(unsigned index, CSSPropertyID) const;
 
-    LonghandRange<LonghandIterator> longhands() const { return { *this }; }
-    LonghandRange<LonghandValueIterator> longhandValues() const { return { *this }; }
+    LonghandRange<LonghandIterator> NODELETE longhands() const { return { *this }; }
+    LonghandRange<LonghandValueIterator> NODELETE longhandValues() const { return { *this }; }
 
     CSSValueID longhandValueID(unsigned index) const;
     bool isLonghandValueID(unsigned index, CSSValueID valueID) const { return longhandValueID(index) == valueID; }
@@ -159,12 +159,12 @@ inline ShorthandSerializer::ShorthandSerializer(const CSS::SerializationContext&
 {
 }
 
-inline CSSPropertyID ShorthandSerializer::longhandProperty(unsigned index) const
+inline CSSPropertyID NODELETE ShorthandSerializer::longhandProperty(unsigned index) const
 {
     return m_shorthand.properties()[index];
 }
 
-inline CSSValue& ShorthandSerializer::longhandValue(unsigned index) const
+inline CSSValue& NODELETE ShorthandSerializer::longhandValue(unsigned index) const
 {
     return *m_longhandValues[index];
 }
@@ -179,7 +179,7 @@ inline bool ShorthandSerializer::isInitialValue(Longhand longhand)
     return isInitialValueForLonghand(longhand.property, longhand.value);
 }
 
-inline unsigned ShorthandSerializer::longhandIndex(unsigned index, CSSPropertyID longhand) const
+inline unsigned NODELETE ShorthandSerializer::longhandIndex(unsigned index, CSSPropertyID longhand) const
 {
     ASSERT_UNUSED(longhand, longhandProperty(index) == longhand);
     return index;
@@ -537,7 +537,7 @@ public:
         m_values[index] = value;
     }
 
-    bool& skip(unsigned index)
+    bool& NODELETE skip(unsigned index)
     {
         ASSERT(index < m_shorthand.length());
         return m_skipSerializing[index];
@@ -569,7 +569,7 @@ public:
         return result && *result != CSSValueInvalid;
     }
 
-    bool isPair(unsigned index) const
+    bool NODELETE isPair(unsigned index) const
     {
         // This returns false for implicit initial values that are pairs, which is OK for now.
         ASSERT(index < m_shorthand.length());
@@ -948,7 +948,7 @@ String ShorthandSerializer::serializeColumnBreak() const
     }
 }
 
-static std::optional<CSSValueID> fontWidthKeyword(double value)
+static std::optional<CSSValueID> NODELETE fontWidthKeyword(double value)
 {
     // If the numeric value does not fit in the fixed point FontSelectionValue, don't convert it to a keyword even if it rounds to a keyword value.
     float valueAsFloat = value;
@@ -1076,7 +1076,7 @@ String ShorthandSerializer::serializeFontVariant() const
     return serializeLonghandsOmittingInitialValues();
 }
 
-static bool isValueIDIncludingList(const CSSValue& value, CSSValueID id)
+static bool NODELETE isValueIDIncludingList(const CSSValue& value, CSSValueID id)
 {
     if (auto* valueList = dynamicDowncast<CSSValueList>(value)) {
         if (valueList->size() != 1)

--- a/Source/WebCore/css/StyleProperties.cpp
+++ b/Source/WebCore/css/StyleProperties.cpp
@@ -192,7 +192,7 @@ AtomString StyleProperties::asTextAtom(const CSS::SerializationContext& context)
     return asTextInternal(context).toAtomString();
 }
 
-static constexpr bool canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSPropertyID longhandID)
+static constexpr bool NODELETE canUseShorthandForLonghand(CSSPropertyID shorthandID, CSSPropertyID longhandID)
 {
     ASSERT(isShorthand(shorthandID));
     ASSERT(isLonghand(longhandID));

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -129,13 +129,13 @@ public:
     String asText(const CSS::SerializationContext&) const;
     AtomString asTextAtom(const CSS::SerializationContext&) const;
 
-    bool hasCSSOMWrapper() const;
+    bool NODELETE hasCSSOMWrapper() const;
     bool isMutable() const { return m_isMutable; }
 
     bool traverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>& handler) const;
     bool mayDependOnBaseURL() const;
 
-    static unsigned averageSizeInBytes();
+    static unsigned NODELETE averageSizeInBytes();
 
 #ifndef NDEBUG
     void showStyle();

--- a/Source/WebCore/css/StylePropertyShorthand.h
+++ b/Source/WebCore/css/StylePropertyShorthand.h
@@ -52,7 +52,7 @@ private:
 };
 
 // Custom StylePropertyShorthand function.
-StylePropertyShorthand transitionShorthandForParsing();
+StylePropertyShorthand NODELETE transitionShorthandForParsing();
 
 // Returns empty value if the property is not a shorthand.
 // The implementation is generated in StylePropertyShorthandFunctions.cpp.
@@ -63,7 +63,7 @@ StylePropertyShorthand shorthandForProperty(CSSPropertyID);
 using StylePropertyShorthandVector = Vector<StylePropertyShorthand, 4>;
 StylePropertyShorthandVector matchingShorthandsForLonghand(CSSPropertyID);
 
-unsigned indexOfShorthandForLonghand(CSSPropertyID, const StylePropertyShorthandVector&);
+unsigned NODELETE indexOfShorthandForLonghand(CSSPropertyID, const StylePropertyShorthandVector&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/StyleRule.h
+++ b/Source/WebCore/css/StyleRule.h
@@ -145,8 +145,8 @@ public:
     void releaseCompiledSelectors() const { m_compiledSelectors = { }; }
 #endif
 
-    static unsigned averageSizeInBytes();
-    void setProperties(Ref<StyleProperties>&&);
+    static unsigned NODELETE averageSizeInBytes();
+    void NODELETE setProperties(Ref<StyleProperties>&&);
 
     String debugDescription() const;
 protected:
@@ -307,7 +307,7 @@ private:
 
 class StyleRuleGroup : public StyleRuleBase {
 public:
-    const Vector<Ref<StyleRuleBase>>& childRules() const;
+    const Vector<Ref<StyleRuleBase>>& NODELETE childRules() const;
 
     void wrapperInsertRule(unsigned, Ref<StyleRuleBase>&&);
     void wrapperRemoveRule(unsigned);

--- a/Source/WebCore/css/StyleRuleImport.h
+++ b/Source/WebCore/css/StyleRuleImport.h
@@ -55,7 +55,7 @@ public:
     String href() const { return m_strHref; }
     StyleSheetContents* styleSheet() const { return m_styleSheet.get(); }
 
-    bool isLoading() const;
+    bool NODELETE isLoading() const;
     
     const MQ::MediaQueryList& mediaQueries() const { return m_mediaQueries; }
     void setMediaQueries(MQ::MediaQueryList&& queries) { m_mediaQueries = WTF::move(queries); }

--- a/Source/WebCore/css/StyleSheetContents.h
+++ b/Source/WebCore/css/StyleSheetContents.h
@@ -67,7 +67,7 @@ public:
     const CSSParserContext& parserContext() const { return m_parserContext; }
     
     const AtomString& defaultNamespace() { return m_defaultNamespace; }
-    const AtomString& namespaceURIFromPrefix(const AtomString& prefix);
+    const AtomString& NODELETE namespaceURIFromPrefix(const AtomString& prefix);
 
     bool parseAuthorStyleSheet(const CachedCSSStyleSheet*, const SecurityOrigin*);
     WEBCORE_EXPORT bool parseString(const String&);
@@ -75,16 +75,16 @@ public:
     bool isCacheable() const;
     bool isCacheableWithNoBaseURLDependency() const;
 
-    bool isLoading() const;
+    bool NODELETE isLoading() const;
     bool subresourcesAllowReuse(CachePolicy, FrameLoader&) const;
     WEBCORE_EXPORT bool isLoadingSubresources() const;
 
     void checkLoaded();
     void startLoadingDynamicSheet();
 
-    StyleSheetContents* rootStyleSheet() const;
-    Node* singleOwnerNode() const;
-    Document* singleOwnerDocument() const;
+    StyleSheetContents* NODELETE rootStyleSheet() const;
+    Node* NODELETE singleOwnerNode() const;
+    Document* NODELETE singleOwnerDocument() const;
 
     ASCIILiteral charset() const { return m_parserContext.charset; }
 
@@ -102,7 +102,7 @@ public:
 
     void parserAddNamespace(const AtomString& prefix, const AtomString& uri);
     void parserAppendRule(Ref<StyleRuleBase>&&);
-    void parserSetEncodingFromCharsetRule(const String& encoding); 
+    void NODELETE parserSetEncodingFromCharsetRule(const String& encoding);
     void parserSetUsesStyleBasedEditability() { m_usesStyleBasedEditability = true; }
 
     void clearRules();
@@ -115,7 +115,7 @@ public:
 
     void notifyLoadedSheet(const CachedCSSStyleSheet*);
     
-    StyleSheetContents* parentStyleSheet() const;
+    StyleSheetContents* NODELETE parentStyleSheet() const;
     StyleRuleImport* ownerRule() const { return m_ownerRule; }
     void clearOwnerRule() { m_ownerRule = nullptr; }
     
@@ -126,8 +126,8 @@ public:
     const URL& baseURL() const { return m_parserContext.baseURL; }
 
     bool isEmpty() const { return !ruleCount(); }
-    unsigned ruleCount() const;
-    StyleRuleBase* ruleAt(unsigned index) const;
+    unsigned NODELETE ruleCount() const;
+    StyleRuleBase* NODELETE ruleAt(unsigned index) const;
 
     bool usesStyleBasedEditability() const { return m_usesStyleBasedEditability; }
 
@@ -150,8 +150,8 @@ public:
     void clearHasNestingRulesCache() { m_hasNestingRulesCache = { }; }
 
     bool isInMemoryCache() const { return m_inMemoryCacheCount; }
-    void addedToMemoryCache();
-    void removedFromMemoryCache();
+    void NODELETE addedToMemoryCache();
+    void NODELETE removedFromMemoryCache();
 
     void shrinkToFit();
 
@@ -169,7 +169,7 @@ private:
     WEBCORE_EXPORT StyleSheetContents(StyleRuleImport* ownerRule, const String& originalURL, const CSSParserContext&);
     StyleSheetContents(const StyleSheetContents&);
 
-    void clearCharsetRule();
+    void NODELETE clearCharsetRule();
 
     StyleRuleImport* m_ownerRule { nullptr };
 

--- a/Source/WebCore/css/StyleSheetList.h
+++ b/Source/WebCore/css/StyleSheetList.h
@@ -47,9 +47,9 @@ public:
 
     CSSStyleSheet* namedItem(const AtomString&) const;
     bool isSupportedPropertyName(const AtomString&) const;
-    Vector<AtomString> supportedPropertyNames();
+    Vector<AtomString> NODELETE supportedPropertyNames();
 
-    Node* ownerNode() const;
+    Node* NODELETE ownerNode() const;
 
     void detach();
 

--- a/Source/WebCore/css/calc/CSSCalcSymbolTable.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolTable.h
@@ -43,8 +43,8 @@ public:
     CSSCalcSymbolTable() = default;
     CSSCalcSymbolTable(std::initializer_list<std::tuple<CSSValueID, CSSUnitType, double>>);
 
-    std::optional<Value> get(CSSValueID) const;
-    bool contains(CSSValueID) const;
+    std::optional<Value> NODELETE get(CSSValueID) const;
+    bool NODELETE contains(CSSValueID) const;
 
 private:
     HashMap<CSSValueID, std::pair<CSSUnitType, double>> m_table;

--- a/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h
+++ b/Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h
@@ -43,8 +43,8 @@ public:
     CSSCalcSymbolsAllowed& operator=(CSSCalcSymbolsAllowed&&) = default;
     CSSCalcSymbolsAllowed(CSSCalcSymbolsAllowed&&) = default;
 
-    std::optional<CSSUnitType> get(CSSValueID) const;
-    bool contains(CSSValueID) const;
+    std::optional<CSSUnitType> NODELETE get(CSSValueID) const;
+    bool NODELETE contains(CSSValueID) const;
 
 private:
     // FIXME: A HashMap here is not ideal, as these tables are always constant expressions

--- a/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp
@@ -87,7 +87,7 @@ template<typename Op> static std::optional<double> executeVariadicMathOperationA
     return result;
 }
 
-std::optional<CSS::Keyword::None> evaluate(const CSS::Keyword::None& none, const EvaluationOptions&)
+std::optional<CSS::Keyword::None> NODELETE evaluate(const CSS::Keyword::None& none, const EvaluationOptions&)
 {
     return none;
 }
@@ -115,17 +115,17 @@ std::optional<std::optional<double>> evaluate(const std::optional<Child>& root, 
     return std::optional<double> { std::nullopt };
 }
 
-std::optional<double> evaluate(const Number& number, const EvaluationOptions&)
+std::optional<double> NODELETE evaluate(const Number& number, const EvaluationOptions&)
 {
     return number.value;
 }
 
-std::optional<double> evaluate(const Percentage& percentage, const EvaluationOptions&)
+std::optional<double> NODELETE evaluate(const Percentage& percentage, const EvaluationOptions&)
 {
     return percentage.value;
 }
 
-std::optional<double> evaluate(const CanonicalDimension& root, const EvaluationOptions&)
+std::optional<double> NODELETE evaluate(const CanonicalDimension& root, const EvaluationOptions&)
 {
     return root.value;
 }

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.cpp
@@ -91,7 +91,7 @@ struct ParserState {
 
 } // namespace (anonymous)
 
-static ParseStatus checkDepth(int depth)
+static ParseStatus NODELETE checkDepth(int depth)
 {
     if (depth > maxExpressionDepth)
         return ParseStatus::TooDeep;
@@ -659,7 +659,7 @@ static std::optional<Random::SharingFixed> consumeOptionalRandomSharingFixed(CSS
     };
 }
 
-static Random::SharingOptions::Auto makeRandomSharingAuto(ParserState& state)
+static Random::SharingOptions::Auto NODELETE makeRandomSharingAuto(ParserState& state)
 {
     return {
         .property = state.propertyParserState.currentProperty,
@@ -1069,7 +1069,7 @@ static std::optional<TypedChild> consumeAnchor(CSSParserTokenRange& tokens, int 
     return TypedChild { makeChild(WTF::move(anchor), type), type };
 }
 
-static std::optional<Style::AnchorSizeDimension> cssValueIDToAnchorSizeDimension(CSSValueID value)
+static std::optional<Style::AnchorSizeDimension> NODELETE cssValueIDToAnchorSizeDimension(CSSValueID value)
 {
     switch (value) {
     case CSSValueWidth:

--- a/Source/WebCore/css/calc/CSSCalcTree+Parser.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Parser.h
@@ -67,7 +67,7 @@ struct ParserOptions {
 std::optional<Tree> parseAndSimplify(CSSParserTokenRange&, CSS::PropertyParserState&, const ParserOptions&, const SimplificationOptions&);
 
 // Returns whether the provided `CSSValueID` is one of the functions that should be parsed as a `calc()`.
-bool isCalcFunction(CSSValueID function);
+bool NODELETE isCalcFunction(CSSValueID function);
 
 } // namespace CSSCalc
 } // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp
@@ -113,7 +113,7 @@ template<typename Op> static void serializeCalculationTree(StringBuilder&, const
 
 // MARK: Sorting
 
-static unsigned sortPriority(CSSUnitType unit)
+static unsigned NODELETE sortPriority(CSSUnitType unit)
 {
     // Sort order: number, percentage, dimension (by unit, ordered ASCII case-insensitively), other.
 

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp
@@ -76,7 +76,7 @@ template<typename... F> static decltype(auto) switchTogether(const Child& a, con
 
 // MARK: Predicate: percentageResolveToDimension
 
-static bool percentageResolveToDimension(const SimplificationOptions& options)
+static bool NODELETE percentageResolveToDimension(const SimplificationOptions& options)
 {
     switch (options.category) {
     case CSS::Category::Integer:
@@ -101,66 +101,66 @@ static bool percentageResolveToDimension(const SimplificationOptions& options)
 
 // MARK: Predicate: unitsMatch
 
-constexpr bool unitsMatch(const Number&, const Number&, const SimplificationOptions&)
+constexpr bool NODELETE unitsMatch(const Number&, const Number&, const SimplificationOptions&)
 {
     return true;
 }
 
-constexpr bool unitsMatch(const Percentage&, const Percentage&, const SimplificationOptions&)
+constexpr bool NODELETE unitsMatch(const Percentage&, const Percentage&, const SimplificationOptions&)
 {
     return true;
 }
 
-static bool unitsMatch(const CanonicalDimension& a, const CanonicalDimension& b, const SimplificationOptions&)
+static bool NODELETE unitsMatch(const CanonicalDimension& a, const CanonicalDimension& b, const SimplificationOptions&)
 {
     return a.dimension == b.dimension;
 }
 
-static bool unitsMatch(const NonCanonicalDimension& a, const NonCanonicalDimension& b, const SimplificationOptions&)
+static bool NODELETE unitsMatch(const NonCanonicalDimension& a, const NonCanonicalDimension& b, const SimplificationOptions&)
 {
     return a.unit == b.unit;
 }
 
 // MARK: Predicate: magnitudeComparable
 
-constexpr bool magnitudeComparable(const Number&, const SimplificationOptions&)
+constexpr bool NODELETE magnitudeComparable(const Number&, const SimplificationOptions&)
 {
     return true;
 }
 
-static bool magnitudeComparable(const Percentage&, const SimplificationOptions& options)
+static bool NODELETE magnitudeComparable(const Percentage&, const SimplificationOptions& options)
 {
     return !percentageResolveToDimension(options);
 }
 
-constexpr bool magnitudeComparable(const CanonicalDimension&, const SimplificationOptions&)
+constexpr bool NODELETE magnitudeComparable(const CanonicalDimension&, const SimplificationOptions&)
 {
     return true;
 }
 
-constexpr bool magnitudeComparable(const NonCanonicalDimension&, const SimplificationOptions&)
+constexpr bool NODELETE magnitudeComparable(const NonCanonicalDimension&, const SimplificationOptions&)
 {
     return true;
 }
 
 // MARK: Predicate: fullyResolved
 
-constexpr bool fullyResolved(const Number&, const SimplificationOptions&)
+constexpr bool NODELETE fullyResolved(const Number&, const SimplificationOptions&)
 {
     return true;
 }
 
-static bool fullyResolved(const Percentage&, const SimplificationOptions& options)
+static bool NODELETE fullyResolved(const Percentage&, const SimplificationOptions& options)
 {
     return !percentageResolveToDimension(options);
 }
 
-constexpr bool fullyResolved(const CanonicalDimension&, const SimplificationOptions&)
+constexpr bool NODELETE fullyResolved(const CanonicalDimension&, const SimplificationOptions&)
 {
     return true;
 }
 
-constexpr bool fullyResolved(const NonCanonicalDimension&, const SimplificationOptions&)
+constexpr bool NODELETE fullyResolved(const NonCanonicalDimension&, const SimplificationOptions&)
 {
     return false;
 }

--- a/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
+++ b/Source/WebCore/css/calc/CSSCalcTree+Simplification.h
@@ -109,7 +109,7 @@ Child copyAndSimplify(const Child&, const SimplificationOptions&);
 
 // MARK: In-place Simplify
 
-std::optional<Child> simplify(Number&, const SimplificationOptions&);
+std::optional<Child> NODELETE simplify(Number&, const SimplificationOptions&);
 std::optional<Child> simplify(Percentage&, const SimplificationOptions&);
 std::optional<Child> simplify(NonCanonicalDimension&, const SimplificationOptions&);
 std::optional<Child> simplify(CanonicalDimension&, const SimplificationOptions&);

--- a/Source/WebCore/css/calc/CSSCalcType.h
+++ b/Source/WebCore/css/calc/CSSCalcType.h
@@ -115,7 +115,7 @@ struct Type {
     static constexpr Type makePercent() { return { .percent = 1 }; }
 
     static Type determineType(CSSUnitType);
-    static PercentHintValue determinePercentHint(CSS::Category);
+    static PercentHintValue NODELETE determinePercentHint(CSS::Category);
 
     static std::optional<Type> add(Type, Type);
     static std::optional<Type> add(std::optional<Type> a, Type b) { if (!a) return a; return add(*a, b); }
@@ -125,7 +125,7 @@ struct Type {
 
     static std::optional<Type> sameType(Type, Type);
     static std::optional<Type> consistentType(Type, Type);
-    static std::optional<Type> madeConsistent(Type base, Type input);
+    static std::optional<Type> NODELETE madeConsistent(Type base, Type input);
 
     static constexpr decltype(auto) allBaseTypes();
     static constexpr decltype(auto) allPotentialPercentHintTypes();
@@ -155,10 +155,10 @@ struct Type {
     };
     template<Match...> constexpr bool matchesAny(MatchingContext = { .allowsPercentHint = false }) const;
 
-    bool matches(CSS::Category) const;
+    bool NODELETE matches(CSS::Category) const;
 
     // Returns the CSS::Category for Type, if there is one.
-    std::optional<CSS::Category> calculationCategory() const;
+    std::optional<CSS::Category> NODELETE calculationCategory() const;
 };
 
 static_assert(sizeof(Type) == 8);

--- a/Source/WebCore/css/calc/CSSCalcValue.h
+++ b/Source/WebCore/css/calc/CSSCalcValue.h
@@ -84,7 +84,7 @@ public:
     CSS::Category category() const { return m_category; }
     CSS::Range range() const { return m_range; }
 
-    CSSUnitType primitiveType() const;
+    CSSUnitType NODELETE primitiveType() const;
 
     // Returns whether the CSSCalc::Tree requires `CSSToLengthConversionData` to fully resolve.
     bool requiresConversionData() const { return m_tree.requiresConversionData; };

--- a/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
+++ b/Source/WebCore/css/parser/CSSCustomPropertySyntax.h
@@ -75,7 +75,7 @@ struct CSSCustomPropertySyntax {
 
     static CSSCustomPropertySyntax universal() { return { }; }
 
-    bool containsUnknownType() const;
+    bool NODELETE containsUnknownType() const;
 
 private:
     template<typename CharacterType> static std::optional<Component> parseComponent(std::span<const CharacterType>);

--- a/Source/WebCore/css/parser/CSSParserContext.cpp
+++ b/Source/WebCore/css/parser/CSSParserContext.cpp
@@ -44,7 +44,7 @@ const CSSParserContext& strictCSSParserContext()
     return strictContext;
 }
 
-static void applyUASheetBehaviorsToContext(CSSParserContext& context)
+static void NODELETE applyUASheetBehaviorsToContext(CSSParserContext& context)
 {
     // FIXME: We should turn all of the features on from their WebCore Settings defaults.
     context.cssAppearanceBaseEnabled = true;

--- a/Source/WebCore/css/parser/CSSParserContext.h
+++ b/Source/WebCore/css/parser/CSSParserContext.h
@@ -95,7 +95,7 @@ struct CSSParserContext {
     CSSParserContext(const Document&, const URL& baseURL, ASCIILiteral charset = ""_s);
     CSSParserContext(const Settings&);
 
-    void setUASheetMode();
+    void NODELETE setUASheetMode();
 
     bool operator==(const CSSParserContext&) const = default;
 };

--- a/Source/WebCore/css/parser/CSSParserFastPaths.cpp
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.cpp
@@ -458,7 +458,7 @@ static inline bool mightBeHSL(std::span<const CharacterType> characters)
         && isASCIIAlphaCaselessEqual(characters[2], 'l');
 }
 
-static std::optional<SRGBA<uint8_t>> finishParsingHexColor(uint32_t value, unsigned length)
+static std::optional<SRGBA<uint8_t>> NODELETE finishParsingHexColor(uint32_t value, unsigned length)
 {
     switch (length) {
     case 3: {

--- a/Source/WebCore/css/parser/CSSParserFastPaths.h
+++ b/Source/WebCore/css/parser/CSSParserFastPaths.h
@@ -52,7 +52,7 @@ public:
 
     // Returns the allowed numeric value range for a length value if the property supports a single length value.
     // FIXME: This should be generated from CSSProperties.json
-    static std::optional<CSS::Range> lengthValueRangeForPropertiesSupportingSimpleLengths(CSSPropertyID);
+    static std::optional<CSS::Range> NODELETE lengthValueRangeForPropertiesSupportingSimpleLengths(CSSPropertyID);
 
     // Parses numeric and named colors.
     static WEBCORE_EXPORT std::optional<SRGBA<uint8_t>> parseSimpleColor(StringView, const CSSParserContext&);

--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.cpp
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.cpp
@@ -46,7 +46,7 @@ unsigned CSSParserObserverWrapper::previousTokenStartOffset(const CSSParserToken
     return m_tokenOffsets[range.begin() - m_firstParserToken - 1];
 }
 
-unsigned CSSParserObserverWrapper::endOffset(const CSSParserTokenRange& range)
+unsigned NODELETE CSSParserObserverWrapper::endOffset(const CSSParserTokenRange& range)
 {
     return m_tokenOffsets[range.end() - m_firstParserToken];
 }

--- a/Source/WebCore/css/parser/CSSParserObserverWrapper.h
+++ b/Source/WebCore/css/parser/CSSParserObserverWrapper.h
@@ -42,11 +42,11 @@ public:
         return adoptRef(*new CSSParserObserverWrapper(observer));
     }
 
-    unsigned startOffset(const CSSParserTokenRange&);
-    unsigned previousTokenStartOffset(const CSSParserTokenRange&);
+    unsigned NODELETE startOffset(const CSSParserTokenRange&);
+    unsigned NODELETE previousTokenStartOffset(const CSSParserTokenRange&);
     unsigned endOffset(const CSSParserTokenRange&); // Includes trailing comments
 
-    void skipCommentsBefore(const CSSParserTokenRange&, bool leaveDirectlyBefore);
+    void NODELETE skipCommentsBefore(const CSSParserTokenRange&, bool leaveDirectlyBefore);
     void yieldCommentsBefore(const CSSParserTokenRange&);
 
     CSSParserObserver& observer() { return m_observer; }

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -108,7 +108,7 @@ public:
 
     CSSParserToken(HashTokenType, StringView);
 
-    static CSSUnitType stringToUnitType(StringView);
+    static CSSUnitType NODELETE stringToUnitType(StringView);
 
     bool operator==(const CSSParserToken& other) const;
 
@@ -116,16 +116,16 @@ public:
     void convertToDimensionWithUnit(StringView);
 
     // Converts NumberToken to PercentageToken.
-    void convertToPercentage();
+    void NODELETE convertToPercentage();
 
     CSSParserTokenType type() const { return static_cast<CSSParserTokenType>(m_type); }
     StringView value() const { return { m_valueDataCharRaw, m_valueLength, m_valueIs8Bit }; }
 
-    char16_t delimiter() const;
-    NumericSign numericSign() const;
-    NumericValueType numericValueType() const;
-    double numericValue() const;
-    StringView originalText() const;
+    char16_t NODELETE delimiter() const;
+    NumericSign NODELETE numericSign() const;
+    NumericValueType NODELETE numericValueType() const;
+    double NODELETE numericValue() const;
+    StringView NODELETE originalText() const;
     HashTokenType getHashTokenType() const { ASSERT(m_type == HashToken); return m_hashTokenType; }
     BlockType getBlockType() const { return static_cast<BlockType>(m_blockType); }
     CSSUnitType unitType() const { return static_cast<CSSUnitType>(m_unit); }
@@ -133,7 +133,7 @@ public:
     CSSValueID id() const;
     CSSValueID functionId() const;
 
-    bool hasStringBacking() const;
+    bool NODELETE hasStringBacking() const;
     bool tryUseStringLiteralBacking();
     bool isBackedByStringLiteral() const { return m_isBackedByStringLiteral; }
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.h
+++ b/Source/WebCore/css/parser/CSSPropertyParser.h
@@ -80,6 +80,6 @@ WEBCORE_EXPORT CSSValueID cssValueKeywordID(StringView);
 
 // MARK: - Custom property name validation
 
-bool isCustomPropertyName(StringView);
+bool NODELETE isCustomPropertyName(StringView);
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Anchor.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Anchor.cpp
@@ -111,7 +111,7 @@ enum class KeywordType : uint8_t {
     Axisless
 };
 
-static std::optional<KeywordType> getKeywordType(CSSValueID id)
+static std::optional<KeywordType> NODELETE getKeywordType(CSSValueID id)
 {
     switch (id) {
     case CSSValueLeft:
@@ -189,7 +189,7 @@ static std::optional<KeywordType> getKeywordType(CSSValueID id)
 
 // Check if the two keyword types are compatible with each other. For example,
 // <physical-area-x> must go with <physical-area-y> or <axisless-keyword>
-static bool typesAreCompatible(KeywordType dim1Type, KeywordType dim2Type)
+static bool NODELETE typesAreCompatible(KeywordType dim1Type, KeywordType dim2Type)
 {
     switch (dim1Type) {
     case KeywordType::PhysicalX:
@@ -225,7 +225,7 @@ static bool typesAreCompatible(KeywordType dim1Type, KeywordType dim2Type)
 }
 
 // Check if a keyword type is explicit about its axis.
-static bool typeIsAxisExplicit(KeywordType type)
+static bool NODELETE typeIsAxisExplicit(KeywordType type)
 {
     switch (type) {
     case KeywordType::PhysicalX:
@@ -242,7 +242,7 @@ static bool typeIsAxisExplicit(KeywordType type)
 }
 
 // Check if a keyword type refers to the X or block axis.
-static bool typeIsBlockOrXAxis(KeywordType type)
+static bool NODELETE typeIsBlockOrXAxis(KeywordType type)
 {
     switch (type) {
     case KeywordType::PhysicalX:
@@ -256,7 +256,7 @@ static bool typeIsBlockOrXAxis(KeywordType type)
 }
 
 // Check if a keyword type refers to the Y or inline axis.
-static bool typeIsInlineOrYAxis(KeywordType type)
+static bool NODELETE typeIsInlineOrYAxis(KeywordType type)
 {
     switch (type) {
     case KeywordType::PhysicalY:
@@ -269,7 +269,7 @@ static bool typeIsInlineOrYAxis(KeywordType type)
     }
 }
 
-static CSSValueID makeAmbiguous(CSSValueID dim)
+static CSSValueID NODELETE makeAmbiguous(CSSValueID dim)
 {
     switch (dim) {
     case CSSValueBlockStart: return CSSValueStart;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp
@@ -57,7 +57,7 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-template<typename ElementType> static void complete4Sides(std::array<ElementType, 4>& sides)
+template<typename ElementType> static void NODELETE complete4Sides(std::array<ElementType, 4>& sides)
 {
     if (!sides[1])
         sides[1] = sides[0];

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h
@@ -54,7 +54,7 @@ struct CSSColorParsingOptions {
 };
 
 // MARK: Mode specific color settings.
-bool isColorKeywordAllowed(CSSValueID, const CSSParserContext&);
+bool NODELETE isColorKeywordAllowed(CSSValueID, const CSSParserContext&);
 
 // MARK: <color> consuming (unresolved)
 std::optional<CSS::Color> consumeUnresolvedColor(CSSParserTokenRange&, CSS::PropertyParserState&, const CSSColorParsingOptions& = { });

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+CounterStyles.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+CounterStyles.cpp
@@ -46,7 +46,7 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-static bool isPredefinedCounterStyle(CSSValueID valueID)
+static bool NODELETE isPredefinedCounterStyle(CSSValueID valueID)
 {
     // https://drafts.csswg.org/css-counter-styles-3/#predefined-counters
 

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp
@@ -77,7 +77,7 @@ namespace CSSPropertyParserHelpers {
 
 using DisplayOutsideInsideMap = EnumeratedArray<DisplayOutside, EnumeratedArray<DisplayInside, CSSValueID>>;
 
-consteval DisplayOutsideInsideMap makeDisplayOutsideInsideMap()
+consteval DisplayOutsideInsideMap NODELETE makeDisplayOutsideInsideMap()
 {
     using enum DisplayOutside;
     using enum DisplayInside;

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp
@@ -82,7 +82,7 @@ static Ref<CSSPrimitiveValue> resolveToCSSPrimitiveValue(CSS::Numeric auto&& pri
     return WTF::switchOn(WTF::move(primitive), [](auto&& alternative) { return CSSPrimitiveValueResolverBase::resolve(WTF::move(alternative), { }); }).releaseNonNull();
 }
 
-static CSSParserMode parserMode(ScriptExecutionContext& context)
+static CSSParserMode NODELETE parserMode(ScriptExecutionContext& context)
 {
     auto* document = dynamicDowncast<Document>(context);
     return (document && document->inQuirksMode()) ? HTMLQuirksMode : HTMLStandardMode;
@@ -516,7 +516,7 @@ Vector<FontTechnology> consumeFontTech(CSSParserTokenRange& range, CSS::Property
     return technologies;
 }
 
-static bool isFontFormatKeywordValid(CSSValueID id)
+static bool NODELETE isFontFormatKeywordValid(CSSValueID id)
 {
     switch (id) {
     case CSSValueCollection:

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h
@@ -113,8 +113,8 @@ RefPtr<CSSValue> consumeFontFamily(CSSParserTokenRange&, CSS::PropertyParserStat
 RefPtr<CSSValue> consumeFamilyName(CSSParserTokenRange&, CSS::PropertyParserState&);
 // Sub-production of 'font-family': <generic-family>
 // https://drafts.csswg.org/css-fonts-4/#generic-family-name-syntax
-const AtomString& genericFontFamily(CSSValueID);
-WebKitFontFamilyNames::FamilyNamesIndex genericFontFamilyIndex(CSSValueID);
+const AtomString& NODELETE genericFontFamily(CSSValueID);
+WebKitFontFamilyNames::FamilyNamesIndex NODELETE genericFontFamilyIndex(CSSValueID);
 
 // MARK: 'font-size-adjust'
 // https://drafts.csswg.org/css-fonts-4/#font-size-adjust-prop

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h
@@ -47,7 +47,7 @@ namespace CSSPropertyParserHelpers {
 enum class AllowEmpty : bool { No, Yes };
 enum TrackListType : uint8_t { GridTemplate, GridTemplateNoRepeat, GridAuto };
 
-bool isGridBreadthIdent(CSSValueID);
+bool NODELETE isGridBreadthIdent(CSSValueID);
 
 // Parses a single <string> token from a <'grid-template-areas'> production.
 std::optional<CSS::GridNamedAreaMapRow> consumeUnresolvedGridTemplateAreasRow(CSSParserTokenRange&, CSS::PropertyParserState&);

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Symbol.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Symbol.cpp
@@ -32,7 +32,7 @@
 namespace WebCore {
 namespace CSSPropertyParserHelpers {
 
-std::optional<CSS::SymbolRaw> validatedRange(CSS::SymbolRaw value, CSSPropertyParserOptions)
+std::optional<CSS::SymbolRaw> NODELETE validatedRange(CSS::SymbolRaw value, CSSPropertyParserOptions)
 {
     return value;
 }

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h
@@ -44,7 +44,7 @@ enum class SingleAnimationRangeType : bool;
 
 namespace CSSPropertyParserHelpers {
 
-bool isAnimationRangeKeyword(CSSValueID);
+bool NODELETE isAnimationRangeKeyword(CSSValueID);
 
 // MARK: - Consumer functions
 

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -379,7 +379,7 @@ static OptionSet<CompoundSelectorFlag> extractCompoundFlags(const MutableCSSSele
     return CompoundSelectorFlag::HasPseudoElementForRightmostCompound;
 }
 
-static bool isDescendantCombinator(CSSSelector::Relation relation)
+static bool NODELETE isDescendantCombinator(CSSSelector::Relation relation)
 {
     return relation == CSSSelector::Relation::DescendantSpace;
 }
@@ -477,7 +477,7 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeRelativeNestedSele
     return selector;
 }
 
-static bool isScrollbarPseudoClass(CSSSelector::PseudoClass pseudo)
+static bool NODELETE isScrollbarPseudoClass(CSSSelector::PseudoClass pseudo)
 {
     switch (pseudo) {
     case CSSSelector::PseudoClass::Enabled:
@@ -501,7 +501,7 @@ static bool isScrollbarPseudoClass(CSSSelector::PseudoClass pseudo)
     }
 }
 
-static bool isUserActionPseudoClass(CSSSelector::PseudoClass pseudo)
+static bool NODELETE isUserActionPseudoClass(CSSSelector::PseudoClass pseudo)
 {
     switch (pseudo) {
     case CSSSelector::PseudoClass::Hover:
@@ -515,7 +515,7 @@ static bool isUserActionPseudoClass(CSSSelector::PseudoClass pseudo)
     }
 }
 
-static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClass pseudoClass, CSSSelector::PseudoElement compoundPseudoElement)
+static bool NODELETE isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClass pseudoClass, CSSSelector::PseudoElement compoundPseudoElement)
 {
     // FIXME: https://drafts.csswg.org/selectors-4/#pseudo-element-states states all pseudo-elements
     // can be followed by isUserActionPseudoClass().
@@ -551,7 +551,7 @@ static bool isPseudoClassValidAfterPseudoElement(CSSSelector::PseudoClass pseudo
     }
 }
 
-static bool isTreeAbidingPseudoElement(CSSSelector::PseudoElement pseudoElement)
+static bool NODELETE isTreeAbidingPseudoElement(CSSSelector::PseudoElement pseudoElement)
 {
     switch (pseudoElement) {
     // FIXME: This list should also include ::placeholder and ::file-selector-button

--- a/Source/WebCore/css/parser/CSSSelectorParser.h
+++ b/Source/WebCore/css/parser/CSSSelectorParser.h
@@ -93,11 +93,11 @@ private:
     CSSSelector::Match consumeAttributeMatch(CSSParserTokenRange&);
     CSSSelector::AttributeMatchType consumeAttributeFlags(CSSParserTokenRange&);
 
-    const AtomString& defaultNamespace() const;
+    const AtomString& NODELETE defaultNamespace() const;
     const AtomString& determineNamespace(const AtomString& prefix);
     void prependTypeSelectorIfNeeded(const AtomString& namespacePrefix, const AtomString& elementName, MutableCSSSelector&);
     static std::unique_ptr<MutableCSSSelector> splitCompoundAtImplicitShadowCrossingCombinator(std::unique_ptr<MutableCSSSelector> compoundSelector, const CSSSelectorParserContext&);
-    static bool containsUnknownWebKitPseudoElements(const CSSSelector& complexSelector);
+    static bool NODELETE containsUnknownWebKitPseudoElements(const CSSSelector& complexSelector);
 
     class DisallowPseudoElementsScope;
 

--- a/Source/WebCore/css/parser/CSSSelectorParserContext.h
+++ b/Source/WebCore/css/parser/CSSSelectorParserContext.h
@@ -56,7 +56,7 @@ struct CSSSelectorParserContext {
     friend bool operator==(const CSSSelectorParserContext&, const CSSSelectorParserContext&) = default;
 };
 
-void add(Hasher&, const CSSSelectorParserContext&);
+void NODELETE add(Hasher&, const CSSSelectorParserContext&);
 
 } // namespace WebCore
 

--- a/Source/WebCore/css/parser/CSSTokenizer.cpp
+++ b/Source/WebCore/css/parser/CSSTokenizer.cpp
@@ -157,7 +157,7 @@ CSSParserToken CSSTokenizer::newline(char16_t)
 }
 
 // http://dev.w3.org/csswg/css-syntax/#check-if-two-code-points-are-a-valid-escape
-static bool twoCharsAreValidEscape(char16_t first, char16_t second)
+static bool NODELETE twoCharsAreValidEscape(char16_t first, char16_t second)
 {
     return first == '\\' && !CSSTokenizer::isNewline(second);
 }
@@ -661,7 +661,7 @@ CSSParserToken CSSTokenizer::consumeStringTokenUntil(char16_t endingCodePoint)
 }
 
 // http://dev.w3.org/csswg/css-syntax/#non-printable-code-point
-static bool isNonPrintableCodePoint(char16_t cc)
+static bool NODELETE isNonPrintableCodePoint(char16_t cc)
 {
     return cc <= '\x8' || cc == '\xb' || (cc >= '\xe' && cc <= '\x1f') || cc == '\x7f';
 }

--- a/Source/WebCore/css/parser/CSSTokenizer.h
+++ b/Source/WebCore/css/parser/CSSTokenizer.h
@@ -52,11 +52,11 @@ public:
     WEBCORE_EXPORT explicit CSSTokenizer(const String&);
     CSSTokenizer(const String&, CSSParserObserverWrapper&); // For the inspector
 
-    WEBCORE_EXPORT CSSParserTokenRange tokenRange() const LIFETIME_BOUND;
-    unsigned tokenCount();
+    WEBCORE_EXPORT CSSParserTokenRange NODELETE tokenRange() const LIFETIME_BOUND;
+    unsigned NODELETE tokenCount();
 
-    static bool isWhitespace(CSSParserTokenType);
-    static bool isNewline(char16_t);
+    static bool NODELETE isWhitespace(CSSParserTokenType);
+    static bool NODELETE isNewline(char16_t);
 
     Vector<String>&& escapedStringsForAdoption() { return WTF::move(m_stringPool); }
 
@@ -65,8 +65,8 @@ private:
 
     CSSParserToken nextToken();
 
-    char16_t consume();
-    void reconsume(char16_t);
+    char16_t NODELETE consume();
+    void NODELETE reconsume(char16_t);
 
     String preprocessString(const String&);
 
@@ -77,17 +77,17 @@ private:
     CSSParserToken consumeURLToken();
 
     void consumeBadUrlRemnants();
-    void consumeSingleWhitespaceIfNext();
-    void consumeUntilCommentEndFound();
+    void NODELETE consumeSingleWhitespaceIfNext();
+    void NODELETE consumeUntilCommentEndFound();
 
-    bool consumeIfNext(char16_t);
+    bool NODELETE consumeIfNext(char16_t);
     StringView consumeName();
     char32_t consumeEscape();
 
-    bool nextTwoCharsAreValidEscape();
-    bool nextCharsAreNumber(char16_t);
+    bool NODELETE nextTwoCharsAreValidEscape();
+    bool NODELETE nextCharsAreNumber(char16_t);
     bool nextCharsAreNumber();
-    bool nextCharsAreIdentifier(char16_t);
+    bool NODELETE nextCharsAreIdentifier(char16_t);
     bool nextCharsAreIdentifier();
 
     CSSParserToken blockStart(CSSParserTokenType);

--- a/Source/WebCore/css/parser/CSSVariableParser.cpp
+++ b/Source/WebCore/css/parser/CSSVariableParser.cpp
@@ -51,7 +51,7 @@ bool CSSVariableParser::isValidVariableName(const CSSParserToken& token)
     return isCustomPropertyName(token.value());
 }
 
-static bool isValidConstantName(const CSSParserToken& token)
+static bool NODELETE isValidConstantName(const CSSParserToken& token)
 {
     return token.type() == IdentToken;
 }

--- a/Source/WebCore/css/parser/MediaQueryBlockWatcher.h
+++ b/Source/WebCore/css/parser/MediaQueryBlockWatcher.h
@@ -36,7 +36,7 @@ class CSSParserToken;
 class MediaQueryBlockWatcher {
 public:
     MediaQueryBlockWatcher();
-    void handleToken(const CSSParserToken&);
+    void NODELETE handleToken(const CSSParserToken&);
     unsigned blockLevel() const { return m_blockLevel; }
 
 private:

--- a/Source/WebCore/css/parser/MutableCSSSelector.h
+++ b/Source/WebCore/css/parser/MutableCSSSelector.h
@@ -97,9 +97,9 @@ public:
     bool needsImplicitShadowCombinatorForMatching() const;
 
     MutableCSSSelector* precedingInComplexSelector() const { return m_precedingInComplexSelector.get(); }
-    MutableCSSSelector* leftmostSimpleSelector();
+    MutableCSSSelector* NODELETE leftmostSimpleSelector();
     const MutableCSSSelector* leftmostSimpleSelector() const;
-    bool startsWithExplicitCombinator() const;
+    bool NODELETE startsWithExplicitCombinator() const;
     void setPrecedingInComplexSelector(std::unique_ptr<MutableCSSSelector> selector) { m_precedingInComplexSelector = WTF::move(selector); }
     void prependInComplexSelector(CSSSelector::Relation, std::unique_ptr<MutableCSSSelector>);
     void prependInComplexSelectorAsRelative(std::unique_ptr<MutableCSSSelector>);

--- a/Source/WebCore/css/parser/SizesAttributeParser.h
+++ b/Source/WebCore/css/parser/SizesAttributeParser.h
@@ -58,7 +58,7 @@ private:
 
     bool mediaConditionMatches(const MQ::MediaQuery&);
 
-    Ref<const Document> protectedDocument() const;
+    Ref<const Document> NODELETE protectedDocument() const;
     std::optional<CSSToLengthConversionData> conversionData() const;
     float effectiveSizeDefaultValue();
 

--- a/Source/WebCore/css/query/ContainerQueryFeatures.cpp
+++ b/Source/WebCore/css/query/ContainerQueryFeatures.cpp
@@ -42,7 +42,7 @@ namespace WebCore::CQ {
 
 using namespace MQ;
 
-static LayoutUnit unscaledSizeForPrincipleBox(const Style::PreferredSize& computedSize, LayoutUnit usedSize, UsesSVGZoomRulesForLength usesSVGZoomRulesForLength, float usedZoom)
+static LayoutUnit NODELETE unscaledSizeForPrincipleBox(const Style::PreferredSize& computedSize, LayoutUnit usedSize, UsesSVGZoomRulesForLength usesSVGZoomRulesForLength, float usedZoom)
 {
     if (usesSVGZoomRulesForLength == UsesSVGZoomRulesForLength::Yes || !computedSize.isFixed())
         return usedSize;

--- a/Source/WebCore/css/query/ContainerQueryParser.h
+++ b/Source/WebCore/css/query/ContainerQueryParser.h
@@ -35,7 +35,7 @@ namespace CQ {
 struct ContainerQueryParser : MQ::GenericMediaQueryParser<ContainerQueryParser>  {
     static std::optional<CQ::ContainerQuery> consumeContainerQuery(CSSParserTokenRange&, const MediaQueryParserContext&);
 
-    static bool isValidFunctionId(CSSValueID);
+    static bool NODELETE isValidFunctionId(CSSValueID);
     static const MQ::FeatureSchema* schemaForFeatureName(const AtomString&, const MediaQueryParserContext&, State&);
     static Vector<const MQ::FeatureSchema*> featureSchemas();
 };

--- a/Source/WebCore/css/query/GenericMediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/GenericMediaQueryEvaluator.h
@@ -41,7 +41,7 @@ EvaluationResult evaluateBooleanFeature(const Feature&, bool, const CSSToLengthC
 EvaluationResult evaluateIntegerFeature(const Feature&, int, const CSSToLengthConversionData&);
 EvaluationResult evaluateNumberFeature(const Feature&, double, const CSSToLengthConversionData&);
 EvaluationResult evaluateResolutionFeature(const Feature&, float, const CSSToLengthConversionData&);
-EvaluationResult evaluateIdentifierFeature(const Feature&, CSSValueID, const CSSToLengthConversionData&);
+EvaluationResult NODELETE evaluateIdentifierFeature(const Feature&, CSSValueID, const CSSToLengthConversionData&);
 
 template<typename ConcreteEvaluator>
 class GenericMediaQueryEvaluator {

--- a/Source/WebCore/css/query/MediaQueryEvaluator.h
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.h
@@ -40,12 +40,12 @@ public:
     bool evaluate(const MediaQueryList&) const;
     bool evaluate(const MediaQuery&) const;
 
-    bool evaluateMediaType(const MediaQuery&) const;
+    bool NODELETE evaluateMediaType(const MediaQuery&) const;
 
     OptionSet<MediaQueryDynamicDependency> collectDynamicDependencies(const MediaQueryList&) const;
     OptionSet<MediaQueryDynamicDependency> collectDynamicDependencies(const MediaQuery&) const;
 
-    bool isPrintMedia() const;
+    bool NODELETE isPrintMedia() const;
 
 private:
     AtomString m_mediaType;

--- a/Source/WebCore/css/typedom/CSSKeywordValue.h
+++ b/Source/WebCore/css/typedom/CSSKeywordValue.h
@@ -41,7 +41,7 @@ public:
     static ExceptionOr<Ref<CSSKeywordValue>> create(const String&);
     
     const String& value() const { return m_value; }
-    ExceptionOr<void> setValue(const String&);
+    ExceptionOr<void> NODELETE setValue(const String&);
     
     CSSStyleValueType styleValueType() const final { return CSSStyleValueType::CSSKeywordValue; }
     

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -172,7 +172,7 @@ ExceptionOr<Vector<Ref<CSSStyleValue>>> CSSStyleValueFactory::parseStyleValue(Do
     return results;
 }
 
-static bool mayConvertCSSValueListToSingleValue(std::optional<CSSPropertyID> propertyID)
+static bool NODELETE mayConvertCSSValueListToSingleValue(std::optional<CSSPropertyID> propertyID)
 {
     if (!propertyID)
         return true;

--- a/Source/WebCore/css/typedom/CSSUnitValue.cpp
+++ b/Source/WebCore/css/typedom/CSSUnitValue.cpp
@@ -298,7 +298,7 @@ static CSS::Range rangeForProperty(CSSPropertyID propertyID, CSSUnitType)
     }
 }
 
-static CSS::Category calculationCategoryForProperty(CSSPropertyID, CSSUnitType unit)
+static CSS::Category NODELETE calculationCategoryForProperty(CSSPropertyID, CSSUnitType unit)
 {
     // FIXME: This should be looking up the supported calculation categories for the CSSPropertyID and picking the one that best matches the unit.
 

--- a/Source/WebCore/css/typedom/CSSUnitValue.h
+++ b/Source/WebCore/css/typedom/CSSUnitValue.h
@@ -59,7 +59,7 @@ private:
 
     CSSStyleValueType styleValueType() const final { return CSSStyleValueType::CSSUnitValue; }
     std::optional<SumValue> toSumValue() const final;
-    bool equals(const CSSNumericValue&) const final;
+    bool NODELETE equals(const CSSNumericValue&) const final;
 
     double m_value;
     const CSSUnitType m_unit;

--- a/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/DeclaredStylePropertyMap.h
@@ -39,13 +39,13 @@ public:
     static Ref<DeclaredStylePropertyMap> create(CSSStyleRule&);
 
     Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
-    unsigned size() const final;
+    unsigned NODELETE size() const final;
     Type type() const final { return Type::Declared; }
 
 private:
     explicit DeclaredStylePropertyMap(CSSStyleRule&);
 
-    StyleRule* styleRule() const;
+    StyleRule* NODELETE styleRule() const;
 
     void clear() final;
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;

--- a/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h
@@ -38,9 +38,9 @@ public:
 
     Type type() const final { return Type::HashMap; }
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
-    String shorthandPropertySerialization(CSSPropertyID) const final;
-    RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final;
-    unsigned size() const final;
+    String NODELETE shorthandPropertySerialization(CSSPropertyID) const final;
+    RefPtr<CSSValue> NODELETE customPropertyValue(const AtomString& property) const final;
+    unsigned NODELETE size() const final;
     Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
 
 private:

--- a/Source/WebCore/css/typedom/InlineStylePropertyMap.h
+++ b/Source/WebCore/css/typedom/InlineStylePropertyMap.h
@@ -41,7 +41,7 @@ public:
     RefPtr<CSSValue> propertyValue(CSSPropertyID) const final;
     String shorthandPropertySerialization(CSSPropertyID) const final;
     RefPtr<CSSValue> customPropertyValue(const AtomString& property) const final;
-    unsigned size() const final;
+    unsigned NODELETE size() const final;
     Vector<StylePropertyMapEntry> entries(ScriptExecutionContext*) const final;
     void removeProperty(CSSPropertyID) final;
     bool setShorthandProperty(CSSPropertyID, const String& value) final;

--- a/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h
+++ b/Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h
@@ -40,7 +40,7 @@ public:
 protected:
     MainThreadStylePropertyMapReadOnly();
 
-    static Document* documentFromContext(ScriptExecutionContext&);
+    static Document* NODELETE documentFromContext(ScriptExecutionContext&);
 
     virtual RefPtr<CSSValue> propertyValue(CSSPropertyID) const = 0;
     virtual String shorthandPropertySerialization(CSSPropertyID) const = 0;

--- a/Source/WebCore/css/typedom/color/CSSHWB.h
+++ b/Source/WebCore/css/typedom/color/CSSHWB.h
@@ -34,7 +34,7 @@ class CSSHWB final : public CSSOMColorValue {
 public:
     static ExceptionOr<Ref<CSSHWB>> create(Ref<CSSNumericValue>&& hue, CSSNumberish&& whiteness, CSSNumberish&& blackness, CSSNumberish&& alpha);
 
-    CSSNumericValue& h() const;
+    CSSNumericValue& NODELETE h() const;
     ExceptionOr<void> setH(Ref<CSSNumericValue>&&);
     CSSNumberish w() const;
     ExceptionOr<void> setW(CSSNumberish&&);

--- a/Source/WebCore/css/typedom/color/CSSOMColor.h
+++ b/Source/WebCore/css/typedom/color/CSSOMColor.h
@@ -34,8 +34,8 @@ class CSSOMColor final : public CSSOMColorValue {
 public:
     template<typename... Args> static Ref<CSSOMColor> create(Args&&... args) { return adoptRef(*new CSSOMColor(std::forward<Args>(args)...)); }
 
-    std::optional<CSSKeywordish> colorSpace() const;
-    void setColorSpace(std::optional<CSSKeywordish>);
+    std::optional<CSSKeywordish> NODELETE colorSpace() const;
+    void NODELETE setColorSpace(std::optional<CSSKeywordish>);
 
     const CSSNumberish& alpha() const { return m_alpha; }
     void setAlpha(CSSNumberish alpha) { m_alpha = WTF::move(alpha); }

--- a/Source/WebCore/css/typedom/color/CSSOMColorValue.h
+++ b/Source/WebCore/css/typedom/color/CSSOMColorValue.h
@@ -43,9 +43,9 @@ using RectifiedCSSColorAngle = Variant<Ref<CSSNumericValue>, Ref<CSSKeywordValue
 
 class CSSOMColorValue : public CSSStyleValue {
 public:
-    RefPtr<CSSKeywordValue> colorSpace();
-    RefPtr<CSSOMColorValue> to(CSSKeywordish);
-    static std::optional<Variant<Ref<CSSOMColorValue>, Ref<CSSStyleValue>>> parse(const String&);
+    RefPtr<CSSKeywordValue> NODELETE colorSpace();
+    RefPtr<CSSOMColorValue> NODELETE to(CSSKeywordish);
+    static std::optional<Variant<Ref<CSSOMColorValue>, Ref<CSSStyleValue>>> NODELETE parse(const String&);
 
     static ExceptionOr<RectifiedCSSColorPercent> rectifyCSSColorPercent(CSSColorPercent&&);
     static ExceptionOr<RectifiedCSSColorAngle> rectifyCSSColorAngle(CSSColorAngle&&);
@@ -55,7 +55,7 @@ public:
     static CSSColorAngle toCSSColorAngle(const RectifiedCSSColorAngle&);
     static CSSColorNumber toCSSColorNumber(const RectifiedCSSColorNumber&);
 
-    RefPtr<CSSValue> toCSSValue() const final;
+    RefPtr<CSSValue> NODELETE toCSSValue() const final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/typedom/numeric/CSSMathMax.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMax.h
@@ -37,7 +37,7 @@ class CSSMathMax final : public CSSMathValue {
 public:
     static ExceptionOr<Ref<CSSMathMax>> create(FixedVector<CSSNumberish>&&);
     static ExceptionOr<Ref<CSSMathMax>> create(Vector<Ref<CSSNumericValue>>&&);
-    const CSSNumericArray& values() const;
+    const CSSNumericArray& NODELETE values() const;
 
     std::optional<CSSCalc::Child> toCalcTreeNode() const final;
 

--- a/Source/WebCore/css/typedom/numeric/CSSMathMin.h
+++ b/Source/WebCore/css/typedom/numeric/CSSMathMin.h
@@ -37,7 +37,7 @@ class CSSMathMin final : public CSSMathValue {
 public:
     static ExceptionOr<Ref<CSSMathMin>> create(FixedVector<CSSNumberish>&&);
     static ExceptionOr<Ref<CSSMathMin>> create(Vector<Ref<CSSNumericValue>>&&);
-    const CSSNumericArray& values() const;
+    const CSSNumericArray& NODELETE values() const;
 
     std::optional<CSSCalc::Child> toCalcTreeNode() const final;
 

--- a/Source/WebCore/css/typedom/numeric/CSSNumericType.h
+++ b/Source/WebCore/css/typedom/numeric/CSSNumericType.h
@@ -53,10 +53,10 @@ public:
     static std::optional<CSSNumericType> addTypes(CSSNumericType, CSSNumericType);
     static std::optional<CSSNumericType> multiplyTypes(const Vector<Ref<CSSNumericValue>>&);
     static std::optional<CSSNumericType> multiplyTypes(const CSSNumericType&, const CSSNumericType&);
-    BaseTypeStorage& valueForType(CSSNumericBaseType);
+    BaseTypeStorage& NODELETE valueForType(CSSNumericBaseType);
     const BaseTypeStorage& valueForType(CSSNumericBaseType type) const { return const_cast<CSSNumericType*>(this)->valueForType(type); }
-    void applyPercentHint(CSSNumericBaseType);
-    size_t nonZeroEntryCount() const;
+    void NODELETE applyPercentHint(CSSNumericBaseType);
+    size_t NODELETE nonZeroEntryCount() const;
 
     template<CSSNumericBaseType type>
     bool matches() const

--- a/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
+++ b/Source/WebCore/css/typedom/transform/CSSMatrixComponent.h
@@ -44,8 +44,8 @@ public:
 
     ~CSSMatrixComponent();
 
-    DOMMatrix& matrix();
-    void setMatrix(Ref<DOMMatrix>&&);
+    DOMMatrix& NODELETE matrix();
+    void NODELETE setMatrix(Ref<DOMMatrix>&&);
 
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;

--- a/Source/WebCore/css/typedom/transform/CSSPerspective.h
+++ b/Source/WebCore/css/typedom/transform/CSSPerspective.h
@@ -57,7 +57,7 @@ public:
 private:
     explicit CSSPerspective(CSSPerspectiveValue);
 
-    void setIs2D(bool);
+    void NODELETE setIs2D(bool);
 
     CSSPerspectiveValue m_length;
 };

--- a/Source/WebCore/css/typedom/transform/CSSRotate.h
+++ b/Source/WebCore/css/typedom/transform/CSSRotate.h
@@ -50,7 +50,7 @@ public:
     ExceptionOr<void> setX(CSSNumberish);
     ExceptionOr<void> setY(CSSNumberish);
     ExceptionOr<void> setZ(CSSNumberish);
-    ExceptionOr<void> setAngle(Ref<CSSNumericValue>);
+    ExceptionOr<void> NODELETE setAngle(Ref<CSSNumericValue>);
 
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;

--- a/Source/WebCore/css/typedom/transform/CSSScale.cpp
+++ b/Source/WebCore/css/typedom/transform/CSSScale.cpp
@@ -45,7 +45,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(CSSScale);
 
-static bool isValidScaleCoord(const CSSNumericValue& coord)
+static bool NODELETE isValidScaleCoord(const CSSNumericValue& coord)
 {
     return coord.type().matchesNumber();
 }

--- a/Source/WebCore/css/typedom/transform/CSSSkew.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkew.h
@@ -44,8 +44,8 @@ public:
     const CSSNumericValue& ax() const { return m_ax.get(); }
     const CSSNumericValue& ay() const { return m_ay.get(); }
     
-    ExceptionOr<void> setAx(Ref<CSSNumericValue>);
-    ExceptionOr<void> setAy(Ref<CSSNumericValue>);
+    ExceptionOr<void> NODELETE setAx(Ref<CSSNumericValue>);
+    ExceptionOr<void> NODELETE setAy(Ref<CSSNumericValue>);
 
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;

--- a/Source/WebCore/css/typedom/transform/CSSSkewX.h
+++ b/Source/WebCore/css/typedom/transform/CSSSkewX.h
@@ -42,7 +42,7 @@ public:
     static ExceptionOr<Ref<CSSSkewX>> create(Ref<const CSSFunctionValue>, Document&);
 
     const CSSNumericValue& ax() const { return m_ax.get(); }
-    ExceptionOr<void> setAx(Ref<CSSNumericValue>);
+    ExceptionOr<void> NODELETE setAx(Ref<CSSNumericValue>);
 
     void serialize(StringBuilder&) const final;
     ExceptionOr<Ref<DOMMatrix>> toMatrix() final;

--- a/Source/WebCore/css/typedom/transform/CSSTransformValue.h
+++ b/Source/WebCore/css/typedom/transform/CSSTransformValue.h
@@ -47,7 +47,7 @@ public:
 
     size_t length() const { return m_components.size(); }
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_components.size(); }
-    RefPtr<CSSTransformComponent> item(size_t);
+    RefPtr<CSSTransformComponent> NODELETE item(size_t);
     ExceptionOr<Ref<CSSTransformComponent>> setItem(size_t, Ref<CSSTransformComponent>&&);
     
     bool is2D() const;

--- a/Source/WebCore/css/values/CSSValueAggregates.h
+++ b/Source/WebCore/css/values/CSSValueAggregates.h
@@ -204,7 +204,7 @@ struct CustomIdentifier {
 };
 TextStream& operator<<(TextStream&, const CustomIdentifier&);
 
-void add(Hasher&, const CustomIdentifier&);
+void NODELETE add(Hasher&, const CustomIdentifier&);
 
 // Helper type used to represent an arbitrary property identifier.
 struct PropertyIdentifier {

--- a/Source/WebCore/css/values/color/CSSColor.h
+++ b/Source/WebCore/css/values/color/CSSColor.h
@@ -152,11 +152,11 @@ public:
 
     bool operator==(const Color&) const;
 
-    bool isResolved() const;
+    bool NODELETE isResolved() const;
     std::optional<ResolvedColor> resolved() const;
-    bool isKeyword() const;
+    bool NODELETE isKeyword() const;
     std::optional<KeywordColor> keyword() const;
-    bool isHex() const;
+    bool NODELETE isHex() const;
     std::optional<HexColor> hex() const;
 
     // Return an absolute color if possible, otherwise an invalid color.

--- a/Source/WebCore/css/values/color/CSSColorMix.cpp
+++ b/Source/WebCore/css/values/color/CSSColorMix.cpp
@@ -94,12 +94,12 @@ bool containsColorSchemeDependentColor(const ColorMix& unresolved)
 
 namespace ColorMixSerializationDetails {
 
-static bool sumTo100Percent(const ColorMix::Component::Percentage& a, const ColorMix::Component::Percentage& b)
+static bool NODELETE sumTo100Percent(const ColorMix::Component::Percentage& a, const ColorMix::Component::Percentage& b)
 {
     return a.isRaw() && b.isRaw() && a.raw()->value + b.raw()->value == 100.0;
 }
 
-static std::optional<PercentageRaw<>> subtractFrom100Percent(const ColorMix::Component::Percentage& percentage)
+static std::optional<PercentageRaw<>> NODELETE subtractFrom100Percent(const ColorMix::Component::Percentage& percentage)
 {
     return percentage.isRaw() ? std::make_optional(PercentageRaw<> { 100.0 - percentage.raw()->value }) : std::nullopt;
 }

--- a/Source/WebCore/css/values/color/CSSKeywordColor.cpp
+++ b/Source/WebCore/css/values/color/CSSKeywordColor.cpp
@@ -37,14 +37,14 @@
 namespace WebCore {
 namespace CSS {
 
-static bool isVGAPaletteColor(CSSValueID id)
+static bool NODELETE isVGAPaletteColor(CSSValueID id)
 {
     // https://drafts.csswg.org/css-color-4/#named-colors
     // "16 of CSS’s named colors come from the VGA palette originally, and were then adopted into HTML"
     return id >= CSSValueAqua && id <= CSSValueGrey;
 }
 
-static bool isNonVGANamedColor(CSSValueID id)
+static bool NODELETE isNonVGANamedColor(CSSValueID id)
 {
     // https://drafts.csswg.org/css-color-4/#named-colors
     return id >= CSSValueAliceblue && id <= CSSValueYellowgreen;

--- a/Source/WebCore/css/values/color/CSSKeywordColor.h
+++ b/Source/WebCore/css/values/color/CSSKeywordColor.h
@@ -49,20 +49,20 @@ struct KeywordColor {
     bool operator==(const KeywordColor&) const = default;
 };
 
-WEBCORE_EXPORT bool isAbsoluteColorKeyword(CSSValueID);
-WEBCORE_EXPORT bool isCurrentColorKeyword(CSSValueID);
-WEBCORE_EXPORT bool isSystemColorKeyword(CSSValueID);
-WEBCORE_EXPORT bool isDeprecatedSystemColorKeyword(CSSValueID);
+WEBCORE_EXPORT bool NODELETE isAbsoluteColorKeyword(CSSValueID);
+WEBCORE_EXPORT bool NODELETE isCurrentColorKeyword(CSSValueID);
+WEBCORE_EXPORT bool NODELETE isSystemColorKeyword(CSSValueID);
+WEBCORE_EXPORT bool NODELETE isDeprecatedSystemColorKeyword(CSSValueID);
 
-bool isColorKeyword(CSSValueID);
+bool NODELETE isColorKeyword(CSSValueID);
 bool isColorKeyword(CSSValueID, OptionSet<ColorType>);
 
 WebCore::Color colorFromAbsoluteKeyword(CSSValueID);
 WebCore::Color colorFromKeyword(CSSValueID, OptionSet<StyleColorOptions>);
 
 WebCore::Color createColor(const KeywordColor&, PlatformColorResolutionState&);
-bool containsCurrentColor(const KeywordColor&);
-bool containsColorSchemeDependentColor(const KeywordColor&);
+bool NODELETE containsCurrentColor(const KeywordColor&);
+bool NODELETE containsColorSchemeDependentColor(const KeywordColor&);
 
 template<> struct Serialize<KeywordColor> { void operator()(StringBuilder&, const SerializationContext&, const KeywordColor&); };
 template<> struct ComputedStyleDependenciesCollector<KeywordColor> { constexpr void operator()(ComputedStyleDependencies&, const KeywordColor&) { } };

--- a/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
+++ b/Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h
@@ -53,7 +53,7 @@ enum class Category : uint8_t;
 
 // Type-erased helpers to allow for shared code.
 
-void unevaluatedCalcRef(CSSCalc::Value*);
+void NODELETE unevaluatedCalcRef(CSSCalc::Value*);
 void unevaluatedCalcDeref(CSSCalc::Value*);
 
 // `UnevaluatedCalc` annotates a `CSSCalc::Value` with the raw value type that it
@@ -70,8 +70,8 @@ struct UnevaluatedCalcBase {
     UnevaluatedCalcBase& operator=(UnevaluatedCalcBase&&);
     ~UnevaluatedCalcBase();
 
-    Ref<CSSCalc::Value> protectedCalc() const;
-    [[nodiscard]] CSSCalc::Value& leakRef();
+    Ref<CSSCalc::Value> NODELETE protectedCalc() const;
+    [[nodiscard]] CSSCalc::Value& NODELETE leakRef();
 
     bool requiresConversionData() const;
 


### PR DESCRIPTION
#### 1f2d95f3afb0534f1e7657b49fdc72f329ba0631
<pre>
Adopt `NODELETE` annotation in more places in Source/WebCore/css
<a href="https://bugs.webkit.org/show_bug.cgi?id=308205">https://bugs.webkit.org/show_bug.cgi?id=308205</a>

Reviewed by Darin Adler.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/css/CSSBackgroundRepeatValue.h:
* Source/WebCore/css/CSSColorSchemeValue.h:
* Source/WebCore/css/CSSComputedStyleDeclaration.h:
* Source/WebCore/css/CSSContainerRule.h:
* Source/WebCore/css/CSSCounterStyle.h:
* Source/WebCore/css/CSSCounterStyleDescriptors.h:
* Source/WebCore/css/CSSCounterStyleRegistry.h:
* Source/WebCore/css/CSSCounterStyleRule.h:
* Source/WebCore/css/CSSCustomPropertyValue.h:
* Source/WebCore/css/CSSFontFace.cpp:
(WebCore::visibility):
* Source/WebCore/css/CSSFontFace.h:
* Source/WebCore/css/CSSFontFaceDescriptors.h:
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/CSSFontFaceSource.h:
* Source/WebCore/css/CSSFontFaceSrcValue.h:
* Source/WebCore/css/CSSFontFeatureValuesRule.h:
* Source/WebCore/css/CSSFontPaletteValuesRule.h:
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/CSSFunctionDescriptors.h:
* Source/WebCore/css/CSSFunctionRule.h:
* Source/WebCore/css/CSSGridAutoRepeatValue.h:
* Source/WebCore/css/CSSImageSetOptionValue.h:
* Source/WebCore/css/CSSImageValue.h:
* Source/WebCore/css/CSSImportRule.h:
* Source/WebCore/css/CSSKeyframeRule.h:
* Source/WebCore/css/CSSKeyframesRule.h:
* Source/WebCore/css/CSSLayerStatementRule.h:
* Source/WebCore/css/CSSMarkup.cpp:
(WebCore::isCSSTokenizerIdentifier):
* Source/WebCore/css/CSSMediaRule.h:
* Source/WebCore/css/CSSNamespaceRule.h:
* Source/WebCore/css/CSSPageDescriptors.h:
* Source/WebCore/css/CSSPositionTryDescriptors.h:
* Source/WebCore/css/CSSPositionTryRule.h:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::isValidCSSUnitTypeForDoubleConversion):
(WebCore::serializedPrimitiveValues):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSPropertyInitialValues.cpp:
(WebCore::isValueIDPair):
(WebCore::isValueID):
* Source/WebCore/css/CSSPropertyRule.h:
* Source/WebCore/css/CSSPropertySourceData.h:
* Source/WebCore/css/CSSRule.h:
* Source/WebCore/css/CSSScopeRule.h:
* Source/WebCore/css/CSSSegmentedFontFace.cpp:
* Source/WebCore/css/CSSSelector.cpp:
(WebCore::SelectorSpecificity::specificityTuple const):
(WebCore::shouldSkipForEqualMode):
* Source/WebCore/css/CSSSelector.h:
* Source/WebCore/css/CSSSelectorList.h:
* Source/WebCore/css/CSSStyleProperties.cpp:
* Source/WebCore/css/CSSStyleProperties.h:
* Source/WebCore/css/CSSStyleRule.cpp:
(WebCore::selectorTextCache):
* Source/WebCore/css/CSSStyleRule.h:
* Source/WebCore/css/CSSStyleSheet.cpp:
(WebCore::styleScopeFor):
* Source/WebCore/css/CSSStyleSheet.h:
* Source/WebCore/css/CSSStyleSheetObservableArray.h:
* Source/WebCore/css/CSSSupportsRule.h:
* Source/WebCore/css/CSSToLengthConversionData.cpp:
(WebCore::renderViewForDocument):
* Source/WebCore/css/CSSToLengthConversionData.h:
* Source/WebCore/css/CSSUnicodeRangeValue.h:
* Source/WebCore/css/CSSUnits.h:
* Source/WebCore/css/CSSValue.h:
* Source/WebCore/css/CSSValuePool.h:
* Source/WebCore/css/CSSVariableReferenceValue.h:
* Source/WebCore/css/CSSViewTransitionRule.cpp:
(WebCore::toViewTransitionNavigationEnum):
* Source/WebCore/css/CSSViewTransitionRule.h:
* Source/WebCore/css/ComputedStyleDependencies.h:
* Source/WebCore/css/DOMCSSPaintWorklet.h:
* Source/WebCore/css/DOMMatrixReadOnly.cpp:
(WebCore::sameValueZero):
* Source/WebCore/css/DOMMatrixReadOnly.h:
* Source/WebCore/css/DeprecatedCSSOMValue.h:
* Source/WebCore/css/FontFace.h:
* Source/WebCore/css/FontFaceSet.h:
* Source/WebCore/css/ImmutableStyleProperties.cpp:
(WebCore::deduplicationMap):
* Source/WebCore/css/ImmutableStyleProperties.h:
* Source/WebCore/css/MediaQueryList.h:
* Source/WebCore/css/MutableStyleProperties.h:
* Source/WebCore/css/PropertySetCSSDescriptors.h:
* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::isFirstChildElement):
(WebCore::isLastChildElement):
(WebCore::isFirstOfType):
(WebCore::isLastOfType):
(WebCore::countElementsBefore):
(WebCore::countElementsOfTypeBefore):
(WebCore::countElementsAfter):
(WebCore::countElementsOfTypeAfter):
(WebCore::localContextForParent):
* Source/WebCore/css/SelectorChecker.h:
* Source/WebCore/css/SelectorFilter.cpp:
(WebCore::isExcludedAttribute):
* Source/WebCore/css/SelectorFilter.h:
* Source/WebCore/css/ShorthandSerializer.cpp:
(WebCore::ShorthandSerializer::LonghandRange::end):
(WebCore::ShorthandSerializer::LonghandRange::size const):
(WebCore::ShorthandSerializer::length const):
(WebCore::ShorthandSerializer::longhand const):
(WebCore::ShorthandSerializer::longhands const):
(WebCore::ShorthandSerializer::longhandValues const):
(WebCore::ShorthandSerializer::longhandProperty const):
(WebCore::ShorthandSerializer::longhandValue const):
(WebCore::ShorthandSerializer::longhandIndex const):
(WebCore::LayerValues::skip):
(WebCore::LayerValues::isPair const):
(WebCore::fontWidthKeyword):
(WebCore::isValueIDIncludingList):
* Source/WebCore/css/StyleProperties.cpp:
(WebCore::canUseShorthandForLonghand):
* Source/WebCore/css/StyleProperties.h:
* Source/WebCore/css/StylePropertyShorthand.h:
* Source/WebCore/css/StyleRule.h:
* Source/WebCore/css/StyleRuleImport.h:
* Source/WebCore/css/StyleSheetContents.h:
* Source/WebCore/css/StyleSheetList.h:
* Source/WebCore/css/calc/CSSCalcSymbolTable.h:
* Source/WebCore/css/calc/CSSCalcSymbolsAllowed.h:
* Source/WebCore/css/calc/CSSCalcTree+Evaluation.cpp:
(WebCore::CSSCalc::evaluate):
* Source/WebCore/css/calc/CSSCalcTree+Parser.cpp:
(WebCore::CSSCalc::checkDepth):
(WebCore::CSSCalc::makeRandomSharingAuto):
(WebCore::CSSCalc::cssValueIDToAnchorSizeDimension):
* Source/WebCore/css/calc/CSSCalcTree+Parser.h:
* Source/WebCore/css/calc/CSSCalcTree+Serialization.cpp:
(WebCore::CSSCalc::sortPriority):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.cpp:
(WebCore::CSSCalc::percentageResolveToDimension):
(WebCore::CSSCalc::unitsMatch):
(WebCore::CSSCalc::magnitudeComparable):
(WebCore::CSSCalc::fullyResolved):
* Source/WebCore/css/calc/CSSCalcTree+Simplification.h:
* Source/WebCore/css/calc/CSSCalcType.h:
* Source/WebCore/css/calc/CSSCalcValue.h:
* Source/WebCore/css/parser/CSSCustomPropertySyntax.h:
* Source/WebCore/css/parser/CSSParserContext.cpp:
(WebCore::applyUASheetBehaviorsToContext):
* Source/WebCore/css/parser/CSSParserContext.h:
* Source/WebCore/css/parser/CSSParserFastPaths.cpp:
(WebCore::finishParsingHexColor):
* Source/WebCore/css/parser/CSSParserFastPaths.h:
* Source/WebCore/css/parser/CSSParserObserverWrapper.cpp:
(WebCore::CSSParserObserverWrapper::endOffset):
* Source/WebCore/css/parser/CSSParserObserverWrapper.h:
* Source/WebCore/css/parser/CSSParserToken.h:
* Source/WebCore/css/parser/CSSPropertyParser.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Anchor.cpp:
(WebCore::CSSPropertyParserHelpers::getKeywordType):
(WebCore::CSSPropertyParserHelpers::typesAreCompatible):
(WebCore::CSSPropertyParserHelpers::typeIsAxisExplicit):
(WebCore::CSSPropertyParserHelpers::typeIsBlockOrXAxis):
(WebCore::CSSPropertyParserHelpers::typeIsInlineOrYAxis):
(WebCore::CSSPropertyParserHelpers::makeAmbiguous):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Background.cpp:
(WebCore::CSSPropertyParserHelpers::complete4Sides):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Color.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+CounterStyles.cpp:
(WebCore::CSSPropertyParserHelpers::isPredefinedCounterStyle):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Display.cpp:
(WebCore::CSSPropertyParserHelpers::makeDisplayOutsideInsideMap):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.cpp:
(WebCore::CSSPropertyParserHelpers::parserMode):
(WebCore::CSSPropertyParserHelpers::isFontFormatKeywordValid):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Font.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Grid.h:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Symbol.cpp:
(WebCore::CSSPropertyParserHelpers::validatedRange):
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.h:
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::isDescendantCombinator):
(WebCore::isScrollbarPseudoClass):
(WebCore::isUserActionPseudoClass):
(WebCore::isPseudoClassValidAfterPseudoElement):
(WebCore::isTreeAbidingPseudoElement):
* Source/WebCore/css/parser/CSSSelectorParser.h:
* Source/WebCore/css/parser/CSSSelectorParserContext.h:
* Source/WebCore/css/parser/CSSTokenizer.cpp:
(WebCore::twoCharsAreValidEscape):
(WebCore::isNonPrintableCodePoint):
* Source/WebCore/css/parser/CSSTokenizer.h:
* Source/WebCore/css/parser/CSSVariableParser.cpp:
(WebCore::isValidConstantName):
* Source/WebCore/css/parser/MediaQueryBlockWatcher.h:
* Source/WebCore/css/parser/MutableCSSSelector.h:
* Source/WebCore/css/parser/SizesAttributeParser.h:
* Source/WebCore/css/query/ContainerQueryFeatures.cpp:
(WebCore::CQ::unscaledSizeForPrincipleBox):
* Source/WebCore/css/query/ContainerQueryParser.h:
* Source/WebCore/css/query/GenericMediaQueryEvaluator.h:
* Source/WebCore/css/query/MediaQueryEvaluator.h:
* Source/WebCore/css/typedom/CSSKeywordValue.h:
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::mayConvertCSSValueListToSingleValue):
* Source/WebCore/css/typedom/CSSUnitValue.cpp:
(WebCore::calculationCategoryForProperty):
* Source/WebCore/css/typedom/CSSUnitValue.h:
* Source/WebCore/css/typedom/DeclaredStylePropertyMap.h:
* Source/WebCore/css/typedom/HashMapStylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/InlineStylePropertyMap.h:
* Source/WebCore/css/typedom/MainThreadStylePropertyMapReadOnly.h:
* Source/WebCore/css/typedom/color/CSSHWB.h:
* Source/WebCore/css/typedom/color/CSSOMColor.h:
* Source/WebCore/css/typedom/color/CSSOMColorValue.h:
* Source/WebCore/css/typedom/numeric/CSSMathMax.h:
* Source/WebCore/css/typedom/numeric/CSSMathMin.h:
* Source/WebCore/css/typedom/numeric/CSSNumericType.h:
* Source/WebCore/css/typedom/transform/CSSMatrixComponent.h:
* Source/WebCore/css/typedom/transform/CSSPerspective.h:
* Source/WebCore/css/typedom/transform/CSSRotate.h:
* Source/WebCore/css/typedom/transform/CSSScale.cpp:
(WebCore::isValidScaleCoord):
* Source/WebCore/css/typedom/transform/CSSSkew.h:
* Source/WebCore/css/typedom/transform/CSSSkewX.h:
* Source/WebCore/css/typedom/transform/CSSTransformValue.h:
* Source/WebCore/css/values/CSSValueAggregates.h:
* Source/WebCore/css/values/color/CSSColor.h:
* Source/WebCore/css/values/color/CSSColorMix.cpp:
(WebCore::CSS::ColorMixSerializationDetails::sumTo100Percent):
(WebCore::CSS::ColorMixSerializationDetails::subtractFrom100Percent):
* Source/WebCore/css/values/color/CSSKeywordColor.cpp:
(WebCore::CSS::isVGAPaletteColor):
(WebCore::CSS::isNonVGANamedColor):
* Source/WebCore/css/values/color/CSSKeywordColor.h:
* Source/WebCore/css/values/primitives/CSSUnevaluatedCalc.h:

Canonical link: <a href="https://commits.webkit.org/307879@main">https://commits.webkit.org/307879@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8d6e064ac19393e5ea0ca06d764a8936005248d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145817 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18508 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154496 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/241860f7-0675-4aac-b132-e2875155eefb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147692 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18992 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18397 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112149 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff3cb926-ee80-4705-a804-75a777747ddf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148780 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14535 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93054 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0da57e3-1b2c-473a-ac1a-918ac31cdab5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1943 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7854 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156809 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/71 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9040 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120152 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18354 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120497 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30888 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18399 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74092 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16224 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7241 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17974 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81760 "Failed to build and analyze WebKit") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17712 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17916 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17770 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->