### PR TITLE
Adopt `NODELETE` annotation in more places in Source/WebCore/html

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -132,7 +132,6 @@ bindings/js/JSNodeCustom.cpp
 bindings/js/JSObservableArray.cpp
 bindings/js/JSObservableArray.h
 bindings/js/JSOffscreenCanvasRenderingContext2DCustom.cpp
-bindings/js/JSPaintRenderingContext2DCustom.cpp
 bindings/js/JSPluginElementFunctions.cpp
 bindings/js/JSPopStateEventCustom.cpp
 bindings/js/JSRTCRtpSFrameTransformCustom.cpp

--- a/Source/WebCore/html/Autofill.cpp
+++ b/Source/WebCore/html/Autofill.cpp
@@ -134,7 +134,7 @@ static inline bool isContactToken(const AtomString& token)
     return token == home || token == work || token == mobile || token == fax || token == pager;
 }
 
-static unsigned maxTokensForAutofillFieldCategory(AutofillCategory category)
+static unsigned NODELETE maxTokensForAutofillFieldCategory(AutofillCategory category)
 {
     switch (category) {
     case AutofillCategory::Automatic:

--- a/Source/WebCore/html/BaseDateAndTimeInputType.h
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.h
@@ -87,7 +87,7 @@ private:
     public:
         DateTimeFormatValidator() { }
 
-        void visitField(DateTimeFormat::FieldType, int);
+        void NODELETE visitField(DateTimeFormat::FieldType, int);
         void visitLiteral(const String&) { }
 
         bool validateFormat(const String& format, const BaseDateAndTimeInputType&);

--- a/Source/WebCore/html/CanvasBase.cpp
+++ b/Source/WebCore/html/CanvasBase.cpp
@@ -95,7 +95,7 @@ RefPtr<ImageBuffer> CanvasBase::makeRenderingResultsAvailable(ShouldApplyPostPro
     return ImageBuffer::create(size(), RenderingMode::Unaccelerated, RenderingPurpose::Unspecified, 1, DestinationColorSpace::SRGB(), PixelFormat::BGRA8);
 }
 
-static inline size_t maxCanvasArea()
+static inline size_t NODELETE maxCanvasArea()
 {
     if (maxCanvasAreaForTesting)
         return *maxCanvasAreaForTesting;

--- a/Source/WebCore/html/CanvasBase.h
+++ b/Source/WebCore/html/CanvasBase.h
@@ -90,7 +90,7 @@ public:
 
     void addObserver(CanvasObserver&);
     void removeObserver(CanvasObserver&);
-    bool hasObserver(CanvasObserver&) const;
+    bool NODELETE hasObserver(CanvasObserver&) const;
     void notifyObserversCanvasChanged(const FloatRect&);
     void notifyObserversCanvasResized();
     void notifyObserversCanvasDestroyed(); // Must be called in destruction before clearing m_context.
@@ -112,7 +112,7 @@ public:
 
     bool shouldAccelerate() const;
 
-    WEBCORE_EXPORT static void setMaxCanvasAreaForTesting(std::optional<size_t>);
+    WEBCORE_EXPORT static void NODELETE setMaxCanvasAreaForTesting(std::optional<size_t>);
     [[nodiscard]] bool validateArea() const;
 
     virtual void queueTaskKeepingObjectAlive(TaskSource, Function<void(CanvasBase&)>&&) = 0;
@@ -140,7 +140,7 @@ protected:
     void removeCanvasNeedingPreparationForDisplayOrFlush();
 
 private:
-    bool shouldInjectNoiseBeforeReadback() const;
+    bool NODELETE shouldInjectNoiseBeforeReadback() const;
 
     mutable IntSize m_size;
     mutable std::unique_ptr<CSSParserContext> m_cssParserContext;
@@ -160,7 +160,7 @@ private:
 #endif
 };
 
-WebCoreOpaqueRoot root(CanvasBase*);
+WebCoreOpaqueRoot NODELETE root(CanvasBase*);
 
 
 inline const CSSParserContext& CanvasBase::cssParserContext() const

--- a/Source/WebCore/html/CanvasNoiseInjection.cpp
+++ b/Source/WebCore/html/CanvasNoiseInjection.cpp
@@ -44,7 +44,7 @@ void CanvasNoiseInjection::clearDirtyRect()
     m_postProcessDirtyRect = { };
 }
 
-static inline bool isIndexInBounds(int size, int index)
+static inline bool NODELETE isIndexInBounds(int size, int index)
 {
     ASSERT(index <= size);
     return index < size;
@@ -208,7 +208,7 @@ void CanvasNoiseInjection::postProcessDirtyCanvasBuffer(ImageBuffer* imageBuffer
     }
 }
 
-static std::pair<int, int> lowerAndUpperBound(int component1, int component2, int component3)
+static std::pair<int, int> NODELETE lowerAndUpperBound(int component1, int component2, int component3)
 {
     if (component1 <= component3) {
         if (component1 == component2 || component2 == component3)
@@ -230,7 +230,7 @@ static std::pair<int, int> lowerAndUpperBound(int component1, int component2, in
     return { component2, component2 };
 }
 
-static void adjustNeighborColorBounds(std::array<int, 4>& neighborColor1, const std::array<int, 4>& color, std::array<int, 4>& neighborColor2)
+static void NODELETE adjustNeighborColorBounds(std::array<int, 4>& neighborColor1, const std::array<int, 4>& color, std::array<int, 4>& neighborColor2)
 {
     auto [redLowerBound, redUpperBound] = lowerAndUpperBound(neighborColor1[0], color[0], neighborColor2[0]);
     auto [greenLowerBound, greenUpperBound] = lowerAndUpperBound(neighborColor1[1], color[1], neighborColor2[1]);

--- a/Source/WebCore/html/CheckboxInputType.h
+++ b/Source/WebCore/html/CheckboxInputType.h
@@ -57,9 +57,9 @@ public:
 
     bool valueMissing(const String&) const final;
     float switchAnimationVisuallyOnProgress() const;
-    bool isSwitchVisuallyOn() const;
+    bool NODELETE isSwitchVisuallyOn() const;
     float switchAnimationHeldProgress() const;
-    bool isSwitchHeld() const;
+    bool NODELETE isSwitchHeld() const;
 
 private:
     explicit CheckboxInputType(HTMLInputElement& element)
@@ -81,14 +81,14 @@ private:
 #endif
     void startSwitchPointerTracking(LayoutPoint);
     void stopSwitchPointerTracking();
-    bool isSwitchPointerTracking() const;
+    bool NODELETE isSwitchPointerTracking() const;
     void willDispatchClick(InputElementClickState&) final;
     void didDispatchClick(Event&, const InputElementClickState&) final;
     bool matchesIndeterminatePseudoClass() const final;
     void willUpdateCheckedness(bool /* nowChecked */, WasSetByJavaScript);
     void disabledStateChanged() final;
-    Seconds switchAnimationStartTime(SwitchAnimationType) const;
-    void setSwitchAnimationStartTime(SwitchAnimationType, Seconds);
+    Seconds NODELETE switchAnimationStartTime(SwitchAnimationType) const;
+    void NODELETE setSwitchAnimationStartTime(SwitchAnimationType, Seconds);
     bool isSwitchAnimating(SwitchAnimationType) const;
     void performSwitchAnimation(SwitchAnimationType);
     void performSwitchVisuallyOnAnimation(SwitchTrigger);

--- a/Source/WebCore/html/ColorInputType.cpp
+++ b/Source/WebCore/html/ColorInputType.cpp
@@ -64,7 +64,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(ColorInputType);
 using namespace HTMLNames;
 
 // https://html.spec.whatwg.org/multipage/infrastructure.html#valid-simple-colour
-static bool isValidSimpleColor(StringView string)
+static bool NODELETE isValidSimpleColor(StringView string)
 {
     if (string.length() != 7)
         return false;
@@ -78,7 +78,7 @@ static bool isValidSimpleColor(StringView string)
 }
 
 // https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#rules-for-parsing-simple-colour-values
-static std::optional<SRGBA<uint8_t>> parseSimpleColorValue(StringView string)
+static std::optional<SRGBA<uint8_t>> NODELETE parseSimpleColorValue(StringView string)
 {
     if (!isValidSimpleColor(string))
         return std::nullopt;

--- a/Source/WebCore/html/FTPDirectoryDocument.cpp
+++ b/Source/WebCore/html/FTPDirectoryDocument.cpp
@@ -176,7 +176,7 @@ static String processFilesizeString(const String& size, bool isDirectory)
     return makeString(FormattedNumber::fixedWidth(*bytes / 1000000000.0, 2), " GB"_s);
 }
 
-static bool wasLastDayOfMonth(int year, int month, int day)
+static bool NODELETE wasLastDayOfMonth(int year, int month, int day)
 {
     static constexpr std::array lastDays { 31, 0, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31 };
     if (month < 0 || month > 11)

--- a/Source/WebCore/html/FormController.cpp
+++ b/Source/WebCore/html/FormController.cpp
@@ -54,7 +54,7 @@ struct AtomStringVectorReader {
     Vector<AtomString> consumeSubvector(size_t subvectorSize);
 };
 
-const AtomString& AtomStringVectorReader::consumeString()
+const AtomString& NODELETE AtomStringVectorReader::consumeString()
 {
     if (index == vector.size())
         return nullAtom();
@@ -104,7 +104,7 @@ class FormController::SavedFormState {
 public:
     static SavedFormState consumeSerializedState(AtomStringVectorReader&);
 
-    bool isEmpty() const { return m_map.isEmpty(); }
+    bool NODELETE isEmpty() const { return m_map.isEmpty(); }
 
     using FormElementKey = std::pair<AtomString, AtomString>;
     FormControlState takeControlState(const FormElementKey&);

--- a/Source/WebCore/html/FormController.h
+++ b/Source/WebCore/html/FormController.h
@@ -47,7 +47,7 @@ public:
     void willDeleteForm(HTMLFormElement&);
     void restoreControlStateFor(ValidatedFormListedElement&);
     void restoreControlStateIn(HTMLFormElement&);
-    bool hasFormStateToRestore() const;
+    bool NODELETE hasFormStateToRestore() const;
 
     WEBCORE_EXPORT static Vector<String> referencedFilePaths(const Vector<AtomString>& stateVector);
     static HTMLFormElement* ownerForm(const FormListedElement&);

--- a/Source/WebCore/html/FormListedElement.h
+++ b/Source/WebCore/html/FormListedElement.h
@@ -68,7 +68,7 @@ public:
 
     // ValidityState attribute implementations
     bool badInput() const { return hasBadInput(); }
-    virtual bool customError() const;
+    virtual bool NODELETE customError() const;
 
     // Implementations of patternMismatch, rangeOverflow, rangerUnderflow, stepMismatch, tooShort, tooLong and valueMissing must call willValidate.
     virtual bool hasBadInput() const;
@@ -106,7 +106,7 @@ protected:
     virtual void willChangeForm();
     virtual void didChangeForm();
 
-    String customValidationMessage() const;
+    String NODELETE customValidationMessage() const;
 
 private:
     void setFormInternal(RefPtr<HTMLFormElement>&&) final;

--- a/Source/WebCore/html/HTMLAnchorElement.h
+++ b/Source/WebCore/html/HTMLAnchorElement.h
@@ -69,7 +69,7 @@ public:
 
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 
-    bool hasRel(Relation) const;
+    bool NODELETE hasRel(Relation) const;
     
     inline SharedStringHash visitedLinkHash() const;
 
@@ -123,7 +123,7 @@ private:
         MouseEventWithShiftKey,
         NonMouseEvent,
     };
-    static EventType eventType(Event&);
+    static EventType NODELETE eventType(Event&);
     bool treatLinkAsLiveForEventType(EventType) const;
 
     Element* rootEditableElementForSelectionOnMouseDown() const;

--- a/Source/WebCore/html/HTMLAreaElement.h
+++ b/Source/WebCore/html/HTMLAreaElement.h
@@ -65,7 +65,7 @@ private:
 
     enum class Shape : uint8_t { Default, Poly, Rect, Circle };
     Path getRegion(const LayoutSize&) const;
-    void invalidateCachedRegion();
+    void NODELETE invalidateCachedRegion();
 
     std::unique_ptr<Path> m_region;
     Vector<double> m_coords;

--- a/Source/WebCore/html/HTMLAttachmentElement.cpp
+++ b/Source/WebCore/html/HTMLAttachmentElement.cpp
@@ -589,11 +589,11 @@ void HTMLAttachmentElement::setFile(RefPtr<File>&& file, UpdateDisplayAttributes
 #if ATTACHMENT_LOG_DOCUMENT_TRAFFIC
 class AttachmentEvent {
 public:
-    uintptr_t attachment() const { return m_attachment; }
-    uintptr_t document() const { return m_document; }
-    String uniqueIdentifier() const { return m_uniqueIdentifier; }
-    WTF::MonotonicTime time() const { return m_time; }
-    StackTrace& stackTrace() const { return *m_stackTrace; }
+    uintptr_t NODELETE attachment() const { return m_attachment; }
+    uintptr_t NODELETE document() const { return m_document; }
+    String NODELETE uniqueIdentifier() const { return m_uniqueIdentifier; }
+    WTF::MonotonicTime NODELETE time() const { return m_time; }
+    StackTrace& NODELETE stackTrace() const { return *m_stackTrace; }
 
     void capture(const HTMLAttachmentElement& a, WTF::MonotonicTime t)
     {

--- a/Source/WebCore/html/HTMLAttachmentElement.h
+++ b/Source/WebCore/html/HTMLAttachmentElement.h
@@ -119,7 +119,7 @@ private:
     void updateSaveButton(bool);
     void updateImage();
 
-    void setNeedsIconRequest();
+    void NODELETE setNeedsIconRequest();
 
     RenderPtr<RenderElement> createElementRenderer(RenderStyle&&, const RenderTreePosition&) final;
     bool isReplaced(const RenderStyle* = nullptr) const final { return true; }

--- a/Source/WebCore/html/HTMLCanvasElement.cpp
+++ b/Source/WebCore/html/HTMLCanvasElement.cpp
@@ -391,7 +391,7 @@ CanvasRenderingContext2D* HTMLCanvasElement::getContext2d(const String& type, Ca
 
 #if ENABLE(WEBGL)
 
-static bool requiresAcceleratedCompositingForWebGL()
+static bool NODELETE requiresAcceleratedCompositingForWebGL()
 {
 #if PLATFORM(GTK) || PLATFORM(WIN)
     return false;
@@ -400,7 +400,7 @@ static bool requiresAcceleratedCompositingForWebGL()
 #endif
 
 }
-static bool shouldEnableWebGL(const Settings& settings)
+static bool NODELETE shouldEnableWebGL(const Settings& settings)
 {
     if (!settings.webGLEnabled())
         return false;

--- a/Source/WebCore/html/HTMLCanvasElement.h
+++ b/Source/WebCore/html/HTMLCanvasElement.h
@@ -137,7 +137,7 @@ public:
     void setIsSnapshotting(bool isSnapshotting) { m_isSnapshotting = isSnapshotting; }
     bool isSnapshotting() const { return m_isSnapshotting; }
 
-    bool isControlledByOffscreen() const;
+    bool NODELETE isControlledByOffscreen() const;
 
     void queueTaskKeepingObjectAlive(TaskSource, Function<void(CanvasBase&)>&&) final;
     void dispatchEvent(Event&) final;

--- a/Source/WebCore/html/HTMLCollection.cpp
+++ b/Source/WebCore/html/HTMLCollection.cpp
@@ -71,7 +71,7 @@ inline auto HTMLCollection::rootTypeFromCollectionType(CollectionType type) -> R
     return HTMLCollection::RootType::AtNode;
 }
 
-static NodeListInvalidationType invalidationTypeExcludingIdAndNameAttributes(CollectionType type)
+static NodeListInvalidationType NODELETE invalidationTypeExcludingIdAndNameAttributes(CollectionType type)
 {
     switch (type) {
     case CollectionType::ByTag:

--- a/Source/WebCore/html/HTMLCollection.h
+++ b/Source/WebCore/html/HTMLCollection.h
@@ -100,7 +100,7 @@ protected:
     void invalidateNamedElementCache(Document&) const;
 
     enum class RootType : bool { AtNode, AtTreeScope };
-    static RootType rootTypeFromCollectionType(CollectionType);
+    static RootType NODELETE rootTypeFromCollectionType(CollectionType);
 
     mutable Lock m_namedElementCacheAssignmentLock;
 

--- a/Source/WebCore/html/HTMLDataListElement.h
+++ b/Source/WebCore/html/HTMLDataListElement.h
@@ -51,7 +51,7 @@ public:
 
     static bool isSuggestion(const HTMLOptionElement& descendant);
     using SuggestionRange = FilteredElementDescendantRange<HTMLOptionElement, isSuggestion>;
-    SuggestionRange suggestions() const;
+    SuggestionRange NODELETE suggestions() const;
 
 private:
     void didMoveToNewDocument(Document& oldDocument, Document& newDocument) final;

--- a/Source/WebCore/html/HTMLDetailsElement.h
+++ b/Source/WebCore/html/HTMLDetailsElement.h
@@ -41,7 +41,7 @@ public:
 
     void queueDetailsToggleEventTask(ToggleState oldState, ToggleState newState);
 
-    bool isOpen() const;
+    bool NODELETE isOpen() const;
 
 private:
     HTMLDetailsElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLDocument.h
+++ b/Source/WebCore/html/HTMLDocument.h
@@ -37,7 +37,7 @@ public:
     
     std::optional<Variant<Ref<WindowProxy>, Ref<Element>, Ref<HTMLCollection>>> namedItem(const AtomString&);
     Vector<AtomString> supportedPropertyNames() const;
-    bool isSupportedPropertyName(const AtomString&) const;
+    bool NODELETE isSupportedPropertyName(const AtomString&) const;
 
     RefPtr<Element> documentNamedItem(const AtomString& name) const { return m_documentNamedItem.getElementByDocumentNamedItem(name, *this); }
     bool hasDocumentNamedItem(const AtomString& name) const { return m_documentNamedItem.contains(name); }

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -127,7 +127,7 @@ String HTMLElement::nodeName() const
     return Element::nodeName();
 }
 
-static inline CSSValueID unicodeBidiAttributeForDirAuto(HTMLElement& element)
+static inline CSSValueID NODELETE unicodeBidiAttributeForDirAuto(HTMLElement& element)
 {
     if (element.hasTagName(preTag) || element.hasTagName(textareaTag))
         return CSSValuePlaintext;

--- a/Source/WebCore/html/HTMLElement.h
+++ b/Source/WebCore/html/HTMLElement.h
@@ -63,7 +63,7 @@ public:
     WEBCORE_EXPORT ExceptionOr<void> setInnerText(String&&);
     WEBCORE_EXPORT ExceptionOr<void> setOuterText(String&&);
 
-    virtual bool hasCustomFocusLogic() const;
+    virtual bool NODELETE hasCustomFocusLogic() const;
     bool supportsFocus() const override;
 
     WEBCORE_EXPORT String contentEditable() const;
@@ -158,7 +158,7 @@ public:
     ExceptionOr<void> hidePopoverInternal(FocusPreviousElement, FireEvents, HTMLElement* = nullptr);
     ExceptionOr<bool> togglePopover(Variant<WebCore::HTMLElement::TogglePopoverOptions, bool>);
 
-    const AtomString& popover() const;
+    const AtomString& NODELETE popover() const;
     void setPopover(const AtomString& value);
     void popoverAttributeChanged(const AtomString& value);
 

--- a/Source/WebCore/html/HTMLFieldSetElement.h
+++ b/Source/WebCore/html/HTMLFieldSetElement.h
@@ -34,7 +34,7 @@ class HTMLFieldSetElement final : public HTMLFormControlElement {
 public:
     static Ref<HTMLFieldSetElement> create(const QualifiedName&, Document&, HTMLFormElement*);
 
-    HTMLLegendElement* legend() const;
+    HTMLLegendElement* NODELETE legend() const;
 
     Ref<HTMLCollection> elements();
 

--- a/Source/WebCore/html/HTMLFormControlElement.h
+++ b/Source/WebCore/html/HTMLFormControlElement.h
@@ -61,7 +61,7 @@ public:
     void setFormControlValueMatchesRenderer(bool b) { m_valueMatchesRenderer = b; }
 
     bool wasChangedSinceLastFormControlChangeEvent() const { return m_wasChangedSinceLastFormControlChangeEvent; }
-    void setChangedSinceLastFormControlChangeEvent(bool);
+    void NODELETE setChangedSinceLastFormControlChangeEvent(bool);
     bool wasCreatedByTaintedScript() const { return m_wasCreatedByTaintedScript; }
 
     virtual void dispatchFormControlChangeEvent();

--- a/Source/WebCore/html/HTMLFormControlsCollection.h
+++ b/Source/WebCore/html/HTMLFormControlsCollection.h
@@ -56,7 +56,7 @@ public:
     HTMLElement* item(unsigned offset) const override;
     std::optional<Variant<Ref<RadioNodeList>, Ref<Element>>> namedItemOrItems(const AtomString&) const;
 
-    HTMLFormElement& ownerNode() const;
+    HTMLFormElement& NODELETE ownerNode() const;
 
     // For CachedHTMLCollection.
     HTMLElement* customElementAfter(Element*) const;

--- a/Source/WebCore/html/HTMLFormElement.h
+++ b/Source/WebCore/html/HTMLFormElement.h
@@ -58,7 +58,7 @@ public:
     WEBCORE_EXPORT unsigned length() const;
     HTMLElement* item(unsigned index);
     std::optional<Variant<Ref<RadioNodeList>, Ref<Element>>> namedItem(const AtomString&);
-    Vector<AtomString> supportedPropertyNames() const;
+    Vector<AtomString> NODELETE supportedPropertyNames() const;
 
     String enctype() const { return m_attributes.encodingType(); }
 
@@ -99,7 +99,7 @@ public:
     AtomString target() const final;
     AtomString effectiveTarget(const Event*, HTMLFormControlElement* submitter) const;
 
-    bool wasUserSubmitted() const;
+    bool NODELETE wasUserSubmitted() const;
 
     HTMLFormControlElement* findSubmitter(const Event*) const;
 
@@ -111,7 +111,7 @@ public:
 
     RadioButtonGroups& radioButtonGroups() { return m_radioButtonGroups; }
 
-    WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& unsafeListedElements() const;
+    WEBCORE_EXPORT const Vector<WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData>>& NODELETE unsafeListedElements() const;
     WEBCORE_EXPORT Vector<Ref<FormListedElement>> copyListedElementsVector() const;
     Vector<Ref<ValidatedFormListedElement>> copyValidatedListedElementsVector() const;
     const Vector<WeakPtr<HTMLImageElement, WeakPtrImplWithEventTargetData>>& imageElements() const { return m_imageElements; }

--- a/Source/WebCore/html/HTMLFrameOwnerElement.h
+++ b/Source/WebCore/html/HTMLFrameOwnerElement.h
@@ -40,9 +40,9 @@ public:
     virtual ~HTMLFrameOwnerElement();
 
     Frame* contentFrame() const { return m_contentFrame.get(); }
-    RefPtr<Frame> protectedContentFrame() const;
-    WEBCORE_EXPORT WindowProxy* contentWindow() const;
-    WEBCORE_EXPORT Document* contentDocument() const;
+    RefPtr<Frame> NODELETE protectedContentFrame() const;
+    WEBCORE_EXPORT WindowProxy* NODELETE contentWindow() const;
+    WEBCORE_EXPORT Document* NODELETE contentDocument() const;
 
     WEBCORE_EXPORT void setContentFrame(Frame&);
     void clearContentFrame();
@@ -52,9 +52,9 @@ public:
     // Most subclasses use RenderWidget (either RenderEmbeddedObject or RenderIFrame)
     // except for HTMLObjectElement and HTMLEmbedElement which may return any
     // RenderElement when using fallback content.
-    RenderWidget* renderWidget() const;
+    RenderWidget* NODELETE renderWidget() const;
 
-    Document* getSVGDocument() const;
+    Document* NODELETE getSVGDocument() const;
 
     virtual ScrollbarMode scrollingMode() const { return ScrollbarMode::Auto; }
 

--- a/Source/WebCore/html/HTMLFrameSetElement.h
+++ b/Source/WebCore/html/HTMLFrameSetElement.h
@@ -53,7 +53,7 @@ public:
 
     static RefPtr<HTMLFrameSetElement> findContaining(Element* descendant);
 
-    Vector<AtomString> supportedPropertyNames() const;
+    Vector<AtomString> NODELETE supportedPropertyNames() const;
     WindowProxy* namedItem(const AtomString&);
     bool isSupportedPropertyName(const AtomString&);
 

--- a/Source/WebCore/html/HTMLHeadingElement.h
+++ b/Source/WebCore/html/HTMLHeadingElement.h
@@ -32,7 +32,7 @@ class HTMLHeadingElement final : public HTMLElement {
 public:
     static Ref<HTMLHeadingElement> create(const QualifiedName&, Document&);
 
-    unsigned level() const;
+    unsigned NODELETE level() const;
 
 private:
     HTMLHeadingElement(const QualifiedName&, Document&);

--- a/Source/WebCore/html/HTMLImageElement.h
+++ b/Source/WebCore/html/HTMLImageElement.h
@@ -85,17 +85,17 @@ public:
 
     const AtomString& altText() const;
 
-    WEBCORE_EXPORT CachedImage* cachedImage() const;
+    WEBCORE_EXPORT CachedImage* NODELETE cachedImage() const;
 
-    void setLoadManually(bool);
+    void NODELETE setLoadManually(bool);
 
-    bool matchesUsemap(const AtomString&) const;
+    bool NODELETE matchesUsemap(const AtomString&) const;
     RefPtr<HTMLMapElement> associatedMapElement() const;
 
     WEBCORE_EXPORT String crossOrigin() const;
     WEBCORE_EXPORT int x() const;
     WEBCORE_EXPORT int y() const;
-    WEBCORE_EXPORT bool complete() const;
+    WEBCORE_EXPORT bool NODELETE complete() const;
     String decoding() const;
 
     DecodingMode decodingMode() const;
@@ -113,7 +113,7 @@ public:
     void setAttachmentElement(Ref<HTMLAttachmentElement>&&) final;
 #endif
 
-    WEBCORE_EXPORT size_t pendingDecodePromisesCountForTesting() const;
+    WEBCORE_EXPORT size_t NODELETE pendingDecodePromisesCountForTesting() const;
 
     bool canContainRangeEndPoint() const override { return false; }
 
@@ -146,19 +146,19 @@ public:
     bool isLazyLoadable() const;
     static bool hasLazyLoadableAttributeValue(StringView);
 
-    bool isDeferred() const;
+    bool NODELETE isDeferred() const;
 
     bool isDroppedImagePlaceholder() const { return m_isDroppedImagePlaceholder; }
     void setIsDroppedImagePlaceholder() { m_isDroppedImagePlaceholder = true; }
 
-    void setIsUserAgentShadowRootResource();
+    void NODELETE setIsUserAgentShadowRootResource();
 
     void evaluateDynamicMediaQueryDependencies();
 
     String referrerPolicyForBindings() const;
     ReferrerPolicy referrerPolicy() const;
 
-    bool allowsOrientationOverride() const;
+    bool NODELETE allowsOrientationOverride() const;
 
     bool allowsAnimation() const;
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)

--- a/Source/WebCore/html/HTMLInputElement.cpp
+++ b/Source/WebCore/html/HTMLInputElement.cpp
@@ -1437,7 +1437,7 @@ ExceptionOr<void> HTMLInputElement::showPicker()
     return { };
 }
 
-static inline bool isRFC2616TokenCharacter(char16_t ch)
+static inline bool NODELETE isRFC2616TokenCharacter(char16_t ch)
 {
     return isASCII(ch) && ch > ' ' && ch != '"' && ch != '(' && ch != ')' && ch != ',' && ch != '/' && (ch < ':' || ch > '@') && (ch < '[' || ch > ']') && ch != '{' && ch != '}' && ch != 0x7f;
 }
@@ -1454,7 +1454,7 @@ static bool isValidMIMEType(StringView type)
     return true;
 }
 
-static bool isValidFileExtension(StringView type)
+static bool NODELETE isValidFileExtension(StringView type)
 {
     if (type.length() < 2)
         return false;
@@ -1930,7 +1930,7 @@ RefPtr<InputType> HTMLInputElement::inputType() const
     return m_inputType;
 }
 
-bool HTMLInputElement::isSteppable() const
+bool NODELETE HTMLInputElement::isSteppable() const
 {
     return m_inputType->isSteppable();
 }

--- a/Source/WebCore/html/HTMLInputElement.h
+++ b/Source/WebCore/html/HTMLInputElement.h
@@ -74,7 +74,7 @@ public:
     WEBCORE_EXPORT void setChecked(bool, WasSetByJavaScript = WasSetByJavaScript::Yes);
     String colorSpace();
     void setColorSpace(const AtomString&);
-    WEBCORE_EXPORT FileList* files();
+    WEBCORE_EXPORT FileList* NODELETE files();
     WEBCORE_EXPORT void setFiles(RefPtr<FileList>&&, WasSetByJavaScript = WasSetByJavaScript::No);
     FileList* filesForBindings() { return files(); }
     void setFilesForBindings(RefPtr<FileList>&& fileList) { return setFiles(WTF::move(fileList), WasSetByJavaScript::Yes); }
@@ -137,40 +137,40 @@ public:
 
     bool isPresentingAttachedView() const;
 
-    RefPtr<InputType> inputType() const;
+    RefPtr<InputType> NODELETE inputType() const;
 
     bool isSteppable() const; // stepUp()/stepDown() for user-interaction.
-    WEBCORE_EXPORT bool isTextButton() const;
-    bool isRadioButton() const;
+    WEBCORE_EXPORT bool NODELETE isTextButton() const;
+    bool NODELETE isRadioButton() const;
     WEBCORE_EXPORT bool isTextField() const final;
-    WEBCORE_EXPORT bool isSearchField() const;
-    bool isInputTypeHidden() const;
-    WEBCORE_EXPORT bool isPasswordField() const;
+    WEBCORE_EXPORT bool NODELETE isSearchField() const;
+    bool NODELETE isInputTypeHidden() const;
+    WEBCORE_EXPORT bool NODELETE isPasswordField() const;
     bool isSecureField() const { return isPasswordField() || autofilledAndObscured(); }
-    bool isCheckbox() const;
-    bool isSwitch() const;
-    bool isCheckable() const;
-    bool isRangeControl() const;
-    WEBCORE_EXPORT bool isColorControl() const;
+    bool NODELETE isCheckbox() const;
+    bool NODELETE isSwitch() const;
+    bool NODELETE isCheckable() const;
+    bool NODELETE isRangeControl() const;
+    WEBCORE_EXPORT bool NODELETE isColorControl() const;
     // FIXME: It's highly likely that any call site calling this function should instead
     // be using a different one. Many input elements behave like text fields, and in addition
     // any unknown input type is treated as text. Consider, for example, isTextField or
     // isTextField && !isPasswordField.
-    WEBCORE_EXPORT bool isText() const;
-    bool isTextType() const;
+    WEBCORE_EXPORT bool NODELETE isText() const;
+    bool NODELETE isTextType() const;
     bool supportsWritingSuggestions() const;
-    WEBCORE_EXPORT bool isEmailField() const;
-    WEBCORE_EXPORT bool isFileUpload() const;
-    bool isImageButton() const;
-    WEBCORE_EXPORT bool isNumberField() const;
+    WEBCORE_EXPORT bool NODELETE isEmailField() const;
+    WEBCORE_EXPORT bool NODELETE isFileUpload() const;
+    bool NODELETE isImageButton() const;
+    WEBCORE_EXPORT bool NODELETE isNumberField() const;
     WEBCORE_EXPORT bool isSubmitButton() const final;
-    WEBCORE_EXPORT bool isTelephoneField() const;
-    WEBCORE_EXPORT bool isURLField() const;
-    WEBCORE_EXPORT bool isDateField() const;
-    WEBCORE_EXPORT bool isDateTimeLocalField() const;
-    WEBCORE_EXPORT bool isMonthField() const;
-    WEBCORE_EXPORT bool isTimeField() const;
-    WEBCORE_EXPORT bool isWeekField() const;
+    WEBCORE_EXPORT bool NODELETE isTelephoneField() const;
+    WEBCORE_EXPORT bool NODELETE isURLField() const;
+    WEBCORE_EXPORT bool NODELETE isDateField() const;
+    WEBCORE_EXPORT bool NODELETE isDateTimeLocalField() const;
+    WEBCORE_EXPORT bool NODELETE isMonthField() const;
+    WEBCORE_EXPORT bool NODELETE isTimeField() const;
+    WEBCORE_EXPORT bool NODELETE isWeekField() const;
 
     bool isDevolvableWidget() const override;
 
@@ -192,7 +192,7 @@ public:
     WEBCORE_EXPORT HTMLElement* autoFillButtonElement() const;
     WEBCORE_EXPORT HTMLElement* dataListButtonElement() const;
 
-    bool matchesCheckedPseudoClass() const;
+    bool NODELETE matchesCheckedPseudoClass() const;
     bool matchesIndeterminatePseudoClass() const final;
     void setDefaultCheckedState(bool);
 
@@ -265,7 +265,7 @@ public:
         Visible,
         Hidden,
     };
-    AutofillVisibility autofillVisibility() const;
+    AutofillVisibility NODELETE autofillVisibility() const;
     void setAutofillVisibility(AutofillVisibility);
     bool autofillSpellcheck() const { return !m_isSpellcheckDisabledExceptTextReplacement; }
     void setAutofillSpellcheck(bool value) { m_isSpellcheckDisabledExceptTextReplacement = !value; }

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -783,7 +783,7 @@ std::optional<LinkIconType> HTMLLinkElement::iconType() const
     return m_relAttribute.iconType;
 }
 
-static bool mayFetchResource(LinkRelAttribute relAttribute)
+static bool NODELETE mayFetchResource(LinkRelAttribute relAttribute)
 {
     // https://html.spec.whatwg.org/multipage/links.html#linkTypes
     return relAttribute.isStyleSheet

--- a/Source/WebCore/html/HTMLLinkElement.h
+++ b/Source/WebCore/html/HTMLLinkElement.h
@@ -71,7 +71,7 @@ public:
 
     const AtomString& type() const;
 
-    std::optional<LinkIconType> iconType() const;
+    std::optional<LinkIconType> NODELETE iconType() const;
 
     CSSStyleSheet* sheet() const { return m_sheet.get(); }
 
@@ -118,7 +118,7 @@ private:
 
     void potentiallyBlockRendering();
     void unblockRendering();
-    bool isImplicitlyPotentiallyRenderBlocking() const;
+    bool NODELETE isImplicitlyPotentiallyRenderBlocking() const;
 
     InsertedIntoAncestorResult insertedIntoAncestor(InsertionType, ContainerNode&) final;
     void didFinishInsertingNode() final;
@@ -154,7 +154,7 @@ private:
 
     void removePendingSheet();
 
-    CheckedPtr<Style::Scope> checkedStyleScope();
+    CheckedPtr<Style::Scope> NODELETE checkedStyleScope();
 
     const Ref<LinkLoader> m_linkLoader;
     CheckedPtr<Style::Scope> m_styleScope;

--- a/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
+++ b/Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h
@@ -40,7 +40,7 @@ public:
     bool isMaybeFormAssociatedCustomElement() const final { return true; }
     bool isFormListedElement() const final;
     bool isValidatedFormListedElement() const final;
-    bool isFormAssociatedCustomElement() const;
+    bool NODELETE isFormAssociatedCustomElement() const;
 
     FormAssociatedElement* asFormAssociatedElement() final;
     FormListedElement* asFormListedElement() final;

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -475,7 +475,7 @@ static bool preferMediaControlsForCandidateSessionOverOtherCandidateSession(cons
     return session.timeOfLastUserInteraction.value_or(MonotonicTime { }) > otherSession.timeOfLastUserInteraction.value_or(MonotonicTime { });
 }
 
-static bool mediaSessionMayBeConfusedWithMainContent(const MediaElementSessionInfo& session, MediaElementSession::PlaybackControlsPurpose purpose)
+static bool NODELETE mediaSessionMayBeConfusedWithMainContent(const MediaElementSessionInfo& session, MediaElementSession::PlaybackControlsPurpose purpose)
 {
     if (purpose == MediaElementSession::PlaybackControlsPurpose::MediaSession)
         return false;
@@ -503,7 +503,7 @@ static bool defaultVolumeLocked()
 #endif
 }
 
-static bool isInWindowOrStandardFullscreen(HTMLMediaElementEnums::VideoFullscreenMode mode)
+static bool NODELETE isInWindowOrStandardFullscreen(HTMLMediaElementEnums::VideoFullscreenMode mode)
 {
     return mode == HTMLMediaElementEnums::VideoFullscreenModeStandard || mode == HTMLMediaElementEnums::VideoFullscreenModeInWindow;
 }
@@ -7964,7 +7964,7 @@ void HTMLMediaElement::setShouldDelayLoadEvent(bool shouldDelay)
         protect(document())->decrementLoadEventDelayCount();
 }
 
-static String& sharedMediaCacheDirectory()
+static String& NODELETE sharedMediaCacheDirectory()
 {
     static NeverDestroyed<String> sharedMediaCacheDirectory;
     return sharedMediaCacheDirectory;
@@ -8453,7 +8453,7 @@ String HTMLMediaElement::mediaPlayerUserAgent() const
     return frame->loader().userAgent(m_currentSrc);
 }
 
-static inline PlatformTextTrackData::TrackKind toPlatform(TextTrack::Kind kind)
+static inline PlatformTextTrackData::TrackKind NODELETE toPlatform(TextTrack::Kind kind)
 {
     switch (kind) {
     case TextTrack::Kind::Captions:
@@ -8473,7 +8473,7 @@ static inline PlatformTextTrackData::TrackKind toPlatform(TextTrack::Kind kind)
     return PlatformTextTrackData::TrackKind::Caption;
 }
 
-static inline PlatformTextTrackData::TrackMode toPlatform(TextTrack::Mode mode)
+static inline PlatformTextTrackData::TrackMode NODELETE toPlatform(TextTrack::Mode mode)
 {
     switch (mode) {
     case TextTrack::Mode::Disabled:

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -202,7 +202,7 @@ public:
     bool hasVideo() const override { return false; }
     WEBCORE_EXPORT bool hasAudio() const override;
 
-    WEBCORE_EXPORT static HashSet<WeakRef<HTMLMediaElement>>& allMediaElements();
+    WEBCORE_EXPORT static HashSet<WeakRef<HTMLMediaElement>>& NODELETE allMediaElements();
 
     WEBCORE_EXPORT void rewind(double timeDelta);
     WEBCORE_EXPORT void returnToRealtime() override;
@@ -217,7 +217,7 @@ public:
     bool doesHaveAttribute(const AtomString&, AtomString* value = nullptr) const override;
 
     PlatformLayer* platformLayer() const;
-    bool isVideoLayerInline();
+    bool NODELETE isVideoLayerInline();
     void setPreparedToReturnVideoLayerToInline(bool);
     void waitForPreparedForInlineThen(Function<void()>&& completionHandler);
 #if ENABLE(VIDEO_PRESENTATION_MODE)
@@ -247,7 +247,7 @@ public:
 
     std::optional<MediaSessionGroupIdentifier> mediaSessionGroupIdentifier() const final;
 
-    WEBCORE_EXPORT bool isActiveNowPlayingSession() const;
+    WEBCORE_EXPORT bool NODELETE isActiveNowPlayingSession() const;
 
 // DOM API
 // error state
@@ -262,7 +262,7 @@ public:
 
 // network state
     using HTMLMediaElementEnums::NetworkState;
-    WEBCORE_EXPORT NetworkState networkState() const;
+    WEBCORE_EXPORT NetworkState NODELETE networkState() const;
 
     WEBCORE_EXPORT String preload() const;
     WEBCORE_EXPORT void setPreload(const AtomString&);
@@ -274,7 +274,7 @@ public:
 // ready state
     using HTMLMediaElementEnums::ReadyState;
     ReadyState readyState() const override;
-    WEBCORE_EXPORT bool seeking() const;
+    WEBCORE_EXPORT bool NODELETE seeking() const;
     void setSeeking(bool);
 
 // playback state
@@ -291,7 +291,7 @@ public:
     void setDefaultPlaybackRate(double) override;
     WEBCORE_EXPORT double playbackRate() const override;
     void setPlaybackRate(double) override;
-    WEBCORE_EXPORT bool preservesPitch() const;
+    WEBCORE_EXPORT bool NODELETE preservesPitch() const;
     WEBCORE_EXPORT void setPreservesPitch(bool);
 
     WEBCORE_EXPORT double mediaPlayerCurrentTime() const;
@@ -329,7 +329,7 @@ public:
 
     using HTMLMediaElementEnums::BufferingPolicy;
     WEBCORE_EXPORT void setBufferingPolicy(BufferingPolicy);
-    WEBCORE_EXPORT BufferingPolicy bufferingPolicy() const;
+    WEBCORE_EXPORT BufferingPolicy NODELETE bufferingPolicy() const;
     WEBCORE_EXPORT void purgeBufferedDataIfPossible();
 
 #if ENABLE(MEDIA_STATISTICS)
@@ -462,7 +462,7 @@ public:
 
     void setTextTrackRepresentataionBounds(const IntRect&);
     void setRequiresTextTrackRepresentation(bool);
-    bool requiresTextTrackRepresentation() const;
+    bool NODELETE requiresTextTrackRepresentation() const;
     void setTextTrackRepresentation(TextTrackRepresentation*);
     void syncTextTrackBounds();
 
@@ -486,7 +486,7 @@ public:
     void setShouldPlayToPlaybackTarget(bool) override;
     void playbackTargetPickerWasDismissed() override;
     bool hasWirelessPlaybackTargetAlternative() const;
-    bool isWirelessPlaybackTargetDisabled() const;
+    bool NODELETE isWirelessPlaybackTargetDisabled() const;
     void isWirelessPlaybackTargetDisabledChanged();
     bool hasTargetAvailabilityListeners();
     bool hasEnabledTargetAvailabilityListeners();
@@ -539,8 +539,8 @@ public:
     void sourceWasAdded(HTMLSourceElement&);
 
     // Media cache management.
-    WEBCORE_EXPORT static void setMediaCacheDirectory(const String&);
-    WEBCORE_EXPORT static const String& mediaCacheDirectory();
+    WEBCORE_EXPORT static void NODELETE setMediaCacheDirectory(const String&);
+    WEBCORE_EXPORT static const String& NODELETE mediaCacheDirectory();
     WEBCORE_EXPORT static HashSet<SecurityOriginData> originsInMediaCache(const String&);
     WEBCORE_EXPORT static void clearMediaCache(const String&, WallTime modifiedSince = { });
     WEBCORE_EXPORT static void clearMediaCacheForOrigins(const String&, const HashSet<SecurityOriginData>&);
@@ -557,7 +557,7 @@ public:
     using HTMLMediaElementEnums::InvalidURLAction;
     bool isSafeToLoadURL(const URL&, InvalidURLAction, bool shouldLog = true) const;
 
-    const String& mediaGroup() const;
+    const String& NODELETE mediaGroup() const;
     void setMediaGroup(const String&);
 
     MediaController* NODELETE controller() const;
@@ -576,7 +576,7 @@ public:
     Ref<VideoPlaybackQuality> getVideoPlaybackQuality() const;
 
     MediaPlayer::Preload preloadValue() const { return m_preload; }
-    MediaPlayer::Preload effectivePreloadValue() const;
+    MediaPlayer::Preload NODELETE effectivePreloadValue() const;
     MediaElementSession* mediaSessionIfExists() const { return m_mediaSession.get(); }
     WEBCORE_EXPORT MediaElementSession& mediaSession() const;
 
@@ -602,8 +602,8 @@ public:
     inline RenderMedia* renderer() const; // Defined in RenderMediaInlines.h.
 
     void resetPlaybackSessionState();
-    WEBCORE_EXPORT bool isVisibleInViewport() const;
-    bool hasEverNotifiedAboutPlaying() const;
+    WEBCORE_EXPORT bool NODELETE isVisibleInViewport() const;
+    bool NODELETE hasEverNotifiedAboutPlaying() const;
     void setShouldDelayLoadEvent(bool);
 
     bool hasEverHadAudio() const { return m_hasEverHadAudio; }
@@ -659,7 +659,7 @@ public:
     void applicationWillResignActive();
     void applicationDidBecomeActive();
 
-    MediaUniqueIdentifier mediaUniqueIdentifier() const;
+    MediaUniqueIdentifier NODELETE mediaUniqueIdentifier() const;
     String mediaSessionTitle() const;
     String sourceApplicationIdentifier() const;
 
@@ -696,7 +696,7 @@ public:
     WEBCORE_EXPORT void requestHostingContext(Function<void(HostingContext)>&&);
     WEBCORE_EXPORT WebCore::HostingContext layerHostingContext();
     WEBCORE_EXPORT WebCore::FloatSize naturalSize();
-    WEBCORE_EXPORT WebCore::FloatSize videoLayerSize() const;
+    WEBCORE_EXPORT WebCore::FloatSize NODELETE videoLayerSize() const;
     void setVideoLayerSizeFenced(const FloatSize&, WTF::MachSendRightAnnotated&&);
     void updateMediaState();
 
@@ -960,8 +960,8 @@ private:
 
     URL selectNextSourceChild(ContentType*, InvalidURLAction);
 
-    bool ignoreTrackDisplayUpdateRequests() const;
-    void beginIgnoringTrackDisplayUpdateRequests();
+    bool NODELETE ignoreTrackDisplayUpdateRequests() const;
+    void NODELETE beginIgnoringTrackDisplayUpdateRequests();
     void endIgnoringTrackDisplayUpdateRequests();
 
     void updateActiveTextTrackCues(const MediaTime&);
@@ -981,7 +981,7 @@ private:
     void markCaptionAndSubtitleTracksAsUnconfigured(ReconfigureMode);
     CaptionUserPreferences::CaptionDisplayMode captionDisplayMode();
 
-    bool textTracksAreReady() const;
+    bool NODELETE textTracksAreReady() const;
     void configureTextTrackDisplay(TextTrackVisibilityCheckType = CheckTextTrackVisibility);
     void updateTextTrackDisplay();
 
@@ -1081,7 +1081,7 @@ private:
     void routingContextUIDDidChange(const AudioSession&) final;
 #endif
 
-    bool hasMediaSource() const;
+    bool NODELETE hasMediaSource() const;
     bool hasManagedMediaSource() const;
 
     bool processingUserGestureForMedia() const;
@@ -1144,7 +1144,7 @@ private:
     };
     void applyConfiguration(const RemotePlaybackConfiguration&);
 
-    bool videoUsesElementFullscreen() const;
+    bool NODELETE videoUsesElementFullscreen() const;
 
 #if !RELEASE_LOG_DISABLED
     uint64_t mediaPlayerLogIdentifier() final { return logIdentifier(); }
@@ -1155,7 +1155,7 @@ private:
     WEBCORE_EXPORT PlatformDynamicRangeLimit computePlayerDynamicRangeLimit() const;
     void updatePlayerDynamicRangeLimit() const;
 
-    bool shouldLogWatchtimeEvent() const;
+    bool NODELETE shouldLogWatchtimeEvent() const;
     bool isWatchtimeTimerActive() const;
     void startWatchtimeTimer();
     void pauseWatchtimeTimer();

--- a/Source/WebCore/html/HTMLMeterElement.h
+++ b/Source/WebCore/html/HTMLMeterElement.h
@@ -57,7 +57,7 @@ private:
     HTMLMeterElement(const QualifiedName&, Document&);
     virtual ~HTMLMeterElement();
 
-    RenderMeter* renderMeter() const;
+    RenderMeter* NODELETE renderMeter() const;
 
     bool isLabelable() const final { return true; }
 

--- a/Source/WebCore/html/HTMLNameCollection.cpp
+++ b/Source/WebCore/html/HTMLNameCollection.cpp
@@ -60,7 +60,7 @@ bool WindowNameCollection::elementMatches(const Element& element, const AtomStri
         || element.getIdAttribute() == name;
 }
 
-static inline bool isObjectElementForDocumentNameCollection(const Element& element)
+static inline bool NODELETE isObjectElementForDocumentNameCollection(const Element& element)
 {
     auto* objectElement = dynamicDowncast<HTMLObjectElement>(element);
     return objectElement && objectElement->isExposed();

--- a/Source/WebCore/html/HTMLNameCollection.h
+++ b/Source/WebCore/html/HTMLNameCollection.h
@@ -83,7 +83,7 @@ public:
     bool elementMatches(const Element& element) const { return elementMatches(element, m_name.impl()); }
 
     static bool elementMatchesIfIdAttributeMatch(const Element&) { return true; }
-    static bool elementMatchesIfNameAttributeMatch(const Element&);
+    static bool NODELETE elementMatchesIfNameAttributeMatch(const Element&);
     static bool elementMatches(const Element&, const AtomString&);
 
 private:

--- a/Source/WebCore/html/HTMLOptGroupElement.h
+++ b/Source/WebCore/html/HTMLOptGroupElement.h
@@ -36,7 +36,7 @@ public:
     static Ref<HTMLOptGroupElement> create(const QualifiedName&, Document&);
 
     bool isDisabledFormControl() const final;
-    WEBCORE_EXPORT HTMLSelectElement* ownerSelectElement() const;
+    WEBCORE_EXPORT HTMLSelectElement* NODELETE ownerSelectElement() const;
     
     WEBCORE_EXPORT String groupLabelText() const;
 

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -55,7 +55,7 @@ public:
     WEBCORE_EXPORT bool selected(AllowStyleInvalidation = AllowStyleInvalidation::Yes) const;
     WEBCORE_EXPORT void setSelected(bool);
 
-    WEBCORE_EXPORT HTMLSelectElement* ownerSelectElement() const;
+    WEBCORE_EXPORT HTMLSelectElement* NODELETE ownerSelectElement() const;
 
     WEBCORE_EXPORT String label() const;
     WEBCORE_EXPORT String displayLabel() const;

--- a/Source/WebCore/html/HTMLPlugInElement.h
+++ b/Source/WebCore/html/HTMLPlugInElement.h
@@ -73,10 +73,10 @@ public:
 #endif
     bool willRespondToMouseClickEventsWithEditability(Editability) const final;
 
-    WEBCORE_EXPORT void pluginDestroyedWithPendingPDFTestCallback(RefPtr<VoidCallback>&&);
-    WEBCORE_EXPORT RefPtr<VoidCallback> takePendingPDFTestCallback();
+    WEBCORE_EXPORT void NODELETE pluginDestroyedWithPendingPDFTestCallback(RefPtr<VoidCallback>&&);
+    WEBCORE_EXPORT RefPtr<VoidCallback> NODELETE takePendingPDFTestCallback();
 
-    RenderEmbeddedObject* renderEmbeddedObject() const;
+    RenderEmbeddedObject* NODELETE renderEmbeddedObject() const;
 
     virtual void updateWidget(CreatePlugins) = 0;
 

--- a/Source/WebCore/html/HTMLProgressElement.h
+++ b/Source/WebCore/html/HTMLProgressElement.h
@@ -66,7 +66,7 @@ private:
 
     bool canContainRangeEndPoint() const final { return false; }
 
-    RefPtr<ProgressValueElement> protectedValueElement();
+    RefPtr<ProgressValueElement> NODELETE protectedValueElement();
 
     WeakPtr<ProgressValueElement, WeakPtrImplWithEventTargetData> m_valueElement;
     bool m_isDeterminate { false };

--- a/Source/WebCore/html/HTMLSelectElement.cpp
+++ b/Source/WebCore/html/HTMLSelectElement.cpp
@@ -95,7 +95,7 @@ static const AtomString& buttonSlotName()
     return buttonSlot;
 }
 
-static bool isFirstElementChildButton(const Node& child)
+static bool NODELETE isFirstElementChildButton(const Node& child)
 {
     return is<HTMLButtonElement>(child) && !child.previousElementSibling();
 }

--- a/Source/WebCore/html/HTMLSelectElement.h
+++ b/Source/WebCore/html/HTMLSelectElement.h
@@ -63,7 +63,7 @@ public:
     ~HTMLSelectElement();
 
     enum class ExcludeOptGroup : bool { No, Yes };
-    static HTMLSelectElement* findOwnerSelect(ContainerNode*, ExcludeOptGroup);
+    static HTMLSelectElement* NODELETE findOwnerSelect(ContainerNode*, ExcludeOptGroup);
 
     WEBCORE_EXPORT int selectedIndex() const;
     WEBCORE_EXPORT void setSelectedIndex(int);
@@ -78,10 +78,10 @@ public:
     unsigned size() const { return m_size; }
     bool multiple() const { return m_multiple; }
 
-    bool usesMenuList() const;
+    bool NODELETE usesMenuList() const;
 
     // This method is deprecated because the return value doesn't match the rendering on iOS for multiple selects.
-    bool usesMenuListDeprecated() const;
+    bool NODELETE usesMenuListDeprecated() const;
 
     using OptionOrOptGroupElement = Variant<Ref<HTMLOptionElement>, Ref<HTMLOptGroupElement>>;
     using HTMLElementOrInt = Variant<Ref<HTMLElement>, int>;
@@ -121,7 +121,7 @@ public:
     bool popupIsVisible() const { return m_popupIsVisible; }
     WEBCORE_EXPORT void setPopupIsVisible(bool);
 
-    bool isOpen() const;
+    bool NODELETE isOpen() const;
 
     void didUpdateActiveOption(int optionIndex);
 
@@ -165,7 +165,7 @@ public:
     int activeSelectionStartListIndex() const;
     int activeSelectionEndListIndex() const;
     void setActiveSelectionAnchorIndex(int);
-    void setActiveSelectionEndIndex(int);
+    void NODELETE setActiveSelectionEndIndex(int);
     void updateListBoxSelection(bool deselectOtherOptions);
 
     // For use in the implementation of HTMLOptionElement.
@@ -181,11 +181,11 @@ public:
 
     void updateSelectedContent(HTMLOptionElement* = nullptr) const;
 
-    void registerSelectedContentElement();
-    void unregisterSelectedContentElement();
+    void NODELETE registerSelectedContentElement();
+    void NODELETE unregisterSelectedContentElement();
 
     WEBCORE_EXPORT bool usesBaseAppearancePicker() const;
-    SelectPopoverElement* pickerPopoverElement() const;
+    SelectPopoverElement* NODELETE pickerPopoverElement() const;
     void hidePickerPopoverElement();
 
     struct NavigationKeyIdentifiers {

--- a/Source/WebCore/html/HTMLStyleElement.h
+++ b/Source/WebCore/html/HTMLStyleElement.h
@@ -45,7 +45,7 @@ public:
 
     CSSStyleSheet* sheet() const { return m_styleSheetOwner.sheet(); }
 
-    WEBCORE_EXPORT bool disabled() const;
+    WEBCORE_EXPORT bool NODELETE disabled() const;
     WEBCORE_EXPORT void setDisabled(bool);
 
     void dispatchPendingEvent(StyleEventSender*, const AtomString& eventType);

--- a/Source/WebCore/html/HTMLTableCellElement.h
+++ b/Source/WebCore/html/HTMLTableCellElement.h
@@ -45,7 +45,7 @@ public:
 
     static Ref<HTMLTableCellElement> create(const QualifiedName&, Document&);
 
-    WEBCORE_EXPORT int cellIndex() const;
+    WEBCORE_EXPORT int NODELETE cellIndex() const;
     WEBCORE_EXPORT unsigned colSpan() const;
     unsigned rowSpan() const;
     WEBCORE_EXPORT unsigned rowSpanForBindings() const;

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -258,7 +258,7 @@ ExceptionOr<void> HTMLTableElement::deleteRow(int index)
     return row->remove();
 }
 
-static inline bool isTableCellAncestor(const Element& element)
+static inline bool NODELETE isTableCellAncestor(const Element& element)
 {
     return element.hasTagName(theadTag)
         || element.hasTagName(tbodyTag)

--- a/Source/WebCore/html/HTMLTableElement.h
+++ b/Source/WebCore/html/HTMLTableElement.h
@@ -42,7 +42,7 @@ public:
     static Ref<HTMLTableElement> create(const QualifiedName&, Document&);
     ~HTMLTableElement();
 
-    WEBCORE_EXPORT RefPtr<HTMLTableCaptionElement> caption() const;
+    WEBCORE_EXPORT RefPtr<HTMLTableCaptionElement> NODELETE caption() const;
     WEBCORE_EXPORT ExceptionOr<void> setCaption(RefPtr<HTMLTableCaptionElement>&&);
 
     WEBCORE_EXPORT RefPtr<HTMLTableSectionElement> tHead() const;
@@ -86,7 +86,7 @@ private:
     enum TableRules { UnsetRules, NoneRules, GroupsRules, RowsRules, ColsRules, AllRules };
     enum CellBorders { NoBorders, SolidBorders, InsetBorders, SolidBordersColsOnly, SolidBordersRowsOnly };
 
-    CellBorders cellBorders() const;
+    CellBorders NODELETE cellBorders() const;
 
     Ref<MutableStyleProperties> createSharedCellStyle() const;
 

--- a/Source/WebCore/html/HTMLTableRowsCollection.cpp
+++ b/Source/WebCore/html/HTMLTableRowsCollection.cpp
@@ -43,7 +43,7 @@ using namespace HTMLNames;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTableRowsCollection);
 
-static inline void assertRowIsInTable(HTMLTableElement& table, HTMLTableRowElement* row)
+static inline void NODELETE assertRowIsInTable(HTMLTableElement& table, HTMLTableRowElement* row)
 {
 #if ASSERT_ENABLED
     UNUSED_PARAM(table);
@@ -59,7 +59,7 @@ static inline void assertRowIsInTable(HTMLTableElement& table, HTMLTableRowEleme
 #endif // not ASSERT_ENABLED
 }
 
-static inline bool isInSection(HTMLTableRowElement& row, const HTMLQualifiedName& sectionTag)
+static inline bool NODELETE isInSection(HTMLTableRowElement& row, const HTMLQualifiedName& sectionTag)
 {
     // Because we know that the parent is a table or a section, it's safe to cast it to an HTMLElement
     // giving us access to the faster hasTagName overload from that class.

--- a/Source/WebCore/html/HTMLTableRowsCollection.h
+++ b/Source/WebCore/html/HTMLTableRowsCollection.h
@@ -56,7 +56,7 @@ public:
     HTMLTableElement& tableElement() const { return downcast<HTMLTableElement>(ownerNode()); }
 
     static HTMLTableRowElement* rowAfter(HTMLTableElement&, HTMLTableRowElement*);
-    static HTMLTableRowElement* lastRow(HTMLTableElement&);
+    static HTMLTableRowElement* NODELETE lastRow(HTMLTableElement&);
 
     // For CachedHTMLCollection.
     Element* customElementAfter(Element*) const;

--- a/Source/WebCore/html/HTMLTextAreaElement.cpp
+++ b/Source/WebCore/html/HTMLTextAreaElement.cpp
@@ -62,7 +62,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLTextAreaElement);
 
 using namespace HTMLNames;
 
-static inline unsigned computeLengthForAPIValue(StringView text)
+static inline unsigned NODELETE computeLengthForAPIValue(StringView text)
 {
     unsigned length = text.length();
     unsigned crlfCount = 0;

--- a/Source/WebCore/html/HTMLTextAreaElement.h
+++ b/Source/WebCore/html/HTMLTextAreaElement.h
@@ -75,7 +75,7 @@ private:
 
     bool supportsPlaceholder() const final { return true; }
     HTMLElement* placeholderElement() const final { return m_placeholder.get(); }
-    RefPtr<HTMLElement> protectedPlaceholderElement() const;
+    RefPtr<HTMLElement> NODELETE protectedPlaceholderElement() const;
     void updatePlaceholderText() final;
     bool isEmptyValue() const final { return value()->isEmpty(); }
 

--- a/Source/WebCore/html/HTMLTextFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLTextFormControlElement.cpp
@@ -177,7 +177,7 @@ void HTMLTextFormControlElement::forwardEvent(Event& event)
         innerText->defaultEventHandler(event);
 }
 
-static bool isNotLineBreak(char16_t ch) { return ch != newlineCharacter && ch != carriageReturn; }
+static bool NODELETE isNotLineBreak(char16_t ch) { return ch != newlineCharacter && ch != carriageReturn; }
 
 bool HTMLTextFormControlElement::isPlaceholderEmpty() const
 {

--- a/Source/WebCore/html/HTMLTextFormControlElement.h
+++ b/Source/WebCore/html/HTMLTextFormControlElement.h
@@ -133,7 +133,7 @@ protected:
 
     void updateInnerTextElementEditability();
 
-    bool cacheSelection(unsigned start, unsigned end, TextFieldSelectionDirection);
+    bool NODELETE cacheSelection(unsigned start, unsigned end, TextFieldSelectionDirection);
 
     void restoreCachedSelection(SelectionRevealMode, const AXTextStateChangeIntent& = AXTextStateChangeIntent());
     bool hasCachedSelection() const { return m_hasCachedSelection; }

--- a/Source/WebCore/html/HTMLTrackElement.h
+++ b/Source/WebCore/html/HTMLTrackElement.h
@@ -55,17 +55,17 @@ public:
     bool isDefault() const;
 
     enum ReadyState { NONE = 0, LOADING = 1, LOADED = 2, TRACK_ERROR = 3 };
-    ReadyState readyState() const;
+    ReadyState NODELETE readyState() const;
     void setReadyState(ReadyState);
 
-    TextTrack& track();
+    TextTrack& NODELETE track();
 
     void scheduleLoad();
 
     enum LoadStatus { Failure, Success };
     void didCompleteLoad(LoadStatus);
 
-    RefPtr<HTMLMediaElement> mediaElement() const;
+    RefPtr<HTMLMediaElement> NODELETE mediaElement() const;
     const AtomString& mediaElementCrossOriginAttribute() const;
 
     void scheduleTask(Function<void(HTMLTrackElement&)>&&);

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -536,7 +536,7 @@ bool HTMLVideoElement::webkitSupportsPresentationMode(VideoPresentationMode mode
     return false;
 }
 
-static inline HTMLMediaElementEnums::VideoFullscreenMode toFullscreenMode(HTMLVideoElement::VideoPresentationMode mode)
+static inline HTMLMediaElementEnums::VideoFullscreenMode NODELETE toFullscreenMode(HTMLVideoElement::VideoPresentationMode mode)
 {
     switch (mode) {
     case HTMLVideoElement::VideoPresentationMode::Fullscreen:

--- a/Source/WebCore/html/HTMLVideoElement.h
+++ b/Source/WebCore/html/HTMLVideoElement.h
@@ -101,16 +101,16 @@ public:
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)
     enum class VideoPresentationMode { Inline, Fullscreen, PictureInPicture, InWindow };
-    static VideoPresentationMode toPresentationMode(HTMLMediaElementEnums::VideoFullscreenMode);
+    static VideoPresentationMode NODELETE toPresentationMode(HTMLMediaElementEnums::VideoFullscreenMode);
     WEBCORE_EXPORT bool webkitSupportsPresentationMode(VideoPresentationMode) const;
-    VideoPresentationMode webkitPresentationMode() const;
-    VideoPresentationMode webkitPresentationModeForBindings() const;
+    VideoPresentationMode NODELETE webkitPresentationMode() const;
+    VideoPresentationMode NODELETE webkitPresentationModeForBindings() const;
     void webkitSetPresentationMode(VideoPresentationMode);
 
     WEBCORE_EXPORT void setPresentationMode(VideoPresentationMode);
     WEBCORE_EXPORT void didEnterFullscreenOrPictureInPicture(const FloatSize&);
     WEBCORE_EXPORT void didExitFullscreenOrPictureInPicture();
-    WEBCORE_EXPORT bool isChangingPresentationMode() const;
+    WEBCORE_EXPORT bool NODELETE isChangingPresentationMode() const;
     WEBCORE_EXPORT void setPresentationModeIgnoringPermissionsPolicy(VideoPresentationMode);
 
     void setVideoFullscreenFrame(const FloatRect&) final;

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -90,7 +90,7 @@ size_t DetachedImageBitmap::memoryCost() const
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(ImageBitmap);
 
-static inline RenderingMode bufferRenderingMode(ScriptExecutionContext& scriptExecutionContext)
+static inline RenderingMode NODELETE bufferRenderingMode(ScriptExecutionContext& scriptExecutionContext)
 {
 #if USE(CA) || USE(SKIA)
     static RenderingMode defaultRenderingMode = RenderingMode::Accelerated;
@@ -287,7 +287,7 @@ static IntSize outputSizeForSourceRectangle(IntRect sourceRectangle, ImageBitmap
     return { outputWidth, outputHeight };
 }
 
-static InterpolationQuality interpolationQualityForResizeQuality(ImageBitmapOptions::ResizeQuality resizeQuality)
+static InterpolationQuality NODELETE interpolationQualityForResizeQuality(ImageBitmapOptions::ResizeQuality resizeQuality)
 {
     switch (resizeQuality) {
     case ImageBitmapOptions::ResizeQuality::Pixelated:
@@ -303,7 +303,7 @@ static InterpolationQuality interpolationQualityForResizeQuality(ImageBitmapOpti
     return InterpolationQuality::Low;
 }
 
-static AlphaPremultiplication alphaPremultiplicationForPremultiplyAlpha(ImageBitmapOptions::PremultiplyAlpha premultiplyAlpha)
+static AlphaPremultiplication NODELETE alphaPremultiplicationForPremultiplyAlpha(ImageBitmapOptions::PremultiplyAlpha premultiplyAlpha)
 {
     // The default is to premultiply - this is the least surprising behavior.
     if (premultiplyAlpha == ImageBitmapOptions::PremultiplyAlpha::None)
@@ -727,18 +727,18 @@ public:
         return adoptRef(*new ImageBitmapImageObserver(mimeType, expectedContentLength, sourceUrl));
     }
 
-    URL sourceUrl() const override { return m_sourceUrl; }
-    String mimeType() const override { return m_mimeType; }
-    long long expectedContentLength() const override { return m_expectedContentLength; }
+    URL NODELETE sourceUrl() const override { return m_sourceUrl; }
+    String NODELETE mimeType() const override { return m_mimeType; }
+    long long NODELETE expectedContentLength() const override { return m_expectedContentLength; }
 
-    void decodedSizeChanged(const Image&, long long) override { }
+    void NODELETE decodedSizeChanged(const Image&, long long) override { }
 
-    void didDraw(const Image&) override { }
+    void NODELETE didDraw(const Image&) override { }
 
-    void imageFrameAvailable(const Image&, ImageAnimatingState, const IntRect* = nullptr, DecodingStatus = DecodingStatus::Invalid) override { }
-    void changedInRect(const Image&, const IntRect* = nullptr) override { }
-    void imageContentChanged(const Image&) override { }
-    void scheduleRenderingUpdate(const Image&) override { }
+    void NODELETE imageFrameAvailable(const Image&, ImageAnimatingState, const IntRect* = nullptr, DecodingStatus = DecodingStatus::Invalid) override { }
+    void NODELETE changedInRect(const Image&, const IntRect* = nullptr) override { }
+    void NODELETE imageContentChanged(const Image&) override { }
+    void NODELETE scheduleRenderingUpdate(const Image&) override { }
 
 private:
     ImageBitmapImageObserver(String mimeType, long long expectedContentLength, const URL& sourceUrl)
@@ -755,7 +755,7 @@ private:
 class PendingImageBitmap final : public RefCounted<PendingImageBitmap>, public ActiveDOMObject, public FileReaderLoaderClient {
     WTF_MAKE_TZONE_ALLOCATED(PendingImageBitmap);
 public:
-    void ref() const final { RefCounted::ref(); }
+    void NODELETE ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
     USING_CAN_MAKE_WEAKPTR(FileReaderLoaderClient);
 
@@ -797,8 +797,8 @@ private:
     void stop() final { m_pendingActivity = nullptr; }
 
     // FileReaderLoaderClient
-    void didStartLoading() final { }
-    void didReceiveData() final { }
+    void NODELETE didStartLoading() final { }
+    void NODELETE didReceiveData() final { }
     void didFinishLoading() final
     {
         createImageBitmapAndCallCompletionHandlerSoon(m_blobLoader->arrayBufferResult());

--- a/Source/WebCore/html/ImageData.cpp
+++ b/Source/WebCore/html/ImageData.cpp
@@ -49,7 +49,7 @@ PredefinedColorSpace ImageData::computeColorSpace(std::optional<ImageDataSetting
     return defaultColorSpace;
 }
 
-static ImageDataPixelFormat computePixelFormat(std::optional<ImageDataSettings> settings, ImageDataPixelFormat defaultPixelFormat = ImageDataPixelFormat::RgbaUnorm8)
+static ImageDataPixelFormat NODELETE computePixelFormat(std::optional<ImageDataSettings> settings, ImageDataPixelFormat defaultPixelFormat = ImageDataPixelFormat::RgbaUnorm8)
 {
     return settings ? settings->pixelFormat : defaultPixelFormat;
 }

--- a/Source/WebCore/html/ImageData.h
+++ b/Source/WebCore/html/ImageData.h
@@ -58,7 +58,7 @@ public:
 
     WEBCORE_EXPORT ~ImageData();
 
-    static PredefinedColorSpace computeColorSpace(std::optional<ImageDataSettings>, PredefinedColorSpace defaultColorSpace = PredefinedColorSpace::SRGB);
+    static PredefinedColorSpace NODELETE computeColorSpace(std::optional<ImageDataSettings>, PredefinedColorSpace defaultColorSpace = PredefinedColorSpace::SRGB);
 
     const IntSize& size() const { return m_size; }
 

--- a/Source/WebCore/html/ImageDataArray.cpp
+++ b/Source/WebCore/html/ImageDataArray.cpp
@@ -36,10 +36,10 @@
 
 // Needed for `downcast` below.
 SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Uint8ClampedArray)
-    static bool isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeUint8Clamped; }
+    static bool NODELETE isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeUint8Clamped; }
 SPECIALIZE_TYPE_TRAITS_END()
 SPECIALIZE_TYPE_TRAITS_BEGIN(JSC::Float16Array)
-    static bool isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeFloat16; }
+    static bool NODELETE isType(const JSC::ArrayBufferView& arrayBufferView) { return arrayBufferView.getType() == JSC::TypeFloat16; }
 SPECIALIZE_TYPE_TRAITS_END()
 
 namespace WebCore {

--- a/Source/WebCore/html/ImageDataArray.h
+++ b/Source/WebCore/html/ImageDataArray.h
@@ -39,7 +39,7 @@ namespace WebCore {
 class ImageDataArray {
 public:
     static constexpr bool isSupported(JSC::TypedArrayType type) { return !!toImageDataPixelFormat(type); }
-    static bool isSupported(const JSC::ArrayBufferView&);
+    static bool NODELETE isSupported(const JSC::ArrayBufferView&);
 
     ImageDataArray(Ref<JSC::Uint8ClampedArray>&&);
     ImageDataArray(Ref<JSC::Float16Array>&&);
@@ -47,7 +47,7 @@ public:
 
     static std::optional<ImageDataArray> tryCreate(size_t, ImageDataPixelFormat, std::span<const uint8_t> = { });
 
-    ImageDataPixelFormat pixelFormat() const;
+    ImageDataPixelFormat NODELETE pixelFormat() const;
     size_t length() const;
 
     JSC::ArrayBufferView& arrayBufferView() const { return m_arrayBufferView.get(); }

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -206,14 +206,14 @@ void ImageDocument::finishedParsing()
     HTMLDocument::finishedParsing();
 }
 
-inline ImageDocument& ImageDocumentParser::document() const
+inline ImageDocument& NODELETE ImageDocumentParser::document() const
 {
     // Only used during parsing, so document is guaranteed to be non-null.
     ASSERT(RawDataDocumentParser::document());
     return downcast<ImageDocument>(*RawDataDocumentParser::document());
 }
 
-inline Ref<ImageDocument> ImageDocumentParser::protectedDocument() const
+inline Ref<ImageDocument> NODELETE ImageDocumentParser::protectedDocument() const
 {
     return document();
 }

--- a/Source/WebCore/html/InputMode.h
+++ b/Source/WebCore/html/InputMode.h
@@ -46,14 +46,14 @@ const AtomString& stringForInputMode(InputMode);
 
 namespace InputModeNames {
 
-const AtomString& none();
-const AtomString& text();
-const AtomString& tel();
-const AtomString& url();
-const AtomString& email();
+const AtomString& NODELETE none();
+const AtomString& NODELETE text();
+const AtomString& NODELETE tel();
+const AtomString& NODELETE url();
+const AtomString& NODELETE email();
 const AtomString& numeric();
 const AtomString& decimal();
-const AtomString& search();
+const AtomString& NODELETE search();
 
 } // namespace InputModeNames
 

--- a/Source/WebCore/html/InputType.cpp
+++ b/Source/WebCore/html/InputType.cpp
@@ -736,12 +736,12 @@ bool InputType::rendererIsNeeded()
     return true;
 }
 
-ValueOrReference<String> InputType::fallbackValue() const
+ValueOrReference<String> NODELETE InputType::fallbackValue() const
 {
     return String();
 }
 
-String InputType::defaultValue() const
+String NODELETE InputType::defaultValue() const
 {
     return String();
 }

--- a/Source/WebCore/html/InputType.h
+++ b/Source/WebCore/html/InputType.h
@@ -205,9 +205,9 @@ public:
 
     Type type() const { return m_type; }
 
-    bool isInteractiveContent() const;
-    bool isLabelable() const;
-    bool isEnumeratable() const;
+    bool NODELETE isInteractiveContent() const;
+    bool NODELETE isLabelable() const;
+    bool NODELETE isEnumeratable() const;
     bool needsShadowSubtree() const { return !nonShadowRootTypes.contains(m_type) || isSwitch(); }
     bool hasCreatedShadowSubtree() const { return m_hasCreatedShadowSubtree; }
 
@@ -217,7 +217,7 @@ public:
 
     // Form value functions.
 
-    virtual bool shouldSaveAndRestoreFormControlState() const;
+    virtual bool NODELETE shouldSaveAndRestoreFormControlState() const;
     virtual FormControlState saveFormControlState() const;
     virtual void restoreFormControlState(const FormControlState&);
     virtual bool isFormDataAppendable() const;
@@ -238,7 +238,7 @@ public:
 
     virtual String validationMessage() const;
     virtual bool typeMismatchFor(const String&) const { return false; }
-    virtual bool supportsRequired() const;
+    virtual bool NODELETE supportsRequired() const;
     virtual bool valueMissing(const String&) const { return false; }
     virtual bool hasBadInput() const { return false; }
     virtual bool patternMismatch(const String&) const { return false; }
@@ -259,7 +259,7 @@ public:
     virtual String badInputText() const;
     virtual String typeMismatchText() const;
     virtual String valueMissingText() const;
-    virtual bool canSetStringValue() const;
+    virtual bool NODELETE canSetStringValue() const;
     virtual String localizeValue(const String&) const;
     virtual String visibleValue() const;
     virtual bool isEmptyValue() const;
@@ -281,7 +281,7 @@ public:
     virtual void handleDOMActivateEvent(Event&) { }
     virtual void handleAccessibilityActivation() { }
 
-    virtual bool allowsShowPickerAcrossFrames();
+    virtual bool NODELETE allowsShowPickerAcrossFrames();
     virtual void showPicker();
 
     enum ShouldCallBaseEventHandler : bool { No, Yes };
@@ -299,14 +299,14 @@ public:
     // Helpers for event handlers.
 
     virtual bool shouldSubmitImplicitly(Event&);
-    virtual bool hasCustomFocusLogic() const;
+    virtual bool NODELETE hasCustomFocusLogic() const;
     virtual bool isKeyboardFocusable(const FocusEventData&) const;
     virtual bool isMouseFocusable() const;
-    virtual bool shouldUseInputMethod() const;
+    virtual bool NODELETE shouldUseInputMethod() const;
     virtual void handleFocusEvent(Node* oldFocusedNode, FocusDirection);
     virtual void handleBlurEvent();
     virtual bool accessKeyAction(bool sendMouseEvents);
-    virtual bool canBeSuccessfulSubmitButton();
+    virtual bool NODELETE canBeSuccessfulSubmitButton();
     virtual void subtreeHasChanged();
     virtual void blur();
 
@@ -327,27 +327,27 @@ public:
     virtual HTMLElement* cancelButtonElement() const { return nullptr; }
     virtual HTMLElement* sliderThumbElement() const { return nullptr; }
     virtual HTMLElement* sliderTrackElement() const { return nullptr; }
-    virtual HTMLElement* placeholderElement() const;
+    virtual HTMLElement* NODELETE placeholderElement() const;
     virtual HTMLElement* dataListButtonElement() const { return nullptr; }
     RefPtr<TextControlInnerTextElement> innerTextElementCreatingShadowSubtreeIfNeeded();
 
     // Miscellaneous functions.
 
-    virtual bool rendererIsNeeded();
+    virtual bool NODELETE rendererIsNeeded();
     virtual RenderPtr<RenderElement> createInputRenderer(RenderStyle&&);
     virtual void addSearchResult();
     virtual void attach();
     virtual void detach();
-    virtual bool shouldRespectAlignAttribute();
-    virtual Icon* icon() const;
-    virtual bool shouldSendChangeEventAfterCheckedChanged();
-    virtual bool storesValueSeparateFromAttribute();
+    virtual bool NODELETE shouldRespectAlignAttribute();
+    virtual Icon* NODELETE icon() const;
+    virtual bool NODELETE shouldSendChangeEventAfterCheckedChanged();
+    virtual bool NODELETE storesValueSeparateFromAttribute();
     virtual void setValue(const String&, bool valueChanged, TextFieldEventBehavior, TextControlSetValueSelection);
-    virtual bool shouldResetOnDocumentActivation();
+    virtual bool NODELETE shouldResetOnDocumentActivation();
     virtual bool shouldRespectListAttribute() { return false; }
-    virtual bool shouldRespectHeightAndWidthAttributes();
-    virtual bool supportsPlaceholder() const;
-    virtual bool supportsReadOnly() const;
+    virtual bool NODELETE shouldRespectHeightAndWidthAttributes();
+    virtual bool NODELETE supportsPlaceholder() const;
+    virtual bool NODELETE supportsReadOnly() const;
     virtual void updateInnerTextValue();
     virtual void updatePlaceholderText();
     virtual void attributeChanged(const QualifiedName&) { }
@@ -358,9 +358,9 @@ public:
     virtual void updateAutoFillButton();
     virtual String defaultToolTip() const;
     virtual bool matchesIndeterminatePseudoClass() const;
-    virtual bool isPresentingAttachedView() const;
-    virtual bool supportsSelectionAPI() const;
-    virtual bool dirAutoUsesValue() const;
+    virtual bool NODELETE isPresentingAttachedView() const;
+    virtual bool NODELETE supportsSelectionAPI() const;
+    virtual bool NODELETE dirAutoUsesValue() const;
     virtual bool isFocusingWithDataListDropdown() const { return false; };
     virtual void willUpdateCheckedness(bool /*nowChecked*/, WasSetByJavaScript) { }
 
@@ -391,9 +391,9 @@ public:
     virtual bool receiveDroppedFiles(const DragData&);
 #endif
 
-    virtual DateComponentsType dateType() const;
+    virtual DateComponentsType NODELETE dateType() const;
 
-    virtual String displayString() const;
+    virtual String NODELETE displayString() const;
 
     virtual String resultForDialogSubmit() const;
 
@@ -405,7 +405,7 @@ protected:
     }
 
     HTMLInputElement* element() const { return m_element; }
-    Chrome* chrome() const;
+    Chrome* NODELETE chrome() const;
     Decimal parseToNumberOrNaN(const String&) const;
 
     // Derive the step base, following the HTML algorithm steps.

--- a/Source/WebCore/html/InputTypeNames.h
+++ b/Source/WebCore/html/InputTypeNames.h
@@ -26,12 +26,12 @@ namespace WebCore {
 
 namespace InputTypeNames {
 
-const AtomString& button();
+const AtomString& NODELETE button();
 const AtomString& checkbox();
 const AtomString& color();
 const AtomString& date();
 const AtomString& datetimelocal();
-const AtomString& email();
+const AtomString& NODELETE email();
 const AtomString& file();
 const AtomString& hidden();
 const AtomString& image();
@@ -40,13 +40,13 @@ const AtomString& number();
 const AtomString& password();
 const AtomString& radio();
 const AtomString& range();
-const AtomString& reset();
-const AtomString& search();
-const AtomString& submit();
-const AtomString& telephone();
-const AtomString& text();
+const AtomString& NODELETE reset();
+const AtomString& NODELETE search();
+const AtomString& NODELETE submit();
+const AtomString& NODELETE telephone();
+const AtomString& NODELETE text();
 const AtomString& time();
-const AtomString& url();
+const AtomString& NODELETE url();
 const AtomString& week();
 
 }

--- a/Source/WebCore/html/LazyLoadFrameObserver.cpp
+++ b/Source/WebCore/html/LazyLoadFrameObserver.cpp
@@ -53,7 +53,7 @@ private:
     {
     }
 
-    bool hasCallback() const final { return true; }
+    bool NODELETE hasCallback() const final { return true; }
 
     CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
     {

--- a/Source/WebCore/html/LazyLoadImageObserver.cpp
+++ b/Source/WebCore/html/LazyLoadImageObserver.cpp
@@ -51,7 +51,7 @@ private:
     {
     }
 
-    bool hasCallback() const final { return true; }
+    bool NODELETE hasCallback() const final { return true; }
 
     CallbackResult<void> invoke(IntersectionObserver&, const Vector<Ref<IntersectionObserverEntry>>& entries, IntersectionObserver&) final
     {

--- a/Source/WebCore/html/LinkIconCollector.cpp
+++ b/Source/WebCore/html/LinkIconCollector.cpp
@@ -38,7 +38,7 @@ namespace WebCore {
 
 constexpr unsigned defaultTouchIconWidth = 60;
 
-static unsigned iconSize(const LinkIcon& icon)
+static unsigned NODELETE iconSize(const LinkIcon& icon)
 {
     if (icon.size)
         return *icon.size;
@@ -49,7 +49,7 @@ static unsigned iconSize(const LinkIcon& icon)
     return 0;
 }
 
-static int compareIcons(const LinkIcon& a, const LinkIcon& b)
+static int NODELETE compareIcons(const LinkIcon& a, const LinkIcon& b)
 {
     // Apple Touch icons always come first.
     if (a.type == LinkIconType::Favicon && b.type != LinkIconType::Favicon)

--- a/Source/WebCore/html/MediaController.h
+++ b/Source/WebCore/html/MediaController.h
@@ -95,7 +95,7 @@ private:
     void bringElementUpToSpeed(HTMLMediaElement&);
     void scheduleEvent(const AtomString& eventName);
     void asyncEventTimerFired();
-    void clearPositionTimerFired();
+    void NODELETE clearPositionTimerFired();
     bool hasEnded() const;
     void scheduleTimeupdateEvent();
     void startTimeupdateTimer();

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -153,7 +153,7 @@ Ref<DocumentParser> MediaDocument::createParser()
     return MediaDocumentParser::create(*this);
 }
 
-static inline HTMLVideoElement* descendantVideoElement(ContainerNode& node)
+static inline HTMLVideoElement* NODELETE descendantVideoElement(ContainerNode& node)
 {
     if (auto* video = dynamicDowncast<HTMLVideoElement>(node))
         return video;

--- a/Source/WebCore/html/MediaElementSession.cpp
+++ b/Source/WebCore/html/MediaElementSession.cpp
@@ -149,7 +149,7 @@ public:
         m_mediaSession->removeObserver(*this);
     }
 
-    void ref() const final { RefCounted::ref(); }
+    void NODELETE ref() const final { RefCounted::ref(); }
     void deref() const final { RefCounted::deref(); }
 
     void metadataChanged(const RefPtr<MediaMetadata>& metadata) final

--- a/Source/WebCore/html/MediaElementSession.h
+++ b/Source/WebCore/html/MediaElementSession.h
@@ -111,7 +111,7 @@ public:
 #endif
 
     bool requiresFullscreenForVideoPlayback() const;
-    WEBCORE_EXPORT bool allowsPictureInPicture() const;
+    WEBCORE_EXPORT bool NODELETE allowsPictureInPicture() const;
     MediaPlayer::Preload effectivePreloadForElement() const;
     bool allowsAutomaticMediaDataLoading() const;
 
@@ -165,7 +165,7 @@ public:
     bool isLargeEnoughForMainContent(MediaSessionMainContentPurpose) const;
     bool isLongEnoughForMainContent() const final;
     bool isMainContentForPurposesOfAutoplayEvents() const;
-    Markable<MonotonicTime> mostRecentUserInteractionTime() const;
+    Markable<MonotonicTime> NODELETE mostRecentUserInteractionTime() const;
 
     bool allowsPlaybackControlsForAutoplayingAudio() const;
 
@@ -193,7 +193,7 @@ public:
 #endif
     void metadataChanged(const RefPtr<MediaMetadata>&);
     void positionStateChanged(const std::optional<MediaPositionState>&);
-    void playbackStateChanged(MediaSessionPlaybackState);
+    void NODELETE playbackStateChanged(MediaSessionPlaybackState);
     void actionHandlersChanged();
 
     MediaSession* mediaSession() const;

--- a/Source/WebCore/html/NumberInputType.cpp
+++ b/Source/WebCore/html/NumberInputType.cpp
@@ -341,32 +341,32 @@ String NumberInputType::serialize(const Decimal& value) const
     return serializeForNumberType(value);
 }
 
-static bool isE(char16_t ch)
+static bool NODELETE isE(char16_t ch)
 {
     return ch == 'e' || ch == 'E';
 }
 
-static bool isPlusSign(char16_t ch)
+static bool NODELETE isPlusSign(char16_t ch)
 {
     return ch == '+';
 }
 
-static bool isSignPrefix(char16_t ch)
+static bool NODELETE isSignPrefix(char16_t ch)
 {
     return ch == '+' || ch == '-';
 }
 
-static bool isDigit(char16_t ch)
+static bool NODELETE isDigit(char16_t ch)
 {
     return ch >= '0' && ch <= '9';
 }
 
-static bool isDecimalSeparator(char16_t ch)
+static bool NODELETE isDecimalSeparator(char16_t ch)
 {
     return ch == '.';
 }
 
-static bool hasTwoSignChars(const String& string)
+static bool NODELETE hasTwoSignChars(const String& string)
 {
     unsigned count = 0;
     for (unsigned i = 0; i < string.length(); ++i) {
@@ -384,7 +384,7 @@ static bool hasDecimalSeparator(const String& string)
     return string.find('.') != notFound;
 }
 
-static bool hasSignNotAfterE(const String& string)
+static bool NODELETE hasSignNotAfterE(const String& string)
 {
     for (unsigned i = 0; i < string.length(); ++i) {
         if (isSignPrefix(string[i]))

--- a/Source/WebCore/html/OffscreenCanvas.cpp
+++ b/Source/WebCore/html/OffscreenCanvas.cpp
@@ -173,7 +173,7 @@ void OffscreenCanvas::didUpdateSizeProperties(bool sizeChanged)
 }
 
 #if ENABLE(WEBGL)
-static bool requiresAcceleratedCompositingForWebGL()
+static bool NODELETE requiresAcceleratedCompositingForWebGL()
 {
 #if PLATFORM(GTK) || PLATFORM(WIN)
     return false;
@@ -182,7 +182,7 @@ static bool requiresAcceleratedCompositingForWebGL()
 #endif
 }
 
-static bool shouldEnableWebGL(const SettingsValues& settings, bool isWorker)
+static bool NODELETE shouldEnableWebGL(const SettingsValues& settings, bool isWorker)
 {
     if (!settings.webGLEnabled)
         return false;

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -89,7 +89,7 @@ public:
     WEBCORE_EXPORT ~DetachedOffscreenCanvas();
     const IntSize& size() const { return m_size; }
     bool originClean() const { return m_originClean; }
-    RefPtr<PlaceholderRenderingContextSource> takePlaceholderSource();
+    RefPtr<PlaceholderRenderingContextSource> NODELETE takePlaceholderSource();
 
 private:
     RefPtr<PlaceholderRenderingContextSource> m_placeholderSource;
@@ -144,7 +144,7 @@ public:
 
     SecurityOrigin* securityOrigin() const final;
 
-    bool canDetach() const;
+    bool NODELETE canDetach() const;
     std::unique_ptr<DetachedOffscreenCanvas> detach();
 
     void commitToPlaceholderCanvas();

--- a/Source/WebCore/html/Origin.h
+++ b/Source/WebCore/html/Origin.h
@@ -45,7 +45,7 @@ public:
 
     static ExceptionOr<Ref<Origin>> from(ScriptExecutionContext&, JSC::JSValue);
 
-    bool opaque() const;
+    bool NODELETE opaque() const;
 
     bool isSameOrigin(const Origin&) const;
     bool isSameSite(const Origin&) const;

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -380,7 +380,7 @@ PermissionsPolicy::PolicyDirective PermissionsPolicy::processPermissionsPolicyAt
 }
 
 // https://w3c.github.io/webappsec-permissions-policy/#algo-get-feature-value-for-origin
-static bool featureValueForOrigin(PermissionsPolicy::Feature feature, const PermissionsPolicy& documentPermissionsPolicy, const SecurityOriginData&)
+static bool NODELETE featureValueForOrigin(PermissionsPolicy::Feature feature, const PermissionsPolicy& documentPermissionsPolicy, const SecurityOriginData&)
 {
     // Declared policy is not implemented yet, so origin is unused.
     return documentPermissionsPolicy.inheritedPolicyValueForFeature(feature);

--- a/Source/WebCore/html/PermissionsPolicy.h
+++ b/Source/WebCore/html/PermissionsPolicy.h
@@ -75,7 +75,7 @@ public:
     };
     enum class ShouldReportViolation : bool { No, Yes };
     static bool isFeatureEnabled(Feature, const Document&, ShouldReportViolation = ShouldReportViolation::Yes);
-    bool inheritedPolicyValueForFeature(Feature) const;
+    bool NODELETE inheritedPolicyValueForFeature(Feature) const;
 
     // InheritedPolicy contains enabled features.
     using InheritedPolicy = HashSet<Feature, IntHash<Feature>, WTF::StrongEnumHashTraits<Feature>>;

--- a/Source/WebCore/html/PluginDocument.h
+++ b/Source/WebCore/html/PluginDocument.h
@@ -44,7 +44,7 @@ public:
 
     virtual ~PluginDocument();
 
-    WEBCORE_EXPORT PluginViewBase* pluginWidget();
+    WEBCORE_EXPORT PluginViewBase* NODELETE pluginWidget();
     HTMLPlugInElement* pluginElement() { return m_pluginElement.get(); }
 
     void setPluginElement(HTMLPlugInElement&);

--- a/Source/WebCore/html/TextFieldInputType.h
+++ b/Source/WebCore/html/TextFieldInputType.h
@@ -68,7 +68,7 @@ protected:
     HTMLElement* NODELETE autoFillButtonElement() const final;
     HTMLElement* NODELETE dataListButtonElement() const final;
 
-    virtual bool needsContainer() const;
+    virtual bool NODELETE needsContainer() const;
     void createShadowSubtree() override;
     void removeShadowSubtree() override;
     void attributeChanged(const QualifiedName&) override;

--- a/Source/WebCore/html/TimeRanges.h
+++ b/Source/WebCore/html/TimeRanges.h
@@ -45,7 +45,7 @@ public:
     WEBCORE_EXPORT void intersectWith(const TimeRanges&);
     void unionWith(const TimeRanges&);
     
-    WEBCORE_EXPORT unsigned length() const;
+    WEBCORE_EXPORT unsigned NODELETE length() const;
 
     WEBCORE_EXPORT void add(double start, double end, AddTimeRangeOption = AddTimeRangeOption::None);
     bool contain(double time) const;

--- a/Source/WebCore/html/URLRegistry.cpp
+++ b/Source/WebCore/html/URLRegistry.cpp
@@ -36,7 +36,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(URLRegistry);
 
 static Lock allRegistriesLock;
-static Vector<URLRegistry*>& allRegistries() WTF_REQUIRES_LOCK(allRegistriesLock)
+static Vector<URLRegistry*>& NODELETE allRegistries() WTF_REQUIRES_LOCK(allRegistriesLock)
 {
     static NeverDestroyed<Vector<URLRegistry*>> list;
     return list;

--- a/Source/WebCore/html/URLSearchParams.h
+++ b/Source/WebCore/html/URLSearchParams.h
@@ -60,7 +60,7 @@ public:
     class Iterator {
     public:
         explicit Iterator(URLSearchParams&);
-        std::optional<KeyValuePair<String, String>> next();
+        std::optional<KeyValuePair<String, String>> NODELETE next();
 
     private:
         const Ref<URLSearchParams> m_target;

--- a/Source/WebCore/html/UserActivation.h
+++ b/Source/WebCore/html/UserActivation.h
@@ -48,7 +48,7 @@ public:
 private:
     explicit UserActivation(Navigator&);
 
-    LocalDOMWindow* window() const;
+    LocalDOMWindow* NODELETE window() const;
 
     WeakPtr<Navigator> m_navigator;
 };

--- a/Source/WebCore/html/ValidatedFormListedElement.h
+++ b/Source/WebCore/html/ValidatedFormListedElement.h
@@ -59,7 +59,7 @@ public:
     void reportNonFocusableControlError();
     WEBCORE_EXPORT void focusAndShowValidationMessage(Ref<HTMLElement> validationAnchor);
     bool isShowingValidationMessage() const;
-    WEBCORE_EXPORT bool isFocusingWithValidationMessage() const;
+    WEBCORE_EXPORT bool NODELETE isFocusingWithValidationMessage() const;
     // This must be called when a validation constraint or control value is changed.
     void updateValidity();
     WEBCORE_EXPORT void setCustomValidity(const String&) override;
@@ -99,7 +99,7 @@ protected:
     void updateWillValidateAndValidity();
     bool disabledByAncestorFieldset() const { return m_disabledByAncestorFieldset; }
 
-    bool validationMessageShadowTreeContains(const Node&) const;
+    bool NODELETE validationMessageShadowTreeContains(const Node&) const;
 
     void insertedIntoAncestor(Node::InsertionType, ContainerNode&);
     void didFinishInsertingNode();
@@ -116,7 +116,7 @@ protected:
     void formWillBeDestroyed() final;
     bool belongsToFormThatIsBeingDestroyed() const { return m_belongsToFormThatIsBeingDestroyed; }
 
-    void setDataListAncestorState(TriState);
+    void NODELETE setDataListAncestorState(TriState);
     void syncWithFieldsetAncestors(ContainerNode* insertionNode);
     void restoreFormControlStateIfNecessary();
 

--- a/Source/WebCore/html/ValidationMessage.h
+++ b/Source/WebCore/html/ValidationMessage.h
@@ -59,13 +59,13 @@ public:
     void updateValidationMessage(HTMLElement&, const String&);
     void requestToHideMessage();
     bool isVisible() const;
-    bool shadowTreeContains(const Node&) const;
+    bool NODELETE shadowTreeContains(const Node&) const;
     void adjustBubblePosition();
 
 private:
     explicit ValidationMessage(HTMLElement&);
 
-    ValidationMessageClient* validationMessageClient() const;
+    ValidationMessageClient* NODELETE validationMessageClient() const;
     void setMessage(String&&);
     void setMessageDOMAndStartTimer();
     void buildBubbleTree();

--- a/Source/WebCore/html/canvas/CanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext.h
@@ -57,10 +57,10 @@ class CanvasRenderingContext : public ScriptWrappable, public CanMakeWeakPtr<Can
 public:
     virtual ~CanvasRenderingContext();
 
-    static HashSet<CanvasRenderingContext*>& instances() WTF_REQUIRES_LOCK(instancesLock());
-    static Lock& instancesLock() WTF_RETURNS_LOCK(s_instancesLock);
+    static HashSet<CanvasRenderingContext*>& NODELETE instances() WTF_REQUIRES_LOCK(instancesLock());
+    static Lock& NODELETE instancesLock() WTF_RETURNS_LOCK(s_instancesLock);
 
-    WEBCORE_EXPORT void ref() const;
+    WEBCORE_EXPORT void NODELETE ref() const;
     WEBCORE_EXPORT void deref() const;
 
     CanvasBase& canvasBase() const { return m_canvas; }
@@ -96,7 +96,7 @@ public:
     // Draws the source buffer to the canvasBase().buffer().
     virtual RefPtr<ImageBuffer> surfaceBufferToImageBuffer(SurfaceBuffer) = 0;
     virtual bool isSurfaceBufferTransparentBlack(SurfaceBuffer) const = 0;
-    bool delegatesDisplay() const;
+    bool NODELETE delegatesDisplay() const;
     virtual RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate();
     virtual void setContentsToLayer(GraphicsLayer&);
 
@@ -120,7 +120,7 @@ public:
     virtual PixelFormat pixelFormat() const;
     virtual DestinationColorSpace colorSpace() const;
     virtual bool isOpaque() const;
-    virtual bool willReadFrequently() const;
+    virtual bool NODELETE willReadFrequently() const;
     virtual std::optional<RenderingMode> renderingModeForTesting() const { return std::nullopt; }
 
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
@@ -133,9 +133,9 @@ public:
     bool isInPreparationForDisplayOrFlush() const { return m_isInPreparationForDisplayOrFlush; }
 
     void updateMemoryCost(size_t newMemoryCost) const;
-    size_t memoryCost() const;
+    size_t NODELETE memoryCost() const;
 #if ENABLE(RESOURCE_USAGE)
-    size_t externalMemoryCost() const;
+    size_t NODELETE externalMemoryCost() const;
 #endif
 
 protected:
@@ -151,7 +151,7 @@ protected:
     };
 
     explicit CanvasRenderingContext(CanvasBase&, Type);
-    bool taintsOrigin(const CanvasPattern*);
+    bool NODELETE taintsOrigin(const CanvasPattern*);
     bool taintsOrigin(const CanvasBase*);
     bool taintsOrigin(const CachedImage*);
     bool taintsOrigin(const HTMLImageElement*);

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp
@@ -111,7 +111,7 @@ static constexpr ASCIILiteral DefaultFont = "10px sans-serif"_s;
 // putImageData data smaller than this is cached in anticipation for next getImageData.
 static constexpr unsigned putImageDataCacheAreaLimit = 60 * 60;
 
-static CanvasLineCap toCanvasLineCap(LineCap lineCap)
+static CanvasLineCap NODELETE toCanvasLineCap(LineCap lineCap)
 {
     switch (lineCap) {
     case LineCap::Butt:
@@ -125,7 +125,7 @@ static CanvasLineCap toCanvasLineCap(LineCap lineCap)
     return CanvasLineCap::Butt;
 }
 
-static LineCap fromCanvasLineCap(CanvasLineCap canvasLineCap)
+static LineCap NODELETE fromCanvasLineCap(CanvasLineCap canvasLineCap)
 {
     switch (canvasLineCap) {
     case CanvasLineCap::Butt:
@@ -139,7 +139,7 @@ static LineCap fromCanvasLineCap(CanvasLineCap canvasLineCap)
     return LineCap::Butt;
 }
 
-static CanvasLineJoin toCanvasLineJoin(LineJoin lineJoin)
+static CanvasLineJoin NODELETE toCanvasLineJoin(LineJoin lineJoin)
 {
     switch (lineJoin) {
     case LineJoin::Round:
@@ -153,7 +153,7 @@ static CanvasLineJoin toCanvasLineJoin(LineJoin lineJoin)
     return CanvasLineJoin::Round;
 }
 
-static LineJoin fromCanvasLineJoin(CanvasLineJoin canvasLineJoin)
+static LineJoin NODELETE fromCanvasLineJoin(CanvasLineJoin canvasLineJoin)
 {
     switch (canvasLineJoin) {
     case CanvasLineJoin::Round:
@@ -167,7 +167,7 @@ static LineJoin fromCanvasLineJoin(CanvasLineJoin canvasLineJoin)
     return LineJoin::Round;
 }
 
-static CanvasTextAlign toCanvasTextAlign(TextAlign textAlign)
+static CanvasTextAlign NODELETE toCanvasTextAlign(TextAlign textAlign)
 {
     switch (textAlign) {
     case StartTextAlign:
@@ -185,7 +185,7 @@ static CanvasTextAlign toCanvasTextAlign(TextAlign textAlign)
     return CanvasTextAlign::Start;
 }
 
-static TextAlign fromCanvasTextAlign(CanvasTextAlign canvasTextAlign)
+static TextAlign NODELETE fromCanvasTextAlign(CanvasTextAlign canvasTextAlign)
 {
     switch (canvasTextAlign) {
     case CanvasTextAlign::Start:
@@ -203,7 +203,7 @@ static TextAlign fromCanvasTextAlign(CanvasTextAlign canvasTextAlign)
     return StartTextAlign;
 }
 
-static CanvasTextBaseline toCanvasTextBaseline(TextBaseline textBaseline)
+static CanvasTextBaseline NODELETE toCanvasTextBaseline(TextBaseline textBaseline)
 {
     switch (textBaseline) {
     case TopTextBaseline:
@@ -223,7 +223,7 @@ static CanvasTextBaseline toCanvasTextBaseline(TextBaseline textBaseline)
     return CanvasTextBaseline::Top;
 }
 
-static TextBaseline fromCanvasTextBaseline(CanvasTextBaseline canvasTextBaseline)
+static TextBaseline NODELETE fromCanvasTextBaseline(CanvasTextBaseline canvasTextBaseline)
 {
     switch (canvasTextBaseline) {
     case CanvasTextBaseline::Top:
@@ -1100,7 +1100,7 @@ static bool validateRectForCanvas(double& x, double& y, double& width, double& h
     return true;
 }
 
-static bool isFullCanvasCompositeMode(CompositeOperator op)
+static bool NODELETE isFullCanvasCompositeMode(CompositeOperator op)
 {
     // See 4.8.11.1.3 Compositing
     // CompositeOperator::SourceAtop and CompositeOperator::DestinationOut are not listed here as the platforms already
@@ -1108,7 +1108,7 @@ static bool isFullCanvasCompositeMode(CompositeOperator op)
     return op == CompositeOperator::SourceIn || op == CompositeOperator::SourceOut || op == CompositeOperator::DestinationIn || op == CompositeOperator::DestinationAtop;
 }
 
-static WindRule toWindRule(CanvasFillRule rule)
+static WindRule NODELETE toWindRule(CanvasFillRule rule)
 {
     return rule == CanvasFillRule::Nonzero ? WindRule::NonZero : WindRule::EvenOdd;
 }
@@ -1544,7 +1544,7 @@ static LayoutSize size(SVGImageElement& element, ImageSizeType sizeType = ImageS
     return size(element.cachedImage(), protect(element.renderer()).get(), sizeType);
 }
 
-static inline FloatSize size(CanvasBase& canvas)
+static inline FloatSize NODELETE size(CanvasBase& canvas)
 {
     return canvas.size();
 }
@@ -2723,7 +2723,7 @@ FloatRect CanvasRenderingContext2DBase::inflatedStrokeRect(const FloatRect& rect
     return inflatedStrokeRect;
 }
 
-static inline InterpolationQuality smoothingToInterpolationQuality(ImageSmoothingQuality quality)
+static inline InterpolationQuality NODELETE smoothingToInterpolationQuality(ImageSmoothingQuality quality)
 {
     switch (quality) {
     case ImageSmoothingQuality::Low:
@@ -2829,7 +2829,7 @@ bool CanvasRenderingContext2DBase::canDrawText(double x, double y, bool fill, st
     return true;
 }
 
-static inline bool isSpaceThatNeedsReplacing(char16_t c)
+static inline bool NODELETE isSpaceThatNeedsReplacing(char16_t c)
 {
     // According to specification all space characters should be replaced with 0x0020 space character.
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-canvas-element.html#text-preparation-algorithm
@@ -3153,7 +3153,7 @@ std::optional<CanvasRenderingContext2DBase::RenderingMode> CanvasRenderingContex
 
 // FIXME: The HTML spec currently doesn't define how <length> units should be resolved, so we only
 // allow units where the resolution is straightforward. See https://github.com/whatwg/html/issues/10893.
-static bool unitAllowedForSpacing(CSS::LengthUnit lenghtUnit)
+static bool NODELETE unitAllowedForSpacing(CSS::LengthUnit lenghtUnit)
 {
     using enum CSS::LengthUnit;
 

--- a/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
+++ b/Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h
@@ -266,7 +266,7 @@ public:
         bool realized() const { return m_font.fontSelector(); }
         void initialize(FontSelector&, const FontCascade&);
         const FontMetrics& metricsOfPrimaryFont() const;
-        const FontCascadeDescription& fontDescription() const;
+        const FontCascadeDescription& NODELETE fontDescription() const;
         float width(const TextRun&, GlyphOverflow* = 0) const;
         void drawBidiText(GraphicsContext&, const TextRun&, const FloatPoint&, FontCascade::CustomFontNotReadyAction) const;
 
@@ -327,10 +327,10 @@ public:
 
         RefPtr<CanvasLayerContextSwitcher> targetSwitcher;
 
-        CanvasLineCap canvasLineCap() const;
-        CanvasLineJoin canvasLineJoin() const;
-        CanvasTextAlign canvasTextAlign() const;
-        CanvasTextBaseline canvasTextBaseline() const;
+        CanvasLineCap NODELETE canvasLineCap() const;
+        CanvasLineJoin NODELETE canvasLineJoin() const;
+        CanvasTextAlign NODELETE canvasTextAlign() const;
+        CanvasTextBaseline NODELETE canvasTextBaseline() const;
         String fontString() const;
         String globalCompositeOperationString() const;
         String shadowColorString() const;

--- a/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
+++ b/Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h
@@ -44,7 +44,7 @@ public:
 protected:
     explicit GPUBasedCanvasRenderingContext(CanvasBase&, CanvasRenderingContext::Type);
 
-    HTMLCanvasElement* htmlCanvas() const;
+    HTMLCanvasElement* NODELETE htmlCanvas() const;
     void markCanvasChanged();
 };
     

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -68,7 +68,7 @@ public:
         } else
             layer.clearContents();
     }
-    GraphicsLayerCompositingCoordinatesOrientation orientation() const final
+    GraphicsLayerCompositingCoordinatesOrientation NODELETE orientation() const final
     {
         return GraphicsLayerCompositingCoordinatesOrientation::TopDown;
     }
@@ -84,11 +84,11 @@ public:
 
         m_displayBuffer = MachSendRight { displayBuffer };
     }
-    void setContentsFormat(ContentsFormat contentsFormat)
+    void NODELETE setContentsFormat(ContentsFormat contentsFormat)
     {
         m_contentsFormat = contentsFormat;
     }
-    void setOpaque(bool opaque)
+    void NODELETE setOpaque(bool opaque)
     {
         m_isOpaque = opaque;
     }
@@ -404,7 +404,7 @@ static DestinationColorSpace toWebCoreColorSpace(const GPUPredefinedColorSpace& 
     return DestinationColorSpace::SRGB();
 }
 
-static WebGPU::TextureFormat computeTextureFormat(GPUTextureFormat format, GPUCanvasToneMappingMode toneMappingMode)
+static WebGPU::TextureFormat NODELETE computeTextureFormat(GPUTextureFormat format, GPUCanvasToneMappingMode toneMappingMode)
 {
     // Force Bgra8unorm to both: clamp color values to SDR, and opt out of CALayer HDR.
     if (format == GPUTextureFormat::Rgba16float && toneMappingMode == GPUCanvasToneMappingMode::Standard)
@@ -413,7 +413,7 @@ static WebGPU::TextureFormat computeTextureFormat(GPUTextureFormat format, GPUCa
     return WebCore::convertToBacking(format);
 }
 
-static bool isSupportedContextFormat(GPUTextureFormat format)
+static bool NODELETE isSupportedContextFormat(GPUTextureFormat format)
 {
     return format == GPUTextureFormat::Bgra8unorm || format == GPUTextureFormat::Rgba8unorm || format == GPUTextureFormat::Rgba16float;
 }

--- a/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h
@@ -44,7 +44,7 @@ public:
     OffscreenCanvas& canvas() const { return downcast<OffscreenCanvas>(canvasBase()); }
 
     void setFont(const String&);
-    CanvasDirection direction() const;
+    CanvasDirection NODELETE direction() const;
     void fillText(const String& text, double x, double y, std::optional<double> maxWidth = std::nullopt);
     void strokeText(const String& text, double x, double y, std::optional<double> maxWidth = std::nullopt);
     Ref<TextMetrics> measureText(const String& text);

--- a/Source/WebCore/html/canvas/PaintRenderingContext2D.h
+++ b/Source/WebCore/html/canvas/PaintRenderingContext2D.h
@@ -45,9 +45,9 @@ public:
     virtual ~PaintRenderingContext2D();
 
     GraphicsContext* drawingContext() const;
-    AffineTransform baseTransform() const;
+    AffineTransform NODELETE baseTransform() const;
 
-    CustomPaintCanvas& canvas() const;
+    CustomPaintCanvas& NODELETE canvas() const;
     void replayDisplayList(GraphicsContext& target) const;
 
 protected:

--- a/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
+++ b/Source/WebCore/html/canvas/PlaceholderRenderingContext.h
@@ -66,8 +66,8 @@ class PlaceholderRenderingContext final : public CanvasRenderingContext {
 public:
     static std::unique_ptr<PlaceholderRenderingContext> create(HTMLCanvasElement&);
 
-    HTMLCanvasElement& canvas() const;
-    IntSize size() const;
+    HTMLCanvasElement& NODELETE canvas() const;
+    IntSize NODELETE size() const;
     void setPlaceholderBuffer(Ref<ImageBuffer>&&, bool originClean, bool opaque);
 
     PlaceholderRenderingContextSource& source() const { return m_source; }

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -2153,7 +2153,7 @@ void WebGL2RenderingContext::bindTransformFeedback(GCGLenum target, WebGLTransfo
     m_boundTransformFeedback = toBeBound;
 }
 
-static bool ValidateTransformFeedbackPrimitiveMode(GCGLenum mode)
+static bool NODELETE ValidateTransformFeedbackPrimitiveMode(GCGLenum mode)
 {
     switch (mode) {
     case GraphicsContextGL::POINTS:
@@ -2740,7 +2740,7 @@ std::optional<Vector<String>> WebGL2RenderingContext::getSupportedExtensions()
     return result;
 }
 
-static bool validateDefaultFramebufferAttachment(GCGLenum attachment)
+static bool NODELETE validateDefaultFramebufferAttachment(GCGLenum attachment)
 {
     switch (attachment) {
     case GraphicsContextGL::BACK:

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.h
@@ -251,13 +251,13 @@ public:
     void readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, GCGLintptr offset);
     void readPixels(GCGLint x, GCGLint y, GCGLsizei width, GCGLsizei height, GCGLenum format, GCGLenum type, ArrayBufferView& dstData, GCGLuint dstOffset);
 
-    GCGLuint maxTransformFeedbackSeparateAttribs() const;
+    GCGLuint NODELETE maxTransformFeedbackSeparateAttribs() const;
 
     bool checkAndTranslateAttachments(ASCIILiteral functionName, GCGLenum, Vector<GCGLenum>&);
 
     void addMembersToOpaqueRoots(JSC::AbstractSlotVisitor&) override;
 
-    bool isTransformFeedbackActiveAndNotPaused();
+    bool NODELETE isTransformFeedbackActiveAndNotPaused();
 
 private:
     using WebGLRenderingContextBase::WebGLRenderingContextBase;
@@ -290,7 +290,7 @@ private:
 
     bool setIndexedBufferBinding(ASCIILiteral functionName, GCGLenum target, GCGLuint index, WebGLBuffer*);
 
-    IntRect getTextureSourceSubRectangle(GCGLsizei width, GCGLsizei height);
+    IntRect NODELETE getTextureSourceSubRectangle(GCGLsizei width, GCGLsizei height);
 
     RefPtr<WebGLTexture> validateTexImageBinding(TexImageFunctionID, GCGLenum) final;
 

--- a/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h
@@ -45,9 +45,9 @@ public:
     IntSize size() const;
     void reshape(IntSize);
     GCGLbitfield dirtyBuffers() const { return m_dirtyBuffers; }
-    void markBuffersClear(GCGLbitfield clearBuffers);
-    void markAllUnpreservedBuffersDirty();
-    void markAllBuffersDirty();
+    void NODELETE markBuffersClear(GCGLbitfield clearBuffers);
+    void NODELETE markAllUnpreservedBuffersDirty();
+    void NODELETE markAllBuffersDirty();
 
 private:
     WebGLDefaultFramebuffer(WebGLRenderingContextBase&);

--- a/Source/WebCore/html/canvas/WebGLFramebuffer.h
+++ b/Source/WebCore/html/canvas/WebGLFramebuffer.h
@@ -90,7 +90,7 @@ public:
     // Apply m_filteredDrawBuffers to GL state if pending sync is needed.
     void applyFilteredDrawBuffers();
 
-    GCGLenum getDrawBuffer(GCGLenum);
+    GCGLenum NODELETE getDrawBuffer(GCGLenum);
 
     void addMembersToOpaqueRoots(const AbstractLocker&, JSC::AbstractSlotVisitor&);
 

--- a/Source/WebCore/html/canvas/WebGLObject.h
+++ b/Source/WebCore/html/canvas/WebGLObject.h
@@ -86,7 +86,7 @@ class WebGLObject : public RefCounted<WebGLObject> {
 public:
     virtual ~WebGLObject();
 
-    RefPtr<WebGLRenderingContextBase> context() const;
+    RefPtr<WebGLRenderingContextBase> NODELETE context() const;
     RefPtr<GraphicsContextGL> graphicsContextGL() const;
 
     PlatformGLObject object() const { return m_object; }
@@ -132,7 +132,7 @@ PlatformGLObject objectOrZero(const T& object)
     return object ? object->object() : 0;
 }
 
-WebCoreOpaqueRoot root(WebGLObject*);
+WebCoreOpaqueRoot NODELETE root(WebGLObject*);
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/canvas/WebGLProgram.h
+++ b/Source/WebCore/html/canvas/WebGLProgram.h
@@ -59,8 +59,8 @@ public:
     void ref() const final { WebGLObject::ref(); }
     void deref() const final { WebGLObject::deref(); }
 
-    static HashMap<WebGLProgram*, WebGLRenderingContextBase*>& instances() WTF_REQUIRES_LOCK(instancesLock());
-    static Lock& instancesLock() WTF_RETURNS_LOCK(s_instancesLock);
+    static HashMap<WebGLProgram*, WebGLRenderingContextBase*>& NODELETE instances() WTF_REQUIRES_LOCK(instancesLock());
+    static Lock& NODELETE instancesLock() WTF_RETURNS_LOCK(s_instancesLock);
 
     void contextDestroyed() final;
 
@@ -80,8 +80,8 @@ public:
     // Also, we invalidate the cached program info.
     void increaseLinkCount();
 
-    RefPtr<WebGLShader> fragmentShader() const;
-    RefPtr<WebGLShader> vertexShader() const;
+    RefPtr<WebGLShader> NODELETE fragmentShader() const;
+    RefPtr<WebGLShader> NODELETE vertexShader() const;
 
     bool attachShader(const AbstractLocker&, WebGLShader&);
     bool detachShader(const AbstractLocker&, WebGLShader&);

--- a/Source/WebCore/html/canvas/WebGLRenderingContext.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContext.h
@@ -63,7 +63,7 @@ private:
     using WebGLRenderingContextBase::WebGLRenderingContextBase;
 };
 
-WebCoreOpaqueRoot root(const WebGLExtension<WebGLRenderingContext>*);
+WebCoreOpaqueRoot NODELETE root(const WebGLExtension<WebGLRenderingContext>*);
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -198,7 +198,7 @@ template <typename T> static IntRect texImageSourceSize(T& source)
 
 // Return true if a character belongs to the ASCII subset as defined in
 // GLSL ES 1.0 spec section 3.1.
-static bool validateCharacter(unsigned char c)
+static bool NODELETE validateCharacter(unsigned char c)
 {
     // Printing characters are valid except " $ ` @ \ ' DEL.
     if (c >= 32 && c <= 126
@@ -366,7 +366,7 @@ static constexpr ASCIILiteral errorCodeToString(GCGLErrorCode error)
     return "INVALID_OPERATION"_s;
 }
 
-static constexpr GCGLenum errorCodeToGLenum(GCGLErrorCode error)
+static constexpr GCGLenum NODELETE errorCodeToGLenum(GCGLErrorCode error)
 {
     switch (error) {
     case GCGLErrorCode::InvalidEnum:
@@ -386,7 +386,7 @@ static constexpr GCGLenum errorCodeToGLenum(GCGLErrorCode error)
     return GraphicsContextGL::INVALID_OPERATION;
 }
 
-static constexpr GCGLErrorCode glEnumToErrorCode(GCGLenum error)
+static constexpr GCGLErrorCode NODELETE glEnumToErrorCode(GCGLenum error)
 {
     switch (error) {
     case GraphicsContextGL::INVALID_ENUM:
@@ -416,7 +416,7 @@ static String ensureNotNull(const CString& text)
     return String::fromUTF8(text.span());
 }
 
-static GraphicsContextGL::SurfaceBuffer toGCGLSurfaceBuffer(CanvasRenderingContext::SurfaceBuffer buffer)
+static GraphicsContextGL::SurfaceBuffer NODELETE toGCGLSurfaceBuffer(CanvasRenderingContext::SurfaceBuffer buffer)
 {
     return buffer == CanvasRenderingContext::SurfaceBuffer::DrawingBuffer ? GraphicsContextGL::SurfaceBuffer::DrawingBuffer : GraphicsContextGL::SurfaceBuffer::DisplayBuffer;
 }
@@ -3173,7 +3173,7 @@ IntRect WebGLRenderingContextBase::getImageDataSize(ImageData* pixels)
 }
 
 #if ENABLE(WEB_CODECS)
-static bool isVideoFrameFormatEligibleToCopy(WebCodecsVideoFrame& frame)
+static bool NODELETE isVideoFrameFormatEligibleToCopy(WebCodecsVideoFrame& frame)
 {
 #if PLATFORM(COCOA)
     // FIXME: We should be able to remove the YUV restriction, see https://bugs.webkit.org/show_bug.cgi?id=251234.

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -251,7 +251,7 @@ public:
     std::optional<Vector<Ref<WebGLShader>>> getAttachedShaders(WebGLProgram&);
     GCGLint getAttribLocation(WebGLProgram&, const String& name);
     WebGLAny getBufferParameter(GCGLenum target, GCGLenum pname);
-    WEBCORE_EXPORT std::optional<WebGLContextAttributes> getContextAttributes();
+    WEBCORE_EXPORT std::optional<WebGLContextAttributes> NODELETE getContextAttributes();
     WebGLContextAttributes creationAttributes() const { return m_creationAttributes; }
     GCGLenum getError();
     virtual std::optional<WebGLExtensionAny> getExtension(const String& name) = 0;
@@ -277,7 +277,7 @@ public:
 
     void hint(GCGLenum target, GCGLenum mode);
     GCGLboolean isBuffer(WebGLBuffer*);
-    bool isContextLost() const;
+    bool NODELETE isContextLost() const;
     GCGLboolean isEnabled(GCGLenum cap);
     GCGLboolean isFramebuffer(WebGLFramebuffer*);
     GCGLboolean isProgram(WebGLProgram*);
@@ -451,7 +451,7 @@ public:
     void removeSharedObject(WebGLObject&);
     void removeContextObject(WebGLObject&);
 
-    bool isContextUnrecoverablyLost() const;
+    bool NODELETE isContextUnrecoverablyLost() const;
 
     // Instanced Array helper functions.
     void drawArraysInstanced(GCGLenum mode, GCGLint first, GCGLsizei count, GCGLsizei primcount);
@@ -479,7 +479,7 @@ public:
     // currently latched into the context - without traversing all of
     // the latched objects to find the current one, which would be
     // prohibitively expensive.
-    Lock& objectGraphLock() WTF_RETURNS_LOCK(m_objectGraphLock);
+    Lock& NODELETE objectGraphLock() WTF_RETURNS_LOCK(m_objectGraphLock);
 
     // Returns the ordinal number of when the context was last active (drew, read pixels).
     uint64_t activeOrdinal() const { return m_activeOrdinal; }
@@ -566,7 +566,7 @@ protected:
 
     // Helper to return the size in bytes of OpenGL data types
     // like GL_FLOAT, GL_INT, etc.
-    unsigned sizeInBytes(GCGLenum type);
+    unsigned NODELETE sizeInBytes(GCGLenum type);
 
     // Validates the incoming WebGL object.
     template<typename T> bool validateWebGLObject(ASCIILiteral, const T&);
@@ -596,7 +596,7 @@ protected:
 
     virtual void uncacheDeletedBuffer(const AbstractLocker&, WebGLBuffer*);
     bool needsPreparationForDisplay() const final { return true; }
-    void updateActiveOrdinal();
+    void NODELETE updateActiveOrdinal();
     void updateMemoryCost() const;
 
     struct ContextLostState {
@@ -853,8 +853,8 @@ protected:
     bool validateReadPixelsDimensions(GCGLint width, GCGLint height);
     bool validateTexImageSubRectangle(TexImageFunctionID, const IntRect& imageSize, const IntRect& subRect, GCGLsizei depth, GCGLint unpackImageHeight, bool* selectingSubRectangle);
 
-    IntRect sentinelEmptyRect();
-    IntRect getImageDataSize(ImageData*);
+    IntRect NODELETE sentinelEmptyRect();
+    IntRect NODELETE getImageDataSize(ImageData*);
 
     ExceptionOr<void> texImageSourceHelper(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, const IntRect& sourceImageRect, GCGLsizei depth, GCGLint unpackImageHeight, TexImageSource&&);
     void texImageArrayBufferViewHelper(TexImageFunctionID, GCGLenum target, GCGLint level, GCGLint internalformat, GCGLsizei width, GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset, RefPtr<ArrayBufferView>&& pixels, NullDisposition, GCGLuint srcOffset);
@@ -862,9 +862,9 @@ protected:
     void texImage2DBase(GCGLenum target, GCGLint level, GCGLenum internalFormat, GCGLsizei width, GCGLsizei height, GCGLint border, GCGLenum format, GCGLenum type, std::span<const uint8_t> pixels);
     void texSubImage2DBase(GCGLenum target, GCGLint level, GCGLint xoffset, GCGLint yoffset, GCGLsizei width, GCGLsizei height, GCGLenum internalFormat, GCGLenum format, GCGLenum type, std::span<const uint8_t> pixels);
     static ASCIILiteral texImageFunctionName(TexImageFunctionID);
-    static TexImageFunctionType texImageFunctionType(TexImageFunctionID);
+    static TexImageFunctionType NODELETE texImageFunctionType(TexImageFunctionID);
 
-    PixelStoreParameters computeUnpackPixelStoreParameters(TexImageDimension) const;
+    PixelStoreParameters NODELETE computeUnpackPixelStoreParameters(TexImageDimension) const;
 
     // Helper function to verify limits on the length of uniform and attribute locations.
     bool validateLocationLength(ASCIILiteral functionName, const String&);
@@ -891,7 +891,7 @@ protected:
     RefPtr<WebGLTexture> validateTexture2DBinding(ASCIILiteral, GCGLenum);
 
     void addExtensionSupportedFormatsAndTypes();
-    void addExtensionSupportedFormatsAndTypesWebGL2();
+    void NODELETE addExtensionSupportedFormatsAndTypesWebGL2();
 
     // Helper function to check input internalformat/format/type for functions
     // Tex{Sub}Image taking TexImageSource source data. Generates GL error and
@@ -909,7 +909,7 @@ protected:
     // Helper function to check input level for functions {copy}Tex{Sub}Image.
     // Generates GL error and returns false if level is invalid.
     bool validateTexFuncLevel(ASCIILiteral functionName, GCGLenum target, GCGLint level);
-    virtual GCGLint maxTextureLevelForTarget(GCGLenum target);
+    virtual GCGLint NODELETE maxTextureLevelForTarget(GCGLenum target);
 
     // Helper function for tex{Sub}Image{2|3}D to check if the input format/type/level/target/width/height/depth/border/xoffset/yoffset/zoffset are valid.
     // Otherwise, it would return quickly without doing other work.
@@ -949,15 +949,15 @@ protected:
     void texParameter(GCGLenum target, GCGLenum pname, GCGLfloat paramf, GCGLint parami, bool isFloat);
 
     // Helper function to print errors and warnings to console.
-    bool shouldPrintToConsole() const;
+    bool NODELETE shouldPrintToConsole() const;
     void printToConsole(MessageLevel, String&&);
 
     // Helper function to validate the target for checkFramebufferStatus and
     // validateFramebufferFuncParameters.
-    virtual bool validateFramebufferTarget(GCGLenum target);
+    virtual bool NODELETE validateFramebufferTarget(GCGLenum target);
 
     // Get the framebuffer bound to the given target.
-    virtual WebGLFramebuffer* getFramebufferBinding(GCGLenum target);
+    virtual WebGLFramebuffer* NODELETE getFramebufferBinding(GCGLenum target);
 
     // Helper function to validate input parameters for framebuffer functions.
     // Generate GL error if parameters are illegal.
@@ -1016,14 +1016,14 @@ protected:
     // Clamp the width and height to GL_MAX_VIEWPORT_DIMS.
     IntSize clampedCanvasSize();
 
-    void setBackDrawBuffer(GCGLenum);
+    void NODELETE setBackDrawBuffer(GCGLenum);
     void setFramebuffer(const AbstractLocker&, GCGLenum, WebGLFramebuffer*);
 
     // Check if EXT_draw_buffers extension is supported and if it satisfies the WebGL requirements.
     bool supportsDrawBuffers();
 
 #if ENABLE(OFFSCREEN_CANVAS)
-    OffscreenCanvas* offscreenCanvas();
+    OffscreenCanvas* NODELETE offscreenCanvas();
 #endif
 
     bool validateTypeAndArrayBufferType(ASCIILiteral functionName, ArrayBufferViewFunctionType, GCGLenum type, ArrayBufferView* pixels);
@@ -1095,7 +1095,7 @@ GCGLboolean WebGLRenderingContextBase::validateIsWebGLObject(const T* object) co
     return true;
 }
 
-WebCoreOpaqueRoot root(WebGLRenderingContextBase*);
+WebCoreOpaqueRoot NODELETE root(WebGLRenderingContextBase*);
 
 WebCoreOpaqueRoot root(const WebGLExtension<WebGLRenderingContextBase>*);
 

--- a/Source/WebCore/html/canvas/WebGLShaderPrecisionFormat.h
+++ b/Source/WebCore/html/canvas/WebGLShaderPrecisionFormat.h
@@ -37,9 +37,9 @@ class WebGLShaderPrecisionFormat : public RefCounted<WebGLShaderPrecisionFormat>
 public:
     static Ref<WebGLShaderPrecisionFormat> create(GCGLint rangeMin, GCGLint rangeMax, GCGLint precision);
 
-    GCGLint rangeMin() const;
-    GCGLint rangeMax() const;
-    GCGLint precision() const;
+    GCGLint NODELETE rangeMin() const;
+    GCGLint NODELETE rangeMax() const;
+    GCGLint NODELETE precision() const;
 
 private:
     WebGLShaderPrecisionFormat(GCGLint rangeMin, GCGLint rangeMax, GCGLint precision);

--- a/Source/WebCore/html/canvas/WebGLSync.h
+++ b/Source/WebCore/html/canvas/WebGLSync.h
@@ -39,8 +39,8 @@ public:
     static RefPtr<WebGLSync> create(WebGLRenderingContextBase&);
 
     void updateCache(WebGLRenderingContextBase&);
-    GCGLint getCachedResult(GCGLenum pname) const;
-    bool isSignaled() const;
+    GCGLint NODELETE getCachedResult(GCGLenum pname) const;
+    bool NODELETE isSignaled() const;
     void scheduleAllowCacheUpdate(WebGLRenderingContextBase&);
 
     bool isUsable() const { return object() && !isDeleted(); }

--- a/Source/WebCore/html/canvas/WebGLTexture.h
+++ b/Source/WebCore/html/canvas/WebGLTexture.h
@@ -39,7 +39,7 @@ public:
 
     static RefPtr<WebGLTexture> create(WebGLRenderingContextBase&);
 
-    void didBind(GCGLenum);
+    void NODELETE didBind(GCGLenum);
     GCGLenum getTarget() const { return m_target; }
 
     static GCGLint computeLevelCount(GCGLsizei width, GCGLsizei height);

--- a/Source/WebCore/html/canvas/WebGLTransformFeedback.h
+++ b/Source/WebCore/html/canvas/WebGLTransformFeedback.h
@@ -62,10 +62,10 @@ public:
     // Returns false if index is out of range and the caller should
     // synthesize a GL error.
     void setBoundIndexedTransformFeedbackBuffer(const AbstractLocker&, GCGLuint index, WebGLBuffer*);
-    bool getBoundIndexedTransformFeedbackBuffer(GCGLuint index, WebGLBuffer** outBuffer);
+    bool NODELETE getBoundIndexedTransformFeedbackBuffer(GCGLuint index, WebGLBuffer** outBuffer);
     bool hasBoundIndexedTransformFeedbackBuffer(const WebGLBuffer* buffer) { return m_boundIndexedTransformFeedbackBuffers.contains(buffer); }
 
-    bool validateProgramForResume(WebGLProgram*) const;
+    bool NODELETE validateProgramForResume(WebGLProgram*) const;
 
     void didBind() { m_hasEverBeenBound = true; }
 
@@ -74,7 +74,7 @@ public:
 
     void unbindBuffer(const AbstractLocker&, WebGLBuffer&);
 
-    bool hasEnoughBuffers(GCGLuint numRequired) const;
+    bool NODELETE hasEnoughBuffers(GCGLuint numRequired) const;
 
     void addMembersToOpaqueRoots(const AbstractLocker&, JSC::AbstractSlotVisitor&);
 

--- a/Source/WebCore/html/canvas/WebGLUniformLocation.h
+++ b/Source/WebCore/html/canvas/WebGLUniformLocation.h
@@ -37,9 +37,9 @@ class WebGLUniformLocation final : public RefCounted<WebGLUniformLocation> {
 public:
     static Ref<WebGLUniformLocation> create(WebGLProgram&, GCGLint location);
     RefPtr<WebGLProgram> program() const;
-    GCGLint location() const;
-    std::optional<GCGLenum> type() const;
-    void setType(GCGLenum);
+    GCGLint NODELETE location() const;
+    std::optional<GCGLenum> NODELETE type() const;
+    void NODELETE setType(GCGLenum);
 
 private:
     WebGLUniformLocation(WebGLProgram&, GCGLint location);

--- a/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
+++ b/Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h
@@ -73,13 +73,13 @@ public:
     WebGLBuffer* getElementArrayBuffer() const { return m_boundElementArrayBuffer.get(); }
     void setElementArrayBuffer(const AbstractLocker&, WebGLBuffer*);
 
-    void setVertexAttribEnabled(int index, bool flag);
+    void NODELETE setVertexAttribEnabled(int index, bool flag);
     const VertexAttribState& getVertexAttribState(int index) { return m_vertexAttribState[index]; }
     void setVertexAttribState(const AbstractLocker&, GCGLuint, GCGLsizei, GCGLint, GCGLenum, GCGLboolean, GCGLsizei, GCGLintptr, bool, WebGLBuffer*);
     bool hasArrayBuffer(WebGLBuffer* buffer) { return m_vertexAttribState.containsIf([&](auto& item) { return item.bufferBinding == buffer; }); }
     void unbindBuffer(const AbstractLocker&, WebGLBuffer&);
 
-    void setVertexAttribDivisor(GCGLuint index, GCGLuint divisor);
+    void NODELETE setVertexAttribDivisor(GCGLuint index, GCGLuint divisor);
 
     void addMembersToOpaqueRoots(const AbstractLocker&, JSC::AbstractSlotVisitor&);
 
@@ -102,7 +102,7 @@ protected:
     std::optional<bool> m_allEnabledAttribBuffersBoundCache;
 };
 
-WebCoreOpaqueRoot root(WebGLVertexArrayObjectBase*);
+WebCoreOpaqueRoot NODELETE root(WebGLVertexArrayObjectBase*);
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/closewatcher/CloseWatcherManager.h
+++ b/Source/WebCore/html/closewatcher/CloseWatcherManager.h
@@ -36,8 +36,8 @@ public:
     void add(Ref<CloseWatcher>);
     void remove(CloseWatcher&);
 
-    void notifyAboutUserActivation();
-    bool canPreventClose();
+    void NODELETE notifyAboutUserActivation();
+    bool NODELETE canPreventClose();
 
     void escapeKeyHandler(KeyboardEvent&);
 private:

--- a/Source/WebCore/html/forms/FileIconLoader.h
+++ b/Source/WebCore/html/forms/FileIconLoader.h
@@ -48,7 +48,7 @@ class FileIconLoader {
 public:
     explicit FileIconLoader(FileIconLoaderClient&);
 
-    void invalidate();
+    void NODELETE invalidate();
     WEBCORE_EXPORT void iconLoaded(RefPtr<Icon>&&);
 
 private:

--- a/Source/WebCore/html/parser/CSSPreloadScanner.h
+++ b/Source/WebCore/html/parser/CSSPreloadScanner.h
@@ -59,7 +59,7 @@ private:
 
     inline void tokenize(char16_t);
     void emitRule();
-    bool hasFinishedRuleValue() const;
+    bool NODELETE hasFinishedRuleValue() const;
 
     State m_state;
     Vector<char16_t> m_rule;

--- a/Source/WebCore/html/parser/HTMLConstructionSite.cpp
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.cpp
@@ -81,7 +81,7 @@ static inline void setAttributes(Element& element, AtomHTMLToken& token, OptionS
     setAttributes(element, token.attributes(), token.hasDuplicateAttribute() ? HasDuplicateAttribute::Yes : HasDuplicateAttribute::No, parserContentPolicy);
 }
 
-static bool hasImpliedEndTag(const HTMLStackItem& item)
+static bool NODELETE hasImpliedEndTag(const HTMLStackItem& item)
 {
     switch (item.elementName()) {
     case HTML::dd:
@@ -100,7 +100,7 @@ static bool hasImpliedEndTag(const HTMLStackItem& item)
     }
 }
 
-static bool shouldUseLengthLimit(const ContainerNode& node)
+static bool NODELETE shouldUseLengthLimit(const ContainerNode& node)
 {
     auto* element = dynamicDowncast<Element>(node);
     if (!element)
@@ -116,7 +116,7 @@ static bool shouldUseLengthLimit(const ContainerNode& node)
     }
 }
 
-static inline bool causesFosterParenting(const HTMLStackItem& item)
+static inline bool NODELETE causesFosterParenting(const HTMLStackItem& item)
 {
     switch (item.elementName()) {
     case HTML::table:

--- a/Source/WebCore/html/parser/HTMLConstructionSite.h
+++ b/Source/WebCore/html/parser/HTMLConstructionSite.h
@@ -141,10 +141,10 @@ public:
 
     HTMLStackItem createElementFromSavedToken(const HTMLStackItem&);
 
-    bool shouldFosterParent() const;
+    bool NODELETE shouldFosterParent() const;
     void fosterParent(Ref<Node>&&);
 
-    std::optional<unsigned> indexOfFirstUnopenFormattingElement() const;
+    std::optional<unsigned> NODELETE indexOfFirstUnopenFormattingElement() const;
     void reconstructTheActiveFormattingElements();
 
     void generateImpliedEndTags();
@@ -170,7 +170,7 @@ public:
 
     void setForm(HTMLFormElement*);
     HTMLFormElement* form() const { return m_form.get(); }
-    RefPtr<HTMLFormElement> takeForm();
+    RefPtr<HTMLFormElement> NODELETE takeForm();
 
     OptionSet<ParserContentPolicy> parserContentPolicy() { return m_parserContentPolicy; }
 
@@ -212,8 +212,8 @@ private:
     void mergeAttributesFromTokenIntoElement(AtomHTMLToken&&, Element&);
     void dispatchDocumentElementAvailableIfNeeded();
 
-    Ref<Document> protectedDocument() const;
-    Ref<ContainerNode> protectedAttachmentRoot() const;
+    Ref<Document> NODELETE protectedDocument() const;
+    Ref<ContainerNode> NODELETE protectedAttachmentRoot() const;
 
     // m_head has to be destroyed after destroying CheckedRef of m_document and m_attachmentRoot
     HTMLStackItem m_head;

--- a/Source/WebCore/html/parser/HTMLDocumentParser.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParser.h
@@ -113,7 +113,7 @@ private:
     // PendingScriptClient
     void notifyFinished(PendingScript&) final;
 
-    Document* contextForParsingSession();
+    Document* NODELETE contextForParsingSession();
 
     enum class SynchronousMode : bool { AllowYield, ForceSynchronous };
     void append(RefPtr<StringImpl>&&, SynchronousMode);
@@ -131,9 +131,9 @@ private:
     void attemptToRunDeferredScriptsAndEnd();
     void end();
 
-    bool isParsingFragment() const;
+    bool NODELETE isParsingFragment() const;
     bool isScheduledForResume() const;
-    bool inPumpSession() const;
+    bool NODELETE inPumpSession() const;
     bool shouldDelayEnd() const;
 
     void didBeginYieldingParser() final;

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp
@@ -344,7 +344,7 @@ public:
         return false;
     }
 
-    HTMLFastPathResult parseResult() const { return m_parseResult; }
+    HTMLFastPathResult NODELETE parseResult() const { return m_parseResult; }
 
 private:
     const Ref<Document> m_document;
@@ -890,9 +890,9 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         out.append('&');
     }
 
-    bool parsingFailed() const { return m_parseResult != HTMLFastPathResult::Succeeded; }
+    bool NODELETE parsingFailed() const { return m_parseResult != HTMLFastPathResult::Succeeded; }
 
-    void didFail(HTMLFastPathResult result)
+    void NODELETE didFail(HTMLFastPathResult result)
     {
         if (m_parseResult == HTMLFastPathResult::Succeeded)
             m_parseResult = result;

--- a/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
+++ b/Source/WebCore/html/parser/HTMLDocumentParserFastPath.h
@@ -42,7 +42,7 @@ class Element;
 enum class ParserContentPolicy : uint8_t;
 
 WEBCORE_EXPORT bool tryFastParsingHTMLFragment(StringView source, Document&, ContainerNode&, Element& contextElement, OptionSet<ParserContentPolicy>);
-unsigned maxCachedSetInnerHTMLStringSize();
+unsigned NODELETE maxCachedSetInnerHTMLStringSize();
 
 } // namespace WebCore
 

--- a/Source/WebCore/html/parser/HTMLElementStack.cpp
+++ b/Source/WebCore/html/parser/HTMLElementStack.cpp
@@ -44,12 +44,12 @@ using namespace ElementNames;
 
 namespace {
 
-inline bool isRootNode(HTMLStackItem& item)
+inline bool NODELETE isRootNode(HTMLStackItem& item)
 {
     return item.isDocumentFragment() || item.elementName() == HTML::html;
 }
 
-inline bool isScopeMarker(HTMLStackItem& item)
+inline bool NODELETE isScopeMarker(HTMLStackItem& item)
 {
     switch (item.elementName()) {
     case HTML::applet:
@@ -78,21 +78,21 @@ inline bool isScopeMarker(HTMLStackItem& item)
     return isRootNode(item);
 }
 
-inline bool isListItemScopeMarker(HTMLStackItem& item)
+inline bool NODELETE isListItemScopeMarker(HTMLStackItem& item)
 {
     return isScopeMarker(item)
         || item.elementName() == HTML::ol
         || item.elementName() == HTML::ul;
 }
 
-inline bool isTableScopeMarker(HTMLStackItem& item)
+inline bool NODELETE isTableScopeMarker(HTMLStackItem& item)
 {
     return item.elementName() == HTML::table
         || item.elementName() == HTML::template_
         || isRootNode(item);
 }
 
-inline bool isTableBodyScopeMarker(HTMLStackItem& item)
+inline bool NODELETE isTableBodyScopeMarker(HTMLStackItem& item)
 {
     return item.elementName() == HTML::tbody
         || item.elementName() == HTML::tfoot
@@ -101,7 +101,7 @@ inline bool isTableBodyScopeMarker(HTMLStackItem& item)
         || isRootNode(item);
 }
 
-inline bool isTableRowScopeMarker(HTMLStackItem& item)
+inline bool NODELETE isTableRowScopeMarker(HTMLStackItem& item)
 {
     return item.elementName() == HTML::tr
         || item.elementName() == HTML::template_
@@ -115,13 +115,13 @@ inline bool isForeignContentScopeMarker(HTMLStackItem& item)
         || isInHTMLNamespace(item);
 }
 
-inline bool isButtonScopeMarker(HTMLStackItem& item)
+inline bool NODELETE isButtonScopeMarker(HTMLStackItem& item)
 {
     return isScopeMarker(item)
         || item.elementName() == HTML::button;
 }
 
-inline bool isSelectScopeMarker(HTMLStackItem& item)
+inline bool NODELETE isSelectScopeMarker(HTMLStackItem& item)
 {
     return item.elementName() != HTML::optgroup
         && item.elementName() != HTML::option;

--- a/Source/WebCore/html/parser/HTMLElementStack.h
+++ b/Source/WebCore/html/parser/HTMLElementStack.h
@@ -62,7 +62,7 @@ public:
 
         void replaceElement(HTMLStackItem&&);
 
-        bool isAbove(ElementRecord&) const;
+        bool NODELETE isAbove(ElementRecord&) const;
 
         ElementRecord* next() const { return m_next.get(); }
 
@@ -85,11 +85,11 @@ public:
     ElementName topElementName() const { return m_top->elementName(); }
     HTMLStackItem& topStackItem() const { return m_top->stackItem(); }
 
-    HTMLStackItem* oneBelowTop() const;
-    ElementRecord& topRecord() const;
-    ElementRecord* find(Element&) const;
-    ElementRecord* furthestBlockForFormattingElement(Element&) const;
-    ElementRecord* topmost(ElementName) const;
+    HTMLStackItem* NODELETE oneBelowTop() const;
+    ElementRecord& NODELETE topRecord() const;
+    ElementRecord* NODELETE find(Element&) const;
+    ElementRecord* NODELETE furthestBlockForFormattingElement(Element&) const;
+    ElementRecord* NODELETE topmost(ElementName) const;
 
     bool containsTemplateElement() const { return m_templateElementCount; }
 
@@ -115,28 +115,28 @@ public:
     void popHTMLBodyElement();
     void popAll();
 
-    static bool isMathMLTextIntegrationPoint(HTMLStackItem&);
+    static bool NODELETE isMathMLTextIntegrationPoint(HTMLStackItem&);
     static bool isHTMLIntegrationPoint(HTMLStackItem&);
 
     void remove(Element&);
     void removeHTMLHeadElement(Element&);
 
-    bool contains(Element&) const;
+    bool NODELETE contains(Element&) const;
 
-    bool inScope(Element&) const;
+    bool NODELETE inScope(Element&) const;
     bool inScope(ElementName) const;
-    bool inListItemScope(ElementName) const;
-    bool inTableScope(ElementName) const;
-    bool hasAnyInTableScope(std::initializer_list<ElementName> targetElements) const;
-    bool inButtonScope(ElementName) const;
-    bool inSelectScope(ElementName) const;
+    bool NODELETE inListItemScope(ElementName) const;
+    bool NODELETE inTableScope(ElementName) const;
+    bool NODELETE hasAnyInTableScope(std::initializer_list<ElementName> targetElements) const;
+    bool NODELETE inButtonScope(ElementName) const;
+    bool NODELETE inSelectScope(ElementName) const;
 
-    bool hasNumberedHeaderElementInScope() const;
+    bool NODELETE hasNumberedHeaderElementInScope() const;
 
-    bool hasOnlyOneElement() const;
-    bool secondElementIsHTMLBodyElement() const;
-    bool hasTemplateInHTMLScope() const;
-    Element& htmlElement() const;
+    bool NODELETE hasOnlyOneElement() const;
+    bool NODELETE secondElementIsHTMLBodyElement() const;
+    bool NODELETE hasTemplateInHTMLScope() const;
+    Element& NODELETE htmlElement() const;
     Element& NODELETE headElement() const;
     Element& NODELETE bodyElement() const;
 

--- a/Source/WebCore/html/parser/HTMLEntityParser.cpp
+++ b/Source/WebCore/html/parser/HTMLEntityParser.cpp
@@ -107,7 +107,7 @@ class SegmentedStringSource {
 public:
     explicit SegmentedStringSource(SegmentedString&);
 
-    bool isEmpty() const { return m_source.isEmpty(); }
+    bool NODELETE isEmpty() const { return m_source.isEmpty(); }
     char16_t currentCharacter() const { return m_source.currentCharacter(); }
     void advance();
     void pushEverythingBack();
@@ -122,7 +122,7 @@ template<typename CharacterType> class StringParsingBufferSource {
 public:
     explicit StringParsingBufferSource(StringParsingBuffer<CharacterType>&);
 
-    static bool isEmpty() { return false; }
+    static bool NODELETE isEmpty() { return false; }
     char16_t currentCharacter() const { return m_source.atEnd() ? 0 : char16_t { *m_source }; }
     void advance() { m_source.advance(); }
     void pushEverythingBack() { m_source.setPosition(m_startPosition); }

--- a/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
+++ b/Source/WebCore/html/parser/HTMLFormattingElementList.cpp
@@ -135,7 +135,7 @@ void HTMLFormattingElementList::clearToLastMarker()
     }
 }
 
-static bool itemsHaveMatchingNames(const HTMLStackItem& a, const HTMLStackItem& b)
+static bool NODELETE itemsHaveMatchingNames(const HTMLStackItem& a, const HTMLStackItem& b)
 {
     if (a.elementName() != b.elementName())
         return false;

--- a/Source/WebCore/html/parser/HTMLFormattingElementList.h
+++ b/Source/WebCore/html/parser/HTMLFormattingElementList.h
@@ -99,7 +99,7 @@ public:
     bool isEmpty() const { return !size(); }
     size_t size() const { return m_entries.size(); }
 
-    Element* closestElementInScopeWithName(ElementName);
+    Element* NODELETE closestElementInScopeWithName(ElementName);
 
     Entry* find(Element&);
     bool contains(Element&);
@@ -112,7 +112,7 @@ public:
 
     void appendMarker();
     // clearToLastMarker also clears the marker (per the HTML5 spec).
-    void clearToLastMarker();
+    void NODELETE clearToLastMarker();
 
     const Entry& at(size_t i) const { return m_entries[i]; }
     Entry& at(size_t i) { return m_entries[i]; }

--- a/Source/WebCore/html/parser/HTMLNameCache.h
+++ b/Source/WebCore/html/parser/HTMLNameCache.h
@@ -127,8 +127,8 @@ private:
     using AtomStringCache = std::array<AtomString, atomStringCacheCapacity>;
     using QualifiedNameCache = std::array<RefPtr<QualifiedName::QualifiedNameImpl>, qualifiedNameCacheCapacity>;
 
-    static AtomStringCache& atomStringCache();
-    static QualifiedNameCache& qualifiedNameCache();
+    static AtomStringCache& NODELETE atomStringCache();
+    static QualifiedNameCache& NODELETE qualifiedNameCache();
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/parser/HTMLParserIdioms.cpp
+++ b/Source/WebCore/html/parser/HTMLParserIdioms.cpp
@@ -275,7 +275,7 @@ static inline bool isHTMLSpaceOrDelimiter(CharacterType character)
     return isASCIIWhitespace(character) || character == ',' || character == ';';
 }
 
-static inline bool isNumberStart(char16_t character)
+static inline bool NODELETE isNumberStart(char16_t character)
 {
     return isASCIIDigit(character) || character == '.' || character == '-';
 }

--- a/Source/WebCore/html/parser/HTMLParserScheduler.cpp
+++ b/Source/WebCore/html/parser/HTMLParserScheduler.cpp
@@ -113,7 +113,7 @@ void HTMLParserScheduler::continueNextChunkTimerFired()
     m_parser->resumeParsingAfterYield();
 }
 
-static bool parsingProgressedSinceLastYield(PumpSession& session)
+static bool NODELETE parsingProgressedSinceLastYield(PumpSession& session)
 {
     // Only yield if there has been progress since last yield.
     if (session.processedTokens > session.processedTokensOnLastYieldBeforeScript) {

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -190,7 +190,7 @@ public:
         return request;
     }
 
-    static bool match(const AtomString& name, const QualifiedName& qName)
+    static bool NODELETE match(const AtomString& name, const QualifiedName& qName)
     {
         ASSERT(isMainThread());
         return qName.localName() == name;
@@ -351,7 +351,7 @@ private:
         }
     }
 
-    static bool relAttributeIsStyleSheet(const LinkRelAttribute& parsedAttribute)
+    static bool NODELETE relAttributeIsStyleSheet(const LinkRelAttribute& parsedAttribute)
     {
         return parsedAttribute.isStyleSheet && !parsedAttribute.isAlternate && !parsedAttribute.iconType && !parsedAttribute.isDNSPrefetch;
     }
@@ -373,7 +373,7 @@ private:
         m_urlToLoad = trimmedURL.toString();
     }
 
-    const String& charset() const
+    const String& NODELETE charset() const
     {
         return m_charset;
     }

--- a/Source/WebCore/html/parser/HTMLScriptRunner.h
+++ b/Source/WebCore/html/parser/HTMLScriptRunner.h
@@ -56,7 +56,7 @@ public:
     void executeScriptsWaitingForStylesheets();
     bool executeScriptsWaitingForParsing();
 
-    bool hasParserBlockingScript() const;
+    bool NODELETE hasParserBlockingScript() const;
     bool isExecutingScript() const { return !!m_scriptNestingLevel; }
 
 private:

--- a/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
+++ b/Source/WebCore/html/parser/HTMLSrcsetParser.cpp
@@ -43,7 +43,7 @@
 
 namespace WebCore {
 
-static inline bool compareByDensity(const ImageCandidate& first, const ImageCandidate& second)
+static inline bool NODELETE compareByDensity(const ImageCandidate& first, const ImageCandidate& second)
 {
     return first.density < second.density;
 }

--- a/Source/WebCore/html/parser/HTMLTokenizer.cpp
+++ b/Source/WebCore/html/parser/HTMLTokenizer.cpp
@@ -39,7 +39,7 @@ namespace WebCore {
 
 using namespace HTMLNames;
 
-static inline Latin1Character convertASCIIAlphaToLower(char16_t character)
+static inline Latin1Character NODELETE convertASCIIAlphaToLower(char16_t character)
 {
     ASSERT(isASCIIAlpha(character));
     return toASCIILowerUnchecked(character);

--- a/Source/WebCore/html/parser/HTMLTokenizer.h
+++ b/Source/WebCore/html/parser/HTMLTokenizer.h
@@ -59,7 +59,7 @@ public:
     //
     // This approximation is also the algorithm called for when parsing an HTML fragment.
     // https://html.spec.whatwg.org/multipage/syntax.html#parsing-html-fragments
-    void updateStateFor(const AtomString& tagName);
+    void NODELETE updateStateFor(const AtomString& tagName);
 
     void setForceNullCharacterReplacement(bool);
 
@@ -155,7 +155,7 @@ private:
     bool processToken(SegmentedString&);
     bool processEntity(SegmentedString&);
 
-    void parseError();
+    void NODELETE parseError();
 
     void bufferASCIICharacter(char16_t);
     void bufferCharacter(char16_t);
@@ -176,12 +176,12 @@ private:
 
     // Sometimes we speculatively consume input characters and we don't know whether they represent
     // end tags or RCDATA, etc. These functions help manage these state.
-    bool inEndTagBufferingState() const;
+    bool NODELETE inEndTagBufferingState() const;
     void appendToPossibleEndTag(char16_t);
     void saveEndTagNameIfNeeded();
     bool isAppropriateEndTag() const;
 
-    bool haveBufferedCharacterToken() const;
+    bool NODELETE haveBufferedCharacterToken() const;
 
     static bool isNullCharacterSkippingState(State);
 

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.cpp
@@ -82,14 +82,14 @@ CustomElementConstructionData::~CustomElementConstructionData() = default;
 
 namespace {
 
-inline bool isASCIIWhitespaceOrReplacementCharacter(char16_t character)
+inline bool NODELETE isASCIIWhitespaceOrReplacementCharacter(char16_t character)
 {
     return isASCIIWhitespace(character) || character == replacementCharacter;
 }
 
 }
 
-static inline TextPosition uninitializedPositionValue1()
+static inline TextPosition NODELETE uninitializedPositionValue1()
 {
     return TextPosition(OrdinalNumber::fromOneBasedInt(-1), OrdinalNumber());
 }
@@ -110,7 +110,7 @@ static bool isTableBodyContextElement(ElementName elementName)
 }
 #endif
 
-static bool isNonAnchorNonNobrFormattingTag(TagName tagName)
+static bool NODELETE isNonAnchorNonNobrFormattingTag(TagName tagName)
 {
     return tagName == TagName::b
         || tagName == TagName::big
@@ -126,13 +126,13 @@ static bool isNonAnchorNonNobrFormattingTag(TagName tagName)
         || tagName == TagName::u;
 }
 
-static bool isNonAnchorFormattingTag(TagName tagName)
+static bool NODELETE isNonAnchorFormattingTag(TagName tagName)
 {
     return tagName == TagName::nobr || isNonAnchorNonNobrFormattingTag(tagName);
 }
 
 // https://html.spec.whatwg.org/multipage/syntax.html#formatting
-bool HTMLConstructionSite::isFormattingTag(TagName tagName)
+bool NODELETE HTMLConstructionSite::isFormattingTag(TagName tagName)
 {
     return tagName == TagName::a || isNonAnchorFormattingTag(tagName);
 }
@@ -158,9 +158,9 @@ public:
         ASSERT(isEmpty());
     }
 
-    bool isEmpty() const { return m_text.isEmpty(); }
+    bool NODELETE isEmpty() const { return m_text.isEmpty(); }
 
-    bool isAll8BitData() const { return m_isAll8BitData; }
+    bool NODELETE isAll8BitData() const { return m_isAll8BitData; }
 
     void skipAtMostOneLeadingNewline()
     {
@@ -446,12 +446,12 @@ void HTMLTreeBuilder::processFakePEndTagIfPInButtonScope()
 
 namespace {
 
-bool isLi(const HTMLStackItem& item)
+bool NODELETE isLi(const HTMLStackItem& item)
 {
     return item.elementName() == HTML::li;
 }
 
-bool isDdOrDt(const HTMLStackItem& item)
+bool NODELETE isDdOrDt(const HTMLStackItem& item)
 {
     return item.elementName() == HTML::dd || item.elementName() == HTML::dt;
 }
@@ -475,7 +475,7 @@ template <bool shouldClose(const HTMLStackItem&)> void HTMLTreeBuilder::processC
     m_tree.insertHTMLElement(WTF::move(token));
 }
 
-static void adjustSVGTagNameCase(AtomHTMLToken& token)
+static void NODELETE adjustSVGTagNameCase(AtomHTMLToken& token)
 {
     if (auto currentTagName = token.tagName(); currentTagName != TagName::Unknown)
         token.setTagName(adjustSVGTagName(currentTagName));

--- a/Source/WebCore/html/parser/HTMLTreeBuilder.h
+++ b/Source/WebCore/html/parser/HTMLTreeBuilder.h
@@ -197,8 +197,8 @@ private:
         FragmentParsingContext(DocumentFragment&, Element& contextElement);
 
         DocumentFragment* fragment() const;
-        Element& contextElement();
-        HTMLStackItem& contextElementStackItem();
+        Element& NODELETE contextElement();
+        HTMLStackItem& NODELETE contextElementStackItem();
 
     private:
         WeakPtr<DocumentFragment, WeakPtrImplWithEventTargetData> m_fragment;

--- a/Source/WebCore/html/shadow/DateTimeEditElement.h
+++ b/Source/WebCore/html/shadow/DateTimeEditElement.h
@@ -78,8 +78,8 @@ public:
 
     virtual ~DateTimeEditElement();
     void addField(Ref<DateTimeFieldElement>);
-    Element& fieldsWrapperElement() const;
-    Ref<Element> protectedFieldsWrapperElement() const;
+    Element& NODELETE fieldsWrapperElement() const;
+    Ref<Element> NODELETE protectedFieldsWrapperElement() const;
     void focusByOwner();
     void resetFields();
     void setEmptyValue(const LayoutParameters&);

--- a/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
+++ b/Source/WebCore/html/shadow/DateTimeNumericFieldElement.h
@@ -39,7 +39,7 @@ public:
         Range(int minimum, int maximum)
             : minimum(minimum), maximum(maximum) { }
         int clampValue(int) const;
-        bool isInRange(int) const;
+        bool NODELETE isInRange(int) const;
 
         int minimum;
         int maximum;
@@ -48,7 +48,7 @@ public:
 protected:
     DateTimeNumericFieldElement(Document&, DateTimeFieldElementFieldOwner&, const Range&, int placeholder);
 
-    int maximum() const;
+    int NODELETE maximum() const;
 
     // DateTimeFieldElement functions:
     bool hasValue() const final;

--- a/Source/WebCore/html/shadow/ProgressShadowElement.h
+++ b/Source/WebCore/html/shadow/ProgressShadowElement.h
@@ -42,7 +42,7 @@ class ProgressShadowElement : public HTMLDivElement {
     WTF_MAKE_TZONE_ALLOCATED(ProgressShadowElement);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(ProgressShadowElement);
 public:
-    HTMLProgressElement* progressElement() const;
+    HTMLProgressElement* NODELETE progressElement() const;
 
 protected:
     explicit ProgressShadowElement(Document&);

--- a/Source/WebCore/html/shadow/SliderThumbElement.cpp
+++ b/Source/WebCore/html/shadow/SliderThumbElement.cpp
@@ -79,7 +79,7 @@ inline static Decimal sliderPosition(HTMLInputElement& element)
     return stepRange.proportionFromValue(stepRange.clampValue(oldValue));
 }
 
-inline static bool hasVerticalAppearance(HTMLInputElement& input)
+inline static bool NODELETE hasVerticalAppearance(HTMLInputElement& input)
 {
     ASSERT(input.renderer());
     return !input.renderer()->isHorizontalWritingMode() || input.renderer()->style().usedAppearance() == StyleAppearance::SliderVertical;
@@ -103,7 +103,7 @@ public:
 
 private:
     void layout() override;
-    bool isFlexibleBoxImpl() const override { return true; }
+    bool NODELETE isFlexibleBoxImpl() const override { return true; }
 };
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderSliderContainer);

--- a/Source/WebCore/html/shadow/SliderThumbElement.h
+++ b/Source/WebCore/html/shadow/SliderThumbElement.h
@@ -48,7 +48,7 @@ public:
 
     void setPositionFromValue();
     void dragFrom(const LayoutPoint&);
-    RefPtr<HTMLInputElement> hostInput() const;
+    RefPtr<HTMLInputElement> NODELETE hostInput() const;
     void setPositionFromPoint(const LayoutPoint&);
 
 #if ENABLE(IOS_TOUCH_EVENTS)

--- a/Source/WebCore/html/shadow/TextControlInnerElements.cpp
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.cpp
@@ -253,7 +253,7 @@ std::optional<Style::UnadjustedStyle> TextControlPlaceholderElement::resolveCust
 
 // MARK: SearchFieldResultsButtonElement
 
-static inline bool searchFieldStyleHasExplicitlySpecifiedTextFieldAppearance(const RenderStyle& style)
+static inline bool NODELETE searchFieldStyleHasExplicitlySpecifiedTextFieldAppearance(const RenderStyle& style)
 {
     auto appearance = style.appearance();
     return appearance == StyleAppearance::TextField && appearance == style.usedAppearance();

--- a/Source/WebCore/html/shadow/TextControlInnerElements.h
+++ b/Source/WebCore/html/shadow/TextControlInnerElements.h
@@ -67,7 +67,7 @@ public:
 
     void defaultEventHandler(Event&) final;
 
-    RenderTextControlInnerBlock* renderer() const;
+    RenderTextControlInnerBlock* NODELETE renderer() const;
 
     inline void updateInnerTextElementEditability(bool isEditable)
     {

--- a/Source/WebCore/html/track/AudioTrack.h
+++ b/Source/WebCore/html/track/AudioTrack.h
@@ -64,7 +64,7 @@ public:
 
     size_t inbandTrackIndex() const;
 
-    Ref<AudioTrackPrivate> protectedPrivate() const;
+    Ref<AudioTrackPrivate> NODELETE protectedPrivate() const;
     const AudioTrackPrivate& privateTrack() const { return m_private; }
     void setPrivate(AudioTrackPrivate&);
 

--- a/Source/WebCore/html/track/AudioTrackList.h
+++ b/Source/WebCore/html/track/AudioTrackList.h
@@ -48,8 +48,8 @@ public:
     RefPtr<AudioTrack> getTrackById(TrackID) const;
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }
-    AudioTrack& item(unsigned index) const;
-    AudioTrack* itemForBindings(unsigned index) const;
+    AudioTrack& NODELETE item(unsigned index) const;
+    AudioTrack* NODELETE itemForBindings(unsigned index) const;
     AudioTrack& lastItem() const { return item(length() - 1); }
     AudioTrack* firstEnabled() const;
     void append(Ref<AudioTrack>&&);

--- a/Source/WebCore/html/track/DataCue.h
+++ b/Source/WebCore/html/track/DataCue.h
@@ -70,7 +70,7 @@ private:
     DataCue(Document&, const MediaTime& start, const MediaTime& end, Ref<SerializedPlatformDataCue>&&, const String&);
     DataCue(Document&, const MediaTime& start, const MediaTime& end, JSC::JSValue, const String&);
 
-    JSC::JSValue valueOrNull() const;
+    JSC::JSValue NODELETE valueOrNull() const;
     CueType cueType() const final { return Data; }
     bool cueContentsMatch(const TextTrackCue&) const final;
     void toJSON(JSON::Object&) const final;

--- a/Source/WebCore/html/track/InbandTextTrack.cpp
+++ b/Source/WebCore/html/track/InbandTextTrack.cpp
@@ -97,7 +97,7 @@ void InbandTextTrack::setMode(Mode mode)
     setModeInternal(mode);
 }
 
-static inline InbandTextTrackPrivate::Mode toPrivate(TextTrack::Mode mode)
+static inline InbandTextTrackPrivate::Mode NODELETE toPrivate(TextTrack::Mode mode)
 {
     switch (mode) {
     case TextTrack::Mode::Disabled:

--- a/Source/WebCore/html/track/InbandTextTrack.h
+++ b/Source/WebCore/html/track/InbandTextTrack.h
@@ -54,7 +54,7 @@ public:
     String inBandMetadataTrackDispatchType() const override;
 
     void setPrivate(InbandTextTrackPrivate&);
-    Ref<InbandTextTrackPrivate> protectedPrivate() const;
+    Ref<InbandTextTrackPrivate> NODELETE protectedPrivate() const;
 #if !RELEASE_LOG_DISABLED
     void setLogger(const Logger&, uint64_t) final;
 #endif

--- a/Source/WebCore/html/track/TextTrack.h
+++ b/Source/WebCore/html/track/TextTrack.h
@@ -63,7 +63,7 @@ public:
 
     static bool isValidKindKeyword(const AtomString&);
 
-    TextTrackList* textTrackList() const;
+    TextTrackList* NODELETE textTrackList() const;
 
     enum class Kind { Subtitles, Captions, Descriptions, Chapters, Metadata, Forced };
     Kind kind() const;
@@ -119,8 +119,8 @@ public:
         m_renderedTrackIndex = std::nullopt;
     }
 
-    bool isRendered();
-    bool isSpoken();
+    bool NODELETE isRendered();
+    bool NODELETE isSpoken();
     int trackIndexRelativeToRenderedTracks();
 
     bool hasBeenConfigured() const { return m_hasBeenConfigured; }

--- a/Source/WebCore/html/track/TextTrackCue.cpp
+++ b/Source/WebCore/html/track/TextTrackCue.cpp
@@ -90,7 +90,7 @@ TextTrackCue* TextTrackCueBox::getCue() const
     return m_cue.get();
 }
 
-static inline bool isLegalNode(Node& node)
+static inline bool NODELETE isLegalNode(Node& node)
 {
     return node.hasTagName(HTMLNames::bTag)
         || node.hasTagName(HTMLNames::brTag)

--- a/Source/WebCore/html/track/TextTrackCue.h
+++ b/Source/WebCore/html/track/TextTrackCue.h
@@ -79,7 +79,7 @@ public:
     void didMoveToNewDocument(Document&);
 
     TextTrack* NODELETE track() const;
-    RefPtr<TextTrack> protectedTrack() const;
+    RefPtr<TextTrack> NODELETE protectedTrack() const;
     void setTrack(TextTrack*);
 
     const AtomString& id() const { return m_id; }
@@ -92,7 +92,7 @@ public:
     void setEndTime(double);
 
     bool pauseOnExit() const { return m_pauseOnExit; }
-    void setPauseOnExit(bool);
+    void NODELETE setPauseOnExit(bool);
 
     MediaTime startMediaTime() const { return m_startTime; }
     void setStartTime(const MediaTime&);
@@ -100,7 +100,7 @@ public:
     MediaTime endMediaTime() const { return m_endTime; }
     void setEndTime(const MediaTime&);
 
-    bool isActive() const;
+    bool NODELETE isActive() const;
     virtual void setIsActive(bool);
 
     virtual bool isOrderedBefore(const TextTrackCue*) const;
@@ -110,7 +110,7 @@ public:
 
     enum CueType { Generic, Data, ConvertedToWebVTT, WebVTT };
     virtual CueType cueType() const { return CueType::Generic; }
-    virtual bool isRenderable() const;
+    virtual bool NODELETE isRenderable() const;
 
     enum CueMatchRules { MatchAllFields, IgnoreDuration };
     bool isEqual(const TextTrackCue&, CueMatchRules) const;
@@ -127,7 +127,7 @@ public:
     String toJSONString() const;
 
     virtual void recalculateStyles() { m_displayTreeNeedsUpdate = true; }
-    virtual void setFontSize(int fontSize, bool important);
+    virtual void NODELETE setFontSize(int fontSize, bool important);
     virtual void updateDisplayTree(const MediaTime&) { }
 
     unsigned cueIndex() const;

--- a/Source/WebCore/html/track/TextTrackCueList.h
+++ b/Source/WebCore/html/track/TextTrackCueList.h
@@ -42,7 +42,7 @@ public:
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
     unsigned length() const;
-    TextTrackCue* item(unsigned index) const;
+    TextTrackCue* NODELETE item(unsigned index) const;
     RefPtr<TextTrackCue> protectedItem(unsigned index) const { return item(index); }
     TextTrackCue* getCueById(const String&) const;
 

--- a/Source/WebCore/html/track/TextTrackList.h
+++ b/Source/WebCore/html/track/TextTrackList.h
@@ -52,7 +52,7 @@ public:
     int getTrackIndexRelativeToRenderedTracks(TextTrack&);
     bool contains(TrackBase&) const final;
 
-    TextTrack* item(unsigned index) const;
+    TextTrack* NODELETE item(unsigned index) const;
     RefPtr<TextTrack> getTrackById(const AtomString&) const;
     RefPtr<TextTrack> getTrackById(TrackID) const;
     TextTrack* lastItem() const { return item(length() - 1); }

--- a/Source/WebCore/html/track/TrackBase.cpp
+++ b/Source/WebCore/html/track/TrackBase.cpp
@@ -128,7 +128,7 @@ WebCoreOpaqueRoot TrackBase::opaqueRoot()
 }
 
 // See: https://tools.ietf.org/html/bcp47#section-2.1
-static bool isValidBCP47LanguageTag(const String& languageTag)
+static bool NODELETE isValidBCP47LanguageTag(const String& languageTag)
 {
     auto const length = languageTag.length();
 

--- a/Source/WebCore/html/track/TrackListBase.h
+++ b/Source/WebCore/html/track/TrackListBase.h
@@ -50,7 +50,7 @@ public:
     void deref() const final { RefCounted::deref(); }
     USING_CAN_MAKE_WEAKPTR(EventTarget);
 
-    virtual unsigned length() const;
+    virtual unsigned NODELETE length() const;
     virtual bool contains(TrackBase&) const;
     virtual bool contains(TrackID) const;
     virtual void remove(TrackBase&, bool scheduleEvent = true);

--- a/Source/WebCore/html/track/VTTCue.h
+++ b/Source/WebCore/html/track/VTTCue.h
@@ -170,12 +170,12 @@ public:
     RefPtr<DocumentFragment> getCueAsHTML() final;
     RefPtr<DocumentFragment> createCueRenderingTree();
 
-    void notifyRegionWhenRemovingDisplayTree(bool);
+    void NODELETE notifyRegionWhenRemovingDisplayTree(bool);
 
-    VTTRegion* region();
+    VTTRegion* NODELETE region();
     void setRegion(VTTRegion*);
 
-    const String& regionId();
+    const String& NODELETE regionId();
 
     void setIsActive(bool) override;
 
@@ -194,10 +194,10 @@ public:
     using DisplayPosition = std::pair<std::optional<double>, std::optional<double>>;
     const DisplayPosition& getCSSPosition() const { return m_displayPosition; };
 
-    CSSValueID getCSSAlignment() const;
-    int getCSSSize() const;
-    CSSValueID getCSSWritingDirection() const;
-    CSSValueID getCSSWritingMode() const;
+    CSSValueID NODELETE getCSSAlignment() const;
+    int NODELETE getCSSSize() const;
+    CSSValueID NODELETE getCSSWritingDirection() const;
+    CSSValueID NODELETE getCSSWritingMode() const;
 
     void recalculateStyles() final { m_displayTreeShouldChange = true; }
     void setFontSize(int, bool important) override;
@@ -209,8 +209,8 @@ public:
 
     void didChange(bool = false) final;
 
-    double calculateComputedTextPosition() const;
-    PositionAlignSetting calculateComputedPositionAlignment() const;
+    double NODELETE calculateComputedTextPosition() const;
+    PositionAlignSetting NODELETE calculateComputedPositionAlignment() const;
     double calculateMaximumSize() const;
 
 #if ENABLE(SPEECH_SYNTHESIS)

--- a/Source/WebCore/html/track/VTTRegion.cpp
+++ b/Source/WebCore/html/track/VTTRegion.cpp
@@ -182,7 +182,7 @@ VTTRegion::RegionSetting VTTRegion::scanSettingName(VTTScanner& input)
     return None;
 }
 
-static inline bool parsedEntireRun(const VTTScanner& input, const VTTScanner::Run& run)
+static inline bool NODELETE parsedEntireRun(const VTTScanner& input, const VTTScanner::Run& run)
 {
     return input.isAt(run.end()); 
 }

--- a/Source/WebCore/html/track/VTTRegion.h
+++ b/Source/WebCore/html/track/VTTRegion.h
@@ -65,7 +65,7 @@ public:
     ExceptionOr<void> setWidth(double);
 
     unsigned lines() const { return m_lines; }
-    void setLines(unsigned);
+    void NODELETE setLines(unsigned);
 
     double regionAnchorX() const { return m_regionAnchor.x(); }
     ExceptionOr<void> setRegionAnchorX(double);
@@ -81,9 +81,9 @@ public:
 
     enum class ScrollSetting : bool { EmptyString, Up };
     ScrollSetting scroll() const { return m_scroll; }
-    void setScroll(const ScrollSetting);
+    void NODELETE setScroll(const ScrollSetting);
 
-    void updateParametersFromRegion(const VTTRegion&);
+    void NODELETE updateParametersFromRegion(const VTTRegion&);
 
     const String& regionSettings() const { return m_settings; }
     void setRegionSettings(const String&);

--- a/Source/WebCore/html/track/VTTRegionList.h
+++ b/Source/WebCore/html/track/VTTRegionList.h
@@ -38,7 +38,7 @@ public:
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < length(); }
     unsigned length() const;
-    VTTRegion* item(unsigned index) const;
+    VTTRegion* NODELETE item(unsigned index) const;
     VTTRegion* getRegionById(const String&) const;
 
     void add(Ref<VTTRegion>&&);

--- a/Source/WebCore/html/track/VTTScanner.h
+++ b/Source/WebCore/html/track/VTTScanner.h
@@ -103,7 +103,7 @@ public:
     // Match the character |c| against the character at the input pointer (~lookahead).
     bool match(char c) const { return !isAtEnd() && currentChar() == c; }
     // Scan the character |c|.
-    bool scan(char);
+    bool NODELETE scan(char);
     // Scan the first |charactersCount| characters of the string |characters|.
     bool scan(std::span<const Latin1Character> characters);
 
@@ -132,7 +132,7 @@ public:
     bool scanRun(const Run&, const String& toMatch);
 
     // Skip to the end of the specified |run|.
-    void skipRun(const Run&);
+    void NODELETE skipRun(const Run&);
 
     // Return the String made up of the characters in |run|, and advance the
     // input pointer to the end of the run.
@@ -152,7 +152,7 @@ public:
     bool scanFloat(float& number, bool* isNegative = nullptr);
 
 protected:
-    Run createRun(Position start, Position end) const;
+    Run NODELETE createRun(Position start, Position end) const;
     Position position() const
     {
         if (m_is8Bit)

--- a/Source/WebCore/html/track/VideoTrack.h
+++ b/Source/WebCore/html/track/VideoTrack.h
@@ -101,7 +101,7 @@ private:
     ASCIILiteral logClassName() const final { return "VideoTrack"_s; }
 #endif
 
-    Ref<VideoTrackPrivate> protectedPrivate() const;
+    Ref<VideoTrackPrivate> NODELETE protectedPrivate() const;
 
     WeakPtr<VideoTrackList> m_videoTrackList;
     WeakHashSet<VideoTrackClient> m_clients;

--- a/Source/WebCore/html/track/VideoTrackList.h
+++ b/Source/WebCore/html/track/VideoTrackList.h
@@ -49,8 +49,8 @@ public:
     int selectedIndex() const;
 
     bool isSupportedPropertyIndex(unsigned index) const { return index < m_inbandTracks.size(); }
-    VideoTrack& item(unsigned) const;
-    VideoTrack* itemForBindings(unsigned) const;
+    VideoTrack& NODELETE item(unsigned) const;
+    VideoTrack* NODELETE itemForBindings(unsigned) const;
     VideoTrack& lastItem() const { return item(length() - 1); }
     VideoTrack* selectedItem() const;
     void append(Ref<VideoTrack>&&);

--- a/Source/WebCore/html/track/WebVTTParser.cpp
+++ b/Source/WebCore/html/track/WebVTTParser.cpp
@@ -519,7 +519,7 @@ public:
 private:
     void constructTreeFromToken(Document&);
 
-    WebVTTNodeType currentType() const { return m_typeStack.isEmpty() ? WebVTTNodeType::None : m_typeStack.last(); }
+    WebVTTNodeType NODELETE currentType() const { return m_typeStack.isEmpty() ? WebVTTNodeType::None : m_typeStack.last(); }
 
     WebVTTToken m_token;
     Vector<WebVTTNodeType> m_typeStack;
@@ -632,7 +632,7 @@ bool WebVTTParser::collectTimeStamp(VTTScanner& input, MediaTime& timeStamp)
     return true;
 }
 
-static WebVTTNodeType tokenToNodeType(WebVTTToken& token)
+static WebVTTNodeType NODELETE tokenToNodeType(WebVTTToken& token)
 {
     switch (token.name().length()) {
     case 1:

--- a/Source/WebCore/html/track/WebVTTParser.h
+++ b/Source/WebCore/html/track/WebVTTParser.h
@@ -167,7 +167,7 @@ private:
 
     static bool collectTimeStamp(VTTScanner& input, MediaTime& timeStamp);
 
-    Ref<Document> protectedDocument() const;
+    Ref<Document> NODELETE protectedDocument() const;
 
     const WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     ParseState m_state { Initial };


### PR DESCRIPTION
#### c6f9a5dbcebbf02e00ce6a983356c190eb1ef2c7
<pre>
Adopt `NODELETE` annotation in more places in Source/WebCore/html
<a href="https://bugs.webkit.org/show_bug.cgi?id=308206">https://bugs.webkit.org/show_bug.cgi?id=308206</a>

Reviewed by Darin Adler and Ryosuke Niwa.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/html/Autofill.cpp:
(WebCore::maxTokensForAutofillFieldCategory):
* Source/WebCore/html/BaseDateAndTimeInputType.h:
* Source/WebCore/html/CanvasBase.cpp:
(WebCore::maxCanvasArea):
* Source/WebCore/html/CanvasBase.h:
* Source/WebCore/html/CanvasNoiseInjection.cpp:
(WebCore::isIndexInBounds):
(WebCore::lowerAndUpperBound):
(WebCore::adjustNeighborColorBounds):
* Source/WebCore/html/CheckboxInputType.h:
* Source/WebCore/html/ColorInputType.cpp:
(WebCore::isValidSimpleColor):
(WebCore::parseSimpleColorValue):
* Source/WebCore/html/FTPDirectoryDocument.cpp:
(WebCore::wasLastDayOfMonth):
* Source/WebCore/html/FormController.cpp:
(WebCore::AtomStringVectorReader::consumeString):
(WebCore::FormController::SavedFormState::isEmpty const):
* Source/WebCore/html/FormController.h:
* Source/WebCore/html/FormListedElement.h:
* Source/WebCore/html/HTMLAnchorElement.h:
* Source/WebCore/html/HTMLAreaElement.h:
* Source/WebCore/html/HTMLAttachmentElement.cpp:
(WebCore::AttachmentEvent::attachment const):
(WebCore::AttachmentEvent::document const):
(WebCore::AttachmentEvent::uniqueIdentifier const):
(WebCore::AttachmentEvent::time const):
(WebCore::AttachmentEvent::stackTrace const):
* Source/WebCore/html/HTMLAttachmentElement.h:
* Source/WebCore/html/HTMLCanvasElement.cpp:
(WebCore::requiresAcceleratedCompositingForWebGL):
(WebCore::shouldEnableWebGL):
* Source/WebCore/html/HTMLCanvasElement.h:
* Source/WebCore/html/HTMLCollection.cpp:
(WebCore::invalidationTypeExcludingIdAndNameAttributes):
* Source/WebCore/html/HTMLCollection.h:
* Source/WebCore/html/HTMLDataListElement.h:
* Source/WebCore/html/HTMLDetailsElement.h:
* Source/WebCore/html/HTMLDocument.h:
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::unicodeBidiAttributeForDirAuto):
* Source/WebCore/html/HTMLElement.h:
* Source/WebCore/html/HTMLFieldSetElement.h:
* Source/WebCore/html/HTMLFormControlElement.h:
* Source/WebCore/html/HTMLFormControlsCollection.h:
* Source/WebCore/html/HTMLFormElement.h:
* Source/WebCore/html/HTMLFrameOwnerElement.h:
* Source/WebCore/html/HTMLFrameSetElement.h:
* Source/WebCore/html/HTMLHeadingElement.h:
* Source/WebCore/html/HTMLImageElement.h:
* Source/WebCore/html/HTMLInputElement.cpp:
(WebCore::isRFC2616TokenCharacter):
(WebCore::isValidFileExtension):
(WebCore::HTMLInputElement::isSteppable const):
* Source/WebCore/html/HTMLInputElement.h:
* Source/WebCore/html/HTMLLinkElement.cpp:
(WebCore::mayFetchResource):
* Source/WebCore/html/HTMLLinkElement.h:
* Source/WebCore/html/HTMLMaybeFormAssociatedCustomElement.h:
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::mediaSessionMayBeConfusedWithMainContent):
(WebCore::isInWindowOrStandardFullscreen):
(WebCore::sharedMediaCacheDirectory):
(WebCore::toPlatform):
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/html/HTMLMeterElement.h:
* Source/WebCore/html/HTMLNameCollection.cpp:
(WebCore::isObjectElementForDocumentNameCollection):
* Source/WebCore/html/HTMLNameCollection.h:
* Source/WebCore/html/HTMLOptGroupElement.h:
* Source/WebCore/html/HTMLOptionElement.h:
* Source/WebCore/html/HTMLPlugInElement.h:
* Source/WebCore/html/HTMLProgressElement.h:
* Source/WebCore/html/HTMLSelectElement.cpp:
(WebCore::isFirstElementChildButton):
* Source/WebCore/html/HTMLSelectElement.h:
* Source/WebCore/html/HTMLStyleElement.h:
* Source/WebCore/html/HTMLTableCellElement.h:
* Source/WebCore/html/HTMLTableElement.cpp:
(WebCore::isTableCellAncestor):
* Source/WebCore/html/HTMLTableElement.h:
* Source/WebCore/html/HTMLTableRowsCollection.cpp:
(WebCore::assertRowIsInTable):
(WebCore::isInSection):
* Source/WebCore/html/HTMLTableRowsCollection.h:
* Source/WebCore/html/HTMLTextAreaElement.cpp:
(WebCore::computeLengthForAPIValue):
* Source/WebCore/html/HTMLTextAreaElement.h:
* Source/WebCore/html/HTMLTextFormControlElement.cpp:
(WebCore::isNotLineBreak):
* Source/WebCore/html/HTMLTextFormControlElement.h:
* Source/WebCore/html/HTMLTrackElement.h:
* Source/WebCore/html/HTMLVideoElement.cpp:
(WebCore::toFullscreenMode):
* Source/WebCore/html/HTMLVideoElement.h:
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::bufferRenderingMode):
(WebCore::interpolationQualityForResizeQuality):
(WebCore::alphaPremultiplicationForPremultiplyAlpha):
* Source/WebCore/html/ImageData.cpp:
(WebCore::computePixelFormat):
* Source/WebCore/html/ImageData.h:
* Source/WebCore/html/ImageDataArray.cpp:
(isType):
* Source/WebCore/html/ImageDataArray.h:
* Source/WebCore/html/ImageDocument.cpp:
(WebCore::ImageDocumentParser::document const):
(WebCore::ImageDocumentParser::protectedDocument const):
* Source/WebCore/html/InputMode.h:
* Source/WebCore/html/InputType.cpp:
(WebCore::InputType::fallbackValue const):
(WebCore::InputType::defaultValue const):
* Source/WebCore/html/InputType.h:
* Source/WebCore/html/InputTypeNames.h:
* Source/WebCore/html/LazyLoadFrameObserver.cpp:
* Source/WebCore/html/LazyLoadImageObserver.cpp:
* Source/WebCore/html/LinkIconCollector.cpp:
(WebCore::iconSize):
(WebCore::compareIcons):
* Source/WebCore/html/MediaController.h:
* Source/WebCore/html/MediaDocument.cpp:
(WebCore::descendantVideoElement):
* Source/WebCore/html/MediaElementSession.cpp:
* Source/WebCore/html/MediaElementSession.h:
* Source/WebCore/html/NumberInputType.cpp:
(WebCore::isE):
(WebCore::isPlusSign):
(WebCore::isSignPrefix):
(WebCore::isDigit):
(WebCore::isDecimalSeparator):
(WebCore::hasTwoSignChars):
(WebCore::hasSignNotAfterE):
* Source/WebCore/html/OffscreenCanvas.cpp:
(WebCore::requiresAcceleratedCompositingForWebGL):
(WebCore::shouldEnableWebGL):
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/html/Origin.h:
* Source/WebCore/html/PermissionsPolicy.cpp:
(WebCore::featureValueForOrigin):
* Source/WebCore/html/PermissionsPolicy.h:
* Source/WebCore/html/PluginDocument.h:
* Source/WebCore/html/TextFieldInputType.h:
* Source/WebCore/html/TimeRanges.h:
* Source/WebCore/html/URLRegistry.cpp:
* Source/WebCore/html/URLSearchParams.h:
* Source/WebCore/html/UserActivation.h:
* Source/WebCore/html/ValidatedFormListedElement.h:
* Source/WebCore/html/ValidationMessage.h:
* Source/WebCore/html/canvas/CanvasRenderingContext.h:
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.cpp:
(WebCore::toCanvasLineCap):
(WebCore::fromCanvasLineCap):
(WebCore::toCanvasLineJoin):
(WebCore::fromCanvasLineJoin):
(WebCore::toCanvasTextAlign):
(WebCore::fromCanvasTextAlign):
(WebCore::toCanvasTextBaseline):
(WebCore::fromCanvasTextBaseline):
(WebCore::isFullCanvasCompositeMode):
(WebCore::toWindRule):
(WebCore::size):
(WebCore::smoothingToInterpolationQuality):
(WebCore::isSpaceThatNeedsReplacing):
(WebCore::unitAllowedForSpacing):
* Source/WebCore/html/canvas/CanvasRenderingContext2DBase.h:
* Source/WebCore/html/canvas/GPUBasedCanvasRenderingContext.h:
* Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
(WebCore::computeTextureFormat):
(WebCore::isSupportedContextFormat):
* Source/WebCore/html/canvas/OffscreenCanvasRenderingContext2D.h:
* Source/WebCore/html/canvas/PaintRenderingContext2D.h:
* Source/WebCore/html/canvas/PlaceholderRenderingContext.h:
* Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
(WebCore::ValidateTransformFeedbackPrimitiveMode):
(WebCore::validateDefaultFramebufferAttachment):
* Source/WebCore/html/canvas/WebGL2RenderingContext.h:
* Source/WebCore/html/canvas/WebGLDefaultFramebuffer.h:
* Source/WebCore/html/canvas/WebGLFramebuffer.h:
* Source/WebCore/html/canvas/WebGLObject.h:
* Source/WebCore/html/canvas/WebGLProgram.h:
* Source/WebCore/html/canvas/WebGLRenderingContext.h:
* Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
(WebCore::validateCharacter):
(WebCore::errorCodeToGLenum):
(WebCore::glEnumToErrorCode):
(WebCore::toGCGLSurfaceBuffer):
(WebCore::isVideoFrameFormatEligibleToCopy):
* Source/WebCore/html/canvas/WebGLRenderingContextBase.h:
* Source/WebCore/html/canvas/WebGLShaderPrecisionFormat.h:
* Source/WebCore/html/canvas/WebGLSync.h:
* Source/WebCore/html/canvas/WebGLTexture.h:
* Source/WebCore/html/canvas/WebGLTransformFeedback.h:
* Source/WebCore/html/canvas/WebGLUniformLocation.h:
* Source/WebCore/html/canvas/WebGLVertexArrayObjectBase.h:
* Source/WebCore/html/closewatcher/CloseWatcherManager.h:
* Source/WebCore/html/forms/FileIconLoader.h:
* Source/WebCore/html/parser/CSSPreloadScanner.h:
* Source/WebCore/html/parser/HTMLConstructionSite.cpp:
(WebCore::hasImpliedEndTag):
(WebCore::shouldUseLengthLimit):
(WebCore::causesFosterParenting):
* Source/WebCore/html/parser/HTMLConstructionSite.h:
* Source/WebCore/html/parser/HTMLDocumentParser.h:
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.cpp:
(WebCore::HTMLFastPathParser::parseResult const):
(WebCore::HTMLFastPathParser::parsingFailed const):
(WebCore::HTMLFastPathParser::didFail):
* Source/WebCore/html/parser/HTMLDocumentParserFastPath.h:
* Source/WebCore/html/parser/HTMLElementStack.cpp:
(WebCore::ElementNames::isRootNode):
(WebCore::ElementNames::isScopeMarker):
(WebCore::ElementNames::isListItemScopeMarker):
(WebCore::ElementNames::isTableScopeMarker):
(WebCore::ElementNames::isTableBodyScopeMarker):
(WebCore::ElementNames::isTableRowScopeMarker):
(WebCore::ElementNames::isButtonScopeMarker):
(WebCore::ElementNames::isSelectScopeMarker):
* Source/WebCore/html/parser/HTMLElementStack.h:
* Source/WebCore/html/parser/HTMLEntityParser.cpp:
(WebCore::SegmentedStringSource::isEmpty const):
(WebCore::StringParsingBufferSource::isEmpty):
* Source/WebCore/html/parser/HTMLFormattingElementList.cpp:
(WebCore::itemsHaveMatchingNames):
* Source/WebCore/html/parser/HTMLFormattingElementList.h:
* Source/WebCore/html/parser/HTMLNameCache.h:
* Source/WebCore/html/parser/HTMLParserIdioms.cpp:
(WebCore::isNumberStart):
* Source/WebCore/html/parser/HTMLParserScheduler.cpp:
(WebCore::parsingProgressedSinceLastYield):
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::match):
(WebCore::TokenPreloadScanner::StartTagScanner::relAttributeIsStyleSheet):
(WebCore::TokenPreloadScanner::StartTagScanner::charset const):
* Source/WebCore/html/parser/HTMLScriptRunner.h:
* Source/WebCore/html/parser/HTMLSrcsetParser.cpp:
(WebCore::compareByDensity):
* Source/WebCore/html/parser/HTMLTokenizer.cpp:
(WebCore::convertASCIIAlphaToLower):
* Source/WebCore/html/parser/HTMLTokenizer.h:
* Source/WebCore/html/parser/HTMLTreeBuilder.cpp:
(WebCore::uninitializedPositionValue1):
(WebCore::isNonAnchorNonNobrFormattingTag):
(WebCore::isNonAnchorFormattingTag):
(WebCore::HTMLConstructionSite::isFormattingTag):
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::isEmpty const):
(WebCore::HTMLTreeBuilder::ExternalCharacterTokenBuffer::isAll8BitData const):
(WebCore::adjustSVGTagNameCase):
* Source/WebCore/html/parser/HTMLTreeBuilder.h:
* Source/WebCore/html/shadow/DateTimeEditElement.h:
* Source/WebCore/html/shadow/DateTimeNumericFieldElement.h:
* Source/WebCore/html/shadow/ProgressShadowElement.h:
* Source/WebCore/html/shadow/SliderThumbElement.cpp:
(WebCore::hasVerticalAppearance):
* Source/WebCore/html/shadow/SliderThumbElement.h:
* Source/WebCore/html/shadow/TextControlInnerElements.cpp:
(WebCore::searchFieldStyleHasExplicitlySpecifiedTextFieldAppearance):
* Source/WebCore/html/shadow/TextControlInnerElements.h:
* Source/WebCore/html/track/AudioTrack.h:
* Source/WebCore/html/track/AudioTrackList.h:
* Source/WebCore/html/track/DataCue.h:
* Source/WebCore/html/track/InbandTextTrack.cpp:
(WebCore::toPrivate):
* Source/WebCore/html/track/InbandTextTrack.h:
* Source/WebCore/html/track/TextTrack.h:
* Source/WebCore/html/track/TextTrackCue.cpp:
(WebCore::isLegalNode):
* Source/WebCore/html/track/TextTrackCue.h:
* Source/WebCore/html/track/TextTrackCueList.h:
* Source/WebCore/html/track/TextTrackList.h:
* Source/WebCore/html/track/TrackBase.cpp:
(WebCore::isValidBCP47LanguageTag):
* Source/WebCore/html/track/TrackListBase.h:
* Source/WebCore/html/track/VTTCue.h:
* Source/WebCore/html/track/VTTRegion.cpp:
(WebCore::parsedEntireRun):
* Source/WebCore/html/track/VTTRegion.h:
* Source/WebCore/html/track/VTTRegionList.h:
* Source/WebCore/html/track/VTTScanner.h:
* Source/WebCore/html/track/VideoTrack.h:
* Source/WebCore/html/track/VideoTrackList.h:
* Source/WebCore/html/track/WebVTTParser.cpp:
(WebCore::WebVTTTreeBuilder::currentType const):
(WebCore::tokenToNodeType):
* Source/WebCore/html/track/WebVTTParser.h:

Canonical link: <a href="https://commits.webkit.org/307962@main">https://commits.webkit.org/307962@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff03ed0385394e484b595f36e5ba21f13ffb5441

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145901 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18591 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154580 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99465 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdccc60b-b4f4-408a-b4eb-a33120ac7cb5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147776 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19074 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18480 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112219 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80355 "1 flakes 1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148864 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14606 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131066 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93125 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13900 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11656 "Found 1 new API test failure: TestWebKitAPI.ScrollbarTests.ScrollbarAvoidanceInConcentricContainerWithNonUniformCornerRadii (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2026 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123452 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156892 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/133 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120229 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15403 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120570 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30933 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18467 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129362 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74155 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16281 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7345 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18049 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81825 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17786 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17844 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->