### PR TITLE
Adopt `NODELETE` annotation in more places in Source/WebCore/rendering

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -288,7 +288,6 @@ layout/integration/LayoutIntegrationFormattingContextLayout.cpp
 layout/integration/flex/LayoutIntegrationFlexLayout.cpp
 layout/integration/flex/LayoutIntegrationFlexLayout.h
 layout/integration/inline/InlineIteratorBox.cpp
-layout/integration/inline/InlineIteratorBoxLegacyPath.h
 layout/integration/inline/InlineIteratorBoxModernPath.h
 layout/integration/inline/InlineIteratorInlineBox.cpp
 layout/integration/inline/InlineIteratorLineBox.cpp
@@ -408,7 +407,6 @@ platform/mock/MockRealtimeVideoSource.cpp
 platform/text/cocoa/LocalizedDateCache.mm
 [ Mac ] plugins/PluginData.cpp
 rendering/AccessibilityRegionContext.cpp
-rendering/AncestorSubgridIterator.cpp
 rendering/AttachmentLayout.mm
 rendering/AutoTableLayout.cpp
 rendering/BackgroundPainter.cpp
@@ -550,7 +548,6 @@ rendering/style/RenderStyle+SettersInlines.h
 rendering/style/RenderStyle.cpp
 rendering/style/RenderStyle.h
 rendering/svg/RenderSVGBlock.cpp
-rendering/svg/RenderSVGContainer.cpp
 rendering/svg/RenderSVGImage.cpp
 rendering/svg/RenderSVGInline.cpp
 rendering/svg/RenderSVGInlineText.cpp
@@ -559,7 +556,6 @@ rendering/svg/RenderSVGPath.cpp
 rendering/svg/RenderSVGResourceClipper.cpp
 rendering/svg/RenderSVGResourceFilterInlines.h
 rendering/svg/RenderSVGResourceFilterPrimitive.cpp
-rendering/svg/RenderSVGResourceMarker.cpp
 rendering/svg/RenderSVGRoot.cpp
 rendering/svg/RenderSVGShape.cpp
 rendering/svg/RenderSVGText.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -699,12 +699,10 @@ rendering/svg/RenderSVGPath.cpp
 rendering/svg/RenderSVGResourceClipper.cpp
 rendering/svg/RenderSVGResourceFilterInlines.h
 rendering/svg/RenderSVGResourceFilterPrimitive.cpp
-rendering/svg/RenderSVGResourceMarker.cpp
 rendering/svg/RenderSVGResourcePattern.cpp
 rendering/svg/RenderSVGRoot.cpp
 rendering/svg/RenderSVGText.cpp
 rendering/svg/RenderSVGTextPath.cpp
-rendering/svg/RenderSVGViewportContainer.cpp
 rendering/svg/SVGLayerTransformComputation.h
 rendering/svg/SVGRenderTreeAsText.cpp
 rendering/svg/SVGRenderingContext.cpp
@@ -727,7 +725,6 @@ rendering/svg/legacy/SVGResourcesCache.cpp
 rendering/updating/RenderTreeBuilder.cpp
 rendering/updating/RenderTreeBuilderFirstLetter.cpp
 rendering/updating/RenderTreeBuilderInline.cpp
-rendering/updating/RenderTreeBuilderList.cpp
 rendering/updating/RenderTreeBuilderMathML.cpp
 rendering/updating/RenderTreeBuilderMultiColumn.cpp
 rendering/updating/RenderTreeBuilderRuby.cpp

--- a/Source/WebCore/rendering/AncestorSubgridIterator.h
+++ b/Source/WebCore/rendering/AncestorSubgridIterator.h
@@ -43,7 +43,7 @@ public:
     bool operator==(const AncestorSubgridIterator&) const;
 
     AncestorSubgridIterator& operator++();
-    AncestorSubgridIterator begin();
+    AncestorSubgridIterator NODELETE begin();
     AncestorSubgridIterator end();
 private:
     AncestorSubgridIterator(SingleThreadWeakPtr<RenderGrid> firstAncestorSubgrid, SingleThreadWeakPtr<RenderGrid> currentAncestor, Style::GridTrackSizingDirection);

--- a/Source/WebCore/rendering/BackgroundPainter.cpp
+++ b/Source/WebCore/rendering/BackgroundPainter.cpp
@@ -576,7 +576,7 @@ void BackgroundPainter::clipRoundedInnerRect(GraphicsContext& context, const Flo
     context.clipRoundedRect(clipRect);
 }
 
-static inline std::optional<LayoutUnit> getSpace(LayoutUnit areaSize, LayoutUnit tileSize)
+static inline std::optional<LayoutUnit> NODELETE getSpace(LayoutUnit areaSize, LayoutUnit tileSize)
 {
     if (int numberOfTiles = areaSize / tileSize; numberOfTiles > 1)
         return (areaSize - numberOfTiles * tileSize) / (numberOfTiles - 1);

--- a/Source/WebCore/rendering/BackgroundPainter.h
+++ b/Source/WebCore/rendering/BackgroundPainter.h
@@ -99,8 +99,8 @@ private:
     template<typename Layer> static BackgroundImageGeometry calculateFillLayerImageGeometryImpl(const RenderBoxModelObject&, const RenderLayerModelObject* paintContainer, const Layer&, const LayoutPoint& paintOffset, const LayoutRect& borderBoxRect, std::optional<FillBox> overrideOrigin = std::nullopt);
     template<typename Layer> static LayoutSize calculateFillTileSize(const RenderBoxModelObject&, const Layer&, const LayoutSize& positioningAreaSize);
 
-    const Document& document() const;
-    const RenderView& view() const;
+    const Document& NODELETE document() const;
+    const RenderView& NODELETE view() const;
 
     RenderBoxModelObject& m_renderer;
     const PaintInfo& m_paintInfo;

--- a/Source/WebCore/rendering/BaselineAlignment.h
+++ b/Source/WebCore/rendering/BaselineAlignment.h
@@ -68,15 +68,15 @@ private:
 
     // Determines whether a baseline-sharing group is compatible with an alignment subject,
     // based on its 'block-flow' and 'baseline-preference'
-    bool isCompatible(FlowDirection, ItemPosition) const;
+    bool NODELETE isCompatible(FlowDirection, ItemPosition) const;
 
     // Determines whether the baseline-sharing group's associated block-flow is opposite (LR vs RL) to particular
     // alignment subject's writing-mode.
-    bool isOppositeBlockFlow(FlowDirection) const;
+    bool NODELETE isOppositeBlockFlow(FlowDirection) const;
 
     // Determines whether the baseline-sharing group's associated block-flow is orthogonal (vertical vs horizontal)
     // to particular alignment subject's writing-mode.
-    bool isOrthogonalBlockFlow(FlowDirection) const;
+    bool NODELETE isOrthogonalBlockFlow(FlowDirection) const;
 
     FlowDirection m_blockFlow;
     ItemPosition m_preference;
@@ -106,9 +106,9 @@ public:
     const BaselineGroup& sharedGroup(const RenderBox& alignmentSubject, ItemPosition preference) const;
 
     void updateSharedGroup(const RenderBox& alignmentSubject, ItemPosition preference, LayoutUnit ascent);
-    Vector<BaselineGroup>& sharedGroups();
+    Vector<BaselineGroup>& NODELETE sharedGroups();
 
-    static FontBaseline dominantBaseline(WritingMode);
+    static FontBaseline NODELETE dominantBaseline(WritingMode);
     static WritingMode usedWritingModeForBaselineAlignment(LogicalBoxAxis alignmentContextAxis, WritingMode alignmentContainerWritingMode, WritingMode alignmentSubjectWritingMode);
     static LayoutUnit synthesizedBaseline(const RenderBox&, FontBaseline baselineType, WritingMode writingModeForSynthesis, LineDirection, BaselineSynthesisEdge);
 

--- a/Source/WebCore/rendering/BlockStepSizing.h
+++ b/Source/WebCore/rendering/BlockStepSizing.h
@@ -34,13 +34,13 @@ class WritingMode;
 
 namespace BlockStepSizing {
 
-bool childHasSupportedStyle(const RenderStyle& childStyle);
+bool NODELETE childHasSupportedStyle(const RenderStyle& childStyle);
 
-LayoutUnit computeExtraSpace(LayoutUnit stepSize, LayoutUnit boxOuterSize);
+LayoutUnit NODELETE computeExtraSpace(LayoutUnit stepSize, LayoutUnit boxOuterSize);
 
 void distributeExtraSpaceToChildMargins(RenderBox& child, LayoutUnit extraSpace, WritingMode containingBlockWritingMode);
-void distributeExtraSpaceToChildPadding(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */);
-void distributeExtraSpaceToChildContentArea(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */);
+void NODELETE distributeExtraSpaceToChildPadding(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */);
+void NODELETE distributeExtraSpaceToChildContentArea(RenderBox& /* child */, LayoutUnit /* extraSpace */, WritingMode /* containingBlockWritingMode */);
 
 } // namespace BlockStepSizing
 

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -53,7 +53,7 @@
 
 namespace WebCore {
 
-static bool borderStyleFillsBorderArea(BorderStyle style)
+static bool NODELETE borderStyleFillsBorderArea(BorderStyle style)
 {
     switch (style) {
     case BorderStyle::None:
@@ -72,7 +72,7 @@ static bool borderStyleFillsBorderArea(BorderStyle style)
     return true;
 }
 
-static bool styleRequiresClipPolygon(BorderStyle style)
+static bool NODELETE styleRequiresClipPolygon(BorderStyle style)
 {
     switch (style) {
     case BorderStyle::None:
@@ -93,7 +93,7 @@ static bool styleRequiresClipPolygon(BorderStyle style)
     return false;
 }
 
-static bool borderStyleHasInnerDetail(BorderStyle style)
+static bool NODELETE borderStyleHasInnerDetail(BorderStyle style)
 {
     switch (style) {
     case BorderStyle::None:
@@ -114,12 +114,12 @@ static bool borderStyleHasInnerDetail(BorderStyle style)
     return false;
 }
 
-static bool borderStyleIsDottedOrDashed(BorderStyle style)
+static bool NODELETE borderStyleIsDottedOrDashed(BorderStyle style)
 {
     return style == BorderStyle::Dotted || style == BorderStyle::Dashed;
 }
 
-static bool decorationHasAllSimpleEdges(const RectEdges<BorderEdge>& edges)
+static bool NODELETE decorationHasAllSimpleEdges(const RectEdges<BorderEdge>& edges)
 {
     for (auto side : allBoxSides) {
         auto& currEdge = edges.at(side);

--- a/Source/WebCore/rendering/BorderPainter.h
+++ b/Source/WebCore/rendering/BorderPainter.h
@@ -46,7 +46,7 @@ public:
     static std::optional<Path> pathForBorderArea(const LayoutRect&, const RenderStyle&, float deviceScaleFactor, RectEdges<bool> closedEdges = { true });
 
     static bool shouldAntialiasLines(GraphicsContext&);
-    static bool decorationHasAllSolidEdges(const RectEdges<BorderEdge>&);
+    static bool NODELETE decorationHasAllSolidEdges(const RectEdges<BorderEdge>&);
 
 private:
     friend class OutlinePainter;
@@ -78,7 +78,7 @@ private:
 
     static Color calculateBorderStyleColor(const BorderStyle&, const BoxSide&, const Color&);
 
-    const Document& document() const;
+    const Document& NODELETE document() const;
 
     CheckedRef<const RenderElement> m_renderer;
     const PaintInfo& m_paintInfo;

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -99,7 +99,7 @@ public:
 
     bool isEmpty() const { return m_borderRect.rect().isEmpty(); }
 
-    void move(LayoutSize);
+    void NODELETE move(LayoutSize);
 
     // This will inflate the m_borderRect, and scale the radii up accordingly. Note that this changes the meaning of "inner shape" which will no longer correspond to the padding box.
     void inflate(LayoutUnit);

--- a/Source/WebCore/rendering/CounterNode.h
+++ b/Source/WebCore/rendering/CounterNode.h
@@ -52,7 +52,7 @@ public:
     bool hasSetType() const { return m_type.contains(Type::Set); }
     int value() const { return m_value; }
     int countInParent() const { return m_countInParent; }
-    RenderElement& owner() const;
+    RenderElement& NODELETE owner() const;
     void addRenderer(RenderCounter&);
     void removeRenderer(RenderCounter&);
 
@@ -64,8 +64,8 @@ public:
     CounterNode* nextSibling() const { return const_cast<CounterNode*>(m_nextSibling.get()); }
     CounterNode* firstChild() const { return const_cast<CounterNode*>(m_firstChild.get()); }
     CounterNode* lastChild() const { return const_cast<CounterNode*>(m_lastChild.get()); }
-    CounterNode* lastDescendant() const;
-    CounterNode* previousInPreOrder() const;
+    CounterNode* NODELETE lastDescendant() const;
+    CounterNode* NODELETE previousInPreOrder() const;
     CounterNode* nextInPreOrder(const CounterNode* stayWithin = nullptr) const;
     CounterNode* nextInPreOrderAfterChildren(const CounterNode* stayWithin = nullptr) const;
 
@@ -75,7 +75,7 @@ public:
 
 private:
     CounterNode(RenderElement&, OptionSet<Type>, int value);
-    int computeCountInParent() const;
+    int NODELETE computeCountInParent() const;
     // Invalidates the text in the renderer of this counter, if any,
     // and in the renderers of all descendants of this counter, if any.
     void resetThisAndDescendantsRenderers();

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -152,7 +152,7 @@ public:
 
 #if ENABLE(WHEEL_EVENT_REGIONS)
     WEBCORE_EXPORT OptionSet<EventListenerRegionType> eventListenerRegionTypesForPoint(const IntPoint&) const;
-    const Region& eventListenerRegionForType(EventListenerRegionType) const;
+    const Region& NODELETE eventListenerRegionForType(EventListenerRegionType) const;
 #endif
 
 #if ENABLE(EDITABLE_REGION)

--- a/Source/WebCore/rendering/FloatingObjects.cpp
+++ b/Source/WebCore/rendering/FloatingObjects.cpp
@@ -165,11 +165,11 @@ public:
 
     virtual ~ComputeFloatOffsetAdapter() = default;
 
-    LayoutUnit lowValue() const { return m_lineTop; }
-    LayoutUnit highValue() const { return m_lineBottom; }
+    LayoutUnit NODELETE lowValue() const { return m_lineTop; }
+    LayoutUnit NODELETE highValue() const { return m_lineBottom; }
     void collectIfNeeded(const IntervalType&);
 
-    LayoutUnit offset() const { return m_offset; }
+    LayoutUnit NODELETE offset() const { return m_offset; }
 
 protected:
     virtual bool updateOffsetIfNeeded(const FloatingObject&) = 0;
@@ -221,12 +221,12 @@ public:
     {
     }
 
-    LayoutUnit lowValue() const { return m_belowLogicalHeight; }
-    LayoutUnit highValue() const { return LayoutUnit::max(); }
+    LayoutUnit NODELETE lowValue() const { return m_belowLogicalHeight; }
+    LayoutUnit NODELETE highValue() const { return LayoutUnit::max(); }
     void collectIfNeeded(const IntervalType&);
 
-    LayoutUnit nextLogicalBottom() const { return m_nextLogicalBottom.value_or(0); }
-    LayoutUnit nextShapeLogicalBottom() const { return m_nextShapeLogicalBottom.value_or(nextLogicalBottom()); }
+    LayoutUnit NODELETE nextLogicalBottom() const { return m_nextLogicalBottom.value_or(0); }
+    LayoutUnit NODELETE nextShapeLogicalBottom() const { return m_nextShapeLogicalBottom.value_or(nextLogicalBottom()); }
 
 private:
     SingleThreadWeakPtr<const RenderBlockFlow> m_renderer;

--- a/Source/WebCore/rendering/FloatingObjects.h
+++ b/Source/WebCore/rendering/FloatingObjects.h
@@ -85,7 +85,7 @@ public:
     void setIsInPlacedTree(bool value) { m_isInPlacedTree = value; }
 #endif
 
-    bool shouldPaint() const;
+    bool NODELETE shouldPaint() const;
 
     bool paintsFloat() const { return m_paintsFloat; }
     void setPaintsFloat(bool paintsFloat) { m_paintsFloat = paintsFloat; }
@@ -101,7 +101,7 @@ public:
         return LayoutSize(m_frameRect.location().x() + m_marginOffset.width(), m_frameRect.location().y() + m_marginOffset.height());
     }
     LayoutSize marginOffset() const { ASSERT(isPlaced()); return m_marginOffset; }
-    LayoutSize translationOffsetToAncestor() const;
+    LayoutSize NODELETE translationOffsetToAncestor() const;
 
 private:
     friend FloatingObjects;
@@ -181,9 +181,9 @@ private:
     const RenderBlockFlow& renderer() const { ASSERT(m_renderer); return *m_renderer; }
     void computePlacedFloatsTree();
     const FloatingObjectTree* placedFloatsTree();
-    void increaseObjectsCount(FloatingObject::Type);
-    void decreaseObjectsCount(FloatingObject::Type);
-    FloatingObjectInterval intervalForFloatingObject(FloatingObject*);
+    void NODELETE increaseObjectsCount(FloatingObject::Type);
+    void NODELETE decreaseObjectsCount(FloatingObject::Type);
+    FloatingObjectInterval NODELETE intervalForFloatingObject(FloatingObject*);
 
     FloatingObjectSet m_set;
     std::unique_ptr<FloatingObjectTree> m_placedFloatsTree;

--- a/Source/WebCore/rendering/GlyphDisplayListCache.h
+++ b/Source/WebCore/rendering/GlyphDisplayListCache.h
@@ -108,7 +108,7 @@ public:
     void remove(const InlineDisplay::Box& run) { remove(&run); }
 
     void clear();
-    unsigned size() const;
+    unsigned NODELETE size() const;
 
     void setForceUseGlyphDisplayListForTesting(bool flag)
     {

--- a/Source/WebCore/rendering/Grid.h
+++ b/Source/WebCore/rendering/Grid.h
@@ -48,7 +48,7 @@ class Grid final {
 public:
     explicit Grid(RenderGrid&);
 
-    unsigned numTracks(Style::GridTrackSizingDirection) const;
+    unsigned NODELETE numTracks(Style::GridTrackSizingDirection) const;
 
     void ensureGridSize(unsigned maximumRowSize, unsigned maximumColumnSize);
     GridArea insert(RenderBox&, const GridArea&);
@@ -63,15 +63,15 @@ public:
     GridSpan gridItemSpan(const RenderBox&, Style::GridTrackSizingDirection) const;
     GridSpan gridItemSpanIgnoringCollapsedTracks(const RenderBox&, Style::GridTrackSizingDirection) const;
 
-    const GridCell& cell(unsigned row, unsigned column) const;
+    const GridCell& NODELETE cell(unsigned row, unsigned column) const;
 
-    unsigned explicitGridStart(Style::GridTrackSizingDirection) const;
-    void setExplicitGridStart(unsigned rowStart, unsigned columnStart);
+    unsigned NODELETE explicitGridStart(Style::GridTrackSizingDirection) const;
+    void NODELETE setExplicitGridStart(unsigned rowStart, unsigned columnStart);
 
-    unsigned autoRepeatTracks(Style::GridTrackSizingDirection) const;
-    void setAutoRepeatTracks(unsigned autoRepeatRows, unsigned autoRepeatColumns);
+    unsigned NODELETE autoRepeatTracks(Style::GridTrackSizingDirection) const;
+    void NODELETE setAutoRepeatTracks(unsigned autoRepeatRows, unsigned autoRepeatColumns);
 
-    void setClampingForSubgrid(unsigned maxRows, unsigned maxColumns);
+    void NODELETE setClampingForSubgrid(unsigned maxRows, unsigned maxColumns);
 
     void clampAreaToSubgridIfNeeded(GridArea&);
 
@@ -79,10 +79,10 @@ public:
     void setAutoRepeatEmptyRows(std::unique_ptr<OrderedTrackIndexSet>);
 
     unsigned autoRepeatEmptyTracksCount(Style::GridTrackSizingDirection) const;
-    bool hasAutoRepeatEmptyTracks(Style::GridTrackSizingDirection) const;
+    bool NODELETE hasAutoRepeatEmptyTracks(Style::GridTrackSizingDirection) const;
     bool isEmptyAutoRepeatTrack(Style::GridTrackSizingDirection, unsigned) const;
 
-    OrderedTrackIndexSet* autoRepeatEmptyTracks(Style::GridTrackSizingDirection) const;
+    OrderedTrackIndexSet* NODELETE autoRepeatEmptyTracks(Style::GridTrackSizingDirection) const;
 
     OrderIterator& orderIterator() { return m_orderIterator; }
     const OrderIterator& orderIterator() const { return m_orderIterator; }
@@ -126,7 +126,7 @@ public:
 
     static GridIterator createForSubgrid(const RenderGrid& subgrid, const GridIterator& outer, GridSpan subgridSpanInOuter);
 
-    RenderBox* nextGridItem();
+    RenderBox* NODELETE nextGridItem();
     bool isEmptyAreaEnough(unsigned rowSpan, unsigned columnSpan) const;
     std::optional<GridArea> nextEmptyGridArea(unsigned fixedTrackSpan, unsigned varyingTrackSpan);
 

--- a/Source/WebCore/rendering/GridBaselineAlignment.h
+++ b/Source/WebCore/rendering/GridBaselineAlignment.h
@@ -69,10 +69,10 @@ private:
     LayoutUnit logicalAscentForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType, ItemPosition) const;
     LayoutUnit ascentForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType, ItemPosition) const;
     LayoutUnit descentForGridItem(const RenderBox&, LayoutUnit, Style::GridTrackSizingDirection alignmentContextType, ExtraMarginsFromSubgrids) const;
-    bool isDescentBaselineForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
-    bool isVerticalAlignmentContext(Style::GridTrackSizingDirection alignmentContextType) const;
-    bool isOrthogonalGridItemForBaseline(const RenderBox&) const;
-    bool isParallelToAlignmentAxisForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
+    bool NODELETE isDescentBaselineForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
+    bool NODELETE isVerticalAlignmentContext(Style::GridTrackSizingDirection alignmentContextType) const;
+    bool NODELETE isOrthogonalGridItemForBaseline(const RenderBox&) const;
+    bool NODELETE isParallelToAlignmentAxisForGridItem(const RenderBox&, Style::GridTrackSizingDirection alignmentContextType) const;
 
     typedef HashMap<unsigned, std::unique_ptr<BaselineAlignmentState>, DefaultHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> BaselineAlignmentStateMap;
 

--- a/Source/WebCore/rendering/GridLayoutFunctions.cpp
+++ b/Source/WebCore/rendering/GridLayoutFunctions.cpp
@@ -39,12 +39,12 @@ namespace WebCore {
 
 namespace GridLayoutFunctions {
 
-static inline bool marginStartIsAuto(const RenderBox& gridItem, Style::GridTrackSizingDirection direction)
+static inline bool NODELETE marginStartIsAuto(const RenderBox& gridItem, Style::GridTrackSizingDirection direction)
 {
     return direction == Style::GridTrackSizingDirection::Columns ? gridItem.style().marginStart().isAuto() : gridItem.style().marginBefore().isAuto();
 }
 
-static inline bool marginEndIsAuto(const RenderBox& gridItem, Style::GridTrackSizingDirection direction)
+static inline bool NODELETE marginEndIsAuto(const RenderBox& gridItem, Style::GridTrackSizingDirection direction)
 {
     return direction == Style::GridTrackSizingDirection::Columns ? gridItem.style().marginEnd().isAuto() : gridItem.style().marginAfter().isAuto();
 }

--- a/Source/WebCore/rendering/GridLayoutFunctions.h
+++ b/Source/WebCore/rendering/GridLayoutFunctions.h
@@ -66,23 +66,23 @@ LayoutUnit computeMarginLogicalSizeForGridItem(const RenderGrid&, Style::GridTra
 LayoutUnit marginLogicalSizeForGridItem(const RenderGrid&, Style::GridTrackSizingDirection, const RenderBox&);
 void setOverridingContentSizeForGridItem(const RenderGrid&, RenderBox& gridItem, LayoutUnit, Style::GridTrackSizingDirection);
 void clearOverridingContentSizeForGridItem(const RenderGrid&, RenderBox& gridItem, Style::GridTrackSizingDirection);
-bool isOrthogonalGridItem(const RenderGrid&, const RenderBox&);
+bool NODELETE isOrthogonalGridItem(const RenderGrid&, const RenderBox&);
 bool isGridItemInlineSizeDependentOnBlockConstraints(const RenderBox& gridItem, const RenderGrid& parentGrid, ItemPosition gridItemAlignSelf);
-bool isOrthogonalParent(const RenderGrid&, const RenderElement& parent);
+bool NODELETE isOrthogonalParent(const RenderGrid&, const RenderElement& parent);
 bool isAspectRatioBlockSizeDependentGridItem(const RenderBox&);
-Style::GridTrackSizingDirection flowAwareDirectionForGridItem(const RenderGrid&, const RenderBox&, Style::GridTrackSizingDirection);
-Style::GridTrackSizingDirection flowAwareDirectionForParent(const RenderGrid&, const RenderElement& parent, Style::GridTrackSizingDirection);
+Style::GridTrackSizingDirection NODELETE flowAwareDirectionForGridItem(const RenderGrid&, const RenderBox&, Style::GridTrackSizingDirection);
+Style::GridTrackSizingDirection NODELETE flowAwareDirectionForParent(const RenderGrid&, const RenderElement& parent, Style::GridTrackSizingDirection);
 std::optional<RenderBox::GridAreaSize> overridingContainingBlockContentSizeForGridItem(const RenderBox&, Style::GridTrackSizingDirection);
 bool hasRelativeOrIntrinsicSizeForGridItem(const RenderBox& gridItem, Style::GridTrackSizingDirection);
 
-bool isFlippedDirection(const RenderGrid&, Style::GridTrackSizingDirection);
-bool isSubgridReversedDirection(const RenderGrid&, Style::GridTrackSizingDirection outerDirection, const RenderGrid& subgrid);
+bool NODELETE isFlippedDirection(const RenderGrid&, Style::GridTrackSizingDirection);
+bool NODELETE isSubgridReversedDirection(const RenderGrid&, Style::GridTrackSizingDirection outerDirection, const RenderGrid& subgrid);
 ExtraMarginsFromSubgrids extraMarginForSubgridAncestors(Style::GridTrackSizingDirection, const RenderBox& gridItem);
 
 unsigned alignmentContextForBaselineAlignment(const GridSpan&, const ItemPosition& alignment);
 
-bool hasAutoMarginsInColumnAxis(const RenderBox&, WritingMode parentWritingMode);
-bool hasAutoMarginsInRowAxis(const RenderBox&, WritingMode parentWritingMode);
+bool NODELETE hasAutoMarginsInColumnAxis(const RenderBox&, WritingMode parentWritingMode);
+bool NODELETE hasAutoMarginsInRowAxis(const RenderBox&, WritingMode parentWritingMode);
 
 bool hasStretchableSizeInColumnAxis(const RenderBox&, const RenderGrid& gridContainer);
 bool hasStretchableSizeInRowAxis(const RenderBox&, const RenderGrid& gridContainer);
@@ -93,7 +93,7 @@ void updateAutoMarginsIfNeeded(RenderBox&, WritingMode);
 void updateAutoMarginsInRowAxisIfNeeded(RenderBox&, WritingMode);
 void updateAutoMarginsInColumnAxisIfNeeded(RenderBox&, WritingMode);
 
-bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackFitContentLength&, std::optional<LayoutUnit> availableSpace);
+bool NODELETE isRelativeGridTrackBreadthAsAuto(const Style::GridTrackFitContentLength&, std::optional<LayoutUnit> availableSpace);
 bool isRelativeGridTrackBreadthAsAuto(const Style::GridTrackBreadth&, std::optional<LayoutUnit> availableSpace);
 
 } // namespace GridLayoutFunctions

--- a/Source/WebCore/rendering/GridMasonryLayout.h
+++ b/Source/WebCore/rendering/GridMasonryLayout.h
@@ -54,7 +54,7 @@ public:
 
     void initializeMasonry(unsigned gridAxisTracks, Style::GridTrackSizingDirection masonryAxisDirection);
     void performMasonryPlacement(const GridTrackSizingAlgorithm&, unsigned gridAxisTracks, Style::GridTrackSizingDirection masonryAxisDirection, GridMasonryLayout::MasonryLayoutPhase);
-    LayoutUnit offsetForGridItem(const RenderBox&) const;
+    LayoutUnit NODELETE offsetForGridItem(const RenderBox&) const;
     LayoutUnit gridContentSize() const { return m_gridContentSize; };
     LayoutUnit gridGap() const { return m_masonryAxisGridGap; };
 
@@ -72,11 +72,11 @@ private:
     void updateRunningPositions(const RenderBox& gridItem, const GridArea&);
     void updateItemOffset(const RenderBox& gridItem, LayoutUnit offset);
     LayoutUnit maxRunningPositionForSpan(unsigned startLine, unsigned spanLength) const;
-    inline Style::GridTrackSizingDirection gridAxisDirection() const;
+    inline Style::GridTrackSizingDirection NODELETE gridAxisDirection() const;
 
     bool hasDefiniteGridAxisPosition(const RenderBox& gridItem, Style::GridTrackSizingDirection masonryDirection) const;
-    GridArea masonryGridAreaFromGridAxisSpan(const GridSpan&) const;
-    GridSpan gridAxisSpanFromArea(const GridArea&) const;
+    GridArea NODELETE masonryGridAreaFromGridAxisSpan(const GridSpan&) const;
+    GridSpan NODELETE gridAxisSpanFromArea(const GridArea&) const;
 
     unsigned m_gridAxisTracksCount;
 

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -134,7 +134,7 @@ void GridTrack::ensureGrowthLimitIsBiggerThanBaseSize()
         m_growthLimit = std::max(m_baseSize, 0_lu);
 }
 
-static bool hasRelativeMarginOrPaddingForGridItem(const RenderBox& gridItem, Style::GridTrackSizingDirection direction)
+static bool NODELETE hasRelativeMarginOrPaddingForGridItem(const RenderBox& gridItem, Style::GridTrackSizingDirection direction)
 {
     if (direction == Style::GridTrackSizingDirection::Columns)
         return gridItem.style().marginStart().isPercentOrCalculated() || gridItem.style().marginEnd().isPercentOrCalculated() || gridItem.style().paddingStart().isPercentOrCalculated() || gridItem.style().paddingEnd().isPercentOrCalculated();
@@ -347,8 +347,8 @@ public:
     {
     }
 
-    RenderBox& gridItem() const { return m_gridItem; }
-    GridSpan span() const { return m_span; }
+    RenderBox& NODELETE gridItem() const { return m_gridItem; }
+    GridSpan NODELETE span() const { return m_span; }
 
     bool operator<(const GridItemWithSpan other) const { return m_span.integerSpan() < other.m_span.integerSpan(); }
 
@@ -402,7 +402,7 @@ LayoutUnit GridTrackSizingAlgorithm::itemSizeForTrackSizeComputationPhaseMasonry
     return 0;
 }
 
-static bool shouldProcessTrackForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const Style::GridTrackSize& trackSize)
+static bool NODELETE shouldProcessTrackForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const Style::GridTrackSize& trackSize)
 {
     switch (phase) {
     case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
@@ -461,7 +461,7 @@ static void updateTrackSizeForTrackSizeComputationPhase(TrackSizeComputationPhas
     ASSERT_NOT_REACHED();
 }
 
-static bool trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const Style::GridTrackSize& trackSize)
+static bool NODELETE trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase(TrackSizeComputationPhase phase, const Style::GridTrackSize& trackSize)
 {
     switch (phase) {
     case TrackSizeComputationPhase::ResolveIntrinsicMinimums:
@@ -712,7 +712,7 @@ void GridTrackSizingAlgorithm::convertIndefiniteItemsToDefiniteMasonry(const Std
 }
 
 template <TrackSizeComputationVariant variant>
-static double getSizeDistributionWeight(const GridTrack& track)
+static double NODELETE getSizeDistributionWeight(const GridTrack& track)
 {
     if (variant != TrackSizeComputationVariant::CrossingFlexibleTracks)
         return 0;

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -71,10 +71,10 @@ public:
     GridTrack() = default;
 
     LayoutUnit baseSize() const;
-    LayoutUnit unclampedBaseSize() const;
+    LayoutUnit NODELETE unclampedBaseSize() const;
     void setBaseSize(LayoutUnit);
 
-    const LayoutUnit& growthLimit() const;
+    const LayoutUnit& NODELETE growthLimit() const;
     bool growthLimitIsInfinite() const { return m_growthLimit == infinity; }
     void setGrowthLimit(LayoutUnit);
 
@@ -85,13 +85,13 @@ public:
     void setPlannedSize(LayoutUnit plannedSize) { m_plannedSize = plannedSize; }
 
     const LayoutUnit& tempSize() const { return m_tempSize; }
-    void setTempSize(const LayoutUnit&);
-    void growTempSize(const LayoutUnit&);
+    void NODELETE setTempSize(const LayoutUnit&);
+    void NODELETE growTempSize(const LayoutUnit&);
 
     bool infinitelyGrowable() const { return m_infinitelyGrowable; }
     void setInfinitelyGrowable(bool infinitelyGrowable) { m_infinitelyGrowable = infinitelyGrowable; }
 
-    void setGrowthLimitCap(std::optional<LayoutUnit>);
+    void NODELETE setGrowthLimitCap(std::optional<LayoutUnit>);
     std::optional<LayoutUnit> growthLimitCap() const { return m_growthLimitCap; }
 
     const Style::GridTrackSize& NODELETE cachedTrackSize() const;
@@ -121,7 +121,7 @@ public:
     ~GridTrackSizingAlgorithm();
 
     void run(Style::GridTrackSizingDirection, unsigned numTracks, SizingOperation, std::optional<LayoutUnit> availableSpace, RenderGridLayoutState&);
-    void reset();
+    void NODELETE reset();
 
     // Required by RenderGrid. Try to minimize the exposed surface.
     const Grid& grid() const { return m_grid; }
@@ -146,10 +146,10 @@ public:
     const Vector<UniqueRef<GridTrack>>& tracks(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? m_columns : m_rows; }
 
     std::optional<LayoutUnit> freeSpace(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? m_freeSpaceColumns : m_freeSpaceRows; }
-    void setFreeSpace(Style::GridTrackSizingDirection, std::optional<LayoutUnit>);
+    void NODELETE setFreeSpace(Style::GridTrackSizingDirection, std::optional<LayoutUnit>);
 
     std::optional<LayoutUnit> availableSpace(Style::GridTrackSizingDirection direction) const { return direction == Style::GridTrackSizingDirection::Columns ? m_availableSpaceColumns : m_availableSpaceRows; }
-    void setAvailableSpace(Style::GridTrackSizingDirection, std::optional<LayoutUnit>);
+    void NODELETE setAvailableSpace(Style::GridTrackSizingDirection, std::optional<LayoutUnit>);
 
     LayoutUnit computeTrackBasedSize() const;
 
@@ -177,7 +177,7 @@ private:
         GridSpan gridSpan;
     };
 
-    std::optional<LayoutUnit> availableSpace() const;
+    std::optional<LayoutUnit> NODELETE availableSpace() const;
     Style::GridTrackSize calculateGridTrackSize(Style::GridTrackSizingDirection, unsigned translatedIndex) const;
     const Style::GridTrackSize& rawGridTrackSize(Style::GridTrackSizingDirection, unsigned translatedIndex) const;
 
@@ -231,7 +231,7 @@ private:
     void convertIndefiniteItemsToDefiniteMasonry(const StdMap<SpanLength, MasonryMinMaxTrackSize>& gridTrackSpans, StdMap<SpanLength, Vector<MasonryMinMaxTrackSizeWithGridSpan>>&, Vector<MasonryMinMaxTrackSizeWithGridSpan>&);
 
     LayoutUnit itemSizeForTrackSizeComputationPhase(TrackSizeComputationPhase, RenderBox&, RenderGridLayoutState&) const;
-    LayoutUnit itemSizeForTrackSizeComputationPhaseMasonry(TrackSizeComputationPhase, const MasonryMinMaxTrackSize&) const;
+    LayoutUnit NODELETE itemSizeForTrackSizeComputationPhaseMasonry(TrackSizeComputationPhase, const MasonryMinMaxTrackSize&) const;
 
     template <TrackSizeComputationVariant variant, TrackSizeComputationPhase phase> void distributeSpaceToTracks(Vector<CheckedRef<GridTrack>>& tracks, Vector<CheckedRef<GridTrack>>* growBeyondGrowthLimitsTracks, LayoutUnit& freeSpace) const;
 
@@ -286,7 +286,7 @@ private:
 
     // State machine.
     void advanceNextState();
-    bool isValidTransition() const;
+    bool NODELETE isValidTransition() const;
 
     bool isDirectionInMasonryDirection() const;
 

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -152,7 +152,7 @@ HitTestResult& HitTestResult::operator=(const HitTestResult& other)
     return *this;
 }
 
-static Node* moveOutOfUserAgentShadowTree(Node& node)
+static Node* NODELETE moveOutOfUserAgentShadowTree(Node& node)
 {
     if (node.isInShadowTree()) {
         if (ShadowRoot* root = node.containingShadowRoot()) {

--- a/Source/WebCore/rendering/HitTestResult.h
+++ b/Source/WebCore/rendering/HitTestResult.h
@@ -60,13 +60,13 @@ public:
 
     WEBCORE_EXPORT HitTestResult& operator=(const HitTestResult&);
 
-    WEBCORE_EXPORT void setInnerNode(Node*);
+    WEBCORE_EXPORT void NODELETE setInnerNode(Node*);
     Node* innerNode() const { return m_innerNode.get(); }
 
     void setInnerNonSharedNode(Node*);
     Node* innerNonSharedNode() const { return m_innerNonSharedNode.get(); }
 
-    WEBCORE_EXPORT Element* innerNonSharedElement() const;
+    WEBCORE_EXPORT Element* NODELETE innerNonSharedElement() const;
 
     void setURLElement(Element*);
     Element* URLElement() const { return m_innerURLElement.get(); }
@@ -77,7 +77,7 @@ public:
     bool isOverWidget() const { return m_isOverWidget; }
     void setIsOverWidget(bool isOverWidget) { m_isOverWidget = isOverWidget; }
 
-    std::optional<Style::PseudoElementIdentifier> pseudoElementIdentifier() const;
+    std::optional<Style::PseudoElementIdentifier> NODELETE pseudoElementIdentifier() const;
     void setPseudoElementIdentifier(std::optional<Style::PseudoElementIdentifier>);
 
     WEBCORE_EXPORT String linkSuggestedFilename() const;
@@ -93,17 +93,17 @@ public:
     const LayoutPoint pointInInnerNodeFrame() const { return LayoutPoint(m_doublePointInInnerNodeFrame); }
     const DoublePoint& doublePointInInnerNodeFrame() const { return m_doublePointInInnerNodeFrame; }
     IntPoint roundedPointInInnerNodeFrame() const { return roundedIntPoint(pointInInnerNodeFrame()); }
-    WEBCORE_EXPORT LocalFrame* innerNodeFrame() const;
+    WEBCORE_EXPORT LocalFrame* NODELETE innerNodeFrame() const;
 
     // The hit-tested point in the coordinates of the inner node.
     const LayoutPoint& localPoint() const { return m_localPoint; }
-    void setLocalPoint(const LayoutPoint&);
+    void NODELETE setLocalPoint(const LayoutPoint&);
 
-    WEBCORE_EXPORT void setToNonUserAgentShadowAncestor();
+    WEBCORE_EXPORT void NODELETE setToNonUserAgentShadowAncestor();
 
     const HitTestLocation& hitTestLocation() const { return m_hitTestLocation; }
 
-    WEBCORE_EXPORT LocalFrame* frame() const;
+    WEBCORE_EXPORT LocalFrame* NODELETE frame() const;
     WEBCORE_EXPORT RefPtr<Frame> targetFrame() const;
     WEBCORE_EXPORT bool isSelected() const;
     WEBCORE_EXPORT bool allowsFollowingLink() const;
@@ -124,7 +124,7 @@ public:
     WEBCORE_EXPORT URL absoluteLinkURL() const;
     WEBCORE_EXPORT bool hasLocalDataForLinkURL() const;
     WEBCORE_EXPORT String textContent() const;
-    bool isOverLink() const;
+    bool NODELETE isOverLink() const;
     WEBCORE_EXPORT bool isContentEditable() const;
     void toggleMediaControlsDisplay() const;
     void toggleMediaLoopPlayback() const;
@@ -140,9 +140,9 @@ public:
     bool mediaPlaying() const;
     bool mediaSupportsFullscreen() const;
     void toggleMediaPlayState() const;
-    WEBCORE_EXPORT bool hasMediaElement() const;
+    WEBCORE_EXPORT bool NODELETE hasMediaElement() const;
     WEBCORE_EXPORT bool mediaHasAudio() const;
-    WEBCORE_EXPORT bool mediaIsVideo() const;
+    WEBCORE_EXPORT bool NODELETE mediaIsVideo() const;
     bool mediaMuted() const;
     void toggleMediaMuteState() const;
     bool mediaSupportsPictureInPicture() const;
@@ -181,11 +181,11 @@ private:
 
 #if ENABLE(ACCESSIBILITY_ANIMATION_CONTROL)
     void setAllowsAnimation(bool /* allowAnimation */) const;
-    HTMLImageElement* imageElement() const;
+    HTMLImageElement* NODELETE imageElement() const;
 #endif
 
 #if ENABLE(VIDEO)
-    HTMLMediaElement* mediaElement() const;
+    HTMLMediaElement* NODELETE mediaElement() const;
 #endif
     HitTestLocation m_hitTestLocation;
 

--- a/Source/WebCore/rendering/ImageQualityController.h
+++ b/Source/WebCore/rendering/ImageQualityController.h
@@ -46,7 +46,7 @@ class ImageQualityController {
 public:
     explicit ImageQualityController(const RenderView&);
 
-    static std::optional<InterpolationQuality> interpolationQualityFromStyle(const RenderStyle&);
+    static std::optional<InterpolationQuality> NODELETE interpolationQualityFromStyle(const RenderStyle&);
     static InterpolationQuality chooseInterpolationQualityForSVG(GraphicsContext&, const RenderElement&, Image&);
     InterpolationQuality chooseInterpolationQuality(GraphicsContext&, RenderBoxModelObject*, Image&, const void* layer, const LayoutSize&);
 

--- a/Source/WebCore/rendering/LayerAncestorClippingStack.h
+++ b/Source/WebCore/rendering/LayerAncestorClippingStack.h
@@ -65,7 +65,7 @@ public:
     LayerAncestorClippingStack(Vector<CompositedClipData>&&);
     ~LayerAncestorClippingStack() = default;
 
-    bool hasAnyScrollingLayers() const;
+    bool NODELETE hasAnyScrollingLayers() const;
     
     bool equalToClipData(const Vector<CompositedClipData>&) const;
     bool updateWithClipData(ScrollingCoordinator*, Vector<CompositedClipData>&&);
@@ -77,8 +77,8 @@ public:
 
     void updateScrollingNodeLayers(ScrollingCoordinator&);
 
-    GraphicsLayer* firstLayer() const;
-    GraphicsLayer* lastLayer() const;
+    GraphicsLayer* NODELETE firstLayer() const;
+    GraphicsLayer* NODELETE lastLayer() const;
     std::optional<ScrollingNodeID> lastOverflowScrollProxyNodeID() const;
 
     struct ClippingStackEntry {

--- a/Source/WebCore/rendering/LayerOverlapMap.cpp
+++ b/Source/WebCore/rendering/LayerOverlapMap.cpp
@@ -90,7 +90,7 @@ public:
     
     String dump(unsigned) const;
 
-    const RenderLayer& scopeLayer() const { return m_scopeLayer.get(); }
+    const RenderLayer& NODELETE scopeLayer() const { return m_scopeLayer.get(); }
 
 private:
     struct ClippingScope {
@@ -105,7 +105,7 @@ private:
         {
         }
 
-        ClippingScope* childWithLayer(const RenderLayer& layer) const
+        ClippingScope* NODELETE childWithLayer(const RenderLayer& layer) const
         {
             for (auto& child : children) {
                 if (&child.layer.get() == &layer)
@@ -138,7 +138,7 @@ private:
         RectList rectList;
     };
 
-    static ClippingScope* clippingScopeContainingLayerChildRecursive(const ClippingScope& currNode, const RenderLayer& layer)
+    static ClippingScope* NODELETE clippingScopeContainingLayerChildRecursive(const ClippingScope& currNode, const RenderLayer& layer)
     {
         for (auto& child : currNode.children) {
             if (&layer == &child.layer.get())
@@ -151,7 +151,7 @@ private:
         return nullptr;
     }
 
-    ClippingScope* scopeContainingLayer(const RenderLayer& layer) const
+    ClippingScope* NODELETE scopeContainingLayer(const RenderLayer& layer) const
     {
         return clippingScopeContainingLayerChildRecursive(m_rootScope, layer);
     }
@@ -163,14 +163,14 @@ private:
 
     void recursiveOutputToStream(TextStream&, const ClippingScope&, unsigned depth) const;
 
-    const ClippingScope& rootScope() const { return m_rootScope; }
-    ClippingScope& rootScope() { return m_rootScope; }
+    const ClippingScope& NODELETE rootScope() const { return m_rootScope; }
+    ClippingScope& NODELETE rootScope() { return m_rootScope; }
 
     ClippingScope m_rootScope;
     const CheckedRef<const RenderLayer> m_scopeLayer;
 };
 
-bool OverlapMapContainer::isEmpty() const
+bool NODELETE OverlapMapContainer::isEmpty() const
 {
     return m_rootScope.rectList.rects.isEmpty() && m_rootScope.children.isEmpty();
 }
@@ -242,7 +242,7 @@ OverlapMapContainer::ClippingScope* OverlapMapContainer::ensureClippingScopeForL
     return const_cast<ClippingScope*>(currScope);
 }
 
-OverlapMapContainer::ClippingScope* OverlapMapContainer::findClippingScopeForLayers(const LayerOverlapMap::LayerAndBoundsVector& enclosingClippingLayers) const
+OverlapMapContainer::ClippingScope* NODELETE OverlapMapContainer::findClippingScopeForLayers(const LayerOverlapMap::LayerAndBoundsVector& enclosingClippingLayers) const
 {
     ASSERT(enclosingClippingLayers.size());
     ASSERT(enclosingClippingLayers[0].layer->isRenderViewLayer());

--- a/Source/WebCore/rendering/LegacyInlineBox.h
+++ b/Source/WebCore/rendering/LegacyInlineBox.h
@@ -121,8 +121,8 @@ public:
         ASSERT(m_parent || !previous);
         m_previousOnLine = previous;
     }
-    bool nextOnLineExists() const;
-    bool previousOnLineExists() const;
+    bool NODELETE nextOnLineExists() const;
+    bool NODELETE previousOnLineExists() const;
 
     virtual bool isLeaf() const { return true; }
     
@@ -140,7 +140,7 @@ public:
     }
     void setParent(LegacyInlineFlowBox* par) { m_parent = par; }
 
-    const LegacyRootInlineBox& root() const;
+    const LegacyRootInlineBox& NODELETE root() const;
     LegacyRootInlineBox& root();
 
     // x() is the left side of the box in the containing block's coordinate system.
@@ -234,7 +234,7 @@ public:
     LayoutPoint flipForWritingMode(const LayoutPoint&) const;
 
     bool knownToHaveNoOverflow() const { return m_bitfields.knownToHaveNoOverflow(); }
-    void clearKnownToHaveNoOverflow();
+    void NODELETE clearKnownToHaveNoOverflow();
 
     // For LegacyInlineTextBox
     bool isInGlyphDisplayListCache() const { return m_bitfields.isInGlyphDisplayListCache(); }

--- a/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
+++ b/Source/WebCore/rendering/LegacyInlineFlowBox.cpp
@@ -74,7 +74,7 @@ void LegacyInlineFlowBox::setHasBadChildList()
 
 #endif
 
-static void setHasTextDescendantsOnAncestors(LegacyInlineFlowBox* box)
+static void NODELETE setHasTextDescendantsOnAncestors(LegacyInlineFlowBox* box)
 {
     while (box && !box->hasTextDescendants()) {
         box->setHasTextDescendants();

--- a/Source/WebCore/rendering/LegacyInlineTextBox.h
+++ b/Source/WebCore/rendering/LegacyInlineTextBox.h
@@ -41,7 +41,7 @@ public:
     explicit LegacyInlineTextBox(RenderSVGInlineText&);
     virtual ~LegacyInlineTextBox();
 
-    RenderSVGInlineText& renderer() const;
+    RenderSVGInlineText& NODELETE renderer() const;
     const RenderStyle& lineStyle() const;
 
     LegacyInlineTextBox* prevTextBox() const { return m_prevTextBox; }
@@ -93,14 +93,14 @@ public:
     RenderObject::HighlightState selectionState() const final;
 
 public:
-    bool isLineBreak() const final;
+    bool NODELETE isLineBreak() const final;
 
 private:
     bool isInlineTextBox() const final { return true; }
 
 public:
     int caretMinOffset() const final { return m_start; }
-    int caretMaxOffset() const final;
+    int NODELETE caretMaxOffset() const final;
 
 private:
     float textPos() const; // returns the x position relative to the left start of the text line.

--- a/Source/WebCore/rendering/LegacyLineLayout.cpp
+++ b/Source/WebCore/rendering/LegacyLineLayout.cpp
@@ -191,7 +191,7 @@ static inline void dirtyLineBoxesForRenderer(RenderObject& renderer)
         renderInline->deleteLegacyLineBoxes();
 }
 
-static bool parentIsConstructedOrHaveNext(LegacyInlineFlowBox* parentBox)
+static bool NODELETE parentIsConstructedOrHaveNext(LegacyInlineFlowBox* parentBox)
 {
     do {
         if (parentBox->isConstructed() || parentBox->nextOnLine())

--- a/Source/WebCore/rendering/LegacyLineLayout.h
+++ b/Source/WebCore/rendering/LegacyLineLayout.h
@@ -64,7 +64,7 @@ public:
     LegacyRootInlineBox* constructLine(BidiRunList<BidiRun>&, const LineInfo&);
     void addOverflowFromInlineChildren();
 
-    size_t lineCount() const;
+    size_t NODELETE lineCount() const;
 
     static void appendRunsForObject(BidiRunList<BidiRun>*, int start, int end, RenderObject&, InlineBidiResolver&);
 
@@ -82,8 +82,8 @@ private:
     void layoutRunsAndFloats(bool hasInlineChild);
     void layoutRunsAndFloatsInRange(InlineBidiResolver&);
 
-    const RenderStyle& style() const;
-    const LocalFrameViewLayoutContext& layoutContext() const;
+    const RenderStyle& NODELETE style() const;
+    const LocalFrameViewLayoutContext& NODELETE layoutContext() const;
 
     RenderBlockFlow& m_flow;
     std::unique_ptr<LegacyRootInlineBox> m_legacyRootInlineBox;

--- a/Source/WebCore/rendering/LegacyRootInlineBox.h
+++ b/Source/WebCore/rendering/LegacyRootInlineBox.h
@@ -42,7 +42,7 @@ public:
     explicit LegacyRootInlineBox(RenderBlockFlow&);
     virtual ~LegacyRootInlineBox();
 
-    RenderBlockFlow& blockFlow() const;
+    RenderBlockFlow& NODELETE blockFlow() const;
 
     LegacyRootInlineBox* nextRootBox() const;
     LegacyRootInlineBox* prevRootBox() const;
@@ -57,8 +57,8 @@ public:
     LayoutUnit lineBoxBottom() const { return m_lineBoxBottom; }
     LayoutUnit lineBoxHeight() const { return lineBoxBottom() - lineBoxTop(); }
 
-    LayoutUnit selectionTop() const;
-    LayoutUnit selectionBottom() const;
+    LayoutUnit NODELETE selectionTop() const;
+    LayoutUnit NODELETE selectionBottom() const;
     LayoutUnit selectionHeight() const { return std::max<LayoutUnit>(0, selectionBottom() - selectionTop()); }
 
     LayoutUnit selectionTopAdjustedForPrecedingBlock() const;
@@ -76,7 +76,7 @@ public:
     const LegacyInlineBox* firstSelectedBox() const;
     const LegacyInlineBox* lastSelectedBox() const;
 
-    void removeLineBoxFromRenderObject() final;
+    void NODELETE removeLineBoxFromRenderObject() final;
 
     FontBaseline baselineType() const { return static_cast<FontBaseline>(m_baselineType); }
     

--- a/Source/WebCore/rendering/MotionPath.h
+++ b/Source/WebCore/rendering/MotionPath.h
@@ -47,7 +47,7 @@ struct MotionPathData {
 class MotionPath {
 public:
     static std::optional<MotionPathData> motionPathDataForRenderer(const RenderElement&);
-    static bool needsUpdateAfterContainingBlockLayout(const Style::OffsetPath&);
+    static bool NODELETE needsUpdateAfterContainingBlockLayout(const Style::OffsetPath&);
 
     static void applyMotionPathTransform(TransformationMatrix&, const TransformOperationData&, FloatPoint transformOrigin, TransformBox, const Path&, std::optional<FloatPoint> offsetAnchor, float offsetDistance, float offsetRotate, bool offsetRotateHasAuto);
 

--- a/Source/WebCore/rendering/NinePieceImagePainter.cpp
+++ b/Source/WebCore/rendering/NinePieceImagePainter.cpp
@@ -59,17 +59,17 @@ static ImagePiece& operator++(ImagePiece& piece)
     return piece;
 }
 
-static bool isCornerPiece(ImagePiece piece)
+static bool NODELETE isCornerPiece(ImagePiece piece)
 {
     return piece == TopLeftPiece || piece == TopRightPiece || piece == BottomLeftPiece || piece == BottomRightPiece;
 }
 
-static bool isHorizontalPiece(ImagePiece piece)
+static bool NODELETE isHorizontalPiece(ImagePiece piece)
 {
     return piece == TopPiece || piece == BottomPiece || piece == MiddlePiece;
 }
 
-static bool isVerticalPiece(ImagePiece piece)
+static bool NODELETE isVerticalPiece(ImagePiece piece)
 {
     return piece == LeftPiece || piece == RightPiece || piece == MiddlePiece;
 }
@@ -129,7 +129,7 @@ static void scaleSlicesIfNeeded(const LayoutSize& size, LayoutBoxExtent& slices,
     slices.left()   *= sliceScaleFactor;
 }
 
-static bool isEmptyPieceRect(ImagePiece piece, const Vector<FloatRect, MaxPiece>& destinationRects, const Vector<FloatRect, MaxPiece>& sourceRects)
+static bool NODELETE isEmptyPieceRect(ImagePiece piece, const Vector<FloatRect, MaxPiece>& destinationRects, const Vector<FloatRect, MaxPiece>& sourceRects)
 {
     return destinationRects[piece].isEmpty() || sourceRects[piece].isEmpty();
 }

--- a/Source/WebCore/rendering/OrderIterator.h
+++ b/Source/WebCore/rendering/OrderIterator.h
@@ -48,10 +48,10 @@ public:
     RenderBox* first();
     RenderBox* next();
     OrderIterator reverse();
-    bool shouldSkipChild(const RenderObject&) const;
+    bool NODELETE shouldSkipChild(const RenderObject&) const;
 
 private:
-    void reset();
+    void NODELETE reset();
 
     RenderBox& m_containerBox;
     RenderBox* m_currentChild;

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -220,7 +220,7 @@ void OutlinePainter::paintOutlineWithLineRects(const RenderInline& renderer, con
         graphicsContext.endTransparencyLayer();
 }
 
-static bool usePlatformFocusRingColorForOutlineStyleAuto()
+static bool NODELETE usePlatformFocusRingColorForOutlineStyleAuto()
 {
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     return true;
@@ -229,7 +229,7 @@ static bool usePlatformFocusRingColorForOutlineStyleAuto()
 #endif
 }
 
-static bool useShrinkWrappedFocusRingForOutlineStyleAuto()
+static bool NODELETE useShrinkWrappedFocusRingForOutlineStyleAuto()
 {
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
     return true;

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.cpp
@@ -527,7 +527,7 @@ bool PositionedLayoutConstraints::alignmentAppliesStretch(ItemPosition normalAli
     return ItemPosition::Stretch == alignmentPosition;
 }
 
-bool PositionedLayoutConstraints::insetFitsContent() const
+bool NODELETE PositionedLayoutConstraints::insetFitsContent() const
 {
     return (m_insetBefore.isAuto() || m_insetAfter.isAuto())
         && !m_defaultAnchorBox; // position-area and align-center zero out auto insets.
@@ -706,7 +706,7 @@ LayoutUnit PositionedLayoutConstraints::computedBlockStaticDistance() const
     return !isOrthogonal() ? staticPosition.y() : staticPosition.x();
 }
 
-static bool shouldInlineStaticDistanceAdjustedWithBoxHeight(WritingMode containinigBlockWritingMode, WritingMode parentWritingMode, WritingMode outOfFlowBoxWritingMode)
+static bool NODELETE shouldInlineStaticDistanceAdjustedWithBoxHeight(WritingMode containinigBlockWritingMode, WritingMode parentWritingMode, WritingMode outOfFlowBoxWritingMode)
 {
     if (!containinigBlockWritingMode.isOrthogonal(parentWritingMode))
         return false;
@@ -760,7 +760,7 @@ void PositionedLayoutConstraints::fixupLogicalLeftPosition(RenderBox::LogicalExt
 }
 
 // FIXME: Let's move this over to RenderBoxModelObject and collapse some of the logic here.
-static bool shouldBlockStaticDistanceAdjustedWithBoxHeight(const RenderBoxModelObject& containingBlock, const RenderElement& parent, WritingMode outOfFlowBoxWritingMode)
+static bool NODELETE shouldBlockStaticDistanceAdjustedWithBoxHeight(const RenderBoxModelObject& containingBlock, const RenderElement& parent, WritingMode outOfFlowBoxWritingMode)
 {
     // This is where we check if the final static position needs to be adjusted with the height of the out-of-flow box.
     // In ::computeBlockStaticDistance we convert the static position relative to the containing block but in some cases

--- a/Source/WebCore/rendering/PositionedLayoutConstraints.h
+++ b/Source/WebCore/rendering/PositionedLayoutConstraints.h
@@ -54,11 +54,11 @@ public:
     WritingMode containingWritingMode() const { return m_containingWritingMode; }
     WritingMode selfWritingMode() const { return m_writingMode; }
 
-    bool needsAnchor() const;
+    bool NODELETE needsAnchor() const;
     const RenderBoxModelObject* defaultAnchorBox() const { return m_defaultAnchorBox.get(); }
     const StyleSelfAlignmentData& alignment() const { return m_alignment; }
     ItemPosition resolveAlignmentValue() const; // Convert auto/normal as necessary.
-    bool alignmentAppliesStretch(ItemPosition normalAlignment) const;
+    bool NODELETE alignmentAppliesStretch(ItemPosition normalAlignment) const;
 
     bool isOrthogonal() const { return m_containingWritingMode.isOrthogonal(m_writingMode); }
     inline bool isOpposing() const;
@@ -89,12 +89,12 @@ public:
     LayoutUnit resolveAlignmentShift(const LayoutUnit unusedSpace, const LayoutUnit itemSize) const;
 
     void fixupLogicalLeftPosition(RenderBox::LogicalExtentComputedValues&) const;
-    void adjustLogicalTopWithLogicalHeightIfNeeded(RenderBox::LogicalExtentComputedValues&) const;
+    void NODELETE adjustLogicalTopWithLogicalHeightIfNeeded(RenderBox::LogicalExtentComputedValues&) const;
 
     LayoutUnit computedInlineStaticDistance() const;
 
 private:
-    bool containingCoordsAreFlipped() const;
+    bool NODELETE containingCoordsAreFlipped() const;
 
     void captureInsets();
     void captureGridArea();

--- a/Source/WebCore/rendering/ReferencedSVGResources.cpp
+++ b/Source/WebCore/rendering/ReferencedSVGResources.cpp
@@ -58,7 +58,7 @@ public:
 
     void resourceChanged(SVGElement&) final;
 
-    const RenderElement& renderer() const final { return m_clientRenderer.get(); }
+    const RenderElement& NODELETE renderer() const final { return m_clientRenderer.get(); }
 
 private:
     const CheckedRef<RenderElement> m_clientRenderer;

--- a/Source/WebCore/rendering/RegionContext.h
+++ b/Source/WebCore/rendering/RegionContext.h
@@ -42,11 +42,11 @@ public:
     virtual ~RegionContext() = default;
 
     void pushTransform(const AffineTransform&);
-    void popTransform();
+    void NODELETE popTransform();
 
     void pushClip(const IntRect&);
     void pushClip(const Path&);
-    void popClip();
+    void NODELETE popClip();
 
     virtual bool isEventRegionContext() const { return false; }
     virtual bool isAccessibilityRegionContext() const { return false; }

--- a/Source/WebCore/rendering/RenderAttachment.cpp
+++ b/Source/WebCore/rendering/RenderAttachment.cpp
@@ -60,7 +60,7 @@ RenderAttachment::RenderAttachment(HTMLAttachmentElement& element, RenderStyle&&
 
 RenderAttachment::~RenderAttachment() = default;
 
-HTMLAttachmentElement& RenderAttachment::attachmentElement() const
+HTMLAttachmentElement& NODELETE RenderAttachment::attachmentElement() const
 {
     return downcast<HTMLAttachmentElement>(nodeForNonAnonymous());
 }

--- a/Source/WebCore/rendering/RenderAttachment.h
+++ b/Source/WebCore/rendering/RenderAttachment.h
@@ -42,7 +42,7 @@ public:
     HTMLAttachmentElement& NODELETE attachmentElement() const;
 
     void setShouldDrawBorder(bool drawBorder) { m_shouldDrawBorder = drawBorder; }
-    bool shouldDrawBorder() const;
+    bool NODELETE shouldDrawBorder() const;
 
     void setHasShadowControls(bool hasShadowControls) { m_hasShadowControls = hasShadowControls; }
     bool hasShadowControls() const { return m_hasShadowControls; }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -228,7 +228,7 @@ public:
             m_containerMap.remove(renderer);
     }
     
-    TrackedRendererListHashSet* positionedRenderers(const RenderBlock& containingBlock) const
+    TrackedRendererListHashSet* NODELETE positionedRenderers(const RenderBlock& containingBlock) const
     {
         return m_descendantsMap.get(containingBlock);
     }
@@ -476,7 +476,7 @@ void RenderBlock::endAndCommitUpdateScrollInfoAfterLayoutTransaction()
     }
 }
 
-static inline bool isDelayingUpdateScrollInfoAfterLayout(const RenderBlock& renderer)
+static inline bool NODELETE isDelayingUpdateScrollInfoAfterLayout(const RenderBlock& renderer)
 {
     auto* transaction = renderer.view().frameView().layoutContext().updateScrollInfoAfterLayoutTransactionIfExists();
     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=97937
@@ -1562,7 +1562,7 @@ GapRects RenderBlock::selectionGaps(RenderBlock& rootBlock, const LayoutPoint& r
     return result;
 }
 
-GapRects RenderBlock::inlineSelectionGaps(RenderBlock&, const LayoutPoint&, const LayoutSize&, LayoutUnit&, LayoutUnit&, LayoutUnit&, const LogicalSelectionOffsetCaches&, const PaintInfo*)
+GapRects NODELETE RenderBlock::inlineSelectionGaps(RenderBlock&, const LayoutPoint&, const LayoutSize&, LayoutUnit&, LayoutUnit&, LayoutUnit&, const LogicalSelectionOffsetCaches&, const PaintInfo*)
 {
     ASSERT_NOT_REACHED();
     return GapRects();
@@ -2155,7 +2155,7 @@ PositionWithAffinity RenderBlock::positionForPointWithInlineChildren(const Layou
     return PositionWithAffinity();
 }
 
-static inline bool isChildHitTestCandidate(const RenderBox& box, HitTestSource source)
+static inline bool NODELETE isChildHitTestCandidate(const RenderBox& box, HitTestSource source)
 {
     auto visibility = source == HitTestSource::Script ? box.style().visibility() : box.style().usedVisibility();
     return box.height() && visibility == Visibility::Visible && !box.isOutOfFlowPositioned() && !box.isRenderFragmentedFlow();
@@ -2496,7 +2496,7 @@ std::optional<LayoutUnit> RenderBlock::lastLineBaseline() const
     return lastInFlowBaseline();
 }
 
-static inline bool isRenderBlockFlowOrRenderButton(RenderElement& renderElement)
+static inline bool NODELETE isRenderBlockFlowOrRenderButton(RenderElement& renderElement)
 {
     // We include isRenderButton in this check because buttons are implemented
     // using flex box but should still support first-line|first-letter.

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -126,7 +126,7 @@ public:
     GapRects selectionGapRectsForRepaint(const RenderLayerModelObject* repaintContainer);
     LayoutRect logicalLeftSelectionGap(RenderBlock& rootBlock, const LayoutPoint& rootBlockPhysicalPosition, const LayoutSize& offsetFromRootBlock, RenderElement* selObj, LayoutUnit logicalLeft, LayoutUnit logicalTop, LayoutUnit logicalHeight, const LogicalSelectionOffsetCaches&, const PaintInfo*);
     LayoutRect logicalRightSelectionGap(RenderBlock& rootBlock, const LayoutPoint& rootBlockPhysicalPosition, const LayoutSize& offsetFromRootBlock, RenderElement* selObj, LayoutUnit logicalRight, LayoutUnit logicalTop, LayoutUnit logicalHeight, const LogicalSelectionOffsetCaches&, const PaintInfo*);
-    void getSelectionGapInfo(HighlightState, bool& leftGap, bool& rightGap);
+    void NODELETE getSelectionGapInfo(HighlightState, bool& leftGap, bool& rightGap);
     bool isSelectionRoot() const;
 
     LayoutRect logicalRectToPhysicalRect(const LayoutPoint& physicalPosition, const LayoutRect& logicalRect);
@@ -223,7 +223,7 @@ public:
 
     RenderFragmentedFlow* NODELETE cachedEnclosingFragmentedFlow() const;
     void setCachedEnclosingFragmentedFlowNeedsUpdate();
-    virtual bool cachedEnclosingFragmentedFlowNeedsUpdate() const;
+    virtual bool NODELETE cachedEnclosingFragmentedFlowNeedsUpdate() const;
     void resetEnclosingFragmentedFlowAndChildInfoIncludingDescendants(RenderFragmentedFlow* = nullptr) final;
 
     std::optional<LayoutUnit> availableLogicalHeightForPercentageComputation() const;

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -2040,7 +2040,7 @@ static inline bool needsAppleMailPaginationQuirk(const RenderBlockFlow& renderer
     return false;
 }
 
-static void clearShouldBreakAtLineToAvoidWidowIfNeeded(RenderBlockFlow& blockFlow)
+static void NODELETE clearShouldBreakAtLineToAvoidWidowIfNeeded(RenderBlockFlow& blockFlow)
 {
     if (!blockFlow.shouldBreakAtLineToAvoidWidow())
         return;
@@ -4007,7 +4007,7 @@ bool RenderBlockFlow::layoutSimpleBlockContentInInline(MarginInfo& marginInfo)
     return true;
 }
 
-static bool hasSimpleStaticPositionForInlineLevelOutOfFlowChildrenByStyle(const RenderStyle& rootStyle)
+static bool NODELETE hasSimpleStaticPositionForInlineLevelOutOfFlowChildrenByStyle(const RenderStyle& rootStyle)
 {
     if (rootStyle.textAlign() != Style::TextAlign::Start)
         return false;
@@ -4360,7 +4360,7 @@ static inline bool resizeTextPermitted(const RenderObject& renderer)
     return true;
 }
 
-static bool isNonBlocksOrNonFixedHeightListItems(const RenderObject& renderer)
+static bool NODELETE isNonBlocksOrNonFixedHeightListItems(const RenderObject& renderer)
 {
     if (!renderer.isRenderBlock())
         return true;
@@ -4615,7 +4615,7 @@ struct InlineMinMaxIterator {
         }
 
     RenderObject* next();
-    bool isEndOfInline() const { return m_isEndOfInline; }
+    bool NODELETE isEndOfInline() const { return m_isEndOfInline; }
 
 private:
     const RenderBlockFlow& m_blockContainer;

--- a/Source/WebCore/rendering/RenderBlockFlow.h
+++ b/Source/WebCore/rendering/RenderBlockFlow.h
@@ -265,15 +265,15 @@ public:
     bool childrenPreventSelfCollapsing() const final;
 
     bool shouldBreakAtLineToAvoidWidow() const { return hasRareBlockFlowData() && rareBlockFlowData()->m_lineBreakToAvoidWidow >= 0; }
-    void clearShouldBreakAtLineToAvoidWidow() const;
+    void NODELETE clearShouldBreakAtLineToAvoidWidow() const;
     int lineBreakToAvoidWidow() const { return hasRareBlockFlowData() ? rareBlockFlowData()->m_lineBreakToAvoidWidow : -1; }
     void setBreakAtLineToAvoidWidow(int);
-    void clearDidBreakAtLineToAvoidWidow();
-    void setDidBreakAtLineToAvoidWidow();
+    void NODELETE clearDidBreakAtLineToAvoidWidow();
+    void NODELETE setDidBreakAtLineToAvoidWidow();
     bool didBreakAtLineToAvoidWidow() const { return hasRareBlockFlowData() && rareBlockFlowData()->m_didBreakAtLineToAvoidWidow; }
 
     RenderMultiColumnFlow* multiColumnFlow() const { return hasRareBlockFlowData() ? multiColumnFlowSlowCase() : nullptr; }
-    RenderMultiColumnFlow* multiColumnFlowSlowCase() const;
+    RenderMultiColumnFlow* NODELETE multiColumnFlowSlowCase() const;
     void setMultiColumnFlow(RenderMultiColumnFlow&);
     void clearMultiColumnFlow();
     bool willCreateColumns(std::optional<unsigned> desiredColumnCount = std::nullopt) const;
@@ -340,7 +340,7 @@ public:
             floatingObject.setMarginOffset(LayoutSize(logicalBeforeMargin, logicalLeftMargin));
     }
 
-    LayoutPoint flipFloatForWritingModeForChild(const FloatingObject&, const LayoutPoint&) const;
+    LayoutPoint NODELETE flipFloatForWritingModeForChild(const FloatingObject&, const LayoutPoint&) const;
 
     LegacyRootInlineBox* legacyRootBox() const { return svgTextLayout() ? svgTextLayout()->legacyRootBox() : nullptr; }
 
@@ -386,7 +386,7 @@ public:
     LayoutUnit pageLogicalTopForOffset(LayoutUnit offset) const;
     LayoutUnit pageLogicalHeightForOffset(LayoutUnit offset) const;
     LayoutUnit pageRemainingLogicalHeightForOffset(LayoutUnit offset, PageBoundaryRule = IncludePageBoundary) const;
-    LayoutUnit logicalHeightForChildForFragmentation(const RenderBox& child) const;
+    LayoutUnit NODELETE logicalHeightForChildForFragmentation(const RenderBox& child) const;
     bool hasNextPage(LayoutUnit logicalOffset, PageBoundaryRule = ExcludePageBoundary) const;
 
     void updateColumnProgressionFromStyle(const RenderStyle&);
@@ -454,10 +454,10 @@ protected:
     std::optional<LayoutUnit> firstLineBaseline() const override;
     std::optional<LayoutUnit> lastLineBaseline() const override;
 
-    void setComputedColumnCountAndWidth(int, LayoutUnit);
+    void NODELETE setComputedColumnCountAndWidth(int, LayoutUnit);
 
     LayoutUnit computedColumnWidth() const;
-    unsigned computedColumnCount() const;
+    unsigned NODELETE computedColumnCount() const;
     
     LayoutOptionalOutsets allowedLayoutOverflow() const override;
 

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -443,7 +443,7 @@ void RenderBox::styleDidChange(Style::Difference diff, const RenderStyle* oldSty
         layoutContext().invalidateAnchorDependenciesForScroller(*this);
 }
 
-static bool hasEquivalentGridPositioningStyle(const RenderStyle& style, const RenderStyle& oldStyle)
+static bool NODELETE hasEquivalentGridPositioningStyle(const RenderStyle& style, const RenderStyle& oldStyle)
 {
     return oldStyle.gridItemColumnStart() == style.gridItemColumnStart()
         && oldStyle.gridItemColumnEnd() == style.gridItemColumnEnd()
@@ -3211,7 +3211,7 @@ RenderBoxFragmentInfo* RenderBox::renderBoxFragmentInfo(RenderFragmentContainer*
     return nullptr;
 }
 
-static bool shouldFlipBeforeAfterMargins(WritingMode containingBlockWritingMode, WritingMode childWritingMode)
+static bool NODELETE shouldFlipBeforeAfterMargins(WritingMode containingBlockWritingMode, WritingMode childWritingMode)
 {
     ASSERT(containingBlockWritingMode.isOrthogonal(childWritingMode));
     auto childBlockFlowDirection = childWritingMode.blockDirection();
@@ -3516,7 +3516,7 @@ std::optional<LayoutUnit> RenderBox::computeContentLogicalHeight(const Style::Fl
     return computeContentLogicalHeightGeneric(logicalHeight, intrinsicContentHeight);
 }
 
-static inline bool isOrthogonal(const RenderBox& renderer, const RenderElement& ancestor)
+static inline bool NODELETE isOrthogonal(const RenderBox& renderer, const RenderElement& ancestor)
 {
     return renderer.isHorizontalWritingMode() != ancestor.isHorizontalWritingMode();
 }
@@ -3680,7 +3680,7 @@ bool RenderBox::skipContainingBlockForPercentHeightCalculation(const RenderBox& 
     return document().inQuirksMode() && !containingBlock.isRenderTableCell() && !containingBlock.isOutOfFlowPositioned() && !containingBlock.isRenderGrid() && !containingBlock.isFlexibleBoxIncludingDeprecated() && containingBlock.style().logicalHeight().isAuto();
 }
 
-static bool tableCellShouldHaveZeroInitialSize(const RenderTableCell& tableCell, const RenderBox& child, bool scrollsOverflowY)
+static bool NODELETE tableCellShouldHaveZeroInitialSize(const RenderTableCell& tableCell, const RenderBox& child, bool scrollsOverflowY)
 {
     // Normally we would let the cell size intrinsically, but scrolling overflow has to be
     // treated differently, since WinIE lets scrolled overflow fragments shrink as needed.
@@ -4437,7 +4437,7 @@ void RenderBox::addVisualEffectOverflow()
         fragmentedFlow->addFragmentsVisualEffectOverflow(*this);
 }
 
-static void convertOutsetsToOverflowCoordinates(LayoutBoxExtent& outsets, WritingMode writingMode)
+static void NODELETE convertOutsetsToOverflowCoordinates(LayoutBoxExtent& outsets, WritingMode writingMode)
 {
     switch (writingMode.blockDirection()) {
     case FlowDirection::TopToBottom:

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -58,7 +58,7 @@ public:
 
     bool requiresLayer() const override;
 
-    bool requiresLayerWithScrollableArea() const;
+    bool NODELETE requiresLayerWithScrollableArea() const;
     bool backgroundIsKnownToBeOpaqueInRect(const LayoutRect& localRect) const override;
 
     LayoutUnit x() const { return m_frameRect.x(); }
@@ -525,9 +525,9 @@ public:
     LayoutUnit offsetLeft() const override;
     LayoutUnit offsetTop() const override;
 
-    LayoutPoint flipForWritingModeForChild(const RenderBox& child, const LayoutPoint&) const;
+    LayoutPoint NODELETE flipForWritingModeForChild(const RenderBox& child, const LayoutPoint&) const;
     LayoutUnit flipForWritingMode(LayoutUnit position) const; // The offset is in the block direction (y for horizontal writing modes, x for vertical writing modes).
-    LayoutPoint flipForWritingMode(const LayoutPoint&) const;
+    LayoutPoint NODELETE flipForWritingMode(const LayoutPoint&) const;
     LayoutSize flipForWritingMode(const LayoutSize&) const;
     FloatPoint flipForWritingMode(const FloatPoint&) const;
 
@@ -545,7 +545,7 @@ public:
     LayoutRect logicalLayoutOverflowRectForPropagation(const WritingMode) const;
     LayoutRect layoutOverflowRectForPropagation(const WritingMode) const;
     LayoutRect applyPaintGeometryTransformToRect(LayoutRect) const;
-    LayoutRect convertRectToParentWritingMode(LayoutRect, const WritingMode parentWritingMode) const;
+    LayoutRect NODELETE convertRectToParentWritingMode(LayoutRect, const WritingMode parentWritingMode) const;
 
     bool hasRenderOverflow() const { return !!m_overflow; }
     bool hasVisualOverflow() const { return m_overflow && !borderBoxRect().contains(m_overflow->visualOverflowRect()); }
@@ -554,15 +554,15 @@ public:
 
     ScrollPosition scrollPosition() const;
     ScrollPosition constrainedScrollPosition() const;
-    LayoutSize cachedSizeForOverflowClip() const;
+    LayoutSize NODELETE cachedSizeForOverflowClip() const;
 
     // Returns false if the rect has no intersection with the applied clip rect. When the context specifies edge-inclusive
     // intersection, this return value allows distinguishing between no intersection and zero-area intersection.
     bool applyCachedClipAndScrollPosition(RepaintRects&, const RenderLayerModelObject* container, VisibleRectContext) const final;
 
-    virtual bool hasRelativeDimensions() const;
-    virtual bool hasRelativeLogicalHeight() const;
-    virtual bool hasRelativeLogicalWidth() const;
+    virtual bool NODELETE hasRelativeDimensions() const;
+    virtual bool NODELETE hasRelativeLogicalHeight() const;
+    virtual bool NODELETE hasRelativeLogicalWidth() const;
 
     bool hasHorizontalLayoutOverflow() const
     {
@@ -631,7 +631,7 @@ public:
     bool includeVerticalScrollbarSize() const;
     bool includeHorizontalScrollbarSize() const;
 
-    void invalidateAncestorBackgroundObscurationStatus();
+    void NODELETE invalidateAncestorBackgroundObscurationStatus();
 
     inline bool backgroundIsKnownToBeObscured(const LayoutPoint& paintOffset);
 
@@ -650,7 +650,7 @@ protected:
     inline bool shouldTrimChildMargin(Style::MarginTrimSide, const RenderBox&) const;
     virtual bool isChildEligibleForMarginTrim(Style::MarginTrimSide, const RenderBox&) const { return false; }
 
-    virtual bool shouldResetLogicalHeightBeforeLayout() const;
+    virtual bool NODELETE shouldResetLogicalHeightBeforeLayout() const;
     void resetLogicalHeightBeforeLayoutIfNeeded();
 
     // Returns false if it could not cheaply compute the extent (e.g. fixed background), in which case the returned rect may be incorrect.
@@ -679,12 +679,12 @@ protected:
     const RenderElement* pushMappingToContainer(const RenderLayerModelObject*, RenderGeometryMap&) const override;
     void mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode>, TransformState&) const override;
 
-    bool skipContainingBlockForPercentHeightCalculation(const RenderBox& containingBlock, bool isPerpendicularWritingMode) const;
+    bool NODELETE skipContainingBlockForPercentHeightCalculation(const RenderBox& containingBlock, bool isPerpendicularWritingMode) const;
 
     void incrementVisuallyNonEmptyPixelCountIfNeeded(const IntSize&);
 
     std::optional<double> resolveAspectRatio() const;
-    bool shouldIgnoreAspectRatio() const;
+    bool NODELETE shouldIgnoreAspectRatio() const;
     bool isRenderReplacedWithIntrinsicRatio() const;
     bool shouldComputeLogicalWidthFromAspectRatio() const;
     LayoutUnit computeLogicalWidthFromAspectRatioInternal() const;

--- a/Source/WebCore/rendering/RenderBoxModelObject.cpp
+++ b/Source/WebCore/rendering/RenderBoxModelObject.cpp
@@ -248,7 +248,7 @@ static LayoutSize accumulateInFlowPositionOffsets(const RenderBoxModelObject& ch
     return offset;
 }
     
-static inline bool isOutOfFlowPositionedWithImplicitHeight(const RenderBoxModelObject& child)
+static inline bool NODELETE isOutOfFlowPositionedWithImplicitHeight(const RenderBoxModelObject& child)
 {
     return child.isOutOfFlowPositioned() && !child.style().logicalTop().isAuto() && !child.style().logicalBottom().isAuto();
 }
@@ -741,17 +741,17 @@ void RenderBoxModelObject::paintMaskForTextFillBox(GraphicsContext& context, con
     paint(maskInfo, scrolledPaintRect.location() - localOffset);
 }
 
-static inline LayoutUnit resolveWidthForRatio(LayoutUnit height, const LayoutSize& intrinsicRatio)
+static inline LayoutUnit NODELETE resolveWidthForRatio(LayoutUnit height, const LayoutSize& intrinsicRatio)
 {
     return height * intrinsicRatio.width() / intrinsicRatio.height();
 }
 
-static inline LayoutUnit resolveHeightForRatio(LayoutUnit width, const LayoutSize& intrinsicRatio)
+static inline LayoutUnit NODELETE resolveHeightForRatio(LayoutUnit width, const LayoutSize& intrinsicRatio)
 {
     return width * intrinsicRatio.height() / intrinsicRatio.width();
 }
 
-static inline LayoutSize resolveAgainstIntrinsicWidthOrHeightAndRatio(const LayoutSize& size, const LayoutSize& intrinsicRatio, LayoutUnit useWidth, LayoutUnit useHeight)
+static inline LayoutSize NODELETE resolveAgainstIntrinsicWidthOrHeightAndRatio(const LayoutSize& size, const LayoutSize& intrinsicRatio, LayoutUnit useWidth, LayoutUnit useHeight)
 {
     if (intrinsicRatio.isEmpty()) {
         if (useWidth)

--- a/Source/WebCore/rendering/RenderBoxModelObject.h
+++ b/Source/WebCore/rendering/RenderBoxModelObject.h
@@ -261,7 +261,7 @@ public:
         ContinuationChainNode(RenderBoxModelObject&);
         ~ContinuationChainNode();
 
-        void insertAfter(ContinuationChainNode&);
+        void NODELETE insertAfter(ContinuationChainNode&);
     };
 
     ContinuationChainNode* continuationChainNode() const;

--- a/Source/WebCore/rendering/RenderButton.cpp
+++ b/Source/WebCore/rendering/RenderButton.cpp
@@ -50,7 +50,7 @@ RenderButton::RenderButton(HTMLFormControlElement& element, RenderStyle&& style)
 
 RenderButton::~RenderButton() = default;
 
-HTMLFormControlElement& RenderButton::formControlElement() const
+HTMLFormControlElement& NODELETE RenderButton::formControlElement() const
 {
     return downcast<HTMLFormControlElement>(nodeForNonAnonymous());
 }

--- a/Source/WebCore/rendering/RenderButton.h
+++ b/Source/WebCore/rendering/RenderButton.h
@@ -55,7 +55,7 @@ public:
     void updateAnonymousChildStyle(RenderStyle&) const override;
 
     void setText(const String&);
-    String text() const;
+    String NODELETE text() const;
 
 #if PLATFORM(IOS_FAMILY)
     void layout() override;

--- a/Source/WebCore/rendering/RenderCounter.cpp
+++ b/Source/WebCore/rendering/RenderCounter.cpp
@@ -105,7 +105,7 @@ static RenderElement* previousInPreOrderRespectingContainment(const RenderElemen
     return nullptr;
 }
 
-static inline Element* parentOrPseudoHostElement(const RenderElement& renderer)
+static inline Element* NODELETE parentOrPseudoHostElement(const RenderElement& renderer)
 {
     if (renderer.isPseudoElement())
         return renderer.generatingElement();
@@ -148,7 +148,7 @@ static RenderElement* previousSiblingOrParent(const RenderElement& renderer)
     return previous ? previous->renderer() : nullptr;
 }
 
-static inline bool areRenderersElementsSiblings(const RenderElement& first, const RenderElement& second)
+static inline bool NODELETE areRenderersElementsSiblings(const RenderElement& first, const RenderElement& second)
 {
     return parentOrPseudoHostElement(first) == parentOrPseudoHostElement(second);
 }

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp
@@ -72,7 +72,7 @@ public:
         reset();
     }
 
-    void reset()
+    void NODELETE reset()
     {
         m_currentChild = nullptr;
         m_ordinalIteration = std::numeric_limits<unsigned>::max();
@@ -155,7 +155,7 @@ static LayoutUnit marginWidthForChild(RenderBox* child)
     return margin;
 }
 
-static bool childDoesNotAffectWidthOrFlexing(RenderObject* child)
+static bool NODELETE childDoesNotAffectWidthOrFlexing(RenderObject* child)
 {
     // Positioned children don't affect the min/max width.
     return child->isOutOfFlowPositioned();

--- a/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h
@@ -56,7 +56,7 @@ private:
     bool hasClampingAndNoFlexing() const;
 
     LayoutUnit allowedChildFlex(RenderBox* child, bool expanding, unsigned group);
-    void placeChild(RenderBox* child, const LayoutPoint& location, LayoutSize* childLayoutDelta = nullptr);
+    void NODELETE placeChild(RenderBox* child, const LayoutPoint& location, LayoutSize* childLayoutDelta = nullptr);
 
     bool hasMultipleLines() const { return style().boxLines() == BoxLines::Multiple; }
     bool isVertical() const { return style().boxOrient() == BoxOrient::Vertical; }

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -105,7 +105,7 @@ public:
     RenderObject* firstInFlowChild() const;
     RenderObject* lastInFlowChild() const;
 
-    Layout::ElementBox* layoutBox();
+    Layout::ElementBox* NODELETE layoutBox();
     const Layout::ElementBox* layoutBox() const;
 
     // Note that even if these 2 "canContain" functions return true for a particular renderer, it does not necessarily mean the renderer is the containing block (see containingBlockForAbsolute(Fixed)Position).
@@ -148,8 +148,8 @@ public:
     virtual void dirtyLineFromChangedChild() { }
 
     void setChildNeedsLayout(MarkingBehavior = MarkContainingBlockChain);
-    void setOutOfFlowChildNeedsStaticPositionLayout();
-    void clearChildNeedsLayout();
+    void NODELETE setOutOfFlowChildNeedsStaticPositionLayout();
+    void NODELETE clearChildNeedsLayout();
     void setNeedsOutOfFlowMovementLayout(const RenderStyle* oldStyle);
     void setNeedsLayoutForStyleDifference(Style::Difference, const RenderStyle* oldStyle);
     void setNeedsLayoutForOverflowChange();
@@ -338,9 +338,9 @@ public:
 
     inline bool hasPotentiallyScrollableOverflow() const;
 
-    inline bool isBeforeContent() const;
-    inline bool isAfterContent() const;
-    inline bool isBeforeOrAfterContent() const;
+    inline bool NODELETE isBeforeContent() const;
+    inline bool NODELETE isAfterContent() const;
+    inline bool NODELETE isBeforeOrAfterContent() const;
     static bool isBeforeContent(const RenderElement*);
     static bool isAfterContent(const RenderElement*);
     static bool isBeforeOrAfterContent(const RenderElement*);
@@ -351,7 +351,7 @@ protected:
     RenderElement(Type, Element&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
     RenderElement(Type, Document&, RenderStyle&&, OptionSet<TypeFlag>, TypeSpecificFlags);
 
-    bool layerCreationAllowedForSubtree() const;
+    bool NODELETE layerCreationAllowedForSubtree() const;
 
     enum class StylePropagationType {
         AllChildren,

--- a/Source/WebCore/rendering/RenderFileUploadControl.cpp
+++ b/Source/WebCore/rendering/RenderFileUploadControl.cpp
@@ -79,7 +79,7 @@ RenderFileUploadControl::RenderFileUploadControl(HTMLInputElement& input, Render
 
 RenderFileUploadControl::~RenderFileUploadControl() = default;
 
-HTMLInputElement& RenderFileUploadControl::inputElement() const
+HTMLInputElement& NODELETE RenderFileUploadControl::inputElement() const
 {
     return downcast<HTMLInputElement>(nodeForNonAnonymous());
 }
@@ -104,13 +104,13 @@ void RenderFileUploadControl::updateFromElement()
         repaint();
 }
 
-static int nodeLogicalWidth(Node* node)
+static int NODELETE nodeLogicalWidth(Node* node)
 {
     return (node && node->renderBox()) ? roundToInt(node->renderBox()->logicalSize().width()) : 0;
 }
 
 #if PLATFORM(COCOA)
-static int nodeLogicalHeight(Node* node)
+static int NODELETE nodeLogicalHeight(Node* node)
 {
     return (node && node->renderBox()) ? roundToInt(node->renderBox()->logicalSize().height()) : 0;
 }

--- a/Source/WebCore/rendering/RenderFileUploadControl.h
+++ b/Source/WebCore/rendering/RenderFileUploadControl.h
@@ -57,7 +57,7 @@ private:
 
     PositionWithAffinity positionForPoint(const LayoutPoint&, HitTestSource, const RenderFragmentContainer*) override;
 
-    HTMLInputElement* uploadButton() const;
+    HTMLInputElement* NODELETE uploadButton() const;
 
     bool m_canReceiveDroppedFiles;
 };

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -358,7 +358,7 @@ std::optional <LayoutUnit> RenderFlexibleBox::lastLineBaseline() const
     return (settings().subpixelInlineLayoutEnabled() ? LayoutUnit(baselineFlexItem->logicalTop()) : LayoutUnit(baselineFlexItem->logicalTop().toInt())) + *baseline;
 }
 
-static const StyleContentAlignmentData& contentAlignmentNormalBehavior()
+static const StyleContentAlignmentData& NODELETE contentAlignmentNormalBehavior()
 {
     // The justify-content property applies along the main axis, but since
     // flexing in the main axis is controlled by flex, stretch behaves as
@@ -559,17 +559,17 @@ bool RenderFlexibleBox::isColumnFlow() const
     return style().isColumnFlexDirection();
 }
 
-bool RenderFlexibleBox::isColumnOrRowReverse() const
+bool NODELETE RenderFlexibleBox::isColumnOrRowReverse() const
 {
     return style().flexDirection() == FlexDirection::ColumnReverse || style().flexDirection() == FlexDirection::RowReverse;
 }
 
-bool RenderFlexibleBox::isWrapReverse() const
+bool NODELETE RenderFlexibleBox::isWrapReverse() const
 {
     return style().flexWrap() == FlexWrap::Reverse;
 }
 
-bool RenderFlexibleBox::isHorizontalFlow() const
+bool NODELETE RenderFlexibleBox::isHorizontalFlow() const
 {
     if (isHorizontalWritingMode())
         return !isColumnFlow();
@@ -583,7 +583,7 @@ bool RenderFlexibleBox::isLeftToRightFlow() const
     return writingMode().isLogicalLeftInlineStart() ^ (style().flexDirection() == FlexDirection::RowReverse);
 }
 
-RenderFlexibleBox::Direction RenderFlexibleBox::crossAxisDirection() const
+RenderFlexibleBox::Direction NODELETE RenderFlexibleBox::crossAxisDirection() const
 {
     auto crossAxisDirection = style().isRowFlexDirection() ? writingMode().blockDirection() : writingMode().inlineDirection();
     switch (crossAxisDirection) {
@@ -2046,7 +2046,7 @@ static LayoutUnit justifyContentSpaceBetweenFlexItems(LayoutUnit availableFreeSp
     return 0;
 }
 
-static LayoutUnit alignmentOffset(LayoutUnit availableFreeSpace, ItemPosition position, std::optional<LayoutUnit> ascent, std::optional<LayoutUnit> maxAscent, bool isWrapReverse)
+static LayoutUnit NODELETE alignmentOffset(LayoutUnit availableFreeSpace, ItemPosition position, std::optional<LayoutUnit> ascent, std::optional<LayoutUnit> maxAscent, bool isWrapReverse)
 {
     switch (position) {
     case ItemPosition::Legacy:

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -99,7 +99,7 @@ public:
 
     bool isComputingFlexBaseSizes() const { return m_isComputingFlexBaseSizes; }
 
-    static std::optional<TextDirection> leftRightAxisDirectionFromStyle(const RenderStyle&);
+    static std::optional<TextDirection> NODELETE leftRightAxisDirectionFromStyle(const RenderStyle&);
 
     bool hasModernLayout() const { return m_hasFlexFormattingContextLayout && *m_hasFlexFormattingContextLayout; }
 
@@ -116,10 +116,10 @@ private:
     public:
         FlexLayoutItem(RenderBox&, LayoutUnit, LayoutUnit, LayoutUnit, std::pair<LayoutUnit, LayoutUnit>, bool);
 
-        LayoutUnit hypotheticalMainAxisMarginBoxSize() const;
-        LayoutUnit flexBaseMarginBoxSize() const;
-        LayoutUnit flexedMarginBoxSize() const;
-        const RenderStyle& style() const;
+        LayoutUnit NODELETE hypotheticalMainAxisMarginBoxSize() const;
+        LayoutUnit NODELETE flexBaseMarginBoxSize() const;
+        LayoutUnit NODELETE flexedMarginBoxSize() const;
+        const RenderStyle& NODELETE style() const;
         LayoutUnit constrainSizeByMinMax(const LayoutUnit size) const;
 
         CheckedRef<RenderBox> renderer;
@@ -148,30 +148,30 @@ private:
     static constexpr unsigned s_lineStatesInitialCapacity = 2;
     using FlexLineStates = Vector<LineState, s_lineStatesInitialCapacity>;
 
-    bool mainAxisIsFlexItemInlineAxis(const RenderBox&) const;
-    bool isColumnFlow() const;
-    bool isLeftToRightFlow() const;
-    bool isMultiline() const;
+    bool NODELETE mainAxisIsFlexItemInlineAxis(const RenderBox&) const;
+    bool NODELETE isColumnFlow() const;
+    bool NODELETE isLeftToRightFlow() const;
+    bool NODELETE isMultiline() const;
     Style::FlexBasis flexBasisForFlexItem(const RenderBox& flexItem) const;
-    const Style::PreferredSize& preferredMainSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::MinimumSize& minMainSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::MaximumSize& maxMainSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::PreferredSize& preferredCrossSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::MinimumSize& minCrossSizeLengthForFlexItem(const RenderBox&) const;
-    const Style::MaximumSize& maxCrossSizeLengthForFlexItem(const RenderBox&) const;
+    const Style::PreferredSize& NODELETE preferredMainSizeLengthForFlexItem(const RenderBox&) const;
+    const Style::MinimumSize& NODELETE minMainSizeLengthForFlexItem(const RenderBox&) const;
+    const Style::MaximumSize& NODELETE maxMainSizeLengthForFlexItem(const RenderBox&) const;
+    const Style::PreferredSize& NODELETE preferredCrossSizeLengthForFlexItem(const RenderBox&) const;
+    const Style::MinimumSize& NODELETE minCrossSizeLengthForFlexItem(const RenderBox&) const;
+    const Style::MaximumSize& NODELETE maxCrossSizeLengthForFlexItem(const RenderBox&) const;
     bool shouldApplyMinSizeAutoForFlexItem(const RenderBox&) const;
-    LayoutUnit crossAxisExtentForFlexItem(const RenderBox& flexItem) const;
+    LayoutUnit NODELETE crossAxisExtentForFlexItem(const RenderBox& flexItem) const;
     LayoutUnit crossAxisIntrinsicExtentForFlexItem(RenderBox& flexItem);
     LayoutUnit flexItemIntrinsicLogicalHeight(RenderBox& flexItem) const;
     LayoutUnit flexItemIntrinsicLogicalWidth(RenderBox& flexItem);
-    LayoutUnit mainAxisExtentForFlexItem(const RenderBox& flexItem) const;
+    LayoutUnit NODELETE mainAxisExtentForFlexItem(const RenderBox& flexItem) const;
     LayoutUnit mainAxisContentExtentForFlexItemIncludingScrollbar(const RenderBox& flexItem) const;
-    LayoutUnit crossAxisExtent() const;
-    LayoutUnit mainAxisExtent() const;
+    LayoutUnit NODELETE crossAxisExtent() const;
+    LayoutUnit NODELETE mainAxisExtent() const;
     LayoutUnit crossAxisContentExtent() const;
     LayoutUnit mainAxisContentExtent(LayoutUnit contentLogicalHeight);
     template<typename SizeType> std::optional<LayoutUnit> computeMainAxisExtentForFlexItem(RenderBox& flexItem, const SizeType&);
-    FlowDirection transformedBlockFlowDirection() const;
+    FlowDirection NODELETE transformedBlockFlowDirection() const;
     LayoutUnit flowAwareBorderStart() const;
     LayoutUnit flowAwareBorderEnd() const;
     LayoutUnit flowAwareBorderBefore() const;
@@ -188,7 +188,7 @@ private:
     LayoutUnit crossAxisScrollbarExtent() const;
     LayoutUnit mainAxisScrollbarExtent() const;
     LayoutUnit crossAxisScrollbarExtentForFlexItem(const RenderBox& flexItem) const;
-    LayoutPoint flowAwareLocationForFlexItem(const RenderBox& flexItem) const;
+    LayoutPoint NODELETE flowAwareLocationForFlexItem(const RenderBox& flexItem) const;
 
     double preferredAspectRatioForFlexItem(const RenderBox&) const;
     bool flexItemHasComputableAspectRatio(const RenderBox&) const;
@@ -199,10 +199,10 @@ private:
     LayoutUnit computeCrossSizeForFlexItemUsingContainerCrossSize(const RenderBox& flexItem) const;
     void computeChildIntrinsicLogicalWidths(RenderBox&, LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
     template<typename SizeType> LayoutUnit computeMainSizeFromAspectRatioUsing(const RenderBox& flexItem, const SizeType& crossSizeLength) const;
-    void setFlowAwareLocationForFlexItem(RenderBox& flexItem, const LayoutPoint&);
+    void NODELETE setFlowAwareLocationForFlexItem(RenderBox& flexItem, const LayoutPoint&);
     LayoutUnit computeFlexBaseSizeForFlexItem(RenderBox& flexItem, LayoutUnit mainAxisBorderAndPadding, RelayoutChildren);
     void maybeCacheFlexItemMainIntrinsicSize(RenderBox& flexItem, RelayoutChildren);
-    void adjustAlignmentForFlexItem(RenderBox& flexItem, LayoutUnit);
+    void NODELETE adjustAlignmentForFlexItem(RenderBox& flexItem, LayoutUnit);
     ItemPosition alignmentForFlexItem(const RenderBox& flexItem) const;
     inline OverflowAlignment overflowAlignmentForFlexItem(const RenderBox& flexItem) const;
     template<typename SizeType> bool canComputePercentageFlexBasis(const RenderBox& flexItem, const SizeType&, UpdatePercentageHeightDescendants);
@@ -210,8 +210,8 @@ private:
     template<typename SizeType> bool flexItemCrossSizeIsDefinite(const RenderBox&, const SizeType&);
     bool needToStretchFlexItemLogicalHeight(const RenderBox& flexItem) const;
     bool flexItemHasIntrinsicMainAxisSize(const RenderBox& flexItem);
-    Overflow mainAxisOverflowForFlexItem(const RenderBox& flexItem) const;
-    Overflow crossAxisOverflowForFlexItem(const RenderBox& flexItem) const;
+    Overflow NODELETE mainAxisOverflowForFlexItem(const RenderBox& flexItem) const;
+    Overflow NODELETE crossAxisOverflowForFlexItem(const RenderBox& flexItem) const;
     void cacheFlexItemMainSize(const RenderBox& flexItem);
 
     void performFlexLayout(RelayoutChildren);
@@ -227,7 +227,7 @@ private:
     std::optional<FlexingLineData> computeNextFlexLine(size_t& nextIndex, const FlexLayoutItems& allItems, LayoutUnit lineBreakLength, LayoutUnit gapBetweenItems);
 
     LayoutUnit autoMarginOffsetInMainAxis(const FlexLayoutItems&, LayoutUnit& availableFreeSpace);
-    void updateAutoMarginsInMainAxis(RenderBox& flexItem, LayoutUnit autoMarginOffset);
+    void NODELETE updateAutoMarginsInMainAxis(RenderBox& flexItem, LayoutUnit autoMarginOffset);
 
     void initializeMarginTrimState(); 
     // Start margin parallel with the cross axis
@@ -245,8 +245,8 @@ private:
     bool canFitItemWithTrimmedMarginEnd(const FlexLayoutItem&, LayoutUnit sumHypotheticalMainSize, LayoutUnit lineBreakLength) const;
     void removeMarginEndFromFlexSizes(FlexLayoutItem&, LayoutUnit& sumFlexBaseSize, LayoutUnit& sumHypotheticalMainSize) const;
 
-    bool hasAutoMarginsInCrossAxis(const RenderBox& flexItem) const;
-    bool updateAutoMarginsInCrossAxis(RenderBox& flexItem, LayoutUnit availableAlignmentSpace);
+    bool NODELETE hasAutoMarginsInCrossAxis(const RenderBox& flexItem) const;
+    bool NODELETE updateAutoMarginsInCrossAxis(RenderBox& flexItem, LayoutUnit availableAlignmentSpace);
     void repositionLogicalHeightDependentFlexItems(FlexLineStates&, LayoutUnit gapBetweenLines);
     
     LayoutUnit availableAlignmentSpaceForFlexItem(LayoutUnit lineCrossAxisExtent, const RenderBox& flexItem);

--- a/Source/WebCore/rendering/RenderFragmentContainer.h
+++ b/Source/WebCore/rendering/RenderFragmentContainer.h
@@ -73,7 +73,7 @@ public:
 
     bool isFirstFragment() const;
     bool isLastFragment() const;
-    virtual bool shouldClipFragmentedFlowContent() const;
+    virtual bool NODELETE shouldClipFragmentedFlowContent() const;
 
     // These methods represent the width and height of a "page" and for a RenderFragmentContainer they are just the
     // content width and content height of a fragment. For RenderFragmentContainerSets, however, they will be the width and
@@ -81,8 +81,8 @@ public:
     virtual LayoutUnit pageLogicalWidth() const;
     virtual LayoutUnit pageLogicalHeight() const;
 
-    LayoutUnit logicalTopOfFragmentedFlowContentRect(const LayoutRect&) const;
-    LayoutUnit logicalBottomOfFragmentedFlowContentRect(const LayoutRect&) const;
+    LayoutUnit NODELETE logicalTopOfFragmentedFlowContentRect(const LayoutRect&) const;
+    LayoutUnit NODELETE logicalBottomOfFragmentedFlowContentRect(const LayoutRect&) const;
     LayoutUnit logicalTopForFragmentedFlowContent() const { return logicalTopOfFragmentedFlowContentRect(fragmentedFlowPortionRect()); };
     LayoutUnit logicalBottomForFragmentedFlowContent() const { return logicalBottomOfFragmentedFlowContentRect(fragmentedFlowPortionRect()); };
 
@@ -142,7 +142,7 @@ private:
     void insertedIntoTree() override;
     void willBeRemovedFromTree() override;
 
-    virtual void installFragmentedFlow();
+    virtual void NODELETE installFragmentedFlow();
 
     LayoutPoint mapFragmentPointIntoFragmentedFlowCoordinates(const LayoutPoint&);
     LayoutRect computedVisualOverflowRectForBox(const RenderBox&) const;

--- a/Source/WebCore/rendering/RenderFragmentContainerSet.h
+++ b/Source/WebCore/rendering/RenderFragmentContainerSet.h
@@ -53,7 +53,7 @@ protected:
     virtual ~RenderFragmentContainerSet();
 
 private:
-    void installFragmentedFlow() final;
+    void NODELETE installFragmentedFlow() final;
 
     ASCIILiteral renderName() const override = 0;
     

--- a/Source/WebCore/rendering/RenderFragmentedFlow.cpp
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.cpp
@@ -271,8 +271,8 @@ public:
     {
     }
 
-    const LayoutUnit& lowValue() const { return m_offset; }
-    const LayoutUnit& highValue() const { return m_offset; }
+    const LayoutUnit& NODELETE lowValue() const { return m_offset; }
+    const LayoutUnit& NODELETE highValue() const { return m_offset; }
 
     void collectIfNeeded(const PODInterval<LayoutUnit, SingleThreadWeakPtr<RenderFragmentContainer>>& interval)
     {
@@ -282,7 +282,7 @@ public:
             m_result = interval.data();
     }
 
-    RenderFragmentContainer* result() const { return m_result.get(); }
+    RenderFragmentContainer* NODELETE result() const { return m_result.get(); }
 
 private:
     LayoutUnit m_offset;

--- a/Source/WebCore/rendering/RenderFragmentedFlow.h
+++ b/Source/WebCore/rendering/RenderFragmentedFlow.h
@@ -120,7 +120,7 @@ public:
     virtual void setFragmentRangeForBox(const RenderBox&, RenderFragmentContainer*, RenderFragmentContainer*);
     bool getFragmentRangeForBox(const RenderBox&, RenderFragmentContainer*& startFragment, RenderFragmentContainer*& endFragment) const;
     bool computedFragmentRangeForBox(const RenderBox&, RenderFragmentContainer*& startFragment, RenderFragmentContainer*& endFragment) const;
-    bool hasCachedFragmentRangeForBox(const RenderBox&) const;
+    bool NODELETE hasCachedFragmentRangeForBox(const RenderBox&) const;
 
     // Check if the object is in fragment and the fragment is part of this flow thread.
     bool objectInFlowFragment(const RenderObject*, const RenderFragmentContainer*) const;
@@ -150,7 +150,7 @@ public:
     LayoutRect mapFromFragmentedFlowToLocal(const RenderBox*, const LayoutRect&) const;
     LayoutRect mapFromLocalToFragmentedFlow(const RenderBox*, const LayoutRect&) const;
 
-    void flipForWritingModeLocalCoordinates(LayoutRect&) const;
+    void NODELETE flipForWritingModeLocalCoordinates(LayoutRect&) const;
 
     // Used to estimate the maximum height of the flow thread.
     static LayoutUnit maxLogicalHeight() { return LayoutUnit::max() / 2; }
@@ -164,7 +164,7 @@ public:
     void layout() override;
 
     void setCurrentFragmentMaintainer(CurrentRenderFragmentContainerMaintainer* currentFragmentMaintainer) { m_currentFragmentMaintainer = currentFragmentMaintainer; }
-    RenderFragmentContainer* currentFragment() const;
+    RenderFragmentContainer* NODELETE currentFragment() const;
 
     bool cachedEnclosingFragmentedFlowNeedsUpdate() const override { return false; }
 

--- a/Source/WebCore/rendering/RenderFrame.cpp
+++ b/Source/WebCore/rendering/RenderFrame.cpp
@@ -44,7 +44,7 @@ RenderFrame::RenderFrame(HTMLFrameElement& frame, RenderStyle&& style)
 
 RenderFrame::~RenderFrame() = default;
 
-HTMLFrameElement& RenderFrame::frameElement() const
+HTMLFrameElement& NODELETE RenderFrame::frameElement() const
 {
     return downcast<HTMLFrameElement>(RenderFrameBase::frameOwnerElement());
 }

--- a/Source/WebCore/rendering/RenderFrameSet.cpp
+++ b/Source/WebCore/rendering/RenderFrameSet.cpp
@@ -66,7 +66,7 @@ RenderFrameSet::RenderFrameSet(HTMLFrameSetElement& frameSet, RenderStyle&& styl
 
 RenderFrameSet::~RenderFrameSet() = default;
 
-HTMLFrameSetElement& RenderFrameSet::frameSetElement() const
+HTMLFrameSetElement& NODELETE RenderFrameSet::frameSetElement() const
 {
     return downcast<HTMLFrameSetElement>(nodeForNonAnonymous());
 }

--- a/Source/WebCore/rendering/RenderFrameSet.h
+++ b/Source/WebCore/rendering/RenderFrameSet.h
@@ -66,8 +66,8 @@ public:
 
     bool userResize(MouseEvent&);
 
-    bool canResizeRow(const IntPoint&) const;
-    bool canResizeColumn(const IntPoint&) const;
+    bool NODELETE canResizeRow(const IntPoint&) const;
+    bool NODELETE canResizeColumn(const IntPoint&) const;
 
     void notifyFrameEdgeInfoChanged();
 
@@ -103,13 +103,13 @@ private:
 
     void layOutAxis(GridAxis&, std::span<const HTMLDimensionsListValue>, int availableSpace);
     void computeEdgeInfo();
-    void fillFromEdgeInfo(const FrameEdgeInfo& edgeInfo, int r, int c);
+    void NODELETE fillFromEdgeInfo(const FrameEdgeInfo&, int r, int c);
     void positionFrames();
 
-    int splitPosition(const GridAxis&, int split) const;
-    int hitTestSplit(const GridAxis&, int position) const;
+    int NODELETE splitPosition(const GridAxis&, int split) const;
+    int NODELETE hitTestSplit(const GridAxis&, int position) const;
 
-    void startResizing(GridAxis&, int position);
+    void NODELETE startResizing(GridAxis&, int position);
     void continueResizing(GridAxis&, int position);
 
     void paintRowBorder(const PaintInfo&, const IntRect&);

--- a/Source/WebCore/rendering/RenderGeometryMap.h
+++ b/Source/WebCore/rendering/RenderGeometryMap.h
@@ -92,7 +92,7 @@ public:
     
     // Called by code walking the renderer or layer trees.
     void pushMappingsToAncestor(const RenderLayer*, const RenderLayer* ancestorLayer, bool respectTransforms = true);
-    void popMappingsToAncestor(const RenderLayer*);
+    void NODELETE popMappingsToAncestor(const RenderLayer*);
     void pushMappingsToAncestor(const RenderElement*, const RenderLayerModelObject* ancestorRenderer);
     void popMappingsToAncestor(const RenderLayerModelObject*);
     
@@ -110,8 +110,8 @@ public:
 private:
     void mapToContainer(TransformState&, const RenderLayerModelObject* container = nullptr) const;
 
-    void stepInserted(const RenderGeometryMapStep&);
-    void stepRemoved(const RenderGeometryMapStep&);
+    void NODELETE stepInserted(const RenderGeometryMapStep&);
+    void NODELETE stepRemoved(const RenderGeometryMapStep&);
     
     bool hasNonUniformStep() const { return m_nonUniformStepsCount; }
     bool hasTransformStep() const { return m_transformedStepsCount; }

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -1530,7 +1530,7 @@ Vector<LayoutUnit> RenderGrid::trackSizesForComputedStyle(Style::GridTrackSizing
     return tracks;
 }
 
-static const StyleContentAlignmentData& contentAlignmentNormalBehaviorGrid()
+static const StyleContentAlignmentData& NODELETE contentAlignmentNormalBehaviorGrid()
 {
     static const StyleContentAlignmentData normalBehavior = {ContentPosition::Normal, ContentDistribution::Stretch};
     return normalBehavior;
@@ -2318,7 +2318,7 @@ std::pair<LayoutUnit, LayoutUnit> RenderGrid::gridAreaPositionForInFlowGridItem(
     return { start, end };
 }
 
-std::pair<OverflowAlignment, ContentPosition> static resolveContentDistributionFallback(ContentDistribution distribution)
+std::pair<OverflowAlignment, ContentPosition> static NODELETE resolveContentDistributionFallback(ContentDistribution distribution)
 {
     switch (distribution) {
     case ContentDistribution::SpaceBetween:

--- a/Source/WebCore/rendering/RenderGrid.h
+++ b/Source/WebCore/rendering/RenderGrid.h
@@ -61,7 +61,7 @@ enum class SubgridDidChange : bool { No, Yes };
 class GridItemSizeCache {
 public:
     void setSizeForGridItem(const RenderBox& gridItem, LayoutUnit size);
-    std::optional<LayoutUnit> sizeForItem(const RenderBox& gridItem) const;
+    std::optional<LayoutUnit> NODELETE sizeForItem(const RenderBox& gridItem) const;
     void invalidateSizeForItem(const RenderBox& gridItem);
 
 private:
@@ -99,7 +99,7 @@ public:
 
     // Required by GridTrackSizingAlgorithm. Keep them under control.
     LayoutUnit guttersSize(Style::GridTrackSizingDirection, unsigned startLine, unsigned span, std::optional<LayoutUnit> availableSize) const;
-    LayoutUnit gridItemOffset(Style::GridTrackSizingDirection) const;
+    LayoutUnit NODELETE gridItemOffset(Style::GridTrackSizingDirection) const;
 
     std::optional<LayoutUnit> explicitIntrinsicInnerLogicalSize(Style::GridTrackSizingDirection) const;
     void updateGridAreaLogicalSize(RenderBox&, std::optional<LayoutUnit> width, std::optional<LayoutUnit> height) const;
@@ -138,7 +138,7 @@ public:
     bool areMasonryRows() const { return isMasonry(Style::GridTrackSizingDirection::Rows); }
     bool areMasonryColumns() const { return isMasonry(Style::GridTrackSizingDirection::Columns); }
 
-    const Grid& currentGrid() const;
+    const Grid& NODELETE currentGrid() const;
     Grid& currentGrid();
 
     unsigned numTracks(Style::GridTrackSizingDirection) const;
@@ -149,10 +149,10 @@ public:
     LayoutUnit gridGap(Style::GridTrackSizingDirection) const;
     LayoutUnit gridGap(Style::GridTrackSizingDirection, std::optional<LayoutUnit> availableSize) const;
 
-    LayoutUnit masonryContentSize() const;
+    LayoutUnit NODELETE masonryContentSize() const;
 
     void updateIntrinsicLogicalHeightsForRowSizingFirstPassCacheAvailability();
-    std::optional<GridItemSizeCache>& intrinsicLogicalHeightsForRowSizingFirstPass() const;
+    std::optional<GridItemSizeCache>& NODELETE intrinsicLogicalHeightsForRowSizingFirstPass() const;
 
     bool shouldCheckExplicitIntrinsicInnerLogicalSize(Style::GridTrackSizingDirection) const;
 
@@ -179,8 +179,8 @@ private:
     bool selfAlignmentChangedToStretch(LogicalBoxAxis containingAxis, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox& gridItem) const;
     bool selfAlignmentChangedFromStretch(LogicalBoxAxis containingAxis, const RenderStyle& oldStyle, const RenderStyle& newStyle, const RenderBox& gridItem) const;
 
-    SubgridDidChange subgridDidChange(const RenderStyle& oldStyle) const;
-    bool explicitGridDidResize(const RenderStyle&) const;
+    SubgridDidChange NODELETE subgridDidChange(const RenderStyle& oldStyle) const;
+    bool NODELETE explicitGridDidResize(const RenderStyle&) const;
     bool namedGridLinesDefinitionDidChange(const RenderStyle&) const;
     bool implicitGridLinesDefinitionDidChange(const RenderStyle&) const;
 
@@ -202,8 +202,8 @@ private:
     void placeAutoMajorAxisItemsOnGrid(const Vector<RenderBox*>&);
     typedef std::pair<unsigned, unsigned> AutoPlacementCursor;
     void placeAutoMajorAxisItemOnGrid(RenderBox&, AutoPlacementCursor&);
-    Style::GridTrackSizingDirection autoPlacementMajorAxisDirection() const;
-    Style::GridTrackSizingDirection autoPlacementMinorAxisDirection() const;
+    Style::GridTrackSizingDirection NODELETE autoPlacementMajorAxisDirection() const;
+    Style::GridTrackSizingDirection NODELETE autoPlacementMinorAxisDirection() const;
 
     static bool itemGridAreaIsWithinImplicitGrid(const GridArea& area, unsigned gridAxisLinesCount, Style::GridTrackSizingDirection gridAxisDirection)
     {
@@ -213,7 +213,7 @@ private:
 
     bool canPerformSimplifiedLayout() const final;
     void prepareGridItemForPositionedLayout(RenderBox&);
-    bool hasStaticPositionForGridItem(const RenderBox&, Style::GridTrackSizingDirection) const;
+    bool NODELETE hasStaticPositionForGridItem(const RenderBox&, Style::GridTrackSizingDirection) const;
     void layoutOutOfFlowBox(RenderBox&, RelayoutChildren, bool fixedPositionObjectsOnly) override;
 
     void computeTrackSizesForDefiniteSize(Style::GridTrackSizingDirection, LayoutUnit availableSpace, RenderGridLayoutState&);
@@ -285,7 +285,7 @@ private:
         Grid m_layoutGrid;
     public:
         GridWrapper(RenderGrid&);
-        void resetCurrentGrid() const;
+        void NODELETE resetCurrentGrid() const;
         mutable std::reference_wrapper<Grid> m_currentGrid { std::ref(m_layoutGrid) };
     } m_grid;
 

--- a/Source/WebCore/rendering/RenderHTMLCanvas.cpp
+++ b/Source/WebCore/rendering/RenderHTMLCanvas.cpp
@@ -59,7 +59,7 @@ RenderHTMLCanvas::RenderHTMLCanvas(HTMLCanvasElement& element, RenderStyle&& sty
 
 RenderHTMLCanvas::~RenderHTMLCanvas() = default;
 
-HTMLCanvasElement& RenderHTMLCanvas::canvasElement() const
+HTMLCanvasElement& NODELETE RenderHTMLCanvas::canvasElement() const
 {
     return downcast<HTMLCanvasElement>(nodeForNonAnonymous());
 }

--- a/Source/WebCore/rendering/RenderHighlight.h
+++ b/Source/WebCore/rendering/RenderHighlight.h
@@ -86,7 +86,7 @@ public:
         : m_isSelection(true)
     { }
 
-    void setRenderRange(const RenderRange&);
+    void NODELETE setRenderRange(const RenderRange&);
     bool setRenderRange(const HighlightRange&); // Returns true if successful.
     const RenderRange& get() const { return m_renderRange; }
 

--- a/Source/WebCore/rendering/RenderIFrame.cpp
+++ b/Source/WebCore/rendering/RenderIFrame.cpp
@@ -53,7 +53,7 @@ RenderIFrame::RenderIFrame(HTMLIFrameElement& element, RenderStyle&& style)
 
 RenderIFrame::~RenderIFrame() = default;
 
-HTMLIFrameElement& RenderIFrame::iframeElement() const
+HTMLIFrameElement& NODELETE RenderIFrame::iframeElement() const
 {
     return downcast<HTMLIFrameElement>(RenderFrameBase::frameOwnerElement());
 }

--- a/Source/WebCore/rendering/RenderIFrame.h
+++ b/Source/WebCore/rendering/RenderIFrame.h
@@ -49,7 +49,7 @@ private:
 
     bool requiresLayer() const override;
 
-    bool isFullScreenIFrame() const;
+    bool NODELETE isFullScreenIFrame() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderImage.h
+++ b/Source/WebCore/rendering/RenderImage.h
@@ -48,7 +48,7 @@ public:
 
     RenderImageResource& imageResource() { return *m_imageResource; }
     const RenderImageResource& imageResource() const { return *m_imageResource; }
-    CheckedRef<RenderImageResource> checkedImageResource() const;
+    CheckedRef<RenderImageResource> NODELETE checkedImageResource() const;
     CachedImage* cachedImage() const { return imageResource().cachedImage(); }
 
     ImageSizeChangeType setImageSizeForAltText(CachedImage* newImage = nullptr);

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -128,7 +128,7 @@ void RenderInline::updateFromStyle()
     setHasReflection(false);    
 }
 
-static RenderElement* inFlowPositionedInlineAncestor(RenderElement* p)
+static RenderElement* NODELETE inFlowPositionedInlineAncestor(RenderElement* p)
 {
     while (p && p->isRenderInline()) {
         if (p->isInFlowPositioned())

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -184,7 +184,7 @@ public:
         return adoptRef(*new ClipRects(other));
     }
 
-    void reset()
+    void NODELETE reset()
     {
         m_overflowClipRect.reset();
         m_fixedClipRect.reset();
@@ -193,18 +193,18 @@ public:
     }
 
     const ClipRect& overflowClipRect() const { return m_overflowClipRect; }
-    void setOverflowClipRect(const ClipRect& clipRect) { m_overflowClipRect = clipRect; }
+    void NODELETE setOverflowClipRect(const ClipRect& clipRect) { m_overflowClipRect = clipRect; }
 
-    const ClipRect& fixedClipRect() const { return m_fixedClipRect; }
-    void setFixedClipRect(const ClipRect& clipRect) { m_fixedClipRect = clipRect; }
+    const ClipRect& NODELETE fixedClipRect() const { return m_fixedClipRect; }
+    void NODELETE setFixedClipRect(const ClipRect& clipRect) { m_fixedClipRect = clipRect; }
 
-    const ClipRect& posClipRect() const { return m_posClipRect; }
-    void setPosClipRect(const ClipRect& clipRect) { m_posClipRect = clipRect; }
+    const ClipRect& NODELETE posClipRect() const { return m_posClipRect; }
+    void NODELETE setPosClipRect(const ClipRect& clipRect) { m_posClipRect = clipRect; }
 
-    bool fixed() const { return m_fixed; }
-    void setFixed(bool fixed) { m_fixed = fixed; }
+    bool NODELETE fixed() const { return m_fixed; }
+    void NODELETE setFixed(bool fixed) { m_fixed = fixed; }
 
-    void setOverflowClipRectAffectedByRadius() { m_overflowClipRect.setAffectedByRadius(true); }
+    void NODELETE setOverflowClipRectAffectedByRadius() { m_overflowClipRect.setAffectedByRadius(true); }
 
     bool operator==(const ClipRects& other) const
     {
@@ -261,12 +261,12 @@ public:
 
     }
 
-    ClipRects* getClipRects(const RenderLayer::ClipRectsContext& context) const
+    ClipRects* NODELETE getClipRects(const RenderLayer::ClipRectsContext& context) const
     {
         return m_clipRects[getIndex(context.clipRectsType, context.respectOverflowClip())].get();
     }
 
-    void setClipRects(ClipRectsType clipRectsType, bool respectOverflowClip, RefPtr<ClipRects>&& clipRects)
+    void NODELETE setClipRects(ClipRectsType clipRectsType, bool respectOverflowClip, RefPtr<ClipRects>&& clipRects)
     {
         m_clipRects[getIndex(clipRectsType, respectOverflowClip)] = WTF::move(clipRects);
     }
@@ -275,7 +275,7 @@ public:
     std::array<const RenderLayer*, NumCachedClipRectsTypes> m_clipRectsRoot;
 #endif
 private:
-    unsigned getIndex(ClipRectsType clipRectsType, bool respectOverflowClip) const
+    unsigned NODELETE getIndex(ClipRectsType clipRectsType, bool respectOverflowClip) const
     {
         unsigned index = static_cast<unsigned>(clipRectsType);
         if (respectOverflowClip)
@@ -307,7 +307,7 @@ static TextStream& operator<<(TextStream& ts, const ClipRects& clipRects)
 
 #endif
 
-static ScrollingScope nextScrollingScope()
+static ScrollingScope NODELETE nextScrollingScope()
 {
     static ScrollingScope currentScope = 0;
     return ++currentScope;
@@ -3273,12 +3273,12 @@ static void performOverlapTests(OverlapTestRequestMap& overlapTestRequests, cons
         overlapTestRequests.remove(client);
 }
 
-static inline bool shouldDoSoftwarePaint(const RenderLayer* layer, bool paintingReflection)
+static inline bool NODELETE shouldDoSoftwarePaint(const RenderLayer* layer, bool paintingReflection)
 {
     return paintingReflection && !layer->has3DTransform();
 }
 
-static inline bool shouldSuppressPaintingLayer(RenderLayer* layer)
+static inline bool NODELETE shouldSuppressPaintingLayer(RenderLayer* layer)
 {
     // Avoid painting all layers if the document is in a state where visual updates aren't allowed.
     // A full repaint will occur in Document::setVisualUpdatesAllowed(bool) if painting is suppressed here.
@@ -3315,7 +3315,7 @@ void RenderLayer::paintSVGResourceLayer(GraphicsContext& context, const AffineTr
     m_isPaintingSVGResourceLayer = wasPaintingSVGResourceLayer;
 }
 
-static inline bool paintForFixedRootBackground(const RenderLayer* layer, OptionSet<RenderLayer::PaintLayerFlag> paintFlags)
+static inline bool NODELETE paintForFixedRootBackground(const RenderLayer* layer, OptionSet<RenderLayer::PaintLayerFlag> paintFlags)
 {
     return layer->renderer().isDocumentElementRenderer() && (paintFlags & RenderLayer::PaintLayerFlag::PaintingRootBackgroundOnly);
 }
@@ -5302,7 +5302,7 @@ RefPtr<ClipRects> RenderLayer::parentClipRects(const ClipRectsContext& clipRects
     return containerLayer->updateClipRects(clipRectsContext);
 }
 
-static inline ClipRect backgroundClipRectForPosition(const ClipRects& parentRects, PositionType position)
+static inline ClipRect NODELETE backgroundClipRectForPosition(const ClipRects& parentRects, PositionType position)
 {
     if (position == PositionType::Fixed)
         return parentRects.fixedClipRect();

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -181,7 +181,7 @@ public:
     WEBCORE_EXPORT ~RenderLayer();
 
     WEBCORE_EXPORT RenderLayerScrollableArea* NODELETE scrollableArea() const;
-    WEBCORE_EXPORT CheckedPtr<RenderLayerScrollableArea> checkedScrollableArea() const;
+    WEBCORE_EXPORT CheckedPtr<RenderLayerScrollableArea> NODELETE checkedScrollableArea() const;
     WEBCORE_EXPORT RenderLayerScrollableArea* ensureLayerScrollableArea();
 
     String name() const;
@@ -195,7 +195,7 @@ public:
     RenderLayer* nextSibling() const { return m_next.get(); }
     RenderLayer* firstChild() const { return m_first.get(); }
     RenderLayer* lastChild() const { return m_last.get(); }
-    bool isDescendantOf(const RenderLayer&) const;
+    bool NODELETE isDescendantOf(const RenderLayer&) const;
     WEBCORE_EXPORT RenderLayer* commonAncestorWithLayer(const RenderLayer&) const;
 
     // This does an ancestor tree walk. Avoid it!
@@ -225,7 +225,7 @@ public:
     bool isCSSStackingContext() const { return m_isCSSStackingContext || m_forcedStackingContext; }
 
     // Gets the enclosing stacking context for this layer, excluding this layer itself.
-    RenderLayer* stackingContext() const;
+    RenderLayer* NODELETE stackingContext() const;
 
     // Gets the enclosing stacking container for this layer, possibly the layer
     // itself, if it is a stacking container.
@@ -235,7 +235,7 @@ public:
 
     RenderLayer* paintOrderParent() const;
 
-    std::optional<LayoutRect> cachedClippedOverflowRect() const;
+    std::optional<LayoutRect> NODELETE cachedClippedOverflowRect() const;
 
     void dirtyNormalFlowList();
     void dirtyZOrderLists();
@@ -255,7 +255,7 @@ public:
     // Convert a point in absolute coords into layer coords, taking transforms into account
     LayoutPoint absoluteToContents(const LayoutPoint&) const;
 
-    void setNeedsPositionUpdate();
+    void NODELETE setNeedsPositionUpdate();
     void setSelfAndChildrenNeedPositionUpdate();
     void setSelfAndDescendantsNeedPositionUpdate();
 
@@ -319,7 +319,7 @@ private:
         };
     }
 
-    void setAncestorsHaveCompositingDirtyFlag(Compositing);
+    void NODELETE setAncestorsHaveCompositingDirtyFlag(Compositing);
 
 public:
     bool hasDescendantNeedingCompositingRequirementsTraversal() const { return m_compositingDirtyBits.contains(Compositing::HasDescendantNeedingRequirementsTraversal); }
@@ -477,8 +477,8 @@ public:
 
     bool hasReflection() const { return renderer().hasReflection(); }
     bool isReflection() const { return renderer().isRenderReplica(); }
-    RenderLayer* reflectionLayer() const;
-    bool isReflectionLayer(const RenderLayer&) const;
+    RenderLayer* NODELETE reflectionLayer() const;
+    bool NODELETE isReflectionLayer(const RenderLayer&) const;
 
     inline const LayoutPoint& location() const;
     void setLocation(const LayoutPoint& p) { m_topLeft = p; }
@@ -498,9 +498,9 @@ public:
     WEBCORE_EXPORT RenderLayer* enclosingScrollableLayer(IncludeSelfOrNot, CrossFrameBoundaries) const;
 
     // Returns true when the layer could do touch scrolling, but doesn't look at whether there is actually scrollable overflow.
-    bool canUseCompositedScrolling() const;
+    bool NODELETE canUseCompositedScrolling() const;
     // Returns true when there is actually scrollable overflow (requires layout to be up-to-date).
-    bool hasCompositedScrollableOverflow() const;
+    bool NODELETE hasCompositedScrollableOverflow() const;
     void computeHasCompositedScrollableOverflow(LayoutUpToDate);
 
     bool hasOverlayScrollbars() const;
@@ -515,7 +515,7 @@ public:
     bool shouldTryToScrollForScrollIntoView(const ScrollRectToVisibleOptions&) const;
     void autoscroll(const IntPoint&);
 
-    bool canResize() const;
+    bool NODELETE canResize() const;
     LayoutSize minimumSizeForResizing(float zoomFactor) const;
     void resize(const PlatformMouseEvent&, const LayoutSize&);
     bool inResizeMode() const { return m_inResizeMode; }
@@ -551,7 +551,7 @@ public:
     void updateTransform();
     
     void updateBlendMode();
-    void willRemoveChildWithBlendMode();
+    void NODELETE willRemoveChildWithBlendMode();
 
     const LayoutSize& offsetForInFlowPosition() const { return m_offsetForPosition; }
 
@@ -568,12 +568,12 @@ public:
     bool hasVisibleDescendant() const { return m_hasVisibleDescendant; }
 
     void setHasVisibleContent();
-    void dirtyVisibleContentStatus();
+    void NODELETE dirtyVisibleContentStatus();
 
     bool hasVisibleBoxDecorationsOrBackground() const;
     bool hasVisibleBoxDecorations() const;
     
-    void setBehavesAsFixed(bool);
+    void NODELETE setBehavesAsFixed(bool);
     bool behavesAsFixed() const { return m_behavesAsFixed; }
 
     struct PaintedContentRequest {
@@ -638,7 +638,7 @@ public:
     // The layer relative to which clipping rects for this layer are computed.
     RenderLayer* clippingRootForPainting() const;
 
-    RenderLayer* enclosingOverflowClipLayer(IncludeSelfOrNot) const;
+    RenderLayer* NODELETE enclosingOverflowClipLayer(IncludeSelfOrNot) const;
 
     // Enclosing compositing layer; if includeSelf is true, may return this.
     RenderLayer* enclosingCompositingLayer(IncludeSelfOrNot = IncludeSelf) const;
@@ -655,7 +655,7 @@ public:
     void setFilterBackendNeedsRepaintingInRect(const LayoutRect&);
     bool hasAncestorWithFilterOutsets() const;
 
-    inline bool canUseOffsetFromAncestor() const;
+    inline bool NODELETE canUseOffsetFromAncestor() const;
     bool canUseOffsetFromAncestor(const RenderLayer& ancestor) const;
 
     // FIXME: adjustForColumns allows us to position compositing layers in columns correctly, but eventually they need to be split across columns too.
@@ -796,7 +796,7 @@ public:
     
     LayoutRect repaintRectIncludingNonCompositingDescendants() const;
 
-    void setRepaintStatus(RepaintStatus);
+    void NODELETE setRepaintStatus(RepaintStatus);
     RepaintStatus repaintStatus() const { return m_repaintStatus; }
     bool needsFullRepaint() const { return m_repaintStatus == RepaintStatus::NeedsFullRepaint || m_repaintStatus == RepaintStatus::NeedsFullRepaintForOutOfFlowMovementLayout; }
 
@@ -871,11 +871,11 @@ public:
 
     bool isComposited() const { return m_backing != nullptr; }
     bool hasCompositingDescendant() const { return m_hasCompositingDescendant; }
-    bool hasCompositedMask() const;
+    bool NODELETE hasCompositedMask() const;
     bool hasCompositedNonContainedDescendants() const { return m_hasCompositedNonContainedDescendants; }
 
     bool hasDescendantNeedingEventRegionUpdate() const { return m_hasDescendantNeedingEventRegionUpdate; }
-    void setAncestorsHaveDescendantNeedingEventRegionUpdate();
+    void NODELETE setAncestorsHaveDescendantNeedingEventRegionUpdate();
     void clearHasDescendantNeedingEventRegionUpdate() { m_hasDescendantNeedingEventRegionUpdate = false; }
 
     // If non-null, a non-ancestor composited layer that this layer paints into (it is sharing its backing store with this layer).
@@ -922,11 +922,11 @@ public:
     bool shouldPaintWithFilters(OptionSet<PaintBehavior> = { }) const;
     bool requiresFullLayerImageForFilters() const;
 
-    Element* enclosingElement() const;
+    Element* NODELETE enclosingElement() const;
 
     static Vector<RenderLayer*> topLayerRenderLayers(const RenderView&);
 
-    bool establishesTopLayer() const;
+    bool NODELETE establishesTopLayer() const;
     void establishesTopLayerWillChange();
     void establishesTopLayerDidChange();
 
@@ -1001,7 +1001,7 @@ private:
 
     bool setIsCSSStackingContext(bool);
 
-    bool setCanBeBackdropRoot(bool);
+    bool NODELETE setCanBeBackdropRoot(bool);
     void isStackingContextChanged();
 
     bool isDirtyStackingContext() const { return m_zOrderListsDirty && isStackingContext(); }
@@ -1045,10 +1045,10 @@ private:
     // Compute and return the clip rects. If useCached is true, will used previously computed clip rects on ancestors
     // (rather than computing them all from scratch up the parent chain).
     void calculateClipRects(const ClipRectsContext&, ClipRects&) const;
-    ClipRects* clipRects(const ClipRectsContext&) const;
+    ClipRects* NODELETE clipRects(const ClipRectsContext&) const;
 
     void setAncestorChainHasSelfPaintingLayerDescendant();
-    void dirtyAncestorChainHasSelfPaintingLayerDescendantStatus();
+    void NODELETE dirtyAncestorChainHasSelfPaintingLayerDescendantStatus();
 
     std::optional<RenderObject::RepaintRects> repaintRects() const
     {
@@ -1063,8 +1063,8 @@ private:
 
     void compositingStatusChanged(LayoutUpToDate);
 
-    void setRepaintRects(const RenderObject::RepaintRects&);
-    void clearRepaintRects();
+    void NODELETE setRepaintRects(const RenderObject::RepaintRects&);
+    void NODELETE clearRepaintRects();
 
     LayoutRect clipRectRelativeToAncestor(const RenderLayer* ancestor, LayoutSize offsetFromAncestor, const LayoutRect& constrainingRect, bool temporaryClipRects = false) const;
 
@@ -1113,7 +1113,7 @@ private:
 
     template<UpdateLayerPositionsMode = Write>
     void recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFlag>);
-    bool ancestorLayerPositionStateChanged(OptionSet<UpdateLayerPositionsFlag>);
+    bool NODELETE ancestorLayerPositionStateChanged(OptionSet<UpdateLayerPositionsFlag>);
 
     enum UpdateLayerPositionsAfterScrollFlag {
         IsOverflowScroll                        = 1 << 0,
@@ -1249,7 +1249,7 @@ private:
 
     bool shouldBeSelfPaintingLayer() const;
 
-    void dirtyAncestorChainVisibleDescendantStatus();
+    void NODELETE dirtyAncestorChainVisibleDescendantStatus();
     
     bool computeHasVisibleContent() const;
 
@@ -1262,7 +1262,7 @@ private:
     bool hasFixedAncestor() const { return m_hasFixedAncestor; }
     bool hasPaginatedAncestor() const { return m_hasPaginatedAncestor; }
 
-    void dirty3DTransformedDescendantStatus();
+    void NODELETE dirty3DTransformedDescendantStatus();
     // Both updates the status, and returns true if descendants of this have 3d.
     bool update3DTransformedDescendantStatus();
 
@@ -1279,10 +1279,10 @@ private:
     void updateFilterPaintingStrategy();
 
     void updateAncestorChainHasBlendingDescendants();
-    void dirtyAncestorChainHasBlendingDescendants();
+    void NODELETE dirtyAncestorChainHasBlendingDescendants();
 
-    void updateAncestorChainHasAlwaysIncludedInZOrderListsDescendants();
-    void dirtyAncestorChainHasAlwaysIncludedInZOrderListsDescendants();
+    void NODELETE updateAncestorChainHasAlwaysIncludedInZOrderListsDescendants();
+    void NODELETE dirtyAncestorChainHasAlwaysIncludedInZOrderListsDescendants();
 
     bool alwaysIncludedInZOrderLists() const { return m_alwaysIncludedInZOrderLists; }
     bool hasAlwaysIncludedInZOrderListsDescendants() const { return m_hasAlwaysIncludedInZOrderListsDescendants; }
@@ -1295,7 +1295,7 @@ private:
     ClipRect calculateBackgroundRect(const ClipRectsContext&, const LayoutSize& offsetFromRoot) const;
     ClipRect calculateForegroundRect(const ClipRectsContext&, const LayoutSize& offsetFromRoot) const;
 
-    RenderLayer* enclosingTransformedAncestor() const;
+    RenderLayer* NODELETE enclosingTransformedAncestor() const;
 
     inline bool hasNonOpacityTransparency() const;
 
@@ -1306,8 +1306,8 @@ private:
     void removeSelfFromCompositor();
     void removeDescendantsFromCompositor();
 
-    void verifyClipRects();
-    void verifyClipRect(const ClipRectsContext&);
+    void NODELETE verifyClipRects();
+    void NODELETE verifyClipRect(const ClipRectsContext&);
 
     void setHasCompositingDescendant(bool b)  { m_hasCompositingDescendant = b; }
     void setHasCompositedNonContainedDescendants(bool value) { m_hasCompositedNonContainedDescendants = value; }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -163,7 +163,7 @@ public:
     }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    void setDetectsHDRContent()
+    void NODELETE setDetectsHDRContent()
     {
         m_hdrContent = RequestState::Unknown;
         m_rendererHDRContent = RequestState::Unknown;
@@ -178,7 +178,7 @@ public:
     }
 
 
-    bool isPaintsContentSatisfied() const
+    bool NODELETE isPaintsContentSatisfied() const
     {
 #if HAVE(SUPPORT_HDR_DISPLAY)
         if (m_hdrContent == RequestState::Unknown)
@@ -202,7 +202,7 @@ public:
     }
 #endif
 
-    bool isContentsTypeSatisfied() const
+    bool NODELETE isContentsTypeSatisfied() const
     {
 #if HAVE(SUPPORT_HDR_DISPLAY)
         if (m_rendererHDRContent == RequestState::Unknown)
@@ -979,7 +979,7 @@ void RenderLayerBacking::updateAppleVisualEffect(const RenderStyle& style)
 }
 #endif
 
-static bool layerOrAncestorIsTransformedOrUsingCompositedScrolling(RenderLayer& layer)
+static bool NODELETE layerOrAncestorIsTransformedOrUsingCompositedScrolling(RenderLayer& layer)
 {
     for (auto* curr = &layer; curr; curr = curr->parent()) {
         if (curr->isTransformed() || curr->hasCompositedScrollableOverflow())

--- a/Source/WebCore/rendering/RenderLayerBacking.h
+++ b/Source/WebCore/rendering/RenderLayerBacking.h
@@ -129,7 +129,7 @@ public:
     bool needsRepaintOnCompositedScroll() const;
 
     bool requiresBackgroundLayer() const { return m_requiresBackgroundLayer; }
-    void setRequiresBackgroundLayer(bool);
+    void NODELETE setRequiresBackgroundLayer(bool);
 
     bool hasScrollingLayer() const { return m_scrollContainerLayer != nullptr; }
     GraphicsLayer* scrollContainerLayer() const { return m_scrollContainerLayer.get(); }
@@ -162,7 +162,7 @@ public:
 
     bool hasMaskLayer() const { return m_maskLayer; }
 
-    WEBCORE_EXPORT GraphicsLayer* parentForSublayers() const;
+    WEBCORE_EXPORT GraphicsLayer* NODELETE parentForSublayers() const;
     GraphicsLayer* childForSuperlayers() const;
     GraphicsLayer* childForSuperlayersExcludingViewTransitions() const;
 
@@ -199,9 +199,9 @@ public:
     void updateAcceleratedEffectsAndBaseValues(HashSet<Ref<AcceleratedTimeline>>&);
 #endif
 
-    WEBCORE_EXPORT LayoutRect compositedBounds() const;
+    WEBCORE_EXPORT LayoutRect NODELETE compositedBounds() const;
     // Returns true if changed.
-    bool setCompositedBounds(const LayoutRect&);
+    bool NODELETE setCompositedBounds(const LayoutRect&);
     // Returns true if changed.
     bool updateCompositedBounds();
     
@@ -212,7 +212,7 @@ public:
     void updateEventRegion();
     
     bool needsEventRegionUpdate() const { return m_needsEventRegionUpdate; }
-    void setNeedsEventRegionUpdate(bool needsUpdate = true);
+    void NODELETE setNeedsEventRegionUpdate(bool needsUpdate = true);
 #endif
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
@@ -363,7 +363,7 @@ private:
 
     void setBackgroundLayerPaintsFixedRootBackground(bool);
 
-    LayoutSize contentOffsetInCompositingLayer() const;
+    LayoutSize NODELETE contentOffsetInCompositingLayer() const;
     LayoutSize offsetRelativeToRendererOriginForDescendantLayers() const;
     
     void ensureClippingStackLayers(LayerAncestorClippingStack&);
@@ -433,8 +433,8 @@ private:
     
     void paintDebugOverlays(const GraphicsLayer*, GraphicsContext&);
 
-    static CSSPropertyID graphicsLayerToCSSProperty(AnimatedProperty);
-    static AnimatedProperty cssToGraphicsLayerProperty(CSSPropertyID);
+    static CSSPropertyID NODELETE graphicsLayerToCSSProperty(AnimatedProperty);
+    static AnimatedProperty NODELETE cssToGraphicsLayerProperty(CSSPropertyID);
 
     bool canIssueSetNeedsDisplay() const { return !paintsIntoWindow() && !paintsIntoCompositedAncestor(); }
     LayoutRect computeParentGraphicsLayerRect(const RenderLayer* compositedAncestor) const;

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -142,7 +142,7 @@ struct RenderLayerCompositor::OverlapExtent {
     bool animationCausesExtentUncertainty { false };
     bool clippingScopesComputed { false };
 
-    bool knownToBeHaveExtentUncertainty() const { return extentComputed && animationCausesExtentUncertainty; }
+    bool NODELETE knownToBeHaveExtentUncertainty() const { return extentComputed && animationCausesExtentUncertainty; }
 };
 
 struct RenderLayerCompositor::CompositingState {
@@ -221,7 +221,7 @@ struct RenderLayerCompositor::CompositingState {
 #endif
     }
 
-    bool hasNonRootCompositedAncestor() const
+    bool NODELETE hasNonRootCompositedAncestor() const
     {
         return compositingAncestor && !compositingAncestor->isRenderViewLayer();
     }
@@ -251,7 +251,7 @@ struct RenderLayerCompositor::UpdateBackingTraversalState {
     {
     }
 
-    UpdateBackingTraversalState stateForDescendants() const
+    UpdateBackingTraversalState NODELETE stateForDescendants() const
     {
         UpdateBackingTraversalState state(compositingAncestor, layersClippedByScrollers, overflowScrollLayers);
 #if !LOG_DISABLED
@@ -325,17 +325,17 @@ public:
         LayoutRect absoluteBounds;
     };
 
-    auto& backingProviderCandidates() { return m_backingProviderCandidates; }
+    auto& NODELETE backingProviderCandidates() { return m_backingProviderCandidates; }
 
-    const RenderLayer* firstProviderCandidateLayer() const
+    const RenderLayer* NODELETE firstProviderCandidateLayer() const
     {
         return !m_backingProviderCandidates.isEmpty() ? m_backingProviderCandidates.first().providerLayer.get() : nullptr;
     }
 
-    RenderLayer* backingSharingStackingContext() const { return m_backingSharingStackingContext; }
+    RenderLayer* NODELETE backingSharingStackingContext() const { return m_backingSharingStackingContext; }
 
     Provider* backingProviderCandidateForLayer(const RenderLayer&, const RenderLayerCompositor&, LayerOverlapMap&, OverlapExtent&);
-    Provider* existingBackingProviderCandidateForLayer(const RenderLayer&);
+    Provider* NODELETE existingBackingProviderCandidateForLayer(const RenderLayer&);
     Provider* backingProviderForLayer(const RenderLayer&);
 
     // Add a layer that would repaint into a layer in m_backingSharingLayers.
@@ -350,13 +350,13 @@ public:
     void startBackingSharingSequence(RenderLayer& candidateLayer, LayoutRect candidateAbsoluteBounds, RenderLayer& candidateStackingContext);
     void endBackingSharingSequence(RenderLayer&);
 
-    std::optional<BackingSharingSnapshot> snapshot() const
+    std::optional<BackingSharingSnapshot> NODELETE snapshot() const
     {
         if (!m_backingSharingStackingContext)
             return std::nullopt;
         return BackingSharingSnapshot { m_sequenceIdentifier, m_backingProviderCandidates.size() };
     }
-    BackingSharingSequenceIdentifier sequenceIdentifier() const { return m_sequenceIdentifier; }
+    BackingSharingSequenceIdentifier NODELETE sequenceIdentifier() const { return m_sequenceIdentifier; }
 
 private:
     void layerWillBeComposited(RenderLayer&);
@@ -802,7 +802,7 @@ void RenderLayerCompositor::scheduleRenderingUpdate()
     protect(page())->scheduleRenderingUpdate(RenderingUpdateStep::LayerFlush);
 }
 
-static inline ScrollableArea::VisibleContentRectIncludesScrollbars scrollbarInclusionForVisibleRect()
+static inline ScrollableArea::VisibleContentRectIncludesScrollbars NODELETE scrollbarInclusionForVisibleRect()
 {
 #if USE(COORDINATED_GRAPHICS)
     return ScrollableArea::VisibleContentRectIncludesScrollbars::Yes;
@@ -2343,7 +2343,7 @@ void RenderLayerCompositor::clearBackingProviderSequencesInStackingContextOfLaye
 }
 
 // FIXME: remove and never ask questions about reflection layers.
-static RenderLayerModelObject& rendererForCompositingTests(const RenderLayer& layer)
+static RenderLayerModelObject& NODELETE rendererForCompositingTests(const RenderLayer& layer)
 {
     auto* renderer = &layer.renderer();
 
@@ -5466,7 +5466,7 @@ StickyPositionViewportConstraints RenderLayerCompositor::computeStickyViewportCo
     return constraints;
 }
 
-static inline ScrollCoordinationRole scrollCoordinationRoleForNodeType(ScrollingNodeType nodeType)
+static inline ScrollCoordinationRole NODELETE scrollCoordinationRoleForNodeType(ScrollingNodeType nodeType)
 {
     switch (nodeType) {
     case ScrollingNodeType::MainFrame:

--- a/Source/WebCore/rendering/RenderLayerCompositor.h
+++ b/Source/WebCore/rendering/RenderLayerCompositor.h
@@ -186,7 +186,7 @@ public:
     // Returns true if the accelerated compositing is enabled
     bool hasAcceleratedCompositing() const { return m_hasAcceleratedCompositing; }
 
-    bool canRender3DTransforms() const;
+    bool NODELETE canRender3DTransforms() const;
 
     void willRecalcStyle();
 
@@ -198,7 +198,7 @@ public:
     void notifyFlushRequired(const GraphicsLayer*) override;
     void notifySubsequentFlushRequired(const GraphicsLayer*) override;
     void flushPendingLayerChanges(bool isFlushRoot = true);
-    void setRenderingIsSuppressed(bool);
+    void NODELETE setRenderingIsSuppressed(bool);
 
     // Called when the GraphicsLayer for the given RenderLayer has flushed changes inside of flushPendingLayerChanges().
     void didChangePlatformLayerForLayer(RenderLayer&, const GraphicsLayer*);
@@ -242,7 +242,7 @@ public:
 
     bool fixedLayerIntersectsViewport(const RenderLayer&) const;
 
-    bool supportsFixedRootBackgroundCompositing() const;
+    bool NODELETE supportsFixedRootBackgroundCompositing() const;
     bool needsFixedRootBackgroundLayer(const RenderLayer&) const;
     GraphicsLayer* fixedRootBackgroundLayer() const;
 
@@ -265,7 +265,7 @@ public:
     void establishesTopLayerWillChangeForLayer(RenderLayer&);
 
     // Get the nearest ancestor layer that has overflow or clip, but is not a stacking context
-    RenderLayer* enclosingNonStackingClippingLayer(const RenderLayer&) const;
+    RenderLayer* NODELETE enclosingNonStackingClippingLayer(const RenderLayer&) const;
 
     // Repaint all composited layers.
     void repaintCompositedLayers();
@@ -273,8 +273,8 @@ public:
     // Returns true if the given layer needs it own backing store.
     bool requiresOwnBackingStore(const RenderLayer&, const RenderLayer* compositingAncestorLayer, const LayoutRect& layerCompositedBoundsInAncestor, const LayoutRect& ancestorCompositedBounds) const;
 
-    WEBCORE_EXPORT RenderLayer& rootRenderLayer() const;
-    GraphicsLayer* rootGraphicsLayer() const;
+    WEBCORE_EXPORT RenderLayer& NODELETE rootRenderLayer() const;
+    GraphicsLayer* NODELETE rootGraphicsLayer() const;
 
     GraphicsLayer* scrollContainerLayer() const { return m_scrollContainerLayer.get(); }
     GraphicsLayer* scrolledContentsLayer() const { return m_scrolledContentsLayer.get(); }
@@ -304,7 +304,7 @@ public:
     void invalidateEventRegionForAllFrames();
     void invalidateEventRegionForAllLayers();
     
-    void layerBecameComposited(const RenderLayer&);
+    void NODELETE layerBecameComposited(const RenderLayer&);
     void layerBecameNonComposited(const RenderLayer&);
     
 #if ENABLE(VIDEO)
@@ -531,7 +531,7 @@ private:
 
     FloatRect visibleRectForLayerFlushing() const;
     
-    Page& page() const;
+    Page& NODELETE page() const;
 
     GraphicsLayerFactory* graphicsLayerFactory() const;
     ScrollingCoordinator* scrollingCoordinator() const;
@@ -539,13 +539,13 @@ private:
     // Non layout-dependent
     bool requiresCompositingForAnimation(RenderLayerModelObject&) const;
     bool requiresCompositingForTransform(RenderLayerModelObject&) const;
-    bool requiresCompositingForBackfaceVisibility(RenderLayerModelObject&) const;
+    bool NODELETE requiresCompositingForBackfaceVisibility(RenderLayerModelObject&) const;
     bool requiresCompositingForViewTransition(RenderLayerModelObject&) const;
     bool requiresCompositingForVideo(RenderLayerModelObject&) const;
     bool requiresCompositingForCanvas(RenderLayerModelObject&) const;
-    bool requiresCompositingForFilters(RenderLayerModelObject&) const;
+    bool NODELETE requiresCompositingForFilters(RenderLayerModelObject&) const;
     bool requiresCompositingForWillChange(RenderLayerModelObject&) const;
-    bool requiresCompositingForModel(RenderLayerModelObject&) const;
+    bool NODELETE requiresCompositingForModel(RenderLayerModelObject&) const;
 
     // Layout-dependent
     bool requiresCompositingForPlugin(RenderLayerModelObject&, RequiresCompositingData&) const;
@@ -553,7 +553,7 @@ private:
     bool requiresCompositingForScrollableFrame(RequiresCompositingData&) const;
     bool requiresCompositingForPosition(RenderLayerModelObject&, const RenderLayer&, RequiresCompositingData&) const;
     bool requiresCompositingForOverflowScrolling(const RenderLayer&, RequiresCompositingData&) const;
-    bool requiresCompositingForAnchorPositioning(const RenderLayer&) const;
+    bool NODELETE requiresCompositingForAnchorPositioning(const RenderLayer&) const;
     IndirectCompositingReason computeIndirectCompositingReason(const RenderLayer&, bool hasCompositedDescendants, bool has3DTransformedDescendants, bool paintsIntoProvidedBacking) const;
 
     static ScrollPositioningBehavior layerScrollBehahaviorRelativeToCompositedAncestor(const RenderLayer&, const RenderLayer& compositedAncestor);
@@ -622,7 +622,7 @@ private:
     void logLayerInfo(const RenderLayer&, ASCIILiteral, int depth);
 #endif
 
-    bool documentUsesTiledBacking() const;
+    bool NODELETE documentUsesTiledBacking() const;
     bool isRootFrameCompositor() const;
     bool isMainFrameCompositor() const;
 

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -63,8 +63,8 @@ public:
     CSSFilterRenderer* filter() const { return m_filter.get(); }
     void clearFilter() { m_filter = nullptr; }
     
-    bool hasFilterThatMovesPixels() const;
-    bool hasFilterThatShouldBeRestrictedBySecurityOrigin() const;
+    bool NODELETE hasFilterThatMovesPixels() const;
+    bool NODELETE hasFilterThatShouldBeRestrictedBySecurityOrigin() const;
     bool hasSourceImage() const;
 
     void updateReferenceFilterClients(const Style::Filter&);

--- a/Source/WebCore/rendering/RenderLayerModelObject.h
+++ b/Source/WebCore/rendering/RenderLayerModelObject.h
@@ -74,7 +74,7 @@ public:
 
     bool NODELETE shouldPlaceVerticalScrollbarOnLeft() const;
 
-    std::optional<LayoutRect> cachedLayerClippedOverflowRect() const;
+    std::optional<LayoutRect> NODELETE cachedLayerClippedOverflowRect() const;
 
     bool startAnimation(double timeOffset, const GraphicsLayerAnimation&, const BlendingKeyframes&) override;
     void animationPaused(double timeOffset, const BlendingKeyframes&) override;
@@ -122,7 +122,7 @@ public:
     void paintSVGClippingMask(PaintInfo&, const FloatRect& objectBoundingBox) const;
     void paintSVGMask(PaintInfo&, const LayoutPoint& adjustedPaintOffset) const;
 
-    TransformationMatrix* layerTransform() const;
+    TransformationMatrix* NODELETE layerTransform() const;
 
     virtual void updateLayerTransform();
     virtual void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const = 0;
@@ -154,7 +154,7 @@ private:
 };
 
 // Pixel-snapping (== 'device pixel alignment') helpers.
-bool rendererNeedsPixelSnapping(const RenderLayerModelObject&);
+bool NODELETE rendererNeedsPixelSnapping(const RenderLayerModelObject&);
 FloatRect snapRectToDevicePixelsIfNeeded(const LayoutRect&, const RenderLayerModelObject&);
 FloatRect snapRectToDevicePixelsIfNeeded(const FloatRect&, const RenderLayerModelObject&);
 

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -82,7 +82,7 @@ public:
     void unregisterAsTouchEventListenerForScrolling();
 #endif
 
-    void setPostLayoutScrollPosition(std::optional<ScrollPosition>);
+    void NODELETE setPostLayoutScrollPosition(std::optional<ScrollPosition>);
     void applyPostLayoutScrollPositionIfNeeded();
     bool hasPostLayoutScrollPosition() { return !!m_postLayoutScrollPosition; }
 
@@ -106,7 +106,7 @@ public:
     void scrollToXOffset(int x) { scrollToOffset(ScrollOffset(x, scrollOffset().y()), ScrollPositionChangeOptions::createProgrammaticUnclamped()); }
     void scrollToYOffset(int y) { scrollToOffset(ScrollOffset(scrollOffset().x(), y), ScrollPositionChangeOptions::createProgrammaticUnclamped()); }
 
-    bool scrollsOverflow() const;
+    bool NODELETE scrollsOverflow() const;
     bool hasScrollableHorizontalOverflow() const;
     bool hasScrollableVerticalOverflow() const;
     bool hasScrollbars() const { return horizontalScrollbar() || verticalScrollbar(); }
@@ -117,27 +117,27 @@ public:
     
     bool needsAnimatedScroll() const final { return m_isRegisteredForAnimatedScroll; }
     
-    OverscrollBehavior horizontalOverscrollBehavior() const final;
-    OverscrollBehavior verticalOverscrollBehavior() const final;
+    OverscrollBehavior NODELETE horizontalOverscrollBehavior() const final;
+    OverscrollBehavior NODELETE verticalOverscrollBehavior() const final;
 
     Color scrollbarThumbColorStyle() const final;
     Color scrollbarTrackColorStyle() const final;
-    Style::ScrollbarGutter scrollbarGutterStyle() const final;
-    ScrollbarWidth scrollbarWidthStyle() const final;
+    Style::ScrollbarGutter NODELETE scrollbarGutterStyle() const final;
+    ScrollbarWidth NODELETE scrollbarWidthStyle() const final;
     std::optional<ScrollbarColor> scrollbarColorStyle() const final;
 
     bool requiresScrollPositionReconciliation() const { return m_requiresScrollPositionReconciliation; }
     void setRequiresScrollPositionReconciliation(bool requiresReconciliation = true) { m_requiresScrollPositionReconciliation = requiresReconciliation; }
 
     // Returns true when the layer could do touch scrolling, but doesn't look at whether there is actually scrollable overflow.
-    bool canUseCompositedScrolling() const;
+    bool NODELETE canUseCompositedScrolling() const;
     // Returns true when there is actually scrollable overflow (requires layout to be up-to-date).
     bool hasCompositedScrollableOverflow() const { return m_hasCompositedScrollableOverflow; }
 
     int verticalScrollbarWidth(OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, bool isHorizontalWritingMode = true) const;
     int horizontalScrollbarHeight(OverlayScrollbarSizeRelevancy = OverlayScrollbarSizeRelevancy::IgnoreOverlayScrollbarSize, bool isHorizontalWritingMode = true) const;
 
-    bool hasOverflowControls() const;
+    bool NODELETE hasOverflowControls() const;
     bool hitTestOverflowControls(HitTestResult&, const IntPoint& localPoint);
     bool hitTestResizerInFragments(const LayerFragments&, const HitTestLocation&, LayoutPoint& pointInFragment) const;
 
@@ -182,19 +182,19 @@ public:
     void didUpdateScroll() final;
 #endif
 
-    GraphicsLayer* layerForHorizontalScrollbar() const final;
-    GraphicsLayer* layerForVerticalScrollbar() const final;
-    GraphicsLayer* layerForScrollCorner() const final;
+    GraphicsLayer* NODELETE layerForHorizontalScrollbar() const final;
+    GraphicsLayer* NODELETE layerForVerticalScrollbar() const final;
+    GraphicsLayer* NODELETE layerForScrollCorner() const final;
 
     bool usesCompositedScrolling() const final;
     bool usesAsyncScrolling() const final;
 
-    bool shouldPlaceVerticalScrollbarOnLeft() const final;
+    bool NODELETE shouldPlaceVerticalScrollbarOnLeft() const final;
 
     bool isRenderLayer() const final { return true; }
     void invalidateScrollbarRect(Scrollbar&, const IntRect&) final;
     void invalidateScrollCornerRect(const IntRect&) final;
-    bool isActive() const final;
+    bool NODELETE isActive() const final;
     bool isScrollCornerVisible() const final;
     IntRect scrollCornerRect() const final;
     IntRect convertFromScrollbarToContainingView(const Scrollbar&, const IntRect&) const final;
@@ -207,15 +207,15 @@ public:
     IntRect visibleContentRectInternal(VisibleContentRectIncludesScrollbars, VisibleContentRectBehavior) const final;
     IntSize overhangAmount() const final;
     IntPoint lastKnownMousePositionInView() const final;
-    bool isHandlingWheelEvent() const final;
+    bool NODELETE isHandlingWheelEvent() const final;
     bool shouldSuspendScrollAnimations() const final;
     IntRect scrollableAreaBoundingBox(bool* isInsideFixed = nullptr) const final;
     bool isUserScrollInProgress() const final;
     bool isRubberBandInProgress() const final;
-    bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;
+    bool NODELETE forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;
     bool isScrollSnapInProgress() const final;
-    bool scrollAnimatorEnabled() const final;
-    bool mockScrollbarsControllerEnabled() const final;
+    bool NODELETE scrollAnimatorEnabled() const final;
+    bool NODELETE mockScrollbarsControllerEnabled() const final;
     void logMockScrollbarsControllerMessage(const String&) const final;
 
     String debugDescription() const final;
@@ -267,7 +267,7 @@ public:
 
     void createScrollbarsController() final;
 
-    std::optional<FrameIdentifier> rootFrameID() const final;
+    std::optional<FrameIdentifier> NODELETE rootFrameID() const final;
 
     void scrollbarWidthChanged(ScrollbarWidth) override;
 
@@ -279,7 +279,7 @@ private:
     bool hasHorizontalOverflow() const;
     bool hasVerticalOverflow() const;
 
-    bool showsOverflowControls() const;
+    bool NODELETE showsOverflowControls() const;
 
     ScrollOffset clampScrollOffset(const ScrollOffset&) const;
 

--- a/Source/WebCore/rendering/RenderLayoutState.h
+++ b/Source/WebCore/rendering/RenderLayoutState.h
@@ -75,7 +75,7 @@ public:
 
     // The page logical offset is the object's offset from the top of the page in the page progression
     // direction (so an x-offset in vertical text and a y-offset for horizontal text).
-    LayoutUnit pageLogicalOffset(RenderBox*, LayoutUnit childLogicalOffset) const;
+    LayoutUnit NODELETE pageLogicalOffset(RenderBox*, LayoutUnit childLogicalOffset) const;
     
     LayoutUnit pageLogicalHeight() const { return m_pageLogicalHeight; }
     bool pageLogicalHeightChanged() const { return m_pageLogicalHeightChanged; }
@@ -97,7 +97,7 @@ public:
     LayoutRect clipRect() const { return m_clipRect; }
     bool isClipped() const { return m_clipped; }
 
-    void addLayoutDelta(LayoutSize);
+    void NODELETE addLayoutDelta(LayoutSize);
     LayoutSize layoutDelta() const { return m_layoutDelta; }
 #if ASSERT_ENABLED
     bool layoutDeltaMatches(LayoutSize) const;

--- a/Source/WebCore/rendering/RenderLineBoxList.h
+++ b/Source/WebCore/rendering/RenderLineBoxList.h
@@ -57,7 +57,7 @@ public:
     void deleteLineBoxTree();
     void deleteLineBoxes();
 
-    void removeLineBox(LegacyInlineFlowBox*);
+    void NODELETE removeLineBox(LegacyInlineFlowBox*);
     
     void dirtyLineBoxes();
     void dirtyLineFromChangedChild(RenderBoxModelObject& parent);

--- a/Source/WebCore/rendering/RenderLineBreak.h
+++ b/Source/WebCore/rendering/RenderLineBreak.h
@@ -58,8 +58,8 @@ private:
 
     PositionWithAffinity positionForPoint(const LayoutPoint&, HitTestSource, const RenderFragmentContainer*) final;
     int caretMinOffset() const final;
-    int caretMaxOffset() const final;
-    bool canBeSelectionLeaf() const final;
+    int NODELETE caretMaxOffset() const final;
+    bool NODELETE canBeSelectionLeaf() const final;
 
     LayoutUnit marginTop() const final { return 0; }
     LayoutUnit marginBottom() const final { return 0; }
@@ -75,7 +75,7 @@ private:
     LayoutRect frameRectForStickyPositioning() const final { ASSERT_NOT_REACHED(); return { }; }
     RepaintRects localRectsForRepaint(RepaintOutlineBounds) const final { return { }; }
 
-    void updateFromStyle() final;
+    void NODELETE updateFromStyle() final;
     bool requiresLayer() const final { return false; }
 };
 

--- a/Source/WebCore/rendering/RenderListBox.cpp
+++ b/Source/WebCore/rendering/RenderListBox.cpp
@@ -104,7 +104,7 @@ void RenderListBox::willBeDestroyed()
     RenderBlockFlow::willBeDestroyed();
 }
 
-HTMLSelectElement& RenderListBox::selectElement() const
+HTMLSelectElement& NODELETE RenderListBox::selectElement() const
 {
     return downcast<HTMLSelectElement>(nodeForNonAnonymous());
 }

--- a/Source/WebCore/rendering/RenderListBox.h
+++ b/Source/WebCore/rendering/RenderListBox.h
@@ -78,7 +78,7 @@ public:
 
     void scrollDidEnd() final;
 
-    bool isScrollableOrRubberbandable() final;
+    bool NODELETE isScrollableOrRubberbandable() final;
 
 private:
     bool isVisibleToHitTesting() const final;
@@ -136,7 +136,7 @@ private:
     ScrollPosition maximumScrollPosition() const final;
 
     void invalidateScrollbarRect(Scrollbar&, const IntRect&) final;
-    bool isActive() const final;
+    bool NODELETE isActive() const final;
     bool isScrollCornerVisible() const final { return false; } // We don't support resize on list boxes yet. If we did these would have to change.
     IntRect scrollCornerRect() const final { return IntRect(); }
     void invalidateScrollCornerRect(const IntRect&) final { }
@@ -144,19 +144,19 @@ private:
     IntRect convertFromContainingViewToScrollbar(const Scrollbar&, const IntRect&) const final;
     IntPoint convertFromScrollbarToContainingView(const Scrollbar&, const IntPoint&) const final;
     IntPoint convertFromContainingViewToScrollbar(const Scrollbar&, const IntPoint&) const final;
-    Scrollbar* verticalScrollbar() const final;
-    Scrollbar* horizontalScrollbar() const final;
+    Scrollbar* NODELETE verticalScrollbar() const final;
+    Scrollbar* NODELETE horizontalScrollbar() const final;
     IntSize contentsSize() const final;
     IntSize visibleSize() const final { return IntSize(width(), height()); }
     IntPoint lastKnownMousePositionInView() const final;
     bool isHandlingWheelEvent() const final;
     bool shouldSuspendScrollAnimations() const final;
-    bool forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;
+    bool NODELETE forceUpdateScrollbarsOnMainThreadForPerformanceTesting() const final;
 
     ScrollableArea* enclosingScrollableArea() const final;
     bool hasScrollableOrRubberbandableAncestor() final;
     IntRect scrollableAreaBoundingBox(bool* = nullptr) const final;
-    bool mockScrollbarsControllerEnabled() const final;
+    bool NODELETE mockScrollbarsControllerEnabled() const final;
     void logMockScrollbarsControllerMessage(const String&) const final;
     String debugDescription() const final;
     void didStartScrollAnimation() final;
@@ -191,7 +191,7 @@ private:
 
     std::optional<int> optionRowIndex(const HTMLOptionElement&) const;
 
-    float deviceScaleFactor() const final;
+    float NODELETE deviceScaleFactor() const final;
 
     LayoutRect rectForScrollbar(const Scrollbar&) const;
 
@@ -200,7 +200,7 @@ private:
     void paintItemBackground(PaintInfo&, const LayoutPoint&, int listIndex);
     void scrollToRevealSelection();
 
-    ScrollbarOrientation scrollbarOrientationForWritingMode() const;
+    ScrollbarOrientation NODELETE scrollbarOrientationForWritingMode() const;
 
     bool shouldPlaceVerticalScrollbarOnLeft() const final { return RenderBlockFlow::shouldPlaceVerticalScrollbarOnLeft(); }
 

--- a/Source/WebCore/rendering/RenderListItem.h
+++ b/Source/WebCore/rendering/RenderListItem.h
@@ -40,7 +40,7 @@ public:
     void updateValue();
 
     WEBCORE_EXPORT String markerTextWithoutSuffix() const;
-    String markerTextWithSuffix() const;
+    String NODELETE markerTextWithSuffix() const;
 
     void updateListMarkerNumbers();
 
@@ -70,7 +70,7 @@ private:
     mutable std::optional<int> m_value;
 };
 
-bool isHTMLListElement(const Node&);
+bool NODELETE isHTMLListElement(const Node&);
 
 inline int RenderListItem::value() const
 {

--- a/Source/WebCore/rendering/RenderListMarker.h
+++ b/Source/WebCore/rendering/RenderListMarker.h
@@ -62,7 +62,7 @@ public:
     String textWithoutSuffix() const { return m_textContent.textWithoutSuffix().toString(); };
     String textWithSuffix() const { return m_textContent.textWithSuffix; };
 
-    bool isInside() const;
+    bool NODELETE isInside() const;
     bool isDisclosureMarker() const;
 
     void updateInlineMarginsAndContent();
@@ -82,7 +82,7 @@ private:
     void paint(PaintInfo&, const LayoutPoint&) final;
     void layout() final;
     void imageChanged(WrappedImagePtr, const IntRect*) final;
-    LayoutRect selectionRectForRepaint(const RenderLayerModelObject* repaintContainer, bool clipToVisibleContent) final;
+    LayoutRect NODELETE selectionRectForRepaint(const RenderLayerModelObject* repaintContainer, bool clipToVisibleContent) final;
     bool canBeSelectionLeaf() const final { return true; }
     void styleWillChange(Style::Difference, const RenderStyle& newStyle) final;
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) final;
@@ -96,7 +96,7 @@ private:
     void updateContent();
     RenderBox* parentBox(RenderBox&);
     FloatRect relativeMarkerRect();
-    LayoutRect localSelectionRect();
+    LayoutRect NODELETE localSelectionRect();
     void paintDisclosureMarker(GraphicsContext&, const FloatRect& markerRect);
 
     RefPtr<CSSCounterStyle> counterStyle() const;

--- a/Source/WebCore/rendering/RenderMarquee.cpp
+++ b/Source/WebCore/rendering/RenderMarquee.cpp
@@ -84,7 +84,7 @@ int RenderMarquee::marqueeSpeed() const
     return result;
 }
 
-static MarqueeDirection reverseDirection(MarqueeDirection direction)
+static MarqueeDirection NODELETE reverseDirection(MarqueeDirection direction)
 {
     switch (direction) {
     case MarqueeDirection::Auto:
@@ -128,7 +128,7 @@ MarqueeDirection RenderMarquee::direction() const
     return result;
 }
 
-bool RenderMarquee::isHorizontal() const
+bool NODELETE RenderMarquee::isHorizontal() const
 {
     return direction() == MarqueeDirection::Left || direction() == MarqueeDirection::Right;
 }

--- a/Source/WebCore/rendering/RenderMarquee.h
+++ b/Source/WebCore/rendering/RenderMarquee.h
@@ -75,7 +75,7 @@ private:
     int speed() const { return m_speed; }
     int marqueeSpeed() const;
 
-    MarqueeDirection direction() const;
+    MarqueeDirection NODELETE direction() const;
 
     int computePosition(MarqueeDirection, bool stopAtClientEdge);
 

--- a/Source/WebCore/rendering/RenderMenuList.cpp
+++ b/Source/WebCore/rendering/RenderMenuList.cpp
@@ -59,7 +59,7 @@ RenderMenuList::RenderMenuList(HTMLSelectElement& element, RenderStyle&& style)
 
 RenderMenuList::~RenderMenuList() = default;
 
-HTMLSelectElement& RenderMenuList::selectElement() const
+HTMLSelectElement& NODELETE RenderMenuList::selectElement() const
 {
     return downcast<HTMLSelectElement>(nodeForNonAnonymous());
 }

--- a/Source/WebCore/rendering/RenderModel.cpp
+++ b/Source/WebCore/rendering/RenderModel.cpp
@@ -48,7 +48,7 @@ RenderModel::RenderModel(HTMLModelElement& element, RenderStyle&& style)
 // Do not add any code to the destructor, instead, add it to willBeDestroyed().
 RenderModel::~RenderModel() = default;
 
-HTMLModelElement& RenderModel::modelElement() const
+HTMLModelElement& NODELETE RenderModel::modelElement() const
 {
     return downcast<HTMLModelElement>(nodeForNonAnonymous());
 }

--- a/Source/WebCore/rendering/RenderModel.h
+++ b/Source/WebCore/rendering/RenderModel.h
@@ -46,7 +46,7 @@ private:
     void element() const = delete;
     ASCIILiteral renderName() const final { return "RenderModel"_s; }
 
-    bool requiresLayer() const final;
+    bool NODELETE requiresLayer() const final;
     void updateFromElement() final;
 
     void update();

--- a/Source/WebCore/rendering/RenderMultiColumnFlow.h
+++ b/Source/WebCore/rendering/RenderMultiColumnFlow.h
@@ -49,7 +49,7 @@ public:
     static RenderBox* nextColumnSetOrSpannerSiblingOf(const RenderBox*);
     static RenderBox* previousColumnSetOrSpannerSiblingOf(const RenderBox*);
 
-    RenderMultiColumnSpannerPlaceholder* findColumnSpannerPlaceholder(const RenderBox& spanner) const;
+    RenderMultiColumnSpannerPlaceholder* NODELETE findColumnSpannerPlaceholder(const RenderBox& spanner) const;
 
     void layout() override;
 

--- a/Source/WebCore/rendering/RenderMultiColumnSet.h
+++ b/Source/WebCore/rendering/RenderMultiColumnSet.h
@@ -63,7 +63,7 @@ public:
     // Return true if the specified renderer (descendant of the flow thread) is inside this column set.
     bool containsRendererInFragmentedFlow(const RenderObject&) const;
 
-    void setLogicalTopInFragmentedFlow(LayoutUnit);
+    void NODELETE setLogicalTopInFragmentedFlow(LayoutUnit);
     LayoutUnit logicalTopInFragmentedFlow() const { return isHorizontalWritingMode() ? fragmentedFlowPortionRect().y() : fragmentedFlowPortionRect().x(); }
     void setLogicalBottomInFragmentedFlow(LayoutUnit);
     LayoutUnit logicalBottomInFragmentedFlow() const { return isHorizontalWritingMode() ? fragmentedFlowPortionRect().maxY() : fragmentedFlowPortionRect().maxX(); }
@@ -176,7 +176,7 @@ private:
     LayoutUnit columnLogicalLeft(unsigned) const;
     LayoutUnit columnLogicalTop(unsigned) const;
 
-    LayoutRect fragmentedFlowPortionRectAt(unsigned index) const;
+    LayoutRect NODELETE fragmentedFlowPortionRectAt(unsigned index) const;
     LayoutRect fragmentedFlowPortionOverflowRect(const LayoutRect& fragmentedFlowPortion, unsigned index, unsigned colCount, LayoutUnit colGap) const;
 
     LayoutUnit initialBlockOffsetForPainting() const;

--- a/Source/WebCore/rendering/RenderObject.cpp
+++ b/Source/WebCore/rendering/RenderObject.cpp
@@ -891,7 +891,7 @@ LayoutRect RenderObject::paintingRootRect(LayoutRect& topLevelRect)
     return result;
 }
 
-static inline bool canRelyOnAncestorLayerFullRepaint(const RenderObject& rendererToRepaint, const RenderLayer& ancestorLayer)
+static inline bool NODELETE canRelyOnAncestorLayerFullRepaint(const RenderObject& rendererToRepaint, const RenderLayer& ancestorLayer)
 {
     auto* renderElement = dynamicDowncast<RenderElement>(rendererToRepaint);
     if (!renderElement || !renderElement->hasSelfPaintingLayer())
@@ -2611,7 +2611,7 @@ static bool shouldRenderSelectionOnSeparateLine(const RenderObject* currentRende
     return false;
 }
 
-static bool hasAncestorWithSelectionOnSeparateLine(RenderObject* descendant, const RenderObject* stayWithin)
+static bool NODELETE hasAncestorWithSelectionOnSeparateLine(RenderObject* descendant, const RenderObject* stayWithin)
 {
     for (CheckedPtr current = descendant; current; current = current->parent()) {
         if (current->isOutOfFlowPositioned())
@@ -2624,7 +2624,7 @@ static bool hasAncestorWithSelectionOnSeparateLine(RenderObject* descendant, con
     return false;
 }
 
-static bool shouldRenderPreviousSelectionOnSeparateLine(RenderObject* previousRenderer, const RenderObject* stayWithin)
+static bool NODELETE shouldRenderPreviousSelectionOnSeparateLine(RenderObject* previousRenderer, const RenderObject* stayWithin)
 {
     if (!previousRenderer || !stayWithin)
         return false;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -346,7 +346,7 @@ public:
     Type type() const { return m_type; }
     Layout::Box* layoutBox() { return m_layoutBox.get(); }
     const Layout::Box* layoutBox() const { return m_layoutBox.get(); }
-    void setLayoutBox(Layout::Box&);
+    void NODELETE setLayoutBox(Layout::Box&);
     void clearLayoutBox();
 
     WEBCORE_EXPORT RenderTheme& theme() const;
@@ -610,7 +610,7 @@ public:
     // to inherit from RenderSVGObject -> RenderObject (some need RenderBlock inheritance for instance)
     void invalidateCachedBoundaries();
     bool usesBoundaryCaching() const;
-    virtual void setNeedsBoundariesUpdate();
+    virtual void NODELETE setNeedsBoundariesUpdate();
     virtual void setNeedsTransformUpdate() { }
 
     // Per SVG 1.1 objectBoundingBox ignores clipping, masking, filter effects, opacity and stroke-width.
@@ -645,7 +645,7 @@ public:
 
     // This only returns the transform="" value from the element
     // most callsites want localToParentTransform() instead.
-    virtual AffineTransform localTransform() const;
+    virtual AffineTransform NODELETE localTransform() const;
 
     // Returns the full transform mapping from local coordinates to local coords for the parent SVG renderer
     // This includes any viewport transforms and x/y offsets as well as the transform="" value off the element.
@@ -732,7 +732,7 @@ public:
     bool effectiveCapturedInViewTransition() const;
 
     inline RenderView& view() const; // Defined in RenderObjectDocument.h
-    CheckedRef<RenderView> checkedView() const;
+    CheckedRef<RenderView> NODELETE checkedView() const;
     inline LocalFrameViewLayoutContext& layoutContext() const;
 
     HostWindow* hostWindow() const;

--- a/Source/WebCore/rendering/RenderProgress.cpp
+++ b/Source/WebCore/rendering/RenderProgress.cpp
@@ -114,7 +114,7 @@ void RenderProgress::updateAnimationState()
         m_animationTimer.stop();
 }
 
-HTMLProgressElement* RenderProgress::progressElement() const
+HTMLProgressElement* NODELETE RenderProgress::progressElement() const
 {
     if (!element())
         return nullptr;

--- a/Source/WebCore/rendering/RenderProgress.h
+++ b/Source/WebCore/rendering/RenderProgress.h
@@ -37,7 +37,7 @@ public:
     double animationProgress() const;
     MonotonicTime animationStartTime() const { return m_animationStartTime; }
 
-    bool isDeterminate() const;
+    bool NODELETE isDeterminate() const;
     void updateFromElement() override;
 
     HTMLProgressElement* NODELETE progressElement() const;

--- a/Source/WebCore/rendering/RenderQuote.h
+++ b/Source/WebCore/rendering/RenderQuote.h
@@ -37,7 +37,7 @@ public:
 
 private:
     ASCIILiteral renderName() const override { return "RenderQuote"_s; }
-    bool isOpen() const;
+    bool NODELETE isOpen() const;
     void styleDidChange(Style::Difference, const RenderStyle*) override;
     void insertedIntoTree() override;
     void willBeRemovedFromTree() override;

--- a/Source/WebCore/rendering/RenderScrollbar.cpp
+++ b/Source/WebCore/rendering/RenderScrollbar.cpp
@@ -196,7 +196,7 @@ void RenderScrollbar::updateScrollbarParts()
     }
 }
 
-static PseudoElementType pseudoForScrollbarPart(ScrollbarPart part)
+static PseudoElementType NODELETE pseudoForScrollbarPart(ScrollbarPart part)
 {
     switch (part) {
         case BackButtonStartPart:

--- a/Source/WebCore/rendering/RenderScrollbarTheme.h
+++ b/Source/WebCore/rendering/RenderScrollbarTheme.h
@@ -57,7 +57,7 @@ public:
 
     void buttonSizesAlongTrackAxis(Scrollbar&, int& beforeSize, int& afterSize);
     
-    static RenderScrollbarTheme* renderScrollbarTheme();
+    static RenderScrollbarTheme* NODELETE renderScrollbarTheme();
 
 private:
     bool hasButtons(Scrollbar&) override;

--- a/Source/WebCore/rendering/RenderSearchField.h
+++ b/Source/WebCore/rendering/RenderSearchField.h
@@ -41,7 +41,7 @@ public:
     bool popupIsVisible() const { return m_searchPopupIsVisible; }
     void showPopup();
     void hidePopup();
-    void popupDidHide();
+    void NODELETE popupDidHide();
     WEBCORE_EXPORT std::span<const RecentSearch> recentSearches();
 
     void updatePopup(const AtomString& name, const Vector<WebCore::RecentSearch>& searchItems);

--- a/Source/WebCore/rendering/RenderSelectFallbackButton.h
+++ b/Source/WebCore/rendering/RenderSelectFallbackButton.h
@@ -41,7 +41,7 @@ class RenderSelectFallbackButton final : public RenderBlockFlow {
 public:
     RenderSelectFallbackButton(SelectFallbackButtonElement&, RenderStyle&&);
 
-    SelectFallbackButtonElement& selectFallbackButtonElement() const;
+    SelectFallbackButtonElement& NODELETE selectFallbackButtonElement() const;
 
     // CheckedPtr interface.
     uint32_t checkedPtrCount() const { return RenderBlockFlow::checkedPtrCount(); }

--- a/Source/WebCore/rendering/RenderSlider.cpp
+++ b/Source/WebCore/rendering/RenderSlider.cpp
@@ -63,7 +63,7 @@ RenderSlider::RenderSlider(HTMLInputElement& element, RenderStyle&& style)
 
 RenderSlider::~RenderSlider() = default;
 
-HTMLInputElement& RenderSlider::element() const
+HTMLInputElement& NODELETE RenderSlider::element() const
 {
     return downcast<HTMLInputElement>(nodeForNonAnonymous());
 }

--- a/Source/WebCore/rendering/RenderTable.cpp
+++ b/Source/WebCore/rendering/RenderTable.cpp
@@ -125,7 +125,7 @@ RenderTableSection* RenderTable::firstBody() const
     return m_firstBody.get();
 }
 
-RenderTableSection* RenderTable::topSection() const
+RenderTableSection* NODELETE RenderTable::topSection() const
 {
     ASSERT(!needsSectionRecalc());
     if (m_head)

--- a/Source/WebCore/rendering/RenderTable.h
+++ b/Source/WebCore/rendering/RenderTable.h
@@ -217,7 +217,7 @@ public:
     
     void markForPaginationRelayoutIfNeeded() final;
 
-    void willInsertTableColumn(RenderTableCol& child, RenderObject* beforeChild);
+    void NODELETE willInsertTableColumn(RenderTableCol& child, RenderObject* beforeChild);
     void willInsertTableSection(RenderTableSection& child, RenderObject* beforeChild);
 
     LayoutUnit sumCaptionsLogicalHeight() const;

--- a/Source/WebCore/rendering/RenderTableCaption.cpp
+++ b/Source/WebCore/rendering/RenderTableCaption.cpp
@@ -49,7 +49,7 @@ void RenderTableCaption::willBeRemovedFromTree()
     table()->removeCaption(*this);
 }
 
-RenderTable* RenderTableCaption::table() const
+RenderTable* NODELETE RenderTableCaption::table() const
 {
     return downcast<RenderTable>(parent());
 }

--- a/Source/WebCore/rendering/RenderTableCell.cpp
+++ b/Source/WebCore/rendering/RenderTableCell.cpp
@@ -1410,7 +1410,7 @@ public:
         }
     }
 
-    CollapsedBorder* nextBorder()
+    CollapsedBorder* NODELETE nextBorder()
     {
         for (unsigned i = 0; i < m_count; i++) {
             if (m_borders[i].borderValue.exists() && m_borders[i].shouldPaint) {
@@ -1520,7 +1520,7 @@ void RenderTableCell::paintCollapsedBorders(PaintInfo& paintInfo, const LayoutPo
     }
 }
 
-static LayoutRect backgroundRectForRow(const RenderBox& tableRow, const RenderTable& table)
+static LayoutRect NODELETE backgroundRectForRow(const RenderBox& tableRow, const RenderTable& table)
 {
     LayoutRect rect = tableRow.frameRect();
     if (!table.collapseBorders()) {
@@ -1535,7 +1535,7 @@ static LayoutRect backgroundRectForRow(const RenderBox& tableRow, const RenderTa
     return rect;
 }
 
-static LayoutRect backgroundRectForSection(const RenderTableSection& tableSection, const RenderTable& table)
+static LayoutRect NODELETE backgroundRectForSection(const RenderTableSection& tableSection, const RenderTable& table)
 {
     LayoutRect rect = { { }, tableSection.size() };
     if (!table.collapseBorders()) {

--- a/Source/WebCore/rendering/RenderTableCell.h
+++ b/Source/WebCore/rendering/RenderTableCell.h
@@ -178,7 +178,7 @@ private:
     void setIntrinsicPaddingAfter(LayoutUnit p) { m_intrinsicPaddingAfter = p; }
     void setIntrinsicPadding(LayoutUnit before, LayoutUnit after) { setIntrinsicPaddingBefore(before); setIntrinsicPaddingAfter(after); }
 
-    bool hasStartBorderAdjoiningTable() const;
+    bool NODELETE hasStartBorderAdjoiningTable() const;
     bool hasEndBorderAdjoiningTable() const;
 
     CollapsedBorderValue collapsedStartBorder(IncludeBorderColorOrNot = IncludeBorderColor) const;

--- a/Source/WebCore/rendering/RenderTableCol.h
+++ b/Source/WebCore/rendering/RenderTableCol.h
@@ -49,7 +49,7 @@ public:
     bool isTableColumn() const { return style().display() == Style::DisplayType::TableColumn; }
     bool isTableColumnGroup() const { return style().display() == Style::DisplayType::TableColumnGroup; }
 
-    RenderTableCol* enclosingColumnGroup() const;
+    RenderTableCol* NODELETE enclosingColumnGroup() const;
     RenderTableCol* enclosingColumnGroupIfAdjacentBefore() const;
     RenderTableCol* enclosingColumnGroupIfAdjacentAfter() const;
 
@@ -87,8 +87,8 @@ private:
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) override;
     void paint(PaintInfo&, const LayoutPoint&) override { }
 
-    RenderTable* table() const;
-    CheckedPtr<RenderTable> checkedTable() const;
+    RenderTable* NODELETE table() const;
+    CheckedPtr<RenderTable> NODELETE checkedTable() const;
 
     unsigned m_span { 1 };
 };

--- a/Source/WebCore/rendering/RenderTableSection.cpp
+++ b/Source/WebCore/rendering/RenderTableSection.cpp
@@ -506,7 +506,7 @@ LayoutUnit RenderTableSection::distributeExtraLogicalHeightToRows(LayoutUnit ext
     return extraLogicalHeight - remainingExtraLogicalHeight;
 }
 
-static bool shouldFlexCellChild(const RenderTableCell& cell, const RenderBox& cellDescendant)
+static bool NODELETE shouldFlexCellChild(const RenderTableCell& cell, const RenderBox& cellDescendant)
 {
     if (!cell.style().logicalHeight().isSpecified())
         return false;
@@ -957,14 +957,14 @@ void RenderTableSection::paint(PaintInfo& paintInfo, const LayoutPoint& paintOff
         paintOutline(paintInfo, LayoutRect(adjustedPaintOffset, size()));
 }
 
-static inline bool compareCellPositions(const SingleThreadWeakPtr<RenderTableCell>& elem1, const SingleThreadWeakPtr<RenderTableCell>& elem2)
+static inline bool NODELETE compareCellPositions(const SingleThreadWeakPtr<RenderTableCell>& elem1, const SingleThreadWeakPtr<RenderTableCell>& elem2)
 {
     return elem1->rowIndex() < elem2->rowIndex();
 }
 
 // This comparison is used only when we have overflowing cells as we have an unsorted array to sort. We thus need
 // to sort both on rows and columns to properly repaint.
-static inline bool compareCellPositionsWithOverflowingCells(const SingleThreadWeakPtr<RenderTableCell>& elem1, const SingleThreadWeakPtr<RenderTableCell>& elem2)
+static inline bool NODELETE compareCellPositionsWithOverflowingCells(const SingleThreadWeakPtr<RenderTableCell>& elem1, const SingleThreadWeakPtr<RenderTableCell>& elem2)
 {
     if (elem1->rowIndex() != elem2->rowIndex())
         return elem1->rowIndex() < elem2->rowIndex();
@@ -1268,7 +1268,7 @@ void RenderTableSection::paintRowGroupBorderIfRequired(const PaintInfo& paintInf
 
 }
 
-static BoxSide physicalBorderForDirection(const WritingMode writingMode, CollapsedBorderSide side)
+static BoxSide NODELETE physicalBorderForDirection(const WritingMode writingMode, CollapsedBorderSide side)
 {
     // FIXME: Replace this with types/methods from BoxSides.h
     switch (side) {

--- a/Source/WebCore/rendering/RenderTableSection.h
+++ b/Source/WebCore/rendering/RenderTableSection.h
@@ -176,11 +176,11 @@ private:
     Color rowGroupBorderColor(CSSPropertyID borderColor) const;
     void paintRowGroupBorder(const PaintInfo&, bool antialias, LayoutRect, BoxSide, CSSPropertyID borderColor, BorderStyle, BorderStyle tableBorderStyle);
     void paintRowGroupBorderIfRequired(const PaintInfo&, const LayoutPoint& paintOffset, unsigned row, unsigned col, BoxSide, RenderTableCell* = 0);
-    LayoutUnit offsetLeftForRowGroupBorder(RenderTableCell*, const LayoutRect& rowGroupRect, unsigned row);
+    LayoutUnit NODELETE offsetLeftForRowGroupBorder(RenderTableCell*, const LayoutRect& rowGroupRect, unsigned row);
 
-    LayoutUnit offsetTopForRowGroupBorder(RenderTableCell*, BoxSide borderSide, unsigned row);
-    LayoutUnit verticalRowGroupBorderHeight(RenderTableCell*, const LayoutRect& rowGroupRect, unsigned row);
-    LayoutUnit horizontalRowGroupBorderWidth(RenderTableCell*, const LayoutRect& rowGroupRect, unsigned row, unsigned column);
+    LayoutUnit NODELETE offsetTopForRowGroupBorder(RenderTableCell*, BoxSide borderSide, unsigned row);
+    LayoutUnit NODELETE verticalRowGroupBorderHeight(RenderTableCell*, const LayoutRect& rowGroupRect, unsigned row);
+    LayoutUnit NODELETE horizontalRowGroupBorderWidth(RenderTableCell*, const LayoutRect& rowGroupRect, unsigned row, unsigned column);
 
     void computeIntrinsicLogicalWidths(LayoutUnit&, LayoutUnit&) const override { }
 
@@ -193,7 +193,7 @@ private:
     void relayoutCellIfFlexed(RenderTableCell&, int rowIndex, int rowHeight);
     
     void distributeExtraLogicalHeightToPercentRows(LayoutUnit& extraLogicalHeight, int totalPercent);
-    void distributeExtraLogicalHeightToAutoRows(LayoutUnit& extraLogicalHeight, unsigned autoRowsCount);
+    void NODELETE distributeExtraLogicalHeightToAutoRows(LayoutUnit& extraLogicalHeight, unsigned autoRowsCount);
     void distributeRemainingExtraLogicalHeight(LayoutUnit& extraLogicalHeight);
 
     bool hasOverflowingCell() const;

--- a/Source/WebCore/rendering/RenderText.cpp
+++ b/Source/WebCore/rendering/RenderText.cpp
@@ -135,7 +135,7 @@ inline void SecureTextTimer::restart(unsigned offsetAfterLastTypedCharacter)
     startOneShot(1_s * m_renderer.settings().passwordEchoDurationInSeconds());
 }
 
-inline unsigned SecureTextTimer::takeOffsetAfterLastTypedCharacter()
+inline unsigned NODELETE SecureTextTimer::takeOffsetAfterLastTypedCharacter()
 {
     unsigned offset = m_offsetAfterLastTypedCharacter;
     m_offsetAfterLastTypedCharacter = 0;
@@ -149,19 +149,19 @@ void SecureTextTimer::fired()
     m_renderer.setText(m_renderer.text(), true /* forcing setting text as it may be masked later */);
 }
 
-static HashMap<SingleThreadWeakRef<const RenderText>, String>& originalTextMap()
+static HashMap<SingleThreadWeakRef<const RenderText>, String>& NODELETE originalTextMap()
 {
     static NeverDestroyed<HashMap<SingleThreadWeakRef<const RenderText>, String>> map;
     return map;
 }
 
-static HashMap<SingleThreadWeakRef<const RenderText>, SingleThreadWeakPtr<RenderInline>>& inlineWrapperForDisplayContentsMap()
+static HashMap<SingleThreadWeakRef<const RenderText>, SingleThreadWeakPtr<RenderInline>>& NODELETE inlineWrapperForDisplayContentsMap()
 {
     static NeverDestroyed<HashMap<SingleThreadWeakRef<const RenderText>, SingleThreadWeakPtr<RenderInline>>> map;
     return map;
 }
 
-static constexpr char16_t convertNoBreakSpaceToSpace(char16_t character)
+static constexpr char16_t NODELETE convertNoBreakSpaceToSpace(char16_t character)
 {
     return character == noBreakSpace ? ' ' : character;
 }
@@ -357,12 +357,12 @@ RenderText::~RenderText()
     ASSERT(!originalTextMap().contains(this));
 }
 
-Layout::InlineTextBox* RenderText::layoutBox()
+Layout::InlineTextBox* NODELETE RenderText::layoutBox()
 {
     return downcast<Layout::InlineTextBox>(RenderObject::layoutBox());
 }
 
-const Layout::InlineTextBox* RenderText::layoutBox() const
+const Layout::InlineTextBox* NODELETE RenderText::layoutBox() const
 {
     return downcast<Layout::InlineTextBox>(RenderObject::layoutBox());
 }
@@ -372,7 +372,7 @@ ASCIILiteral RenderText::renderName() const
     return "RenderText"_s;
 }
 
-Text* RenderText::textNode() const
+Text* NODELETE RenderText::textNode() const
 {
     return downcast<Text>(RenderObject::node());
 }
@@ -930,7 +930,7 @@ PositionWithAffinity RenderText::positionForPoint(const LayoutPoint& point, HitT
     return createPositionWithAffinity(0, Affinity::Downstream);
 }
 
-static inline std::optional<float> combineTextWidth(const RenderText& renderer, const FontCascade& fontCascade, const RenderStyle& style)
+static inline std::optional<float> NODELETE combineTextWidth(const RenderText& renderer, const FontCascade& fontCascade, const RenderStyle& style)
 {
     if (style.textCombine() == TextCombine::None)
         return { };
@@ -1113,7 +1113,7 @@ RenderText::Widths RenderText::trimmedPreferredWidths(float leadWidth, bool& str
     return widths;
 }
 
-static inline bool isSpaceAccordingToStyle(char16_t c, const RenderStyle& style)
+static inline bool NODELETE isSpaceAccordingToStyle(char16_t c, const RenderStyle& style)
 {
     return c == ' ' || (c == noBreakSpace && style.nbspMode() == NBSPMode::Space);
 }
@@ -1539,7 +1539,7 @@ void RenderText::setSelectionState(HighlightState state)
         containingBlock->setSelectionState(state);
 }
 
-static inline bool isInlineFlowOrEmptyText(const RenderObject& renderer)
+static inline bool NODELETE isInlineFlowOrEmptyText(const RenderObject& renderer)
 {
     if (is<RenderInline>(renderer))
         return true;

--- a/Source/WebCore/rendering/RenderText.h
+++ b/Source/WebCore/rendering/RenderText.h
@@ -124,9 +124,9 @@ public:
 
     float hangablePunctuationStartWidth(unsigned index) const;
     float hangablePunctuationEndWidth(unsigned index) const;
-    unsigned firstCharacterIndexStrippingSpaces() const;
-    unsigned lastCharacterIndexStrippingSpaces() const;
-    static bool isHangableStopOrComma(char16_t);
+    unsigned NODELETE firstCharacterIndexStrippingSpaces() const;
+    unsigned NODELETE lastCharacterIndexStrippingSpaces() const;
+    static bool NODELETE isHangableStopOrComma(char16_t);
     
     WEBCORE_EXPORT virtual IntRect linesBoundingBox() const;
     WEBCORE_EXPORT IntPoint firstRunLocation() const;
@@ -177,7 +177,7 @@ public:
 
     Vector<std::pair<unsigned, unsigned>> contentRangesBetweenOffsetsForType(const DocumentMarkerType, unsigned startOffset, unsigned endOffset) const;
 
-    RenderInline* inlineWrapperForDisplayContents();
+    RenderInline* NODELETE inlineWrapperForDisplayContents();
     void setInlineWrapperForDisplayContents(RenderInline*);
 
     template <typename MeasureTextCallback>
@@ -268,8 +268,8 @@ String applyTextTransform(const RenderStyle&, const String&, Vector<char16_t> pr
 String applyTextTransform(const RenderStyle&, const String&);
 String capitalize(const String&, Vector<char16_t> previousCharacter);
 String capitalize(const String&);
-TextBreakIterator::LineMode::Behavior mapLineBreakToIteratorMode(LineBreak);
-TextBreakIterator::ContentAnalysis mapWordBreakToContentAnalysis(WordBreak);
+TextBreakIterator::LineMode::Behavior NODELETE mapLineBreakToIteratorMode(LineBreak);
+TextBreakIterator::ContentAnalysis NODELETE mapWordBreakToContentAnalysis(WordBreak);
 
 inline char16_t RenderText::characterAt(unsigned i) const
 {

--- a/Source/WebCore/rendering/RenderTextControl.cpp
+++ b/Source/WebCore/rendering/RenderTextControl.cpp
@@ -52,7 +52,7 @@ RenderTextControl::RenderTextControl(Type type, HTMLTextFormControlElement& elem
 
 RenderTextControl::~RenderTextControl() = default;
 
-HTMLTextFormControlElement& RenderTextControl::textFormControlElement() const
+HTMLTextFormControlElement& NODELETE RenderTextControl::textFormControlElement() const
 {
     return downcast<HTMLTextFormControlElement>(nodeForNonAnonymous());
 }

--- a/Source/WebCore/rendering/RenderTextControlMultiLine.h
+++ b/Source/WebCore/rendering/RenderTextControlMultiLine.h
@@ -34,7 +34,7 @@ public:
     RenderTextControlMultiLine(HTMLTextAreaElement&, RenderStyle&&);
     virtual ~RenderTextControlMultiLine();
 
-    HTMLTextAreaElement& textAreaElement() const;
+    HTMLTextAreaElement& NODELETE textAreaElement() const;
 
 private:
     void element() const = delete;

--- a/Source/WebCore/rendering/RenderTextControlSingleLine.h
+++ b/Source/WebCore/rendering/RenderTextControlSingleLine.h
@@ -42,7 +42,7 @@ public:
 protected:
     HTMLElement* containerElement() const;
     HTMLElement* innerBlockElement() const;
-    HTMLInputElement& inputElement() const;
+    HTMLInputElement& NODELETE inputElement() const;
 
 private:
     void textFormControlElement() const = delete;

--- a/Source/WebCore/rendering/RenderTextLineBoxes.h
+++ b/Source/WebCore/rendering/RenderTextLineBoxes.h
@@ -42,7 +42,7 @@ public:
 
     LegacyInlineTextBox* createAndAppendLineBox(RenderSVGInlineText&);
 
-    void remove(LegacyInlineTextBox&);
+    void NODELETE remove(LegacyInlineTextBox&);
 
     void removeAllFromParent(RenderSVGInlineText&);
     void deleteAll();
@@ -58,7 +58,7 @@ public:
 #endif
 
 private:
-    void checkConsistency() const;
+    void NODELETE checkConsistency() const;
 
     LegacyInlineTextBox* m_first { nullptr };
     LegacyInlineTextBox* m_last { nullptr };

--- a/Source/WebCore/rendering/RenderTheme.cpp
+++ b/Source/WebCore/rendering/RenderTheme.cpp
@@ -212,7 +212,7 @@ StyleAppearance RenderTheme::adjustAppearanceForElement(RenderStyle& style, cons
     return appearance;
 }
 
-static bool isAppearanceAllowedForAllElements(StyleAppearance appearance)
+static bool NODELETE isAppearanceAllowedForAllElements(StyleAppearance appearance)
 {
 #if ENABLE(APPLE_PAY)
     if (appearance == StyleAppearance::ApplePayButton)
@@ -233,7 +233,7 @@ static bool devolvableWidgetsEnabledAndSupported(const Element* element)
 #endif
 }
 
-static bool shouldCheckLegacyStylesForNativeAppearance(const Element* element)
+static bool NODELETE shouldCheckLegacyStylesForNativeAppearance(const Element* element)
 {
 #if PLATFORM(MAC)
 #if ENABLE(FORM_CONTROL_REFRESH)

--- a/Source/WebCore/rendering/RenderTheme.h
+++ b/Source/WebCore/rendering/RenderTheme.h
@@ -142,7 +142,7 @@ public:
 
     // A method for asking if a control is a container or not.  Leaf controls have to have some special behavior (like
     // the baseline position API above).
-    bool isControlContainer(StyleAppearance) const;
+    bool NODELETE isControlContainer(StyleAppearance) const;
 
     // A method asking if the control changes its tint when the window has focus or not.
     virtual bool controlSupportsTints(const RenderElement&) const { return false; }
@@ -159,7 +159,7 @@ public:
     virtual void adjustRepaintRect(const RenderBox&, FloatRect&) { }
 
     // A method asking if the theme is able to draw the focus ring.
-    virtual bool supportsFocusRing(const RenderElement&, const RenderStyle&) const;
+    virtual bool NODELETE supportsFocusRing(const RenderElement&, const RenderStyle&) const;
 
     // A method asking if the theme's controls actually care about redrawing when hovered.
     virtual bool supportsHover() const { return false; }
@@ -404,7 +404,7 @@ protected:
     virtual void adjustSearchFieldResultsButtonStyle(RenderStyle&, const Element*) const { }
     virtual bool paintSearchFieldResultsButton(const RenderBox&, const PaintInfo&, const FloatRect&) { return true; }
 
-    void adjustSwitchStyleDisplay(RenderStyle&) const;
+    void NODELETE adjustSwitchStyleDisplay(RenderStyle&) const;
     virtual void adjustSwitchStyle(RenderStyle&, const Element*) const;
     void adjustSwitchThumbOrSwitchTrackStyle(RenderStyle&) const;
     virtual bool paintSwitchThumb(const RenderElement&, const PaintInfo&, const FloatRect&) { return true; }
@@ -439,7 +439,7 @@ private:
     void adjustButtonOrCheckboxOrColorWellOrInnerSpinButtonOrRadioStyle(RenderStyle&, const Element*) const;
 
 public:
-    bool isWindowActive(const RenderElement&) const;
+    bool NODELETE isWindowActive(const RenderElement&) const;
     bool isChecked(const RenderElement&) const;
     bool isIndeterminate(const RenderElement&) const;
     bool isEnabled(const RenderElement&) const;
@@ -450,7 +450,7 @@ public:
     bool isSpinUpButtonPartHovered(const RenderElement&) const;
     bool isPresenting(const RenderElement&) const;
     bool isReadOnlyControl(const RenderElement&) const;
-    bool isDefault(const RenderElement&) const;
+    bool NODELETE isDefault(const RenderElement&) const;
     bool hasListButton(const RenderElement&) const;
     bool hasListButtonPressed(const RenderElement&) const;
 

--- a/Source/WebCore/rendering/RenderTreeAsText.cpp
+++ b/Source/WebCore/rendering/RenderTreeAsText.cpp
@@ -183,7 +183,7 @@ String quoteAndEscapeNonPrintables(StringView s)
     return result.toString();
 }
 
-inline bool shouldEnableSubpixelPrecisionForTextDump(const Document& document)
+inline bool NODELETE shouldEnableSubpixelPrecisionForTextDump(const Document& document)
 {
     // If LBSE is activated and the document contains outermost <svg> elements, generate the text
     // representation with subpixel precision. It would be awkward to only see the SVG part of a

--- a/Source/WebCore/rendering/RenderVTTCue.h
+++ b/Source/WebCore/rendering/RenderVTTCue.h
@@ -55,7 +55,7 @@ private:
     RenderVTTCue* overlappingObjectForRect(const IntRect&) const;
     bool shouldSwitchDirection(const InlineIterator::InlineBox&, LayoutUnit) const;
 
-    void moveBoxesByStep(LayoutUnit);
+    void NODELETE moveBoxesByStep(LayoutUnit);
     bool switchDirection(bool&, LayoutUnit&);
     void moveIfNecessaryToKeepWithinContainer();
     bool findNonOverlappingPosition(int& x, int& y) const;

--- a/Source/WebCore/rendering/RenderVideo.cpp
+++ b/Source/WebCore/rendering/RenderVideo.cpp
@@ -317,7 +317,7 @@ void RenderVideo::styleDidChange(Style::Difference difference, const RenderStyle
         setNeedsLayout();
 }
 
-HTMLVideoElement& RenderVideo::videoElement() const
+HTMLVideoElement& NODELETE RenderVideo::videoElement() const
 {
     return downcast<HTMLVideoElement>(RenderMedia::mediaElement());
 }

--- a/Source/WebCore/rendering/RenderVideo.h
+++ b/Source/WebCore/rendering/RenderVideo.h
@@ -45,7 +45,7 @@ public:
     IntRect videoBox() const;
     WEBCORE_EXPORT IntRect videoBoxInRootView() const;
 
-    static IntSize defaultSize();
+    static IntSize NODELETE defaultSize();
 
     bool supportsAcceleratedRendering() const;
     void acceleratedRenderingStateChanged();

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -139,7 +139,7 @@ public:
 
     WEBCORE_EXPORT RenderLayerCompositor& compositor();
     WEBCORE_EXPORT CheckedRef<RenderLayerCompositor> checkedCompositor();
-    WEBCORE_EXPORT bool usesCompositing() const;
+    WEBCORE_EXPORT bool NODELETE usesCompositing() const;
 
     WEBCORE_EXPORT IntRect unscaledDocumentRect() const;
     LayoutRect unextendedBackgroundRect() const;
@@ -216,12 +216,12 @@ public:
     void unregisterPositionTryBox(const RenderBox&);
     const SingleThreadWeakHashSet<const RenderBox>& positionTryBoxes() const { return m_positionTryBoxes; }
 
-    SingleThreadWeakPtr<RenderBlockFlow> viewTransitionContainingBlock() const;
+    SingleThreadWeakPtr<RenderBlockFlow> NODELETE viewTransitionContainingBlock() const;
     void setViewTransitionContainingBlock(RenderBlockFlow& renderer);
 
     void addViewTransitionGroup(const AtomString&, RenderBox&);
     void removeViewTransitionGroup(const AtomString&);
-    RenderBox* viewTransitionGroupForName(const AtomString&);
+    RenderBox* NODELETE viewTransitionGroupForName(const AtomString&);
 
 protected:
     void willBeDestroyed() override;

--- a/Source/WebCore/rendering/RenderViewTransitionCapture.h
+++ b/Source/WebCore/rendering/RenderViewTransitionCapture.h
@@ -55,11 +55,11 @@ public:
     LayoutRect captureLocalOverflowRect() const { return m_localOverflowRect; }
 
     // Inset of the scaled capture from the visualOverflowRect()
-    LayoutPoint captureContentInset() const;
+    LayoutPoint NODELETE captureContentInset() const;
 
     bool canUseExistingLayers() const { return !hasNonVisibleOverflow(); }
 
-    bool paintsContent() const final;
+    bool NODELETE paintsContent() const final;
 
     bool isRootElementCapture() const { return m_isRootElementCapture; }
 

--- a/Source/WebCore/rendering/RenderWidget.cpp
+++ b/Source/WebCore/rendering/RenderWidget.cpp
@@ -53,7 +53,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderWidget);
 
-static HashMap<SingleThreadWeakRef<const Widget>, SingleThreadWeakRef<RenderWidget>>& widgetRendererMap()
+static HashMap<SingleThreadWeakRef<const Widget>, SingleThreadWeakRef<RenderWidget>>& NODELETE widgetRendererMap()
 {
     static NeverDestroyed<HashMap<SingleThreadWeakRef<const Widget>, SingleThreadWeakRef<RenderWidget>>> staticWidgetRendererMap;
     return staticWidgetRendererMap;
@@ -128,7 +128,7 @@ RenderWidget::~RenderWidget() = default;
 // Widgets are always placed on integer boundaries, so rounding the size is actually
 // the desired behavior. This function is here because it's otherwise seldom what we
 // want to do with a LayoutRect.
-static inline IntRect roundedIntRect(const LayoutRect& rect)
+static inline IntRect NODELETE roundedIntRect(const LayoutRect& rect)
 {
     return IntRect(roundedIntPoint(rect.location()), roundedIntSize(rect.size()));
 }
@@ -478,7 +478,7 @@ bool RenderWidget::requiresAcceleratedCompositing() const
     return false;
 }
 
-RemoteFrame* RenderWidget::remoteFrame() const
+RemoteFrame* NODELETE RenderWidget::remoteFrame() const
 {
     return dynamicDowncast<RemoteFrame>(frameOwnerElement().contentFrame());
 }

--- a/Source/WebCore/rendering/RenderWidget.h
+++ b/Source/WebCore/rendering/RenderWidget.h
@@ -49,7 +49,7 @@ public:
 
 private:
     using WidgetToParentMap = HashMap<Ref<Widget>, SingleThreadWeakPtr<LocalFrameView>>;
-    static WidgetToParentMap& widgetNewParentMap();
+    static WidgetToParentMap& NODELETE widgetNewParentMap();
 
     WEBCORE_EXPORT void moveWidgets();
     WEBCORE_EXPORT static unsigned s_widgetHierarchyUpdateSuspendCount;
@@ -67,7 +67,7 @@ public:
     Widget* widget() const { return m_widget.get(); }
     WEBCORE_EXPORT void setWidget(RefPtr<Widget>&&);
 
-    static RenderWidget* find(const Widget&);
+    static RenderWidget* NODELETE find(const Widget&);
 
     enum class ChildWidgetState { Valid, Destroyed };
     [[nodiscard]] ChildWidgetState updateWidgetPosition();

--- a/Source/WebCore/rendering/TextBoxPainter.h
+++ b/Source/WebCore/rendering/TextBoxPainter.h
@@ -84,10 +84,10 @@ protected:
     bool computeHaveSelection() const;
     std::pair<unsigned, unsigned> selectionStartEnd() const;
     MarkedText createMarkedTextFromSelectionInBox();
-    const FontCascade& fontCascade() const;
+    const FontCascade& NODELETE fontCascade() const;
     WritingMode writingMode() const { return m_style->writingMode(); }
     FloatPoint textOriginFromPaintRect(const FloatRect&) const;
-    bool isInsideShapedContent() const;
+    bool NODELETE isInsideShapedContent() const;
 
     struct DecoratingBox {
         InlineIterator::InlineBoxIterator inlineBox;

--- a/Source/WebCore/rendering/TextBoxTrimmer.cpp
+++ b/Source/WebCore/rendering/TextBoxTrimmer.cpp
@@ -37,14 +37,14 @@
 
 namespace WebCore {
 
-static TextBoxTrim textBoxTrim(const RenderBlockFlow& textBoxTrimRoot)
+static TextBoxTrim NODELETE textBoxTrim(const RenderBlockFlow& textBoxTrimRoot)
 {
     if (auto* multiColumnFlow = dynamicDowncast<RenderMultiColumnFlow>(textBoxTrimRoot))
         return multiColumnFlow->multiColumnBlockFlow()->style().textBoxTrim();
     return textBoxTrimRoot.style().textBoxTrim();
 }
 
-static void removeTextBoxTrimStart(LocalFrameViewLayoutContext& layoutContext)
+static void NODELETE removeTextBoxTrimStart(LocalFrameViewLayoutContext& layoutContext)
 {
     auto textBoxTrim = layoutContext.textBoxTrim();
     if (!textBoxTrim || !textBoxTrim->trimFirstFormattedLine) {

--- a/Source/WebCore/rendering/TextDecorationPainter.cpp
+++ b/Source/WebCore/rendering/TextDecorationPainter.cpp
@@ -40,7 +40,7 @@
 
 namespace WebCore {
 
-static StrokeStyle textDecorationStyleToStrokeStyle(TextDecorationStyle decorationStyle)
+static StrokeStyle NODELETE textDecorationStyleToStrokeStyle(TextDecorationStyle decorationStyle)
 {
     StrokeStyle strokeStyle = StrokeStyle::SolidStroke;
     switch (decorationStyle) {

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -218,12 +218,12 @@ static constexpr auto logicalSwitchHeight = 18.f;
 static constexpr FloatSize idealRefreshedSwitchSize = { 64, 28 };
 static constexpr auto logicalRefreshedSwitchWidth = logicalSwitchHeight * (idealRefreshedSwitchSize.width() / idealRefreshedSwitchSize.height());
 
-static bool renderThemePaintSwitchThumb(OptionSet<ControlStyle::State>, const RenderElement&, const PaintInfo&, const FloatRect&, const Color&)
+static bool NODELETE renderThemePaintSwitchThumb(OptionSet<ControlStyle::State>, const RenderElement&, const PaintInfo&, const FloatRect&, const Color&)
 {
     return true;
 }
 
-static bool renderThemePaintSwitchTrack(OptionSet<ControlStyle::State>, const RenderElement&, const PaintInfo&, const FloatRect&)
+static bool NODELETE renderThemePaintSwitchTrack(OptionSet<ControlStyle::State>, const RenderElement&, const PaintInfo&, const FloatRect&)
 {
     return true;
 }
@@ -245,7 +245,7 @@ constexpr int kThumbnailBorderCornerRadius = 1;
 constexpr int kVisibleBackgroundImageWidth = 1;
 constexpr int kMultipleThumbnailShrinkSize = 2;
 
-static inline bool canShowCapsLockIndicator()
+static inline bool NODELETE canShowCapsLockIndicator()
 {
 #if HAVE(ACCELERATED_TEXT_INPUT)
     if (redesignedTextCursorEnabled())

--- a/Source/WebCore/rendering/line/LineInfo.h
+++ b/Source/WebCore/rendering/line/LineInfo.h
@@ -53,7 +53,7 @@ public:
 
     void setFirstLine(bool firstLine) { m_isFirstLine = firstLine; }
     void setLastLine(bool lastLine) { m_isLastLine = lastLine; }
-    void setEmpty(bool);
+    void NODELETE setEmpty(bool);
 
 private:
     bool m_isFirstLine;

--- a/Source/WebCore/rendering/line/LineWidth.h
+++ b/Source/WebCore/rendering/line/LineWidth.h
@@ -69,7 +69,7 @@ public:
         addUncommittedWidth(delta);
         m_hasUncommittedReplaced = true;
     }
-    void commit();
+    void NODELETE commit();
     void setTrailingWhitespaceWidth(float collapsedWhitespace, float borderPaddingMargin = 0);
 
 private:

--- a/Source/WebCore/rendering/mac/RenderThemeMac.h
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.h
@@ -73,8 +73,8 @@ public:
 
     void adjustSliderThumbSize(RenderStyle&, const Element*) const final;
 
-    IntSize sliderTickSize() const final;
-    int sliderTickOffsetFromTrackCenter() const final;
+    IntSize NODELETE sliderTickSize() const final;
+    int NODELETE sliderTickOffsetFromTrackCenter() const final;
 
     Style::PaddingBox popupInternalPaddingBox(const RenderStyle&) const final;
     PopupMenuStyle::Size popupMenuSize(const RenderStyle&, IntRect&) const final;
@@ -84,12 +84,12 @@ public:
     Style::PreferredSizePair controlSize(StyleAppearance, const FontCascade&, const Style::PreferredSizePair&, float zoomFactor) const final;
     Style::MinimumSizePair minimumControlSize(StyleAppearance, const FontCascade&, const Style::MinimumSizePair&, float zoomFactor) const final;
     Style::LineWidthBox controlBorder(StyleAppearance, const FontCascade&, const Style::LineWidthBox&, float zoomFactor, const Element*) const final;
-    bool controlRequiresPreWhiteSpace(StyleAppearance) const final;
+    bool NODELETE controlRequiresPreWhiteSpace(StyleAppearance) const final;
 
     bool popsMenuByArrowKeys() const final { return true; }
 
     FloatSize meterSizeForBounds(const RenderMeter&, const FloatRect&) const final;
-    bool supportsMeter(StyleAppearance) const final;
+    bool NODELETE supportsMeter(StyleAppearance) const final;
 
     void createColorWellSwatchSubtree(HTMLElement&) final;
     void setColorWellSwatchBackground(HTMLElement&, Color) final;
@@ -105,9 +105,9 @@ public:
     bool hasSwitchHapticFeedback(SwitchTrigger trigger) const final { return trigger == SwitchTrigger::PointerTracking; }
 
     bool canPaint(const PaintInfo&, const Settings&, StyleAppearance) const final;
-    bool canCreateControlPartForRenderer(const RenderElement&) const final;
-    bool canCreateControlPartForBorderOnly(const RenderElement&) const final;
-    bool canCreateControlPartForDecorations(const RenderElement&) const final;
+    bool NODELETE canCreateControlPartForRenderer(const RenderElement&) const final;
+    bool NODELETE canCreateControlPartForBorderOnly(const RenderElement&) const final;
+    bool NODELETE canCreateControlPartForDecorations(const RenderElement&) const final;
 
     int baselinePosition(const RenderBox&) const final;
 
@@ -144,7 +144,7 @@ public:
 
     String fileListNameForWidth(const FileList*, const FontCascade&, int width, bool multipleFilesAllowed) const final;
 
-    bool searchFieldShouldAppearAsTextField(const RenderStyle&, const Settings&) const final;
+    bool NODELETE searchFieldShouldAppearAsTextField(const RenderStyle&, const Settings&) const final;
 
 #if ENABLE(SERVICE_CONTROLS)
     IntSize imageControlsButtonSize() const final;
@@ -154,10 +154,10 @@ public:
 private:
     RenderThemeMac();
 
-    std::span<const IntSize, 4> menuListSizes() const;
-    std::span<const IntSize, 4> searchFieldSizes() const;
-    std::span<const IntSize, 4> cancelButtonSizes() const;
-    std::span<const IntSize, 4> resultsButtonSizes() const;
+    std::span<const IntSize, 4> NODELETE menuListSizes() const;
+    std::span<const IntSize, 4> NODELETE searchFieldSizes() const;
+    std::span<const IntSize, 4> NODELETE cancelButtonSizes() const;
+    std::span<const IntSize, 4> NODELETE resultsButtonSizes() const;
     void setSearchFieldSize(RenderStyle&) const;
 
     mutable RetainPtr<NSPopUpButtonCell> m_popupButton;

--- a/Source/WebCore/rendering/mac/RenderThemeMac.mm
+++ b/Source/WebCore/rendering/mac/RenderThemeMac.mm
@@ -856,7 +856,7 @@ static Style::PreferredSizePair sizeFromFont(const FontCascade& font, const Styl
 
 // Popup button
 
-static std::span<const int, 4> popupButtonMargins(NSControlSize size)
+static std::span<const int, 4> NODELETE popupButtonMargins(NSControlSize size)
 {
     static constexpr std::array margins {
         std::array { 0, 3, 1, 3 },
@@ -867,7 +867,7 @@ static std::span<const int, 4> popupButtonMargins(NSControlSize size)
     return margins[size];
 }
 
-static std::span<const IntSize, 4> popupButtonSizes()
+static std::span<const IntSize, 4> NODELETE popupButtonSizes()
 {
     static constexpr std::array sizes {
         IntSize { 0, 21 },
@@ -878,7 +878,7 @@ static std::span<const IntSize, 4> popupButtonSizes()
     return sizes;
 }
 
-static std::span<const int, 4> popupButtonPadding(NSControlSize size, bool isRTL)
+static std::span<const int, 4> NODELETE popupButtonPadding(NSControlSize size, bool isRTL)
 {
     static constexpr std::array paddingLTR {
         std::array { 2, 26, 3, 8 },
@@ -897,7 +897,7 @@ static std::span<const int, 4> popupButtonPadding(NSControlSize size, bool isRTL
 
 // Checkboxes and radio buttons
 
-static const std::span<const IntSize, 4> checkboxSizes()
+static const std::span<const IntSize, 4> NODELETE checkboxSizes()
 {
     static constexpr std::array sizes = {
         IntSize { 14, 14 },
@@ -908,7 +908,7 @@ static const std::span<const IntSize, 4> checkboxSizes()
     return sizes;
 }
 
-static std::span<const int, 4> checkboxMargins(NSControlSize controlSize)
+static std::span<const int, 4> NODELETE checkboxMargins(NSControlSize controlSize)
 {
     static constexpr std::array margins {
         // top right bottom left
@@ -941,7 +941,7 @@ static const std::span<const IntSize, 4> radioSizes()
     return sizes;
 }
 
-static std::span<const int, 4> radioMargins(NSControlSize controlSize)
+static std::span<const int, 4> NODELETE radioMargins(NSControlSize controlSize)
 {
     static constexpr std::array margins {
         // top right bottom left
@@ -965,7 +965,7 @@ static Style::PreferredSizePair radioSize(const Style::PreferredSizePair& zoomed
 // Buttons
 
 // Buttons really only constrain height. They respect width.
-static const std::span<const IntSize, 4> buttonSizes()
+static const std::span<const IntSize, 4> NODELETE buttonSizes()
 {
     static constexpr std::array sizes = {
         IntSize { 0, 20 },
@@ -976,7 +976,7 @@ static const std::span<const IntSize, 4> buttonSizes()
     return sizes;
 }
 
-static std::span<const int, 4> buttonMargins(NSControlSize controlSize)
+static std::span<const int, 4> NODELETE buttonMargins(NSControlSize controlSize)
 {
     // FIXME: These values may need to be reevaluated. They appear to have been originally chosen
     // to reflect the size of shadows around native form controls on macOS, but as of macOS 10.15,
@@ -992,7 +992,7 @@ static std::span<const int, 4> buttonMargins(NSControlSize controlSize)
 
 // Stepper
 
-static const std::span<const IntSize, 4> stepperSizes()
+static const std::span<const IntSize, 4> NODELETE stepperSizes()
 {
     static constexpr std::array sizes = {
         IntSize { 19, 27 },
@@ -1019,7 +1019,7 @@ static NSControlSize stepperControlSizeForFont(const FontCascade& font)
 
 // Switch
 
-static const std::span<const IntSize, 4> switchSizes()
+static const std::span<const IntSize, 4> NODELETE switchSizes()
 {
     static constexpr std::array sizes = {
         IntSize { 38, 22 },
@@ -1030,7 +1030,7 @@ static const std::span<const IntSize, 4> switchSizes()
     return sizes;
 }
 
-static std::span<const int, 4> visualSwitchMargins(NSControlSize controlSize, bool isVertical)
+static std::span<const int, 4> NODELETE visualSwitchMargins(NSControlSize controlSize, bool isVertical)
 {
     static constexpr std::array switchMarginsNonMini { 2, 2, 1, 2 };
     static constexpr std::array switchMarginsMini { 1, 1, 0, 1 };
@@ -1317,7 +1317,7 @@ const int styledPopupPaddingLeft = 8;
 const int styledPopupPaddingTop = 1;
 const int styledPopupPaddingBottom = 2;
 
-static std::span<const IntSize, 4> menuListButtonSizes()
+static std::span<const IntSize, 4> NODELETE menuListButtonSizes()
 {
     static constexpr std::array sizes { IntSize(0, 21), IntSize(0, 18), IntSize(0, 15), IntSize(0, 28) };
     return sizes;

--- a/Source/WebCore/rendering/mathml/MathMLStyle.h
+++ b/Source/WebCore/rendering/mathml/MathMLStyle.h
@@ -43,7 +43,7 @@ public:
     static void resolveMathMLStyleTree(RenderObject*);
 
 private:
-    const MathMLStyle* getMathMLStyle(RenderObject* renderer);
+    const MathMLStyle* NODELETE getMathMLStyle(RenderObject* renderer);
     RenderObject* getMathMLParentNode(RenderObject*);
     void updateStyleIfNeeded(RenderObject*, MathVariant);
 

--- a/Source/WebCore/rendering/mathml/MathOperator.h
+++ b/Source/WebCore/rendering/mathml/MathOperator.h
@@ -80,7 +80,7 @@ private:
         LeftAndRight
     };
 
-    LayoutUnit stretchSize() const;
+    LayoutUnit NODELETE stretchSize() const;
     bool getGlyph(const RenderStyle&, char32_t character, GlyphData&) const;
     bool getBaseGlyph(const RenderStyle& style, GlyphData& baseGlyph) const { return getGlyph(style, m_baseCharacter, baseGlyph); }
     void setSizeVariant(const GlyphData&);
@@ -88,7 +88,7 @@ private:
     void getMathVariantsWithFallback(const RenderStyle&, bool isVertical, Vector<Glyph>&, Vector<OpenTypeMathData::AssemblyPart>&);
     void calculateDisplayStyleLargeOperator(const RenderStyle&);
     void calculateStretchyData(const RenderStyle&, bool calculateMaxPreferredWidth, LayoutUnit targetSize = 0_lu);
-    bool calculateGlyphAssemblyFallback(const Vector<OpenTypeMathData::AssemblyPart>&, GlyphAssemblyData&) const;
+    bool NODELETE calculateGlyphAssemblyFallback(const Vector<OpenTypeMathData::AssemblyPart>&, GlyphAssemblyData&) const;
 
     LayoutRect paintGlyph(const RenderStyle&, PaintInfo&, const GlyphData&, const LayoutPoint& origin, GlyphPaintTrimming);
     void fillWithVerticalExtensionGlyph(const RenderStyle&, PaintInfo&, const LayoutPoint& from, const LayoutPoint& to);

--- a/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLBlock.h
@@ -65,7 +65,7 @@ protected:
     inline LayoutUnit ruleThicknessFallback() const;
 
     LayoutUnit mathAxisHeight() const;
-    LayoutUnit mirrorIfNeeded(LayoutUnit horizontalOffset, LayoutUnit boxWidth = 0_lu) const;
+    LayoutUnit NODELETE mirrorIfNeeded(LayoutUnit horizontalOffset, LayoutUnit boxWidth = 0_lu) const;
     inline LayoutUnit mirrorIfNeeded(LayoutUnit horizontalOffset, const RenderBox& child) const;
 
     static inline LayoutUnit ascentForChild(const RenderBox& child);

--- a/Source/WebCore/rendering/mathml/RenderMathMLFraction.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLFraction.h
@@ -57,7 +57,7 @@ private:
     RenderMathMLOperator* unembellishedOperator() const final;
     bool isMathContentCentered() const final { return true; }
 
-    MathMLFractionElement& element() const;
+    MathMLFractionElement& NODELETE element() const;
 
     bool isValid() const;
     RenderBox& numerator() const;

--- a/Source/WebCore/rendering/mathml/RenderMathMLOperator.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLOperator.h
@@ -43,7 +43,7 @@ public:
     RenderMathMLOperator(Type, Document&, RenderStyle&&);
     virtual ~RenderMathMLOperator();
 
-    MathMLOperatorElement& element() const;
+    MathMLOperatorElement& NODELETE element() const;
 
     void stretchTo(LayoutUnit heightAboveBaseline, LayoutUnit depthBelowBaseline);
     void stretchTo(LayoutUnit width);

--- a/Source/WebCore/rendering/mathml/RenderMathMLPadded.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLPadded.h
@@ -46,7 +46,7 @@ private:
     void layoutBlock(RelayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) final;
     std::optional<LayoutUnit> firstLineBaseline() const final;
 
-    MathMLPaddedElement& element() const;
+    MathMLPaddedElement& NODELETE element() const;
     LayoutUnit voffset() const;
     LayoutUnit lspace() const;
     LayoutUnit mpaddedWidth(LayoutUnit contentWidth) const;

--- a/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRoot.h
@@ -53,8 +53,8 @@ private:
     RenderBox& getBase() const;
     RenderBox& getIndex() const;
     ASCIILiteral renderName() const final { return "RenderMathMLRoot"_s; }
-    MathMLRootElement& element() const;
-    RootType rootType() const;
+    MathMLRootElement& NODELETE element() const;
+    RootType NODELETE rootType() const;
 
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) final;
 

--- a/Source/WebCore/rendering/mathml/RenderMathMLRow.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLRow.h
@@ -39,7 +39,7 @@ class RenderMathMLRow : public RenderMathMLBlock {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderMathMLRow);
 public:
     RenderMathMLRow(Type, MathMLRowElement&, RenderStyle&&);
-    MathMLRowElement& element() const;
+    MathMLRowElement& NODELETE element() const;
     virtual ~RenderMathMLRow();
 
 protected:

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp
@@ -41,7 +41,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderMathMLScripts);
 
-static bool isPrescriptDelimiter(const RenderObject& renderObject)
+static bool NODELETE isPrescriptDelimiter(const RenderObject& renderObject)
 {
     return renderObject.node() && renderObject.node()->hasTagName(MathMLNames::mprescriptsTag);
 }

--- a/Source/WebCore/rendering/mathml/RenderMathMLScripts.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLScripts.h
@@ -47,12 +47,12 @@ public:
 protected:
     bool isRenderMathMLScripts() const override { return true; }
     ASCIILiteral renderName() const override { return "RenderMathMLScripts"_s; }
-    MathMLScriptsElement::ScriptType scriptType() const;
+    MathMLScriptsElement::ScriptType NODELETE scriptType() const;
     void computePreferredLogicalWidths() override;
     void layoutBlock(RelayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) override;
 
 private:
-    MathMLScriptsElement& element() const;
+    MathMLScriptsElement& NODELETE element() const;
     std::optional<LayoutUnit> firstLineBaseline() const final;
     struct ReferenceChildren {
         RenderBox* base;

--- a/Source/WebCore/rendering/mathml/RenderMathMLSpace.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLSpace.h
@@ -39,7 +39,7 @@ public:
     RenderMathMLSpace(MathMLSpaceElement&, RenderStyle&&);
     virtual ~RenderMathMLSpace();
 
-    MathMLSpaceElement& element() const;
+    MathMLSpaceElement& NODELETE element() const;
 
 private:
     ASCIILiteral renderName() const final { return "RenderMathMLSpace"_s; }

--- a/Source/WebCore/rendering/mathml/RenderMathMLToken.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLToken.h
@@ -43,7 +43,7 @@ public:
     RenderMathMLToken(Type, Document&, RenderStyle&&);
     virtual ~RenderMathMLToken();
 
-    MathMLTokenElement& element();
+    MathMLTokenElement& NODELETE element();
 
     virtual void updateTokenContent();
     void updateFromElement() override;

--- a/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.h
+++ b/Source/WebCore/rendering/mathml/RenderMathMLUnderOver.h
@@ -45,7 +45,7 @@ private:
     bool isRenderMathMLScripts() const final { return false; }
     bool isMathContentCentered() const final { return !shouldMoveLimits(); }
     ASCIILiteral renderName() const final { return "RenderMathMLUnderOver"_s; }
-    MathMLUnderOverElement& element() const;
+    MathMLUnderOverElement& NODELETE element() const;
 
     void computePreferredLogicalWidths() final;
     void layoutBlock(RelayoutChildren, LayoutUnit pageLogicalHeight = 0_lu) final;

--- a/Source/WebCore/rendering/shapes/LayoutShape.h
+++ b/Source/WebCore/rendering/shapes/LayoutShape.h
@@ -84,7 +84,7 @@ public:
 protected:
     float shapeMargin() const { return m_margin; }
     WritingMode writingMode() const { return m_writingMode; }
-    static bool shouldFlipStartAndEndPoints(WritingMode);
+    static bool NODELETE shouldFlipStartAndEndPoints(WritingMode);
 
 private:
     bool lineOverlapsBoundingBox(LayoutUnit lineTop, LayoutUnit lineHeight, const LayoutRect& rect) const

--- a/Source/WebCore/rendering/shapes/RasterLayoutShape.cpp
+++ b/Source/WebCore/rendering/shapes/RasterLayoutShape.cpp
@@ -61,7 +61,7 @@ MarginIntervalGenerator::MarginIntervalGenerator(unsigned radius)
         m_xIntercepts[y] = sqrt(static_cast<double>(radiusSquared - y * y));
 }
 
-void MarginIntervalGenerator::set(int y, const IntShapeInterval& interval)
+void NODELETE MarginIntervalGenerator::set(int y, const IntShapeInterval& interval)
 {
     ASSERT(y >= 0 && interval.x1() >= 0);
     m_y = y;

--- a/Source/WebCore/rendering/style/GridSpan.h
+++ b/Source/WebCore/rendering/style/GridSpan.h
@@ -41,13 +41,13 @@ public:
 
     friend bool operator==(const GridSpan&, const GridSpan&) = default;
 
-    unsigned integerSpan() const;
+    unsigned NODELETE integerSpan() const;
 
-    int untranslatedStartLine() const;
-    int untranslatedEndLine() const;
+    int NODELETE untranslatedStartLine() const;
+    int NODELETE untranslatedEndLine() const;
 
-    unsigned startLine() const;
-    unsigned endLine() const;
+    unsigned NODELETE startLine() const;
+    unsigned NODELETE endLine() const;
 
     struct GridSpanIterator {
         GridSpanIterator(unsigned value)
@@ -61,18 +61,18 @@ public:
         unsigned value;
     };
 
-    GridSpanIterator begin() const;
+    GridSpanIterator NODELETE begin() const;
 
-    GridSpanIterator end() const;
+    GridSpanIterator NODELETE end() const;
 
-    bool isTranslatedDefinite() const;
-    bool isIndefinite() const;
+    bool NODELETE isTranslatedDefinite() const;
+    bool NODELETE isIndefinite() const;
 
-    void translate(unsigned offset);
+    void NODELETE translate(unsigned offset);
 
     // Moves this span to be in the same coordinate space as |parent|.
     // If reverse is specified, then swaps the direction to handle RTL/LTR changes.
-    void translateTo(const GridSpan& parent, bool reverse);
+    void NODELETE translateTo(const GridSpan& parent, bool reverse);
 
     void clamp(int max);
 

--- a/Source/WebCore/rendering/style/OutlineValue.h
+++ b/Source/WebCore/rendering/style/OutlineValue.h
@@ -38,7 +38,7 @@ struct OutlineValue {
     PREFERRED_TYPE(OutlineStyle) unsigned outlineStyle : 4 { static_cast<unsigned>(OutlineStyle::None) };
 
     bool isVisible() const;
-    bool nonZero() const;
+    bool NODELETE nonZero() const;
 
     bool operator==(const OutlineValue&) const = default;
 };

--- a/Source/WebCore/rendering/style/PositionTryOrder.h
+++ b/Source/WebCore/rendering/style/PositionTryOrder.h
@@ -39,7 +39,7 @@ enum class PositionTryOrder : uint8_t {
     MostInlineSize
 };
 
-LogicalBoxAxis boxAxisForPositionTryOrder(PositionTryOrder, WritingMode);
+LogicalBoxAxis NODELETE boxAxisForPositionTryOrder(PositionTryOrder, WritingMode);
 
 WTF::TextStream& operator<<(WTF::TextStream&, PositionTryOrder);
 

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -38,7 +38,7 @@ public:
     explicit RenderStyle(CreateDefaultStyleTag);
     RenderStyle(const RenderStyle&, CloneTag);
 
-    [[nodiscard]] RenderStyle replace(RenderStyle&&);
+    [[nodiscard]] RenderStyle NODELETE replace(RenderStyle&&);
 
     static RenderStyle& defaultStyleSingleton();
 
@@ -48,7 +48,7 @@ public:
     static std::unique_ptr<RenderStyle> createPtr();
     static std::unique_ptr<RenderStyle> createPtrWithRegisteredInitialValues(const Style::CustomPropertyRegistry&);
 
-    static RenderStyle clone(const RenderStyle&);
+    static RenderStyle NODELETE clone(const RenderStyle&);
     static RenderStyle cloneIncludingPseudoElements(const RenderStyle&);
     static std::unique_ptr<RenderStyle> clonePtr(const RenderStyle&);
 
@@ -68,7 +68,7 @@ public:
     // MARK: - Specific style change queries
 
     bool scrollAnchoringSuppressionStyleDidChange(const RenderStyle*) const;
-    bool outOfFlowPositionStyleDidChange(const RenderStyle*) const;
+    bool NODELETE outOfFlowPositionStyleDidChange(const RenderStyle*) const;
 
     // MARK: - Comparisons
 
@@ -376,10 +376,10 @@ public:
     inline const Style::InsetEdge& logicalBottom() const;
 
     // Logical Border (aggregate)
-    const BorderValue& borderBefore(const WritingMode) const;
-    const BorderValue& borderAfter(const WritingMode) const;
-    const BorderValue& borderStart(const WritingMode) const;
-    const BorderValue& borderEnd(const WritingMode) const;
+    const BorderValue& NODELETE borderBefore(const WritingMode) const;
+    const BorderValue& NODELETE borderAfter(const WritingMode) const;
+    const BorderValue& NODELETE borderStart(const WritingMode) const;
+    const BorderValue& NODELETE borderEnd(const WritingMode) const;
     inline const BorderValue& borderBefore() const;
     inline const BorderValue& borderAfter() const;
     inline const BorderValue& borderStart() const;
@@ -417,7 +417,7 @@ public:
     inline PointerEvents usedPointerEvents() const;
     inline Visibility usedVisibility() const;
     inline UserModify usedUserModify() const;
-    WEBCORE_EXPORT UserSelect usedUserSelect() const;
+    WEBCORE_EXPORT UserSelect NODELETE usedUserSelect() const;
     Style::Contain usedContain() const;
     inline TransformStyle3D usedTransformStyle3D() const;
     inline float usedPerspective() const;

--- a/Source/WebCore/rendering/style/RenderStyleConstants.h
+++ b/Source/WebCore/rendering/style/RenderStyleConstants.h
@@ -622,7 +622,7 @@ enum class BreakBetween : uint8_t {
     RectoPage,
     VersoPage
 };
-bool alwaysPageBreak(BreakBetween);
+bool NODELETE alwaysPageBreak(BreakBetween);
     
 enum class BreakInside : uint8_t {
     Auto,
@@ -1108,7 +1108,7 @@ enum class MaskType : uint8_t {
     Alpha
 };
 
-CSSBoxType transformBoxToCSSBoxType(TransformBox);
+CSSBoxType NODELETE transformBoxToCSSBoxType(TransformBox);
 
 constexpr float defaultMiterLimit = 4;
 

--- a/Source/WebCore/rendering/style/StyleContentAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleContentAlignmentData.h
@@ -59,11 +59,11 @@ public:
         return ContentPosition::Normal == static_cast<ContentPosition>(m_position)
         && ContentDistribution::Default == static_cast<ContentDistribution>(m_distribution);
     }
-    bool isStartward(std::optional<TextDirection> leftRightAxisDirection = std::nullopt, bool isFlexReverse = false) const;
-    bool isEndward(std::optional<TextDirection> leftRightAxisDirection = std::nullopt, bool isFlexReverse = false) const;
+    bool NODELETE isStartward(std::optional<TextDirection> leftRightAxisDirection = std::nullopt, bool isFlexReverse = false) const;
+    bool NODELETE isEndward(std::optional<TextDirection> leftRightAxisDirection = std::nullopt, bool isFlexReverse = false) const;
     // leftRightAxisDirection is only needed for justify-content (invalid for align-content).
     // Pass std::nullopt if neither the inline axis nor the physical left-right axis matches the justify-content axis (e.g. in flexbox).
-    bool isCentered() const;
+    bool NODELETE isCentered() const;
 
     friend bool operator==(const StyleContentAlignmentData&, const StyleContentAlignmentData&) = default;
 

--- a/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
+++ b/Source/WebCore/rendering/style/StyleSelfAlignmentData.h
@@ -79,7 +79,7 @@ public:
 
     // Must resolve Auto before calling. Normal treated as Start.
     // Returns position adjustment from container's start edge.
-    static LayoutUnit adjustmentFromStartEdge(LayoutUnit extraSpace, ItemPosition alignmentPosition, LogicalBoxAxis containerAxis, WritingMode containerWritingMode, WritingMode selfWritingMode);
+    static LayoutUnit NODELETE adjustmentFromStartEdge(LayoutUnit extraSpace, ItemPosition alignmentPosition, LogicalBoxAxis containerAxis, WritingMode containerWritingMode, WritingMode selfWritingMode);
 
     friend bool operator==(const StyleSelfAlignmentData&, const StyleSelfAlignmentData&) = default;
 

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.h
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.h
@@ -51,7 +51,7 @@ private:
     void calculateRadiiAndCenter();
 
 private:
-    bool canUseStrokeHitTestFastPath() const;
+    bool NODELETE canUseStrokeHitTestFastPath() const;
 
     FloatPoint m_center;
     FloatSize m_radii;

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
@@ -38,7 +38,7 @@ public:
     RenderSVGForeignObject(SVGForeignObjectElement&, RenderStyle&&);
     virtual ~RenderSVGForeignObject();
 
-    SVGForeignObjectElement& foreignObjectElement() const;
+    SVGForeignObjectElement& NODELETE foreignObjectElement() const;
 
     void paint(PaintInfo&, const LayoutPoint&) override;
 

--- a/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h
@@ -43,8 +43,8 @@ private:
 
     void paint(PaintInfo&, const LayoutPoint&) final { }
 
-    LayoutRect clippedOverflowRect(const RenderLayerModelObject*, VisibleRectContext) const final;
-    std::optional<RepaintRects> computeVisibleRectsInContainer(const RepaintRects& rects, const RenderLayerModelObject*, VisibleRectContext) const final;
+    LayoutRect NODELETE clippedOverflowRect(const RenderLayerModelObject*, VisibleRectContext) const final;
+    std::optional<RepaintRects> NODELETE computeVisibleRectsInContainer(const RepaintRects&, const RenderLayerModelObject*, VisibleRectContext) const final;
 
     void boundingRects(Vector<LayoutRect>&, const LayoutPoint&) const final { }
     void absoluteQuads(Vector<FloatQuad>&, bool*) const final { }

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -39,7 +39,7 @@ public:
     RenderSVGImage(SVGImageElement&, RenderStyle&&);
     virtual ~RenderSVGImage();
 
-    SVGImageElement& imageElement() const;
+    SVGImageElement& NODELETE imageElement() const;
 
     RenderImageResource& imageResource() { return m_imageResource; }
     const RenderImageResource& imageResource() const { return m_imageResource; }

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.cpp
@@ -250,7 +250,7 @@ static bool intersectsAllowingEmpty(const FloatRect& r, const FloatRect& other)
 
 // One of the element types that can cause graphics to be drawn onto the target canvas. Specifically: circle, ellipse,
 // image, line, path, polygon, polyline, rect, text and use.
-static bool isGraphicsElement(const RenderElement& renderer)
+static bool NODELETE isGraphicsElement(const RenderElement& renderer)
 {
     return renderer.isRenderSVGShape() || renderer.isRenderSVGText() || renderer.isRenderSVGImage() || renderer.element()->hasTagName(SVGNames::useTag);
 }

--- a/Source/WebCore/rendering/svg/RenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGModelObject.h
@@ -118,7 +118,7 @@ protected:
     mutable std::optional<LayoutRect> m_cachedVisualOverflowRect;
 
 private:
-    LayoutSize cachedSizeForOverflowClip() const;
+    LayoutSize NODELETE cachedSizeForOverflowClip() const;
 
     LayoutRect m_layoutRect;
 };

--- a/Source/WebCore/rendering/svg/RenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.cpp
@@ -190,7 +190,7 @@ void RenderSVGPath::strokeZeroLengthSubpaths(GraphicsContext& context) const
     }
 }
 
-static inline RenderSVGResourceMarker* markerForType(SVGMarkerType type, RenderSVGResourceMarker* markerStart, RenderSVGResourceMarker* markerMid, RenderSVGResourceMarker* markerEnd)
+static inline RenderSVGResourceMarker* NODELETE markerForType(SVGMarkerType type, RenderSVGResourceMarker* markerStart, RenderSVGResourceMarker* markerMid, RenderSVGResourceMarker* markerEnd)
 {
     switch (type) {
     case StartMarker:

--- a/Source/WebCore/rendering/svg/RenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGPath.h
@@ -52,7 +52,7 @@ private:
 
     void styleDidChange(Style::Difference, const RenderStyle*) final;
 
-    bool shouldStrokeZeroLengthSubpath() const;
+    bool NODELETE shouldStrokeZeroLengthSubpath() const;
     Path* zeroLengthLinecapPath(const FloatPoint&) const;
     FloatRect zeroLengthSubpathRect(const FloatPoint&, float) const;
     void updateZeroLengthSubpaths();

--- a/Source/WebCore/rendering/svg/RenderSVGRect.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.h
@@ -41,7 +41,7 @@ public:
     RenderSVGRect(SVGRectElement&, RenderStyle&&);
     virtual ~RenderSVGRect();
 
-    SVGRectElement& rectElement() const;
+    SVGRectElement& NODELETE rectElement() const;
 
 private:
     void graphicsElement() const = delete;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -61,7 +61,7 @@ enum class ClippingMode {
     MaskClipping
 };
 
-static ClippingMode& currentClippingMode()
+static ClippingMode& NODELETE currentClippingMode()
 {
     static ClippingMode s_clippingMode { ClippingMode::NoClipping };
     return s_clippingMode;

--- a/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h
@@ -38,7 +38,7 @@ class RenderSVGResourceFilterPrimitive final : public RenderSVGHiddenContainer {
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(RenderSVGResourceFilterPrimitive);
 public:
     RenderSVGResourceFilterPrimitive(SVGFilterPrimitiveStandardAttributes&, RenderStyle&&);
-    SVGFilterPrimitiveStandardAttributes& filterPrimitiveElement() const;
+    SVGFilterPrimitiveStandardAttributes& NODELETE filterPrimitiveElement() const;
 
     void markFilterEffectForRepaint(FilterEffect*);
     void markFilterEffectForRebuild();

--- a/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceGradient.h
@@ -51,7 +51,7 @@ protected:
 
     bool buildGradientIfNeeded(const RenderLayerModelObject&, const RenderStyle&, AffineTransform& userspaceTransform);
     GradientColorStops stopsByApplyingColorFilter(const GradientColorStops&, const RenderStyle&) const;
-    GradientSpreadMethod platformSpreadMethodFromSVGType(SVGSpreadMethodType) const;
+    GradientSpreadMethod NODELETE platformSpreadMethodFromSVGType(SVGSpreadMethodType) const;
     ColorInterpolationMethod gradientColorInterpolationMethod() const;
 
     RefPtr<Gradient> m_gradient;

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.h
@@ -39,7 +39,7 @@ public:
     RenderSVGRoot(SVGSVGElement&, RenderStyle&&);
     virtual ~RenderSVGRoot();
 
-    SVGSVGElement& svgSVGElement() const;
+    SVGSVGElement& NODELETE svgSVGElement() const;
     FloatSize computeViewportSize() const;
 
     bool isEmbeddedThroughSVGImage() const;
@@ -56,9 +56,9 @@ public:
     IntSize containerSize() const { return m_containerSize; }
     void setContainerSize(const IntSize& containerSize) { m_containerSize = containerSize; }
 
-    bool hasRelativeDimensions() const final;
+    bool NODELETE hasRelativeDimensions() const final;
 
-    bool shouldApplyViewportClip() const;
+    bool NODELETE shouldApplyViewportClip() const;
 
     FloatRect objectBoundingBox() const final { return m_objectBoundingBox; }
     FloatRect objectBoundingBoxWithoutTransformations() const final { return m_objectBoundingBoxWithoutTransformations; }
@@ -88,7 +88,7 @@ private:
     bool paintingAffectedByExternalOffset() const;
 
     // To prevent certain legacy code paths to hit assertions in debug builds, when switching off LBSE (during the teardown of the LBSE tree).
-    std::optional<FloatRect> computeFloatVisibleRectInContainer(const FloatRect&, const RenderLayerModelObject*, VisibleRectContext) const final;
+    std::optional<FloatRect> NODELETE computeFloatVisibleRectInContainer(const FloatRect&, const RenderLayerModelObject*, VisibleRectContext) const final;
 
     LayoutUnit computeReplacedLogicalWidth(ShouldComputePreferred  = ShouldComputePreferred::ComputeActual) const final;
     LayoutUnit computeReplacedLogicalHeight(std::optional<LayoutUnit> estimatedUsedWidth = std::nullopt) const final;

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -106,7 +106,7 @@ protected:
     Path& ensurePath();
 
     virtual void updateShapeFromElement() = 0;
-    virtual bool isEmpty() const;
+    virtual bool NODELETE isEmpty() const;
     virtual bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace);
     virtual bool shapeDependentFillContains(const FloatPoint&, const WindRule) const;
     float strokeWidth() const;

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -208,7 +208,7 @@ void RenderSVGText::subtreeChildWasAdded(RenderObject* child)
     m_layoutAttributes = newLayoutAttributes;
 }
 
-static inline void checkLayoutAttributesConsistency(RenderSVGText* text, Vector<SVGTextLayoutAttributes*>& expectedLayoutAttributes)
+static inline void NODELETE checkLayoutAttributesConsistency(RenderSVGText* text, Vector<SVGTextLayoutAttributes*>& expectedLayoutAttributes)
 {
 #ifndef NDEBUG
     Vector<SVGTextLayoutAttributes*> newLayoutAttributes;

--- a/Source/WebCore/rendering/svg/RenderSVGText.h
+++ b/Source/WebCore/rendering/svg/RenderSVGText.h
@@ -46,7 +46,7 @@ public:
     RenderSVGText(SVGTextElement&, RenderStyle&&);
     virtual ~RenderSVGText();
 
-    SVGTextElement& textElement() const;
+    SVGTextElement& NODELETE textElement() const;
 
     bool isChildAllowed(const RenderObject&, const RenderStyle&) const override;
 
@@ -56,7 +56,7 @@ public:
     // FIXME: [LBSE] Only needed for legacy SVG engine.
     void setNeedsTransformUpdate() override { m_needsTransformUpdate = true; }
 
-    static RenderSVGText* locateRenderSVGTextAncestor(RenderObject&);
+    static RenderSVGText* NODELETE locateRenderSVGTextAncestor(RenderObject&);
     static const RenderSVGText* locateRenderSVGTextAncestor(const RenderObject&);
 
     bool needsReordering() const { return m_needsReordering; }
@@ -119,7 +119,7 @@ private:
     AffineTransform localTransform() const override { return m_localTransform; }
     // FIXME: [LBSE] End code only needed for legacy SVG engine.
 
-    bool shouldHandleSubtreeMutations() const;
+    bool NODELETE shouldHandleSubtreeMutations() const;
 
     bool m_needsReordering : 1 { false };
     bool m_needsPositioningValuesUpdate : 1 { false };

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.h
@@ -36,11 +36,11 @@ public:
     RenderSVGTextPath(SVGTextPathElement&, RenderStyle&&);
     virtual ~RenderSVGTextPath();
 
-    SVGTextPathElement& textPathElement() const;
+    SVGTextPathElement& NODELETE textPathElement() const;
     SVGGeometryElement* targetElement() const;
 
     Path layoutPath() const;
-    const SVGLengthValue& startOffset() const;
+    const SVGLengthValue& NODELETE startOffset() const;
 
 private:
     void graphicsElement() const = delete;

--- a/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h
@@ -40,7 +40,7 @@ private:
     ASCIILiteral renderName() const final { return "RenderSVGTransformableContainer"_s; }
 
     void element() const = delete;
-    SVGGraphicsElement& graphicsElement() const;
+    SVGGraphicsElement& NODELETE graphicsElement() const;
 
     void applyTransform(TransformationMatrix&, const RenderStyle&, const FloatRect& boundingBox, OptionSet<Style::TransformResolverOption>) const final;
     void updateLayerTransform() final;

--- a/Source/WebCore/rendering/svg/SVGContainerLayout.h
+++ b/Source/WebCore/rendering/svg/SVGContainerLayout.h
@@ -40,10 +40,10 @@ public:
     void positionChildrenRelativeToContainer();
 
     static void verifyLayoutLocationConsistency(const RenderLayerModelObject&);
-    static bool transformToRootChanged(const RenderObject* ancestor);
+    static bool NODELETE transformToRootChanged(const RenderObject* ancestor);
 
 private:
-    bool layoutSizeOfNearestViewportChanged() const;
+    bool NODELETE layoutSizeOfNearestViewportChanged() const;
 
     SingleThreadWeakRef<RenderLayerModelObject> m_container;
     Vector<std::reference_wrapper<RenderLayerModelObject>> m_positionedChildren;

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -263,7 +263,7 @@ static inline void invalidateResourcesOfChildren(RenderElement& renderer)
         invalidateResourcesOfChildren(child);
 }
 
-static inline bool layoutSizeOfNearestViewportChanged(const RenderElement& renderer)
+static inline bool NODELETE layoutSizeOfNearestViewportChanged(const RenderElement& renderer)
 {
     for (CheckedPtr start = &renderer; start; start = start->parent()) {
         if (auto* svgRoot = dynamicDowncast<LegacyRenderSVGRoot>(*start))

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.h
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.h
@@ -51,7 +51,7 @@ public:
     static void layoutChildren(RenderElement&, bool selfNeedsLayout);
 
     // Helper function determining wheter overflow is hidden
-    static bool isOverflowHidden(const RenderElement&);
+    static bool NODELETE isOverflowHidden(const RenderElement&);
 
     // Applies filter/clipper/masker resource effects to a geometric bounding rect.
     // This is the preferred API for resource code (masks, gradients, clippers) that needs
@@ -92,10 +92,10 @@ public:
 
     static FloatRect calculateApproximateStrokeBoundingBox(const RenderElement&);
 
-    static void updateAncestorNonScalingStrokeCounts(RenderElement&, int delta);
+    static void NODELETE updateAncestorNonScalingStrokeCounts(RenderElement&, int delta);
 
-    static void elementInsertedIntoTree(RenderElement&);
-    static void elementWillBeRemovedFromTree(RenderElement&);
+    static void NODELETE elementInsertedIntoTree(RenderElement&);
+    static void NODELETE elementWillBeRemovedFromTree(RenderElement&);
 
     // Shared between SVG renderers and resources.
     static void applyStrokeStyleToContext(GraphicsContext&, const RenderStyle&, const RenderElement&);
@@ -110,7 +110,7 @@ public:
     static bool isolatesBlending(const RenderStyle&);
     static void updateMaskedAncestorShouldIsolateBlending(const RenderElement&);
 
-    static LegacyRenderSVGRoot* findTreeRootObject(RenderElement&);
+    static LegacyRenderSVGRoot* NODELETE findTreeRootObject(RenderElement&);
     static const LegacyRenderSVGRoot* findTreeRootObject(const RenderElement&);
 
 private:

--- a/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderingContext.cpp
@@ -204,7 +204,7 @@ void SVGRenderingContext::prepareToRenderSVGContent(RenderElement& renderer, Pai
     m_renderingFlags |= RenderingPrepared;
 }
 
-static AffineTransform& currentContentTransformation()
+static AffineTransform& NODELETE currentContentTransformation()
 {
     static NeverDestroyed<AffineTransform> s_currentContentTransformation;
     return s_currentContentTransformation;

--- a/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp
@@ -108,7 +108,7 @@ FloatRect selectionRectForTextFragment(const RenderSVGInlineText& renderer, Text
     return snappedSelectionRect;
 }
 
-static inline bool textShouldBePainted(const RenderSVGInlineText& textRenderer)
+static inline bool NODELETE textShouldBePainted(const RenderSVGInlineText& textRenderer)
 {
     return textRenderer.scaledFont().size() >= 0.5;
 }
@@ -414,7 +414,7 @@ static inline float positionOffsetForDecoration(Style::TextDecorationLine decora
     return 0.0f;
 }
 
-static inline float thicknessForDecoration(Style::TextDecorationLine, const FontCascade& font)
+static inline float NODELETE thicknessForDecoration(Style::TextDecorationLine, const FontCascade& font)
 {
     // FIXME: For SVG Fonts we need to use the attributes defined in the <font-face> if specified.
     // Compatible with Batik/Opera

--- a/Source/WebCore/rendering/svg/SVGTextChunk.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.h
@@ -38,7 +38,7 @@ class SVGTextChunk {
 public:
     SVGTextChunk(const Vector<InlineIterator::SVGTextBoxIterator>&, unsigned first, unsigned limit, SVGTextFragmentMap&);
 
-    unsigned totalCharacters() const;
+    unsigned NODELETE totalCharacters() const;
     float totalLength() const;
     float totalAnchorShift() const;
     void layout(SVGChunkTransformMap&) const;

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
@@ -42,7 +42,7 @@ public:
     SVGTextChunkBuilder(const SVGTextChunkBuilder&) = delete;
 
     const Vector<SVGTextChunk>& textChunks() const { return m_textChunks; }
-    unsigned totalCharacters() const;
+    unsigned NODELETE totalCharacters() const;
     float totalLength() const;
     float totalAnchorShift() const;
     AffineTransform transformationForTextBox(InlineIterator::SVGTextBoxIterator) const;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h
@@ -52,7 +52,7 @@ public:
     static constexpr float emptyValue() { return std::numeric_limits<float>::quiet_NaN(); }
     static bool isEmptyValue(float value) { return std::isnan(value); }
 
-    RenderSVGInlineText& context();
+    RenderSVGInlineText& NODELETE context();
     const RenderSVGInlineText& context() const;
     
     SVGCharacterDataMap& characterDataMap() { return m_characterDataMap; }

--- a/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp
@@ -80,7 +80,7 @@ void SVGTextLayoutAttributesBuilder::rebuildMetricsForSubtree(RenderSVGText& tex
     m_metricsBuilder.measureTextRenderer(text, nullptr);
 }
 
-static inline void processRenderSVGInlineText(const RenderSVGInlineText& text, unsigned& atCharacter, bool& lastCharacterWasSpace)
+static inline void NODELETE processRenderSVGInlineText(const RenderSVGInlineText& text, unsigned& atCharacter, bool& lastCharacterWasSpace)
 {
     auto& string = text.text();
     auto length = string.length();

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngine.h
@@ -72,8 +72,8 @@ private:
     bool currentLogicalCharacterMetrics(SVGTextLayoutAttributes*&, SVGTextMetrics&);
     bool currentVisualCharacterMetrics(const InlineIterator::SVGTextBox&, const Vector<SVGTextMetrics>&, SVGTextMetrics&);
 
-    void advanceToNextLogicalCharacter(const SVGTextMetrics&);
-    void advanceToNextVisualCharacter(const SVGTextMetrics&);
+    void NODELETE advanceToNextLogicalCharacter(const SVGTextMetrics&);
+    void NODELETE advanceToNextVisualCharacter(const SVGTextMetrics&);
 
 private:
     Vector<SVGTextLayoutAttributes*>& m_layoutAttributes;

--- a/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.h
+++ b/Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.h
@@ -43,7 +43,7 @@ public:
     float calculateGlyphAdvanceAndOrientation(bool isVerticalText, const SVGTextMetrics&, float angle, float& xOrientationShift, float& yOrientationShift) const;
 
 private:
-    AlignmentBaseline dominantBaselineToAlignmentBaseline(bool isVerticalText, const RenderElement& textRenderer) const;
+    AlignmentBaseline NODELETE dominantBaselineToAlignmentBaseline(bool isVerticalText, const RenderElement& textRenderer) const;
 
     CheckedRef<const FontCascade> m_font;
 };

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp
@@ -101,7 +101,7 @@ void SVGTextMetricsBuilder::advanceIterator(ComplexTextController& complexTextCo
     m_totalWidth = m_complexStartToCurrentMetrics.width();
 }
 
-static inline bool shouldUseComplexTextController(FontCascade::CodePath codePathToUse, const FontCascade& scaledFont)
+static inline bool NODELETE shouldUseComplexTextController(FontCascade::CodePath codePathToUse, const FontCascade& scaledFont)
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
     if (codePathToUse != FontCascade::CodePath::Complex && scaledFont.shouldUseComplexTextControllerForSimpleText())

--- a/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h
@@ -42,7 +42,7 @@ private:
     template<typename Iterator> bool advance(Iterator&);
     void advanceIterator(WidthIterator&);
     void advanceIterator(ComplexTextController&);
-    bool currentCharacterStartsSurrogatePair() const;
+    bool NODELETE currentCharacterStartsSurrogatePair() const;
 
     void initializeMeasurementWithTextRenderer(RenderSVGInlineText&);
     void walkTree(RenderElement&, RenderSVGInlineText* stopAtLeaf, MeasureTextData&);

--- a/Source/WebCore/rendering/svg/SVGTextQuery.h
+++ b/Source/WebCore/rendering/svg/SVGTextQuery.h
@@ -57,8 +57,8 @@ private:
     void modifyStartEndPositionsRespectingLigatures(Data*, const SVGTextFragment&, unsigned& startPosition, unsigned& endPosition) const;
 
 private:
-    bool numberOfCharactersCallback(Data*, const SVGTextFragment&) const;
-    bool textLengthCallback(Data*, const SVGTextFragment&) const;
+    bool NODELETE numberOfCharactersCallback(Data*, const SVGTextFragment&) const;
+    bool NODELETE textLengthCallback(Data*, const SVGTextFragment&) const;
     bool subStringLengthCallback(Data*, const SVGTextFragment&) const;
     bool startPositionOfCharacterCallback(Data*, const SVGTextFragment&) const;
     bool endPositionOfCharacterCallback(Data*, const SVGTextFragment&) const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.h
@@ -50,7 +50,7 @@ private:
     void calculateRadiiAndCenter();
 
 private:
-    bool canUseStrokeHitTestFastPath() const;
+    bool NODELETE canUseStrokeHitTestFastPath() const;
 
     FloatPoint m_center;
     FloatSize m_radii;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h
@@ -36,7 +36,7 @@ public:
     LegacyRenderSVGForeignObject(SVGForeignObjectElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGForeignObject();
 
-    SVGForeignObjectElement& foreignObjectElement() const;
+    SVGForeignObjectElement& NODELETE foreignObjectElement() const;
 
     void paint(PaintInfo&, const LayoutPoint&) override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h
@@ -39,10 +39,10 @@ protected:
 private:
     ASCIILiteral renderName() const override { return "RenderSVGHiddenContainer"_s; }
 
-    void paint(PaintInfo&, const LayoutPoint&) final;
+    void NODELETE paint(PaintInfo&, const LayoutPoint&) final;
 
-    LayoutRect clippedOverflowRect(const RenderLayerModelObject*, VisibleRectContext) const final;
-    void absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const final;
+    LayoutRect NODELETE clippedOverflowRect(const RenderLayerModelObject*, VisibleRectContext) const final;
+    void NODELETE absoluteQuads(Vector<FloatQuad>&, bool* wasFixed) const final;
 
     bool nodeAtFloatPoint(const HitTestRequest&, HitTestResult&, const FloatPoint& pointInParent, HitTestAction) final;
 };

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h
@@ -39,7 +39,7 @@ public:
     LegacyRenderSVGImage(SVGImageElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGImage();
 
-    SVGImageElement& imageElement() const;
+    SVGImageElement& NODELETE imageElement() const;
 
     bool updateImageViewport();
     void setNeedsBoundariesUpdate() override { m_needsBoundariesUpdate = true; }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -193,7 +193,7 @@ static bool intersectsAllowingEmpty(const FloatRect& r, const FloatRect& other)
 
 // One of the element types that can cause graphics to be drawn onto the target canvas. Specifically: circle, ellipse,
 // image, line, path, polygon, polyline, rect, text and use.
-static bool isGraphicsElement(const RenderElement& renderer)
+static bool NODELETE isGraphicsElement(const RenderElement& renderer)
 {
     return renderer.isLegacyRenderSVGShape() || renderer.isRenderSVGText() || renderer.isLegacyRenderSVGImage() || renderer.element()->hasTagName(SVGNames::useTag);
 }

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp
@@ -205,7 +205,7 @@ void LegacyRenderSVGPath::strokeZeroLengthSubpaths(GraphicsContext& context) con
     }
 }
 
-static inline LegacyRenderSVGResourceMarker* markerForType(SVGMarkerType type, LegacyRenderSVGResourceMarker* markerStart, LegacyRenderSVGResourceMarker* markerMid, LegacyRenderSVGResourceMarker* markerEnd)
+static inline LegacyRenderSVGResourceMarker* NODELETE markerForType(SVGMarkerType type, LegacyRenderSVGResourceMarker* markerStart, LegacyRenderSVGResourceMarker* markerMid, LegacyRenderSVGResourceMarker* markerEnd)
 {
     switch (type) {
     case StartMarker:

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h
@@ -49,7 +49,7 @@ private:
 
     void styleDidChange(Style::Difference, const RenderStyle*) final;
 
-    bool shouldStrokeZeroLengthSubpath() const;
+    bool NODELETE shouldStrokeZeroLengthSubpath() const;
     Path* zeroLengthLinecapPath(const FloatPoint&) const;
     FloatRect zeroLengthSubpathRect(const FloatPoint&, float) const;
     void updateZeroLengthSubpaths();

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h
@@ -39,7 +39,7 @@ public:
     LegacyRenderSVGRect(SVGRectElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGRect();
 
-    SVGRectElement& rectElement() const;
+    SVGRectElement& NODELETE rectElement() const;
 
 private:
     void graphicsElement() const = delete;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h
@@ -38,7 +38,7 @@ public:
     void layout() override;
     void styleDidChange(Style::Difference, const RenderStyle* oldStyle) final;
 
-    static float computeTextPaintingScale(const RenderElement&);
+    static float NODELETE computeTextPaintingScale(const RenderElement&);
     static AffineTransform transformOnNonScalingStroke(RenderObject*, const AffineTransform& resourceTransform);
 
     void removeClientFromCacheAndMarkForInvalidation(RenderElement&, bool markForInvalidation = true) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h
@@ -38,7 +38,7 @@ class LegacyRenderSVGResourceFilterPrimitive final : public LegacyRenderSVGHidde
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(LegacyRenderSVGResourceFilterPrimitive);
 public:
     LegacyRenderSVGResourceFilterPrimitive(SVGFilterPrimitiveStandardAttributes&, RenderStyle&&);
-    SVGFilterPrimitiveStandardAttributes& filterPrimitiveElement() const;
+    SVGFilterPrimitiveStandardAttributes& NODELETE filterPrimitiveElement() const;
 
     void styleDidChange(Style::Difference, const RenderStyle*) override;
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h
@@ -86,7 +86,7 @@ protected:
     LegacyRenderSVGResourceGradient(Type, SVGGradientElement&, RenderStyle&&);
 
     static GradientColorStops stopsByApplyingColorFilter(const GradientColorStops&, const RenderStyle&);
-    static GradientSpreadMethod platformSpreadMethodFromSVGType(SVGSpreadMethodType);
+    static GradientSpreadMethod NODELETE platformSpreadMethodFromSVGType(SVGSpreadMethodType);
     ColorInterpolationMethod gradientColorInterpolationMethod() const;
 
 private:

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h
@@ -46,7 +46,7 @@ public:
     LegacyRenderSVGResourcePattern(SVGPatternElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGResourcePattern();
 
-    SVGPatternElement& patternElement() const;
+    SVGPatternElement& NODELETE patternElement() const;
 
     void removeAllClientsFromCache() override;
     void removeAllClientsFromCacheAndMarkForInvalidationIfNeeded(bool markForInvalidation, SingleThreadWeakHashSet<RenderObject>* visitedRenderers) override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h
@@ -40,7 +40,7 @@ public:
     LegacyRenderSVGRoot(SVGSVGElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGRoot();
 
-    SVGSVGElement& svgSVGElement() const;
+    SVGSVGElement& NODELETE svgSVGElement() const;
 
     bool isEmbeddedThroughSVGImage() const;
     bool isEmbeddedThroughFrameContainingSVGDocument() const;
@@ -115,7 +115,7 @@ private:
     bool canBeSelectionLeaf() const override { return false; }
     bool canHaveChildren() const override { return true; }
 
-    bool shouldApplyViewportClip() const;
+    bool NODELETE shouldApplyViewportClip() const;
     void updateCachedBoundaries();
     void buildLocalToBorderBoxTransform();
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h
@@ -92,7 +92,7 @@ protected:
     Path& ensurePath();
 
     virtual void updateShapeFromElement() = 0;
-    virtual bool isEmpty() const;
+    virtual bool NODELETE isEmpty() const;
     virtual bool shapeDependentStrokeContains(const FloatPoint&, PointCoordinateSpace = GlobalCoordinateSpace);
     virtual bool shapeDependentFillContains(const FloatPoint&, const WindRule) const;
     float strokeWidth() const;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h
@@ -41,7 +41,7 @@ public:
     const FloatSize& additionalTranslation() const { return m_additionalTranslation; }
 
 private:
-    SVGGraphicsElement& graphicsElement();
+    SVGGraphicsElement& NODELETE graphicsElement();
 
     void element() const = delete;
     bool calculateLocalTransform() override;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h
@@ -35,7 +35,7 @@ public:
     LegacyRenderSVGViewportContainer(SVGSVGElement&, RenderStyle&&);
     virtual ~LegacyRenderSVGViewportContainer();
 
-    SVGSVGElement& svgSVGElement() const;
+    SVGSVGElement& NODELETE svgSVGElement() const;
 
     FloatRect viewport() const { return m_viewport; }
 

--- a/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResources.cpp
@@ -169,7 +169,7 @@ static inline String targetReferenceFromResource(SVGElement& element)
     return SVGURIReference::fragmentIdentifierFromIRIString(target, protect(element.document()));
 }
 
-static inline bool isChainableResource(const SVGElement& element, const SVGElement& linkedResource)
+static inline bool NODELETE isChainableResource(const SVGElement& element, const SVGElement& linkedResource)
 {
     if (is<SVGPatternElement>(element))
         return is<SVGPatternElement>(linkedResource);

--- a/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
+++ b/Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp
@@ -132,7 +132,7 @@ void SVGResourcesCache::clientLayoutChanged(RenderElement& renderer)
         resources->removeClientFromCacheAndMarkForInvalidation(renderer, false);
 }
 
-static inline bool rendererCanHaveResources(RenderObject& renderer)
+static inline bool NODELETE rendererCanHaveResources(RenderObject& renderer)
 {
     return renderer.node() && renderer.node()->isSVGElement() && !renderer.isRenderSVGInlineText();
 }

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.h
@@ -44,7 +44,7 @@ public:
 
     const RenderView& view() const { return m_view; }
 
-    static bool isRebuildRootForChildren(const RenderElement&);
+    static bool NODELETE isRebuildRootForChildren(const RenderElement&);
 
     void attach(RenderElement& parent, RenderPtr<RenderObject>, RenderObject* beforeChild = nullptr);
 

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp
@@ -44,7 +44,7 @@ namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RenderTreeBuilder::Inline);
 
-static bool canUseAsParentForContinuation(const RenderObject* renderer)
+static bool NODELETE canUseAsParentForContinuation(const RenderObject* renderer)
 {
     if (!renderer)
         return false;
@@ -94,7 +94,7 @@ static RenderPtr<RenderInline> cloneAsContinuation(RenderInline& renderer)
     return cloneInline;
 }
 
-static RenderElement* inFlowPositionedInlineAncestor(RenderElement& renderer)
+static RenderElement* NODELETE inFlowPositionedInlineAncestor(RenderElement& renderer)
 {
     auto* ancestor = &renderer;
     while (ancestor && ancestor->isRenderInline()) {

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderInline.h
@@ -46,7 +46,7 @@ public:
 private:
     void insertChildToContinuation(RenderInline& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void splitInlines(RenderInline& parent, RenderBlock* fromBlock, RenderBlock* toBlock, RenderBlock* middleBlock, RenderObject* beforeChild, RenderBoxModelObject* oldCont);
-    bool newChildIsInline(const RenderInline& parent, const RenderObject& child);
+    bool NODELETE newChildIsInline(const RenderInline& parent, const RenderObject& child);
     void splitFlow(RenderInline& parent, RenderObject* beforeChild, RenderPtr<RenderBlock> newBlockBox, RenderPtr<RenderObject> child, RenderBoxModelObject* oldCont);
 
     RenderTreeBuilder& m_builder;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderTable.h
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderTable.h
@@ -51,7 +51,7 @@ public:
     void attach(RenderTableSection& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
     void attach(RenderTableRow& parent, RenderPtr<RenderObject> child, RenderObject* beforeChild);
 
-    bool childRequiresTable(const RenderElement& parent, const RenderObject& child);
+    bool NODELETE childRequiresTable(const RenderElement& parent, const RenderObject& child);
 
     void collapseAndDestroyAnonymousSiblingCells(const RenderTableCell& willBeDestroyed);
     void collapseAndDestroyAnonymousSiblingRows(const RenderTableRow& willBeDestroyed);

--- a/Source/WebCore/rendering/updating/RenderTreePosition.h
+++ b/Source/WebCore/rendering/updating/RenderTreePosition.h
@@ -48,7 +48,7 @@ public:
     void computeNextSibling(const Node&);
     void moveToLastChild();
     void invalidateNextSibling() { m_hasValidNextSibling = false; }
-    void invalidateNextSibling(const RenderObject&);
+    void NODELETE invalidateNextSibling(const RenderObject&);
 
     RenderObject* nextSiblingRenderer(const Node&) const;
 

--- a/Source/WebCore/rendering/updating/RenderTreeUpdater.h
+++ b/Source/WebCore/rendering/updating/RenderTreeUpdater.h
@@ -69,7 +69,7 @@ private:
     void updateBeforeDescendants(Element&, const Style::ElementUpdate*);
     void updateAfterDescendants(Element&, const Style::ElementUpdate*);
     bool textRendererIsNeeded(const Text& textNode);
-    void storePreviousRenderer(Node&);
+    void NODELETE storePreviousRenderer(Node&);
 
     void destroyAndCancelAnimationsForSubtree(RenderElement&);
 
@@ -86,8 +86,8 @@ private:
         Parent(Element&, const Style::ElementUpdate*);
     };
     Parent& parent() { return m_parentStack.last(); }
-    Parent& renderingParent();
-    RenderTreePosition& renderTreePosition();
+    Parent& NODELETE renderingParent();
+    RenderTreePosition& NODELETE renderTreePosition();
 
     GeneratedContent& generatedContent() { return m_generatedContent; }
     ViewTransition& viewTransition() { return m_viewTransition; }
@@ -110,7 +110,7 @@ private:
 
     void updateRebuildRoots();
 
-    RenderView& renderView();
+    RenderView& NODELETE renderView();
 
     const Ref<Document> m_document;
     std::unique_ptr<Style::Update> m_styleUpdate;


### PR DESCRIPTION
#### c64ec272b5f488db3bdbbfbb024c63cee7a7e8f4
<pre>
Adopt `NODELETE` annotation in more places in Source/WebCore/rendering
<a href="https://bugs.webkit.org/show_bug.cgi?id=308207">https://bugs.webkit.org/show_bug.cgi?id=308207</a>

Reviewed by Alan Baradlay.

* Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/rendering/AncestorSubgridIterator.h:
* Source/WebCore/rendering/BackgroundPainter.cpp:
(WebCore::getSpace):
* Source/WebCore/rendering/BackgroundPainter.h:
* Source/WebCore/rendering/BaselineAlignment.h:
* Source/WebCore/rendering/BlockStepSizing.h:
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::borderStyleFillsBorderArea):
(WebCore::styleRequiresClipPolygon):
(WebCore::borderStyleHasInnerDetail):
(WebCore::borderStyleIsDottedOrDashed):
(WebCore::decorationHasAllSimpleEdges):
* Source/WebCore/rendering/BorderPainter.h:
* Source/WebCore/rendering/BorderShape.h:
* Source/WebCore/rendering/CounterNode.h:
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/FloatingObjects.cpp:
(WebCore::ComputeFloatOffsetAdapter::lowValue const):
(WebCore::ComputeFloatOffsetAdapter::highValue const):
(WebCore::ComputeFloatOffsetAdapter::offset const):
(WebCore::FindNextFloatLogicalBottomAdapter::lowValue const):
(WebCore::FindNextFloatLogicalBottomAdapter::highValue const):
(WebCore::FindNextFloatLogicalBottomAdapter::nextLogicalBottom const):
(WebCore::FindNextFloatLogicalBottomAdapter::nextShapeLogicalBottom const):
* Source/WebCore/rendering/FloatingObjects.h:
* Source/WebCore/rendering/GlyphDisplayListCache.h:
* Source/WebCore/rendering/Grid.h:
* Source/WebCore/rendering/GridBaselineAlignment.h:
* Source/WebCore/rendering/GridLayoutFunctions.cpp:
(WebCore::GridLayoutFunctions::marginStartIsAuto):
(WebCore::GridLayoutFunctions::marginEndIsAuto):
* Source/WebCore/rendering/GridLayoutFunctions.h:
* Source/WebCore/rendering/GridMasonryLayout.h:
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::hasRelativeMarginOrPaddingForGridItem):
(WebCore::GridItemWithSpan::gridItem const):
(WebCore::GridItemWithSpan::span const):
(WebCore::shouldProcessTrackForTrackSizeComputationPhase):
(WebCore::trackShouldGrowBeyondGrowthLimitsForTrackSizeComputationPhase):
(WebCore::getSizeDistributionWeight):
* Source/WebCore/rendering/GridTrackSizingAlgorithm.h:
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::moveOutOfUserAgentShadowTree):
* Source/WebCore/rendering/HitTestResult.h:
* Source/WebCore/rendering/ImageQualityController.h:
* Source/WebCore/rendering/LayerAncestorClippingStack.h:
* Source/WebCore/rendering/LayerOverlapMap.cpp:
(WebCore::OverlapMapContainer::scopeLayer const):
(WebCore::OverlapMapContainer::ClippingScope::childWithLayer const):
(WebCore::OverlapMapContainer::clippingScopeContainingLayerChildRecursive):
(WebCore::OverlapMapContainer::scopeContainingLayer const):
(WebCore::OverlapMapContainer::rootScope const):
(WebCore::OverlapMapContainer::rootScope):
(WebCore::OverlapMapContainer::isEmpty const):
(WebCore::OverlapMapContainer::findClippingScopeForLayers const):
* Source/WebCore/rendering/LegacyInlineBox.h:
* Source/WebCore/rendering/LegacyInlineFlowBox.cpp:
(WebCore::setHasTextDescendantsOnAncestors):
* Source/WebCore/rendering/LegacyInlineTextBox.h:
* Source/WebCore/rendering/LegacyLineLayout.cpp:
(WebCore::parentIsConstructedOrHaveNext):
* Source/WebCore/rendering/LegacyLineLayout.h:
* Source/WebCore/rendering/LegacyRootInlineBox.h:
* Source/WebCore/rendering/MotionPath.h:
* Source/WebCore/rendering/NinePieceImagePainter.cpp:
(WebCore::isCornerPiece):
(WebCore::isHorizontalPiece):
(WebCore::isVerticalPiece):
(WebCore::isEmptyPieceRect):
* Source/WebCore/rendering/OrderIterator.h:
* Source/WebCore/rendering/OutlinePainter.cpp:
(WebCore::usePlatformFocusRingColorForOutlineStyleAuto):
(WebCore::useShrinkWrappedFocusRingForOutlineStyleAuto):
* Source/WebCore/rendering/PositionedLayoutConstraints.cpp:
(WebCore::PositionedLayoutConstraints::insetFitsContent const):
(WebCore::shouldInlineStaticDistanceAdjustedWithBoxHeight):
(WebCore::shouldBlockStaticDistanceAdjustedWithBoxHeight):
* Source/WebCore/rendering/PositionedLayoutConstraints.h:
* Source/WebCore/rendering/ReferencedSVGResources.cpp:
* Source/WebCore/rendering/RegionContext.h:
* Source/WebCore/rendering/RenderAttachment.cpp:
(WebCore::RenderAttachment::attachmentElement const):
* Source/WebCore/rendering/RenderAttachment.h:
* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::OutOfFlowDescendantsMap::positionedRenderers const):
(WebCore::isDelayingUpdateScrollInfoAfterLayout):
(WebCore::RenderBlock::inlineSelectionGaps):
(WebCore::isChildHitTestCandidate):
(WebCore::isRenderBlockFlowOrRenderButton):
* Source/WebCore/rendering/RenderBlock.h:
* Source/WebCore/rendering/RenderBlockFlow.cpp:
(WebCore::clearShouldBreakAtLineToAvoidWidowIfNeeded):
(WebCore::hasSimpleStaticPositionForInlineLevelOutOfFlowChildrenByStyle):
(WebCore::isNonBlocksOrNonFixedHeightListItems):
(WebCore::InlineMinMaxIterator::isEndOfInline const):
* Source/WebCore/rendering/RenderBlockFlow.h:
* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::hasEquivalentGridPositioningStyle):
(WebCore::shouldFlipBeforeAfterMargins):
(WebCore::isOrthogonal):
(WebCore::tableCellShouldHaveZeroInitialSize):
(WebCore::convertOutsetsToOverflowCoordinates):
* Source/WebCore/rendering/RenderBox.h:
* Source/WebCore/rendering/RenderBoxModelObject.cpp:
(WebCore::isOutOfFlowPositionedWithImplicitHeight):
(WebCore::resolveWidthForRatio):
(WebCore::resolveHeightForRatio):
(WebCore::resolveAgainstIntrinsicWidthOrHeightAndRatio):
* Source/WebCore/rendering/RenderBoxModelObject.h:
* Source/WebCore/rendering/RenderButton.cpp:
(WebCore::RenderButton::formControlElement const):
* Source/WebCore/rendering/RenderButton.h:
* Source/WebCore/rendering/RenderCounter.cpp:
(WebCore::parentOrPseudoHostElement):
(WebCore::areRenderersElementsSiblings):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.cpp:
(WebCore::FlexBoxIterator::reset):
(WebCore::childDoesNotAffectWidthOrFlexing):
* Source/WebCore/rendering/RenderDeprecatedFlexibleBox.h:
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderFileUploadControl.cpp:
(WebCore::RenderFileUploadControl::inputElement const):
(WebCore::nodeLogicalWidth):
(WebCore::nodeLogicalHeight):
* Source/WebCore/rendering/RenderFileUploadControl.h:
* Source/WebCore/rendering/RenderFlexibleBox.cpp:
(WebCore::contentAlignmentNormalBehavior):
(WebCore::RenderFlexibleBox::isColumnOrRowReverse const):
(WebCore::RenderFlexibleBox::isWrapReverse const):
(WebCore::RenderFlexibleBox::isHorizontalFlow const):
(WebCore::RenderFlexibleBox::crossAxisDirection const):
(WebCore::alignmentOffset):
* Source/WebCore/rendering/RenderFlexibleBox.h:
* Source/WebCore/rendering/RenderFragmentContainer.h:
* Source/WebCore/rendering/RenderFragmentContainerSet.h:
* Source/WebCore/rendering/RenderFragmentedFlow.cpp:
(WebCore::RenderFragmentedFlow::FragmentSearchAdapter::lowValue const):
(WebCore::RenderFragmentedFlow::FragmentSearchAdapter::highValue const):
(WebCore::RenderFragmentedFlow::FragmentSearchAdapter::result const):
* Source/WebCore/rendering/RenderFragmentedFlow.h:
* Source/WebCore/rendering/RenderFrame.cpp:
(WebCore::RenderFrame::frameElement const):
* Source/WebCore/rendering/RenderFrameSet.cpp:
(WebCore::RenderFrameSet::frameSetElement const):
* Source/WebCore/rendering/RenderFrameSet.h:
* Source/WebCore/rendering/RenderGeometryMap.h:
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::contentAlignmentNormalBehaviorGrid):
(WebCore::resolveContentDistributionFallback):
* Source/WebCore/rendering/RenderGrid.h:
* Source/WebCore/rendering/RenderHTMLCanvas.cpp:
(WebCore::RenderHTMLCanvas::canvasElement const):
* Source/WebCore/rendering/RenderHighlight.h:
* Source/WebCore/rendering/RenderIFrame.cpp:
(WebCore::RenderIFrame::iframeElement const):
* Source/WebCore/rendering/RenderIFrame.h:
* Source/WebCore/rendering/RenderImage.h:
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::inFlowPositionedInlineAncestor):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::ClipRects::reset):
(WebCore::ClipRects::setOverflowClipRect):
(WebCore::ClipRects::fixedClipRect const):
(WebCore::ClipRects::setFixedClipRect):
(WebCore::ClipRects::posClipRect const):
(WebCore::ClipRects::setPosClipRect):
(WebCore::ClipRects::fixed const):
(WebCore::ClipRects::setFixed):
(WebCore::ClipRects::setOverflowClipRectAffectedByRadius):
(WebCore::ClipRectsCache::getClipRects const):
(WebCore::ClipRectsCache::setClipRects):
(WebCore::ClipRectsCache::getIndex const):
(WebCore::nextScrollingScope):
(WebCore::shouldDoSoftwarePaint):
(WebCore::shouldSuppressPaintingLayer):
(WebCore::paintForFixedRootBackground):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::PaintedContentsInfo::setDetectsHDRContent):
(WebCore::PaintedContentsInfo::isPaintsContentSatisfied const):
(WebCore::PaintedContentsInfo::isContentsTypeSatisfied const):
(WebCore::layerOrAncestorIsTransformedOrUsingCompositedScrolling):
* Source/WebCore/rendering/RenderLayerBacking.h:
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::OverlapExtent::knownToBeHaveExtentUncertainty const):
(WebCore::RenderLayerCompositor::CompositingState::hasNonRootCompositedAncestor const):
(WebCore::RenderLayerCompositor::UpdateBackingTraversalState::stateForDescendants const):
(WebCore::RenderLayerCompositor::BackingSharingState::backingProviderCandidates):
(WebCore::RenderLayerCompositor::BackingSharingState::firstProviderCandidateLayer const):
(WebCore::RenderLayerCompositor::BackingSharingState::backingSharingStackingContext const):
(WebCore::RenderLayerCompositor::BackingSharingState::snapshot const):
(WebCore::RenderLayerCompositor::BackingSharingState::sequenceIdentifier const):
(WebCore::scrollbarInclusionForVisibleRect):
(WebCore::rendererForCompositingTests):
(WebCore::scrollCoordinationRoleForNodeType):
* Source/WebCore/rendering/RenderLayerCompositor.h:
* Source/WebCore/rendering/RenderLayerFilters.h:
* Source/WebCore/rendering/RenderLayerModelObject.h:
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* Source/WebCore/rendering/RenderLayoutState.h:
* Source/WebCore/rendering/RenderLineBoxList.h:
* Source/WebCore/rendering/RenderLineBreak.h:
* Source/WebCore/rendering/RenderListBox.cpp:
(WebCore::RenderListBox::selectElement const):
* Source/WebCore/rendering/RenderListBox.h:
* Source/WebCore/rendering/RenderListItem.h:
* Source/WebCore/rendering/RenderListMarker.h:
* Source/WebCore/rendering/RenderMarquee.cpp:
(WebCore::reverseDirection):
(WebCore::RenderMarquee::isHorizontal const):
* Source/WebCore/rendering/RenderMarquee.h:
* Source/WebCore/rendering/RenderMenuList.cpp:
(WebCore::RenderMenuList::selectElement const):
* Source/WebCore/rendering/RenderModel.cpp:
(WebCore::RenderModel::modelElement const):
* Source/WebCore/rendering/RenderModel.h:
* Source/WebCore/rendering/RenderMultiColumnFlow.h:
* Source/WebCore/rendering/RenderMultiColumnSet.h:
* Source/WebCore/rendering/RenderObject.cpp:
(WebCore::canRelyOnAncestorLayerFullRepaint):
(WebCore::hasAncestorWithSelectionOnSeparateLine):
(WebCore::shouldRenderPreviousSelectionOnSeparateLine):
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/RenderProgress.cpp:
(WebCore::RenderProgress::progressElement const):
* Source/WebCore/rendering/RenderProgress.h:
* Source/WebCore/rendering/RenderQuote.h:
* Source/WebCore/rendering/RenderScrollbar.cpp:
(WebCore::pseudoForScrollbarPart):
* Source/WebCore/rendering/RenderScrollbarTheme.h:
* Source/WebCore/rendering/RenderSearchField.h:
* Source/WebCore/rendering/RenderSelectFallbackButton.h:
* Source/WebCore/rendering/RenderSlider.cpp:
(WebCore::RenderSlider::element const):
* Source/WebCore/rendering/RenderTable.cpp:
(WebCore::RenderTable::topSection const):
* Source/WebCore/rendering/RenderTable.h:
* Source/WebCore/rendering/RenderTableCaption.cpp:
(WebCore::RenderTableCaption::table const):
* Source/WebCore/rendering/RenderTableCell.cpp:
(WebCore::CollapsedBorders::nextBorder):
(WebCore::backgroundRectForRow):
(WebCore::backgroundRectForSection):
* Source/WebCore/rendering/RenderTableCell.h:
* Source/WebCore/rendering/RenderTableCol.h:
* Source/WebCore/rendering/RenderTableSection.cpp:
(WebCore::shouldFlexCellChild):
(WebCore::compareCellPositions):
(WebCore::compareCellPositionsWithOverflowingCells):
(WebCore::physicalBorderForDirection):
* Source/WebCore/rendering/RenderTableSection.h:
* Source/WebCore/rendering/RenderText.cpp:
(WebCore::SecureTextTimer::takeOffsetAfterLastTypedCharacter):
(WebCore::originalTextMap):
(WebCore::inlineWrapperForDisplayContentsMap):
(WebCore::convertNoBreakSpaceToSpace):
(WebCore::RenderText::layoutBox):
(WebCore::RenderText::layoutBox const):
(WebCore::RenderText::textNode const):
(WebCore::combineTextWidth):
(WebCore::isSpaceAccordingToStyle):
(WebCore::isInlineFlowOrEmptyText):
* Source/WebCore/rendering/RenderText.h:
* Source/WebCore/rendering/RenderTextControl.cpp:
(WebCore::RenderTextControl::textFormControlElement const):
* Source/WebCore/rendering/RenderTextControlMultiLine.h:
* Source/WebCore/rendering/RenderTextControlSingleLine.h:
* Source/WebCore/rendering/RenderTextLineBoxes.h:
* Source/WebCore/rendering/RenderTheme.cpp:
(WebCore::isAppearanceAllowedForAllElements):
(WebCore::shouldCheckLegacyStylesForNativeAppearance):
* Source/WebCore/rendering/RenderTheme.h:
* Source/WebCore/rendering/RenderTreeAsText.cpp:
(WebCore::shouldEnableSubpixelPrecisionForTextDump):
* Source/WebCore/rendering/RenderVTTCue.h:
* Source/WebCore/rendering/RenderVideo.cpp:
(WebCore::RenderVideo::videoElement const):
* Source/WebCore/rendering/RenderVideo.h:
* Source/WebCore/rendering/RenderView.h:
* Source/WebCore/rendering/RenderViewTransitionCapture.h:
* Source/WebCore/rendering/RenderWidget.cpp:
(WebCore::widgetRendererMap):
(WebCore::roundedIntRect):
(WebCore::RenderWidget::remoteFrame const):
* Source/WebCore/rendering/RenderWidget.h:
* Source/WebCore/rendering/TextBoxPainter.h:
* Source/WebCore/rendering/TextBoxTrimmer.cpp:
(WebCore::textBoxTrim):
(WebCore::removeTextBoxTrimStart):
* Source/WebCore/rendering/TextDecorationPainter.cpp:
(WebCore::textDecorationStyleToStrokeStyle):
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::renderThemePaintSwitchThumb):
(WebCore::renderThemePaintSwitchTrack):
(WebCore::canShowCapsLockIndicator):
* Source/WebCore/rendering/line/LineInfo.h:
* Source/WebCore/rendering/line/LineWidth.h:
* Source/WebCore/rendering/mac/RenderThemeMac.h:
* Source/WebCore/rendering/mac/RenderThemeMac.mm:
(WebCore::popupButtonMargins):
(WebCore::popupButtonSizes):
(WebCore::popupButtonPadding):
(WebCore::checkboxSizes):
(WebCore::checkboxMargins):
(WebCore::radioMargins):
(WebCore::buttonSizes):
(WebCore::buttonMargins):
(WebCore::stepperSizes):
(WebCore::switchSizes):
(WebCore::visualSwitchMargins):
(WebCore::menuListButtonSizes):
* Source/WebCore/rendering/mathml/MathMLStyle.h:
* Source/WebCore/rendering/mathml/MathOperator.h:
* Source/WebCore/rendering/mathml/RenderMathMLBlock.h:
* Source/WebCore/rendering/mathml/RenderMathMLFraction.h:
* Source/WebCore/rendering/mathml/RenderMathMLOperator.h:
* Source/WebCore/rendering/mathml/RenderMathMLPadded.h:
* Source/WebCore/rendering/mathml/RenderMathMLRoot.h:
* Source/WebCore/rendering/mathml/RenderMathMLRow.h:
* Source/WebCore/rendering/mathml/RenderMathMLScripts.cpp:
(WebCore::isPrescriptDelimiter):
* Source/WebCore/rendering/mathml/RenderMathMLScripts.h:
* Source/WebCore/rendering/mathml/RenderMathMLSpace.h:
* Source/WebCore/rendering/mathml/RenderMathMLToken.h:
* Source/WebCore/rendering/mathml/RenderMathMLUnderOver.h:
* Source/WebCore/rendering/shapes/LayoutShape.h:
* Source/WebCore/rendering/shapes/RasterLayoutShape.cpp:
(WebCore::MarginIntervalGenerator::set):
* Source/WebCore/rendering/style/GridSpan.h:
* Source/WebCore/rendering/style/OutlineValue.h:
* Source/WebCore/rendering/style/PositionTryOrder.h:
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/rendering/style/RenderStyleConstants.h:
* Source/WebCore/rendering/style/StyleContentAlignmentData.h:
* Source/WebCore/rendering/style/StyleSelfAlignmentData.h:
* Source/WebCore/rendering/svg/RenderSVGEllipse.h:
* Source/WebCore/rendering/svg/RenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/RenderSVGHiddenContainer.h:
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/RenderSVGModelObject.cpp:
(WebCore::isGraphicsElement):
* Source/WebCore/rendering/svg/RenderSVGModelObject.h:
* Source/WebCore/rendering/svg/RenderSVGPath.cpp:
(WebCore::markerForType):
* Source/WebCore/rendering/svg/RenderSVGPath.h:
* Source/WebCore/rendering/svg/RenderSVGRect.h:
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::currentClippingMode):
* Source/WebCore/rendering/svg/RenderSVGResourceFilterPrimitive.h:
* Source/WebCore/rendering/svg/RenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/RenderSVGRoot.h:
* Source/WebCore/rendering/svg/RenderSVGShape.h:
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::checkLayoutAttributesConsistency):
* Source/WebCore/rendering/svg/RenderSVGText.h:
* Source/WebCore/rendering/svg/RenderSVGTextPath.h:
* Source/WebCore/rendering/svg/RenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/SVGContainerLayout.h:
* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::layoutSizeOfNearestViewportChanged):
* Source/WebCore/rendering/svg/SVGRenderSupport.h:
* Source/WebCore/rendering/svg/SVGRenderingContext.cpp:
(WebCore::currentContentTransformation):
* Source/WebCore/rendering/svg/SVGTextBoxPainter.cpp:
(WebCore::textShouldBePainted):
(WebCore::thicknessForDecoration):
* Source/WebCore/rendering/svg/SVGTextChunk.h:
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.h:
* Source/WebCore/rendering/svg/SVGTextLayoutAttributes.h:
* Source/WebCore/rendering/svg/SVGTextLayoutAttributesBuilder.cpp:
(WebCore::processRenderSVGInlineText):
* Source/WebCore/rendering/svg/SVGTextLayoutEngine.h:
* Source/WebCore/rendering/svg/SVGTextLayoutEngineBaseline.h:
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.cpp:
(WebCore::shouldUseComplexTextController):
* Source/WebCore/rendering/svg/SVGTextMetricsBuilder.h:
* Source/WebCore/rendering/svg/SVGTextQuery.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGEllipse.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGHiddenContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::isGraphicsElement):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.cpp:
(WebCore::markerForType):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGPath.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRect.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceFilterPrimitive.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceGradient.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourcePattern.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGTransformableContainer.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGViewportContainer.h:
* Source/WebCore/rendering/svg/legacy/SVGResources.cpp:
(WebCore::isChainableResource):
* Source/WebCore/rendering/svg/legacy/SVGResourcesCache.cpp:
(WebCore::rendererCanHaveResources):
* Source/WebCore/rendering/updating/RenderTreeBuilder.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.cpp:
(WebCore::canUseAsParentForContinuation):
(WebCore::inFlowPositionedInlineAncestor):
* Source/WebCore/rendering/updating/RenderTreeBuilderInline.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderTable.h:
* Source/WebCore/rendering/updating/RenderTreePosition.h:
* Source/WebCore/rendering/updating/RenderTreeUpdater.h:

Canonical link: <a href="https://commits.webkit.org/307967@main">https://commits.webkit.org/307967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5d9fd9f11250d60e3afbd92686ec414b62216849

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146093 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18771 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/11035 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154763 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1b9a1a1-0d97-4029-889b-ef61092e9d1c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147968 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19245 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18665 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112404 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99576 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/265ec807-72d8-406c-970d-dcd0f7e28e01) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14757 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131239 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93275 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fc3e4828-e101-465c-98e8-4204becd43d7) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/14024 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11779 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2209 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123589 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8254 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157081 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/257 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9525 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120422 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18593 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15561 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120727 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30935 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129700 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74292 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16410 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7539 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18211 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81966 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17947 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18117 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18005 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->