### PR TITLE
[SaferCPP] Fix some UncountedCallArgsChecker in Source/WebCore/css/typedom/

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncheckedCallArgsCheckerExpectations
@@ -83,7 +83,6 @@ css/SelectorCheckerTestFunctions.h
 css/SelectorFilter.cpp
 css/StyleAttributeMutationScope.h
 css/parser/SizesAttributeParser.cpp
-css/typedom/ComputedStylePropertyMapReadOnly.cpp
 css/typedom/InlineStylePropertyMap.cpp
 dom/Attr.cpp
 dom/BoundaryPoint.cpp

--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -229,13 +229,8 @@ css/StyleRule.cpp
 css/StyleRuleImport.cpp
 css/StyleRuleImport.h
 css/StyleSheetContents.cpp
-css/typedom/CSSOMVariableReferenceValue.cpp
-css/typedom/CSSStyleValue.cpp
-css/typedom/CSSStyleValueFactory.cpp
-css/typedom/ComputedStylePropertyMapReadOnly.cpp
 css/typedom/DeclaredStylePropertyMap.cpp
 css/typedom/InlineStylePropertyMap.cpp
-css/typedom/StylePropertyMap.cpp
 css/typedom/numeric/CSSMathInvert.cpp
 css/typedom/numeric/CSSMathMax.cpp
 css/typedom/numeric/CSSMathMin.cpp

--- a/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp
+++ b/Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp
@@ -68,7 +68,7 @@ void CSSOMVariableReferenceValue::serialize(StringBuilder& builder, OptionSet<Se
     builder.append("var("_s, m_variable);
     if (m_fallback) {
         builder.append(',');
-        m_fallback->serialize(builder, arguments);
+        protect(m_fallback)->serialize(builder, arguments);
     }
     builder.append(')');
 }

--- a/Source/WebCore/css/typedom/CSSStyleValue.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValue.cpp
@@ -93,7 +93,7 @@ String CSSStyleValue::toString() const
 void CSSStyleValue::serialize(StringBuilder& builder, OptionSet<SerializationArguments>) const
 {
     if (m_propertyValue)
-        builder.append(m_propertyValue->cssText(CSS::defaultSerializationContext()));
+        builder.append(protect(m_propertyValue)->cssText(CSS::defaultSerializationContext()));
 }
 
 CSSStyleValue::~CSSStyleValue() = default;

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -365,7 +365,7 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
         if (!valueList->length())
             return Exception { ExceptionCode::TypeError, "The CSSValueList should not be empty."_s };
         if ((valueList->length() == 1 && mayConvertCSSValueListToSingleValue(propertyID)) || (propertyID && CSSProperty::isListValuedProperty(*propertyID)))
-            return reifyValue(document, (*valueList)[0], propertyID);
+            return reifyValue(document, protect((*valueList)[0]), propertyID);
     }
 
     return CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue)));

--- a/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
+++ b/Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp
@@ -80,7 +80,7 @@ unsigned ComputedStylePropertyMapReadOnly::size() const
     if (!style)
         return 0;
 
-    return element->document().exposedComputedCSSPropertyIDs().size() + style->inheritedCustomProperties().size() + style->nonInheritedCustomProperties().size();
+    return protect(element->document())->exposedComputedCSSPropertyIDs().size() + style->inheritedCustomProperties().size() + style->nonInheritedCustomProperties().size();
 }
 
 Vector<StylePropertyMapReadOnly::StylePropertyMapEntry> ComputedStylePropertyMapReadOnly::entries(ScriptExecutionContext*) const

--- a/Source/WebCore/css/typedom/StylePropertyMap.cpp
+++ b/Source/WebCore/css/typedom/StylePropertyMap.cpp
@@ -75,7 +75,7 @@ ExceptionOr<void> StylePropertyMap::set(Document& document, const AtomString& pr
         if (styleValues.size() != 1 || !is<CSSUnparsedValue>(styleValues[0].get()))
             return Exception { ExceptionCode::TypeError, "Invalid values"_s };
 
-        auto value = styleValues[0]->toCSSValue();
+        auto value = protect(styleValues[0])->toCSSValue();
         if (!value)
             return Exception { ExceptionCode::TypeError, "Invalid values"_s };
         setCustomProperty(document, property, downcast<CSSVariableReferenceValue>(value.releaseNonNull()));


### PR DESCRIPTION
#### f7908ef17548511a6fea0bdd108cb8cd69193d04
<pre>
[SaferCPP] Fix some UncountedCallArgsChecker in Source/WebCore/css/typedom/
<a href="https://bugs.webkit.org/show_bug.cgi?id=308209">https://bugs.webkit.org/show_bug.cgi?id=308209</a>
<a href="https://rdar.apple.com/170706080">rdar://170706080</a>

Reviewed by Ryosuke Niwa.

As dictated by the SaferCPP bot.

No new tests since no change in behavior.

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/css/typedom/CSSOMVariableReferenceValue.cpp:
(WebCore::CSSOMVariableReferenceValue::serialize):
* Source/WebCore/css/typedom/CSSStyleValue.cpp:
(WebCore::CSSStyleValue::serialize):
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):
* Source/WebCore/css/typedom/ComputedStylePropertyMapReadOnly.cpp:
(WebCore::ComputedStylePropertyMapReadOnly::size const):
* Source/WebCore/css/typedom/StylePropertyMap.cpp:
(WebCore::StylePropertyMap::set):

Canonical link: <a href="https://commits.webkit.org/307895@main">https://commits.webkit.org/307895@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f40a67bbadb83079d8706ab302eacd1b8b196d7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18445 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154433 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99371 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8bf0c584-523a-47b9-b3ae-a2bc9dbea5d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18930 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18334 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112098 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83d01ace-36c4-4c23-a56b-882ad6ec08ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148717 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130923 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93001 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32050994-362a-4232-a7e9-17969b528ef4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13787 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11543 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1880 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7777 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156746 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/24 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120104 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18292 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120448 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30894 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18342 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74037 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16176 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7184 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17913 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81703 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17650 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17859 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17711 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->