### PR TITLE
Get rid of remaining `checked*()` and `protected*()` functions in Source/WebKit

### DIFF
--- a/Source/WebCore/Modules/reporting/Report.h
+++ b/Source/WebCore/Modules/reporting/Report.h
@@ -44,7 +44,7 @@ public:
     WEBCORE_EXPORT const String& NODELETE type() const;
     WEBCORE_EXPORT const String& NODELETE url() const;
     ReportBody* body() const { return m_body.get(); }
-    RefPtr<ReportBody> protectedBody() const { return m_body; }
+    RefPtr<ReportBody> bodyForSerialization() const { return m_body; }
 
     static Ref<FormData> createReportFormDataForViolation(const String& type, const URL&, const String& userAgent, const String& destination, NOESCAPE const Function<void(JSON::Object&)>& populateBody);
 

--- a/Source/WebCore/Modules/reporting/ReportingScope.cpp
+++ b/Source/WebCore/Modules/reporting/ReportingScope.cpp
@@ -101,7 +101,7 @@ void ReportingScope::notifyReportObservers(Ref<Report>&& report)
     for (auto& observer : possibleReportObservers)
         observer->appendQueuedReportIfCorrectType(report);
 
-    auto currentReportType = report->protectedBody()->reportBodyType();
+    auto currentReportType = protect(report->body())->reportBodyType();
 
     // Step 4.2.2
     m_queuedReportTypeCounts.add(currentReportType);

--- a/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
+++ b/Source/WebCore/platform/cocoa/CoreVideoSoftLink.h
@@ -30,8 +30,11 @@
 #include <wtf/Platform.h>
 #include <wtf/SoftLinking.h>
 #include <wtf/StdLibExtras.h>
+#include <wtf/cf/CFTypeTraits.h>
 
 typedef struct __IOSurface* IOSurfaceRef;
+
+WTF_DECLARE_CF_TYPE_TRAIT(CVPixelBufferPool);
 
 SOFT_LINK_FRAMEWORK_FOR_HEADER(WebCore, CoreVideo)
 

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -944,14 +944,13 @@ static NSDictionary<NSString *, id> *extractResolutionReport(NSError *error)
 
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didBecomeDownloadTask:(NSURLSessionDownloadTask *)downloadTask
 {
-    auto networkDataTask = [self existingTask:dataTask];
+    RefPtr networkDataTask = [self existingTask:dataTask];
     if (!networkDataTask)
         return;
     CheckedPtr sessionCocoa = networkDataTask->networkSession();
     if (!sessionCocoa)
         return;
 
-    Ref<NetworkDataTaskCocoa> protectedNetworkDataTask(*networkDataTask);
     auto downloadID = *networkDataTask->pendingDownloadID();
     CheckedRef downloadManager = sessionCocoa->networkProcess().downloadManager();
     Ref download = WebKit::Download::create(downloadManager, downloadID, downloadTask, *sessionCocoa, networkDataTask->suggestedFilename());

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm
@@ -442,7 +442,7 @@ void ResourceMonitorURLsController::prepare(CompletionHandler<void(WKContentRule
 
     Ref<API::ContentRuleListStore> store = m_contentRuleListStore ? *m_contentRuleListStore : API::ContentRuleListStore::defaultStoreSingleton();
 
-    [[PAL::getWPResourcesClassSingleton() sharedInstance] prepareResourceMonitorRulesForStore:protectedWrapper(store.get()).get() completionHandler:^(WKContentRuleList *list, bool updated, NSError *error) {
+    [[PAL::getWPResourcesClassSingleton() sharedInstance] prepareResourceMonitorRulesForStore:protect(wrapper(store.get())).get() completionHandler:^(WKContentRuleList *list, bool updated, NSError *error) {
         if (error)
             RELEASE_LOG_ERROR(ResourceMonitoring, "Failed to request resource monitor urls from WebPrivacy: %@", error);
 

--- a/Source/WebKit/Shared/API/APIArray.h
+++ b/Source/WebKit/Shared/API/APIArray.h
@@ -51,8 +51,6 @@ public:
     }
 
     Object* at(size_t i) const { return m_elements[i].get(); }
-    RefPtr<Object> protectedAt(size_t i) const { return m_elements[i]; }
-
     size_t size() const { return m_elements.size(); }
 
     const Vector<RefPtr<Object>>& elements() const { return m_elements; }

--- a/Source/WebKit/Shared/API/c/WKArray.cpp
+++ b/Source/WebKit/Shared/API/c/WKArray.cpp
@@ -55,7 +55,7 @@ WKArrayRef WKArrayCreateAdoptingValues(WKTypeRef* rawValues, size_t numberOfValu
 
 WKTypeRef WKArrayGetItemAtIndex(WKArrayRef arrayRef, size_t index)
 {
-    return WebKit::toAPI(WebKit::toProtectedImpl(arrayRef)->protectedAt(index).get());
+    return WebKit::toAPI(protect(WebKit::toProtectedImpl(arrayRef)->at(index)).get());
 }
 
 size_t WKArrayGetSize(WKArrayRef arrayRef)

--- a/Source/WebKit/Shared/Cocoa/WKNSError.mm
+++ b/Source/WebKit/Shared/Cocoa/WKNSError.mm
@@ -34,7 +34,7 @@
 {
     RefPtr underlyingError = downcast<API::Error>(&self._apiObject)->underlyingError();
     if (underlyingError)
-        return [bridge_cast(downcast<API::Error>(&self._apiObject)->platformError().protectedCFError(bridge_cast(protectedWrapper(*underlyingError)).get())) copy];
+        return [bridge_cast(downcast<API::Error>(&self._apiObject)->platformError().protectedCFError(bridge_cast(protect(wrapper(*underlyingError))).get())) copy];
     return [bridge_cast(downcast<API::Error>(&self._apiObject)->platformError().protectedCFError()) copy];
 }
 

--- a/Source/WebKit/Shared/Cocoa/WKObject.h
+++ b/Source/WebKit/Shared/Cocoa/WKObject.h
@@ -66,16 +66,6 @@ template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::Wrapp
     return object ? wrapper(*object) : nil;
 }
 
-template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> protectedWrapper(ObjectClass& object)
-{
-    return wrapper(object);
-}
-
-template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> protectedWrapper(ObjectClass* object)
-{
-    return wrapper(object);
-}
-
 template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(const Ref<ObjectClass>& object)
 {
     return wrapper(object.get());
@@ -84,16 +74,6 @@ template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::Wrapp
 template<typename ObjectClass> inline typename WrapperTraits<ObjectClass>::WrapperClass *wrapper(const RefPtr<ObjectClass>& object)
 {
     return wrapper(object.get());
-}
-
-template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> protectedWrapper(const Ref<ObjectClass>& object)
-{
-    return wrapper(object);
-}
-
-template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> protectedWrapper(const RefPtr<ObjectClass>& object)
-{
-    return wrapper(object);
 }
 
 template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectClass>::WrapperClass> wrapper(Ref<ObjectClass>&& object)
@@ -110,7 +90,6 @@ template<typename ObjectClass> inline RetainPtr<typename WrapperTraits<ObjectCla
 
 namespace API {
 
-using WebKit::protectedWrapper;
 using WebKit::wrapper;
 
 }

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.cpp
@@ -91,11 +91,6 @@ WebBackForwardListFrameItem* WebBackForwardListFrameItem::childItemForFrameID(Fr
     return nullptr;
 }
 
-RefPtr<WebBackForwardListFrameItem> WebBackForwardListFrameItem::protectedChildItemForFrameID(FrameIdentifier frameID)
-{
-    return childItemForFrameID(frameID);
-}
-
 WebBackForwardListItem* WebBackForwardListFrameItem::backForwardListItem() const
 {
     return m_backForwardListItem.get();

--- a/Source/WebKit/Shared/WebBackForwardListFrameItem.h
+++ b/Source/WebKit/Shared/WebBackForwardListFrameItem.h
@@ -59,7 +59,6 @@ public:
     Ref<WebBackForwardListFrameItem> rootFrame();
     Ref<WebBackForwardListFrameItem> mainFrame();
     WebBackForwardListFrameItem* childItemForFrameID(WebCore::FrameIdentifier);
-    RefPtr<WebBackForwardListFrameItem> protectedChildItemForFrameID(WebCore::FrameIdentifier);
 
     WebBackForwardListItem* backForwardListItem() const;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -1443,7 +1443,7 @@ header: <WebCore/Report.h>
 [RefCounted] class WebCore::Report {
     String type()
     String url()
-    RefPtr<WebCore::ReportBody> protectedBody()
+    RefPtr<WebCore::ReportBody> bodyForSerialization()
 };
 
 [RefCounted] class WebCore::TestReportBody {

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -534,8 +534,7 @@ void WKPageSetCustomTextEncodingName(WKPageRef pageRef, WKStringRef encodingName
 void WKPageTerminate(WKPageRef pageRef)
 {
     CRASH_IF_SUSPENDED;
-    Ref<WebProcessProxy> protectedProcessProxy(toProtectedImpl(pageRef)->legacyMainFrameProcess());
-    protectedProcessProxy->requestTermination(ProcessTerminationReason::RequestedByClient);
+    protect(toProtectedImpl(pageRef)->legacyMainFrameProcess())->requestTermination(ProcessTerminationReason::RequestedByClient);
 }
 
 void WKPageResetStateBetweenTests(WKPageRef pageRef)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.mm
@@ -32,34 +32,29 @@
 
 WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
-static Ref<API::FormInfo> protectedFormInfo(WKFormInfo *formInfo)
-{
-    return *formInfo->_formInfo;
-}
-
 - (WKFrameInfo *)targetFrame
 {
-    return wrapper(protectedFormInfo(self)->targetFrame());
+    return wrapper(protect(*_formInfo)->targetFrame());
 }
 
 - (WKFrameInfo *)sourceFrame
 {
-    return wrapper(protectedFormInfo(self)->sourceFrame());
+    return wrapper(protect(*_formInfo)->sourceFrame());
 }
 
 - (NSURL *)submissionURL
 {
-    return protectedFormInfo(self)->submissionURL().createNSURL().autorelease();
+    return protect(*_formInfo)->submissionURL().createNSURL().autorelease();
 }
 
 - (NSString *)httpMethod
 {
-    return nsStringNilIfEmpty(protectedFormInfo(self)->httpMethod()).autorelease();
+    return nsStringNilIfEmpty(protect(*_formInfo)->httpMethod()).autorelease();
 }
 
 - (NSDictionary<NSString *, NSString *> *)formValues
 {
-    auto protectedAPIFormInfo = protectedFormInfo(self);
+    Ref protectedAPIFormInfo = *_formInfo;
     auto& formValues = protectedAPIFormInfo->formValues();
     RetainPtr valueMap = adoptNS([[NSMutableDictionary alloc] initWithCapacity:formValues.size()]);
     for (const auto& pair : formValues)

--- a/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm
@@ -156,7 +156,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 
 - (NSString *)description
 {
-    return [NSString stringWithFormat:@"<%@: %p; configuration = %@>", RetainPtr { NSStringFromClass(self.class) }.get(), self, protectedWrapper(_processPool->configuration()).get()];
+    return [NSString stringWithFormat:@"<%@: %p; configuration = %@>", RetainPtr { NSStringFromClass(self.class) }.get(), self, protect(wrapper(_processPool->configuration())).get()];
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN

--- a/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm
@@ -94,7 +94,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 - (_WKUserContentWorld *)_userContentWorld
 {
-    return adoptNS([[_WKUserContentWorld alloc] _initWithContentWorld:protectedWrapper(_userScript->contentWorld()).get()]).autorelease();
+    return adoptNS([[_WKUserContentWorld alloc] _initWithContentWorld:protect(wrapper(_userScript->contentWorld())).get()]).autorelease();
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2192,21 +2192,21 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
 {
     RetainPtr uiDelegate = (id <WKUIDelegatePrivate>)self.UIDelegate;
     if ([uiDelegate respondsToSelector:@selector(_webView:didInsertAttachment:withSource:)])
-        [uiDelegate _webView:self didInsertAttachment:protectedWrapper(attachment).get() withSource:source];
+        [uiDelegate _webView:self didInsertAttachment:protect(wrapper(attachment)).get() withSource:source];
 }
 
 - (void)_didRemoveAttachment:(API::Attachment&)attachment
 {
     RetainPtr uiDelegate = (id <WKUIDelegatePrivate>)self.UIDelegate;
     if ([uiDelegate respondsToSelector:@selector(_webView:didRemoveAttachment:)])
-        [uiDelegate _webView:self didRemoveAttachment:protectedWrapper(attachment).get()];
+        [uiDelegate _webView:self didRemoveAttachment:protect(wrapper(attachment)).get()];
 }
 
 - (void)_didInvalidateDataForAttachment:(API::Attachment&)attachment
 {
     RetainPtr uiDelegate = (id <WKUIDelegatePrivate>)self.UIDelegate;
     if ([uiDelegate respondsToSelector:@selector(_webView:didInvalidateDataForAttachment:)])
-        [uiDelegate _webView:self didInvalidateDataForAttachment:protectedWrapper(attachment).get()];
+        [uiDelegate _webView:self didInvalidateDataForAttachment:protect(wrapper(attachment)).get()];
 }
 
 #endif // ENABLE(ATTACHMENT_ELEMENT)
@@ -2322,7 +2322,7 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
     THROW_IF_SUSPENDED;
     _page->getWebArchiveData([completionHandler = makeBlockPtr(completionHandler)](API::Data* data) {
         if (data)
-            completionHandler(protectedWrapper(data).get(), nil);
+            completionHandler(protect(wrapper(data)).get(), nil);
         else
             completionHandler(nil, unknownError().get());
     });
@@ -4330,7 +4330,7 @@ static RetainPtr<NSArray> wkTextManipulationErrors(NSArray<_WKTextManipulationIt
 - (void)_dataTaskWithRequest:(NSURLRequest *)request runAtForegroundPriority:(BOOL)runAtForegroundPriority completionHandler:(void(^)(_WKDataTask *))completionHandler
 {
     _page->dataTaskWithRequest(request, std::nullopt, !!runAtForegroundPriority, [completionHandler = makeBlockPtr(completionHandler)] (Ref<API::DataTask>&& task) {
-        completionHandler(protectedWrapper(task.get()).get());
+        completionHandler(protect(wrapper(task.get())).get());
     });
 }
 
@@ -5130,13 +5130,10 @@ static void convertAndAddHighlight(Vector<Ref<WebCore::SharedMemory>>& buffers, 
 - (void)_killWebContentProcessAndResetState
 {
     THROW_IF_SUSPENDED;
-    Ref<WebKit::WebProcessProxy> protectedProcessProxy(_page->legacyMainFrameProcess());
-    protectedProcessProxy->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
+    protect(_page->legacyMainFrameProcess())->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
 
-    if (RefPtr provisionalPageProxy = _page->provisionalPageProxy()) {
-        Ref<WebKit::WebProcessProxy> protectedProcessProxy(provisionalPageProxy->process());
-        protectedProcessProxy->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
-    }
+    if (RefPtr provisionalPageProxy = _page->provisionalPageProxy())
+        protect(provisionalPageProxy->process())->requestTermination(WebKit::ProcessTerminationReason::RequestedByClient);
 }
 
 - (void)_takePDFSnapshotWithConfiguration:(WKSnapshotConfiguration *)snapshotConfiguration completionHandler:(void (^)(NSData *, NSError *))completionHandler
@@ -5579,7 +5576,7 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 {
     THROW_IF_SUSPENDED;
     _page->getMainResourceDataOfFrame(protect(_page->mainFrame()), [completionHandler = makeBlockPtr(completionHandler)](API::Data* data) {
-        completionHandler(protectedWrapper(data).get(), nil);
+        completionHandler(protect(wrapper(data)).get(), nil);
     });
 }
 
@@ -5612,7 +5609,7 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 
     _page->getWebArchiveDataWithFrame(*webFrame, [completionHandler = makeBlockPtr(completionHandler)](API::Data* data) {
         if (data)
-            completionHandler(protectedWrapper(data).get(), nil);
+            completionHandler(protect(wrapper(data)).get(), nil);
         else
             completionHandler(nil, unknownError().get());
     });
@@ -5654,7 +5651,7 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
 
     _page->getWebArchiveDataWithSelectedFrames(*webRootFrame, targetFrameIDs, [completionHandler = makeBlockPtr(completionHandler)](API::Data* data) {
         if (data)
-            completionHandler(protectedWrapper(data).get(), nil);
+            completionHandler(protect(wrapper(data)).get(), nil);
         else
             completionHandler(nil, unknownError().get());
     });
@@ -5702,7 +5699,7 @@ static inline OptionSet<WebCore::LayoutMilestone> layoutMilestones(_WKRenderingP
         if (completionHandler) {
             if (manifest) {
                 Ref apiManifest = API::ApplicationManifest::create(*manifest);
-                completionHandler(protectedWrapper(apiManifest.get()).get());
+                completionHandler(protect(wrapper(apiManifest.get())).get());
             } else
                 completionHandler(nil);
         }

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm
@@ -191,7 +191,7 @@ private:
 
         RetainPtr nsURL = URL { url }.createNSURL();
         auto apiOrigin = API::SecurityOrigin::create(serviceWorkerOrigin);
-        [m_delegate.get() websiteDataStore:m_dataStore.get().get() openWindow:nsURL.get() fromServiceWorkerOrigin:protectedWrapper(apiOrigin.get()).get() completionHandler:completionHandler.get()];
+        [m_delegate.get() websiteDataStore:m_dataStore.get().get() openWindow:nsURL.get() fromServiceWorkerOrigin:protect(wrapper(apiOrigin.get())).get() completionHandler:completionHandler.get()];
     }
 
     void reportServiceWorkerConsoleMessage(const URL&, const WebCore::SecurityOriginData&, MessageSource, MessageLevel, const String& message, unsigned long)
@@ -254,7 +254,7 @@ private:
             completionHandler(WTF::move(notificationDatas));
         });
 
-        [m_delegate.get() websiteDataStore:m_dataStore.get().get() getDisplayedNotificationsForWorkerOrigin:protectedWrapper(apiOrigin.get()).get() completionHandler:delegateCompletionHandler.get()];
+        [m_delegate.get() websiteDataStore:m_dataStore.get().get() getDisplayedNotificationsForWorkerOrigin:protect(wrapper(apiOrigin.get())).get() completionHandler:delegateCompletionHandler.get()];
     }
 
     void workerUpdatedAppBadge(const WebCore::SecurityOriginData& origin, std::optional<uint64_t> badge) final
@@ -267,7 +267,7 @@ private:
         if (badge)
             nsBadge = @(*badge);
 
-        [m_delegate.get() websiteDataStore:m_dataStore.get().get() workerOrigin:protectedWrapper(apiOrigin.get()).get() updatedAppBadge:nsBadge.get()];
+        [m_delegate.get() websiteDataStore:m_dataStore.get().get() workerOrigin:protect(wrapper(apiOrigin.get())).get() updatedAppBadge:nsBadge.get()];
     }
 
     void navigationToNotificationActionURL(const URL& url) final

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSession.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSession.mm
@@ -35,11 +35,6 @@
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/WeakObjCPtr.h>
 
-static Ref<WebKit::WebAutomationSession> protectedSession(_WKAutomationSession *session)
-{
-    return *session->_session;
-}
-
 @implementation _WKAutomationSession {
     RetainPtr<_WKAutomationSessionConfiguration> _configuration;
     WeakObjCPtr<id <_WKAutomationSessionDelegate>> _delegate;
@@ -67,7 +62,7 @@ static Ref<WebKit::WebAutomationSession> protectedSession(_WKAutomationSession *
     if (WebCoreObjCScheduleDeallocateOnMainRunLoop(_WKAutomationSession.class, self))
         return;
 
-    protectedSession(self)->setClient(nullptr);
+    protect(*_session)->setClient(nullptr);
     SUPPRESS_UNCOUNTED_ARG _session->~WebAutomationSession();
 
     [super dealloc];
@@ -81,7 +76,7 @@ static Ref<WebKit::WebAutomationSession> protectedSession(_WKAutomationSession *
 - (void)setDelegate:(id <_WKAutomationSessionDelegate>)delegate
 {
     _delegate = delegate;
-    protectedSession(self)->setClient(delegate ? makeUnique<WebKit::AutomationSessionClient>(delegate) : nullptr);
+    protect(*_session)->setClient(delegate ? makeUnique<WebKit::AutomationSessionClient>(delegate) : nullptr);
 }
 
 - (NSString *)sessionIdentifier
@@ -101,33 +96,33 @@ static Ref<WebKit::WebAutomationSession> protectedSession(_WKAutomationSession *
 
 - (BOOL)isPaired
 {
-    return protectedSession(self)->isPaired();
+    return protect(*_session)->isPaired();
 }
 
 - (BOOL)isPendingTermination
 {
-    return protectedSession(self)->isPendingTermination();
+    return protect(*_session)->isPendingTermination();
 }
 
 - (BOOL)isSimulatingUserInteraction
 {
-    return protectedSession(self)->isSimulatingUserInteraction();
+    return protect(*_session)->isSimulatingUserInteraction();
 }
 
 - (void)terminate
 {
-    protectedSession(self)->terminate();
+    protect(*_session)->terminate();
 }
 
 #if PLATFORM(MAC)
 - (BOOL)wasEventSynthesizedForAutomation:(NSEvent *)event
 {
-    return protectedSession(self)->wasEventSynthesizedForAutomation(event);
+    return protect(*_session)->wasEventSynthesizedForAutomation(event);
 }
 
 - (void)markEventAsSynthesizedForAutomation:(NSEvent *)event
 {
-    protectedSession(self)->markEventAsSynthesizedForAutomation(event);
+    protect(*_session)->markEventAsSynthesizedForAutomation(event);
 }
 #endif
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKContentRuleListAction.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKContentRuleListAction.mm
@@ -29,11 +29,6 @@
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-static Ref<API::ContentRuleListAction> protectedAction(_WKContentRuleListAction *action)
-{
-    return *action->_action;
-}
-
 @implementation _WKContentRuleListAction
 
 - (void)dealloc
@@ -49,7 +44,7 @@ static Ref<API::ContentRuleListAction> protectedAction(_WKContentRuleListAction 
 - (BOOL)blockedLoad
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return protectedAction(self)->blockedLoad();
+    return protect(*_action)->blockedLoad();
 #else
     return NO;
 #endif
@@ -58,7 +53,7 @@ static Ref<API::ContentRuleListAction> protectedAction(_WKContentRuleListAction 
 - (BOOL)blockedCookies
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return protectedAction(self)->blockedCookies();
+    return protect(*_action)->blockedCookies();
 #else
     return NO;
 #endif
@@ -67,7 +62,7 @@ static Ref<API::ContentRuleListAction> protectedAction(_WKContentRuleListAction 
 - (BOOL)madeHTTPS
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return protectedAction(self)->madeHTTPS();
+    return protect(*_action)->madeHTTPS();
 #else
     return NO;
 #endif
@@ -76,7 +71,7 @@ static Ref<API::ContentRuleListAction> protectedAction(_WKContentRuleListAction 
 - (BOOL)redirected
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return protectedAction(self)->redirected();
+    return protect(*_action)->redirected();
 #else
     return NO;
 #endif
@@ -85,7 +80,7 @@ static Ref<API::ContentRuleListAction> protectedAction(_WKContentRuleListAction 
 - (BOOL)modifiedHeaders
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    return protectedAction(self)->modifiedHeaders();
+    return protect(*_action)->modifiedHeaders();
 #else
     return NO;
 #endif
@@ -94,7 +89,7 @@ static Ref<API::ContentRuleListAction> protectedAction(_WKContentRuleListAction 
 - (NSArray<NSString *> *)notifications
 {
 #if ENABLE(CONTENT_EXTENSIONS)
-    auto& vector = protectedAction(self)->notifications();
+    auto& vector = protect(*_action)->notifications();
     if (vector.isEmpty())
         return nil;
     return createNSArray(vector).autorelease();

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKCustomHeaderFields.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKCustomHeaderFields.mm
@@ -31,11 +31,6 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-static Ref<API::CustomHeaderFields> protectedFields(_WKCustomHeaderFields *fields)
-{
-    return *fields->_fields;
-}
-
 @implementation _WKCustomHeaderFields
 
 - (instancetype)init
@@ -72,17 +67,17 @@ static Ref<API::CustomHeaderFields> protectedFields(_WKCustomHeaderFields *field
         if (auto field = WebCore::HTTPHeaderField::create((NSString *)key, (NSString *)value); field && startsWithLettersIgnoringASCIICase(field->name(), "x-"_s))
             vector.append(WTF::move(*field));
     }).get()];
-    protectedFields(self)->setFields(WTF::move(vector));
+    protect(*_fields)->setFields(WTF::move(vector));
 }
 
 - (NSArray<NSString *> *)thirdPartyDomains
 {
-    return createNSArray(protectedFields(self)->thirdPartyDomains()).autorelease();
+    return createNSArray(protect(*_fields)->thirdPartyDomains()).autorelease();
 }
 
 - (void)setThirdPartyDomains:(NSArray<NSString *> *)thirdPartyDomains
 {
-    protectedFields(self)->setThirdPartyDomains(makeVector<String>(thirdPartyDomains));
+    protect(*_fields)->setThirdPartyDomains(makeVector<String>(thirdPartyDomains));
 }
 
 - (API::Object&)_apiObject

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm
@@ -31,12 +31,6 @@
 #import "WebURLSchemeHandlerCocoa.h"
 #import <WebCore/WebCoreObjCExtras.h>
 
-
-static Ref<API::InspectorConfiguration> protectedConfiguration(_WKInspectorConfiguration* configuration)
-{
-    return *configuration->_configuration;
-}
-
 @implementation _WKInspectorConfiguration
 
 - (instancetype)init
@@ -64,18 +58,18 @@ static Ref<API::InspectorConfiguration> protectedConfiguration(_WKInspectorConfi
 
 - (void)setURLSchemeHandler:(id <WKURLSchemeHandler>)urlSchemeHandler forURLScheme:(NSString *)urlScheme
 {
-    protectedConfiguration(self)->addURLSchemeHandler(WebKit::WebURLSchemeHandlerCocoa::create(urlSchemeHandler), urlScheme);
+    protect(*_configuration)->addURLSchemeHandler(WebKit::WebURLSchemeHandlerCocoa::create(urlSchemeHandler), urlScheme);
 }
 
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 - (void)setProcessPool:(WKProcessPool *)processPool
 {
-    protectedConfiguration(self)->setProcessPool(RefPtr { processPool ? processPool->_processPool.get() : nullptr });
+    protect(*_configuration)->setProcessPool(RefPtr { processPool ? processPool->_processPool.get() : nullptr });
 }
 
 - (WKProcessPool *)processPool
 {
-    return wrapper(protectedConfiguration(self)->processPool());
+    return wrapper(protect(*_configuration)->processPool());
 }
 ALLOW_DEPRECATED_DECLARATIONS_END
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm
@@ -38,11 +38,6 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/URL.h>
 
-static Ref<API::InspectorExtension> protectedExtension(_WKInspectorExtension *extension)
-{
-    return *extension->_extension;
-}
-
 @implementation _WKInspectorExtension
 
 - (void)dealloc
@@ -77,7 +72,7 @@ static Ref<API::InspectorExtension> protectedExtension(_WKInspectorExtension *ex
 
 - (void)createTabWithName:(NSString *)tabName tabIconURL:(NSURL *)tabIconURL sourceURL:(NSURL *)sourceURL completionHandler:(void(^)(NSError *, NSString *))completionHandler
 {
-    protectedExtension(self)->createTab(tabName, { tabIconURL.baseURL, tabIconURL.relativeString }, { tabIconURL.baseURL, sourceURL.relativeString }, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<Inspector::ExtensionTabID, Inspector::ExtensionError> result) mutable {
+    protect(*_extension)->createTab(tabName, { tabIconURL.baseURL, tabIconURL.relativeString }, { tabIconURL.baseURL, sourceURL.relativeString }, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(completionHandler)] (Expected<Inspector::ExtensionTabID, Inspector::ExtensionError> result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
@@ -91,7 +86,7 @@ static Ref<API::InspectorExtension> protectedExtension(_WKInspectorExtension *ex
 {
     std::optional<URL> optionalFrameURL = frameURL ? std::make_optional(URL(frameURL)) : std::nullopt;
     std::optional<URL> optionalContextSecurityOrigin = contextSecurityOrigin ? std::make_optional(URL(contextSecurityOrigin)) : std::nullopt;
-    protectedExtension(self)->evaluateScript(scriptSource, optionalFrameURL, optionalContextSecurityOrigin, useContentScriptContext, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTF::move(completionHandler))] (Inspector::ExtensionEvaluationResult&& result) mutable {
+    protect(*_extension)->evaluateScript(scriptSource, optionalFrameURL, optionalContextSecurityOrigin, useContentScriptContext, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTF::move(completionHandler))] (Inspector::ExtensionEvaluationResult&& result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
@@ -109,7 +104,7 @@ static Ref<API::InspectorExtension> protectedExtension(_WKInspectorExtension *ex
 
 - (void)evaluateScript:(NSString *)scriptSource inTabWithIdentifier:(NSString *)extensionTabIdentifier completionHandler:(void(^)(NSError *, id))completionHandler
 {
-    protectedExtension(self)->evaluateScriptInExtensionTab(extensionTabIdentifier, scriptSource, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTF::move(completionHandler))] (Inspector::ExtensionEvaluationResult&& result) mutable {
+    protect(*_extension)->evaluateScriptInExtensionTab(extensionTabIdentifier, scriptSource, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTF::move(completionHandler))] (Inspector::ExtensionEvaluationResult&& result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get(), nil);
             return;
@@ -127,7 +122,7 @@ static Ref<API::InspectorExtension> protectedExtension(_WKInspectorExtension *ex
 
 - (void)navigateToURL:(NSURL *)url inTabWithIdentifier:(NSString *)extensionTabIdentifier completionHandler:(void(^)(NSError *))completionHandler
 {
-    protectedExtension(self)->navigateTab(extensionTabIdentifier, url, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTF::move(completionHandler))] (const std::optional<Inspector::ExtensionError> result) mutable {
+    protect(*_extension)->navigateTab(extensionTabIdentifier, url, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTF::move(completionHandler))] (const std::optional<Inspector::ExtensionError> result) mutable {
         if (result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.value()).createNSString().get() }]).get());
             return;
@@ -141,7 +136,7 @@ static Ref<API::InspectorExtension> protectedExtension(_WKInspectorExtension *ex
 {
     std::optional<String> optionalUserAgent = userAgent ? std::make_optional(String(userAgent)) : std::nullopt;
     std::optional<String> optionalInjectedScript = injectedScript ? std::make_optional(String(injectedScript)) : std::nullopt;
-    protectedExtension(self)->reloadIgnoringCache(ignoreCache, optionalUserAgent, optionalInjectedScript, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTF::move(completionHandler))] (Inspector::ExtensionVoidResult&& result) mutable {
+    protect(*_extension)->reloadIgnoringCache(ignoreCache, optionalUserAgent, optionalInjectedScript, [protectedSelf = retainPtr(self), capturedBlock = makeBlockPtr(WTF::move(completionHandler))] (Inspector::ExtensionVoidResult&& result) mutable {
         if (!result) {
             capturedBlock(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:@{ NSLocalizedFailureReasonErrorKey: Inspector::extensionErrorToString(result.error()).createNSString().get() }]).get());
             return;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h
@@ -38,8 +38,6 @@ template<> struct WrapperTraits<WebInspectorUIProxy> {
 
 }
 
-Ref<WebKit::WebInspectorUIProxy> protectedInspector(_WKInspector *);
-
 @interface _WKInspector () <WKObject> {
 @package
     AlignedStorage<WebKit::WebInspectorUIProxy> _inspector;

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm
@@ -53,13 +53,13 @@ static NSString *JavaScriptSnippetToFetchURL(NSURL *url)
 
 - (void)_fetchURLForTesting:(NSURL *)url
 {
-    protectedInspector(self)->evaluateInFrontendForTesting(JavaScriptSnippetToFetchURL(url));
+    protect(*_inspector)->evaluateInFrontendForTesting(JavaScriptSnippetToFetchURL(url));
 }
 
 - (void)_openURLExternallyForTesting:(NSURL *)url useFrontendAPI:(BOOL)useFrontendAPI
 {
     if (useFrontendAPI)
-        protectedInspector(self)->evaluateInFrontendForTesting(JavaScriptSnippetToOpenURLExternally(url));
+        protect(*_inspector)->evaluateInFrontendForTesting(JavaScriptSnippetToOpenURLExternally(url));
     else {
         // Force the navigation request to be handled naturally through the
         // internal NavigationDelegate of WKInspectorViewController.

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm
@@ -32,12 +32,6 @@
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-ALLOW_DEPRECATED_DECLARATIONS_BEGIN
-static Ref<API::ProcessPoolConfiguration> protectedProcessPoolConfiguration(_WKProcessPoolConfiguration *configuration)
-{
-    return *configuration->_processPoolConfiguration;
-}
-ALLOW_DEPRECATED_DECLARATIONS_END
 
 ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 @implementation _WKProcessPoolConfiguration
@@ -166,7 +160,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
         paths.append(String::fromUTF8(url.fileSystemRepresentation));
     }
 
-    protectedProcessPoolConfiguration(self)->setAdditionalReadAccessAllowedPaths(WTF::move(paths));
+    protect(*_processPoolConfiguration)->setAdditionalReadAccessAllowedPaths(WTF::move(paths));
 }
 
 #if PLATFORM(IOS_FAMILY) && !PLATFORM(IOS_FAMILY_SIMULATOR)
@@ -187,7 +181,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)setCachePartitionedURLSchemes:(NSArray *)cachePartitionedURLSchemes
 {
-    protectedProcessPoolConfiguration(self)->setCachePartitionedURLSchemes(makeVector<String>(cachePartitionedURLSchemes));
+    protect(*_processPoolConfiguration)->setCachePartitionedURLSchemes(makeVector<String>(cachePartitionedURLSchemes));
 }
 
 - (NSArray *)alwaysRevalidatedURLSchemes
@@ -197,7 +191,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)setAlwaysRevalidatedURLSchemes:(NSArray *)alwaysRevalidatedURLSchemes
 {
-    protectedProcessPoolConfiguration(self)->setAlwaysRevalidatedURLSchemes(makeVector<String>(alwaysRevalidatedURLSchemes));
+    protect(*_processPoolConfiguration)->setAlwaysRevalidatedURLSchemes(makeVector<String>(alwaysRevalidatedURLSchemes));
 }
 
 - (NSString *)sourceApplicationBundleIdentifier
@@ -354,7 +348,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    return [wrapper(protectedProcessPoolConfiguration(self)->copy()) retain];
+    return [wrapper(protect(*_processPoolConfiguration)->copy()) retain];
 }
 
 - (NSString *)customWebContentServiceBundleIdentifier
@@ -388,7 +382,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
 
 - (void)setMemoryFootprintPollIntervalForTesting:(NSTimeInterval)pollInterval
 {
-    protectedProcessPoolConfiguration(self)->setMemoryFootprintPollIntervalForTesting(Seconds { pollInterval });
+    protect(*_processPoolConfiguration)->setMemoryFootprintPollIntervalForTesting(Seconds { pollInterval });
 }
 
 - (NSTimeInterval)memoryFootprintPollIntervalForTesting
@@ -411,7 +405,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     sizes.reserveCapacity(thresholds.count);
     for (NSNumber *threshold in thresholds)
         sizes.append(static_cast<uint64_t>(threshold.unsignedLongLongValue));
-    protectedProcessPoolConfiguration(self)->setMemoryFootprintNotificationThresholds(WTF::move(sizes));
+    protect(*_processPoolConfiguration)->setMemoryFootprintNotificationThresholds(WTF::move(sizes));
 }
 
 - (BOOL)suspendsWebProcessesAggressivelyOnMemoryPressure

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm
@@ -190,7 +190,7 @@ private:
             return;
         }
 
-        capturedBlock(nil, protectedWrapper(result.value()).get());
+        capturedBlock(nil, protect(wrapper(result.value())).get());
     });
 #else
     completionHandler(adoptNS([[NSError alloc] initWithDomain:WKErrorDomain code:WKErrorUnknown userInfo:nil]).get(), nil);

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm
@@ -36,10 +36,6 @@
 #import <wtf/BlockPtr.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-static Ref<API::TargetedElementInfo> protectedInfo(_WKTargetedElementInfo *info)
-{
-    return *info->_info;
-}
 
 @implementation _WKTargetedElementInfo
 
@@ -79,7 +75,7 @@ static Ref<API::TargetedElementInfo> protectedInfo(_WKTargetedElementInfo *info)
 
 - (CGRect)boundsInWebView
 {
-    return protectedInfo(self)->boundsInWebView();
+    return protect(*_info)->boundsInWebView();
 }
 
 - (CGRect)boundsInClientCoordinates
@@ -142,7 +138,7 @@ static Ref<API::TargetedElementInfo> protectedInfo(_WKTargetedElementInfo *info)
 
 - (void)getChildFrames:(void(^)(NSArray<_WKFrameTreeNode *> *))completion
 {
-    return protectedInfo(self)->childFrames([completion = makeBlockPtr(completion)](auto&& nodes) {
+    return protect(*_info)->childFrames([completion = makeBlockPtr(completion)](auto&& nodes) {
         completion(createNSArray(WTF::move(nodes), [](API::FrameTreeNode& node) {
             return wrapper(node);
         }).autorelease());
@@ -151,7 +147,7 @@ static Ref<API::TargetedElementInfo> protectedInfo(_WKTargetedElementInfo *info)
 
 - (BOOL)isSameElement:(_WKTargetedElementInfo *)other
 {
-    return protectedInfo(self)->isSameElement(protectedInfo(other));
+    return protect(*_info)->isSameElement(protect(*other->_info));
 }
 
 - (BOOL)isNearbyTarget
@@ -196,7 +192,7 @@ static Ref<API::TargetedElementInfo> protectedInfo(_WKTargetedElementInfo *info)
 
 - (void)takeSnapshotWithCompletionHandler:(void(^)(CGImageRef))completion
 {
-    return protectedInfo(self)->takeSnapshot([completion = makeBlockPtr(completion)](std::optional<WebCore::ShareableBitmapHandle>&& imageHandle) mutable {
+    return protect(*_info)->takeSnapshot([completion = makeBlockPtr(completion)](std::optional<WebCore::ShareableBitmapHandle>&& imageHandle) mutable {
         if (!imageHandle)
             return completion(nullptr);
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm
@@ -28,11 +28,6 @@
 
 #import <WebCore/WebCoreObjCExtras.h>
 
-static Ref<API::TargetedElementRequest> protectedRequest(_WKTargetedElementRequest *request)
-{
-    return *request->_request;
-}
-
 @implementation _WKTargetedElementRequest {
     RetainPtr<NSString> _searchText;
 }
@@ -64,7 +59,7 @@ static Ref<API::TargetedElementRequest> protectedRequest(_WKTargetedElementReque
     if (!(self = [self init]))
         return nil;
 
-    protectedRequest(self)->setSearchText(searchText);
+    protect(*_request)->setSearchText(searchText);
     return self;
 }
 
@@ -73,7 +68,7 @@ static Ref<API::TargetedElementRequest> protectedRequest(_WKTargetedElementReque
     if (!(self = [self init]))
         return nil;
 
-    protectedRequest(self)->setPoint(point);
+    protect(*_request)->setPoint(point);
     return self;
 }
 
@@ -92,7 +87,7 @@ static Ref<API::TargetedElementRequest> protectedRequest(_WKTargetedElementReque
         selectorsForElement.append(WTF::move(selectors));
     }
 
-    protectedRequest(self)->setSelectors(WTF::move(selectorsForElement));
+    protect(*_request)->setSelectors(WTF::move(selectorsForElement));
     return self;
 }
 

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm
@@ -31,10 +31,6 @@
 
 #if ENABLE(WEB_AUTHN)
 
-static Ref<API::WebAuthenticationAssertionResponse> protectedResponse(_WKWebAuthenticationAssertionResponse *response)
-{
-    return *response->_response;
-}
 
 #endif // ENABLE(WEB_AUTHN)
 
@@ -64,7 +60,7 @@ static Ref<API::WebAuthenticationAssertionResponse> protectedResponse(_WKWebAuth
 
 - (NSData *)userHandle
 {
-    return wrapper(protectedResponse(self)->userHandle()).autorelease();
+    return wrapper(protect(*_response)->userHandle()).autorelease();
 }
 
 - (BOOL)synchronizable
@@ -79,7 +75,7 @@ static Ref<API::WebAuthenticationAssertionResponse> protectedResponse(_WKWebAuth
 
 - (NSData *)credentialID
 {
-    return wrapper(protectedResponse(self)->credentialID()).autorelease();
+    return wrapper(protect(*_response)->credentialID()).autorelease();
 }
 
 - (NSString *)accessGroup
@@ -92,7 +88,7 @@ static Ref<API::WebAuthenticationAssertionResponse> protectedResponse(_WKWebAuth
 - (void)setLAContext:(LAContext *)context
 {
 #if ENABLE(WEB_AUTHN)
-    protectedResponse(self)->setLAContext(context);
+    protect(*_response)->setLAContext(context);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -1363,7 +1363,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
 - (id)_web_immediateActionAnimationControllerForHitTestResultInternal:(API::HitTestResult*)hitTestResult withType:(uint32_t)type userData:(API::Object*)userData
 {
     RetainPtr data = userData ? static_cast<id<NSSecureCoding>>(userData->wrapper()) : nil;
-    return [self _immediateActionAnimationControllerForHitTestResult:protectedWrapper(*hitTestResult).get() withType:(_WKImmediateActionType)type userData:data.get()];
+    return [self _immediateActionAnimationControllerForHitTestResult:protect(wrapper(*hitTestResult)).get() withType:(_WKImmediateActionType)type userData:data.get()];
 }
 
 - (void)_web_prepareForImmediateActionAnimation

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm
@@ -115,7 +115,7 @@
 - (void)_retrieveAccessibilityTreeData:(void (^)(NSData *, NSError *))completionHandler
 {
     _page->getAccessibilityTreeData([completionHandler = makeBlockPtr(completionHandler)] (API::Data* data) {
-        completionHandler(protectedWrapper(data).get(), nil);
+        completionHandler(protect(wrapper(data)).get(), nil);
     });
 }
 

--- a/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
+++ b/Source/WebKit/UIProcess/Cocoa/NavigationState.mm
@@ -311,7 +311,7 @@ void NavigationState::willRecordNavigationSnapshot(WebBackForwardListItem& item)
     if (!navigationDelegate)
         return;
 
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:webView().get() willSnapshotBackForwardListItem:protectedWrapper(item).get()];
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:webView().get() willSnapshotBackForwardListItem:protect(wrapper(item)).get()];
 }
 
 void NavigationState::navigationGestureSnapshotWasRemoved()
@@ -392,7 +392,7 @@ bool NavigationState::NavigationClient::didChangeBackForwardList(WebPageProxy&, 
             return wrapper(removedItem.get());
         });
     }
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() backForwardListItemAdded:protectedWrapper(added).get() removed:removedItems.get()];
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() backForwardListItemAdded:protect(wrapper(added)).get() removed:removedItems.get()];
     return true;
 }
 
@@ -411,21 +411,21 @@ void NavigationState::NavigationClient::shouldGoToBackForwardListItem(WebPagePro
     }
 
     if (navigationState->m_navigationDelegateMethods.webViewShouldGoToBackForwardListItemWillUseInstantBackCompletionHandler) {
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) webView:navigationState->webView().get() shouldGoToBackForwardListItem:protectedWrapper(item).get() willUseInstantBack:inBackForwardCache completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)] (BOOL result) mutable {
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) webView:navigationState->webView().get() shouldGoToBackForwardListItem:protect(wrapper(item)).get() willUseInstantBack:inBackForwardCache completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)] (BOOL result) mutable {
             completionHandler(result);
         }).get()];
         return;
     }
 
     if (navigationState->m_navigationDelegateMethods.webViewShouldGoToBackForwardListItemInBackForwardCacheCompletionHandler) {
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() shouldGoToBackForwardListItem:protectedWrapper(item).get() inPageCache:inBackForwardCache completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)] (BOOL result) mutable {
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() shouldGoToBackForwardListItem:protect(wrapper(item)).get() inPageCache:inBackForwardCache completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)] (BOOL result) mutable {
             completionHandler(result);
         }).get()];
         return;
     }
 
     if (navigationState->m_navigationDelegateMethods.webViewWillGoToBackForwardListItemInBackForwardCache)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() willGoToBackForwardListItem:protectedWrapper(item).get() inPageCache:inBackForwardCache];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() willGoToBackForwardListItem:protect(wrapper(item)).get() inPageCache:inBackForwardCache];
 
     completionHandler(true);
 }
@@ -704,9 +704,9 @@ void NavigationState::NavigationClient::decidePolicyForNavigationAction(WebPageP
     RetainPtr navigationActionWrapper = wrapper(navigationAction);
     if (delegateHasWebpagePreferences) {
         if (m_navigationState->m_navigationDelegateMethods.webViewDecidePolicyForNavigationActionWithPreferencesDecisionHandler)
-            [navigationDelegate webView:protect(m_navigationState)->webView().get() decidePolicyForNavigationAction:navigationActionWrapper.get() preferences:protectedWrapper(defaultWebsitePolicies.get()).get() decisionHandler:makeBlockPtr(WTF::move(decisionHandlerWithPreferencesOrPolicies)).get()];
+            [navigationDelegate webView:protect(m_navigationState)->webView().get() decidePolicyForNavigationAction:navigationActionWrapper.get() preferences:protect(wrapper(defaultWebsitePolicies.get())).get() decisionHandler:makeBlockPtr(WTF::move(decisionHandlerWithPreferencesOrPolicies)).get()];
         else
-            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protect(m_navigationState)->webView().get() decidePolicyForNavigationAction:navigationActionWrapper.get() preferences:protectedWrapper(defaultWebsitePolicies.get()).get() userInfo:nil decisionHandler:makeBlockPtr(WTF::move(decisionHandlerWithPreferencesOrPolicies)).get()];
+            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protect(m_navigationState)->webView().get() decidePolicyForNavigationAction:navigationActionWrapper.get() preferences:protect(wrapper(defaultWebsitePolicies.get())).get() userInfo:nil decisionHandler:makeBlockPtr(WTF::move(decisionHandlerWithPreferencesOrPolicies)).get()];
     } else {
         auto decisionHandler = [decisionHandlerWithPreferencesOrPolicies = WTF::move(decisionHandlerWithPreferencesOrPolicies)] (WKNavigationActionPolicy actionPolicy) mutable {
             decisionHandlerWithPreferencesOrPolicies(actionPolicy, nil);
@@ -755,7 +755,7 @@ void NavigationState::NavigationClient::contentRuleListNotification(WebPageProxy
 
     if (m_navigationState->m_navigationDelegateMethods.webViewContentRuleListWithIdentifierPerformedActionForURL) {
         for (auto&& pair : WTF::move(results.results))
-            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protect(m_navigationState)->webView().get() contentRuleListWithIdentifier:pair.first.createNSString().get() performedAction:protectedWrapper(API::ContentRuleListAction::create(WTF::move(pair.second)).get()).get() forURL:url.createNSURL().get()];
+            [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:protect(m_navigationState)->webView().get() contentRuleListWithIdentifier:pair.first.createNSString().get() performedAction:protect(wrapper(API::ContentRuleListAction::create(WTF::move(pair.second)).get())).get() forURL:url.createNSURL().get()];
     }
 }
 
@@ -799,7 +799,7 @@ void NavigationState::NavigationClient::decidePolicyForNavigationResponse(WebPag
         return;
 
     auto checker = CompletionHandlerCallChecker::create(navigationDelegate.get(), @selector(webView:decidePolicyForNavigationResponse:decisionHandler:));
-    [navigationDelegate webView:navigationState->webView().get() decidePolicyForNavigationResponse:protectedWrapper(navigationResponse.get()).get() decisionHandler:makeBlockPtr([localListener = WTF::move(listener), checker = WTF::move(checker)](WKNavigationResponsePolicy responsePolicy) mutable {
+    [navigationDelegate webView:navigationState->webView().get() decidePolicyForNavigationResponse:protect(wrapper(navigationResponse.get())).get() decisionHandler:makeBlockPtr([localListener = WTF::move(listener), checker = WTF::move(checker)](WKNavigationResponsePolicy responsePolicy) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -833,7 +833,7 @@ void NavigationState::NavigationClient::didStartProvisionalNavigation(WebPagePro
 
     // FIXME: We should assert that navigation is not null here, but it's currently null for some navigations through the back/forward cache.
     if (navigationState->m_navigationDelegateMethods.webViewDidStartProvisionalNavigation)
-        [navigationDelegate webView:navigationState->webView().get() didStartProvisionalNavigation:protectedWrapper(navigation).get()];
+        [navigationDelegate webView:navigationState->webView().get() didStartProvisionalNavigation:protect(wrapper(navigation)).get()];
 }
 
 void NavigationState::NavigationClient::didStartProvisionalLoadForFrame(WebPageProxy& page, WebCore::ResourceRequest&& request, FrameInfoData&& frameInfo)
@@ -865,7 +865,7 @@ void NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNa
 
     // FIXME: We should assert that navigation is not null here, but it's currently null for some navigations through the back/forward cache.
 
-    [navigationDelegate webView:navigationState->webView().get() didReceiveServerRedirectForProvisionalNavigation:protectedWrapper(navigation).get()];
+    [navigationDelegate webView:navigationState->webView().get() didReceiveServerRedirectForProvisionalNavigation:protect(wrapper(navigation)).get()];
 }
 
 void NavigationState::NavigationClient::willPerformClientRedirect(WebPageProxy& page, WTF::String&& urlString, double delay)
@@ -924,7 +924,7 @@ void NavigationState::NavigationClient::didCancelClientRedirect(WebPageProxy& pa
 static RetainPtr<NSError> createErrorWithRecoveryAttempter(WKWebView *webView, const FrameInfoData& frameInfo, NSError *originalError, const URL& url)
 {
     auto frameHandle = API::FrameHandle::create(frameInfo.frameID);
-    auto recoveryAttempter = adoptNS([[WKReloadFrameErrorRecoveryAttempter alloc] initWithWebView:webView frameHandle:protectedWrapper(frameHandle.get()).get() urlString:url.string()]);
+    auto recoveryAttempter = adoptNS([[WKReloadFrameErrorRecoveryAttempter alloc] initWithWebView:webView frameHandle:protect(wrapper(frameHandle.get())).get() urlString:url.string()]);
 
     auto userInfo = adoptNS([[NSMutableDictionary alloc] initWithObjectsAndKeys:recoveryAttempter.get(), _WKRecoveryAttempterErrorKey, nil]);
 
@@ -949,7 +949,7 @@ void NavigationState::NavigationClient::didFailProvisionalNavigationWithError(We
     if (frameInfo.isMainFrame) {
         // FIXME: We should assert that navigation is not null here, but it's currently null for some navigations through the back/forward cache.
         if (navigationState->m_navigationDelegateMethods.webViewDidFailProvisionalNavigationWithError)
-            [navigationDelegate webView:navigationState->webView().get() didFailProvisionalNavigation:protectedWrapper(navigation).get() withError:errorWithRecoveryAttempter.get()];
+            [navigationDelegate webView:navigationState->webView().get() didFailProvisionalNavigation:protect(wrapper(navigation)).get() withError:errorWithRecoveryAttempter.get()];
     } else {
         if (navigationState->m_navigationDelegateMethods.webViewNavigationDidFailProvisionalLoadInSubframeWithError)
             [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() navigation:nil didFailProvisionalLoadInSubframe:wrapper(API::FrameInfo::create(WTF::move(frameInfo))).get() withError:errorWithRecoveryAttempter.get()];
@@ -984,7 +984,7 @@ void NavigationState::NavigationClient::didCommitNavigation(WebPageProxy& page, 
 
     // FIXME: We should assert that navigation is not null here, but it's currently null for some navigations through the back/forward cache.
     if (navigationState->m_navigationDelegateMethods.webViewDidCommitNavigation)
-        [navigationDelegate webView:navigationState->webView().get() didCommitNavigation:protectedWrapper(navigation).get()];
+        [navigationDelegate webView:navigationState->webView().get() didCommitNavigation:protect(wrapper(navigation)).get()];
 }
 
 void NavigationState::NavigationClient::didCommitLoadForFrame(WebKit::WebPageProxy& page, WebCore::ResourceRequest&& request, FrameInfoData&& frameInfo)
@@ -1016,7 +1016,7 @@ void NavigationState::NavigationClient::didFinishDocumentLoad(WebPageProxy& page
 
     // FIXME: We should assert that navigation is not null here, but it's currently null for some navigations through the back/forward cache.
 
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() navigationDidFinishDocumentLoad:protectedWrapper(navigation).get()];
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() navigationDidFinishDocumentLoad:protect(wrapper(navigation)).get()];
 }
 
 void NavigationState::NavigationClient::didFinishNavigation(WebPageProxy&, API::Navigation* navigation, API::Object*)
@@ -1031,7 +1031,7 @@ void NavigationState::NavigationClient::didFinishNavigation(WebPageProxy&, API::
 
     // FIXME: We should assert that navigation is not null here, but it's currently null for some navigations through the back/forward cache.
     if (navigationState->m_navigationDelegateMethods.webViewDidFinishNavigation)
-        [navigationDelegate webView:navigationState->webView().get() didFinishNavigation:protectedWrapper(navigation).get()];
+        [navigationDelegate webView:navigationState->webView().get() didFinishNavigation:protect(wrapper(navigation)).get()];
 }
 
 void NavigationState::NavigationClient::didFinishLoadForFrame(WebPageProxy& page, WebCore::ResourceRequest&& request, FrameInfoData&& frameInfo)
@@ -1104,9 +1104,9 @@ void NavigationState::NavigationClient::didFailNavigationWithError(WebPageProxy&
 
     // FIXME: We should assert that navigation is not null here, but it's currently null for some navigations through the back/forward cache.
     if (navigationState->m_navigationDelegateMethods.webViewDidFailNavigationWithErrorUserInfo)
-        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didFailNavigation:protectedWrapper(navigation).get() withError:errorWithRecoveryAttempter.get() userInfo:RetainPtr { userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil }.get()];
+        [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() didFailNavigation:protect(wrapper(navigation)).get() withError:errorWithRecoveryAttempter.get() userInfo:RetainPtr { userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil }.get()];
     else if (navigationState->m_navigationDelegateMethods.webViewDidFailNavigationWithError)
-        [navigationDelegate webView:navigationState->webView().get() didFailNavigation:protectedWrapper(navigation).get() withError:errorWithRecoveryAttempter.get()];
+        [navigationDelegate webView:navigationState->webView().get() didFailNavigation:protect(wrapper(navigation)).get() withError:errorWithRecoveryAttempter.get()];
 }
 
 void NavigationState::NavigationClient::didFailLoadWithErrorForFrame(WebPageProxy& page, WebCore::ResourceRequest&& request, const WebCore::ResourceError& error, FrameInfoData&& frameInfo)
@@ -1138,7 +1138,7 @@ void NavigationState::NavigationClient::didSameDocumentNavigation(WebPageProxy&,
     if (!navigationDelegate)
         return;
 
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() navigation:protectedWrapper(navigation).get() didSameDocumentNavigation:toWKSameDocumentNavigationType(navigationType)];
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() navigation:protect(wrapper(navigation)).get() didSameDocumentNavigation:toWKSameDocumentNavigationType(navigationType)];
 }
 
 void NavigationState::NavigationClient::renderingProgressDidChange(WebPageProxy&, OptionSet<WebCore::LayoutMilestone> layoutMilestones)
@@ -1180,7 +1180,7 @@ void NavigationState::NavigationClient::didReceiveAuthenticationChallenge(WebPag
         return authenticationChallenge.listener().completeChallenge(WebKit::AuthenticationChallengeDisposition::RejectProtectionSpaceAndContinue);
 
     auto checker = CompletionHandlerCallChecker::create(navigationDelegate.get(), @selector(webView:didReceiveAuthenticationChallenge:completionHandler:));
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) webView:navigationState->webView().get() didReceiveAuthenticationChallenge:protectedWrapper(authenticationChallenge).get() completionHandler:makeBlockPtr([challenge = protect(authenticationChallenge), checker = WTF::move(checker)](NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential) {
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) webView:navigationState->webView().get() didReceiveAuthenticationChallenge:protect(wrapper(authenticationChallenge)).get() completionHandler:makeBlockPtr([challenge = protect(authenticationChallenge), checker = WTF::move(checker)](NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1204,7 +1204,7 @@ void NavigationState::NavigationClient::shouldAllowLegacyTLS(WebPageProxy& page,
 
     if (navigationState->m_navigationDelegateMethods.webViewAuthenticationChallengeShouldAllowDeprecatedTLS) {
         auto checker = CompletionHandlerCallChecker::create(navigationDelegate.get(), @selector(webView:authenticationChallenge:shouldAllowDeprecatedTLS:));
-        [navigationDelegate webView:navigationState->webView().get() authenticationChallenge:protectedWrapper(authenticationChallenge).get() shouldAllowDeprecatedTLS:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)](BOOL shouldAllow) mutable {
+        [navigationDelegate webView:navigationState->webView().get() authenticationChallenge:protect(wrapper(authenticationChallenge)).get() shouldAllowDeprecatedTLS:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)](BOOL shouldAllow) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -1213,7 +1213,7 @@ void NavigationState::NavigationClient::shouldAllowLegacyTLS(WebPageProxy& page,
         return;
     }
     auto checker = CompletionHandlerCallChecker::create(navigationDelegate.get(), @selector(_webView:authenticationChallenge:shouldAllowLegacyTLS:));
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() authenticationChallenge:protectedWrapper(authenticationChallenge).get() shouldAllowLegacyTLS:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)](BOOL shouldAllow) mutable {
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() authenticationChallenge:protect(wrapper(authenticationChallenge)).get() shouldAllowLegacyTLS:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)](BOOL shouldAllow) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1374,7 +1374,7 @@ void NavigationState::NavigationClient::navigationActionDidBecomeDownload(WebPag
     if (!navigationDelegate)
         return;
 
-    [navigationDelegate webView:navigationState->webView().get() navigationAction:protectedWrapper(navigationAction).get() didBecomeDownload:protectedWrapper(download).get()];
+    [navigationDelegate webView:navigationState->webView().get() navigationAction:protect(wrapper(navigationAction)).get() didBecomeDownload:protect(wrapper(download)).get()];
 }
 
 void NavigationState::NavigationClient::navigationResponseDidBecomeDownload(WebPageProxy&, API::NavigationResponse& navigationResponse, DownloadProxy& download)
@@ -1390,7 +1390,7 @@ void NavigationState::NavigationClient::navigationResponseDidBecomeDownload(WebP
     if (!navigationDelegate)
         return;
 
-    [navigationDelegate webView:navigationState->webView().get() navigationResponse:protectedWrapper(navigationResponse).get() didBecomeDownload:protectedWrapper(download).get()];
+    [navigationDelegate webView:navigationState->webView().get() navigationResponse:protect(wrapper(navigationResponse)).get() didBecomeDownload:protect(wrapper(download)).get()];
 }
 
 void NavigationState::NavigationClient::contextMenuDidCreateDownload(WebPageProxy&, DownloadProxy& download)
@@ -1406,7 +1406,7 @@ void NavigationState::NavigationClient::contextMenuDidCreateDownload(WebPageProx
     if (!navigationDelegate)
         return;
 
-    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() contextMenuDidCreateDownload:protectedWrapper(download).get()];
+    [static_cast<id<WKNavigationDelegatePrivate>>(navigationDelegate) _webView:navigationState->webView().get() contextMenuDidCreateDownload:protect(wrapper(download)).get()];
 }
 
 #if USE(QUICK_LOOK)

--- a/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm
@@ -88,7 +88,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didSendRequest(WebKit::ResourceLo
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didSendRequest:protect(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)).get()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didSendRequest:protect(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::UpdateHTTPBody)).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceRequest&& request) const
@@ -100,7 +100,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection(WebKit:
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didPerformHTTPRedirection:protect(response.nsURLResponse()).get() newRequest:protect(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody)).get()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didPerformHTTPRedirection:protect(response.nsURLResponse()).get() newRequest:protect(request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody)).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didReceiveChallenge(WebKit::ResourceLoadInfo&& loadInfo, WebCore::AuthenticationChallenge&& challenge) const
@@ -112,7 +112,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didReceiveChallenge(WebKit::Resou
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didReceiveChallenge:protectedMac(challenge).get()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didReceiveChallenge:protectedMac(challenge).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response) const
@@ -124,7 +124,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse(WebKit::Resour
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didReceiveResponse:protect(response.nsURLResponse()).get()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didReceiveResponse:protect(response.nsURLResponse()).get()];
 }
 
 void ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError(WebKit::ResourceLoadInfo&& loadInfo, WebCore::ResourceResponse&& response, WebCore::ResourceError&& error) const
@@ -136,7 +136,7 @@ void ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError(WebKit::Reso
     if (!delegate)
         return;
 
-    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:protectedWrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didCompleteWithError:protect(error.nsError()).get() response:protect(response.nsURLResponse()).get()];
+    [delegate webView:m_resourceLoadDelegate->m_webView.get().get() resourceLoad:wrapper(API::ResourceLoadInfo::create(WTF::move(loadInfo))).get() didCompleteWithError:protect(error.nsError()).get() response:protect(response.nsURLResponse()).get()];
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -295,7 +295,7 @@ void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy& page, NSM
     auto contextMenuElementInfo = API::ContextMenuElementInfoMac::create(data, page);
     if (uiDelegate->m_delegateMethods.webViewGetContextMenuFromProposedMenuForElementUserInfoCompletionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:getContextMenuFromProposedMenu:forElement:userInfo:completionHandler:));
-        [delegate _webView:uiDelegate->m_webView.get().get() getContextMenuFromProposedMenu:menu forElement:protectedWrapper(contextMenuElementInfo.get()).get() userInfo:RetainPtr { userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil }.get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)] (NSMenu *menu) mutable {
+        [delegate _webView:uiDelegate->m_webView.get().get() getContextMenuFromProposedMenu:menu forElement:protect(wrapper(contextMenuElementInfo.get())).get() userInfo:RetainPtr { userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil }.get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)] (NSMenu *menu) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -306,9 +306,9 @@ void UIDelegate::ContextMenuClient::menuFromProposedMenu(WebPageProxy& page, NSM
     
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (uiDelegate->m_delegateMethods.webViewContextMenuForElement)
-        return completionHandler([delegate _webView:uiDelegate->m_webView.get().get() contextMenu:menu forElement:protectedWrapper(contextMenuElementInfo.get()).get()]);
+        return completionHandler([delegate _webView:uiDelegate->m_webView.get().get() contextMenu:menu forElement:protect(wrapper(contextMenuElementInfo.get())).get()]);
 
-    completionHandler([delegate _webView:uiDelegate->m_webView.get().get() contextMenu:menu forElement:protectedWrapper(contextMenuElementInfo.get()).get() userInfo:RetainPtr { userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil }.get()]);
+    completionHandler([delegate _webView:uiDelegate->m_webView.get().get() contextMenu:menu forElement:protect(wrapper(contextMenuElementInfo.get())).get() userInfo:RetainPtr { userInfo ? static_cast<id<NSSecureCoding>>(userInfo->wrapper()) : nil }.get()]);
 ALLOW_DEPRECATED_DECLARATIONS_END
 }
 #endif
@@ -345,7 +345,7 @@ void UIDelegate::UIClient::mouseDidMoveOverElement(WebPageProxy& page, const Web
 #else
     auto modifierFlags = WebKit::WebIOSEventFactory::toUIKeyModifierFlags(modifiers);
 #endif
-    [delegate _webView:uiDelegate->m_webView.get().get() mouseDidMoveOverElement:protectedWrapper(apiHitTestResult.get()).get() withFlags:modifierFlags userInfo:nil];
+    [delegate _webView:uiDelegate->m_webView.get().get() mouseDidMoveOverElement:protect(wrapper(apiHitTestResult.get())).get() withFlags:modifierFlags userInfo:nil];
 }
 #endif
 
@@ -369,14 +369,14 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageCon
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     // FIXME: Remove this once the cause of rdar://148942809 is found and fixed.
-    RetainPtr relatedWebView = [protectedWrapper(configuration) _relatedWebView];
+    RetainPtr relatedWebView = [protect(wrapper(configuration)) _relatedWebView];
     ALLOW_DEPRECATED_DECLARATIONS_END
     bool siteIsolationEnabled = protect(configuration->preferences())->siteIsolationEnabled();
 
     if (uiDelegate->m_delegateMethods.webViewCreateWebViewWithConfigurationForNavigationActionWindowFeaturesAsync) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:createWebViewWithConfiguration:forNavigationAction:windowFeatures:completionHandler:));
 
-        [delegate _webView:uiDelegate->m_webView.get().get() createWebViewWithConfiguration:protectedWrapper(configuration).get() forNavigationAction:protectedWrapper(navigationAction).get() windowFeatures:protectedWrapper(apiWindowFeatures).get() completionHandler:makeBlockPtr([siteIsolationEnabled, relatedWebView, completionHandler = WTF::move(completionHandler), checker = WTF::move(checker), openerFrameIdentifier] (WKWebView *webView) mutable {
+        [delegate _webView:uiDelegate->m_webView.get().get() createWebViewWithConfiguration:protect(wrapper(configuration)).get() forNavigationAction:protect(wrapper(navigationAction)).get() windowFeatures:protect(wrapper(apiWindowFeatures)).get() completionHandler:makeBlockPtr([siteIsolationEnabled, relatedWebView, completionHandler = WTF::move(completionHandler), checker = WTF::move(checker), openerFrameIdentifier] (WKWebView *webView) mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -402,7 +402,7 @@ void UIDelegate::UIClient::createNewPage(WebKit::WebPageProxy&, Ref<API::PageCon
     if (!uiDelegate->m_delegateMethods.webViewCreateWebViewWithConfigurationForNavigationActionWindowFeatures)
         return completionHandler(nullptr);
 
-    RetainPtr<WKWebView> webView = [delegate webView:uiDelegate->m_webView.get().get() createWebViewWithConfiguration:protectedWrapper(configuration).get() forNavigationAction:protectedWrapper(navigationAction).get() windowFeatures:protectedWrapper(apiWindowFeatures).get()];
+    RetainPtr<WKWebView> webView = [delegate webView:uiDelegate->m_webView.get().get() createWebViewWithConfiguration:protect(wrapper(configuration)).get() forNavigationAction:protect(wrapper(navigationAction)).get() windowFeatures:protect(wrapper(apiWindowFeatures)).get()];
     if (!webView)
         return completionHandler(nullptr);
 
@@ -697,7 +697,7 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
 
     if (uiDelegate->m_delegateMethods.webViewDecideDatabaseQuotaForSecurityOriginDatabaseNameDisplayNameCurrentQuotaCurrentOriginUsageCurrentDatabaseUsageExpectedUsageDecisionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:decideDatabaseQuotaForSecurityOrigin:databaseName:displayName:currentQuota:currentOriginUsage:currentDatabaseUsage:expectedUsage:decisionHandler:));
-        [delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:protectedWrapper(*securityOrigin).get() databaseName:databaseName.createNSString().get() displayName:displayName.createNSString().get() currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)](unsigned long long newQuota) {
+        [delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:protect(wrapper(*securityOrigin)).get() databaseName:databaseName.createNSString().get() displayName:displayName.createNSString().get() currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)](unsigned long long newQuota) {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -707,7 +707,7 @@ void UIDelegate::UIClient::exceededDatabaseQuota(WebPageProxy*, WebFrameProxy*, 
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:decideDatabaseQuotaForSecurityOrigin:currentQuota:currentOriginUsage:currentDatabaseUsage:expectedUsage:decisionHandler:));
-    [delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:protectedWrapper(*securityOrigin).get() currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)](unsigned long long newQuota) {
+    [delegate _webView:uiDelegate->m_webView.get().get() decideDatabaseQuotaForSecurityOrigin:protect(wrapper(*securityOrigin)).get() currentQuota:currentQuota currentOriginUsage:currentOriginUsage currentDatabaseUsage:currentUsage expectedUsage:expectedUsage decisionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)](unsigned long long newQuota) {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -852,7 +852,7 @@ void UIDelegate::UIClient::decidePolicyForNotificationPermissionRequest(WebKit::
         return completionHandler(false);
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:requestNotificationPermissionForSecurityOrigin:decisionHandler:));
-    [delegate _webView:uiDelegate->m_webView.get().get() requestNotificationPermissionForSecurityOrigin:protectedWrapper(securityOrigin).get() decisionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)] (BOOL result) mutable {
+    [delegate _webView:uiDelegate->m_webView.get().get() requestNotificationPermissionForSecurityOrigin:protect(wrapper(securityOrigin)).get() decisionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)] (BOOL result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -898,7 +898,7 @@ bool UIDelegate::UIClient::runOpenPanel(WebPageProxy& page, WebFrameProxy* webFr
 
     Ref checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(webView:runOpenPanelWithParameters:initiatedByFrame:completionHandler:));
 
-    [delegate webView:uiDelegate->m_webView.get().get() runOpenPanelWithParameters:protectedWrapper(*openPanelParameters).get() initiatedByFrame:protectedWrapper(frame).get() completionHandler:makeBlockPtr([checker = WTF::move(checker), openPanelParameters = Ref { *openPanelParameters }, listener = RefPtr { listener }] (NSArray *URLs) mutable {
+    [delegate webView:uiDelegate->m_webView.get().get() runOpenPanelWithParameters:protect(wrapper(*openPanelParameters)).get() initiatedByFrame:protect(wrapper(frame)).get() completionHandler:makeBlockPtr([checker = WTF::move(checker), openPanelParameters = Ref { *openPanelParameters }, listener = RefPtr { listener }] (NSArray *URLs) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1176,7 +1176,7 @@ void UIDelegate::UIClient::saveDataToFileInDownloadsFolder(WebPageProxy*, const 
     if (!delegate)
         return;
 
-    [delegate _webView:uiDelegate->m_webView.get().get() saveDataToFile:protectedWrapper(data).get() suggestedFilename:suggestedFilename.createNSString().get() mimeType:mimeType.createNSString().get() originatingURL:originatingURL.createNSURL().get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() saveDataToFile:protect(wrapper(data)).get() suggestedFilename:suggestedFilename.createNSString().get() mimeType:mimeType.createNSString().get() originatingURL:originatingURL.createNSURL().get()];
 }
 
 Ref<API::InspectorConfiguration> UIDelegate::UIClient::configurationForLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
@@ -1192,7 +1192,7 @@ Ref<API::InspectorConfiguration> UIDelegate::UIClient::configurationForLocalInsp
     if (!delegate)
         return API::InspectorConfiguration::create();
 
-    return downcast<API::InspectorConfiguration>([[delegate _webView:uiDelegate->m_webView.get().get() configurationForLocalInspector:protectedWrapper(inspector).get()] _apiObject]);
+    return downcast<API::InspectorConfiguration>([[delegate _webView:uiDelegate->m_webView.get().get() configurationForLocalInspector:protect(wrapper(inspector)).get()] _apiObject]);
 }
 
 void UIDelegate::UIClient::didAttachLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
@@ -1208,7 +1208,7 @@ void UIDelegate::UIClient::didAttachLocalInspector(WebPageProxy&, WebInspectorUI
     if (!delegate)
         return;
 
-    [delegate _webView:uiDelegate->m_webView.get().get() didAttachLocalInspector:protectedWrapper(inspector).get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() didAttachLocalInspector:protect(wrapper(inspector)).get()];
 }
 
 void UIDelegate::UIClient::willCloseLocalInspector(WebPageProxy&, WebInspectorUIProxy& inspector)
@@ -1224,7 +1224,7 @@ void UIDelegate::UIClient::willCloseLocalInspector(WebPageProxy&, WebInspectorUI
     if (!delegate)
         return;
 
-    [delegate _webView:uiDelegate->m_webView.get().get() willCloseLocalInspector:protectedWrapper(inspector).get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() willCloseLocalInspector:protect(wrapper(inspector)).get()];
 }
 
 #endif
@@ -1312,7 +1312,7 @@ void UIDelegate::UIClient::callDisplayCapturePermissionDelegate(WebPageProxy& pa
     RetainPtr<WKFrameInfo> frameInfoWrapper = wrapper(API::FrameInfo::create(WTF::move(frameInfo)));
 
     BOOL requestSystemAudio = !!request.requiresDisplayCaptureWithAudio();
-    [delegate _webView:uiDelegate->m_webView.get().get() requestDisplayCapturePermissionForOrigin:protectedWrapper(topLevelOrigin).get() initiatedByFrame:frameInfoWrapper.get() withSystemAudio:requestSystemAudio decisionHandler:decisionHandler.get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() requestDisplayCapturePermissionForOrigin:protect(wrapper(topLevelOrigin)).get() initiatedByFrame:frameInfoWrapper.get() withSystemAudio:requestSystemAudio decisionHandler:decisionHandler.get()];
 
 }
 void UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest(WebPageProxy& page, WebFrameProxy& frame, API::SecurityOrigin& userMediaOrigin, API::SecurityOrigin& topLevelOrigin, UserMediaPermissionRequestProxy& request)
@@ -1385,7 +1385,7 @@ void UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest(WebPageProx
         WKMediaCaptureType type = WKMediaCaptureTypeCamera;
         if (request.requiresAudioCapture())
             type = request.requiresVideoCapture() ? WKMediaCaptureTypeCameraAndMicrophone : WKMediaCaptureTypeMicrophone;
-        [delegate webView:uiDelegate->m_webView.get().get() requestMediaCapturePermissionForOrigin:protectedWrapper(topLevelOrigin).get() initiatedByFrame:frameInfoWrapper.get() type:type decisionHandler:decisionHandler.get()];
+        [delegate webView:uiDelegate->m_webView.get().get() requestMediaCapturePermissionForOrigin:protect(wrapper(topLevelOrigin)).get() initiatedByFrame:frameInfoWrapper.get() type:type decisionHandler:decisionHandler.get()];
         return;
     }
 
@@ -1458,7 +1458,7 @@ void UIDelegate::UIClient::decidePolicyForScreenCaptureUnmuting(WebPageProxy& pa
         mainFrameID = mainFrame->frameID();
     RetainPtr<WKFrameInfo> frameInfoWrapper = wrapper(API::FrameInfo::create(WTF::move(frameInfo)));
 
-    [delegate _webView:uiDelegate->m_webView.get().get() decidePolicyForScreenCaptureUnmutingForOrigin:protectedWrapper(topLevelOrigin).get() initiatedByFrame:frameInfoWrapper.get() decisionHandler:decisionHandler.get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() decidePolicyForScreenCaptureUnmutingForOrigin:protect(wrapper(topLevelOrigin)).get() initiatedByFrame:frameInfoWrapper.get() decisionHandler:decisionHandler.get()];
 }
 
 void UIDelegate::UIClient::mediaCaptureStateDidChange(WebCore::MediaProducerMediaStateFlags state)
@@ -1491,7 +1491,7 @@ void UIDelegate::UIClient::printFrame(WebPageProxy&, WebFrameProxy& webFrameProx
     auto handle = API::FrameHandle::create(webFrameProxy.frameID());
     if (uiDelegate->m_delegateMethods.webViewPrintFramePDFFirstPageSizeCompletionHandler) {
         auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:printFrame:pdfFirstPageSize:completionHandler:));
-        [delegate _webView:uiDelegate->m_webView.get().get() printFrame:protectedWrapper(handle).get() pdfFirstPageSize:static_cast<CGSize>(pdfFirstPageSize) completionHandler:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)] () mutable {
+        [delegate _webView:uiDelegate->m_webView.get().get() printFrame:protect(wrapper(handle)).get() pdfFirstPageSize:static_cast<CGSize>(pdfFirstPageSize) completionHandler:makeBlockPtr([checker = WTF::move(checker), completionHandler = WTF::move(completionHandler)] () mutable {
             if (checker->completionHandlerHasBeenCalled())
                 return;
             checker->didCallCompletionHandler();
@@ -1501,7 +1501,7 @@ void UIDelegate::UIClient::printFrame(WebPageProxy&, WebFrameProxy& webFrameProx
     }
 
     if (uiDelegate->m_delegateMethods.webViewPrintFrame)
-        [delegate _webView:uiDelegate->m_webView.get().get() printFrame:protectedWrapper(handle).get()];
+        [delegate _webView:uiDelegate->m_webView.get().get() printFrame:protect(wrapper(handle)).get()];
     completionHandler();
 }
 
@@ -1835,7 +1835,7 @@ void UIDelegate::UIClient::runWebAuthenticationPanel(WebPageProxy& page, API::We
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:runWebAuthenticationPanel:initiatedByFrame:completionHandler:));
-    [delegate _webView:uiDelegate->m_webView.get().get() runWebAuthenticationPanel:protectedWrapper(panel).get() initiatedByFrame:wrapper(API::FrameInfo::create(WTF::move(frameInfo))).get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)] (_WKWebAuthenticationPanelResult result) mutable {
+    [delegate _webView:uiDelegate->m_webView.get().get() runWebAuthenticationPanel:protect(wrapper(panel)).get() initiatedByFrame:wrapper(API::FrameInfo::create(WTF::move(frameInfo))).get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler), checker = WTF::move(checker)] (_WKWebAuthenticationPanelResult result) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1918,7 +1918,7 @@ void UIDelegate::UIClient::queryPermission(const String& permissionName, API::Se
     }
 
     auto checker = CompletionHandlerCallChecker::create(delegate.get(), @selector(_webView:queryPermission:forOrigin:completionHandler:));
-    [delegate _webView:uiDelegate->m_webView.get().get() queryPermission:permissionName.createNSString().get() forOrigin:protectedWrapper(origin).get() completionHandler:makeBlockPtr([callback = WTF::move(callback), checker = WTF::move(checker)](WKPermissionDecision permissionState) mutable {
+    [delegate _webView:uiDelegate->m_webView.get().get() queryPermission:permissionName.createNSString().get() forOrigin:protect(wrapper(origin)).get() completionHandler:makeBlockPtr([callback = WTF::move(callback), checker = WTF::move(checker)](WKPermissionDecision permissionState) mutable {
         if (checker->completionHandlerHasBeenCalled())
             return;
         checker->didCallCompletionHandler();
@@ -1994,7 +1994,7 @@ void UIDelegate::UIClient::updateAppBadge(WebPageProxy&, const WebCore::Security
         nsBadge = @(*badge);
 
     auto apiOrigin = API::SecurityOrigin::create(origin);
-    [delegate _webView:uiDelegate->m_webView.get().get() updatedAppBadge:nsBadge.get() fromSecurityOrigin:protectedWrapper(apiOrigin.get()).get()];
+    [delegate _webView:uiDelegate->m_webView.get().get() updatedAppBadge:nsBadge.get() fromSecurityOrigin:protect(wrapper(apiOrigin.get())).get()];
 }
 
 void UIDelegate::UIClient::didAdjustVisibilityWithSelectors(WebPageProxy&, Vector<String>&& selectors)

--- a/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm
@@ -118,7 +118,7 @@ WebPageProxy* RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow()
     m_objCAdapter = adoptNS([[WKRemoteWebInspectorUIProxyObjCAdapter alloc] initWithRemoteWebInspectorUIProxy:this]);
 
     Ref<API::InspectorConfiguration> configuration = protect(m_client)->configurationForRemoteInspector(*this);
-    m_inspectorView = adoptNS([[WKInspectorViewController alloc] initWithConfiguration:protectedWrapper(configuration.get()).get() inspectedPage:nullptr]);
+    m_inspectorView = adoptNS([[WKInspectorViewController alloc] initWithConfiguration:protect(wrapper(configuration.get())).get() inspectedPage:nullptr]);
     [m_inspectorView.get() setDelegate:m_objCAdapter.get()];
 
     m_window = WebInspectorUIProxy::createFrontendWindow(NSZeroRect, WebInspectorUIProxy::InspectionTargetType::Remote);

--- a/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm
@@ -196,7 +196,7 @@ static void* const safeAreaInsetsKVOContext = (void*)&safeAreaInsetsKVOContext;
 
     ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (useDefaultProcessPool)
-        [configuration setProcessPool:protectedWrapper(Ref { WebKit::defaultInspectorProcessPool(inspectorLevel) }.get()).get()];
+        [configuration setProcessPool:wrapper(protect(WebKit::defaultInspectorProcessPool(inspectorLevel))).get()];
     ALLOW_DEPRECATED_DECLARATIONS_END
 
     // Ensure that a page group identifier is set. This is for computing inspection levels.

--- a/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
+++ b/Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm
@@ -480,7 +480,7 @@ RefPtr<WebPageProxy> WebInspectorUIProxy::platformCreateFrontendPage()
     [[NSNotificationCenter defaultCenter] addObserver:m_objCAdapter.get() selector:@selector(inspectedViewFrameDidChange:) name:NSViewFrameDidChangeNotification object:inspectedView.get()];
 
     Ref configuration = inspectedPage->uiClient().configurationForLocalInspector(*inspectedPage, *this);
-    m_inspectorViewController = adoptNS([[WKInspectorViewController alloc] initWithConfiguration:protectedWrapper(configuration.get()).get() inspectedPage:inspectedPage.get()]);
+    m_inspectorViewController = adoptNS([[WKInspectorViewController alloc] initWithConfiguration:protect(WebKit::wrapper(configuration.get())).get() inspectedPage:inspectedPage.get()]);
     [m_inspectorViewController setDelegate:m_objCAdapter.get()];
 
     RefPtr inspectorPage = [m_inspectorViewController webView]->_page.get();

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -140,7 +140,6 @@ public:
     void deref() const final { API::ObjectImpl<API::Object::Type::Frame>::deref(); }
 
     static WebFrameProxy* webFrame(std::optional<WebCore::FrameIdentifier>);
-    static RefPtr<WebFrameProxy> protectedWebFrame(std::optional<WebCore::FrameIdentifier> identifier) { return webFrame(identifier); }
 
     static bool canCreateFrame(WebCore::FrameIdentifier);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1820,7 +1820,7 @@ void WebPageProxy::initializeWebPage(const Site& site, WebCore::SandboxFlags eff
     // as the opener. To do so, we can pass the opener's origin to BrowsingContextGroup::ensureProcessForSite.
     Site effectiveSite = site.isEmpty() && internals().openerOrigin ? Site { *internals().openerOrigin } : site;
 
-    m_mainFrame = WebFrameProxy::create(*this, browsingContextGroup->ensureProcessForSite(effectiveSite, site, process, preferences), generateFrameIdentifier(), effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, WebFrameProxy::protectedWebFrame(m_openerFrameIdentifier).get(), IsMainFrame::Yes);
+    m_mainFrame = WebFrameProxy::create(*this, browsingContextGroup->ensureProcessForSite(effectiveSite, site, process, preferences), generateFrameIdentifier(), effectiveSandboxFlags, effectiveReferrerPolicy, ScrollbarMode::Auto, protect(WebFrameProxy::webFrame(m_openerFrameIdentifier)), IsMainFrame::Yes);
     if (preferences->siteIsolationEnabled())
         browsingContextGroup->addPage(*this);
     process->send(Messages::WebProcess::CreateWebPage(m_webPageID, creationParameters(process, *protect(drawingArea()), m_mainFrame->frameID(), std::nullopt)), 0);
@@ -15494,7 +15494,7 @@ void WebPageProxy::loadSynchronousURLSchemeTask(IPC::Connection& connection, URL
 
 void WebPageProxy::requestStorageAccessConfirm(const RegistrableDomain& subFrameDomain, const RegistrableDomain& topFrameDomain, FrameIdentifier frameID, std::optional<OrganizationStorageAccessPromptQuirk>&& organizationStorageAccessPromptQuirk, CompletionHandler<void(bool)>&& completionHandler)
 {
-    m_uiClient->requestStorageAccessConfirm(*this, WebFrameProxy::protectedWebFrame(frameID).get(), subFrameDomain, topFrameDomain, WTF::move(organizationStorageAccessPromptQuirk), WTF::move(completionHandler));
+    m_uiClient->requestStorageAccessConfirm(*this, protect(WebFrameProxy::webFrame(frameID)), subFrameDomain, topFrameDomain, WTF::move(organizationStorageAccessPromptQuirk), WTF::move(completionHandler));
     m_navigationClient->didPromptForStorageAccess(*this, topFrameDomain.string(), subFrameDomain.string(), !!organizationStorageAccessPromptQuirk);
 }
 

--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.h
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.h
@@ -335,8 +335,6 @@ private:
 
     void positionInformationDidChange(const InteractionInformationAtPosition&) override;
 
-    CheckedPtr<WebViewImpl> checkedImpl() const { return m_impl.get(); }
-
     bool isViewVisible(NSView *, NSWindow *);
 
     WeakObjCPtr<NSView> m_view;

--- a/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h
@@ -215,10 +215,8 @@ private:
     void gpuProcessConnectionDidClose(GPUProcessConnection&);
 
     IPC::Connection* encoderConnection(Encoder&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);
-    RefPtr<IPC::Connection> protectedEncoderConnection(Encoder&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);
     void setEncoderConnection(Encoder&, RefPtr<IPC::Connection>&&) WTF_REQUIRES_LOCK(m_encodersConnectionLock);
     IPC::Connection* decoderConnection(Decoder&) WTF_REQUIRES_LOCK(m_connectionLock);
-    RefPtr<IPC::Connection> protectedDecoderConnection(Decoder&) WTF_REQUIRES_LOCK(m_connectionLock);
     void setDecoderConnection(Decoder&, RefPtr<IPC::Connection>&&) WTF_REQUIRES_LOCK(m_connectionLock);
 
     template<typename Buffer> bool copySharedVideoFrame(LibWebRTCCodecs::Encoder&, IPC::Connection&, Buffer&&);

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp
@@ -247,7 +247,7 @@ RetainPtr<CVPixelBufferRef> SharedVideoFrameReader::readBufferFromSharedMemory()
         return { };
     }
 
-    auto result = info->createPixelBufferFromMemory(data.subspan(SharedVideoFrameInfoEncodingLength), protectedPixelBufferPool(*info).get());
+    auto result = info->createPixelBufferFromMemory(data.subspan(SharedVideoFrameInfoEncodingLength), protect(pixelBufferPool(*info)));
     if (result && m_resourceOwner && m_useIOSurfaceBufferPool == UseIOSurfaceBufferPool::Yes)
         setOwnershipIdentityForCVPixelBuffer(result.get(), m_resourceOwner);
     return result;
@@ -313,11 +313,6 @@ CVPixelBufferPoolRef SharedVideoFrameReader::pixelBufferPool(const SharedVideoFr
     }
 
     return m_bufferPool.get();
-}
-
-RetainPtr<CVPixelBufferPoolRef> SharedVideoFrameReader::protectedPixelBufferPool(const SharedVideoFrameInfo& info)
-{
-    return pixelBufferPool(info);
 }
 
 bool SharedVideoFrameReader::setSharedMemory(SharedMemory::Handle&& handle)

--- a/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
+++ b/Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h
@@ -119,7 +119,6 @@ public:
 
 private:
     CVPixelBufferPoolRef pixelBufferPool(const WebCore::SharedVideoFrameInfo&);
-    RetainPtr<CVPixelBufferPoolRef> protectedPixelBufferPool(const WebCore::SharedVideoFrameInfo&);
     RetainPtr<CVPixelBufferRef> readBufferFromSharedMemory();
 
     const RefPtr<RemoteVideoFrameObjectHeap> m_objectHeap;

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm
@@ -58,7 +58,7 @@ static void didCreatePage(WKBundleRef bundle, WKBundlePageRef page, const void* 
     RetainPtr principalClassInstance = plugInController->_principalClassInstance.get();
 
     if ([principalClassInstance respondsToSelector:@selector(webProcessPlugIn:didCreateBrowserContextController:)])
-        [principalClassInstance webProcessPlugIn:plugInController didCreateBrowserContextController:protectedWrapper(*WebKit::toProtectedImpl(page)).get()];
+        [principalClassInstance webProcessPlugIn:plugInController didCreateBrowserContextController:protect(wrapper(*WebKit::toProtectedImpl(page))).get()];
 }
 
 static void willDestroyPage(WKBundleRef bundle, WKBundlePageRef page, const void* clientInfo)
@@ -67,7 +67,7 @@ static void willDestroyPage(WKBundleRef bundle, WKBundlePageRef page, const void
     RetainPtr principalClassInstance = plugInController->_principalClassInstance.get();
 
     if ([principalClassInstance respondsToSelector:@selector(webProcessPlugIn:willDestroyBrowserContextController:)])
-        [principalClassInstance webProcessPlugIn:plugInController willDestroyBrowserContextController:protectedWrapper(*WebKit::toProtectedImpl(page)).get()];
+        [principalClassInstance webProcessPlugIn:plugInController willDestroyBrowserContextController:protect(wrapper(*WebKit::toProtectedImpl(page))).get()];
 }
 
 static void setUpBundleClient(WKWebProcessPlugInController *plugInController, WebKit::InjectedBundle& bundle)

--- a/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm
@@ -89,7 +89,7 @@ static void didStartProvisionalLoadForFrame(WKBundlePageRef page, WKBundleFrameR
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didStartProvisionalLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didStartProvisionalLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didStartProvisionalLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
 }
 
 static void didReceiveServerRedirectForProvisionalLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef *userDataRef, const void *clientInfo)
@@ -98,7 +98,7 @@ static void didReceiveServerRedirectForProvisionalLoadForFrame(WKBundlePageRef p
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didReceiveServerRedirectForProvisionalLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didReceiveServerRedirectForProvisionalLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didReceiveServerRedirectForProvisionalLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
 }
 
 static void didFinishLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void *clientInfo)
@@ -107,7 +107,7 @@ static void didFinishLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFinishLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
 }
 
 static void didClearWindowObjectForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -116,7 +116,7 @@ static void didClearWindowObjectForFrame(WKBundlePageRef page, WKBundleFrameRef 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
     
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didClearWindowObjectForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didClearWindowObjectForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() inScriptWorld:protectedWrapper(*WebKit::toProtectedImpl(scriptWorld)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didClearWindowObjectForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() inScriptWorld:protect(wrapper(*WebKit::toProtectedImpl(scriptWorld))).get()];
 }
 
 static void globalObjectIsAvailableForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -125,7 +125,7 @@ static void globalObjectIsAvailableForFrame(WKBundlePageRef page, WKBundleFrameR
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:globalObjectIsAvailableForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController globalObjectIsAvailableForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() inScriptWorld:protectedWrapper(*WebKit::toProtectedImpl(scriptWorld)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController globalObjectIsAvailableForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() inScriptWorld:protect(wrapper(*WebKit::toProtectedImpl(scriptWorld))).get()];
 }
 
 static void serviceWorkerGlobalObjectIsAvailableForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -134,7 +134,7 @@ static void serviceWorkerGlobalObjectIsAvailableForFrame(WKBundlePageRef page, W
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:serviceWorkerGlobalObjectIsAvailableForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController serviceWorkerGlobalObjectIsAvailableForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() inScriptWorld:protectedWrapper(*WebKit::toProtectedImpl(scriptWorld)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController serviceWorkerGlobalObjectIsAvailableForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() inScriptWorld:protect(wrapper(*WebKit::toProtectedImpl(scriptWorld))).get()];
 }
 
 static void willInjectUserScriptForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKBundleScriptWorldRef scriptWorld, const void* clientInfo)
@@ -143,7 +143,7 @@ static void willInjectUserScriptForFrame(WKBundlePageRef page, WKBundleFrameRef 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:willInjectUserScriptForFrame:inScriptWorld:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController willInjectUserScriptForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() inScriptWorld:protectedWrapper(*WebKit::toProtectedImpl(scriptWorld)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController willInjectUserScriptForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() inScriptWorld:protect(wrapper(*WebKit::toProtectedImpl(scriptWorld))).get()];
 }
 
 static void didRemoveFrameFromHierarchy(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void* clientInfo)
@@ -152,7 +152,7 @@ static void didRemoveFrameFromHierarchy(WKBundlePageRef page, WKBundleFrameRef f
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didRemoveFrameFromHierarchy:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didRemoveFrameFromHierarchy:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didRemoveFrameFromHierarchy:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
 }
 
 static void didCommitLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void *clientInfo)
@@ -161,7 +161,7 @@ static void didCommitLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didCommitLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didCommitLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didCommitLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
 }
 
 static void didFinishDocumentLoadForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKTypeRef* userData, const void *clientInfo)
@@ -170,7 +170,7 @@ static void didFinishDocumentLoadForFrame(WKBundlePageRef page, WKBundleFrameRef
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFinishDocumentLoadForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishDocumentLoadForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFinishDocumentLoadForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
 }
 
 static void didFailProvisionalLoadWithErrorForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKErrorRef wkError, WKTypeRef* userData, const void *clientInfo)
@@ -179,7 +179,7 @@ static void didFailProvisionalLoadWithErrorForFrame(WKBundlePageRef page, WKBund
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFailProvisionalLoadWithErrorForFrame:error:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailProvisionalLoadWithErrorForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() error:protectedWrapper(*WebKit::toProtectedImpl(wkError)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailProvisionalLoadWithErrorForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() error:protect(wrapper(*WebKit::toProtectedImpl(wkError))).get()];
 }
 
 static void didFailLoadWithErrorForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKErrorRef wkError, WKTypeRef* userData, const void *clientInfo)
@@ -188,7 +188,7 @@ static void didFailLoadWithErrorForFrame(WKBundlePageRef page, WKBundleFrameRef 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFailLoadWithErrorForFrame:error:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailLoadWithErrorForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() error:protectedWrapper(*WebKit::toProtectedImpl(wkError)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFailLoadWithErrorForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() error:protect(wrapper(*WebKit::toProtectedImpl(wkError))).get()];
 }
 
 static void didSameDocumentNavigationForFrame(WKBundlePageRef page, WKBundleFrameRef frame, WKSameDocumentNavigationType type, WKTypeRef* userData, const void *clientInfo)
@@ -197,11 +197,11 @@ static void didSameDocumentNavigationForFrame(WKBundlePageRef page, WKBundleFram
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didSameDocumentNavigation:forFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigation:toWKSameDocumentNavigationType(WebKit::toSameDocumentNavigationType(type)) forFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigation:toWKSameDocumentNavigationType(WebKit::toSameDocumentNavigationType(type)) forFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
     else {
         // FIXME: Remove this once clients switch to implementing the above delegate method.
         if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didSameDocumentNavigationForFrame:)])
-            [(NSObject *)loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigationForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+            [(NSObject *)loadDelegate webProcessPlugInBrowserContextController:pluginContextController didSameDocumentNavigationForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
     }
 }
 
@@ -211,7 +211,7 @@ static void didLayoutForFrame(WKBundlePageRef page, WKBundleFrameRef frame, cons
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didLayoutForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didLayoutForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didLayoutForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
 }
 
 static void didReachLayoutMilestone(WKBundlePageRef page, WKLayoutMilestones milestones, WKTypeRef* userData, const void *clientInfo)
@@ -241,7 +241,7 @@ static void didFirstVisuallyNonEmptyLayoutForFrame(WKBundlePageRef page, WKBundl
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didFirstVisuallyNonEmptyLayoutForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFirstVisuallyNonEmptyLayoutForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didFirstVisuallyNonEmptyLayoutForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
 }
 
 static void didHandleOnloadEventsForFrame(WKBundlePageRef page, WKBundleFrameRef frame, const void* clientInfo)
@@ -250,7 +250,7 @@ static void didHandleOnloadEventsForFrame(WKBundlePageRef page, WKBundleFrameRef
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:didHandleOnloadEventsForFrame:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didHandleOnloadEventsForFrame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController didHandleOnloadEventsForFrame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get()];
 }
 
 static void setUpPageLoaderClient(WKWebProcessPlugInBrowserContextController *contextController, WebKit::WebPage& page)
@@ -290,14 +290,14 @@ static WKURLRequestRef willSendRequestForFrame(WKBundlePageRef, WKBundleFrameRef
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:willSendRequestForResource:request:redirectResponse:)]) {
         RetainPtr originalRequest = wrapper(*WebKit::toImpl(request));
-        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() willSendRequestForResource:resourceIdentifier
+        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() willSendRequestForResource:resourceIdentifier
             request:originalRequest.get() redirectResponse:WebKit::toImpl(redirectResponse)->resourceResponse().protectedNSURLResponse().get()];
 
         if (substituteRequest != originalRequest.get())
             return substituteRequest ? WKURLRequestCreateWithNSURLRequest(substituteRequest.get()) : nullptr;
     } else if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:willSendRequest:redirectResponse:)]) {
         RetainPtr originalRequest = wrapper(*WebKit::toImpl(request));
-        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() willSendRequest:originalRequest.get()
+        RetainPtr<NSURLRequest> substituteRequest = [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() willSendRequest:originalRequest.get()
             redirectResponse:WebKit::toImpl(redirectResponse)->resourceResponse().protectedNSURLResponse().get()];
 
         if (substituteRequest != originalRequest.get())
@@ -314,10 +314,10 @@ static void didInitiateLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, 
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didInitiateLoadForResource:request:pageIsProvisionallyLoading:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didInitiateLoadForResource:resourceIdentifier request:protectedWrapper(*WebKit::toProtectedImpl(request)).get()
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didInitiateLoadForResource:resourceIdentifier request:protect(wrapper(*WebKit::toProtectedImpl(request))).get()
             pageIsProvisionallyLoading:pageIsProvisionallyLoading];
     } else if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didInitiateLoadForResource:request:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didInitiateLoadForResource:resourceIdentifier request:protectedWrapper(*WebKit::toProtectedImpl(request)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didInitiateLoadForResource:resourceIdentifier request:protect(wrapper(*WebKit::toProtectedImpl(request))).get()];
     }
 }
 
@@ -327,7 +327,7 @@ static void didReceiveResponseForResource(WKBundlePageRef, WKBundleFrameRef fram
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didReceiveResponse:forResource:)])
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didReceiveResponse:WebKit::toImpl(response)->resourceResponse().protectedNSURLResponse().get() forResource:resourceIdentifier];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didReceiveResponse:WebKit::toImpl(response)->resourceResponse().protectedNSURLResponse().get() forResource:resourceIdentifier];
 }
 
 static void didFinishLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, uint64_t resourceIdentifier, const void* clientInfo)
@@ -336,7 +336,7 @@ static void didFinishLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, ui
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didFinishLoadForResource:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didFinishLoadForResource:resourceIdentifier];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didFinishLoadForResource:resourceIdentifier];
     }
 }
 
@@ -346,7 +346,7 @@ static void didFailLoadForResource(WKBundlePageRef, WKBundleFrameRef frame, uint
     auto loadDelegate = pluginContextController->_loadDelegate.get();
 
     if ([loadDelegate respondsToSelector:@selector(webProcessPlugInBrowserContextController:frame:didFailLoadForResource:error:)]) {
-        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protectedWrapper(*WebKit::toProtectedImpl(frame)).get() didFailLoadForResource:resourceIdentifier error:protectedWrapper(*WebKit::toProtectedImpl(error)).get()];
+        [loadDelegate webProcessPlugInBrowserContextController:pluginContextController frame:protect(wrapper(*WebKit::toProtectedImpl(frame))).get() didFailLoadForResource:resourceIdentifier error:protect(wrapper(*WebKit::toProtectedImpl(error))).get()];
     }
 }
 
@@ -480,7 +480,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
             auto formDelegate = controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:didFocusTextField:inFrame:)])
-                [formDelegate _webProcessPlugInBrowserContextController:controller.get() didFocusTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:protectedWrapper(*frame).get()];
+                [formDelegate _webProcessPlugInBrowserContextController:controller.get() didFocusTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:protect(wrapper(*frame)).get()];
         }
 
         void willSendSubmitEvent(WebKit::WebPage*, WebCore::HTMLFormElement* formElement, WebKit::WebFrame* targetFrame, WebKit::WebFrame* sourceFrame, const Vector<std::pair<String, String>>& values) final
@@ -494,8 +494,8 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
                 auto valueMap = adoptNS([[NSMutableDictionary alloc] initWithCapacity:values.size()]);
                 for (const auto& pair : values)
                     [valueMap setObject:pair.second.createNSString().get() forKey:pair.first.createNSString().get()];
-                [formDelegate _webProcessPlugInBrowserContextController:controller.get() willSendSubmitEventToForm:protectedWrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get()).get()
-                    inFrame:protectedWrapper(*sourceFrame).get() targetFrame:protectedWrapper(*targetFrame).get() values:valueMap.get()];
+                [formDelegate _webProcessPlugInBrowserContextController:controller.get() willSendSubmitEventToForm:protect(wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get())).get()
+                    inFrame:protect(wrapper(*sourceFrame)).get() targetFrame:protect(wrapper(*targetFrame)).get() values:valueMap.get()];
             }
         }
 
@@ -510,7 +510,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
                 auto valueMap = adoptNS([[NSMutableDictionary alloc] initWithCapacity:values.size()]);
                 for (const auto& pair : values)
                     [valueMap setObject:pair.second.createNSString().get() forKey:pair.first.createNSString().get()];
-                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willSubmitForm:protectedWrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get()).get() toFrame:protectedWrapper(*frame).get() fromFrame:protectedWrapper(*sourceFrame).get() withValues:valueMap.get()]);
+                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willSubmitForm:protect(wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(formElement).get())).get() toFrame:protect(wrapper(*frame)).get() fromFrame:protect(wrapper(*sourceFrame)).get() withValues:valueMap.get()]);
             }
         }
 
@@ -522,7 +522,7 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
             auto formDelegate = controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:textDidChangeInTextField:inFrame:initiatedByUserTyping:)])
-                [formDelegate _webProcessPlugInBrowserContextController:controller.get() textDidChangeInTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:protectedWrapper(*frame).get() initiatedByUserTyping:initiatedByUserTyping];
+                [formDelegate _webProcessPlugInBrowserContextController:controller.get() textDidChangeInTextField:wrapper(WebKit::InjectedBundleNodeHandle::getOrCreate(inputElement)).get() inFrame:protect(wrapper(*frame)).get() initiatedByUserTyping:initiatedByUserTyping];
         }
 
         void willBeginInputSession(WebKit::WebPage*, WebCore::Element* element, WebKit::WebFrame* frame, bool userIsInteracting, RefPtr<API::Object>& userData) final
@@ -533,13 +533,13 @@ static void setUpResourceLoadClient(WKWebProcessPlugInBrowserContextController *
 
             auto formDelegate = controller->_formDelegate.get();
             if ([formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:willBeginInputSessionForElement:inFrame:userIsInteracting:)]) {
-                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willBeginInputSessionForElement:protectedWrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element)).get() inFrame:protectedWrapper(*frame).get() userIsInteracting:userIsInteracting]);
+                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willBeginInputSessionForElement:protect(wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element))).get() inFrame:protect(wrapper(*frame)).get() userIsInteracting:userIsInteracting]);
             } else if (userIsInteracting && [formDelegate respondsToSelector:@selector(_webProcessPlugInBrowserContextController:willBeginInputSessionForElement:inFrame:)]) {
                 // FIXME: We check userIsInteracting so that we don't begin an input session for a
                 // programmatic focus that doesn't cause the keyboard to appear. But this misses the case of
                 // a programmatic focus happening while the keyboard is already shown. Once we have a way to
                 // know the keyboard state in the Web Process, we should refine the condition.
-                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willBeginInputSessionForElement:protectedWrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element)).get() inFrame:protectedWrapper(*frame).get()]);
+                userData = API::Object::fromNSObject([formDelegate _webProcessPlugInBrowserContextController:controller.get() willBeginInputSessionForElement:protect(wrapper(*WebKit::InjectedBundleNodeHandle::getOrCreate(element))).get() inFrame:protect(wrapper(*frame)).get()]);
             }
         }
 
@@ -616,7 +616,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
                 return true;
 
             RetainPtr controller = m_controller.get();
-            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() shouldInsertText:text.createNSString().get() replacingRange:protectedWrapper(*WebKit::createHandle(rangeToReplace)).get() givenAction:toWK(action)];
+            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() shouldInsertText:text.createNSString().get() replacingRange:protect(wrapper(*WebKit::createHandle(rangeToReplace))).get() givenAction:toWK(action)];
         }
 
         bool shouldChangeSelectedRange(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>& fromRange, const std::optional<WebCore::SimpleRange>& toRange, WebCore::Affinity affinity, bool stillSelecting) final
@@ -657,7 +657,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
                 return;
 
             RetainPtr controller = m_controller.get();
-            [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() willWriteRangeToPasteboard:protectedWrapper(WebKit::createHandle(range).get()).get()];
+            [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() willWriteRangeToPasteboard:protect(wrapper(WebKit::createHandle(range).get())).get()];
         }
 
         void getPasteboardDataForRange(WebKit::WebPage&, const std::optional<WebCore::SimpleRange>& range, Vector<String>& pasteboardTypes, Vector<RefPtr<WebCore::SharedBuffer>>& pasteboardData) final
@@ -666,7 +666,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
                 return;
 
             RetainPtr controller = m_controller.get();
-            RetainPtr dataByType = [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() pasteboardDataForRange:protectedWrapper(WebKit::createHandle(range).get()).get()];
+            RetainPtr dataByType = [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() pasteboardDataForRange:protect(wrapper(WebKit::createHandle(range).get())).get()];
             for (NSString *type in dataByType.get()) {
                 pasteboardTypes.append(type);
                 pasteboardData.append(WebCore::SharedBuffer::create(dataByType.get()[type]));
@@ -690,7 +690,7 @@ static inline WKEditorInsertAction toWK(WebCore::EditorInsertAction action)
             auto rangeHandle = WebKit::createHandle(range);
             auto nodeHandle = WebKit::InjectedBundleNodeHandle::getOrCreate(&fragment);
             RetainPtr controller = m_controller.get();
-            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() performTwoStepDrop:protectedWrapper(*nodeHandle).get() atDestination:protectedWrapper(*rangeHandle).get() isMove:isMove];
+            return [controller->_editingDelegate.get() _webProcessPlugInBrowserContextController:controller.get() performTwoStepDrop:protect(wrapper(*nodeHandle)).get() atDestination:protect(wrapper(*rangeHandle)).get() isMove:isMove];
         }
 
         WeakObjCPtr<WKWebProcessPlugInBrowserContextController> m_controller;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm
@@ -769,7 +769,7 @@ void PDFIncrementalLoader::transitionToMainThreadDocument()
     }
 }
 
-void PDFIncrementalLoader::threadEntry(Ref<PDFIncrementalLoader>&& protectedLoader)
+void PDFIncrementalLoader::threadEntry(Ref<PDFIncrementalLoader>&& loader)
 {
     CGDataProviderDirectAccessRangesCallbacks dataProviderCallbacks {
         0,
@@ -778,10 +778,10 @@ void PDFIncrementalLoader::threadEntry(Ref<PDFIncrementalLoader>&& protectedLoad
         dataProviderReleaseInfoCallback,
     };
 
-    auto scopeExit = makeScopeExit([protectedLoader = WTF::move(protectedLoader)] mutable {
+    auto scopeExit = makeScopeExit([loader = WTF::move(loader)] mutable {
         // Keep the PDFPlugin alive until the end of this function and the end
         // of the last main thread task submitted by this function.
-        callOnMainRunLoop([protectedLoader = WTF::move(protectedLoader)] { });
+        callOnMainRunLoop([loader = WTF::move(loader)] { });
     });
 
     RefPtr plugin = m_plugin.get();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -961,13 +961,13 @@ void WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse(const ResourceRe
     RefPtr policyDocumentLoader = m_localFrame->loader().provisionalDocumentLoader();
     auto navigationID = policyDocumentLoader ? policyDocumentLoader->navigationID() : std::nullopt;
 
-    auto protectedFrame = m_frame.copyRef();
-    uint64_t listenerID = protectedFrame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::No);
+    Ref frame = m_frame;
+    uint64_t listenerID = frame->setUpPolicyListener(WTF::move(function), WebFrame::ForNavigationAction::No);
 
     bool isShowingInitialAboutBlank = m_localFrame->loader().stateMachine().isDisplayingInitialEmptyDocument();
     auto activeDocumentCOOPValue = m_localFrame->document() ? protect(m_localFrame->document())->crossOriginOpenerPolicy().value : CrossOriginOpenerPolicyValue::SameOrigin;
 
-    webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForResponse(protectedFrame->info(), navigationID, response, request, canShowResponse, downloadAttribute, isShowingInitialAboutBlank, activeDocumentCOOPValue), [frame = protectedFrame, listenerID] (PolicyDecision&& policyDecision) {
+    webPage->sendWithAsyncReply(Messages::WebPageProxy::DecidePolicyForResponse(frame->info(), navigationID, response, request, canShowResponse, downloadAttribute, isShowingInitialAboutBlank, activeDocumentCOOPValue), [frame, listenerID] (PolicyDecision&& policyDecision) {
         frame->didReceivePolicyDecision(listenerID, WTF::move(policyDecision));
     });
 }


### PR DESCRIPTION
#### 6b9be047cf997ae7de8dc19c5e359722fad317fe
<pre>
Get rid of remaining `checked*()` and `protected*()` functions in Source/WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=308210">https://bugs.webkit.org/show_bug.cgi?id=308210</a>

Reviewed by Anne van Kesteren.

* Source/WebCore/Modules/reporting/Report.h:
(WebCore::Report::bodyForSerialization const):
(WebCore::Report::protectedBody const): Deleted.
* Source/WebCore/Modules/reporting/ReportingScope.cpp:
(WebCore::ReportingScope::notifyReportObservers):
* Source/WebCore/platform/cocoa/CoreVideoSoftLink.h:
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(-[WKNetworkSessionDelegate URLSession:dataTask:didBecomeDownloadTask:]):
* Source/WebKit/Platform/cocoa/WebPrivacyHelpers.mm:
(WebKit::ResourceMonitorURLsController::prepare):
* Source/WebKit/Shared/API/APIArray.h:
* Source/WebKit/Shared/API/c/WKArray.cpp:
(WKArrayGetItemAtIndex):
* Source/WebKit/Shared/Cocoa/WKNSError.mm:
(-[WKNSError _web_createTarget]):
* Source/WebKit/Shared/Cocoa/WKObject.h:
(WebKit::protectedWrapper): Deleted.
* Source/WebKit/Shared/WebBackForwardListFrameItem.cpp:
(WebKit::WebBackForwardListFrameItem::protectedChildItemForFrameID): Deleted.
* Source/WebKit/Shared/WebBackForwardListFrameItem.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageTerminate):
* Source/WebKit/UIProcess/API/Cocoa/WKDownload.mm:
(-[WKDownload cancel:]):
(-[WKDownload webView]):
(-[WKDownload setDelegate:]):
(-[WKDownload progress]):
(-[WKDownload protectedDownload]): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKFormInfo.mm:
(-[WKFormInfo targetFrame]):
(-[WKFormInfo sourceFrame]):
(-[WKFormInfo submissionURL]):
(-[WKFormInfo httpMethod]):
(-[WKFormInfo formValues]):
(protectedFormInfo): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/WKProcessPool.mm:
(-[WKProcessPool description]):
* Source/WebKit/UIProcess/API/Cocoa/WKUserScript.mm:
(-[WKUserScript _userContentWorld]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _didInsertAttachment:withSource:]):
(-[WKWebView _didRemoveAttachment:]):
(-[WKWebView _didInvalidateDataForAttachment:]):
(-[WKWebView createWebArchiveDataWithCompletionHandler:]):
(-[WKWebView _dataTaskWithRequest:runAtForegroundPriority:completionHandler:]):
(-[WKWebView _killWebContentProcessAndResetState]):
(-[WKWebView _getMainResourceDataWithCompletionHandler:]):
(-[WKWebView _createWebArchiveForFrame:completionHandler:]):
(-[WKWebView _createWebArchiveForFrames:rootFrame:completionHandler:]):
(-[WKWebView _getApplicationManifestWithCompletionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/WKWebsiteDataStore.mm:
* Source/WebKit/UIProcess/API/Cocoa/_WKAutomationSession.mm:
(-[_WKAutomationSession dealloc]):
(-[_WKAutomationSession setDelegate:]):
(-[_WKAutomationSession isPaired]):
(-[_WKAutomationSession isPendingTermination]):
(-[_WKAutomationSession isSimulatingUserInteraction]):
(-[_WKAutomationSession terminate]):
(-[_WKAutomationSession wasEventSynthesizedForAutomation:]):
(-[_WKAutomationSession markEventAsSynthesizedForAutomation:]):
(protectedSession): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKContentRuleListAction.mm:
(-[_WKContentRuleListAction blockedLoad]):
(-[_WKContentRuleListAction blockedCookies]):
(-[_WKContentRuleListAction madeHTTPS]):
(-[_WKContentRuleListAction redirected]):
(-[_WKContentRuleListAction modifiedHeaders]):
(-[_WKContentRuleListAction notifications]):
(protectedAction): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKCustomHeaderFields.mm:
(-[_WKCustomHeaderFields setFields:]):
(-[_WKCustomHeaderFields thirdPartyDomains]):
(-[_WKCustomHeaderFields setThirdPartyDomains:]):
(protectedFields): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKDataTask.mm:
(-[_WKDataTask cancel]):
(-[_WKDataTask setDelegate:]):
(protectedDataTask): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKInspector.mm:
(-[_WKInspector setDelegate:]):
(-[_WKInspector isFront]):
(-[_WKInspector connect]):
(-[_WKInspector show]):
(-[_WKInspector hide]):
(-[_WKInspector close]):
(-[_WKInspector showConsole]):
(-[_WKInspector showResources]):
(-[_WKInspector showMainResourceForFrame:]):
(-[_WKInspector attach]):
(-[_WKInspector detach]):
(-[_WKInspector togglePageProfiling]):
(-[_WKInspector toggleElementSelection]):
(-[_WKInspector _setDiagnosticLoggingDelegate:]):
(-[_WKInspector registerExtensionWithID:extensionBundleIdentifier:displayName:completionHandler:]):
(-[_WKInspector unregisterExtension:completionHandler:]):
(-[_WKInspector showExtensionTabWithIdentifier:completionHandler:]):
(-[_WKInspector navigateExtensionTabWithIdentifier:toURL:completionHandler:]):
(protectedInspector): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorConfiguration.mm:
(-[_WKInspectorConfiguration setURLSchemeHandler:forURLScheme:]):
(-[_WKInspectorConfiguration setProcessPool:]):
(-[_WKInspectorConfiguration processPool]):
(protectedConfiguration): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorExtension.mm:
(-[_WKInspectorExtension createTabWithName:tabIconURL:sourceURL:completionHandler:]):
(-[_WKInspectorExtension evaluateScript:frameURL:contextSecurityOrigin:useContentScriptContext:completionHandler:]):
(-[_WKInspectorExtension evaluateScript:inTabWithIdentifier:completionHandler:]):
(-[_WKInspectorExtension navigateToURL:inTabWithIdentifier:completionHandler:]):
(-[_WKInspectorExtension reloadIgnoringCache:userAgent:injectedScript:completionHandler:]):
(protectedExtension): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorInternal.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKInspectorTesting.mm:
(-[_WKInspector _fetchURLForTesting:]):
(-[_WKInspector _openURLExternallyForTesting:useFrontendAPI:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKProcessPoolConfiguration.mm:
(-[_WKProcessPoolConfiguration setAdditionalReadAccessAllowedURLs:]):
(-[_WKProcessPoolConfiguration setCachePartitionedURLSchemes:]):
(-[_WKProcessPoolConfiguration setAlwaysRevalidatedURLSchemes:]):
(-[_WKProcessPoolConfiguration copyWithZone:]):
(-[_WKProcessPoolConfiguration setMemoryFootprintPollIntervalForTesting:]):
(-[_WKProcessPoolConfiguration setMemoryFootprintNotificationThresholds:]):
(protectedProcessPoolConfiguration): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKRemoteWebInspectorViewController.mm:
(-[_WKRemoteWebInspectorViewController registerExtensionWithID:extensionBundleIdentifier:displayName:completionHandler:]):
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementInfo.mm:
(-[_WKTargetedElementInfo boundsInWebView]):
(-[_WKTargetedElementInfo getChildFrames:]):
(-[_WKTargetedElementInfo isSameElement:]):
(-[_WKTargetedElementInfo takeSnapshotWithCompletionHandler:]):
(protectedInfo): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKTargetedElementRequest.mm:
(-[_WKTargetedElementRequest initWithSearchText:]):
(-[_WKTargetedElementRequest initWithPoint:]):
(-[_WKTargetedElementRequest initWithSelectors:]):
(protectedRequest): Deleted.
* Source/WebKit/UIProcess/API/Cocoa/_WKWebAuthenticationAssertionResponse.mm:
(-[_WKWebAuthenticationAssertionResponse userHandle]):
(-[_WKWebAuthenticationAssertionResponse credentialID]):
(-[_WKWebAuthenticationAssertionResponse setLAContext:]):
(protectedResponse): Deleted.
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView _web_immediateActionAnimationControllerForHitTestResultInternal:withType:userData:]):
* Source/WebKit/UIProcess/API/mac/WKWebViewTestingMac.mm:
(-[WKWebView _retrieveAccessibilityTreeData:]):
* Source/WebKit/UIProcess/Cocoa/NavigationState.mm:
(WebKit::NavigationState::willRecordNavigationSnapshot):
(WebKit::NavigationState::NavigationClient::didChangeBackForwardList):
(WebKit::NavigationState::NavigationClient::shouldGoToBackForwardListItem):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationAction):
(WebKit::NavigationState::NavigationClient::contentRuleListNotification):
(WebKit::NavigationState::NavigationClient::decidePolicyForNavigationResponse):
(WebKit::NavigationState::NavigationClient::didStartProvisionalNavigation):
(WebKit::NavigationState::NavigationClient::didReceiveServerRedirectForProvisionalNavigation):
(WebKit::createErrorWithRecoveryAttempter):
(WebKit::NavigationState::NavigationClient::didFailProvisionalNavigationWithError):
(WebKit::NavigationState::NavigationClient::didCommitNavigation):
(WebKit::NavigationState::NavigationClient::didFinishDocumentLoad):
(WebKit::NavigationState::NavigationClient::didFinishNavigation):
(WebKit::NavigationState::NavigationClient::didFailNavigationWithError):
(WebKit::NavigationState::NavigationClient::didSameDocumentNavigation):
(WebKit::NavigationState::NavigationClient::didReceiveAuthenticationChallenge):
(WebKit::NavigationState::NavigationClient::shouldAllowLegacyTLS):
(WebKit::NavigationState::NavigationClient::navigationActionDidBecomeDownload):
(WebKit::NavigationState::NavigationClient::navigationResponseDidBecomeDownload):
(WebKit::NavigationState::NavigationClient::contextMenuDidCreateDownload):
* Source/WebKit/UIProcess/Cocoa/ResourceLoadDelegate.mm:
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didSendRequest const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didPerformHTTPRedirection const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didReceiveChallenge const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didReceiveResponse const):
(WebKit::ResourceLoadDelegate::ResourceLoadClient::didCompleteWithError const):
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::ContextMenuClient::menuFromProposedMenu):
(WebKit::UIDelegate::UIClient::mouseDidMoveOverElement):
(WebKit::UIDelegate::UIClient::createNewPage):
(WebKit::UIDelegate::UIClient::exceededDatabaseQuota):
(WebKit::UIDelegate::UIClient::decidePolicyForNotificationPermissionRequest):
(WebKit::UIDelegate::UIClient::runOpenPanel):
(WebKit::UIDelegate::UIClient::saveDataToFileInDownloadsFolder):
(WebKit::UIDelegate::UIClient::configurationForLocalInspector):
(WebKit::UIDelegate::UIClient::didAttachLocalInspector):
(WebKit::UIDelegate::UIClient::willCloseLocalInspector):
(WebKit::UIDelegate::UIClient::callDisplayCapturePermissionDelegate):
(WebKit::UIDelegate::UIClient::decidePolicyForUserMediaPermissionRequest):
(WebKit::UIDelegate::UIClient::decidePolicyForScreenCaptureUnmuting):
(WebKit::UIDelegate::UIClient::printFrame):
(WebKit::UIDelegate::UIClient::runWebAuthenticationPanel):
(WebKit::UIDelegate::UIClient::queryPermission):
(WebKit::UIDelegate::UIClient::updateAppBadge):
* Source/WebKit/UIProcess/Inspector/mac/RemoteWebInspectorUIProxyMac.mm:
(WebKit::RemoteWebInspectorUIProxy::platformCreateFrontendPageAndWindow):
* Source/WebKit/UIProcess/Inspector/mac/WKInspectorViewController.mm:
(-[WKInspectorViewController webViewConfiguration]):
* Source/WebKit/UIProcess/Inspector/mac/WebInspectorUIProxyMac.mm:
(WebKit::WebInspectorUIProxy::platformCreateFrontendPage):
* Source/WebKit/UIProcess/WebFrameProxy.h:
(WebKit::WebFrameProxy::protectedWebFrame): Deleted.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::initializeWebPage):
(WebKit::WebPageProxy::requestStorageAccessConfirm):
* Source/WebKit/UIProcess/mac/PageClientImplMac.h:
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.cpp:
(WebKit::LibWebRTCCodecs::releaseDecoder):
(WebKit::LibWebRTCCodecs::releaseEncoder):
(WebKit::LibWebRTCCodecs::initializeEncoderInternal):
(WebKit::LibWebRTCCodecs::protectedEncoderConnection): Deleted.
(WebKit::LibWebRTCCodecs::protectedDecoderConnection): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/LibWebRTCCodecs.h:
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.cpp:
(WebKit::SharedVideoFrameReader::readBufferFromSharedMemory):
(WebKit::SharedVideoFrameReader::protectedPixelBufferPool): Deleted.
* Source/WebKit/WebProcess/GPU/webrtc/SharedVideoFrame.h:
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugIn.mm:
(didCreatePage):
(willDestroyPage):
* Source/WebKit/WebProcess/InjectedBundle/API/mac/WKWebProcessPlugInBrowserContextController.mm:
(didStartProvisionalLoadForFrame):
(didReceiveServerRedirectForProvisionalLoadForFrame):
(didFinishLoadForFrame):
(didClearWindowObjectForFrame):
(globalObjectIsAvailableForFrame):
(serviceWorkerGlobalObjectIsAvailableForFrame):
(willInjectUserScriptForFrame):
(didRemoveFrameFromHierarchy):
(didCommitLoadForFrame):
(didFinishDocumentLoadForFrame):
(didFailProvisionalLoadWithErrorForFrame):
(didFailLoadWithErrorForFrame):
(didSameDocumentNavigationForFrame):
(didLayoutForFrame):
(didFirstVisuallyNonEmptyLayoutForFrame):
(didHandleOnloadEventsForFrame):
(willSendRequestForFrame):
(didInitiateLoadForResource):
(didReceiveResponseForResource):
(didFinishLoadForResource):
(didFailLoadForResource):
(-[WKWebProcessPlugInBrowserContextController _setFormDelegate:]):
(-[WKWebProcessPlugInBrowserContextController _setEditingDelegate:]):
* Source/WebKit/WebProcess/Plugins/PDF/PDFIncrementalLoader.mm:
(WebKit::PDFIncrementalLoader::threadEntry):
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::dispatchDecidePolicyForResponse):

Canonical link: <a href="https://commits.webkit.org/307880@main">https://commits.webkit.org/307880@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b146c350a1283a15a30326600653ca0c31b426c1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145825 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18516 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10519 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154504 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4766d0df-8c16-46e4-9835-c25dbbb2666b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147700 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112156 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99418 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e6e6c8b-032f-4c91-a24d-63eece4b607e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148788 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14541 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130982 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93061 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db0861e6-9f33-4f18-b73c-c87980e88e11) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1951 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7856 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156817 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/78 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9042 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120159 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18362 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15333 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120504 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30889 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18407 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129207 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74099 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/16234 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7243 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17982 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17720 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17923 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17778 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->