### PR TITLE
[LBSE] Fix some getBBox issues

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -260,8 +260,6 @@ svg/custom/pointer-events-text.svg                [ ImageOnlyFailure ]
 
 # Bounding box issues
 imported/w3c/web-platform-tests/svg/interact/scripted/svg-pointer-events-bbox.html    [ Failure ]
-imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06.html [ Failure ]
-svg/text/text-bbox-empty.html                                                         [ Failure ]
 
 # Failing WPT reftests
 imported/w3c/web-platform-tests/svg/animations/animate-rewind-freeze-indefinite.svg                    [ ImageOnlyFailure ]

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01-expected.txt
@@ -17,5 +17,5 @@ PASS getBBox on path with no height
 PASS path with no height should contribute to parent bbox
 PASS arc bbox should be tight
 PASS empty foreignObject does not contribute to parent bbox
-FAIL empty image does not contribute to parent bbox assert_approx_equals: x expected 5 +/- 5.960464477539063e-8 but got 0
+PASS empty image does not contribute to parent bbox
 

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.h
@@ -49,6 +49,8 @@ public:
     FloatRect repaintRectInLocalCoordinates(RepaintRectCalculation = RepaintRectCalculation::Fast) const final { return SVGBoundingBoxComputation::computeRepaintBoundingBox(*this); }
     FloatRect decoratedBoundingBox() const final { return m_viewport; }
 
+    bool isObjectBoundingBoxValid() const { return !m_viewport.isEmpty(); }
+
 private:
     void graphicsElement() const = delete;
     ASCIILiteral renderName() const override { return "RenderSVGForeignObject"_s; }

--- a/Source/WebCore/rendering/svg/RenderSVGImage.h
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.h
@@ -46,6 +46,8 @@ public:
 
     bool updateImageViewport();
 
+    bool isObjectBoundingBoxValid() const { return !m_objectBoundingBox.isEmpty(); }
+
 private:
     void willBeDestroyed() final;
 

--- a/Source/WebCore/svg/SVGLocatable.cpp
+++ b/Source/WebCore/svg/SVGLocatable.cpp
@@ -81,7 +81,7 @@ FloatRect SVGLocatable::getBBox(SVGElement* element, StyleUpdateStrategy styleUp
         protect(element->document())->updateLayoutIgnorePendingStylesheets({ LayoutOptions::TreatContentVisibilityHiddenAsVisible, LayoutOptions::TreatContentVisibilityAutoAsVisible }, element);
 
     // FIXME: Eventually we should support getBBox for detached elements.
-    if (!element->renderer())
+    if (!element->renderer() || element->renderer()->isRenderSVGHiddenContainer())
         return FloatRect();
 
     return element->renderer()->objectBoundingBox();


### PR DESCRIPTION
#### 272edbae9c8b2782f15789d69afc369851f1cda1
<pre>
[LBSE] Fix some getBBox issues
<a href="https://bugs.webkit.org/show_bug.cgi?id=308212">https://bugs.webkit.org/show_bug.cgi?id=308212</a>

Reviewed by Nikolas Zimmermann.

Fix some getBBox issues by checking more carefully whether child bounding boxes
are valid in container bbox calculations. Also add some logic to always make
getBBox return the empty rectangle for hidden containers (defs/symbol etc.).

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-01-expected.txt:
* Source/WebCore/rendering/svg/RenderSVGForeignObject.h:
* Source/WebCore/rendering/svg/RenderSVGImage.h:
* Source/WebCore/rendering/svg/SVGBoundingBoxComputation.cpp:
(WebCore::SVGBoundingBoxComputation::handleRootOrContainer const):
* Source/WebCore/svg/SVGLocatable.cpp:
(WebCore::SVGLocatable::getBBox):

Canonical link: <a href="https://commits.webkit.org/307915@main">https://commits.webkit.org/307915@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccdf34ee906db850d0224edd4eac756f528cfd9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18618 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10732 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154607 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147803 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18507 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112242 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148891 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14626 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93148 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13919 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11677 "Build is in progress. Recent messages:") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2053 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123472 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/8012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156919 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9237 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120251 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18458 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15425 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120592 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30909 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18493 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129408 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16305 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7376 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81851 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17813 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17870 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->