### PR TITLE
Add DOMWindow/Location debug logging

### DIFF
--- a/Source/WebCore/page/DOMWindow.cpp
+++ b/Source/WebCore/page/DOMWindow.cpp
@@ -43,6 +43,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalFrame.h"
 #include "Location.h"
+#include "Logging.h"
 #include "MediaQueryList.h"
 #include "Navigation.h"
 #include "Navigator.h"
@@ -112,7 +113,10 @@ bool DOMWindow::closed() const
 
 void DOMWindow::close(Document& document)
 {
-    if (document.canNavigate(protect(frame()).get()) != CanNavigateState::Able)
+    bool canClose = document.canNavigate(protect(frame()).get()) == CanNavigateState::Able;
+    RELEASE_LOG_DEBUG(DOMAPI, "DOMWindow::close canClose=%d frameID=%" PRIu64, canClose, frame() ? protect(frame())->frameID().toUInt64() : 0);
+
+    if (!canClose)
         return;
     close();
 }
@@ -159,6 +163,9 @@ WebCoreOpaqueRoot root(DOMWindow* window)
 WindowProxy* DOMWindow::opener() const
 {
     RefPtr frame = this->frame();
+
+    RELEASE_LOG_DEBUG(DOMAPI, "DOMWindow::opener hasOpener=%d frameID=%" PRIu64, frame && frame->opener(), frame ? frame->frameID().toUInt64() : 0);
+
     if (!frame)
         return nullptr;
 
@@ -561,6 +568,7 @@ ExceptionOr<Performance&> DOMWindow::performance() const
 
 ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& globalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue message, WindowPostMessageOptions&& options)
 {
+    RELEASE_LOG_DEBUG(DOMAPI, "DOMWindow::postMessage frameID=%" PRIu64, frame() ? frame()->frameID().toUInt64() : 0);
     switch (m_type) {
     case DOMWindowType::Local:
         return downcast<LocalDOMWindow>(*this).postMessage(globalObject, incumbentWindow, message, WTF::move(options));
@@ -572,6 +580,7 @@ ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& globalObject, Loca
 
 ExceptionOr<void> DOMWindow::postMessage(JSC::JSGlobalObject& globalObject, LocalDOMWindow& incumbentWindow, JSC::JSValue message, String&& targetOrigin, Vector<JSC::Strong<JSC::JSObject>>&& transfer)
 {
+    RELEASE_LOG_DEBUG(DOMAPI, "DOMWindow::postMessage frameID=%" PRIu64, frame() ? protect(frame())->frameID().toUInt64() : 0);
     return postMessage(globalObject, incumbentWindow, message, WindowPostMessageOptions { { WTF::move(transfer) }, WTF::move(targetOrigin) });
 }
 

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -35,6 +35,7 @@
 #include "LocalDOMWindow.h"
 #include "LocalDOMWindowProperty.h"
 #include "LocalFrame.h"
+#include "Logging.h"
 #include "NavigationScheduler.h"
 #include "Quirks.h"
 #include "ScriptWrappableInlines.h"
@@ -144,6 +145,7 @@ Ref<DOMStringList> Location::ancestorOrigins() const
 
 String Location::hash() const
 {
+    RELEASE_LOG_DEBUG(DOMAPI, "Location::hash length=%u frameID=%" PRIu64, url().fragmentIdentifier().length(), frame() ? protect(frame())->frameID().toUInt64() : 0);
     return url().fragmentIdentifier().isEmpty() ? emptyString() : url().fragmentIdentifierWithLeadingNumberSign().toString();
 }
 

--- a/Source/WebCore/platform/Logging.h
+++ b/Source/WebCore/platform/Logging.h
@@ -96,6 +96,7 @@ namespace WebCore {
     M(DisplayLink) \
     M(DisplayLists) \
     M(DragAndDrop) \
+    M(DOMAPI) \
     M(DOMTimers) \
     M(Editing) \
     M(EME) \


### PR DESCRIPTION
#### 28a27645938924647145b2e3965778eb98830eec
<pre>
Add DOMWindow/Location debug logging
<a href="https://rdar.apple.com/170712043">rdar://170712043</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308215">https://bugs.webkit.org/show_bug.cgi?id=308215</a>

Reviewed by Chris Dumez.

We add some debug logging related to window.location.hash, window.opener, window.postMessage and window.close.

Canonical link: <a href="https://commits.webkit.org/307907@main">https://commits.webkit.org/307907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1626baa03b82500f402cc725d2d0fc32aad3f34

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145661 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18343 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10226 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99298 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19241b51-d8fe-48ea-b38c-e682ab57c5b4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18236 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112021 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80261 "2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9ea5e8c7-5356-44fb-91e0-b1ba74a923e6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148624 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14396 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130837 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92926 "Found 1 new API test failure: WPE/TestWebKitWebXR:/webkit/WebKitWebXR/leave-immersive-mode (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ba71b9e-b2e2-4281-af52-6ebd11fd8530) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13705 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11464 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1780 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123251 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156646 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8773 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120020 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18193 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15177 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120372 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30902 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/128950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/73933 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16101 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7088 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17814 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81594 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17551 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17759 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17614 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->