### PR TITLE
REGRESSION(305273@main): [GTK] Another PDF rendering regression

### DIFF
--- a/LayoutTests/fast/canvas/canvas-recording-clip-state-across-frames-expected.html
+++ b/LayoutTests/fast/canvas/canvas-recording-clip-state-across-frames-expected.html
@@ -1,0 +1,24 @@
+<style>
+    canvas {
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<body>
+    <p>This test verifies that clip state is preserved across canvas recording flush boundaries.</p>
+    <canvas id="canvas"></canvas>
+    <script>
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 200;
+        canvas.height = 200;
+
+        // Green background.
+        ctx.fillStyle = 'green';
+        ctx.fillRect(0, 0, 200, 200);
+
+        // Blue square only in the clipped area.
+        ctx.fillStyle = 'blue';
+        ctx.fillRect(50, 50, 100, 100);
+    </script>
+</body>

--- a/LayoutTests/fast/canvas/canvas-recording-clip-state-across-frames.html
+++ b/LayoutTests/fast/canvas/canvas-recording-clip-state-across-frames.html
@@ -1,0 +1,47 @@
+<style>
+    canvas {
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<body>
+    <p>This test verifies that clip state is preserved across canvas recording flush boundaries.</p>
+    <canvas id="canvas"></canvas>
+    <script>
+        if (window.testRunner)
+            testRunner.waitUntilDone();
+
+        const canvas = document.getElementById('canvas');
+        const ctx = canvas.getContext('2d');
+        canvas.width = 200;
+        canvas.height = 200;
+
+        // Fill entire canvas green.
+        ctx.fillStyle = 'green';
+        ctx.fillRect(0, 0, 200, 200);
+
+        // Set up a clipping region.
+        ctx.save();
+        ctx.beginPath();
+        ctx.rect(50, 50, 100, 100);
+        ctx.clip();
+
+        // Use a double requestAnimationFrame to guarantee at least one
+        // composite cycle (prepareForDisplay) happens between setting up
+        // the clip and the subsequent draw. This flushes the canvas
+        // recording to the GPU surface and starts a new recording.
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                // This fillRect should still be clipped to (50,50)-(150,150).
+                // Without proper state replay the clip would be lost after
+                // the recording flush, and the blue would cover the entire canvas.
+                ctx.fillStyle = 'blue';
+                ctx.fillRect(0, 0, 200, 200);
+                ctx.restore();
+
+                if (window.testRunner)
+                    testRunner.notifyDone();
+            });
+        });
+    </script>
+</body>

--- a/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
+++ b/Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h
@@ -66,7 +66,6 @@ private:
 
     std::unique_ptr<GLFence> flushCanvasRecordingContextIfNeeded();
     void ensureCanvasRecordingContext();
-    void copyGraphicsState(const GraphicsContextSkia& from, GraphicsContextSkia& to);
 
 #if USE(COORDINATED_GRAPHICS)
     RefPtr<GraphicsLayerContentsDisplayDelegate> layerContentsDisplayDelegate() const final;
@@ -74,7 +73,7 @@ private:
     RefPtr<GraphicsLayerContentsDisplayDelegate> m_layerContentsDisplayDelegate;
 #endif
 
-    bool m_shouldUseCanvasRecording { true };
+    bool m_hasActiveRecording : 1 { false };
     SkPictureRecorder m_pictureRecorder;
     std::unique_ptr<SkiaSwitchableCanvas> m_switchableCanvas;
     std::unique_ptr<GraphicsContextSkia> m_canvasRecordingContext;


### PR DESCRIPTION
#### 84a16ff08493df0ab04b93727da476c05ee37ff6
<pre>
REGRESSION(305273@main): [GTK] Another PDF rendering regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=306621">https://bugs.webkit.org/show_bug.cgi?id=306621</a>

Reviewed by Carlos Garcia Campos.

The canvas 2D operation recording feature (webkit.org/b/303575) introduced
a mechanism to batch canvas operations into an SkPicture for deferred GPU
replay. When flushing the recording, the implementation switched between a
recording canvas and the GPU surface canvas. To preserve drawing state
across these switches, it attempted to copy individual GraphicsContext
properties (fill color, stroke, CTM, etc.) from one context to the other.
This approach was inherently fragile: it could not reproduce the full
save/restore nesting, clip stack, or transparency layer state,
causing PDF rendering and other complex painting scenarios to break.

Replace the state-copying approach with a state replay mechanism.
GraphicsContextSkia now optionally tracks the full sequence of
save/restore operations, transparency layers, and clip operations
(rect, path, shader) along with their associated transforms. When
the canvas recording is flushed and the switchable canvas is
redirected to a new target, replayStateOnCanvas() reconstructs
the exact save/clip/CTM nesting on that canvas, ensuring drawing
state is fully preserved.

Unify SkiaState and LayerState into a single SkiaState struct that
handles both regular saves and transparency layers. Move recording
context creation from lazy initialization into the constructor,
eliminating the need for ensureCanvasRecordingContext() and the
error-prone copyGraphicsState() helper.

Test: fast/canvas/canvas-recording-clip-state-across-frames.html

* LayoutTests/fast/canvas/canvas-recording-clip-state-across-frames-expected.html: Added.
* LayoutTests/fast/canvas/canvas-recording-clip-state-across-frames.html: Added.
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::pushSkiaState):
(WebCore::GraphicsContextSkia::popSkiaState):
(WebCore::GraphicsContextSkia::recordClipIfNeeded):
(WebCore::GraphicsContextSkia::save):
(WebCore::GraphicsContextSkia::restore):
(WebCore::GraphicsContextSkia::drawOutsetShadow):
(WebCore::GraphicsContextSkia::createFillPaint const):
(WebCore::GraphicsContextSkia::createStrokePaint const):
(WebCore::GraphicsContextSkia::clip):
(WebCore::GraphicsContextSkia::clipPath):
(WebCore::GraphicsContextSkia::clipToImageBuffer):
(WebCore::GraphicsContextSkia::saveLayer):
(WebCore::GraphicsContextSkia::restoreLayer):
(WebCore::GraphicsContextSkia::setLineCap):
(WebCore::GraphicsContextSkia::setLineDash):
(WebCore::GraphicsContextSkia::setLineJoin):
(WebCore::GraphicsContextSkia::setMiterLimit):
(WebCore::GraphicsContextSkia::clipOut):
(WebCore::GraphicsContextSkia::enableStateReplayTracking):
(WebCore::GraphicsContextSkia::replayStateOnCanvas const):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.cpp:
(WebCore::ImageBufferSkiaAcceleratedBackend::~ImageBufferSkiaAcceleratedBackend):
(WebCore::ImageBufferSkiaAcceleratedBackend::context):
(WebCore::ImageBufferSkiaAcceleratedBackend::ensureCanvasRecordingContext):
(WebCore::ImageBufferSkiaAcceleratedBackend::flushCanvasRecordingContextIfNeeded):
(WebCore::ImageBufferSkiaAcceleratedBackend::flushContext):
(WebCore::ImageBufferSkiaAcceleratedBackend::prepareForDisplay):
(WebCore::ImageBufferSkiaAcceleratedBackend::copyGraphicsState): Deleted.
* Source/WebCore/platform/graphics/skia/ImageBufferSkiaAcceleratedBackend.h:

Canonical link: <a href="https://commits.webkit.org/308033@main">https://commits.webkit.org/308033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f7e1c908e15dbd130f1b8881cf7f2ea7013abd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146312 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18989 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/12330 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154979 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148187 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19462 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18884 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/112596 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99759 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/149275 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14948 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131457 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93465 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14215 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2425 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123783 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/9201 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/157300 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/471 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/10633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120627 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18806 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15757 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120925 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30971 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18826 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/130938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74591 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/16597 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/7975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18427 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82179 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18157 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18322 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18215 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->