### PR TITLE
[WPE] Fix speaker selection

### DIFF
--- a/LayoutTests/fast/mediastream/enumerate-speaker.html
+++ b/LayoutTests/fast/mediastream/enumerate-speaker.html
@@ -5,6 +5,7 @@
     <title>Test passing capture device IDs to getUserMedia</title>
     <script src="../../resources/testharness.js"></script>
     <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/platform-helper.js"></script>
     <script>
 
     function deviceFromLabel(devices, label)
@@ -24,6 +25,9 @@
 
     promise_test(async (test) => {
         window.internals.settings.setExposeSpeakersWithoutMicrophoneEnabled(false);
+        if (isWPE()) {
+            window.internals.settings.setExposeDefaultSpeakerAsSpecificDeviceEnabled(true);
+        }
 
         const stream = await navigator.mediaDevices.getUserMedia({ audio:true, video:true })
         test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2883,9 +2883,26 @@ ExposeDefaultSpeakerAsSpecificDeviceEnabled:
   condition: ENABLE(MEDIA_STREAM)
   defaultValue:
     WebKit:
+      "PLATFORM(WPE)": false
       default: true
     WebCore:
+      "PLATFORM(WPE)": false
       default: true
+
+ExposeJustDefaultSpeakerWithoutMicrophoneEnabled:
+  type: bool
+  status: internal
+  category: media
+  humanReadableName: "Expose only default speaker without label when no microphone is present"
+  humanReadableDescription: "Expose only default speaker without label when no microphone is present"
+  condition: ENABLE(MEDIA_STREAM)
+  defaultValue:
+    WebKit:
+      "PLATFORM(WPE)": true
+      default: false
+    WebCore:
+      "PLATFORM(WPE)": true
+      default: false
 
 ExposeRollAngleAsTwistEnabled:
   type: bool
@@ -2912,8 +2929,10 @@ ExposeSpeakersEnabled:
   defaultValue:
     WebKit:
       "PLATFORM(COCOA)": true
+      "PLATFORM(WPE)": true
       default: false
     WebCore:
+      "PLATFORM(WPE)": true
       default: false
 
 ExposeSpeakersWithoutMicrophoneEnabled:
@@ -2926,8 +2945,10 @@ ExposeSpeakersWithoutMicrophoneEnabled:
   defaultValue:
     WebKit:
       "PLATFORM(COCOA)": true
+      "PLATFORM(WPE)": true
       default: false
     WebCore:
+      "PLATFORM(WPE)": true
       default: false
 
 ExtendedAudioDescriptionsEnabled:
@@ -7828,8 +7849,10 @@ SpeakerSelectionRequiresUserGesture:
     WebKitLegacy:
       default: true
     WebKit:
+      "PLATFORM(WPE)": false
       default: true
     WebCore:
+      "PLATFORM(WPE)": false
       default: true
 
 SpeculationRulesPrefetchEnabled:

--- a/Source/WebCore/Modules/mediastream/MediaDevices.cpp
+++ b/Source/WebCore/Modules/mediastream/MediaDevices.cpp
@@ -376,6 +376,12 @@ void MediaDevices::exposeDevices(Vector<CaptureDeviceWithCapabilities>&& newDevi
     bool canAccessCamera = checkCameraAccess(document);
     bool canAccessMicrophone = checkMicrophoneAccess(document);
     bool canAccessSpeaker = checkSpeakerAccess(document);
+    bool shouldExposeSpeakersWithoutMic = exposeSpeakersWithoutMicrophoneAccess(document);
+    bool shouldExposeJustDefaultSpeakerWithoutMic = document->frame()->settings().exposeJustDefaultSpeakerWithoutMicrophoneEnabled()
+        && !shouldExposeDefaultSpeakerAsSpecificDevice && canAccessSpeaker && shouldExposeSpeakersWithoutMic;
+    bool hasAnyMicrophone = std::ranges::any_of(newDevices, [](auto& d) {
+        return d.device.type() == CaptureDevice::DeviceType::Microphone;
+    });
 
     m_audioOutputDeviceIdToPersistentId.clear();
 
@@ -398,14 +404,19 @@ void MediaDevices::exposeDevices(Vector<CaptureDeviceWithCapabilities>&& newDevi
         auto groupId = center.hashStringWithSalt(newDevice.groupId(), deviceIDHashSalts.ephemeralDeviceSalt);
 
         if (newDevice.type() == CaptureDevice::DeviceType::Speaker) {
-            if (exposeSpeakersWithoutMicrophoneAccess(document) || haveMicrophoneDevice(newDevices, newDevice.groupId())) {
+            bool hasMic = haveMicrophoneDevice(newDevices, newDevice.groupId());
+            if (shouldExposeSpeakersWithoutMic || hasMic) {
                 if (shouldExposeDefaultSpeakerAsSpecificDevice) {
                     shouldExposeDefaultSpeakerAsSpecificDevice = false;
                     devices.append(createDefaultSpeakerAsSpecificDevice(newDevice, groupId));
                 }
 
-                m_audioOutputDeviceIdToPersistentId.add(deviceId, newDevice.persistentId());
-                devices.append(MediaDeviceInfo::create(newDevice.label(), WTF::move(deviceId), WTF::move(groupId), MediaDeviceInfo::Kind::Audiooutput));
+                if (shouldExposeJustDefaultSpeakerWithoutMic && !hasAnyMicrophone)
+                    devices.append(MediaDeviceInfo::create(emptyString(), emptyString(), WTF::move(groupId), MediaDeviceInfo::Kind::Audiooutput));
+                else {
+                    m_audioOutputDeviceIdToPersistentId.add(deviceId, newDevice.persistentId());
+                    devices.append(MediaDeviceInfo::create(newDevice.label(), WTF::move(deviceId), WTF::move(groupId), MediaDeviceInfo::Kind::Audiooutput));
+                }
             }
         } else {
             if (newDevice.type() == CaptureDevice::DeviceType::Camera && !newDevice.label().isEmpty())

--- a/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
+++ b/Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp
@@ -313,6 +313,7 @@ void GStreamerCaptureDeviceManager::refreshCaptureDevices()
 {
     GST_DEBUG_OBJECT(m_deviceMonitor.get(), "Refreshing capture devices");
     m_devices.clear();
+    m_speakerDevices.clear();
     m_gstreamerDevices.clear();
     if (m_isTearingDown)
         return;

--- a/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
+++ b/Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp
@@ -993,8 +993,16 @@ void UserMediaPermissionRequestManagerProxy::computeFilteredDeviceList(FrameIden
 
     bool revealIdsAndLabels = cameraState == PermissionState::Granted || microphoneState == PermissionState::Granted;
     RefPtr page = m_page.get();
-    bool shoulExposeCaptureDevicesBasedOnPermission = page && !protect(page->preferences())->exposeCaptureDevicesAfterCaptureEnabled();
-    platformGetMediaStreamDevices(revealIdsAndLabels || wasGrantedVideoAccess(frameID) || wasGrantedAudioAccess(frameID), [frameID, logIdentifier = LOGIDENTIFIER, weakThis = WeakPtr { *this }, cameraState, microphoneState, revealIdsAndLabels, shoulExposeCaptureDevicesBasedOnPermission, completion = WTF::move(completion)](auto&& devicesWithCapabilities) mutable {
+    bool shouldExposeCaptureDevicesBasedOnPermission = false;
+    bool exposeJustDefaultSpeakerWithoutMicrophone = false;
+    if (page) {
+        Ref prefs = page->preferences();
+        shouldExposeCaptureDevicesBasedOnPermission = !prefs->exposeCaptureDevicesAfterCaptureEnabled();
+        exposeJustDefaultSpeakerWithoutMicrophone = prefs->exposeJustDefaultSpeakerWithoutMicrophoneEnabled()
+            && !prefs->exposeDefaultSpeakerAsSpecificDeviceEnabled() && prefs->exposeSpeakersEnabled()
+            && prefs->exposeSpeakersWithoutMicrophoneEnabled();
+    }
+    platformGetMediaStreamDevices(revealIdsAndLabels || wasGrantedVideoAccess(frameID) || wasGrantedAudioAccess(frameID), [frameID, logIdentifier = LOGIDENTIFIER, weakThis = WeakPtr { *this }, cameraState, microphoneState, revealIdsAndLabels, shouldExposeCaptureDevicesBasedOnPermission, exposeJustDefaultSpeakerWithoutMicrophone, completion = WTF::move(completion)](auto&& devicesWithCapabilities) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis) {
             completion({ });
@@ -1007,12 +1015,15 @@ void UserMediaPermissionRequestManagerProxy::computeFilteredDeviceList(FrameIden
 
         bool shouldRestrictCamera = !protectedThis->wasGrantedVideoAccess(frameID);
         bool shouldRestrictMicrophone = !protectedThis->wasGrantedAudioAccess(frameID);
-        if (shoulExposeCaptureDevicesBasedOnPermission) {
+        if (shouldExposeCaptureDevicesBasedOnPermission) {
             shouldRestrictCamera = cameraState == PermissionState::Denied || (!revealIdsAndLabels && !protectedThis->wasGrantedVideoAccess(frameID));
             shouldRestrictMicrophone = microphoneState == PermissionState::Denied || (!revealIdsAndLabels && !protectedThis->wasGrantedAudioAccess(frameID));
         }
 
         bool shouldRestrictSpeaker = !protectedThis->wasGrantedAudioAccess(frameID);
+        bool hasMicrophones = std::ranges::any_of(devicesWithCapabilities, [](auto& d) {
+            return d.device.type() == WebCore::CaptureDevice::DeviceType::Microphone && d.device.enabled();
+        });
         Vector<CaptureDeviceWithCapabilities> filteredDevices;
         for (auto& deviceWithCapabilities : devicesWithCapabilities) {
             auto& device = deviceWithCapabilities.device;
@@ -1038,12 +1049,15 @@ void UserMediaPermissionRequestManagerProxy::computeFilteredDeviceList(FrameIden
                 }
                 filteredDevices.append(deviceWithCapabilities);
                 break;
-            case WebCore::CaptureDevice::DeviceType::Speaker:
-                if (shouldRestrictSpeaker)
+            case WebCore::CaptureDevice::DeviceType::Speaker: {
+                bool canExposeJustDefault = exposeJustDefaultSpeakerWithoutMicrophone && !hasMicrophones;
+                bool shouldDropSpeaker = (canExposeJustDefault && !device.isDefault()) || (!canExposeJustDefault && shouldRestrictSpeaker);
+                if (shouldDropSpeaker)
                     break;
                 speakerCount++;
                 filteredDevices.append(deviceWithCapabilities);
                 break;
+            }
             default:
                 break;
             }


### PR DESCRIPTION
#### 6be6b0a7d01f8a949457f7c62f820bdc5960a07c
<pre>
[WPE] Fix speaker selection
<a href="https://bugs.webkit.org/show_bug.cgi?id=308219">https://bugs.webkit.org/show_bug.cgi?id=308219</a>

Reviewed by NOBODY (OOPS!).

Speaker selection had several issues that we fixed. First was the
default configurations for WPE.

The most complex one was fixing the problem of not returning any speaker
when there is no microphone present. For that we created a new setting
that allows a behavior closer to what Chromium does. It will return just
a device with an empty label and an empty device ID.

* LayoutTests/fast/mediastream/enumerate-speaker.html:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/Modules/mediastream/MediaDevices.cpp:
(WebCore::MediaDevices::exposeDevices):
* Source/WebCore/platform/mediastream/gstreamer/GStreamerCaptureDeviceManager.cpp:
(WebCore::GStreamerCaptureDeviceManager::refreshCaptureDevices):
* Source/WebKit/UIProcess/UserMediaPermissionRequestManagerProxy.cpp:
(WebKit::UserMediaPermissionRequestManagerProxy::computeFilteredDeviceList):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6be6b0a7d01f8a949457f7c62f820bdc5960a07c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/14116 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/101253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20427 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/156521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/101253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150800 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/16222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/156521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/15369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/13155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/3961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/139808 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/124974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/10693 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158856 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/8626 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/12184 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/122005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20322 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/17084 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/122206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/20333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/132490 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/76464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/9255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/179260 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19938 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83700 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/45925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/19667 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19818 "Built successfully") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/19725 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->