### PR TITLE
Use more Ref instead of RefPtr in WebCore's history, loader, & platform

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -625,7 +625,7 @@ void BackForwardCache::prune(PruningReason pruningReason)
     }
 }
 
-void BackForwardCache::clearEntriesForOrigins(const HashSet<RefPtr<SecurityOrigin>>& origins)
+void BackForwardCache::clearEntriesForOrigins(const HashSet<Ref<SecurityOrigin>>& origins)
 {
     m_cachedPageMap.removeIf([&](auto& pair) -> bool {
         if (auto* cachedPage = std::get_if<UniqueRef<CachedPage>>(&pair.value)) {

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -64,7 +64,7 @@ public:
 
     void removeAllItemsForPage(Page&);
 
-    WEBCORE_EXPORT void clearEntriesForOrigins(const HashSet<RefPtr<SecurityOrigin>>&);
+    WEBCORE_EXPORT void clearEntriesForOrigins(const HashSet<Ref<SecurityOrigin>>&);
 
     unsigned pageCount() const { return m_items.size(); }
     WEBCORE_EXPORT unsigned frameCount() const;

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2039,7 +2039,7 @@ void DocumentLoader::addSubresourceLoader(SubresourceLoader& loader)
     }
 #endif
 
-    m_subresourceLoaders.add(&loader);
+    m_subresourceLoaders.add(loader);
 }
 
 void DocumentLoader::removeSubresourceLoader(LoadCompletionType type, SubresourceLoader& loader)
@@ -2055,7 +2055,7 @@ void DocumentLoader::addPlugInStreamLoader(ResourceLoader& loader)
 {
     ASSERT(!m_plugInStreamLoaders.contains(&loader));
 
-    m_plugInStreamLoaders.add(&loader);
+    m_plugInStreamLoaders.add(loader);
 }
 
 void DocumentLoader::removePlugInStreamLoader(ResourceLoader& loader)
@@ -2409,7 +2409,7 @@ void DocumentLoader::clearMainResource()
 
 void DocumentLoader::subresourceLoaderFinishedLoadingOnePart(ResourceLoader& loader)
 {
-    if (!m_multipartSubresourceLoaders.add(&loader).isNewEntry)
+    if (!m_multipartSubresourceLoaders.add(loader).isNewEntry)
         ASSERT(!m_subresourceLoaders.contains(&loader));
     else {
         ASSERT(m_subresourceLoaders.contains(&loader));

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -108,7 +108,7 @@ enum class LoadWillContinueInAnotherProcess : bool;
 enum class ShouldContinue;
 enum class ShouldTreatAsContinuingLoad : uint8_t;
 
-using ResourceLoaderMap = HashSet<RefPtr<ResourceLoader>>;
+using ResourceLoaderMap = HashSet<Ref<ResourceLoader>>;
 
 enum class AutoplayQuirk : uint8_t {
     SynthesizedPauseEvents = 1 << 0,

--- a/Source/WebCore/loader/archive/Archive.cpp
+++ b/Source/WebCore/loader/archive/Archive.cpp
@@ -38,16 +38,16 @@ Archive::~Archive() = default;
 
 void Archive::clearAllSubframeArchives()
 {
-    HashSet<RefPtr<Archive>> clearedArchives;
-    clearedArchives.add(this);
+    HashSet<Ref<Archive>> clearedArchives;
+    clearedArchives.add(*this);
     clearAllSubframeArchives(clearedArchives);
 }
 
-void Archive::clearAllSubframeArchives(HashSet<RefPtr<Archive>>& clearedArchives)
+void Archive::clearAllSubframeArchives(HashSet<Ref<Archive>>& clearedArchives)
 {
-    ASSERT(clearedArchives.contains(this));
+    ASSERT(clearedArchives.contains(*this));
     for (auto& archive : m_subframeArchives) {
-        if (clearedArchives.add(archive.ptr()))
+        if (clearedArchives.add(archive).isNewEntry)
             archive->clearAllSubframeArchives(clearedArchives);
     }
     m_subframeArchives.clear();

--- a/Source/WebCore/loader/archive/Archive.h
+++ b/Source/WebCore/loader/archive/Archive.h
@@ -59,7 +59,7 @@ protected:
     void clearAllSubframeArchives();
 
 private:
-    void clearAllSubframeArchives(HashSet<RefPtr<Archive>>&);
+    void clearAllSubframeArchives(HashSet<Ref<Archive>>&);
 
     RefPtr<ArchiveResource> m_mainResource;
     Vector<Ref<ArchiveResource>> m_subresources;

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -576,7 +576,7 @@ void MemoryCache::removeResourcesWithOrigin(const ClientOrigin& origin)
     removeResourcesWithOrigin(origin.clientOrigin.securityOrigin(), cachePartition);
 }
 
-void MemoryCache::removeResourcesWithOrigins(PAL::SessionID sessionID, const HashSet<RefPtr<SecurityOrigin>>& origins)
+void MemoryCache::removeResourcesWithOrigins(PAL::SessionID sessionID, const HashSet<Ref<SecurityOrigin>>& origins)
 {
     RELEASE_ASSERT(isMainThread());
     auto* resourceMap = sessionResourceMap(sessionID);
@@ -621,11 +621,11 @@ void MemoryCache::getOriginsWithCache(SecurityOriginSet& origins)
     }
 }
 
-HashSet<RefPtr<SecurityOrigin>> MemoryCache::originsWithCache(PAL::SessionID sessionID) const
+HashSet<Ref<SecurityOrigin>> MemoryCache::originsWithCache(PAL::SessionID sessionID) const
 {
     RELEASE_ASSERT(isMainThread());
 
-    HashSet<RefPtr<SecurityOrigin>> origins;
+    HashSet<Ref<SecurityOrigin>> origins;
 
     auto it = m_sessionResources.find(sessionID);
     if (it != m_sessionResources.end()) {

--- a/Source/WebCore/loader/cache/MemoryCache.h
+++ b/Source/WebCore/loader/cache/MemoryCache.h
@@ -161,13 +161,13 @@ public:
     void resourceAccessed(CachedResource&);
     bool inLiveDecodedResourcesList(CachedResource&) const;
 
-    using SecurityOriginSet = HashSet<RefPtr<SecurityOrigin>>;
+    using SecurityOriginSet = HashSet<Ref<SecurityOrigin>>;
     WEBCORE_EXPORT void removeResourcesWithOrigin(const SecurityOrigin&);
     void removeResourcesWithOrigin(const SecurityOrigin&, const String& cachePartition);
     WEBCORE_EXPORT void removeResourcesWithOrigin(const ClientOrigin&);
-    WEBCORE_EXPORT void removeResourcesWithOrigins(PAL::SessionID, const HashSet<RefPtr<SecurityOrigin>>&);
+    WEBCORE_EXPORT void removeResourcesWithOrigins(PAL::SessionID, const HashSet<Ref<SecurityOrigin>>&);
     WEBCORE_EXPORT void getOriginsWithCache(SecurityOriginSet& origins);
-    WEBCORE_EXPORT HashSet<RefPtr<SecurityOrigin>> originsWithCache(PAL::SessionID) const;
+    WEBCORE_EXPORT HashSet<Ref<SecurityOrigin>> originsWithCache(PAL::SessionID) const;
 
     // pruneDead*() - Flush decoded and encoded data from resources not referenced by Web pages.
     // pruneLive*() - Flush decoded data from resources still referenced by Web pages.

--- a/Source/WebCore/loader/mac/DocumentLoaderMac.cpp
+++ b/Source/WebCore/loader/mac/DocumentLoaderMac.cpp
@@ -35,13 +35,13 @@ namespace WebCore {
 
 static void scheduleAll(const ResourceLoaderMap& loaders, SchedulePair& pair)
 {
-    for (RefPtr loader : copyToVector(loaders))
+    for (Ref loader : copyToVector(loaders))
         loader->schedule(pair);
 }
 
 static void unscheduleAll(const ResourceLoaderMap& loaders, SchedulePair& pair)
 {
-    for (RefPtr loader : copyToVector(loaders))
+    for (Ref loader : copyToVector(loaders))
         loader->unschedule(pair);
 }
 

--- a/Source/WebCore/page/SecurityOriginHash.h
+++ b/Source/WebCore/page/SecurityOriginHash.h
@@ -30,8 +30,7 @@
 
 #include <WebCore/SecurityOrigin.h>
 #include <wtf/Hasher.h>
-#include <wtf/RefPtr.h>
-#include <wtf/URL.h>
+#include <wtf/Ref.h>
 
 namespace WebCore {
 
@@ -40,9 +39,9 @@ struct SecurityOriginHash {
     {
         return computeHash(*origin);
     }
-    static unsigned hash(const RefPtr<SecurityOrigin>& origin)
+    static unsigned hash(const Ref<SecurityOrigin>& origin)
     {
-        return hash(origin.get());
+        return hash(origin.ptr());
     }
 
     static bool equal(const SecurityOrigin* a, const SecurityOrigin* b)
@@ -51,17 +50,17 @@ struct SecurityOriginHash {
             return a == b;
         return a->isSameSchemeHostPort(*b);
     }
-    static bool equal(const SecurityOrigin* a, const RefPtr<SecurityOrigin>& b)
+    static bool equal(const SecurityOrigin* a, const Ref<SecurityOrigin>& b)
     {
-        return equal(a, b.get());
+        return equal(a, b.ptr());
     }
-    static bool equal(const RefPtr<SecurityOrigin>& a, const SecurityOrigin* b)
+    static bool equal(const Ref<SecurityOrigin>& a, const SecurityOrigin* b)
     {
-        return equal(a.get(), b);
+        return equal(a.ptr(), b);
     }
-    static bool equal(const RefPtr<SecurityOrigin>& a, const RefPtr<SecurityOrigin>& b)
+    static bool equal(const Ref<SecurityOrigin>& a, const Ref<SecurityOrigin>& b)
     {
-        return equal(a.get(), b.get());
+        return equal(a.ptr(), b.ptr());
     }
 
     static const bool safeToCompareToEmptyOrDeleted = false;
@@ -72,6 +71,6 @@ struct SecurityOriginHash {
 namespace WTF {
 
 template<typename> struct DefaultHash;
-template<> struct DefaultHash<RefPtr<WebCore::SecurityOrigin>> : WebCore::SecurityOriginHash { };
+template<> struct DefaultHash<Ref<WebCore::SecurityOrigin>> : WebCore::SecurityOriginHash { };
 
 } // namespace WTF

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateAVFoundationObjC.mm
@@ -142,12 +142,6 @@
 
 #import <pal/cocoa/MediaToolboxSoftLink.h>
 
-namespace std {
-template <> struct iterator_traits<HashSet<RefPtr<WebCore::MediaSelectionOptionAVFObjC>>::iterator> {
-    typedef RefPtr<WebCore::MediaSelectionOptionAVFObjC> value_type;
-};
-}
-
 // Note: This must be defined before our SOFT_LINK macros:
 @class AVMediaSelectionOption;
 @interface AVMediaSelectionOption (OutOfBandExtensions)

--- a/Source/WebCore/platform/mock/GeolocationClientMock.cpp
+++ b/Source/WebCore/platform/mock/GeolocationClientMock.cpp
@@ -85,7 +85,7 @@ int GeolocationClientMock::numberOfPendingPermissionRequests() const
 
 void GeolocationClientMock::requestPermission(Geolocation& geolocation)
 {
-    m_pendingPermission.add(&geolocation);
+    m_pendingPermission.add(geolocation);
     if (m_permissionState != PermissionStateUnset)
         asyncUpdatePermission();
 }
@@ -93,7 +93,7 @@ void GeolocationClientMock::requestPermission(Geolocation& geolocation)
 void GeolocationClientMock::cancelPermissionRequest(Geolocation& geolocation)
 {
     // Called from Geolocation::disconnectFrame() in response to Frame destruction.
-    m_pendingPermission.remove(&geolocation);
+    m_pendingPermission.remove(geolocation);
     if (m_pendingPermission.isEmpty() && m_permissionTimer.isActive())
         m_permissionTimer.stop();
 }
@@ -114,7 +114,7 @@ void GeolocationClientMock::permissionTimerFired()
     // no further requests for permission to the mock. Consequently the callbacks
     // which fire synchronously from Geolocation::setIsAllowed() cannot reentrantly modify
     // m_pendingPermission.
-    for (RefPtr permission : m_pendingPermission)
+    for (Ref permission : m_pendingPermission)
         permission->setIsAllowed(allowed, { });
     m_pendingPermission.clear();
 }

--- a/Source/WebCore/platform/mock/GeolocationClientMock.h
+++ b/Source/WebCore/platform/mock/GeolocationClientMock.h
@@ -97,7 +97,7 @@ private:
         PermissionStateDenied,
     } m_permissionState { PermissionStateUnset };
 
-    using GeolocationSet = HashSet<RefPtr<Geolocation>>;
+    using GeolocationSet = HashSet<Ref<Geolocation>>;
     GeolocationSet m_pendingPermission;
 };
 

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.h
@@ -80,7 +80,7 @@ WEBCORE_EXPORT @interface WebCoreNSURLSession : NSObject {
     RetainPtr<NSURLSessionConfiguration> _configuration;
     Lock _dataTasksLock;
     HashSet<RetainPtr<WebCoreNSURLSessionDataTask>> _dataTasks WTF_GUARDED_BY_LOCK(_dataTasksLock);
-    HashSet<RefPtr<WebCore::SecurityOrigin>> _origins WTF_GUARDED_BY_LOCK(_dataTasksLock);
+    HashSet<Ref<WebCore::SecurityOrigin>> _origins WTF_GUARDED_BY_LOCK(_dataTasksLock);
     BOOL _invalidated; // Access on multiple thread, must be accessed via ObjC property.
     NSUInteger _nextTaskIdentifier;
     RefPtr<WTF::WorkQueue> _internalQueue;

--- a/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
+++ b/Source/WebCore/platform/network/cocoa/WebCoreNSURLSession.mm
@@ -447,7 +447,7 @@ NS_ASSUME_NONNULL_END
     ASSERT(isMainThread());
     Locker<Lock> locker(_dataTasksLock);
     for (auto& responseOrigin : _origins) {
-        if (!origin.isSameOriginDomain(*responseOrigin))
+        if (!origin.isSameOriginDomain(responseOrigin))
             return true;
     }
     return false;

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1701,7 +1701,7 @@ void WebProcess::deleteWebsiteDataForOrigin(OptionSet<WebsiteDataType> websiteDa
     if (websiteDataTypes.contains(WebsiteDataType::MemoryCache)) {
         MemoryCache::singleton().removeResourcesWithOrigin(origin);
         if (origin.topOrigin == origin.clientOrigin)
-            BackForwardCache::singleton().clearEntriesForOrigins({ RefPtr<SecurityOrigin> { origin.clientOrigin.securityOrigin() } });
+            BackForwardCache::singleton().clearEntriesForOrigins({ Ref { origin.clientOrigin.securityOrigin() } });
     }
     completionHandler();
 }
@@ -1718,7 +1718,7 @@ void WebProcess::reloadExecutionContextsForOrigin(const ClientOrigin& origin, st
 void WebProcess::deleteWebsiteDataForOrigins(OptionSet<WebsiteDataType> websiteDataTypes, const Vector<WebCore::SecurityOriginData>& originDatas, CompletionHandler<void()>&& completionHandler)
 {
     if (websiteDataTypes.contains(WebsiteDataType::MemoryCache)) {
-        HashSet<RefPtr<SecurityOrigin>> origins;
+        HashSet<Ref<SecurityOrigin>> origins;
         for (auto& originData : originDatas)
             origins.add(originData.securityOrigin());
 


### PR DESCRIPTION
#### c05551f8aa4f5f03cdd707b0a07b140ecb8df2ac
<pre>
Use more Ref instead of RefPtr in WebCore&apos;s history, loader, &amp; platform
<a href="https://bugs.webkit.org/show_bug.cgi?id=308223">https://bugs.webkit.org/show_bug.cgi?id=308223</a>

Reviewed by Chris Dumez.

Improve code clarity.

Canonical link: <a href="https://commits.webkit.org/307882@main">https://commits.webkit.org/307882@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1198f24969641f23d5a42bae85cb80502a12a47b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145720 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99353 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bee081f8-b3a0-46bd-8ae0-538eeb41707c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147595 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18896 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18300 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112073 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148683 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14448 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130900 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92976 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/caf3cac7-a3b6-43a7-8a3d-aac78f3f477c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13761 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11523 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123309 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156713 "Built successfully") | | 
| | [⏳ 🛠 ios-safer-cpp ](https://ews-build.webkit.org/#/builders/Apple-iOS-26-Safer-CPP-Checks-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8892 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120078 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18258 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15247 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120422 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129053 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74004 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22483 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16151 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7155 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17879 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17615 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17825 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17678 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->