### PR TITLE
[appearance: base] Optimize ::picker-icon renderer look ups

### DIFF
--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -2595,6 +2595,16 @@ void RenderElement::setBackdropRenderer(RenderBlockFlow& renderer)
     ensureRareData().backdropRenderer = renderer;
 }
 
+SingleThreadWeakPtr<RenderBlockFlow> RenderElement::pickerIconRenderer() const
+{
+    return hasRareData() ? rareData().pickerIconRenderer : nullptr;
+}
+
+void RenderElement::setPickerIconRenderer(RenderBlockFlow& renderer)
+{
+    ensureRareData().pickerIconRenderer = renderer;
+}
+
 Overflow RenderElement::effectiveOverflowX() const
 {
     auto overflowX = style().overflowX();

--- a/Source/WebCore/rendering/RenderElement.h
+++ b/Source/WebCore/rendering/RenderElement.h
@@ -293,6 +293,9 @@ public:
     SingleThreadWeakPtr<RenderBlockFlow> backdropRenderer() const;
     void setBackdropRenderer(RenderBlockFlow&);
 
+    SingleThreadWeakPtr<RenderBlockFlow> pickerIconRenderer() const;
+    void setPickerIconRenderer(RenderBlockFlow&);
+
     ReferencedSVGResources& ensureReferencedSVGResources();
 
     Overflow NODELETE effectiveOverflowX() const;

--- a/Source/WebCore/rendering/RenderObject.h
+++ b/Source/WebCore/rendering/RenderObject.h
@@ -1293,6 +1293,7 @@ private:
         // From RenderElement
         std::unique_ptr<ReferencedSVGResources> referencedSVGResources;
         SingleThreadWeakPtr<RenderBlockFlow> backdropRenderer;
+        SingleThreadWeakPtr<RenderBlockFlow> pickerIconRenderer;
 
         // From RenderBox
         RefPtr<ControlPart> controlPart;

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp
@@ -112,6 +112,8 @@ void RenderTreeBuilder::FormControls::updateAfterDescendants(RenderElement& rend
 void RenderTreeBuilder::FormControls::updatePseudoElement(PseudoElementType type, RenderElement& renderer, StyleAppearance usedAppearance, RenderObject* beforeChild)
 {
     auto existingPseudoElement = [&] -> CheckedPtr<RenderElement> {
+        if (type == PseudoElementType::PickerIcon)
+            return renderer.pickerIconRenderer().get();
         for (CheckedRef child : childrenOfType<RenderElement>(renderer)) {
             if (child->style().pseudoElementType() == type)
                 return child;
@@ -156,6 +158,9 @@ void RenderTreeBuilder::FormControls::updatePseudoElement(PseudoElementType type
 
     if (pseudoElement->style().content().isData())
         RenderTreeUpdater::GeneratedContent::createContentRenderers(m_builder, *pseudoElement, pseudoElement->style(), type);
+
+    if (type == PseudoElementType::PickerIcon)
+        renderer.setPickerIconRenderer(*pseudoElement.get());
 
     m_builder.attach(renderer, WTF::move(pseudoElement), beforeChild);
 }

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -91,10 +91,9 @@ const std::optional<const Styleable> Styleable::fromRenderer(const RenderElement
         break;
     }
     case PseudoElementType::PickerIcon: {
-        /* FIXME: Optimize this to avoid the full ancestor walk. */
         auto* ancestor = renderer.parent();
         while (ancestor) {
-            if (ancestor->element())
+            if (ancestor->element() && ancestor->pickerIconRenderer() == &renderer)
                 return Styleable(*ancestor->element(), Style::PseudoElementIdentifier { PseudoElementType::PickerIcon });
             ancestor = ancestor->parent();
         }


### PR DESCRIPTION
#### 9602fd73f1e55c18f9f1b69c060b9625082a9ce1
<pre>
[appearance: base] Optimize ::picker-icon renderer look ups
<a href="https://bugs.webkit.org/show_bug.cgi?id=308229">https://bugs.webkit.org/show_bug.cgi?id=308229</a>
<a href="https://rdar.apple.com/170737149">rdar://170737149</a>

Reviewed by Antti Koivisto.

Store a WeakPtr to the :picker-icon renderer in the &lt;select&gt; element renderer.
Use this pointer while navigating up to ensure we return the ancestor &lt;select&gt;
element correctly.

* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::pickerIconRenderer const):
(WebCore::RenderElement::setPickerIconRenderer):
* Source/WebCore/rendering/RenderElement.h:
* Source/WebCore/rendering/RenderObject.h:
* Source/WebCore/rendering/updating/RenderTreeBuilderFormControls.cpp:
(WebCore::RenderTreeBuilder::FormControls::updatePseudoElement):
* Source/WebCore/style/Styleable.cpp:
(WebCore::Styleable::fromRenderer):

Canonical link: <a href="https://commits.webkit.org/308291@main">https://commits.webkit.org/308291@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe6ec8dda763009e4792717b64dc778c6af65c44

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19735 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155736 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/100468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/189a08b2-0403-429b-98c5-5652d58a7e6e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148928 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/20193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/19635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/113321 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/100468 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c450ef5f-cbfc-4122-aae3-e562ca81bd03) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150016 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/20193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/132115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94077 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d4fe473-13a5-4863-b787-835d897b4b48) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/20193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3178 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/20193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158067 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/1198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11476 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/121350 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19536 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/19635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121551 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31129 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/19545 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131793 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/75504 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/8611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82906 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/18881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19032 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/18940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->