### PR TITLE
Web Inspector: Remove experimental setting for case-insensitive JS completion

### DIFF
--- a/LayoutTests/inspector/console/js-completions-expected.txt
+++ b/LayoutTests/inspector/console/js-completions-expected.txt
@@ -14,7 +14,7 @@ PASS: Completions should change after cache is cleared.
 PASS: Completions should not contain myVariable after it's deleted by code run in console.
 
 -- Running test case: console.jsCompletions.completionOrdering
-Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":""} and experimentalShowCaseSensitiveAutocomplete=false:
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":""}:
 [
   "aa",
   "Aa",
@@ -24,7 +24,7 @@ Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":
   "__ab__"
 ]
 
-Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"a"} and experimentalShowCaseSensitiveAutocomplete=false:
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"a"}:
 [
   "aa",
   "ab",
@@ -32,7 +32,7 @@ Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":
   "Ab"
 ]
 
-Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"A"} and experimentalShowCaseSensitiveAutocomplete=false:
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"A"}:
 [
   "Aa",
   "Ab",
@@ -40,13 +40,13 @@ Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":
   "ab"
 ]
 
-Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"_"} and experimentalShowCaseSensitiveAutocomplete=false:
+Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"_"}:
 [
   "__aa__",
   "__ab__"
 ]
 
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":""} and experimentalShowCaseSensitiveAutocomplete=false:
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":""}:
 [
   "1",
   "2",
@@ -60,13 +60,13 @@ Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":
   "\"Ab\""
 ]
 
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"1"} and experimentalShowCaseSensitiveAutocomplete=false:
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"1"}:
 [
   "1",
   "10"
 ]
 
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"a"} and experimentalShowCaseSensitiveAutocomplete=false:
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"a"}:
 [
   "\"aa\"",
   "\"ab\"",
@@ -74,7 +74,7 @@ Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":
   "\"Ab\""
 ]
 
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"A"} and experimentalShowCaseSensitiveAutocomplete=false:
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"A"}:
 [
   "\"Aa\"",
   "\"Ab\"",
@@ -82,73 +82,7 @@ Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":
   "\"ab\""
 ]
 
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"_"} and experimentalShowCaseSensitiveAutocomplete=false:
-[
-  "\"__aa__\"",
-  "\"__ab__\""
-]
-
-Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":""} and experimentalShowCaseSensitiveAutocomplete=true:
-[
-  "aa",
-  "Aa",
-  "ab",
-  "Ab",
-  "__aa__",
-  "__ab__"
-]
-
-Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"a"} and experimentalShowCaseSensitiveAutocomplete=true:
-[
-  "aa",
-  "ab"
-]
-
-Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"A"} and experimentalShowCaseSensitiveAutocomplete=true:
-[
-  "Aa",
-  "Ab"
-]
-
-Completions with options={"baseString":"objectWithMixedPropertyKinds.","prefix":"_"} and experimentalShowCaseSensitiveAutocomplete=true:
-[
-  "__aa__",
-  "__ab__"
-]
-
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":""} and experimentalShowCaseSensitiveAutocomplete=true:
-[
-  "1",
-  "2",
-  "10",
-  "20",
-  "\"__aa__\"",
-  "\"__ab__\"",
-  "\"aa\"",
-  "\"Aa\"",
-  "\"ab\"",
-  "\"Ab\""
-]
-
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"1"} and experimentalShowCaseSensitiveAutocomplete=true:
-[
-  "1",
-  "10"
-]
-
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"a"} and experimentalShowCaseSensitiveAutocomplete=true:
-[
-  "\"aa\"",
-  "\"ab\""
-]
-
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"A"} and experimentalShowCaseSensitiveAutocomplete=true:
-[
-  "\"Aa\"",
-  "\"Ab\""
-]
-
-Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"_"} and experimentalShowCaseSensitiveAutocomplete=true:
+Completions with options={"baseString":"objectWithMixedPropertyKinds[","prefix":"\"_"}:
 [
   "\"__aa__\"",
   "\"__ab__\""

--- a/LayoutTests/inspector/console/js-completions.html
+++ b/LayoutTests/inspector/console/js-completions.html
@@ -70,12 +70,11 @@ function test()
         description: "Test that the JavaScript completions are ordered correctly.",
         async test() {
             const outputCompletions = async (options) => {
-                InspectorTest.log(`Completions with options=${JSON.stringify(options)} and experimentalShowCaseSensitiveAutocomplete=${WI.settings.experimentalShowCaseSensitiveAutocomplete.value}:`);
+                InspectorTest.log(`Completions with options=${JSON.stringify(options)}:`);
                 InspectorTest.json(await generateJSCompletions(options));
                 InspectorTest.log("");
             };
 
-            WI.settings.experimentalShowCaseSensitiveAutocomplete.value = false;
             WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
             await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: ""}));
             await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "a"}));
@@ -86,20 +85,6 @@ function test()
             await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"a"}));
             await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"A"}));
             await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"_"}));
-
-            WI.settings.experimentalShowCaseSensitiveAutocomplete.value = true;
-            WI.javaScriptRuntimeCompletionProvider.clearCachedPropertyNames();
-            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: ""}));
-            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "a"}));
-            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "A"}));
-            await outputCompletions(({baseString: "objectWithMixedPropertyKinds.", prefix: "_"}));
-            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: ""}));
-            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "1"}));
-            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"a"}));
-            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"A"}));
-            await outputCompletions(({baseString: "objectWithMixedPropertyKinds[", prefix: "\"_"}));
-
-            WI.settings.experimentalShowCaseSensitiveAutocomplete.reset();
         }
     });
 

--- a/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
+++ b/Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js
@@ -1891,7 +1891,6 @@ localizedStrings["Update Font"] = "Update Font";
 localizedStrings["Update Image"] = "Update Image";
 localizedStrings["Update Local Override"] = "Update Local Override";
 localizedStrings["Usage: %s"] = "Usage: %s";
-localizedStrings["Use case sensitive autocomplete"] = "Use case sensitive autocomplete";
 localizedStrings["Use default media styles"] = "Use default media styles";
 localizedStrings["Use fuzzy matching for CSS code completion"] = "Use fuzzy matching for CSS code completion";
 localizedStrings["Use mock capture devices"] = "Use mock capture devices";

--- a/Source/WebInspectorUI/UserInterface/Base/Setting.js
+++ b/Source/WebInspectorUI/UserInterface/Base/Setting.js
@@ -243,7 +243,6 @@ WI.settings = {
     experimentalCSSSortPropertyNameAutocompletionByUsage: new WI.Setting("experimental-css-sort-property-name-autocompletion-by-usage", true),
     experimentalEnableNetworkEmulatedCondition: new WI.Setting("experimental-enable-network-emulated-condition", false),
     experimentalGroupSourceMapErrors: new WI.Setting("experimental-group-source-map-errors", true),
-    experimentalShowCaseSensitiveAutocomplete: new WI.Setting("experimental-show-case-sensitive-auto-complete", false),
     experimentalLimitSourceCodeHighlighting: new WI.Setting("engineering-limit-source-code-highlighting", false),
     experimentalUseFuzzyMatchingForCSSCodeCompletion: new WI.Setting("experimental-use-fuzzy-matching-for-css-code-completion", true),
     experimentalUseStrictCheckForGlobMatching: new WI.Setting("experimental-use-strict-check-for-glob-matching", false),

--- a/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js
@@ -648,9 +648,8 @@ WI.CodeMirrorCompletionController = class CodeMirrorCompletionController extends
 
         var matchingWords = [];
 
-        var prefix = this._prefix;
+        let prefix = this._prefix;
         let prefixLowerCase = prefix.toLowerCase();
-        let caseSensitiveMatching = WI.settings.experimentalShowCaseSensitiveAutocomplete.value;
 
         var localState = mainToken.state.localState ? mainToken.state.localState : mainToken.state;
 
@@ -692,8 +691,7 @@ WI.CodeMirrorCompletionController = class CodeMirrorCompletionController extends
                 if (declaringVariable && !allowedKeywordsWhenDeclaringVariable.has(keyword))
                     continue;
 
-                let startsWithPrefix = caseSensitiveMatching ? keyword.startsWith(prefix) : keyword.toLowerCase().startsWith(prefixLowerCase);
-                if (!startsWithPrefix)
+                if (!keyword.toLowerCase().startsWith(prefixLowerCase))
                     continue;
 
                 matchingWords.push(keyword);
@@ -712,8 +710,7 @@ WI.CodeMirrorCompletionController = class CodeMirrorCompletionController extends
                     if (matchingWords.includes(variable.name))
                         continue;
 
-                    let startsWithPrefix = caseSensitiveMatching ? variable.name.startsWith(prefix) : variable.name.toLowerCase().startsWith(prefixLowerCase);
-                    if (!startsWithPrefix)
+                    if (!variable.name.toLowerCase().startsWith(prefixLowerCase))
                         continue;
 
                     matchingWords.push(variable.name);

--- a/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js
@@ -358,10 +358,9 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
                     implicitSuffix = "]";
             }
 
-            var completions = defaultCompletions;
+            let completions = defaultCompletions;
             let knownCompletions = new Set(completions);
             let prefixLowerCase = prefix.toLowerCase();
-            let caseSensitiveMatching = WI.settings.experimentalShowCaseSensitiveAutocomplete.value;
 
             for (var i = 0; i < propertyNames.length; ++i) {
                 var property = propertyNames[i];
@@ -377,8 +376,7 @@ WI.JavaScriptRuntimeCompletionProvider = class JavaScriptRuntimeCompletionProvid
                 if (knownCompletions.has(property))
                     continue;
 
-                let startsWithPrefix = caseSensitiveMatching ? property.startsWith(prefix) : property.toLowerCase().startsWith(prefixLowerCase);
-                if (!startsWithPrefix)
+                if (!property.toLowerCase().startsWith(prefixLowerCase))
                     continue;
 
                 completions.push(property);

--- a/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js
@@ -411,7 +411,6 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         
         let consoleGroup = experimentalSettingsView.addGroup(WI.UIString("Console:"));
         consoleGroup.addSetting(WI.settings.experimentalGroupSourceMapErrors, WI.UIString("Group source map network errors"));
-        consoleGroup.addSetting(WI.settings.experimentalShowCaseSensitiveAutocomplete, WI.UIString("Use case sensitive autocomplete"));
         
         experimentalSettingsView.addSeparator();
 
@@ -473,7 +472,6 @@ WI.SettingsTabContentView = class SettingsTabContentView extends WI.TabContentVi
         }
 
         listenForChange(WI.settings.experimentalGroupSourceMapErrors);
-        listenForChange(WI.settings.experimentalShowCaseSensitiveAutocomplete);
 
         if (hasCSSDomain) {
             listenForChange(WI.settings.experimentalEnableStylesJumpToEffective);


### PR DESCRIPTION
#### 35607a3cdd9121ad87d417649b9de7088e33ef60
<pre>
Web Inspector: Remove experimental setting for case-insensitive JS completion
<a href="https://bugs.webkit.org/show_bug.cgi?id=308232">https://bugs.webkit.org/show_bug.cgi?id=308232</a>

Reviewed by BJ Burg and Devin Rousso.

Remove the experimental setting and make case-insensitive autocompletion
the default behavior.

Test: inspector/console/js-completions-expected.txt

* LayoutTests/inspector/console/js-completions-expected.txt:
* LayoutTests/inspector/console/js-completions.html:
* Source/WebInspectorUI/Localizations/en.lproj/localizedStrings.js:
* Source/WebInspectorUI/UserInterface/Base/Setting.js:
* Source/WebInspectorUI/UserInterface/Controllers/CodeMirrorCompletionController.js:
(WI.CodeMirrorCompletionController.prototype._generateJavaScriptCompletions.):
(WI.CodeMirrorCompletionController.prototype._generateJavaScriptCompletions):
* Source/WebInspectorUI/UserInterface/Controllers/JavaScriptRuntimeCompletionProvider.js:
* Source/WebInspectorUI/UserInterface/Views/SettingsTabContentView.js:
(WI.SettingsTabContentView.prototype._createExperimentalSettingsView):

Canonical link: <a href="https://commits.webkit.org/308293@main">https://commits.webkit.org/308293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73c9ad658cd51ec7052fbb31b5a23337da8a0faa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18419 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154408 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99359 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18905 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18309 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112077 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80293 "1 flakes 1 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b0821b2a-c141-4948-b955-af81a44cb08c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130907 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92980 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8d0af28-8797-412b-a975-c79ed32eb6d7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13766 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11528 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1855 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123315 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7749 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156721 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/8 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8902 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120083 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18267 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15253 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120427 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18317 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74012 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22679 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16154 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7163 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17888 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81679 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17625 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17834 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17687 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->