### PR TITLE
Selection jumps around when selecting absolutely-positioned content inside element with user-select:none

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none-expected.txt
@@ -1,0 +1,6 @@
+First: Lorem ipsum dolor sit amet Second: Lorem ipsum dolor sit amet
+
+PASS Text with user-select:text is selectable even if it is inside a user-select:none element.
+PASS Select user-select:text content and then extend selection to user-select:none content.
+PASS Select user-select:text content and then extend selection to the next user-select:text element by crossing the user-select:none element.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+<body>
+<meta name="assert" content="Drag a selection that starts in a user-select:text element, should not extend to user-select:none content">
+<link rel="help" href="https://drafts.csswg.org/css-ui/#valdef-user-select-none">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src='/resources/testdriver-vendor.js'></script>
+
+<style>
+#container {
+  user-select: none;
+  -webkit-user-select: none;
+  width: 400px;
+  height: 200px;
+}
+#container div {
+  user-select: text;
+  -webkit-user-select: text;
+  position: absolute;
+}
+</style>
+
+<div id="container">
+    <div id="first" style="top: 20px; left: 20px;"> First: Lorem ipsum <span id="target" style="color: green;"> dolor sit</span> amet</div>
+    <div id="second" style="top: 120px; left: 20px;"> Second: Lorem ipsum dolor sit amet</div>
+</div>
+
+<script>
+promise_test(async function () {
+  const rect = target.getBoundingClientRect();
+  let actions = new test_driver.Actions();
+  await actions.pointerMove(rect.left + 5, rect.top + 5)
+      .pointerDown()
+      .pointerMove(rect.left + rect.width - 5, rect.top + 5)
+      .pointerUp()
+      .send();
+
+  const selection = window.getSelection();
+  assert_equals(selection.anchorNode, target.firstChild, "Anchor node: ");
+  assert_equals(selection.focusNode, target.firstChild, "Focus node: ");
+}, 'Text with user-select:text is selectable even if it is inside a user-select:none element.');
+
+promise_test(async function () {
+  const rect = target.getBoundingClientRect();
+  let actions = new test_driver.Actions();
+  await actions.pointerMove(rect.left + 5, rect.top + 5)
+      .pointerDown()
+      .pointerMove(rect.left + rect.width - 5, rect.top + 5)
+      .pointerMove(rect.left + rect.width - 5, rect.top + 50)
+      .pointerUp()
+      .send();
+
+  const selection = window.getSelection();
+  assert_equals(selection.anchorNode, target.firstChild, "Anchor node: ");
+  assert_equals(selection.focusNode, target.firstChild, "Focus node: ");
+}, 'Select user-select:text content and then extend selection to user-select:none content.');
+
+promise_test(async function () {
+  const rect = target.getBoundingClientRect();
+  let actions = new test_driver.Actions();
+  await actions.pointerMove(rect.left + 5, rect.top + 5)
+      .pointerDown()
+      .pointerMove(rect.left + rect.width - 5, rect.top + 5)
+      .pointerMove(rect.left + rect.width - 5, rect.top + 50)
+      .pointerMove(rect.left + rect.width - 5, rect.top + 100)
+      .pointerUp()
+      .send();
+
+  const selection = window.getSelection();
+  assert_equals(selection.anchorNode, target.firstChild, "Anchor node: ");
+  assert_equals(selection.focusNode, second.firstChild, "Focus node: ");
+}, 'Select user-select:text content and then extend selection to the next user-select:text element by crossing the user-select:none element.');
+</script>
+

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none-expected.txt
@@ -1,0 +1,6 @@
+First: Lorem ipsum dolor sit amet Second: Lorem ipsum dolor sit amet
+
+FAIL Text with user-select:text is selectable even if it is inside a user-select:none element. assert_equals: Anchor node:  expected Text node " dolor sit" but got null
+FAIL Select user-select:text content and then extend selection to user-select:none content. assert_equals: Anchor node:  expected Text node " dolor sit" but got null
+FAIL Select user-select:text content and then extend selection to the next user-select:text element by crossing the user-select:none element. assert_equals: Anchor node:  expected Text node " dolor sit" but got null
+

--- a/Source/WebCore/dom/Position.cpp
+++ b/Source/WebCore/dom/Position.cpp
@@ -929,7 +929,7 @@ bool Position::hasRenderedNonAnonymousDescendantsWithHeight(const RenderElement&
     return false;
 }
 
-bool Position::nodeIsUserSelectNone(Node* node)
+bool Position::nodeIsUserSelectNone(const Node* node)
 {
     if (!node)
         return false;

--- a/Source/WebCore/dom/Position.h
+++ b/Source/WebCore/dom/Position.h
@@ -179,7 +179,7 @@ public:
     static unsigned positionCountBetweenPositions(const Position&, const Position&);
 
     static bool hasRenderedNonAnonymousDescendantsWithHeight(const RenderElement&);
-    static bool nodeIsUserSelectNone(Node*);
+    static bool nodeIsUserSelectNone(const Node*);
     static bool nodeIsUserSelectAll(const Node*);
     static RefPtr<Node> rootUserSelectAllForNode(Node*);
 

--- a/Source/WebCore/html/HTMLElement.cpp
+++ b/Source/WebCore/html/HTMLElement.cpp
@@ -82,6 +82,7 @@
 #include "NodeName.h"
 #include "NodeTraversal.h"
 #include "PopoverData.h"
+#include "Position.h"
 #include "PseudoClassChangeInvalidation.h"
 #include "RenderElement.h"
 #include "ScriptController.h"
@@ -1029,10 +1030,40 @@ void HTMLElement::setHidden(const std::optional<Variant<bool, double, String>>& 
     });
 }
 
+
+// Determines if two nodes share the same nearest out-of-flow positioned ancestor.
+static bool haveSameOutOfFlowAncestor(const Node& anchorNode, const Node& targetNode)
+{
+    const CheckedPtr anchorRenderer = anchorNode.renderer();
+    const CheckedPtr targetRenderer = targetNode.renderer();
+    if (!anchorRenderer || !targetRenderer)
+        return true;
+
+    auto nearestOutOfFlowAncestor = [](CheckedPtr<RenderObject> renderer) -> CheckedPtr<RenderObject> {
+        while (renderer) {
+            if (renderer->isOutOfFlowPositioned())
+                return renderer;
+            renderer = renderer->containingBlock();
+        }
+        return nullptr;
+    };
+
+    CheckedPtr anchorOutOfFlowAncestor = nearestOutOfFlowAncestor(anchorRenderer);
+    CheckedPtr targetOutOfFlowAncestor = nearestOutOfFlowAncestor(targetRenderer);
+    return targetOutOfFlowAncestor == anchorOutOfFlowAncestor;
+}
+
 bool HTMLElement::shouldExtendSelectionToTargetNode(const Node& targetNode, const VisibleSelection& selectionBeforeUpdate)
 {
     if (auto range = selectionBeforeUpdate.range(); range && ImageOverlay::isInsideOverlay(*range))
         return ImageOverlay::isOverlayText(targetNode);
+
+    if (Position::nodeIsUserSelectNone(&targetNode)) {
+        if (RefPtr anchorNode = selectionBeforeUpdate.anchor().anchorNode()) {
+            // Don't extend selection to a user-select: none node if they are not in the same flow.
+            return haveSameOutOfFlowAncestor(*anchorNode, targetNode);
+        }
+    }
 
     return true;
 }


### PR DESCRIPTION
#### fada263bd12885ac2d60422b539da003d5531e9c
<pre>
Selection jumps around when selecting absolutely-positioned content inside element with user-select:none
<a href="https://bugs.webkit.org/show_bug.cgi?id=307340">https://bugs.webkit.org/show_bug.cgi?id=307340</a>

Reviewed by Simon Fraser.

In this scenario the content with user-select:text and its container with user-select:none are not in a same flow.
If a selection starts from the content then extend to its unselectable container, the selection jumps. To avoid it,
this patch stops extending the selection to an element with user-select:none if they are not in a same flow.

Test: imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none.html

* LayoutTests/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none.html: Added.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none-expected.txt: Added.
* Source/WebCore/html/HTMLElement.cpp:
(WebCore::haveSameOutOfFlowAncestor): Return true if target node and anchor node have same nearest out-of-flow ancestor.
(WebCore::HTMLElement::shouldExtendSelectionToTargetNode):

Canonical link: <a href="https://commits.webkit.org/308451@main">https://commits.webkit.org/308451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db64cfe9bdd576dc3b73c8d6edbcfc34d1aedfbb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147040 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/19721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/155722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/100454 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/148914 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/19621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113307 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80849 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/15545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94063 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/14752 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/12530 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3164 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124339 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158053 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1184 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/11460 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121331 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/19522 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16382 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/121532 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31237 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/19531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/131777 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/75490 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17090 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/8598 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19137 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/82892 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/18867 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19018 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/18926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->