### PR TITLE
REGRESSION(306540@main) : It caused Speedometer3 regression

### DIFF
--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics.html
@@ -1,23 +1,24 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
 <style>
     input:is([type=checkbox]:not([switch]), [type=radio]) {
-        appearance: base;
-        width: 200px;
-        height: 200px;
         font: 11px system-ui;
-        border: 0.3em solid currentColor;
+        height: -internal-auto-base(unset, 2em);
+        width: -internal-auto-base(unset, 2em);
+        border: -internal-auto-base(unset, 0.3em solid currentColor);
+        background-color: -internal-auto-base(unset, transparent);
     }
 
-    input[type="checkbox"] {
-        border-radius: 0.5em;
+    input:is([type=checkbox]:not([switch])) {
+        border-radius: -internal-auto-base(unset, 0.5em);
     }
 
-    input:is([type="checkbox"], [type="radio"]):disabled {
-        border-color: color-mix(in srgb, currentColor 30%, transparent);
-        background-color: color-mix(in srgb, currentColor 10%, transparent);
+    input[type=radio] {
+        border-radius: -internal-auto-base(unset, 100%);
     }
 
-    input:is([type=checkbox]:not([switch]), [type=radio]):checked:disabled::checkmark {
-        background-color: color-mix(in srgb, currentColor 30%, transparent);
+    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
+        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
+        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
     }
 
     .enabled input:is([type=checkbox]:not([switch]), [type=radio]) {
@@ -26,6 +27,12 @@
 
     .disabled input:is([type=checkbox]:not([switch]), [type=radio]) {
         color: darkgreen;
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        appearance: base;
+        width: 200px;
+        height: 200px;
     }
 </style>
 <body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-content-dynamic.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-content-dynamic.html
@@ -19,6 +19,10 @@
         line-height: 100%;
     }
 
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        content: "\2713" / "";
+    }
+
     .enabled input[type="checkbox"] {
         color: darkblue;
     }

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-content-text.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-content-text.html
@@ -18,6 +18,10 @@
         line-height: 100%; 
     }
 
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        content: "\2713" / "";
+    }
+
     input[type="checkbox"]:disabled {
         border-color: color-mix(in srgb, currentColor 30%, transparent);
         background-color: color-mix(in srgb, currentColor 10%, transparent);

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic-expected.html
@@ -1,19 +1,25 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
 <style>
+    /* This is supposed to be UA sheet. */
     input:is([type="radio"], [type="checkbox"]) {
         margin: 3px 2px;
         box-sizing: border-box;
-        border: 0.3em solid currentColor;
+        border: -internal-auto-base(initial, 0.3em solid currentColor);
         padding: initial;
-        background-color: transparent;
+        background-color: -internal-auto-base(initial, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch])) {
+        border-radius: -internal-auto-base(unset, 0.5em);
     }
 
     input[type=radio] {
-        border-radius: 50%;
+        border-radius: -internal-auto-base(unset, 100%);
     }
 
     input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
-        border-color: color-mix(in srgb, currentColor 30%, transparent);
-        background-color: color-mix(in srgb, currentColor 10%, transparent);
+        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
+        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
     }
 
     input[type=checkbox]:not([switch]):checked::checkmark {
@@ -36,6 +42,7 @@
         background-color: color-mix(in srgb, currentColor 30%, transparent);
     }
 
+    /* This is the beginning of the author sheet. */
     input:is([type=checkbox]:not([switch]), [type=radio]) {
         width: 50px;
         height: 50px;

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html
@@ -1,27 +1,39 @@
-<meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-1330" />
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
 <style>
-    input:is([type=checkbox]:not([switch]), [type=radio]) {
-        width: 50px;
-        height: 50px;
-        color: darkgreen;
-        font: 11px system-ui;
-        border: 0.3em solid currentColor;
+    /* This is supposed to be UA sheet. */
+    input:is([type="radio"], [type="checkbox"]) {
+        margin: 3px 2px;
+        box-sizing: border-box;
+        border: -internal-auto-base(initial, 0.3em solid currentColor);
+        padding: initial;
+        background-color: -internal-auto-base(initial, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch])) {
+        border-radius: -internal-auto-base(unset, 0.5em);
+    }
+
+    input[type=radio] {
+        border-radius: -internal-auto-base(unset, 100%);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
+        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
+        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
     }
 
     input[type=checkbox]:not([switch]):checked::checkmark {
-        background-color: currentColor;
-        display: inline-block;
         height: 100%;
         width: 100%;
-        mask: url("data:image/svg+xml, \
-            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
-                <path style='fill:black;' \
-                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
-            </svg>");
+        display: inline-block;
+        background-color: currentColor;
         content: none;
     }
 
     input[type=radio]:checked::checkmark {
+        background-color: currentColor;
+        display: inline-block;
+        border-radius: inherit;
         margin: 10%;
         height: 80%;
         width: 80%;
@@ -29,6 +41,25 @@
 
     input:is([type=checkbox]:not([switch]), [type=radio]):checked:disabled::checkmark {
         background-color: color-mix(in srgb, currentColor 30%, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark {
+        display: none;
+    }
+
+    /* This is the beginning of the author sheet. */
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        width: 50px;
+        height: 50px;
+        color: darkgreen;
+    }
+
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        mask: url("data:image/svg+xml, \
+            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
+                <path style='fill:black;' \
+                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
+            </svg>");
     }
 </style>
 <body>

--- a/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html
+++ b/LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html
@@ -1,36 +1,40 @@
+<!-- webkit-test-runner [ CSSInternalAutoBaseParsingEnabled=true ] -->
 <meta name="fuzzy" content="maxDifference=0-255; totalPixels=0-2486" />
 <style>
-    input:is([type=checkbox]:not([switch]), [type=radio]) {
-        appearance: base;
-        width: 50px;
-        height: 50px;
-        font: 11px system-ui;
-        border: 0.3em solid currentColor;
+    /* This is supposed to be UA sheet. */
+    input:is([type="radio"], [type="checkbox"]) {
+        margin: 3px 2px;
+        box-sizing: border-box;
+        border: -internal-auto-base(initial, 0.3em solid currentColor);
+        padding: initial;
+        background-color: -internal-auto-base(initial, transparent);
     }
 
-    input[type="checkbox"] {
-        border-radius: 0.5em;
+    input:is([type=checkbox]:not([switch])) {
+        border-radius: -internal-auto-base(unset, 0.5em);
     }
 
-    input:is([type="checkbox"], [type="radio"]):disabled {
-        border-color: color-mix(in srgb, currentColor 30%, transparent);
-        background-color: color-mix(in srgb, currentColor 10%, transparent);
+    input[type=radio] {
+        border-radius: -internal-auto-base(unset, 100%);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):disabled {
+        border-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 30%, transparent));
+        background-color: -internal-auto-base(unset, color-mix(in srgb, currentColor 10%, transparent));
     }
 
     input[type=checkbox]:not([switch]):checked::checkmark {
-        background-color: currentColor;
-        display: inline-block;
         height: 100%;
         width: 100%;
-        mask: url("data:image/svg+xml, \
-            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
-                <path style='fill:black;' \
-                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
-            </svg>");
+        display: inline-block;
+        background-color: currentColor;
         content: none;
     }
 
     input[type=radio]:checked::checkmark {
+        background-color: currentColor;
+        display: inline-block;
+        border-radius: inherit;
         margin: 10%;
         height: 80%;
         width: 80%;
@@ -38,6 +42,26 @@
 
     input:is([type=checkbox]:not([switch]), [type=radio]):checked:disabled::checkmark {
         background-color: color-mix(in srgb, currentColor 30%, transparent);
+    }
+
+    input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark {
+        display: none;
+    }
+
+    /* This is the beginning of the author sheet. */
+    input:is([type=checkbox]:not([switch]), [type=radio]) {
+        appearance: base;
+        width: 50px;
+        height: 50px;
+        font: 11px system-ui;
+    }
+
+    input[type=checkbox]:not([switch]):checked::checkmark {
+        mask: url("data:image/svg+xml, \
+            <svg viewBox='0 0 48 48' xmlns='http://www.w3.org/2000/svg'> \
+                <path style='fill:black;' \
+                    d='m 13.296976,22.378053 q 1.132246,0 1.712901,1.858069 1.161279,3.48387 1.654818,3.48387 0.377437,0 0.783891,-0.580641 8.15805,-11.990307 15.096756,-17.070959 2.932262,-2.1483891 5.719358,-2.1483891 3.687104,0 4.441945,0.2322692 0.319353,0.087116 0.319353,0.7257912 0,0.5225878 -0.667756,1.3064627 -18.667725,21.425788 -22.238696,27.870954 -1.219346,2.20644 -5.632257,2.20644 -1.451615,0 -3.048381,-0.754841 -0.667725,-0.348371 -2.3225729,-4.441929 -2.090338,-5.167737 -2.090338,-9.05806 0,-1.422565 2.032254,-2.351608 2.7870949,-1.277429 4.1806419,-1.277429 z' /> \
+            </svg>");
     }
 
     .container {

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -799,14 +799,12 @@ input:is([type="radio"], [type="checkbox"]) {
     box-sizing: border-box;
     border: initial;
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
-    width: -internal-auto-base(16px, 1em);
-    height: -internal-auto-base(16px, 1em);
-    padding: -internal-auto-base(0px, unset);
+    width: 16px;
+    height: 16px;
+    padding: 0px;
     /* We want to be as close to background:transparent as possible without actually being transparent */
     background-color: rgba(255, 255, 255, 0.01);
 #else
-    width: -internal-auto-base(unset, 1em);
-    height: -internal-auto-base(unset, 1em);
     padding: initial;
     background-color: initial;
 #endif
@@ -821,8 +819,6 @@ input[type="checkbox"] {
 input[type="radio"] {
 #if defined(WTF_PLATFORM_IOS_FAMILY) && WTF_PLATFORM_IOS_FAMILY
     border-radius: 50%;
-#else
-    border-radius: -internal-auto-base(unset, 50%);
 #endif
 }
 
@@ -856,22 +852,6 @@ input:is([type="checkbox"], [type="radio"]):checked:disabled {
     opacity: initial;
     background: rgba(0, 0, 0, 0.8);
 #endif
-}
-
-input[type=checkbox]:not([switch]):checked::checkmark {
-    content: "\2713" / "";
-}
-
-input[type=radio]:checked::checkmark {
-    background-color: currentColor;
-    display: inline-block;
-    border-radius: inherit;
-    height: 100%;
-    width: 100%;
-}
-
-input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark {
-    display: none;
 }
 
 input:is([type="button"], [type="submit"], [type="reset"]) {


### PR DESCRIPTION
#### 6c50837901213023ebd79b4bfd95fc18826ce3c9
<pre>
REGRESSION(306540@main) : It caused Speedometer3 regression
<a href="https://bugs.webkit.org/show_bug.cgi?id=308234">https://bugs.webkit.org/show_bug.cgi?id=308234</a>
<a href="https://rdar.apple.com/170328335">rdar://170328335</a>

Unreviewed.

The change 306540@main touches the CSS properties of the checkable controls
in the UA style sheet. Speedometer3 uses many check-boxes and radio buttons.

* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-basics.html:
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-content-dynamic.html:
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-content-text.html:
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic-expected.html:
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-dynamic.html:
* LayoutTests/fast/forms/appearance-base/appearance-base-checkable-checkmark-initial.html:
* Source/WebCore/css/html.css:
(input:is([type=&quot;radio&quot;], [type=&quot;checkbox&quot;])):
(input[type=&quot;radio&quot;]):
(input[type=checkbox]:not([switch]):checked::checkmark): Deleted.
(input[type=radio]:checked::checkmark): Deleted.
(input:is([type=checkbox]:not([switch]), [type=radio]):not(:checked)::checkmark): Deleted.

Canonical link: <a href="https://commits.webkit.org/307852@main">https://commits.webkit.org/307852@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6ce99c25cee2ece069bd45f4b5cfaa41f4ce9e2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145734 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154413 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b81bf3ce-908c-4081-8d87-206ed9cf8f8d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147609 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112082 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148697 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130911 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/92985 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09fa58b4-898c-4fae-9472-0cef83ddf2dd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13770 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11534 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1860 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123319 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7755 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156726 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/13 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120088 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120432 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30871 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18322 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129075 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74018 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16158 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7168 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17893 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81684 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17630 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17839 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17692 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->