### PR TITLE
Handle Memory64 load and store base + index overflow in IPInt

### DIFF
--- a/JSTests/wasm/stress/memory64-overflow.js
+++ b/JSTests/wasm/stress/memory64-overflow.js
@@ -1,0 +1,39 @@
+//@ skip if $addressBits <= 32
+//@ runDefaultWasm("-m", "--useWasmMemory64=1", "--useOMGJIT=0")
+import { instantiate } from "../wabt-wrapper.js";
+import * as assert from "../assert.js";
+
+async function test() {
+  const wat = `
+  (module
+      (memory i64 1)
+      (func (export "load") (param $addr i64) (result i32)
+          local.get $addr
+          i32.load offset=1
+      )
+      (func (export "store") (param $addr i64)
+          local.get $addr
+          i32.const 0
+          i32.store offset=1
+      )
+  )
+  `;
+
+  const instance = await instantiate(wat, {}, { threads: false });
+  const { load, store } = instance.exports;
+
+  const outOfBoundsError = [
+    WebAssembly.RuntimeError,
+    "Out of bounds memory access (evaluating 'func(...args)')",
+  ];
+  // 0xFFFFFFFFFFFFFFFF + offset=1 wraps to 0x0, which is in bounds —
+  // without overflow detection this would incorrectly succeed.
+  assert.throws(() => load(0xffffffffffffffffn), ...outOfBoundsError);
+  assert.throws(() => store(0xffffffffffffffffn), ...outOfBoundsError);
+
+  // 0xFFFFFFFFFFFFFFFE + offset=1 + size-1=3 wraps to 2, also falsely in bounds.
+  assert.throws(() => load(0xfffffffffffffffen), ...outOfBoundsError);
+  assert.throws(() => store(0xfffffffffffffffen), ...outOfBoundsError);
+}
+
+await assert.asyncTest(test());

--- a/JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js
+++ b/JSTests/wasm/stress/memory64-write-to-address-over-4-gigs.js
@@ -19,17 +19,12 @@ const {write, read} = instance.exports;
 
 const writeAddr = BigInt(Number.MAX_SAFE_INTEGER + 1);
 function test() {
-    const writeAndRead = (val) => {
-        write(val, writeAddr);
-
-        const readResult = read(writeAddr);
-        assert.eq(readResult, val);
-    }
-
-    writeAndRead(42);
-    // reset
-    writeAndRead(0);
+    const outOfBoundsError = [
+        WebAssembly.RuntimeError,
+        "Out of bounds memory access (evaluating 'func(...args)')",
+    ];
+    assert.throws(() => write(42, writeAddr), ...outOfBoundsError);
+    assert.throws(() => read(writeAddr), ...outOfBoundsError);
 }
 
-for (let i = 0; i < wasmTestLoopCount; i++)
-    test();
+test();


### PR DESCRIPTION
#### efd2123c28f008096e5fbb020097221f2b563b0f
<pre>
Handle Memory64 load and store base + index overflow in IPInt
<a href="https://bugs.webkit.org/show_bug.cgi?id=308239">https://bugs.webkit.org/show_bug.cgi?id=308239</a>
<a href="https://rdar.apple.com/170743839">rdar://170743839</a>

Reviewed by Keith Miller.

I added checks for overflow when adding base + index and
address + size while doing bounds checking in IPInt.

* JSTests/wasm/stress/memory64-overflow.js: Added.
(async test):
* Source/JavaScriptCore/llint/InPlaceInterpreter64.asm:

Canonical link: <a href="https://commits.webkit.org/307945@main">https://commits.webkit.org/307945@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/590a5df91c2549f8a68bf51563046e5595e550ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145977 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154656 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99513 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88043b00-cbdf-4e75-93c0-14d9bc79d6b6) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112287 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148940 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14672 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131131 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93187 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5de5f23c-efd5-4ca0-a14d-0599bbc3637a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13954 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11708 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2101 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137959 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123510 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8064 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156967 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6781 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/188 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9304 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120294 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18500 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15468 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120633 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30923 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18533 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129479 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74211 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7421 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177281 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18119 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81887 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45506 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17855 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/18035 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17915 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->