### PR TITLE
[LBSE] Fix imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html

### DIFF
--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations
@@ -260,7 +260,6 @@ svg/custom/pointer-events-text.svg                [ ImageOnlyFailure ]
 
 # Bounding box issues
 imported/w3c/web-platform-tests/svg/interact/scripted/svg-pointer-events-bbox.html    [ Failure ]
-imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html [ Failure ]
 imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-06.html [ Failure ]
 svg/text/text-bbox-empty.html                                                         [ Failure ]
 

--- a/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03-expected.txt
+++ b/LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03-expected.txt
@@ -1,0 +1,12 @@
+
+PASS rect1
+PASS rect2
+PASS circle
+PASS ellipse1
+PASS ellipse2
+PASS image3
+PASS image4
+PASS foreign1
+PASS foreign2
+PASS SVGGraphicsElement.prototype.getBBox for elements with negative sizes
+

--- a/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGEllipse.cpp
@@ -60,8 +60,11 @@ void RenderSVGEllipse::updateShapeFromElement()
     calculateRadiiAndCenter();
 
     // Spec: "A negative value is illegal. A value of zero disables rendering of the element."
-    if (m_radii.isEmpty())
+    if (m_radii.isEmpty()) {
+        // We set this for getBBox().
+        m_fillBoundingBox = FloatRect(m_center.x() - m_radii.width(), m_center.y() - m_radii.height(), 2 * m_radii.width(), 2 * m_radii.height());
         return;
+    }
 
     if (m_radii.width() == m_radii.height())
         m_shapeType = ShapeType::Circle;

--- a/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp
@@ -99,8 +99,8 @@ void RenderSVGForeignObject::layout()
     // Cache viewport boundaries
     auto x = useForeignObjectElement->x().value(lengthContext);
     auto y = useForeignObjectElement->y().value(lengthContext);
-    auto width = useForeignObjectElement->width().value(lengthContext);
-    auto height = useForeignObjectElement->height().value(lengthContext);
+    auto width = std::max(0.0f, useForeignObjectElement->width().value(lengthContext));
+    auto height = std::max(0.0f, useForeignObjectElement->height().value(lengthContext));
     m_viewport = { x, y, width, height };
 
     RenderSVGBlock::layout();

--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -68,8 +68,12 @@ void RenderSVGRect::updateShapeFromElement()
     FloatSize boundingBoxSize(lengthContext.valueForLength(style->width(), usedZoom, SVGLengthMode::Width), lengthContext.valueForLength(style->height(), usedZoom, SVGLengthMode::Height));
 
     // Spec: "A negative value is illegal. A value of zero disables rendering of the element."
-    if (boundingBoxSize.isEmpty())
+    if (boundingBoxSize.isEmpty()) {
+        // We set this for getBBox().
+        m_fillBoundingBox = FloatRect(FloatPoint(lengthContext.valueForLength(style->x(), Style::ZoomNeeded { }, SVGLengthMode::Width),
+            lengthContext.valueForLength(style->y(), Style::ZoomNeeded { }, SVGLengthMode::Height)), boundingBoxSize);
         return;
+    }
 
     if (lengthContext.valueForLength(style->rx(), Style::ZoomNeeded { }, SVGLengthMode::Width) > 0
         || lengthContext.valueForLength(style->ry(), Style::ZoomNeeded { }, SVGLengthMode::Height) > 0)
@@ -84,8 +88,7 @@ void RenderSVGRect::updateShapeFromElement()
     }
 
     m_fillBoundingBox = FloatRect(FloatPoint(lengthContext.valueForLength(style->x(), Style::ZoomNeeded { }, SVGLengthMode::Width),
-        lengthContext.valueForLength(style->y(), Style::ZoomNeeded { }, SVGLengthMode::Height)),
-        boundingBoxSize);
+        lengthContext.valueForLength(style->y(), Style::ZoomNeeded { }, SVGLengthMode::Height)), boundingBoxSize);
 
     auto strokeBoundingBox = m_fillBoundingBox;
     if (!style->stroke().isNone())


### PR DESCRIPTION
#### 1bac38361f5718b861b264f413480a397c9a4f2e
<pre>
[LBSE] Fix imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=308237">https://bugs.webkit.org/show_bug.cgi?id=308237</a>

Reviewed by Nikolas Zimmermann.

Fix imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03.html by properly
treating negative values for rect and foreignObject width/height, radii in ellipse/circle object
bounding boxes and thus the getBBox method returned rectangle.

* LayoutTests/platform/mac-tahoe-wk2-lbse-text/TestExpectations:
* LayoutTests/platform/mac-tahoe-wk2-lbse-text/imported/w3c/web-platform-tests/svg/types/scripted/SVGGraphicsElement.getBBox-03-expected.txt: Added.
* Source/WebCore/rendering/svg/RenderSVGEllipse.cpp:
(WebCore::RenderSVGEllipse::updateShapeFromElement):
* Source/WebCore/rendering/svg/RenderSVGForeignObject.cpp:
(WebCore::RenderSVGForeignObject::layout):
* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
(WebCore::RenderSVGRect::updateShapeFromElement):

Canonical link: <a href="https://commits.webkit.org/307910@main">https://commits.webkit.org/307910@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c8cebe1a50ef46f80431fff8e0b223861cb19d6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145880 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18570 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10627 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154559 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99452 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147755 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18459 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112202 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80344 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148843 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131041 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93107 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13881 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11637 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2005 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7940 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156871 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/117 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9141 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120207 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18412 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15381 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120552 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30905 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18448 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129307 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74139 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16262 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7318 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18029 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81810 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17766 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17825 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->