### PR TITLE
[threaded-animations] running Jetstream on iOS crashes under `AcceleratedEffectStackUpdater::update()`

### DIFF
--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp
@@ -52,16 +52,15 @@ void AcceleratedEffectStackUpdater::update()
     HashSet<Ref<AcceleratedTimeline>> timelinesInUpdate;
 
     auto targetsPendingUpdate = std::exchange(m_targetsPendingUpdate, { });
-    for (auto [element, pseudoElementIdentifier] : targetsPendingUpdate) {
-        if (!element)
+    for (auto weakTarget : targetsPendingUpdate) {
+        auto target = weakTarget.styleable();
+        if (!target)
             continue;
 
-        Styleable target { *element, pseudoElementIdentifier };
-
         if (!page)
-            page = protect(element->document())->page();
+            page = protect(target->element.document())->page();
 
-        CheckedPtr renderer = dynamicDowncast<RenderLayerModelObject>(target.renderer());
+        CheckedPtr renderer = dynamicDowncast<RenderLayerModelObject>(target->renderer());
         if (!renderer || !renderer->isComposited())
             continue;
 
@@ -76,7 +75,7 @@ void AcceleratedEffectStackUpdater::update()
 
 void AcceleratedEffectStackUpdater::scheduleUpdateForTarget(const Styleable& target)
 {
-    m_targetsPendingUpdate.add({ &target.element, target.pseudoElementIdentifier });
+    m_targetsPendingUpdate.add({ target });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
+++ b/Source/WebCore/animation/AcceleratedEffectStackUpdater.h
@@ -29,7 +29,7 @@
 
 #include <WebCore/AcceleratedEffect.h>
 #include <WebCore/AnimationMalloc.h>
-#include <wtf/HashSet.h>
+#include <WebCore/Styleable.h>
 
 namespace WebCore {
 
@@ -47,8 +47,7 @@ public:
     bool hasTargetsPendingUpdate() const { return !m_targetsPendingUpdate.isEmpty(); }
 
 private:
-    using HashedStyleable = std::pair<Element*, std::optional<Style::PseudoElementIdentifier>>;
-    HashSet<HashedStyleable> m_targetsPendingUpdate;
+    WeakStyleableHashSet m_targetsPendingUpdate;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1415c430401bdf534e4190c7122d3fbcacfbf2e0
<pre>
[threaded-animations] running Jetstream on iOS crashes under `AcceleratedEffectStackUpdater::update()`
<a href="https://bugs.webkit.org/show_bug.cgi?id=308132">https://bugs.webkit.org/show_bug.cgi?id=308132</a>
<a href="https://rdar.apple.com/170636362">rdar://170636362</a>

Reviewed by Ryosuke Niwa and Tim Nguyen.

Use `WeakStyleable` for the `HashSet` holding the targets pending an update in `AcceleratedEffectStackUpdater`.

No new layout test but this issue was caught by Apple&apos;s automated performance testing infrastructure.

* Source/WebCore/animation/AcceleratedEffectStackUpdater.cpp:
(WebCore::AcceleratedEffectStackUpdater::update):
(WebCore::AcceleratedEffectStackUpdater::scheduleUpdateForTarget):
* Source/WebCore/animation/AcceleratedEffectStackUpdater.h:
* Source/WebCore/style/Styleable.h:
(WebCore::WeakStyleableHashTraits::isWeakNullValue):
(WebCore::WeakStyleableHashTraits::constructDeletedValue):
(WebCore::WeakStyleableHashTraits::isDeletedValue):
(WebCore::WeakStyleableHash::hash):
(WebCore::WeakStyleableHash::equal):

Canonical link: <a href="https://commits.webkit.org/307912@main">https://commits.webkit.org/307912@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/150d6706ad3e0f30987b8d4b61a465b27fa6fc19

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145889 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10651 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99456 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a459ee02-82f1-4662-a2b5-654bfb772679) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147764 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19062 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18468 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112209 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/225432a7-0838-4650-aaa7-e5c09d8ecd7b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14599 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131053 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c92ceab-b044-4f24-9099-3a56e9c37af1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13894 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11644 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2014 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123446 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156880 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/124 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120216 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18420 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15389 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18456 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129338 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74146 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22497 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16274 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7331 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18037 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81816 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17774 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17970 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17833 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->