### PR TITLE
[JSC] Respect shouldNegate() on WasmRefTypeCheckValue nodes in OMG

### DIFF
--- a/JSTests/wasm/gc/br_on_cast_fail.js
+++ b/JSTests/wasm/gc/br_on_cast_fail.js
@@ -1,0 +1,48 @@
+// (module
+//  (rec
+//    (type (;0;) (struct (field (mut i32))))
+//    (type (;1;) (struct (field (mut i32)) (field (mut i64)) (field (mut i64))))
+//  )
+//  (type (;2;) (func (result (ref struct))))
+//  (type (;3;) (func (result i32)))
+//  (export "fail" (func 0))
+//  (export "pass" (func 1))
+//  (func (;0;) (type 3) (result i32)
+//    block (type 2) (result (ref struct)) ;; label = @1
+//      i32.const 42
+//      struct.new 0
+//      br_on_cast_fail 0 (;@1;) (ref struct) (ref 1)
+//      drop
+//      i32.const 0
+//      return
+//    end
+//    drop
+//    i32.const 1
+//  )
+//  (func (;1;) (type 3) (result i32)
+//    block (type 2) (result (ref struct)) ;; label = @1
+//      i32.const 99
+//      i64.const 0
+//      i64.const 0
+//      struct.new 1
+//      br_on_cast_fail 0 (;@1;) (ref struct) (ref 1)
+//      drop
+//      i32.const 1
+//      return
+//    end
+//    drop
+//    i32.const 0
+//  )
+// )
+
+const bytes = new Uint8Array([0,97,115,109,1,0,0,0,1,28,3,78,2,79,0,95,1,127,1,79,0,95,3,127,1,126,1,126,1,96,0,1,100,107,96,0,1,127,3,3,2,3,3,7,15,2,4,102,97,105,108,0,0,4,112,97,115,115,0,1,10,54,2,23,0,2,2,65,42,251,0,0,251,25,0,0,107,1,26,65,0,15,11,26,65,1,11,28,0,2,2,65,227,0,66,0,66,0,251,0,1,251,25,0,0,107,1,26,65,1,15,11,26,65,0,11]);
+const mod = new WebAssembly.Module(bytes);
+const { pass, fail } = new WebAssembly.Instance(mod).exports;
+
+for (let i = 0; i < 200000; i++) {
+    fail();
+    pass();
+}
+
+if (fail() === 0 || pass() === 0)
+    throw new Error("br_cast_on_fail incorrect");

--- a/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
+++ b/Source/JavaScriptCore/b3/B3ReduceStrength.cpp
@@ -3604,6 +3604,8 @@ private:
                 SUPPRESS_UNCOUNTED_LOCAL const Wasm::RTT* targetRTT = cast->targetRTT();
                 if (!Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType))) {
                     if (rtt->isSubRTT(*targetRTT)) {
+                        // shouldNegate can only be set on WasmRefTest.
+                        ASSERT(!cast->shouldNegate());
                         replaceWithIdentity(structNew);
                         break;
                     }
@@ -3669,7 +3671,8 @@ private:
                 int32_t toHeapType = cast->targetHeapType();
                 SUPPRESS_UNCOUNTED_LOCAL const Wasm::RTT* targetRTT = cast->targetRTT();
                 if (!Wasm::typeIndexIsType(static_cast<Wasm::TypeIndex>(toHeapType))) {
-                    replaceWithNewValue(m_proc.addIntConstant(m_value, !!rtt->isSubRTT(*targetRTT)));
+                    const bool isSubtype = rtt->isSubRTT(*targetRTT);
+                    replaceWithNewValue(m_proc.addIntConstant(m_value, cast->shouldNegate() ? !isSubtype : isSubtype));
                     break;
                 }
             }


### PR DESCRIPTION
#### af957bf20474d10f05178f7c72952bd9bed0260e
<pre>
[JSC] Respect shouldNegate() on WasmRefTypeCheckValue nodes in OMG
<a href="https://bugs.webkit.org/show_bug.cgi?id=308231">https://bugs.webkit.org/show_bug.cgi?id=308231</a>
<a href="https://rdar.apple.com/170645626">rdar://170645626</a>

Reviewed by Dan Hecht.

This PR fixes a bug B3 strength reduction where shouldNegate() on
WasmRefTypeCheckValue nodes weren&apos;t being respected.

Test: JSTests/wasm/gc/br_on_cast_fail.js

* JSTests/wasm/gc/br_on_cast_fail.js: Added.
* Source/JavaScriptCore/b3/B3ReduceStrength.cpp:

Canonical link: <a href="https://commits.webkit.org/307860@main">https://commits.webkit.org/307860@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa02541ef1faa634b040e3a34cf8652962e42ec1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18454 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10420 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154442 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/895c1018-1fca-4868-a259-074039bd18fe) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18939 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18343 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112104 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce855567-cccb-43b5-9ce0-c2ae21a7bf2c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14485 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/130934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93007 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1f7b582-3c36-445a-a936-bea6b0e892cb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1889 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/137757 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123343 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156755 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/6571 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120110 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18301 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15280 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120454 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30877 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129118 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74045 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7196 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/177066 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81711 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/45472 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17659 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17868 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->