### PR TITLE
Rename WebUITextIndicatorData to WebUITextIndicator with staging for UIKit.

### DIFF
--- a/Source/WebKitLegacy/ios/WebKit.iOS.exp
+++ b/Source/WebKitLegacy/ios/WebKit.iOS.exp
@@ -6,6 +6,7 @@
 .objc_class_name_WebPDFView
 .objc_class_name_WebPDFViewPlaceholder
 .objc_class_name_WebSelectionRect
+.objc_class_name_WebUITextIndicator
 .objc_class_name_WebUITextIndicatorData
 .objc_class_name_WebVisiblePosition
 _WebDatabaseOriginsDidChangeNotification

--- a/Source/WebKitLegacy/mac/WebView/WebView.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebView.mm
@@ -825,7 +825,7 @@ static bool isLockdownModeEnabled()
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
 
-@implementation WebUITextIndicatorData
+@implementation WebUITextIndicator
 
 @synthesize dataInteractionImage = _dataInteractionImage;
 @synthesize selectionRectInRootViewCoordinates = _selectionRectInRootViewCoordinates;
@@ -851,9 +851,9 @@ static bool isLockdownModeEnabled()
 
 @end
 
-@implementation WebUITextIndicatorData (WebUITextIndicatorInternal)
+@implementation WebUITextIndicator (WebUITextIndicatorInternal)
 
-- (WebUITextIndicatorData *)initWithImage:(CGImageRef)image textIndicator:(RefPtr<WebCore::TextIndicator>&&)indicator scale:(CGFloat)scale
+- (WebUITextIndicator *)initWithImage:(CGImageRef)image textIndicator:(RefPtr<WebCore::TextIndicator>&&)indicator scale:(CGFloat)scale
 {
     if (!(self = [super init]))
         return nil;
@@ -882,7 +882,7 @@ static bool isLockdownModeEnabled()
     return self;
 }
 
-- (WebUITextIndicatorData *)initWithImage:(CGImageRef)image scale:(CGFloat)scale
+- (WebUITextIndicator *)initWithImage:(CGImageRef)image scale:(CGFloat)scale
 {
     if (!(self = [super init]))
         return nil;
@@ -893,7 +893,13 @@ static bool isLockdownModeEnabled()
 }
 
 @end
+
+@implementation WebUITextIndicatorData
+@end
 #elif !PLATFORM(MAC)
+@implementation WebUITextIndicator
+@end
+
 @implementation WebUITextIndicatorData
 @end
 #endif
@@ -1913,9 +1919,9 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     RefPtr<WebCore::TextIndicator> textIndicator = dragImage.textIndicator();
 
     if (textIndicator)
-        _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image textIndicator:WTF::move(textIndicator) scale:_private->page->deviceScaleFactor()]);
+        _private->textIndicator = adoptNS([[WebUITextIndicator alloc] initWithImage:image textIndicator:WTF::move(textIndicator) scale:_private->page->deviceScaleFactor()]);
     else
-        _private->textIndicatorData = adoptNS([[WebUITextIndicatorData alloc] initWithImage:image scale:_private->page->deviceScaleFactor()]);
+        _private->textIndicator = adoptNS([[WebUITextIndicator alloc] initWithImage:image scale:_private->page->deviceScaleFactor()]);
     _private->draggedLinkURL = dragItem.url.isEmpty() ? RetainPtr<NSURL>() : dragItem.url.createNSURL();
     _private->draggedLinkTitle = dragItem.title.isEmpty() ? nil : dragItem.title.createNSString().get();
     _private->dragPreviewFrameInRootViewCoordinates = dragItem.dragPreviewFrameInRootViewCoordinates;
@@ -1931,7 +1937,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     return { };
 }
 
-- (WebUITextIndicatorData *)_dataOperationTextIndicator
+- (WebUITextIndicator *)_dataOperationTextIndicator
 {
     return _private->dataOperationTextIndicator.get();
 }
@@ -1958,7 +1964,12 @@ static void WebKitInitializeGamepadProviderIfNecessary()
 
 - (WebUITextIndicatorData *)_getDataInteractionData
 {
-    return _private->textIndicatorData.get();
+    return (WebUITextIndicatorData *)_private->textIndicator.get();
+}
+
+- (WebUITextIndicator *)_getDataInteraction
+{
+    return _private->textIndicator.get();
 }
 
 - (WebDragDestinationAction)dragDestinationActionMaskForSession:(id <UIDropSession>)session
@@ -2060,7 +2071,7 @@ static void WebKitInitializeGamepadProviderIfNecessary()
         return;
     if (auto range = frame->selection().selection().toNormalizedRange()) {
         if (RefPtr textIndicator = WebCore::TextIndicator::createWithRange(*range, defaultEditDragTextIndicatorOptions, WebCore::TextIndicatorPresentationTransition::None, WebCore::FloatSize()))
-            _private->dataOperationTextIndicator = adoptNS([[WebUITextIndicatorData alloc] initWithImage:nil textIndicator:WTF::move(textIndicator) scale:page->deviceScaleFactor()]);
+            _private->dataOperationTextIndicator = adoptNS([[WebUITextIndicator alloc] initWithImage:nil textIndicator:WTF::move(textIndicator) scale:page->deviceScaleFactor()]);
     }
 }
 
@@ -2071,12 +2082,12 @@ static void WebKitInitializeGamepadProviderIfNecessary()
     return NO;
 }
 
-- (WebUITextIndicatorData *)_getDataInteractionData
+- (WebUITextIndicator *)_getDataInteraction
 {
     return nil;
 }
 
-- (WebUITextIndicatorData *)_dataOperationTextIndicator
+- (WebUITextIndicator *)_dataOperationTextIndicator
 {
     return nil;
 }

--- a/Source/WebKitLegacy/mac/WebView/WebViewData.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewData.h
@@ -59,7 +59,7 @@ class PlaybackSessionModelMediaElement;
 }
 
 @class UIImage;
-@class WebUITextIndicatorData;
+@class WebUITextIndicator;
 @class WebImmediateActionController;
 @class WebInspector;
 @class WebNodeHighlight;
@@ -250,8 +250,8 @@ class WebSelectionServiceController;
 #endif
     
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT)
-    RetainPtr<WebUITextIndicatorData> textIndicatorData;
-    RetainPtr<WebUITextIndicatorData> dataOperationTextIndicator;
+    RetainPtr<WebUITextIndicator> textIndicator;
+    RetainPtr<WebUITextIndicator> dataOperationTextIndicator;
     CGRect dragPreviewFrameInRootViewCoordinates;
     WebDragSourceAction dragSourceAction;
     RetainPtr<NSURL> draggedLinkURL;

--- a/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewInternal.h
@@ -129,9 +129,9 @@ OptionSet<WebCore::LayoutMilestone> coreLayoutMilestones(WebLayoutMilestones);
 WebLayoutMilestones kitLayoutMilestones(OptionSet<WebCore::LayoutMilestone>);
 
 #if PLATFORM(IOS_FAMILY) && ENABLE(DRAG_SUPPORT) && defined(__cplusplus)
-@interface WebUITextIndicatorData (WebUITextIndicatorInternal)
-- (WebUITextIndicatorData *)initWithImage:(CGImageRef)image textIndicator:(RefPtr<WebCore::TextIndicator>&&)indicator scale:(CGFloat)scale;
-- (WebUITextIndicatorData *)initWithImage:(CGImageRef)image scale:(CGFloat)scale;
+@interface WebUITextIndicator (WebUITextIndicatorInternal)
+- (WebUITextIndicator *)initWithImage:(CGImageRef)image textIndicator:(RefPtr<WebCore::TextIndicator>&&)indicator scale:(CGFloat)scale;
+- (WebUITextIndicator *)initWithImage:(CGImageRef)image scale:(CGFloat)scale;
 @end
 #endif
 

--- a/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
+++ b/Source/WebKitLegacy/mac/WebView/WebViewPrivate.h
@@ -146,7 +146,7 @@ typedef enum {
 } WebNotificationPermission;
 
 #if TARGET_OS_IPHONE
-@interface WebUITextIndicatorData : NSObject
+@interface WebUITextIndicator : NSObject
 @property (nonatomic, retain) UIImage *dataInteractionImage;
 @property (nonatomic, assign) CGRect selectionRectInRootViewCoordinates;
 @property (nonatomic, assign) CGRect textBoundingRectInRootViewCoordinates;
@@ -157,6 +157,10 @@ typedef enum {
 @property (nonatomic, retain) UIImage *contentImageWithoutSelection;
 @property (nonatomic, assign) CGRect contentImageWithoutSelectionRectInRootViewCoordinates;
 @property (nonatomic, retain) UIColor *estimatedBackgroundColor;
+@end
+
+// Backwards compatibility alias
+@interface WebUITextIndicatorData : WebUITextIndicator
 @end
 #endif
 
@@ -438,7 +442,8 @@ Could be worth adding to the API.
 #if TARGET_OS_IOS
 - (BOOL)_requestStartDataInteraction:(CGPoint)clientPosition globalPosition:(CGPoint)globalPosition;
 - (WebUITextIndicatorData *)_getDataInteractionData;
-@property (nonatomic, readonly, strong, getter=_dataOperationTextIndicator) WebUITextIndicatorData *dataOperationTextIndicator;
+- (WebUITextIndicator *)_getDataInteraction;
+@property (nonatomic, readonly, strong, getter=_dataOperationTextIndicator) WebUITextIndicator *dataOperationTextIndicator;
 @property (nonatomic, readonly) NSUInteger _dragSourceAction;
 @property (nonatomic, strong, readonly) NSString *_draggedLinkTitle;
 @property (nonatomic, strong, readonly) NSURL *_draggedLinkURL;


### PR DESCRIPTION
#### 6c02861dd9d7724357451e82c0cdc68cb654d7ed
<pre>
Rename WebUITextIndicatorData to WebUITextIndicator with staging for UIKit.
<a href="https://bugs.webkit.org/show_bug.cgi?id=308241">https://bugs.webkit.org/show_bug.cgi?id=308241</a>
<a href="https://rdar.apple.com/170745464">rdar://170745464</a>

Reviewed by Abrar Rahman Protyasha.

With all of the work I am doing to remove
TextIndicatorData, I keep running into this
legacy class. Since it mirrors TextIndicator
more than TextIndicatorData and it is old, and it
is making my TextIndicatorData removal work
more difficult, I would like to rename this class.
This needs to be staged to not break UIKit, though.
Staging will be removed when UIKit is updated.

* Source/WebKitLegacy/ios/WebKit.iOS.exp:
* Source/WebKitLegacy/mac/WebView/WebView.mm:
(-[WebUITextIndicator initWithImage:textIndicator:scale:]):
(-[WebUITextIndicator initWithImage:scale:]):
(-[WebView _startDrag:]):
(-[WebView _dataOperationTextIndicator]):
(-[WebView _getDataInteractionData]):
(-[WebView _getDataInteraction]):
(-[WebView _didConcludeEditDrag]):
(-[WebUITextIndicatorData dealloc]): Deleted.
(-[WebUITextIndicatorData initWithImage:textIndicator:scale:]): Deleted.
(-[WebUITextIndicatorData initWithImage:scale:]): Deleted.
* Source/WebKitLegacy/mac/WebView/WebViewData.h:
* Source/WebKitLegacy/mac/WebView/WebViewInternal.h:
* Source/WebKitLegacy/mac/WebView/WebViewPrivate.h:

Canonical link: <a href="https://commits.webkit.org/309082@main">https://commits.webkit.org/309082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/df45232d3630e4370309d915cb62280be5f489bb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/149155 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/21868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/15438 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/157843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/102586 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/22322 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/21746 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/114990 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81849 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ed463e27-a61f-4c31-93b2-c1314b0310ab) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/152115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/17162 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/133846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/95746 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/46de99a2-d602-4c85-a416-2f8259fccb4d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/16262 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/14134 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/5696 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/125862 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests (cancelled)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/11778 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/160328 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/3315 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/13524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/123036 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/21670 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/18169 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/123264 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/33550 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/21678 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/133571 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/77879 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/18507 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/10323 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/21280 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/85082 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/21012 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/21160 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/21068 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->