### PR TITLE
AX: accessibility/iframe-bastardization.html should wait for the iframe to load before running the test

### DIFF
--- a/LayoutTests/accessibility/iframe-bastardization.html
+++ b/LayoutTests/accessibility/iframe-bastardization.html
@@ -8,22 +8,27 @@
 
 <script>
 var output = "This test makes sure that the AX parent chain hierarchy with iframes is correct\n\n";
+jsTestIsAsync = true;
 
-if (window.accessibilityController) {
+document.getElementById("iframe1").addEventListener("load", function() {
+    if (!window.accessibilityController)
+        return;
+
     var body = document.getElementById("body");
     body.focus();
-    var webArea = accessibilityController.focusedElement;
+    webArea = accessibilityController.focusedElement;
 
-    var iframeScrollArea = webArea.childAtIndex(0);
-    var iframeWebArea = iframeScrollArea.childAtIndex(0);
+    iframeScrollArea = webArea.childAtIndex(0);
+    iframeWebArea = iframeScrollArea.childAtIndex(0);
 
-    var parentIframeWebArea = iframeWebArea.parentElement();
-    var parentIframeScrollArea = parentIframeWebArea.parentElement();
+    parentIframeWebArea = iframeWebArea.parentElement();
+    parentIframeScrollArea = parentIframeWebArea.parentElement();
 
     output += expect("parentIframeWebArea.isEqual(iframeScrollArea)", "true");
     output += expect("parentIframeScrollArea.isEqual(webArea)", "true");
     debug(output);
-}
+    finishJSTest();
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### a619a4af0a76b75080d8c1a04144d292f5978019
<pre>
AX: accessibility/iframe-bastardization.html should wait for the iframe to load before running the test
<a href="https://bugs.webkit.org/show_bug.cgi?id=308245">https://bugs.webkit.org/show_bug.cgi?id=308245</a>
<a href="https://rdar.apple.com/170751492">rdar://170751492</a>

Reviewed by Joshua Hoffman.

This fixes with test when run with ITM + ENABLE_ACCESSIBILITY_LOCAL_FRAME (and presumably this test is / was flakey in
other configurations due to this bug).

* LayoutTests/accessibility/iframe-bastardization.html:

Canonical link: <a href="https://commits.webkit.org/308132@main">https://commits.webkit.org/308132@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a507bb5721ce0771ad335f022de8c3cf45d22b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18459 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154447 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99379 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/432878a7-227a-4779-98ba-9d8e62cc1f45) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18944 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112110 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80306 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e06d89e-b778-465c-aba9-d6da6330178e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14494 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130937 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93013 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64e30237-697d-46a6-8859-57ed0c9c7be7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13799 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11552 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1894 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123352 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7793 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156760 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/8959 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120116 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15287 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120460 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31025 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18356 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129123 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74050 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16189 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7199 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17927 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17664 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17873 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17725 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->