### PR TITLE
Fix zoom being applied twice to font-size in SVG foreignObject

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-foreignObject-font-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-foreignObject-font-size-expected.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Zoom: foreignObject font-size reference</title>
+<style>
+  :root {
+      zoom: 4;
+      font-size: 16px;
+  }
+</style>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-foreignObject-font-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-foreignObject-font-size-ref.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Zoom: foreignObject font-size reference</title>
+<style>
+  :root {
+      zoom: 4;
+      font-size: 16px;
+  }
+</style>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-foreignObject-font-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-foreignObject-font-size.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>CSS Zoom: foreignObject font-size should not be double-zoomed</title>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="match" href="svg-foreignObject-font-size-ref.html">
+<style>
+  :root {
+      zoom: 4;
+      font-size: 16px;
+  }
+</style>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div style="font-size:16px">TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25">
+  <foreignObject width="50" height="25">
+    <div style="font-size:inherit">TEST</div>
+  </foreignObject>
+</svg>
+<svg width="50" height="25" style="font-size:inherit">
+  <foreignObject width="50" height="25">
+    <div>TEST</div>
+  </foreignObject>
+</svg>

--- a/LayoutTests/svg/zoom/page/zoom-foreignObject-text-zoom-expected.html
+++ b/LayoutTests/svg/zoom/page/zoom-foreignObject-text-zoom-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+:root {
+  zoom: 2;
+  font-size: 16px;
+}
+svg {
+  display: block;
+}
+</style>
+</head>
+<body>
+<svg width="200" height="50">
+  <foreignObject width="200" height="50">
+    <div style="font-size:16px">TEST</div>
+  </foreignObject>
+</svg>
+</body>
+</html>

--- a/LayoutTests/svg/zoom/page/zoom-foreignObject-text-zoom.html
+++ b/LayoutTests/svg/zoom/page/zoom-foreignObject-text-zoom.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.internals)
+  internals.setTextZoomFactor(2.0);
+</script>
+<style>
+:root {
+  zoom: 2;
+  font-size: 16px;
+}
+svg {
+  display: block;
+}
+</style>
+</head>
+<body>
+<svg width="200" height="50">
+  <foreignObject width="200" height="50">
+    <div>TEST</div>
+  </foreignObject>
+</svg>
+</body>
+</html>

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -72,6 +72,7 @@
 #include "StylableInlines.h"
 #include "StyleContainmentCheckerInlines.h"
 #include "StyleComputedStyle+InitialInlines.h"
+#include "StyleFontSizeFunctions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleSelfAlignmentData.h"
 #include "StyleTextDecorationLine.h"
@@ -901,8 +902,19 @@ void Adjuster::adjustSVGElementStyle(RenderStyle& style, const SVGElement& svgEl
 
     // (Legacy)RenderSVGRoot handles zooming for the whole SVG subtree, so foreignObject content should
     // not be scaled again.
-    if (svgElement.hasTagName(SVGNames::foreignObjectTag))
+    if (svgElement.hasTagName(SVGNames::foreignObjectTag)) {
         style.setUsedZoom(evaluate<float>(ComputedStyle::initialZoom()));
+
+        // The font's computed size may have been inherited from the HTML tree with CSS zoom
+        // already applied. Since we just reset usedZoom for foreignObject, recompute the font's
+        // computed size from the specified size without zoom (useSVGZoomRules=true), so that
+        // children inherit the correct (unzoomed) computed size. The SVG root transform handles
+        // the zoom scaling, consistent with other SVG content.
+        auto fontDescription = style.fontDescription();
+        auto computedFontSize = computedFontSizeFromSpecifiedSize(fontDescription.specifiedSize(), fontDescription.isAbsoluteSize(), /*useSVGZoomRules=*/true, style.computedStyle(), svgElement.document());
+        fontDescription.setComputedSize(computedFontSize.size, computedFontSize.usedZoomFactor);
+        style.setFontDescription(WTF::move(fontDescription));
+    }
 
     // SVG text layout code expects us to be a block-level style element.
     // While in theory any block level element would work (flex, grid etc), since we construct RenderBlockFlow for both foreign object and svg text,


### PR DESCRIPTION
#### bbc4a14664c35da9b061dd3a07df90be7b3030f9
<pre>
Fix zoom being applied twice to font-size in SVG foreignObject
<a href="https://bugs.webkit.org/show_bug.cgi?id=279041">https://bugs.webkit.org/show_bug.cgi?id=279041</a>
<a href="https://rdar.apple.com/135615620">rdar://135615620</a>

Reviewed by Vitor Roriz.

When CSS zoom is set on :root, text inside foreignObject renders
at double the expected zoom — once from the inherited computedSize
and again from RenderSVGRoot&apos;s zoom transform.

StyleAdjuster resets usedZoom to 1.0 on foreignObject, but this
runs after the builder phase, so the font&apos;s computedSize still
carries the zoom from the HTML tree. Children inherit this stale
zoomed value.

The Fix recomputes computedSize resetting zoom on foreignObject.

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-foreignObject-font-size-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-foreignObject-font-size-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/svg-foreignObject-font-size.html: Added.
* LayoutTests/svg/zoom/page/zoom-foreignObject-text-zoom-expected.html: Added.
* LayoutTests/svg/zoom/page/zoom-foreignObject-text-zoom.html: Added.

* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::Adjuster::adjustSVGElementStyle):

Canonical link: <a href="https://commits.webkit.org/308476@main">https://commits.webkit.org/308476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e72363ae0b4b5e63e577839f7fe3ba18c1d0cfb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/147652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/20337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/13928 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/156334 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/101067 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/afcfe3e7-b717-466d-bb28-a77f3a6d2cda) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/149525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/20794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/20237 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/113819 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/81181 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/834e7296-860a-4791-af90-3d87127830cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/150614 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/16060 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/132618 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/94580 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb0ee859-95b9-43b4-a07b-fd8162f6a5a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/15225 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/13011 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/3775 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/124821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/10535 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/158668 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/1804 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/12007 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/121845 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/20136 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/16914 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/122046 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/31256 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/20147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/132316 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/76259 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/17583 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/9096 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/19751 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/83514 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/19481 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/19632 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/19539 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->