### PR TITLE
REGRESSION (305325@main): Layout of columns is incorrect for some fonts

### DIFF
--- a/LayoutTests/fast/repaint/emoji-glyph-overflow-repaint-fail-expected.txt
+++ b/LayoutTests/fast/repaint/emoji-glyph-overflow-repaint-fail-expected.txt
@@ -1,7 +1,6 @@
 (repaint rects
   (rect 8 10 21 17)
-  (rect 8 -6 784 14)
-  (rect 8 -6 784 14)
-  (rect 0 -6 800 6)
+  (rect 8 7 784 1)
+  (rect 8 7 784 1)
 )
 

--- a/LayoutTests/platform/glib/fast/repaint/emoji-glyph-overflow-repaint-fail-expected.txt
+++ b/LayoutTests/platform/glib/fast/repaint/emoji-glyph-overflow-repaint-fail-expected.txt
@@ -1,7 +1,4 @@
 (repaint rects
   (rect 8 10 20 16)
-  (rect 8 -5 784 13)
-  (rect 8 -5 784 13)
-  (rect 0 -5 800 5)
 )
 

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItem.cpp
@@ -43,8 +43,6 @@ struct SameSizeAsInlineItem {
     bool widthBool : 1;
     bool softHyphenBool : 1;
     bool isWordSeparator : 1;
-    uint8_t glyphTopOverflow : 5;
-    uint8_t glyphBottomOverflow : 3;
 };
 
 static_assert(sizeof(InlineItem) == sizeof(SameSizeAsInlineItem));

--- a/Source/WebCore/layout/formattingContexts/inline/InlineItem.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineItem.h
@@ -97,8 +97,6 @@ protected:
     bool m_hasWidth : 1 { false };
     bool m_hasTrailingSoftHyphen : 1 { false };
     bool m_isWordSeparator : 1 { false };
-    uint8_t m_glyphTopOverflow : 5 { 0 };
-    uint8_t m_glyphBottomOverflow : 3 { 0 };
 };
 
 inline InlineItem::InlineItem(const Box& layoutBox, Type type, UBiDiLevel bidiLevel)

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp
@@ -872,10 +872,6 @@ Line::Run::Run(const InlineTextItem& inlineTextItem, const RenderStyle& style, I
         if (*whitespaceType == TrailingWhitespace::Type::Collapsed)
             length =  1;
         m_trailingWhitespace = { *whitespaceType, length, logicalWidth };
-    } else {
-        auto glyphOverflow = inlineTextItem.glyphOverflow();
-        if (glyphOverflow.first || glyphOverflow.second)
-            m_glyphOverflow = { glyphOverflow.first, glyphOverflow.second };
     }
     m_textContent = { inlineTextItem.start(), length };
 }
@@ -895,10 +891,6 @@ void Line::Run::expand(const InlineTextItem& inlineTextItem, InlineLayoutUnit lo
         m_trailingWhitespace = { };
         m_textContent.length += inlineTextItem.length();
         m_lastNonWhitespaceContentStart = inlineTextItem.start();
-
-        auto glyphOverflow = inlineTextItem.glyphOverflow();
-        if (glyphOverflow.first || glyphOverflow.second)
-            m_glyphOverflow = { std::max(m_glyphOverflow.top, glyphOverflow.first), std::max(m_glyphOverflow.bottom, glyphOverflow.second) };
         return;
     }
     auto whitespaceWidth = !hasTrailingWhitespace() ? logicalWidth : m_trailingWhitespace.width + logicalWidth;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineLine.h
@@ -146,14 +146,6 @@ public:
         InlineLayoutUnit trailingWhitespaceWidth() const { return m_trailingWhitespace.width; }
         bool isWhitespaceOnly() const { return hasTrailingWhitespace() && m_trailingWhitespace.length == m_textContent.length; }
 
-        struct GlyphOverflow {
-            bool isEmpty() const { return !top && !bottom; }
-
-            uint8_t top : 5 { 0 };
-            uint8_t bottom: 3 { 0 };
-        };
-        GlyphOverflow glyphOverflow() const { return m_glyphOverflow; }
-
         inline TextDirection inlineDirection() const;
         InlineLayoutUnit letterSpacing() const;
         bool hasTextCombine() const;
@@ -217,7 +209,6 @@ public:
         InlineLayoutUnit m_logicalWidth { 0 };
         UBiDiLevel m_bidiLevel { UBIDI_DEFAULT_LTR };
         InlineLayoutUnit m_textSpacingAdjustment { 0 };
-        GlyphOverflow m_glyphOverflow;
         const Box* m_layoutBox { nullptr };
         const RenderStyle& m_style;
         InlineDisplay::Box::Expansion m_expansion;

--- a/Source/WebCore/layout/formattingContexts/inline/InlineTextItem.h
+++ b/Source/WebCore/layout/formattingContexts/inline/InlineTextItem.h
@@ -37,8 +37,7 @@ class InlineItemsBuilder;
 class InlineTextItem : public InlineItem {
 public:
     static InlineTextItem createWhitespaceItem(const InlineTextBox&, unsigned start, unsigned length, UBiDiLevel, bool isWordSeparator, std::optional<InlineLayoutUnit> width);
-    static InlineTextItem createNonWhitespaceItem(const InlineTextBox&, unsigned start, unsigned length, UBiDiLevel, bool hasTrailingSoftHyphen);
-    static InlineTextItem createNonWhitespaceItem(const InlineTextBox&, unsigned start, unsigned length, UBiDiLevel, bool hasTrailingSoftHyphen, InlineLayoutUnit width, std::optional<std::pair<LayoutUnit, LayoutUnit>> glyphTopBottomOverflow);
+    static InlineTextItem createNonWhitespaceItem(const InlineTextBox&, unsigned start, unsigned length, UBiDiLevel, bool hasTrailingSoftHyphen, std::optional<InlineLayoutUnit> width = { });
     static InlineTextItem createEmptyItem(const InlineTextBox&);
 
     unsigned start() const { return m_startOrPosition; }
@@ -53,7 +52,6 @@ public:
     bool isFullyTrimmable() const;
     bool hasTrailingSoftHyphen() const { return m_hasTrailingSoftHyphen; }
     std::optional<InlineLayoutUnit> width() const { return m_hasWidth ? std::make_optional(m_width) : std::optional<InlineLayoutUnit> { }; }
-    std::pair<uint8_t, uint8_t> glyphOverflow() const { return { m_glyphTopOverflow, m_glyphBottomOverflow }; }
 
     const InlineTextBox& inlineTextBox() const { return downcast<InlineTextBox>(layoutBox()); }
 
@@ -70,7 +68,6 @@ private:
     using InlineItem::TextItemType;
 
     InlineTextItem split(size_t leftSideLength);
-    void setGlyphOverflow(LayoutUnit top, LayoutUnit bottom);
 
     InlineTextItem(const InlineTextBox&, unsigned start, unsigned length, UBiDiLevel, bool hasTrailingSoftHyphen, bool isWordSeparator, std::optional<InlineLayoutUnit> width, TextItemType);
     explicit InlineTextItem(const InlineTextBox&);
@@ -81,31 +78,15 @@ inline InlineTextItem InlineTextItem::createWhitespaceItem(const InlineTextBox& 
     return { inlineTextBox, start, length, bidiLevel, false, isWordSeparator, width, TextItemType::Whitespace };
 }
 
-inline InlineTextItem InlineTextItem::createNonWhitespaceItem(const InlineTextBox& inlineTextBox, unsigned start, unsigned length, UBiDiLevel bidiLevel, bool hasTrailingSoftHyphen)
+inline InlineTextItem InlineTextItem::createNonWhitespaceItem(const InlineTextBox& inlineTextBox, unsigned start, unsigned length, UBiDiLevel bidiLevel, bool hasTrailingSoftHyphen, std::optional<InlineLayoutUnit> width)
 {
-    return { inlineTextBox, start, length, bidiLevel, hasTrailingSoftHyphen, false, { }, TextItemType::NonWhitespace };
-}
-
-inline InlineTextItem InlineTextItem::createNonWhitespaceItem(const InlineTextBox& inlineTextBox, unsigned start, unsigned length, UBiDiLevel bidiLevel, bool hasTrailingSoftHyphen, InlineLayoutUnit width, std::optional<std::pair<LayoutUnit, LayoutUnit>> glyphTopBottomOverflow)
-{
-    if (!glyphTopBottomOverflow)
-        return { inlineTextBox, start, length, bidiLevel, hasTrailingSoftHyphen, false, width, TextItemType::NonWhitespace };
-
-    auto inlineTextItem = InlineTextItem { inlineTextBox, start, length, bidiLevel, hasTrailingSoftHyphen, false, width, TextItemType::NonWhitespace };
-    inlineTextItem.setGlyphOverflow(glyphTopBottomOverflow->first, glyphTopBottomOverflow->second);
-    return inlineTextItem;
+    return { inlineTextBox, start, length, bidiLevel, hasTrailingSoftHyphen, false, width, TextItemType::NonWhitespace };
 }
 
 inline InlineTextItem InlineTextItem::createEmptyItem(const InlineTextBox& inlineTextBox)
 {
     ASSERT(!inlineTextBox.content().length());
     return InlineTextItem { inlineTextBox };
-}
-
-inline void InlineTextItem::setGlyphOverflow(LayoutUnit top, LayoutUnit bottom)
-{
-    m_glyphTopOverflow = top.ceil();
-    m_glyphBottomOverflow = bottom.ceil();
 }
 
 }

--- a/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp
@@ -225,20 +225,15 @@ void InlineDisplayContentBuilder::appendTextDisplayBox(const Line::Run& lineRun,
         addTextShadow();
 
         auto addGlyphOverflow = [&] {
-            auto glyphOverflow = lineRun.glyphOverflow();
-            if (glyphOverflow.isEmpty())
+            if (inlineTextBox->canUseSimpleFontCodePath()) {
+                // canUseSimpleFontCodePath maps to CodePath::Simple (and content with potential glyph overflow would says CodePath::SimpleWithGlyphOverflow).
                 return;
-
-            // Maxed-out glyph overflow values indicate arithmetic overflow. Fallback to collecting overflow post-measure.
-            constexpr size_t maximumAscent = 31;
-            constexpr size_t maximumDescent = 7;
-            if (glyphOverflow.top == maximumAscent || glyphOverflow.bottom == maximumDescent) {
-                auto enclosingAscentAndDescent = TextUtil::enclosingGlyphBoundsForText(StringView(content).substring(text.start, text.length), style, inlineTextBox->shouldUseSimpleGlyphOverflowCodePath() ? TextUtil::ShouldUseSimpleGlyphOverflowCodePath::Yes : TextUtil::ShouldUseSimpleGlyphOverflowCodePath::No);
-                auto& fontMetrics = style.metricsOfPrimaryFont();
-                glyphOverflow.top = std::max(0.f, InlineFormattingUtils::snapToInt(-enclosingAscentAndDescent.ascent, inlineTextBox) - InlineFormattingUtils::ascent(fontMetrics, FontBaseline::Alphabetic, inlineTextBox));
-                glyphOverflow.bottom = std::max(0.f, InlineFormattingUtils::snapToInt(enclosingAscentAndDescent.descent, inlineTextBox) - InlineFormattingUtils::descent(fontMetrics, FontBaseline::Alphabetic, inlineTextBox));
             }
-            inkOverflow.inflate(glyphOverflow.top, { }, glyphOverflow.bottom, { });
+            auto enclosingAscentAndDescent = TextUtil::enclosingGlyphBoundsForText(StringView(content).substring(text.start, text.length), style, inlineTextBox->shouldUseSimpleGlyphOverflowCodePath() ? TextUtil::ShouldUseSimpleGlyphOverflowCodePath::Yes : TextUtil::ShouldUseSimpleGlyphOverflowCodePath::No);
+            auto& fontMetrics = style.metricsOfPrimaryFont();
+            auto glyphOverflowTop = std::max(0.f, InlineFormattingUtils::snapToInt(-enclosingAscentAndDescent.ascent, inlineTextBox) - InlineFormattingUtils::ascent(fontMetrics, FontBaseline::Alphabetic, inlineTextBox));
+            auto glyphOverflowBottom = std::max(0.f, InlineFormattingUtils::snapToInt(enclosingAscentAndDescent.descent, inlineTextBox) - InlineFormattingUtils::descent(fontMetrics, FontBaseline::Alphabetic, inlineTextBox));
+            inkOverflow.inflate(glyphOverflowTop, { }, glyphOverflowBottom, { });
         };
         addGlyphOverflow();
 

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp
@@ -57,7 +57,7 @@ InlineLayoutUnit TextUtil::singleSpaceWidth(const FontCascade& fontCascade, bool
     return width;
 }
 
-InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontCascade& fontCascade, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization useTrailingWhitespaceMeasuringOptimization, TextSpacing::SpacingState spacingState, GlyphOverflow* glyphOverflow)
+InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontCascade& fontCascade, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization useTrailingWhitespaceMeasuringOptimization, TextSpacing::SpacingState spacingState)
 {
     if (from == to)
         return 0;
@@ -90,7 +90,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextBox& inlineTextBox, const FontC
             run.setTabSize(true, Style::toPlatform(style->tabSize()));
         // FIXME: consider moving this to TextRun ctor
         run.setTextSpacingState(spacingState);
-        width = fontCascade.width(run, { }, glyphOverflow);
+        width = fontCascade.width(run);
     }
 
     if (extendedMeasuring)
@@ -106,7 +106,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const Fon
     return TextUtil::width(inlineTextItem, fontCascade, inlineTextItem.start(), inlineTextItem.end(), contentLogicalLeft);
 }
 
-InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const FontCascade& fontCascade, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization useTrailingWhitespaceMeasuringOptimization, TextSpacing::SpacingState spacingState, GlyphOverflow* glyphOverflow)
+InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const FontCascade& fontCascade, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization useTrailingWhitespaceMeasuringOptimization, TextSpacing::SpacingState spacingState)
 {
     RELEASE_ASSERT(from >= inlineTextItem.start());
     RELEASE_ASSERT(to <= inlineTextItem.end());
@@ -117,7 +117,7 @@ InlineLayoutUnit TextUtil::width(const InlineTextItem& inlineTextItem, const Fon
         if (singleWhiteSpace)
             return std::max(0.f, singleSpaceWidth(fontCascade, inlineTextBox->canUseSimplifiedContentMeasuring()));
     }
-    return width(inlineTextItem.inlineTextBox(), fontCascade, from, to, contentLogicalLeft, useTrailingWhitespaceMeasuringOptimization, spacingState, glyphOverflow);
+    return width(inlineTextItem.inlineTextBox(), fontCascade, from, to, contentLogicalLeft, useTrailingWhitespaceMeasuringOptimization, spacingState);
 }
 
 InlineLayoutUnit TextUtil::trailingWhitespaceWidth(const InlineTextBox& inlineTextBox, const FontCascade& fontCascade, size_t startPosition, size_t endPosition)

--- a/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
+++ b/Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h
@@ -54,8 +54,8 @@ class TextUtil {
 public:
     enum class UseTrailingWhitespaceMeasuringOptimization : bool { No, Yes };
     static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, InlineLayoutUnit contentLogicalLeft);
-    static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes, TextSpacing::SpacingState spacingState = { }, GlyphOverflow* = nullptr);
-    static InlineLayoutUnit width(const InlineTextBox&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes, TextSpacing::SpacingState spacingState = { }, GlyphOverflow* = nullptr);
+    static InlineLayoutUnit width(const InlineTextItem&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes, TextSpacing::SpacingState spacingState = { });
+    static InlineLayoutUnit width(const InlineTextBox&, const FontCascade&, unsigned from, unsigned to, InlineLayoutUnit contentLogicalLeft, UseTrailingWhitespaceMeasuringOptimization = UseTrailingWhitespaceMeasuringOptimization::Yes, TextSpacing::SpacingState spacingState = { });
 
     static InlineLayoutUnit trailingWhitespaceWidth(const InlineTextBox&, const FontCascade&, size_t startPosition, size_t endPosition);
     static InlineLayoutUnit singleSpaceWidth(const FontCascade&, bool canUseSimplifiedContentMeasuring);


### PR DESCRIPTION
#### 280cd6f5cdbb213cd2f873a70e1bf5c46b55f09f
<pre>
REGRESSION (305325@main): Layout of columns is incorrect for some fonts
<a href="https://bugs.webkit.org/show_bug.cgi?id=308087">https://bugs.webkit.org/show_bug.cgi?id=308087</a>
<a href="https://rdar.apple.com/170594582">rdar://170594582</a>

Reviewed by Alan Baradlay.

Revert glyph overflow tracking changes from 8161ef47a831

* LayoutTests/fast/repaint/emoji-glyph-overflow-repaint-fail-expected.txt:
* LayoutTests/platform/glib/fast/repaint/emoji-glyph-overflow-repaint-fail-expected.txt:
* Source/WebCore/layout/formattingContexts/inline/InlineItem.cpp:
* Source/WebCore/layout/formattingContexts/inline/InlineItem.h:
* Source/WebCore/layout/formattingContexts/inline/InlineItemsBuilder.cpp:
(WebCore::Layout::nonWhitespaceContentWidth):
(WebCore::Layout::InlineItemsBuilder::computeInlineTextItemWidthsAndTextSpacing):
(WebCore::Layout::InlineItemsBuilder::buildInlineItemListForTextFromBreakingPositionsCache):
(WebCore::Layout::InlineItemsBuilder::handleTextContent):
* Source/WebCore/layout/formattingContexts/inline/InlineLine.cpp:
(WebCore::Layout::Line::Run::Run):
(WebCore::Layout::Line::Run::expand):
* Source/WebCore/layout/formattingContexts/inline/InlineLine.h:
(WebCore::Layout::Line::Run::GlyphOverflow::isEmpty const): Deleted.
(WebCore::Layout::Line::Run::glyphOverflow const): Deleted.
* Source/WebCore/layout/formattingContexts/inline/InlineTextItem.h:
(WebCore::Layout::InlineTextItem::createNonWhitespaceItem):
(WebCore::Layout::InlineTextItem::width const):
(WebCore::Layout::InlineTextItem::glyphOverflow const): Deleted.
(WebCore::Layout::InlineTextItem::setGlyphOverflow): Deleted.
* Source/WebCore/layout/formattingContexts/inline/display/InlineDisplayContentBuilder.cpp:
(WebCore::Layout::InlineDisplayContentBuilder::appendTextDisplayBox):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.cpp:
(WebCore::Layout::TextUtil::width):
* Source/WebCore/layout/formattingContexts/inline/text/TextUtil.h:
(WebCore::Layout::TextUtil::width):

Canonical link: <a href="https://commits.webkit.org/307942@main">https://commits.webkit.org/307942@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7620ad8db69df2bceb0271f1d689efb4cf905ea8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/146005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18692 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154684 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/51d79382-cae8-483e-9e81-f08798f84d8c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147880 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19171 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18584 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/112316 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148968 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14695 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131154 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93210 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21fcf1ec-3de0-4ade-86db-613cbb949e8a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/13971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/2128 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/123529 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/8098 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156995 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9341 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/120329 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18523 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/15492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120656 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30920 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18554 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129516 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74232 "Built successfully") | | 
| | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/7446 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18142 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81906 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17878 "Built successfully") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/18056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17938 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->