### PR TITLE
[macOS] imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe.html is a flaky text failure.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe.html
@@ -48,8 +48,7 @@
       "initial transform style"
     );
 
-    await trusted_request(iframe);
-    await fullScreenChange();
+    await Promise.all([trusted_request(iframe), fullScreenChange()]);
 
     const fullscreenStyle = getComputedStyle(iframe);
     assert_dir_properties(

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2496,5 +2496,3 @@ webkit.org/b/308079 [ Tahoe Release arm64 ] http/tests/site-isolation/inspector/
 webkit.org/b/308165 [ Debug ] scrollingcoordinator/mac/latching/simple-page-rubberbands.html [ Pass Failure ]
 
 webkit.org/b/308243 [ Release ] http/tests/site-isolation/mixedContent/redirect-https-to-http-iframe-in-main-frame.html [ Pass Failure ]
-
-webkit.org/b/308259 imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe.html [ Pass Failure ]


### PR DESCRIPTION
#### 793de962fdf23b424f74d15e18473751f2b33ce5
<pre>
[macOS] imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe.html is a flaky text failure.
<a href="https://rdar.apple.com/170764288">rdar://170764288</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=308259">https://bugs.webkit.org/show_bug.cgi?id=308259</a>

Reviewed by Tim Nguyen.

The test was intermittently timing out because the fullscreenchange
event listener was registered after the event had already fired.

The sequential awaits:
    await trusted_request(iframe);
    await fullScreenChange();
caused the fullscreenchange event to fire while waiting for
requestFullscreen() to resolve, before the listener in
fullScreenChange() was registered.

Using Promise.all() ensures the listener is registered synchronously
before the fullscreen transition completes:
await Promise.all([trusted_request(iframe), fullScreenChange()]);

* LayoutTests/imported/w3c/web-platform-tests/fullscreen/rendering/ua-style-iframe.html:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/307923@main">https://commits.webkit.org/307923@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b44399dc2096bba543d404f060d10ec6c6d0601

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145815 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18506 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154494 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99411 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112147 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80317 "1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148778 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130973 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93052 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13826 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11586 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1941 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7846 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156807 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9031 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120151 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18352 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15320 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120496 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30912 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18397 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129195 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74090 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16221 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7237 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17972 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17710 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17914 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17768 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->