### PR TITLE
Rotating bounding box invalidation does not redraw a border on other element

### DIFF
--- a/LayoutTests/fast/repaint/border-radius-partial-repaint-corner-expected.html
+++ b/LayoutTests/fast/repaint/border-radius-partial-repaint-corner-expected.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+body { margin: 0; }
+#trigger {
+    position: absolute;
+    top: 65px;
+    left: 65px;
+    width: 20px;
+    height: 20px;
+    background: lightgray;
+}
+#bordered {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+    width: 200px;
+    height: 200px;
+    border: 20px solid black;
+    border-radius: 40px;
+    background: white;
+}
+</style>
+<div id="trigger"></div>
+<div id="bordered"></div>

--- a/LayoutTests/fast/repaint/border-radius-partial-repaint-corner.html
+++ b/LayoutTests/fast/repaint/border-radius-partial-repaint-corner.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<script src="../../resources/ui-helper.js"></script>
+<style>
+body { margin: 0; }
+#trigger {
+    position: absolute;
+    top: 65px;
+    left: 65px;
+    width: 20px;
+    height: 20px;
+    background: white;
+}
+#bordered {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+    width: 200px;
+    height: 200px;
+    border: 20px solid black;
+    border-radius: 40px;
+    background: white;
+}
+</style>
+<div id="trigger"></div>
+<div id="bordered"></div>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dontForceRepaint();
+}
+
+window.addEventListener('load', async () => {
+    await UIHelper.renderingUpdate();
+
+    document.getElementById('trigger').style.backgroundColor = 'lightgray';
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+</script>

--- a/Source/WebCore/rendering/BorderPainter.cpp
+++ b/Source/WebCore/rendering/BorderPainter.cpp
@@ -270,13 +270,14 @@ void BorderPainter::paintBorder(const LayoutRect& rect, const RenderStyle& style
         return std::tuple<BorderShape, BorderEdges> { BorderShape({ }, { 0_lu }), { } };
     }();
 
-    bool outerEdgeIsRectangular = !shape.isRounded() || shape.outerShapeContains(m_paintInfo.rect);
+    bool haveAllSolidEdges = decorationHasAllSolidEdges(edges);
+    bool outerEdgeIsRectangular = !shape.isRounded() || (haveAllSolidEdges && shape.allCornersClippedOut(m_paintInfo.rect));
     bool innerEdgeIsRectangular = shape.innerShapeIsRectangular();
 
     paintSides(shape, {
         style.border().hasBorderRadius() ? std::optional { style.borderRadii() } : std::nullopt,
         edges,
-        decorationHasAllSolidEdges(edges),
+        haveAllSolidEdges,
         outerEdgeIsRectangular,
         innerEdgeIsRectangular,
         bleedAvoidance,

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -218,6 +218,40 @@ bool BorderShape::outerShapeContains(const LayoutRect& rect) const
     return m_borderRect.contains(rect);
 }
 
+bool BorderShape::allCornersClippedOut(const LayoutRect& rect) const
+{
+    if (!isRounded())
+        return true;
+
+    auto borderRect = m_borderRect.rect();
+    if (rect.contains(borderRect))
+        return false;
+
+    auto radii = m_borderRect.radii();
+
+    LayoutRect topLeftRect(borderRect.location(), radii.topLeft());
+    if (rect.intersects(topLeftRect))
+        return false;
+
+    LayoutRect topRightRect(borderRect.location(), radii.topRight());
+    topRightRect.setX(borderRect.maxX() - topRightRect.width());
+    if (rect.intersects(topRightRect))
+        return false;
+
+    LayoutRect bottomLeftRect(borderRect.location(), radii.bottomLeft());
+    bottomLeftRect.setY(borderRect.maxY() - bottomLeftRect.height());
+    if (rect.intersects(bottomLeftRect))
+        return false;
+
+    LayoutRect bottomRightRect(borderRect.location(), radii.bottomRight());
+    bottomRightRect.setX(borderRect.maxX() - bottomRightRect.width());
+    bottomRightRect.setY(borderRect.maxY() - bottomRightRect.height());
+    if (rect.intersects(bottomRightRect))
+        return false;
+
+    return true;
+}
+
 bool BorderShape::outerShapeIsRectangular() const
 {
     return !m_borderRect.isRounded();

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -75,9 +75,13 @@ public:
     FloatRoundedRect deprecatedPixelSnappedRoundedRect(float deviceScaleFactor) const;
     FloatRoundedRect deprecatedPixelSnappedInnerRoundedRect(float deviceScaleFactor) const;
 
-    // Returns true if the given rect is entirely inside the shape, without impinging on any of the corners.
+    // Returns true if the given rect is entirely inside the inner/outer shape.
     bool innerShapeContains(const LayoutRect&) const;
     bool outerShapeContains(const LayoutRect&) const;
+
+    // Returns true if no corner regions of the outer border intersect the given rect,
+    // meaning border painting can use simpler rectangular paths.
+    bool allCornersClippedOut(const LayoutRect&) const;
 
     const LayoutRoundedRectRadii& radii() const { return m_borderRect.radii(); }
     void setRadii(const LayoutRoundedRectRadii& radii) { m_borderRect.setRadii(radii); }


### PR DESCRIPTION
#### 54b6555c4fa661e33fb980e8d541ab22a608b2e5
<pre>
Rotating bounding box invalidation does not redraw a border on other element
<a href="https://rdar.apple.com/170438404">rdar://170438404</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=307949">https://bugs.webkit.org/show_bug.cgi?id=307949</a>

Reviewed by Simon Fraser.

The regression from 290951@main replaced allCornersClippedOut() with
outerShapeContains(), but these have different semantics. outerShapeContains
checks if the dirty rect is inside the rounded shape, while
allCornersClippedOut() checked if the dirty rect avoids all corner regions.
A rect inside the shape but within a corner region still needs curved-path
painting. Re-add allCornersClippedOut() to restore the correct
operation for this case.

Test: fast/repaint/border-radius-partial-repaint-corner.html

* LayoutTests/fast/repaint/border-radius-partial-repaint-corner-expected.html: Added.
* LayoutTests/fast/repaint/border-radius-partial-repaint-corner.html: Added.
* Source/WebCore/rendering/BorderPainter.cpp:
(WebCore::BorderPainter::paintBorder const):
* Source/WebCore/rendering/BorderShape.cpp:
(WebCore::BorderShape::allCornersClippedOut const):
* Source/WebCore/rendering/BorderShape.h:

Canonical link: <a href="https://commits.webkit.org/307930@main">https://commits.webkit.org/307930@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/52acdde60b2a49cae57c9cf8bba86c72a1ab2402

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145821 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10514 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154500 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99415 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18402 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112152 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80319 "2 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148784 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14534 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130974 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93057 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13834 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11591 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1947 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123387 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156813 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/74 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9032 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120155 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18358 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15326 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120500 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30915 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18403 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74095 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16227 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7238 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17978 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81869 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17716 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17919 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17774 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->