### PR TITLE
Fix -webkit-text-decorations-in-effect grammar: parses 'grammar-error'

### DIFF
--- a/LayoutTests/css3/text-decoration/webkit-text-decorations-in-effect-parsing-expected.txt
+++ b/LayoutTests/css3/text-decoration/webkit-text-decorations-in-effect-parsing-expected.txt
@@ -1,0 +1,8 @@
+Test underline
+Test spelling-error
+Test grammar-error
+
+PASS -webkit-text-decorations-in-effect: underline can be set directly
+PASS -webkit-text-decorations-in-effect: spelling-error can be set directly
+PASS -webkit-text-decorations-in-effect: grammar-error can be set directly
+

--- a/LayoutTests/css3/text-decoration/webkit-text-decorations-in-effect-parsing.html
+++ b/LayoutTests/css3/text-decoration/webkit-text-decorations-in-effect-parsing.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="test-underline" style="-webkit-text-decorations-in-effect: underline">Test underline</div>
+<div id="test-spelling" style="-webkit-text-decorations-in-effect: spelling-error">Test spelling-error</div>
+<div id="test-grammar" style="-webkit-text-decorations-in-effect: grammar-error">Test grammar-error</div>
+
+<script>
+test(() => {
+    const el = document.getElementById('test-underline');
+    const value = el.style.getPropertyValue('-webkit-text-decorations-in-effect');
+    assert_equals(value, 'underline', 'underline should be settable via style attribute');
+}, '-webkit-text-decorations-in-effect: underline can be set directly');
+
+test(() => {
+    const el = document.getElementById('test-spelling');
+    const value = el.style.getPropertyValue('-webkit-text-decorations-in-effect');
+    assert_equals(value, 'spelling-error', 'spelling-error should be settable via style attribute');
+}, '-webkit-text-decorations-in-effect: spelling-error can be set directly');
+
+test(() => {
+    const el = document.getElementById('test-grammar');
+    const value = el.style.getPropertyValue('-webkit-text-decorations-in-effect');
+    assert_equals(value, 'grammar-error', 'grammar-error should be settable via style attribute');
+}, '-webkit-text-decorations-in-effect: grammar-error can be set directly');
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -11779,7 +11779,7 @@
                 "computed-style-storage-container": "struct",
                 "computed-style-storage-kind": "raw",
                 "computed-style-type": "Style::TextDecorationLine",
-                "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt) | spelling-error@(settings-flag=cssTextDecorationLineErrorValues)",
+                "parser-grammar": "none | [ underline || overline || line-through || blink ]@(no-single-item-opt) | spelling-error@(settings-flag=cssTextDecorationLineErrorValues) | grammar-error@(settings-flag=cssTextDecorationLineErrorValues)",
                 "comment": "FIXME: Should this be an alias of text-decoration-line?"
             },
             "status": "non-standard"


### PR DESCRIPTION
#### 2ad88d98db5a660d5b2b6b1cf322585fac0ff087
<pre>
Fix -webkit-text-decorations-in-effect grammar: parses &apos;grammar-error&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=308267">https://bugs.webkit.org/show_bug.cgi?id=308267</a>
<a href="https://rdar.apple.com/170766651">rdar://170766651</a>

Reviewed by Tim Nguyen.

It is a bit odd that we allow authors to set -webkit-text-decorations-in-effect,
instead of making it an internal property and maybe we should stop doing that,
if retro compatibility allows it.

Either way, since we allow that, we should allow all its values, &apos;grammar-error&apos;
was missing from the grammar.

Test: css3/text-decoration/webkit-text-decorations-in-effect-parsing.html
* LayoutTests/css3/text-decoration/webkit-text-decorations-in-effect-parsing-expected.txt: Added.
* LayoutTests/css3/text-decoration/webkit-text-decorations-in-effect-parsing.html: Added.
* Source/WebCore/css/CSSProperties.json:

Canonical link: <a href="https://commits.webkit.org/307884@main">https://commits.webkit.org/307884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f63efe6ec3c10b3ced8a15256f7df298c300c801

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145824 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10518 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154503 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a7237ed2-eaaf-49d9-9c06-d004ef0925a5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147699 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/18999 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18405 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112155 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99417 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148787 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14531 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130983 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93060 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d65ecec5-9025-4a68-b2b3-4682df100ea2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13831 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1950 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156816 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/77 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120157 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120502 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30890 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18406 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129208 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74098 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16232 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7244 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17981 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81767 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17719 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17777 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->