### PR TITLE
Enhanced <select>: properly set `position-try-fallbacks` on picker

### DIFF
--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html
@@ -23,6 +23,9 @@
 
     <div>This should be visible (base).</div>
 
+    <div>block-start span-inline-end, block-end span-inline-start</div>
+    <div>block-end span-inline-end, block-start span-inline-start, block-start span-inline-start</div>
+
     <div class="fake-base-select">This select should be green with white text. (base-select)</div>
     <div class="fake-base-select">This select should be green with white text. (base)</div>
     <select><option>This select should be red with white text. (default)</option></select>

--- a/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
+++ b/LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html
@@ -13,6 +13,13 @@
         .display-toggle {
             display: -internal-auto-base(none, block);
         }
+        /* Test argument parsing with braces */
+        .position-try-fallbacks {
+            position-try-fallbacks: -internal-auto-base({block-start span-inline-end, block-end span-inline-start}, {
+                block-end span-inline-end,   /* First try above and span-right. */
+                block-start span-inline-start,   /* Then below but span-left. */
+                block-start span-inline-start });
+        }
         select {
             all: unset; /* Remove all UA styles */
             display: inline-block;
@@ -31,8 +38,17 @@
     <div class="display-toggle" style="appearance: base-select">This should be hidden (base-select on non-select).</div>
     <div class="display-toggle" style="appearance: base">This should be visible (base).</div>
 
+    <div class="position-try-fallbacks"></div>
+    <div class="position-try-fallbacks" style="appearance: base"></div>
+
     <select style="appearance: base-select"><option>This select should be green with white text. (base-select)</option></select>
     <select style="appearance: base"><option>This select should be green with white text. (base)</option></select>
     <select><option>This select should be red with white text. (default)</option></select>
+
+    <script>
+        document.querySelectorAll(".position-try-fallbacks").forEach(element => {
+            element.textContent = getComputedStyle(element).positionTryFallbacks;
+        });
+    </script>
 </body>
 </html>

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -1148,10 +1148,10 @@ select::picker-icon {
     /* Below and span-right, by default. */
     position-area: -internal-auto-base(unset, block-end span-inline-end);
     position-try-order: -internal-auto-base(unset, most-block-size);
-    position-try-fallbacks: -internal-auto-base(unset,
+    position-try-fallbacks: -internal-auto-base(unset, {
         block-start span-inline-end,   /* First try above and span-right. */
         block-end span-inline-start,   /* Then below but span-left. */
-        block-start span-inline-start); /* Then above and span-left. */
+        block-start span-inline-start }); /* Then above and span-left. */
 
     display: -internal-auto-base(contents, none);
 }

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -233,6 +233,16 @@ static bool consumeFunctionArgument(CSSParserTokenRange& range, unsigned index, 
     if (!argument)
         return false;
 
+    // If the argument is a block, strip the braces.
+    if (argument->peek().type() == LeftBraceToken) {
+        auto last = argument->consumeLast();
+        if (last.type() != RightBraceToken)
+            return false;
+        argument->consume(); // Consume left brace.
+        argument->consumeWhitespace();
+        argument->trimTrailingWhitespace();
+    }
+
     const auto& context = state.context;
     auto important = state.important;
     auto ruleType = state.currentRule;


### PR DESCRIPTION
#### 9698376bb1cca0a3f3edfe8df8c1c29979ec4d52
<pre>
Enhanced &lt;select&gt;: properly set `position-try-fallbacks` on picker
<a href="https://bugs.webkit.org/show_bug.cgi?id=308268">https://bugs.webkit.org/show_bug.cgi?id=308268</a>
<a href="https://rdar.apple.com/170773150">rdar://170773150</a>

Reviewed by Anne van Kesteren.

We need to use braces around the argument value, since the value is comma separated.
This is what the spec currently says for argument values: <a href="https://github.com/w3c/csswg-drafts/issues/9539#issuecomment-2377487819">https://github.com/w3c/csswg-drafts/issues/9539#issuecomment-2377487819</a>

Add support for those only in -internal-auto-base().
`consumeArgument()` appears to consume blocks with braces (for mixins), but doesn&apos;t strip the braces, so the value ends up not parsed properly.
Do that in `consumeFunctionArgument()`.

Update html.css with correct syntax. There are reftests covering the ::picker() change, but they fail for other reasons.

* LayoutTests/fast/forms/appearance-base/internal-auto-base-function-expected.html:
* LayoutTests/fast/forms/appearance-base/internal-auto-base-function.html:
* Source/WebCore/css/html.css:
(:-internal-select-popover):
();):
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
(WebCore::consumeFunctionArgument):

Canonical link: <a href="https://commits.webkit.org/307926@main">https://commits.webkit.org/307926@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5246092695605c250c3f039814dac0f8edc8b705

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18529 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154517 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99426 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a10141d-176f-442f-baea-0c2c2e37dbe4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147713 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18418 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112167 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/80327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3af0733-a838-40b0-873d-f546c7170157) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14545 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/130998 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93071 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [⏳ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/iOS-26-Simulator-WPT-WK2-Tests-EWS "Waiting to run tests") | [⏳ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/macOS-Tahoe-Debug-API-Tests-EWS "Waiting to run tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1964 "Built successfully") | | 
| | [⏳ 🧪 api-ios](https://ews-build.webkit.org/#/builders/API-Tests-iOS-Simulator-EWS "Waiting to run tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7884 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156830 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/86 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9075 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120170 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15341 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120515 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18417 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129241 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74108 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22504 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16240 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7262 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17993 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81778 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17730 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17933 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17789 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->