### PR TITLE
[Soup] NetworkStorageSession::domCookiesForHost shoudn't return httpOnly cookies

### DIFF
--- a/LayoutTests/http/tests/cookies/set-http-only-cookie-expected.txt
+++ b/LayoutTests/http/tests/cookies/set-http-only-cookie-expected.txt
@@ -1,0 +1,11 @@
+Get DOM cookies while setting a cookie asynchronously with Cookie Store API
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS Do not have DOM cookie "foo".
+PASS Do not have DOM cookie "foo".
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/cookies/set-http-only-cookie.html
+++ b/LayoutTests/http/tests/cookies/set-http-only-cookie.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<script src="/js-test-resources/js-test.js"></script>
+<script src="resources/cookie-utilities.js"></script>
+<script src="resources/resetCookies.js"></script>
+<script>
+description('Get DOM cookies while setting a cookie asynchronously with Cookie Store API');
+jsTestIsAsync = true;
+
+function setHTTPOnlyCookie(name) {
+    let promise = new Promise((resolved, rejected) => {
+        let xhr = new XMLHttpRequest;
+        xhr.open("GET", `resources/set-http-only-cookie.py?cookieName=${name}`);
+        xhr.onload = () => resolved(xhr.responseText);
+        xhr.onerror = rejected;
+        xhr.send(null);
+    });
+    return promise;
+}
+  
+onload = async () => {
+    await setHTTPOnlyCookie('foo');
+    // Get DOM cookies to make WebCookieCache cache the cookies
+    shouldNotHaveDOMCookie('foo');
+    // Start setting a cookie by using Cookie Store API in order to make WebCookieCache out of sync.
+    let promise = cookieStore.set('cookieName', 'cookieValue');
+    // Get DOM cookies again while WebCookieCache has a stale cache.
+    shouldNotHaveDOMCookie('foo');
+    finishJSTest();
+}
+</script>

--- a/LayoutTests/platform/glib/http/tests/cookies/js-get-and-set-http-only-cookie-expected.txt
+++ b/LayoutTests/platform/glib/http/tests/cookies/js-get-and-set-http-only-cookie-expected.txt
@@ -1,0 +1,12 @@
+Test for <https://bugs.webkit.org/show_bug.cgi?id=86067> [BlackBerry] Possible to clobber httpOnly cookie.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+Check that we can't get or set httpOnly Cookies by JavaScript.
+PASS We can't get httpOnly cookies by JavaScript.
+FAIL We shouldn't set httpOnly cookies by JavaScript.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
+++ b/Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp
@@ -770,6 +770,8 @@ Vector<Cookie> NetworkStorageSession::domCookiesForHost(const URL& url)
     Vector<Cookie> cookies;
     for (GSList* iter = soupCookies.get(); iter; iter = g_slist_next(iter)) {
         auto* soupCookie = static_cast<SoupCookie*>(iter->data);
+        if (soup_cookie_get_http_only(soupCookie))
+            continue;
         if (soup_cookie_domain_matches(soupCookie, host.data())) {
             // soup_cookie_jar_all_cookies() always returns a reversed list.
             cookies.insert(0, Cookie(soupCookie));


### PR DESCRIPTION
#### 8cb5592cf41f088fb34c7c8b2e7ae4a03e17a050
<pre>
[Soup] NetworkStorageSession::domCookiesForHost shoudn&apos;t return httpOnly cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=308204">https://bugs.webkit.org/show_bug.cgi?id=308204</a>

Reviewed by Carlos Garcia Campos.

GTK and WPE ports were observing an assertion failure in WebCookieCache.cpp
while browsing some web sites.

&gt; ASSERTION FAILED: !cookie.httpOnly
&gt; ../../../Source/WebKit/WebProcess/WebPage/WebCookieCache.cpp(57) : String WebKit::cookiesToString(const Vector&lt;WebCore::Cookie&gt; &amp;)

httpOnly cookies shouldn&apos;t be included in DOM cookies. Changed
NetworkStorageSession::domCookiesForHost not to include httpOnly cookies.

After this change, http/tests/cookies/js-get-and-set-http-only-cookie.html
started to fail. However, it&apos;s the same result as Mac port. Copied
platform/mac/http/tests/cookies/js-get-and-set-http-only-cookie-expected.txt to
glib.

Test: http/tests/cookies/set-http-only-cookie.html

* LayoutTests/http/tests/cookies/set-http-only-cookie-expected.txt: Added.
* LayoutTests/http/tests/cookies/set-http-only-cookie.html: Added.
* LayoutTests/platform/glib/http/tests/cookies/js-get-and-set-http-only-cookie-expected.txt: Added.
* Source/WebCore/platform/network/soup/NetworkStorageSessionSoup.cpp:
(WebCore::NetworkStorageSession::domCookiesForHost):

Canonical link: <a href="https://commits.webkit.org/307889@main">https://commits.webkit.org/307889@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/72b3075ecd0c69b47bd51ee367e837b808756879

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10566 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154526 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/99433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147722 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19021 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18426 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112172 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/99433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14554 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/131012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93076 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13850 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/11612 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1972 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123403 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/7899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156838 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/93 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9093 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120176 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15352 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120521 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/18424 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129259 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/74115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/22487 "Built successfully and passed tests") | [⏳ 🧪 vision-wk2 ](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/7277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/18001 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/81786 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17738 "Built successfully") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/17940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17797 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->