### PR TITLE
Readonly date input can be edited via keyboard

### DIFF
--- a/LayoutTests/fast/forms/date/date-editable-components/date-readonly-picker-does-not-open-on-space-keypress-expected.txt
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-readonly-picker-does-not-open-on-space-keypress-expected.txt
@@ -1,0 +1,15 @@
+Tests that a readonly date input's calendar view cannot be opened using the space key.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS showingPicker is false
+Focusing readonly input using tab key and then pressing space key.
+PASS showingPicker is false
+PASS document.getElementById('input').value is "1970-01-01"
+Removing readonly attribute and pressing space key.
+PASS showingPicker is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/date/date-editable-components/date-readonly-picker-does-not-open-on-space-keypress.html
+++ b/LayoutTests/fast/forms/date/date-editable-components/date-readonly-picker-does-not-open-on-space-keypress.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../../resources/js-test.js"></script>
+<script src="../../../../resources/ui-helper.js"></script>
+</head>
+<body>
+
+<input id="input" type="date" readonly value="1970-01-01"/>
+
+<script>
+
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    description("Tests that a readonly date input's calendar view cannot be opened using the space key.");
+
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeFalse("showingPicker");
+
+    debug("Focusing readonly input using tab key and then pressing space key.");
+    UIHelper.keyDown("\t");
+    UIHelper.keyDown(" ");
+    await UIHelper.ensurePresentationUpdate();
+
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeFalse("showingPicker");
+
+    shouldBeEqualToString("document.getElementById('input').value", "1970-01-01");
+
+    debug("Removing readonly attribute and pressing space key.");
+    document.getElementById("input").removeAttribute("readonly");
+    UIHelper.keyDown(" ");
+    await UIHelper.ensurePresentationUpdate();
+
+    showingPicker = await UIHelper.isShowingDateTimePicker();
+    shouldBeTrue("showingPicker");
+
+    finishJSTest();
+});
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/html/BaseDateAndTimeInputType.cpp
+++ b/Source/WebCore/html/BaseDateAndTimeInputType.cpp
@@ -597,6 +597,10 @@ void BaseDateAndTimeInputType::didChangeValueFromControl()
 
 void BaseDateAndTimeInputType::didReceiveSpaceKeyFromControl()
 {
+    ASSERT(element());
+    if (!element()->renderer() || !protect(element())->isMutable())
+        return;
+
     // One of our subfields received a space key event, so let's move focus into the picker.
     m_pickerWasActivatedByKeyboard = true;
     m_didTransferFocusToPicker = true;


### PR DESCRIPTION
#### 4d6199e554199dbc1904116f697d8b4caaade059
<pre>
Readonly date input can be edited via keyboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=306307">https://bugs.webkit.org/show_bug.cgi?id=306307</a>
<a href="https://rdar.apple.com/169488939">rdar://169488939</a>

Reviewed by Ryosuke Niwa.

Fix readonly date input picker opening via space key by adding
an isMutable() guard to didReceiveSpaceKeyFromControl(),
matching the existing guards in handleDOMActivateEvent()
and handleAccessibilityActivation().

Test: fast/forms/date/date-editable-components/date-readonly-picker-does-not-open-on-space-keypress.html

* LayoutTests/fast/forms/date/date-editable-components/date-readonly-picker-does-not-open-on-space-keypress-expected.txt: Added.
* LayoutTests/fast/forms/date/date-editable-components/date-readonly-picker-does-not-open-on-space-keypress.html: Added.
* Source/WebCore/html/BaseDateAndTimeInputType.cpp:
(WebCore::BaseDateAndTimeInputType::didReceiveSpaceKeyFromControl):

Canonical link: <a href="https://commits.webkit.org/307934@main">https://commits.webkit.org/307934@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e28499a6bf91eef1b00cf70dc3b8bf2354101a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/145840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/18531 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/10552 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/154519 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/99427 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/147715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/19014 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/18420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/112169 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/80329 "2 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/148803 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/14551 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/131000 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/93073 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/13847 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/11605 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/1966 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/123400 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/7887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/156832 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/87 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/9078 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/120172 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/18376 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/15345 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/120517 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/30916 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/18418 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/129244 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/74109 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/16242 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/7265 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/17995 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/81780 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/17732 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/17934 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/17791 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->